### PR TITLE
Migrating composed modals to simple modals

### DIFF
--- a/frontend/src/metabase/admin/settings/notifications/CreateWebhookModal.tsx
+++ b/frontend/src/metabase/admin/settings/notifications/CreateWebhookModal.tsx
@@ -51,21 +51,18 @@ export const CreateWebhookModal = ({
   };
 
   return (
-    <Modal.Root opened={isOpen} onClose={onClose} size="36rem">
-      <Modal.Overlay />
-      <Modal.Content>
-        <Modal.Header p="2.5rem" mb="1.5rem">
-          <Modal.Title>{t`New webhook destination`}</Modal.Title>
-          <Modal.CloseButton />
-        </Modal.Header>
-        <Modal.Body p="2.5rem">
-          <WebhookForm
-            onSubmit={handleSubmit}
-            onCancel={onClose}
-            initialValues={initialValues}
-          />
-        </Modal.Body>
-      </Modal.Content>
-    </Modal.Root>
+    <Modal
+      opened={isOpen}
+      onClose={onClose}
+      size="36rem"
+      padding="2.5rem"
+      title={t`New webhook destination`}
+    >
+      <WebhookForm
+        onSubmit={handleSubmit}
+        onCancel={onClose}
+        initialValues={initialValues}
+      />
+    </Modal>
   );
 };

--- a/frontend/src/metabase/admin/settings/notifications/EditWebhookModal.tsx
+++ b/frontend/src/metabase/admin/settings/notifications/EditWebhookModal.tsx
@@ -70,23 +70,20 @@ export const EditWebhookModal = ({
   );
 
   return (
-    <Modal.Root opened={isOpen} onClose={onClose} size="36rem">
-      <Modal.Overlay />
-      <Modal.Content>
-        <Modal.Header p="2.5rem" mb="1.5rem">
-          <Modal.Title>{t`Edit this webhook`}</Modal.Title>
-          <Modal.CloseButton />
-        </Modal.Header>
-        <Modal.Body p="2.5rem">
-          <WebhookForm
-            onSubmit={handleSumbit}
-            onCancel={onClose}
-            onDelete={handleDelete}
-            initialValues={initialValues}
-            submitLabel={t`Save changes`}
-          />
-        </Modal.Body>
-      </Modal.Content>
-    </Modal.Root>
+    <Modal
+      opened={isOpen}
+      onClose={onClose}
+      size="36rem"
+      padding="2.5rem"
+      title={t`Edit this webhook`}
+    >
+      <WebhookForm
+        onSubmit={handleSumbit}
+        onCancel={onClose}
+        onDelete={handleDelete}
+        initialValues={initialValues}
+        submitLabel={t`Save changes`}
+      />
+    </Modal>
   );
 };

--- a/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/ConfirmMoveDashboardQuestionCandidatesModal.module.css
+++ b/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/ConfirmMoveDashboardQuestionCandidatesModal.module.css
@@ -5,6 +5,8 @@
 }
 
 .modalHeader {
+  padding: 2rem 2.5rem;
+  padding-right: 2.5rem;
   flex-shrink: 0;
 }
 

