### PR TITLE
Support relative-time-interval in the expression editor

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -385,7 +385,7 @@ const filter: TestCase[] = [
     "time interval filter",
   ],
   [
-    'offsetInterval([Created At], -1, "month", -2, "years")',
+    'intervalStartingFrom([Created At], -1, "month", -2, "years")',
     ["relative-time-interval", created, -1, "month", -2, "years"],
     "relative time interval filter",
   ],

--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -385,7 +385,7 @@ const filter: TestCase[] = [
     "time interval filter",
   ],
   [
-    'relativeInterval([Created At], -1, "month", -2, "years")',
+    'offsetInterval([Created At], -1, "month", -2, "years")',
     ["relative-time-interval", created, -1, "month", -2, "years"],
     "relative time interval filter",
   ],

--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -385,7 +385,7 @@ const filter: TestCase[] = [
     "time interval filter",
   ],
   [
-    'relativeTimeInterval([Created At], -1, "month", -2, "years")',
+    'relativeInterval([Created At], -1, "month", -2, "years")',
     ["relative-time-interval", created, -1, "month", -2, "years"],
     "relative time interval filter",
   ],

--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -384,6 +384,11 @@ const filter: TestCase[] = [
     ["time-interval", created, -1, "month"],
     "time interval filter",
   ],
+  [
+    'relativeTimeInterval([Created At], -1, "month", -2, "years")',
+    ["relative-time-interval", created, -1, "month", -2, "years"],
+    "relative time interval filter",
+  ],
   ["[Expensive Things]", segment, "segment"],
   ["NOT [Expensive Things]", ["not", segment], "not segment"],
   [

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -253,7 +253,7 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     hasOptions: true,
   },
   "relative-time-interval": {
-    displayName: "relativeTimeInterval",
+    displayName: "relativeInterval",
     type: "boolean",
     args: ["expression", "number", "string", "number", "string"],
   },

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -252,6 +252,11 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     args: ["expression", "number", "string"],
     hasOptions: true,
   },
