### PR TITLE
Allow impersonated users to hit cache again (#54521)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -724,7 +724,7 @@
    clojurewerkz.quartzite.schedule.cron/schedule                                 macros.quartz/schedule
    clojurewerkz.quartzite.schedule.simple/schedule                               macros.quartz/simple-schedule
    clojurewerkz.quartzite.triggers/build                                         macros.quartz/build-trigger
-   metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!   macros.metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!
+   metabase-enterprise.impersonation.util-test/with-impersonations!              macros.metabase-enterprise.impersonation.util-test/with-impersonations!
    metabase-enterprise.query-reference-validation.api-test/with-test-setup!      macros.metabase-enterprise.query-reference-validation.api-test/with-test-setup!
    metabase-enterprise.sandbox.test-util/with-gtaps!                             macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.sandbox.test-util/with-gtaps-for-user!                    macros.metabase-enterprise.sandbox.test-util/with-gtaps!

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -586,10 +586,9 @@
 
   enterprise/advanced-permissions
   {:api  #{metabase-enterprise.advanced-permissions.api.routes
-           metabase-enterprise.advanced-permissions.api.util
            metabase-enterprise.advanced-permissions.common
            metabase-enterprise.advanced-permissions.models.permissions.group-manager}
-   :uses #{api audit driver lib models permissions premium-features query-processor util enterprise/sandbox}}
+   :uses #{api audit driver enterprise/impersonation lib models permissions premium-features query-processor util enterprise/sandbox}}
 
   enterprise/airgap
   {:api  #{}
@@ -646,6 +645,11 @@
            metabase-enterprise.enhancements.integrations.ldap}
    :uses #{integrations models premium-features util enterprise/sso}}
 
+  enterprise/impersonation
+  {:api #{metabase-enterprise.impersonation.core
+          metabase-enterprise.impersonation.api}
+   :uses #{api audit driver enterprise/sandbox lib models permissions premium-features query-processor util}}
+
   enterprise/llm
   {:api  #{metabase-enterprise.llm.api}
    :uses #{analytics analyze api models query-processor util}}
@@ -669,7 +673,7 @@
            query-processor
            request
            util
-           enterprise/advanced-permissions
+           enterprise/impersonation
            enterprise/api}}
 
   enterprise/scim