--- a/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/ConfirmMoveDashboardQuestionCandidatesModal.tsx
+++ b/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/ConfirmMoveDashboardQuestionCandidatesModal.tsx
@@ -50,117 +50,112 @@ export const ConfirmMoveDashboardQuestionCandidatesModal = ({
   );
 
   return (
-    <Modal.Root
+    <Modal
       opened
       onClose={onCancel}
       data-testid="move-questions-into-dashboard-modal"
       size="64rem"
+      padding={0}
+      title={
+        fetchError || isLoading || rows.length === 0
+          ? t`Move these questions into their dashboards?`
+          : ngettext(
+              msgid`Move this question into its dashboard?`,
+              `Move these ${rows.length} questions into their dashboards?`,
+              rows.length,
+            )
+      }
+      classNames={{
+        content: S.modal,
+        header: S.modalHeader,
+        body: S.modalBody,
+      }}
+      styles={{
+        header: {
+          paddingRight: "2.5rem", // Needed for increased specifity
+        },
+      }}
     >
-      <Modal.Content
-        classNames={{
-          content: S.modal,
-        }}
-      >
-        <Modal.Header
-          px="2.5rem"
-          pt="2rem"
-          pb="1.5rem"
-          className={S.modalHeader}
-        >
-          <Modal.Title fz="20px">
-            {fetchError || isLoading || rows.length === 0
-              ? t`Move these questions into their dashboards?`
-              : ngettext(
-                  msgid`Move this question into its dashboard?`,
-                  `Move these ${rows.length} questions into their dashboards?`,
-                  rows.length,
-                )}
-          </Modal.Title>
-          <Modal.CloseButton />
-        </Modal.Header>
-        <Modal.Body p="0" className={S.modalBody}>
-          <div className={S.tableHeader}>
-            <div className={S.tableRow}>
-              <div className={S.column}>
-                <Flex gap="sm" align="center">
-                  <Icon name="folder" c="brand" />
-                  {t`Question`}
-                </Flex>
-              </div>
-              <div className={S.column}>
-                <Flex gap="sm" align="center">
-                  <Icon name="dashboard" c="brand" />
-                  {t`Dashboard it'll be moved to`}
-                </Flex>
-              </div>
-            </div>
-          </div>
-          <div className={S.tbody}>
-            {match({ isLoading, fetchError, rows })
-              .with({ isLoading: true }, () => (
-                <Flex justify="center" py="18.25rem">
-                  <Loader size="xl" data-testid="loading-indicator" />
-                </Flex>
-              ))
-              .with({ fetchError: P.not(P.nullish) }, ({ fetchError }) => {
-                return (
-                  <Flex justify="center" py="19rem">
-                    <Text color="error" size="1.25rem" px="md">
-                      {fetchError instanceof Error
-                        ? (fetchError?.message ?? defaultErrMsg)
-                        : defaultErrMsg}
-                    </Text>
-                  </Flex>
-                );
-              })
-              .with({ rows: [] }, () => (
-                <Flex justify="center" py="19rem">
-                  <Text size="1.25rem" px="md" color="text-light">
-                    {t`There aren't any questions to move into dashboards. Looks like everything is in its place.`}
-                  </Text>
-                </Flex>
-              ))
-              .otherwise(() =>
-                rows.map(row => (
-                  <div key={row.id} className={S.tableRow}>
-                    <div className={S.cell}>{row.questionName}</div>
-                    <div className={S.cell}>{row.dashboardName}</div>
-                  </div>
-                )),
-              )}
-          </div>
-          <Flex
-            className={S.modalFooter}
-            justify="space-between"
-            align="center"
-            gap="md"
-            py="1rem"
-            px="1.25rem"
-          >
-            {mutationError ? (
-              <Text color="error">
-                {mutationError instanceof Error
-                  ? (mutationError?.message ?? defaultErrMsg)
-                  : defaultErrMsg}
-              </Text>
-            ) : (
-              <div />
-            )}
-            <Flex gap="md" ml="1.5rem">
-              <Button variant="subtle" onClick={onCancel}>{t`Cancel`}</Button>
-              <Button
-                loading={isMutating}
-                variant="filled"
-                onClick={onConfirm}
-                disabled={ctaDisabled}
-                color={mutationError ? "error" : "brand"}
-              >
-                {t`Move these questions`}
-              </Button>
+      <div className={S.tableHeader}>
+        <div className={S.tableRow}>
+          <div className={S.column}>
+            <Flex gap="sm" align="center">
+              <Icon name="folder" c="brand" />
+              {t`Question`}
             </Flex>
-          </Flex>
-        </Modal.Body>
-      </Modal.Content>
-    </Modal.Root>
+          </div>
+          <div className={S.column}>
+            <Flex gap="sm" align="center">
+              <Icon name="dashboard" c="brand" />
+              {t`Dashboard it'll be moved to`}
+            </Flex>
+          </div>
+        </div>
+      </div>
+      <div className={S.tbody}>
+        {match({ isLoading, fetchError, rows })
+          .with({ isLoading: true }, () => (
+            <Flex justify="center" py="18.25rem">
+              <Loader size="xl" data-testid="loading-indicator" />
+            </Flex>
+          ))
+          .with({ fetchError: P.not(P.nullish) }, ({ fetchError }) => {
+            return (
+              <Flex justify="center" py="19rem">
+                <Text color="error" size="1.25rem" px="md">
+                  {fetchError instanceof Error
+                    ? (fetchError?.message ?? defaultErrMsg)
+                    : defaultErrMsg}
+                </Text>
+              </Flex>
+            );
+          })
+          .with({ rows: [] }, () => (
+            <Flex justify="center" py="19rem">
+              <Text size="1.25rem" px="md" color="text-light">
+                {t`There aren't any questions to move into dashboards. Looks like everything is in its place.`}
+              </Text>
+            </Flex>
+          ))
+          .otherwise(() =>
+            rows.map(row => (
+              <div key={row.id} className={S.tableRow}>
+                <div className={S.cell}>{row.questionName}</div>
+                <div className={S.cell}>{row.dashboardName}</div>
+              </div>
+            )),
+          )}
+      </div>
+      <Flex
+        className={S.modalFooter}
+        justify="space-between"
+        align="center"
+        gap="md"
+        py="1rem"
+        px="1.25rem"
+      >
+        {mutationError ? (
+          <Text color="error">
+            {mutationError instanceof Error
+              ? (mutationError?.message ?? defaultErrMsg)
+              : defaultErrMsg}
+          </Text>
+        ) : (
+          <div />
+        )}
+        <Flex gap="md" ml="1.5rem">
+          <Button variant="subtle" onClick={onCancel}>{t`Cancel`}</Button>
+          <Button
+            loading={isMutating}
+            variant="filled"
+            onClick={onConfirm}
+            disabled={ctaDisabled}
+            color={mutationError ? "error" : "brand"}
+          >
+            {t`Move these questions`}
+          </Button>
+        </Flex>
+      </Flex>
+    </Modal>
   );
 };

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -37,20 +37,29 @@ export function ChartSettingsButton({
         <DashCardActionButton.Icon name="palette" />
       </DashCardActionButton>
 
-      <Modal.Root opened={isOpened} onClose={close} size="85%">
-        <Modal.Overlay />
-        <Modal.Content h="85%" style={{ overflowY: "hidden" }}>
-          <Modal.Body h="100%" p={0}>
-            <DashboardChartSettings
-              series={series}
-              onChange={onReplaceAllVisualizationSettings}
-              dashboard={dashboard}
-              dashcard={dashcard}
-              onClose={close}
-            />
-          </Modal.Body>
-        </Modal.Content>
-      </Modal.Root>
+      <Modal
+        opened={isOpened}
+        onClose={close}
+        size="85%"
+        padding={0}
+        withCloseButton={false}
+        styles={{
+          body: {
+            height: "100%",
+          },
+          content: {
+            height: "85%",
+          },
+        }}
+      >
+        <DashboardChartSettings
+          series={series}
+          onChange={onReplaceAllVisualizationSettings}
+          dashboard={dashboard}
+          dashcard={dashcard}
+          onClose={close}
+        />
+      </Modal>
     </>
   );
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -49,6 +49,7 @@ export function ChartSettingsButton({
           },
           content: {
             height: "85%",
+            overflowY: "hidden",
           },
         }}
       >

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -5,7 +5,7 @@ import { updateDashboardAndCards } from "metabase/dashboard/actions/save";
 import { useConfirmRouteLeaveModal } from "metabase/hooks/use-confirm-route-leave-modal";
 import { useDispatch } from "metabase/lib/redux";
 import { dismissAllUndo } from "metabase/redux/undo";
