### PR TITLE
Don't allow pulse.updated_at to change when dashboard changes

### DIFF
--- a/src/metabase/pulse/dashboard_subscription.clj
+++ b/src/metabase/pulse/dashboard_subscription.clj
@@ -50,5 +50,8 @@
                         ;; pulse.name is no longer used for generating title.
                         ;; pulse.collection_id is a thing for the old "Pulse" feature, but it was removed
                         {:name (:name dashboard)
-                         :collection_id (:collection_id dashboard)})
+                         :collection_id (:collection_id dashboard)
+                         ;; not allowing updated_at to change because this is usually triggered after a "last_viewed_at" update on dashboard which doesn't warrant a pulse update.
+                         ;; plus, the name and collection_id are not really used for anything so it's fine they don't trigger a pulse update_at change even if they do change.
+                         :updated_at :updated_at})
             (pulse-card/bulk-create! new-pulse-cards)))))))


### PR DESCRIPTION
Partially fixes #53687 

### Description

Simple fix to stop pulse.updated_at until the larger notification refactoring job actually fixes it.

Forces `pulse.updated_at` to not change when dashboard changes, since the changes to dashboard are either `last_viewed_at` which should not update it OR does update to to the name and/or collection_id and since those are not really used fields anyway not having `pulse.updated_at` update is fine.

### How to verify

Watch the SQL logs and see that the pulse update has `"updated_at" = "updated_at"`


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