--- a/.clj-kondo/macros/metabase_enterprise/impersonation/util_test.clj
+++ b/.clj-kondo/macros/metabase_enterprise/impersonation/util_test.clj
@@ -1,5 +1,6 @@
-(ns macros.metabase-enterprise.advanced-permissions.api.util-test
-  (:require [macros.common]))
+(ns macros.metabase-enterprise.impersonation.util-test
+  (:require
+   [macros.common]))
 
 (defmacro with-impersonations! [impersonations-and-attributes-map & body]
   `(let [~(macros.common/ignore-unused '&group) ~impersonations-and-attributes-map]

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -81,7 +81,7 @@
   throttle.core/with-throttling                                                        [[:block 1]]
   ;; the rest of the stuff in this list is generated automatically based on `:style/indent` specs
   ;; by running [[dev.generate-cljfmt-config/specs]]... use that code to update this list
-  metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!          [[:inner 0]]
+  metabase-enterprise.impersonation.util-test/with-impersonations!                     [[:inner 0]]
   metabase-enterprise.cache.config-test/with-temp-persist-models                       [[:block 1]]
   metabase-enterprise.sandbox.test-util/with-gtaps!                                    [[:inner 0]]
   metabase-enterprise.sandbox.test-util/with-gtaps-for-user!                           [[:inner 0]]

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/routes.clj
@@ -1,17 +1,17 @@
 (ns metabase-enterprise.advanced-permissions.api.routes
   (:require
    [metabase-enterprise.advanced-permissions.api.application]
-   [metabase-enterprise.advanced-permissions.api.impersonation]
+   [metabase-enterprise.impersonation.api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]))
 
 (comment metabase-enterprise.advanced-permissions.api.application/keep-me
-         metabase-enterprise.advanced-permissions.api.impersonation/keep-me)
+         metabase-enterprise.impersonation.api/keep-me)
 
 (def ^:private route-map
   {"/application"   (+auth (api.macros/ns-handler 'metabase-enterprise.advanced-permissions.api.application))
-   "/impersonation" (+auth (api.macros/ns-handler 'metabase-enterprise.advanced-permissions.api.impersonation))})
+   "/impersonation" (+auth (api.macros/ns-handler 'metabase-enterprise.impersonation.api))})
 
 (def ^{:arglists '([request respond raise])} routes
   "Ring routes for advanced permissions API endpoints."

--- a/enterprise/backend/src/metabase_enterprise/impersonation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/api.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.advanced-permissions.api.impersonation
+(ns metabase-enterprise.impersonation.api
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]

--- a/enterprise/backend/src/metabase_enterprise/impersonation/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/core.clj
@@ -1,0 +1,11 @@
+(ns metabase-enterprise.impersonation.core
+  (:require
+   [metabase-enterprise.impersonation.driver]
+   [metabase-enterprise.impersonation.util]
+   [potemkin :as p]))
+
+(p/import-vars
+ [metabase-enterprise.impersonation.driver enforced-impersonations-for-db]
+ [metabase-enterprise.impersonation.util
+  impersonated-user?
+  impersonation-enforced-for-db?])

--- a/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
@@ -1,0 +1,15 @@
+(ns metabase-enterprise.impersonation.middleware
+  (:require
+   [metabase-enterprise.impersonation.driver :as impersonation.driver]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.query-processor.store :as qp.store]))
+
+(defenterprise apply-impersonation
+  "Pre-processing middleware. Adds a key to the query. Currently used solely for caching."
+  :feature :advanced-permissions
+  [query]
+  (if-let [role (impersonation.driver/connection-impersonation-role
+                 (lib.metadata/database (qp.store/metadata-provider)))]
+    (assoc query :impersonation/role role)
+    query))

--- a/enterprise/backend/src/metabase_enterprise/impersonation/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/model.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.advanced-permissions.models.connection-impersonation
+(ns metabase-enterprise.impersonation.model
   "Model definition for Connection Impersonations, which are used to define specific database roles used by users in
   certain permission groups when running queries."
   (:require

--- a/enterprise/backend/src/metabase_enterprise/impersonation/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/util.clj
@@ -1,6 +1,6 @@
-(ns metabase-enterprise.advanced-permissions.api.util
+(ns metabase-enterprise.impersonation.util
   (:require
-   [metabase-enterprise.advanced-permissions.driver.impersonation :as advanced-perms.driver.impersonation]
+   [metabase-enterprise.impersonation.driver :as impersonation.driver]
    [metabase.api.common :refer [*current-user-id* *is-superuser?*]]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
@@ -14,7 +14,7 @@
   (boolean
    (when-not *is-superuser?*
      (if *current-user-id*
-       (seq (advanced-perms.driver.impersonation/enforced-impersonations-for-db db-or-id))
+       (seq (impersonation.driver/enforced-impersonations-for-db db-or-id))
        ;; If no *current-user-id* is bound we can't check for impersonations, so we should throw in this case to avoid
        ;; returning `false` for users who should actually be using impersonation.
        (throw (ex-info (str (tru "No current user found"))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.sandbox.models.params.field-values
   (:require
-   [metabase-enterprise.advanced-permissions.api.util
-    :as advanced-perms.api.u]
+   [metabase-enterprise.impersonation.core :as impersonation]
    [metabase-enterprise.sandbox.api.table :as table]
    [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions
     :as row-level-restrictions]
@@ -112,7 +111,7 @@
     ;; Impersonation can have row-level security enforced by the database, so we still need to store field values per-user.
     ;; TODO: only do this for DBs with impersonation in effect
     (and api/*current-user-id*
-         (advanced-perms.api.u/impersonated-user?))
+         (impersonation/impersonated-user?))
     (params.field-values/get-or-create-advanced-field-values! :impersonation field)
 
     :else

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -1,10 +1,10 @@
 (ns ^:mb/driver-tests metabase-enterprise.advanced-permissions.common-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.advanced-permissions.api.util-test
-    :as advanced-perms.api.tu]
    [metabase-enterprise.advanced-permissions.common
     :as advanced-permissions.common]
+   [metabase-enterprise.impersonation.util-test
+    :as advanced-perms.api.tu]
    [metabase.api.database :as api.database]
    [metabase.driver :as driver]
    [metabase.models.database :as database]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
@@ -1,10 +1,10 @@
 (ns metabase-enterprise.advanced-permissions.models.field-values-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.advanced-permissions.api.util-test
-    :as advanced-perms.api.tu]
-   [metabase-enterprise.advanced-permissions.driver.impersonation
+   [metabase-enterprise.impersonation.driver
     :as impersonation]
+   [metabase-enterprise.impersonation.util-test
+    :as impersonation.util-test]
    [metabase.models.params.field-values :as params.field-values]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -15,8 +15,8 @@
     (let [field (t2/select-one :model/Field :id (mt/id :categories :id))]
       (try
         (testing "creates new field values for user using impersonation"
-          (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                       :attributes     {"impersonation_attr" "impersonation_role"}}
+          (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                         :attributes     {"impersonation_attr" "impersonation_role"}}
             (let [hash-key-1 (impersonation/hash-key-for-impersonation (u/the-id field))]
               (params.field-values/get-or-create-advanced-field-values! :impersonation field)
               (is (= #{hash-key-1}
@@ -28,8 +28,8 @@
                 (is (= 1 (t2/count :model/FieldValues :field_id (u/the-id field) :type :impersonation))))
 
               (testing "changing the impersonation role creates new FieldValues"
-                (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                             :attributes     {"impersonation_attr" "impersonation_role_2"}}
+                (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                               :attributes     {"impersonation_attr" "impersonation_role_2"}}
                   (let [hash-key-2 (impersonation/hash-key-for-impersonation (u/the-id field))]
                     (params.field-values/get-or-create-advanced-field-values! :impersonation field)
                     (is (= #{hash-key-1 hash-key-2}

--- a/enterprise/backend/test/metabase_enterprise/impersonation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/api_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.advanced-permissions.api.impersonation-test
+(ns metabase-enterprise.impersonation.api-test
   "Tests for creating and updating Connection Impersonation configs via the permisisons API"
   (:require
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/impersonation/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/cache_test.clj
@@ -1,0 +1,36 @@
+(ns metabase-enterprise.impersonation.cache-test
+  (:require
+   [clojure.core.async :as a]
+   [clojure.test :refer [deftest testing is]]
+   [metabase-enterprise.impersonation.util-test :as impersonation.util-test]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.middleware.cache-test :as cache-test]
+   [metabase.test :as mt]))
+
+(deftest impersonated-users-get-a-different-cache
+  (let [query (assoc (mt/mbql-query products)
+                     :cache-strategy
+                     {:type :ttl
+                      :multiplier 60
+                      :avg-execution-ms 1000
+                      :min-duration-ms 1})]
+    (mt/with-premium-features #{:advanced-permissions}
+      (cache-test/with-mock-cache! [save-chan purge-chan]
+        (while (a/poll! save-chan))
+        (while (a/poll! purge-chan))
+        (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                       :attributes     {:impersonation_attr "impersonation_role"}}
+          (testing "on the first run, rasta's query is not cached"
+            (is (not (:cached (:cache/details (mt/with-test-user :rasta (qp/process-query query)))))))
+          (mt/wait-for-result save-chan)
+          (testing "on the second run, rasta's query is cached"
+            (is (:cached (:cache/details (mt/with-test-user :rasta (qp/process-query query))))))
+          (is (not (:cached (:cache/details (mt/with-test-user :crowberto (qp/process-query query))))))
+          (mt/wait-for-result save-chan)
+          (let [{rasta-hash :hash rasta-updated :updated_at rasta-cached? :cached}
+                (:cache/details (mt/with-test-user :rasta (qp/process-query query)))
+                {crowberto-hash :hash crowberto-updated :updated_at crowberto-cached? :cached}
+                (:cache/details (mt/with-test-user :crowberto (qp/process-query query)))]
+            (is (= true rasta-cached? crowberto-cached?))
+            (is (not= rasta-hash crowberto-hash))
+            (is (not= rasta-updated crowberto-updated))))))))

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1,10 +1,10 @@
-(ns ^:mb/driver-tests metabase-enterprise.advanced-permissions.driver.impersonation-test
+(ns ^:mb/driver-tests metabase-enterprise.impersonation.driver-test
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.advanced-permissions.api.util-test :as advanced-perms.api.tu]
-   [metabase-enterprise.advanced-permissions.driver.impersonation :as impersonation]
+   [metabase-enterprise.impersonation.driver :as impersonation.driver]
+   [metabase-enterprise.impersonation.util-test :as impersonation.util-test]
    [metabase-enterprise.test :as met]
    [metabase.driver.postgres-test :as postgres-test]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -19,77 +19,78 @@
 (deftest ^:parallel connection-impersonation-role-test
   (testing "Returns nil when no impersonations are in effect"
     (mt/with-test-user :rasta
-      (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))))
+      (is (nil? (impersonation.driver/connection-impersonation-role (mt/db)))))))
 
 (deftest connection-impersonation-role-test-2
   (testing "Correctly fetches the impersonation when one is in effect"
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {"impersonation_attr" "impersonation_role"}}
       (is (= "impersonation_role"
-             (@#'impersonation/connection-impersonation-role (mt/db)))))))
+             (impersonation.driver/connection-impersonation-role (mt/db)))))))
 
 (deftest connection-impersonation-role-test-3
   (testing "Throws exception if multiple conflicting impersonations are in effect"
     ;; Use nested `with-impersonations!` macros so that different groups are used
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_1"}]
-                                                 :attributes     {"impersonation_attr_1" "impersonation_role_1"}}
-      (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_2"}]
-                                                   :attributes     {"impersonation_attr_2" "impersonation_role_2"}}
+    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_1"}]
+                                                   :attributes     {"impersonation_attr_1" "impersonation_role_1"}}
+      (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_2"}]
+                                                     :attributes     {"impersonation_attr_2" "impersonation_role_2"}}
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Multiple conflicting connection impersonation policies found for current user"
-             (@#'impersonation/connection-impersonation-role (mt/db))))))))
+             (impersonation.driver/connection-impersonation-role (mt/db))))))))
 
 (deftest connection-impersonation-role-test-4
   (testing "Returns nil if the permissions in another group supercede the impersonation"
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {"impersonation_attr" "impersonation_role"}}
       ;; `with-impersonations!` creates a new group and revokes data perms in `all users`, so if we re-grant data perms
       ;; for all users, it should supercede the impersonation policy in the new group
       (mt/with-full-data-perms-for-all-users!
-        (is (nil? (@#'impersonation/connection-impersonation-role (mt/db))))))))
+        (is (nil? (impersonation.driver/connection-impersonation-role (mt/db))))))))
 
 (deftest connection-impersonation-role-test-5
   (testing "Returns nil for superuser, even if they are in a group with an impersonation policy defined"
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {"impersonation_attr" "impersonation_role"}}
       (request/as-admin
-        (is (nil? (@#'impersonation/connection-impersonation-role (mt/db))))))))
+        (is (nil? (impersonation.driver/connection-impersonation-role (mt/db))))))))
 
 (deftest connection-impersonation-role-test-6
   (testing "Does not throw an exception if passed a nil `database-or-id`"
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
-      (is (nil? (@#'impersonation/connection-impersonation-role nil))))))
+    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {"impersonation_attr" "impersonation_role"}}
+      (is (nil? (impersonation.driver/connection-impersonation-role nil))))))
 
 (deftest connection-impersonation-role-test-7
   (testing "Throws an exception if impersonation should be enforced, but the user doesn't have the required attribute"
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {}}
+    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {}}
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"User does not have attribute required for connection impersonation."
-           (@#'impersonation/connection-impersonation-role (mt/db)))))))
+           (impersonation.driver/connection-impersonation-role (mt/db)))))))
 
 (deftest connection-impersonation-role-test-8
   (testing "Throws an exception if impersonation should be enforced, but the user's attribute is not a single string"
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" ["one" "two" "three"]}}
+    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {"impersonation_attr" ["one" "two" "three"]}}
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Connection impersonation attribute is invalid: role must be a single non-empty string."
-           (@#'impersonation/connection-impersonation-role (mt/db)))))))
+           (impersonation.driver/connection-impersonation-role (mt/db)))))))
 
 (deftest connection-impersonation-role-test-9
   (testing "Throws an exception if sandboxing policies are also defined for the current user on the DB"
-    (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)}}}
-      (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                   :attributes     {"impersonation_attr" "impersonation_role"}}
-        (mt/with-test-user :rasta
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"Conflicting sandboxing and impersonation policies found."
-               (@#'impersonation/connection-impersonation-role (mt/db)))))))))
+    (mt/with-premium-features #{:advanced-permissions}
+      (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)}}}
+        (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                       :attributes     {"impersonation_attr" "impersonation_role"}}
+          (mt/with-test-user :rasta
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Conflicting sandboxing and impersonation policies found."
+                 (impersonation.driver/connection-impersonation-role (mt/db))))))))))
 
 (deftest conn-impersonation-test-postgres
   (mt/test-driver :postgres
@@ -109,8 +110,8 @@
           (jdbc/execute! spec [statement]))
         (mt/with-temp [:model/Database database {:engine :postgres, :details details}]
           (mt/with-db database (sync/sync-database! database)
-            (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                         :attributes     {"impersonation_attr" "impersonation.role"}}
+            (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                           :attributes     {"impersonation_attr" "impersonation.role"}}
               (is (= []
                      (-> {:query "SELECT * FROM \"table_with_access\";"}
                          mt/native-query
@@ -143,8 +144,8 @@
               (jdbc/execute! spec statement))
             (mt/with-db database
               (sync/sync-database! database {:scan :schema})
-              (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                           :attributes     {"impersonation_attr" user}}
+              (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                             :attributes     {"impersonation_attr" user}}
                 (is (= []
                        (-> {:query (format "SELECT * FROM \"%s\".table_with_access;" schema)}
                            mt/native-query
@@ -165,8 +166,8 @@
 (deftest conn-impersonation-test-snowflake
   (mt/test-driver :snowflake
     (mt/with-premium-features #{:advanced-permissions}
-      (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                   :attributes     {"impersonation_attr" "LIMITED.ROLE"}}
+      (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                     :attributes     {"impersonation_attr" "LIMITED.ROLE"}}
         ;; Test database initially has no default role set. All queries should fail, even for non-impersonated users,
         ;; since there is no way to reset the connection after impersonation is applied.
         (is (thrown-with-msg?
@@ -211,8 +212,8 @@
                                           :dataset_query (mt/mbql-query products)}]
           (mt/with-persistence-enabled! [persist-models!]
             (mt/as-admin (persist-models!))
-            (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                         :attributes     {"impersonation_attr" "impersonation_role"}}
+            (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                           :attributes     {"impersonation_attr" "impersonation_role"}}
               (let [details (t2/select-one-fn :details :model/Database (mt/id))
                     spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
                 ;; Create impersonation_role on test DB so that the non-admin can execute queries

--- a/enterprise/backend/test/metabase_enterprise/impersonation/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/util_test.clj
@@ -1,7 +1,7 @@
-(ns metabase-enterprise.advanced-permissions.api.util-test
+(ns metabase-enterprise.impersonation.util-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.advanced-permissions.api.util :as advanced-perms.api.u]
+   [metabase-enterprise.impersonation.util :as impersonation.util]
    [metabase-enterprise.sandbox.test-util :as met]
    [metabase.api.common :as api]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -66,15 +66,15 @@
     (testing "Returns true when a user has an active connection impersonation policy"
       (with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "KEY"}]
                              :attributes     {"KEY" "VAL"}}
-        (is (advanced-perms.api.u/impersonated-user?))))
+        (is (impersonation.util/impersonated-user?))))
 
     (testing "Returns true if current user is a superuser, even if they are in a group with an impersonation policy in place"
       (with-impersonations-for-user! :crowberto {:impersonations [{:db-id (mt/id) :attribute "KEY"}]
                                                  :attributes     {"KEY" "VAL"}}
-        (is (not (advanced-perms.api.u/impersonated-user?)))))
+        (is (not (impersonation.util/impersonated-user?)))))
 
     (testing "An exception is thrown if no user is bound"
       (binding [api/*current-user-id* nil]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"No current user found"
-                              (advanced-perms.api.u/impersonated-user?)))))))
+                              (impersonation.util/impersonated-user?)))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [metabase-enterprise.advanced-permissions.models.connection-impersonation]
+   [metabase-enterprise.impersonation.model]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
    [metabase-enterprise.serialization.v2.models :as serdes.models]
@@ -14,7 +14,7 @@
    [toucan2.core :as t2]))
 
 (comment
-  metabase-enterprise.advanced-permissions.models.connection-impersonation/keep-me)
+  metabase-enterprise.impersonation.model/keep-me)
 
 (def ^:private datetime? #{"timestamptz"
                            "TIMESTAMP WITH TIME ZONE"

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -228,7 +228,7 @@
 
 (defenterprise set-role-if-supported!
   "OSS no-op implementation of `set-role-if-supported!`."
-  metabase-enterprise.advanced-permissions.driver.impersonation
+  metabase-enterprise.impersonation.driver
   [_ _ _])
 
 ;; TODO - since we're not running the queries in a transaction, does this make any difference at all? (metabase#40012)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -319,7 +319,7 @@
 
 (defenterprise hash-key-for-impersonation
   "Return a hash-key that will be used for impersonated fieldvalues."
-  metabase-enterprise.advanced-permissions.driver.impersonation
+  metabase-enterprise.impersonation.driver
   [_field-id]
   nil)
 

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -26,7 +26,7 @@
     :model/Collection                        metabase.models.collection
     :model/CollectionBookmark                metabase.bookmarks.models.bookmark
     :model/CollectionPermissionGraphRevision metabase.models.collection-permission-graph-revision
-    :model/ConnectionImpersonation           metabase-enterprise.advanced-permissions.models.connection-impersonation
+    :model/ConnectionImpersonation           metabase-enterprise.impersonation.model
     :model/Dashboard                         metabase.models.dashboard
     :model/DashboardBookmark                 metabase.bookmarks.models.bookmark
     :model/DashboardCard                     metabase.models.dashboard-card

--- a/src/metabase/permissions/api.clj
+++ b/src/metabase/permissions/api.clj
@@ -102,7 +102,7 @@
 
 (defenterprise insert-impersonations!
   "OSS implementation of `insert-impersonations!`. Errors since this is an enterprise feature."
-  metabase-enterprise.advanced-permissions.models.connection-impersonation
+  metabase-enterprise.impersonation.model
   [_impersonations]
   (throw (premium-features/ee-feature-error (tru "Connection impersonation"))))
 

--- a/src/metabase/permissions/models/data_permissions/graph.clj
+++ b/src/metabase/permissions/models/data_permissions/graph.clj
@@ -43,7 +43,7 @@
 
 (defenterprise add-impersonations-to-permissions-graph
   "Augment the permissions graph with active connection impersonation policies. OSS implementation returns graph as-is."
-  metabase-enterprise.advanced-permissions.models.connection-impersonation
+  metabase-enterprise.impersonation.model
   [graph & [_opts]]
   graph)
 
@@ -188,7 +188,7 @@
 (defenterprise delete-impersonations-if-needed-after-permissions-change!
   "Delete connection impersonation policies that are no longer needed after the permissions graph is updated. This is
   EE-specific -- OSS impl is a no-op, since connection impersonation is an EE-only feature."
-  metabase-enterprise.advanced-permissions.models.connection-impersonation
+  metabase-enterprise.impersonation.model
   [_])
 
 (defn ee-permissions-exception

--- a/src/metabase/permissions/util.clj
+++ b/src/metabase/permissions/util.clj
@@ -310,7 +310,7 @@
 (defenterprise impersonated-user?
   "Returns a boolean if the current user uses connection impersonation for any database. In OSS this is always false.
   Will throw an error if [[api/*current-user-id*]] is not bound."
-  metabase-enterprise.advanced-permissions.api.util
+  metabase-enterprise.impersonation.util
   []
   (when-not api/*current-user-id*
     ;; If no *current-user-id* is bound we can't check for impersonations, so we should throw in this case to avoid
@@ -324,7 +324,7 @@
 (defenterprise impersonation-enforced-for-db?
   "Returns a boolean if the current user has an enforced connection impersonation policy for a provided database. In OSS
   this is always false. Will throw an error if [[api/*current-user-id*]] is not bound."
-  metabase-enterprise.advanced-permissions.api.util
+  metabase-enterprise.impersonation.util
   [_db-or-id]
   (when-not api/*current-user-id*
     ;; If no *current-user-id* is bound we can't check for impersonations, so we should throw in this case to avoid

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -10,10 +10,8 @@
   (:require
    [java-time.api :as t]
    [medley.core :as m]
-   [metabase.api.common :as api]
    [metabase.config :as config]
    [metabase.lib.query :as lib.query]
-   [metabase.permissions.core :as perms]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
@@ -217,12 +215,9 @@
               (fn [metadata]
                 (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))))
 
-(defn- is-cacheable? {:arglists '([query])} [{:keys [cache-strategy] :as query}]
+(defn- is-cacheable? {:arglists '([query])} [{:keys [cache-strategy]}]
   (and (public-settings/enable-query-caching)
        (some? cache-strategy)
-       ;; sometimes, e.g. on scheduled cache refresh, we don't have a user here
-       (or (nil? api/*current-user-id*)
-           (not (perms/impersonation-enforced-for-db? (:database query))))
        (not= (:type cache-strategy) :nocache)))
 
 (defn maybe-return-cached-results

--- a/src/metabase/query_processor/middleware/enterprise.clj
+++ b/src/metabase/query_processor/middleware/enterprise.clj
@@ -21,6 +21,12 @@
   [query]
   query)
 
+(defenterprise apply-impersonation
+  "Pre-processing middleware. Adds a key to the query if the user will be impersonated. Currently used solely for cache."
+  metabase-enterprise.impersonation.middleware
+  [query]
+  query)
+
 (defenterprise apply-download-limit
   "Pre-processing middleware to apply row limits to MBQL export queries if the user has `limited` download perms. This
   does not apply to native queries, which are instead limited by the [[limit-download-result-rows]] post-processing

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -116,6 +116,7 @@
    (ensure-pmbql #'qp.auto-bucket-datetimes/auto-bucket-datetimes)
    (ensure-legacy #'reconcile-bucketing/reconcile-breakout-and-order-by-bucketing)
    (ensure-legacy #'qp.add-source-metadata/add-source-metadata-for-source-queries)
+   (ensure-pmbql #'qp.middleware.enterprise/apply-impersonation)
    (ensure-legacy #'qp.middleware.enterprise/apply-sandboxing)
    (ensure-legacy #'qp.persistence/substitute-persisted-query)
    (ensure-legacy #'qp.add-implicit-clauses/add-implicit-clauses)

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -96,7 +96,7 @@
   (This is done so irrelevant info or options that don't affect query results doesn't result in the same query
   producing different hashes.)"
   [query :- [:maybe :map]]
-  (let [{:keys [constraints parameters], :as query} (select-keys query [:database :lib/type :stages :parameters :constraints])]
+  (let [{:keys [constraints parameters], :as query} (select-keys query [:database :lib/type :stages :parameters :constraints :impersonation/role])]
     (cond-> query
       (empty? constraints) (dissoc :constraints)
       true                 (update :parameters sort-parameter-values)


### PR DESCRIPTION
* Allow impersonated users to hit cache again

As part of this I refactored a bit: `impersonation` is now its own module, used by the `advanced-permissions` module.

The real changes are in:

- `middleware.cache`, where we're no longer not caching impersonated users,

- `metabase.impersonation.middleware`, where we're adding a key to the query if it'll be impersonated, and

- `metabase.query-processor.util/select-keys-for-hashing`, where we're selecting that key as part of the query hash.

- a new test in `metabase-enterprise.impersonation.cache-test`, an e2e test which verifies that impersonated users get a different cache than non-impersonated users.

* Fix throwing when sandbox/gtap both enforceable

`enforce-impersonations?` was returning `false` because due to the sandbox, we had "unrestricted" data access from another group (the sandboxed group).

i refactored a bit:

- `enforced-impersonations-for-db?` now is responsible for throwing in the sandbox conflict case, rather than `connection-impersonation-role`.

- this way, if there's a conflicting sandbox, we'll throw before we even check to see whether those impersonations will be enforced (rather than checking and deciding "nope, they have unrestricted access so we won't enforce them.")

* kondo yay