-import { Button, Flex, Modal, Text } from "metabase/ui";
+import { Box, Button, Flex, Modal, Text } from "metabase/ui";
 
 import { isNavigatingToCreateADashboardQuestion } from "./utils";
 
@@ -41,7 +41,6 @@ export const DashboardLeaveConfirmationModal = withRouter(
           title: t`Save your changes?`,
           message: t`You’ll need to save your changes before leaving to create a new question.`,
           actionBtn: {
-            color: "primary",
             message: t`Save changes`,
           },
         }
@@ -55,31 +54,39 @@ export const DashboardLeaveConfirmationModal = withRouter(
         };
 
     return (
-      <Modal.Root opened={opened} onClose={close} size="28.5rem">
-        <Modal.Overlay />
-        <Modal.Content data-testid="leave-confirmation">
-          <Modal.Header p="2.5rem 3rem" mb="sm">
-            <Modal.Title fz="1rem" color="text-primary">
-              {content.title}
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body p="2.5rem 3rem">
-            <Text lh="1.5rem" mb={"lg"}>
-              {content.message}
-            </Text>
-            <Flex justify="flex-end" gap="md">
-              <Button onClick={close}>{t`Cancel`}</Button>
-              <Button
-                color={content.actionBtn.color}
-                variant="filled"
-                onClick={onSave}
-              >
-                {content.actionBtn.message}
-              </Button>
-            </Flex>
-          </Modal.Body>
-        </Modal.Content>
-      </Modal.Root>
+      <Modal
+        opened={opened}
+        onClose={close}
+        size="28.5rem"
+        padding="2.5rem"
+        title={content.title}
+        data-testid="leave-confirmation"
+        withCloseButton={false}
+        styles={{
+          title: {
+            fontSize: "1rem",
+          },
+          header: {
+            marginBottom: "0.5rem",
+          },
+        }}
+      >
+        <Box>
+          <Text lh="1.5rem" mb={"lg"}>
+            {content.message}
+          </Text>
+          <Flex justify="flex-end" gap="md">
+            <Button onClick={close}>{t`Cancel`}</Button>
+            <Button
+              color={content.actionBtn.color}
+              variant="filled"
+              onClick={onSave}
+            >
+              {content.actionBtn.message}
+            </Button>
+          </Flex>
+        </Box>
+      </Modal>
     );
   },
 );

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/AlertModalSettingsBlock.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/AlertModalSettingsBlock.tsx
@@ -12,7 +12,7 @@ export const AlertModalSettingsBlock = ({
   children,
 }: AlertModalSettingsBlockProps) => {
   return (
-    <Stack gap="0.75rem">
+    <Stack spacing="0.75rem">
       <Text size="lg" lineClamp={1}>
         {title}
       </Text>

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/AlertModalSettingsBlock.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/AlertModalSettingsBlock.tsx
@@ -12,7 +12,7 @@ export const AlertModalSettingsBlock = ({
   children,
 }: AlertModalSettingsBlockProps) => {
   return (
-    <Stack spacing="0.75rem">
+    <Stack gap="0.75rem">
       <Text size="lg" lineClamp={1}>
         {title}
       </Text>

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -262,7 +262,7 @@ export const CreateOrEditQuestionAlertModal = ({
         },
       }}
     >
-      <Stack spacing="xl" mt="1.5rem" mb="2rem" px="2.5rem">
+      <Stack gap="xl" mt="1.5rem" mb="2rem" px="2.5rem">
         <AlertModalSettingsBlock
           title={t`What do you want to be alerted about?`}
         >

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -248,143 +248,141 @@ export const CreateOrEditQuestionAlertModal = ({
   const hasChanges = !isEqual(editingNotification, notification);
 
   return (
-    <Modal.Root
+    <Modal
       data-testid="alert-create"
       opened
       size={rem(680)}
       onClose={onClose}
+      padding="2.5rem"
+      title={isEditMode ? t`Edit alert` : t`New alert`}
+      styles={{
+        body: {
+          paddingLeft: 0,
+          paddingRight: 0,
+        },
+      }}
     >
-      <Modal.Overlay />
-      <Modal.Content>
-        <Modal.Header p="2.5rem" pb="2rem">
-          <Modal.Title>{isEditMode ? t`Edit alert` : t`New alert`}</Modal.Title>
-          <Modal.CloseButton />
-        </Modal.Header>
-        <Modal.Body p="0 2.5rem 2rem">
-          <Stack gap="xl">
-            <AlertModalSettingsBlock
-              title={t`What do you want to be alerted about?`}
-            >
-              <Flex gap="lg" align="center">
-                <AlertTriggerIcon />
-                {hasSingleTriggerOption ? (
-                  <Paper
-                    data-testid="alert-goal-select"
-                    withBorder
-                    shadow="none"
-                    py="sm"
-                    px="1.5rem"
-                    bg="transparent"
-                  >
-                    <Text>{triggerOptions[0].label}</Text>
-                  </Paper>
-                ) : (
-                  <Select
-                    data-testid="alert-goal-select"
-                    data={triggerOptions}
-                    value={notification.payload.send_condition}
-                    w={276}
-                    onChange={value =>
-                      setNotification({
-                        ...notification,
-                        payload: {
-                          ...notification.payload,
-                          send_condition:
-                            value as NotificationCardSendCondition,
-                        },
-                      })
-                    }
-                  />
-                )}
-              </Flex>
-            </AlertModalSettingsBlock>
-            <AlertModalSettingsBlock title={t`When do you want to check this?`}>
-              <SchedulePicker
-                mt={0}
-                schedule={
-                  cronToScheduleSettings(subscription.cron_schedule) ||
-                  DEFAULT_ALERT_SCHEDULE // default is just for typechecking
-                }
-                scheduleOptions={ALERT_SCHEDULE_OPTIONS}
-                onScheduleChange={(nextSchedule: ScheduleSettings) => {
-                  if (nextSchedule.schedule_type) {
-                    setNotification({
-                      ...notification,
-                      subscriptions: [
-                        {
-                          ...subscription,
-                          cron_schedule: scheduleSettingsToCron(nextSchedule),
-                        },
-                      ],
-                    });
-                  }
-                }}
-                textBeforeInterval={t`Check`}
-              />
-            </AlertModalSettingsBlock>
-            <AlertModalSettingsBlock
-              title={t`Where do you want to send the results?`}
-            >
-              <NotificationChannelsPicker
-                notificationHandlers={notification.handlers}
-                channels={channelSpec ? channelSpec.channels : undefined}
-                onChange={(newHandlers: NotificationHandler[]) => {
-                  setNotification({
-                    ...notification,
-                    handlers: newHandlers,
-                  });
-                }}
-                emailRecipientText={t`Email alerts to:`}
-                getInvalidRecipientText={domains =>
-                  t`You're only allowed to email alerts to addresses ending in ${domains}`
-                }
-              />
-            </AlertModalSettingsBlock>
-            <AlertModalSettingsBlock title={t`More options`}>
-              <Switch
-                label={t`Only send this alert once`}
-                labelPosition="right"
-                size="sm"
-                checked={notification.payload.send_once}
-                onChange={e =>
+      <Stack spacing="xl" mt="1.5rem" mb="2rem" px="2.5rem">
+        <AlertModalSettingsBlock
+          title={t`What do you want to be alerted about?`}
+        >
+          <Flex gap="lg" align="center">
+            <AlertTriggerIcon />
+            {hasSingleTriggerOption ? (
+              <Paper
+                data-testid="alert-goal-select"
+                withBorder
+                shadow="none"
+                py="sm"
+                px="1.5rem"
+                bg="transparent"
+              >
+                <Text>{triggerOptions[0].label}</Text>
+              </Paper>
+            ) : (
+              <Select
+                data-testid="alert-goal-select"
+                data={triggerOptions}
+                value={notification.payload.send_condition}
+                w={276}
+                onChange={value =>
                   setNotification({
                     ...notification,
                     payload: {
                       ...notification.payload,
-                      send_once: e.target.checked,
+                      send_condition: value as NotificationCardSendCondition,
                     },
                   })
                 }
               />
-            </AlertModalSettingsBlock>
-          </Stack>
-        </Modal.Body>
-        <Flex
-          justify="space-between"
-          px="2.5rem"
-          py="lg"
-          className={CS.borderTop}
+            )}
+          </Flex>
+        </AlertModalSettingsBlock>
+        <AlertModalSettingsBlock title={t`When do you want to check this?`}>
+          <SchedulePicker
+            mt={0}
+            schedule={
+              cronToScheduleSettings(subscription.cron_schedule) ||
+              DEFAULT_ALERT_SCHEDULE // default is just for typechecking
+            }
+            scheduleOptions={ALERT_SCHEDULE_OPTIONS}
+            onScheduleChange={(nextSchedule: ScheduleSettings) => {
+              if (nextSchedule.schedule_type) {
+                setNotification({
+                  ...notification,
+                  subscriptions: [
+                    {
+                      ...subscription,
+                      cron_schedule: scheduleSettingsToCron(nextSchedule),
+                    },
+                  ],
+                });
+              }
+            }}
+            textBeforeInterval={t`Check`}
+          />
+        </AlertModalSettingsBlock>
+        <AlertModalSettingsBlock
+          title={t`Where do you want to send the results?`}
         >
-          <Button
-            variant="outline"
-            color="brand"
-            loading={isLoading}
-            onClick={onSendNow}
-          >
-            {isLoading ? t`Sending…` : t`Send now`}
-          </Button>
-          <div>
-            <Button onClick={onClose} className={CS.mr2}>{t`Cancel`}</Button>
-            <ButtonWithStatus
-              titleForState={{
-                default: isEditMode && hasChanges ? t`Save changes` : t`Done`,
-              }}
-              disabled={!isValid}
-              onClickOperation={onCreateOrEditAlert}
-            />
-          </div>
-        </Flex>
-      </Modal.Content>
-    </Modal.Root>
+          <NotificationChannelsPicker
+            notificationHandlers={notification.handlers}
+            channels={channelSpec ? channelSpec.channels : undefined}
+            onChange={(newHandlers: NotificationHandler[]) => {
+              setNotification({
+                ...notification,
+                handlers: newHandlers,
+              });
+            }}
+            emailRecipientText={t`Email alerts to:`}
+            getInvalidRecipientText={domains =>
+              t`You're only allowed to email alerts to addresses ending in ${domains}`
+            }
+          />
+        </AlertModalSettingsBlock>
+        <AlertModalSettingsBlock title={t`More options`}>
+          <Switch
+            label={t`Only send this alert once`}
+            labelPosition="right"
+            size="sm"
+            checked={notification.payload.send_once}
+            onChange={e =>
+              setNotification({
+                ...notification,
+                payload: {
+                  ...notification.payload,
+                  send_once: e.target.checked,
+                },
+              })
+            }
+          />
+        </AlertModalSettingsBlock>
+      </Stack>
+      <Flex
+        justify="space-between"
+        px="2.5rem"
+        pt="lg"
+        className={CS.borderTop}
+      >
+        <Button
+          variant="outline"
+          color="brand"
+          loading={isLoading}
+          onClick={onSendNow}
+        >
+          {isLoading ? t`Sending…` : t`Send now`}
+        </Button>
+        <div>
+          <Button onClick={onClose} className={CS.mr2}>{t`Cancel`}</Button>
+          <ButtonWithStatus
+            titleForState={{
+              default: isEditMode && hasChanges ? t`Save changes` : t`Done`,
+            }}
+            disabled={!isValid}
+            onClickOperation={onCreateOrEditAlert}
+          />
+        </div>
+      </Flex>
+    </Modal>
   );
 };

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
@@ -55,43 +55,36 @@ export const AlertListModal = ({
   const sortedQuestionAlerts = [...ownAlerts, ...othersAlerts];
 
   return (
-    <Modal.Root
+    <Modal
       data-testid="alert-list-modal"
       opened={opened}
       size={rem(600)}
       onClose={onClose}
+      padding="xl"
+      title={t`Edit alerts`}
     >
-      <Modal.Overlay />
-      <Modal.Content>
-        <Modal.Header p="xl" pb="lg">
-          <Modal.Title>{t`Edit alerts`}</Modal.Title>
-          <Modal.CloseButton />
-        </Modal.Header>
-        <Modal.Body p="xl" pt="0">
-          <Stack gap="lg" mb="lg">
-            {sortedQuestionAlerts.map(alert => {
-              const canEditAlert =
-                isAdmin ||
-                (canManageSubscriptions && isCreatedByCurrentUser(alert));
-              return (
-                <AlertListItem
-                  key={alert.id}
-                  alert={alert}
-                  users={users?.data}
-                  httpChannelsConfig={httpChannelsConfig}
-                  canEdit={canEditAlert}
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                  onUnsubscribe={onUnsubscribe}
-                />
-              );
-            })}
-          </Stack>
-          <div>
-            <Button variant="filled" onClick={onCreate}>{t`New alert`}</Button>
-          </div>
-        </Modal.Body>
-      </Modal.Content>
-    </Modal.Root>
+      <Stack spacing="lg" mb="lg" mt="1rem">
+        {sortedQuestionAlerts.map(alert => {
+          const canEditAlert =
+            isAdmin ||
+            (canManageSubscriptions && isCreatedByCurrentUser(alert));
+          return (
+            <AlertListItem
+              key={alert.id}
+              alert={alert}
+              users={users?.data}
+              httpChannelsConfig={httpChannelsConfig}
+              canEdit={canEditAlert}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onUnsubscribe={onUnsubscribe}
+            />
+          );
+        })}
+      </Stack>
+      <div>
+        <Button variant="filled" onClick={onCreate}>{t`New alert`}</Button>
+      </div>
+    </Modal>
   );
 };

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
@@ -63,7 +63,7 @@ export const AlertListModal = ({
       padding="xl"
       title={t`Edit alerts`}
     >
-      <Stack spacing="lg" mb="lg" mt="1rem">
+      <Stack gap="lg" mb="lg" mt="1rem">
         {sortedQuestionAlerts.map(alert => {
           const canEditAlert =
             isAdmin ||


### PR DESCRIPTION
Closes ADM-455
Closes ADM-454
Closes ADM-453
Closes ADM-452
Closes ADM-450
Closes ADM-449
Closes ADM-448

### Description
Migrating composed modals to be simple Modal instances for consistency

### How to verify
Navigate to the modals in the screenshots below and ensure they render properly, and possibly compare them with stats

### Demo
Modals after PR:

![image](https://github.com/user-attachments/assets/7157e3ed-cae1-44dc-889f-369905972558)
![image](https://github.com/user-attachments/assets/4fff4a99-ba58-42c7-92bb-d3dbf9b1d544)
![image](https://github.com/user-attachments/assets/e89a5705-1e0d-46b1-ab0e-5076bb792cb2)
![image](https://github.com/user-attachments/assets/e66ec844-f268-44ec-be26-ff72e9c69d66)
![image](https://github.com/user-attachments/assets/cbe76744-408f-4a51-a6d7-bd6db3b99355)
![image](https://github.com/user-attachments/assets/13d3a85b-852c-47f6-9db3-a2519f2f191e)
![image](https://github.com/user-attachments/assets/a20af14c-741a-4e53-8820-89dd19738834)