+  "relative-time-interval": {
+    displayName: "relativeTimeInterval",
+    type: "boolean",
+    args: ["expression", "number", "string", "number", "string"],
+  },
   "relative-datetime": {
     displayName: "relativeDateTime",
     type: "expression",
@@ -563,6 +568,7 @@ export const EXPRESSION_FUNCTIONS = new Set([
   "starts-with",
   "between",
   "time-interval",
+  "relative-time-interval",
   "relative-datetime",
   "interval",
   "is-null",
@@ -597,41 +603,6 @@ export const OPERATORS = new Set([
   ...BOOLEAN_UNARY_OPERATORS,
   ...LOGICAL_AND_OPERATOR,
   ...LOGICAL_OR_OPERATOR,
-]);
-
-// "standard" filters, can be edited using UI
-export const STANDARD_FILTERS = new Set([
-  "!=",
-  "<=",
-  ">=",
-  "<",
-  ">",
-  "=",
-  "contains",
-  "does-not-contain",
-  "ends-with",
-  "starts-with",
-  "between",
-  "time-interval",
-  "is-null",
-  "not-null",
-  "is-empty",
-  "not-empty",
-  "inside",
-]);
-
-// "standard" aggregations, can be edited using UI
-export const STANDARD_AGGREGATIONS = new Set([
-  "count",
-  "cum-count",
-  "sum",
-  "cum-sum",
-  "distinct",
-  "stddev",
-  "avg",
-  "min",
-  "max",
-  "median",
 ]);
 
 export const POPULAR_FUNCTIONS = [

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -253,7 +253,7 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     hasOptions: true,
   },
   "relative-time-interval": {
-    displayName: "offsetInterval",
+    displayName: "intervalStartingFrom",
     type: "boolean",
     args: ["expression", "number", "string", "number", "string"],
   },

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -253,7 +253,7 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     hasOptions: true,
   },
   "relative-time-interval": {
-    displayName: "relativeInterval",
+    displayName: "offsetInterval",
     type: "boolean",
     args: ["expression", "number", "string", "number", "string"],
   },

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -794,6 +794,39 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     ],
   },
   {
+    name: "relative-time-interval",
+    structure: "relativeInterval",
+    description: () =>
+      t`Checks a date column's values to see if they're within the relative range.`,
+    args: [
+      {
+        name: t`column`,
+        description: t`The date column to return interval of.`,
+        example: formatIdentifier(t`Created At`),
+      },
+      {
+        name: t`value`,
+        description: t`Period of interval, where negative values are back in time.`,
+        example: "-1",
+      },
+      {
+        name: t`unit`,
+        description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
+        example: formatStringLiteral("month"),
+      },
+      {
+        name: t`offsetValue`,
+        description: t`Period of interval, where negative values are back in time.`,
+        example: "-1",
+      },
+      {
+        name: t`offsetUnit`,
+        description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
+        example: formatStringLiteral("month"),
+      },
+    ],
+  },
+  {
     name: "relative-datetime",
     structure: "relativeDateTime",
     description: () => t`Gets a timestamp relative to the current time`,

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -795,7 +795,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
   },
   {
     name: "relative-time-interval",
-    structure: "offsetInterval",
+    structure: "intervalStartingFrom",
     description: () =>
       t`Returns true if a column's value falls within an interval, starting from an initial, offsetting interval.`,
     args: [

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -795,19 +795,19 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
   },
   {
     name: "relative-time-interval",
-    structure: "relativeInterval",
+    structure: "offsetInterval",
     description: () =>
-      t`Checks a date column's values to see if they're within the relative range.`,
+      t`Returns true if a column's value falls within an interval, starting from an initial, offsetting interval.`,
     args: [
       {
         name: t`column`,
-        description: t`The date column to return interval of.`,
+        description: t`The date column to check.`,
         example: formatIdentifier(t`Created At`),
       },
       {
         name: t`value`,
-        description: t`Period of interval, where negative values are back in time.`,
-        example: "-1",
+        description: t`Period of the interval, where negative numbers go back in time.`,
+        example: "-20",
       },
       {
         name: t`unit`,
@@ -816,13 +816,13 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
       },
       {
         name: t`offsetValue`,
-        description: t`Period of interval, where negative values are back in time.`,
-        example: "-1",
+        description: t`The initial interval period to start from, where negative values are back in time.`,
+        example: "-10",
       },
       {
         name: t`offsetUnit`,
         description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
-        example: formatStringLiteral("month"),
+        example: formatStringLiteral("year"),
       },
     ],
   },

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
@@ -166,7 +166,7 @@ describe("recursive-parser", () => {
       expression: ["time-interval", B, -1, "days", { "include-current": true }],
     },
     {
-      source: "relativeInterval(B, -1, 'days', -5, 'years')",
+      source: "offsetInterval(B, -1, 'days', -5, 'years')",
       expression: ["relative-time-interval", B, -1, "days", -5, "years"],
     },
   ])("should handle function options: $source", ({ source, expression }) => {

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
@@ -165,6 +165,10 @@ describe("recursive-parser", () => {
       source: "interval(B, -1, 'days', 'include-current')",
       expression: ["time-interval", B, -1, "days", { "include-current": true }],
     },
+    {
+      source: "relativeTimeInterval(B, -1, 'days', -5, 'years')",
+      expression: ["relative-time-interval", B, -1, "days", -5, "years"],
+    },
   ])("should handle function options: $source", ({ source, expression }) => {
     expect(filter(source)).toEqual(expression);
   });

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
@@ -166,7 +166,7 @@ describe("recursive-parser", () => {
       expression: ["time-interval", B, -1, "days", { "include-current": true }],
     },
     {
-      source: "relativeTimeInterval(B, -1, 'days', -5, 'years')",
+      source: "relativeInterval(B, -1, 'days', -5, 'years')",
       expression: ["relative-time-interval", B, -1, "days", -5, "years"],
     },
   ])("should handle function options: $source", ({ source, expression }) => {

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
@@ -166,7 +166,7 @@ describe("recursive-parser", () => {
       expression: ["time-interval", B, -1, "days", { "include-current": true }],
     },
     {
-      source: "offsetInterval(B, -1, 'days', -5, 'years')",
+      source: "intervalStartingFrom(B, -1, 'days', -5, 'years')",
       expression: ["relative-time-interval", B, -1, "days", -5, "years"],
     },
   ])("should handle function options: $source", ({ source, expression }) => {

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.module.css
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.module.css
@@ -1,5 +1,5 @@
 .usage {
-  padding: 1rem 0 1rem 0.5rem;
+  padding-left: 0.5rem;
   background-color: white;
   color: var(--mb-color-text-secondary);
   cursor: pointer;
@@ -7,6 +7,7 @@
   flex-shrink: 0;
   font-size: 0.75rem;
   min-height: 2.5rem;
+  line-height: 2.5rem;
   box-sizing: border-box;
 }
 

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.module.css
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.module.css
@@ -1,5 +1,5 @@
 .usage {
-  padding-left: 0.5rem;
+  padding: 1rem 0 1rem 0.5rem;
   background-color: white;
   color: var(--mb-color-text-secondary);
   cursor: pointer;
@@ -7,7 +7,6 @@
   flex-shrink: 0;
   font-size: 0.75rem;
   min-height: 2.5rem;
-  line-height: 2.5rem;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Fix https://github.com/metabase/metabase/issues/54146

How to verify:
- New -> Question -> Orders
- Filter -> Created At -> Relative -> "Starting from..." -> Add filter
- Click on the filter -> Back -> Back -> Custom expression
- Make sure that you can see the help popover when clicking on the function name
- Make sure that you can modify the expression via the expression editor

<img width="522" alt="Screenshot 2025-03-05 at 10 44 29" src="https://github.com/user-attachments/assets/5254979d-7bcd-4af6-b877-83ac1b89b0dd" />

