### PR TITLE
fetch settings using RTK Query

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -602,8 +602,7 @@ describe("scenarios > admin > permissions", () => {
     });
 
     cy.visit("/admin/permissions/");
-    //Both the command palette and the admin app call refresh settings
-    cy.wait(["@sessionProps", "@sessionProps"]);
+    cy.wait("@sessionProps");
 
     cy.findByRole("dialog", { name: /permissions may look different/ })
       .findByRole("button", { name: "Got it" })
@@ -650,8 +649,7 @@ describe("scenarios > admin > permissions", () => {
     });
 
     cy.visit("/admin/permissions/");
-    //Both the command palette and the admin app call refresh settings
-    cy.wait(["@sessionProps", "@sessionProps"]);
+    cy.wait("@sessionProps");
 
     cy.findByRole("dialog", { name: /permissions may look different/ })
       .findByRole("button", { name: "Got it" })

--- a/enterprise/frontend/src/embedding-sdk/store/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/auth.ts
@@ -45,7 +45,7 @@ export const initAuth = createAsyncThunk(
     // Fetch user and site settings
     const [user, siteSettings] = await Promise.all([
       dispatch(refreshCurrentUser()),
-      dispatch(refreshSiteSettings({})),
+      dispatch(refreshSiteSettings()),
     ]);
 
     const mbVersion = siteSettings.payload?.version?.tag;

--- a/enterprise/frontend/src/embedding-sdk/store/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/auth.ts
@@ -14,6 +14,7 @@ import api from "metabase/lib/api";
 import { createAsyncThunk } from "metabase/lib/redux";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { refreshCurrentUser } from "metabase/redux/user";
+import type { Settings } from "metabase-types/api";
 
 import { getOrRefreshSession } from "./reducer";
 import { getFetchRefreshTokenFn } from "./selectors";
@@ -48,7 +49,7 @@ export const initAuth = createAsyncThunk(
       dispatch(refreshSiteSettings()),
     ]);
 
-    const mbVersion = siteSettings.payload?.version?.tag;
+    const mbVersion = (siteSettings.payload as Settings)?.version?.tag;
     const sdkVersion = getEmbeddingSdkVersion();
 
     if (mbVersion && sdkVersion !== "unknown") {

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -260,6 +260,7 @@ export const createMockSettings = (
   "show-updated-permission-modal": false,
   "show-updated-permission-banner": false,
   "site-locale": "en",
+  "site-name": "Metabae",
   "site-url": "http://localhost:3000",
   "site-uuid": "1234",
   "slack-app-token": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -278,6 +278,7 @@ interface InstanceSettings {
   "show-homepage-data": boolean;
   "show-homepage-pin-message": boolean;
   "show-homepage-xrays": boolean;
+  "site-name": string;
   "site-uuid": string;
   "subscription-allowed-domains": string | null;
   "uploads-settings": UploadsSettings;

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -130,7 +130,7 @@ export const ModelPersistenceConfiguration = () => {
         ? PersistedModelsApi.enablePersistence()
         : PersistedModelsApi.disablePersistence();
       await resolveWithToasts([promise]);
-      dispatch(refreshSiteSettings({}));
+      dispatch(refreshSiteSettings());
     },
     [resolveWithToasts, setModelPersistenceEnabled, dispatch],
   );
@@ -186,7 +186,7 @@ export const ModelPersistenceConfiguration = () => {
             onChange={async (value: unknown) => {
               await resolveWithToasts([
                 PersistedModelsApi.setRefreshSchedule({ cron: value }),
-                dispatch(refreshSiteSettings({})),
+                dispatch(refreshSiteSettings()),
               ]);
             }}
           />

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.tsx
@@ -62,7 +62,7 @@ export const CloudPanel = ({
   useEffect(
     function syncSiteSettings() {
       if (migrationState) {
-        dispatch(refreshSiteSettings({}));
+        dispatch(refreshSiteSettings());
       }
     },
     [dispatch, migrationState],
@@ -81,7 +81,7 @@ export const CloudPanel = ({
 
   const handleCreateMigration = async () => {
     const newMigration = await createCloudMigration().unwrap();
-    await dispatch(refreshSiteSettings({}));
+    await dispatch(refreshSiteSettings());
     onMigrationStart(storeUrl, newMigration);
   };
 

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -24,6 +24,7 @@ export const TAG_TYPES = [
   "revision",
   "schema",
   "segment",
+  "session-properties",
   "snippet",
   "subscription",
   "subscription-channel",

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -42,7 +42,7 @@ export const refreshSession = createAsyncThunk(
   async (_, { dispatch }) => {
     await Promise.all([
       dispatch(refreshCurrentUser()),
-      dispatch(refreshSiteSettings({})),
+      dispatch(refreshSiteSettings()),
     ]);
     await dispatch(refreshLocale()).unwrap();
   },

--- a/frontend/src/metabase/redux/settings.ts
+++ b/frontend/src/metabase/redux/settings.ts
@@ -1,22 +1,24 @@
-import { createReducer } from "@reduxjs/toolkit";
+import { createAction, createReducer } from "@reduxjs/toolkit";
 
+import { sessionApi } from "metabase/api";
 import { createAsyncThunk } from "metabase/lib/redux";
-import MetabaseSettings from "metabase/lib/settings";
-import { SessionApi, SettingsApi } from "metabase/services";
-import type { UserSettings } from "metabase-types/api";
-
+import { SettingsApi } from "metabase/services";
+import type { Settings, UserSettings } from "metabase-types/api";
 export const REFRESH_SITE_SETTINGS = "metabase/settings/REFRESH_SITE_SETTINGS";
 
 export const refreshSiteSettings = createAsyncThunk(
   REFRESH_SITE_SETTINGS,
-  async ({ locale }: { locale?: string } = {}) => {
-    const settings = await SessionApi.properties(null, {
-      // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
-      headers: locale ? { "X-Metabase-Locale": locale } : {},
-    });
-    MetabaseSettings.setAll(settings);
-    return settings;
+  async (_, { dispatch }) => {
+    await dispatch(
+      sessionApi.endpoints.getSessionProperties.initiate(undefined, {
+        forceRefetch: true,
+      }),
+    );
   },
+);
+
+export const loadSettings = createAction<Settings>(
+  "metabase/settings/LOAD_SETTINGS",
 );
 
 interface UpdateUserSettingProps<K extends keyof UserSettings> {
@@ -51,29 +53,35 @@ export const updateUserSetting = createAsyncThunk(
       throw error;
     } finally {
       if (shouldRefresh) {
-        await dispatch(refreshSiteSettings({}));
+        await dispatch(refreshSiteSettings());
       }
     }
   },
 );
 
 export const settings = createReducer(
+  // note: this sets the initial state to the current values in the window object
+  // this is necessary so that we never have empty settings
   { values: window.MetabaseBootstrap || {}, loading: false },
   builder => {
-    builder.addCase(refreshSiteSettings.pending, state => {
-      state.loading = true;
-    });
-    builder.addCase(refreshSiteSettings.fulfilled, (state, { payload }) => {
-      state.loading = false;
-      state.values = payload;
-    });
-    builder.addCase(refreshSiteSettings.rejected, state => {
-      state.loading = false;
-    });
-    builder.addCase(updateUserSetting.fulfilled, (state, { payload }) => {
-      if (payload) {
-        state.values[payload.key] = payload.value;
-      }
-    });
+    builder
+      .addCase(refreshSiteSettings.pending, state => {
+        state.loading = true;
+      })
+      .addCase(refreshSiteSettings.fulfilled, state => {
+        state.loading = false;
+      })
+      .addCase(refreshSiteSettings.rejected, state => {
+        state.loading = false;
+      })
+      .addCase(loadSettings, (state, { payload }) => {
+        state.loading = false;
+        state.values = payload;
+      })
+      .addCase(updateUserSetting.fulfilled, (state, { payload }) => {
+        if (payload) {
+          state.values[payload.key] = payload.value;
+        }
+      });
   },
 );

--- a/frontend/src/metabase/redux/settings.ts
+++ b/frontend/src/metabase/redux/settings.ts
@@ -9,11 +9,12 @@ export const REFRESH_SITE_SETTINGS = "metabase/settings/REFRESH_SITE_SETTINGS";
 export const refreshSiteSettings = createAsyncThunk(
   REFRESH_SITE_SETTINGS,
   async (_, { dispatch }) => {
-    await dispatch(
+    const response = await dispatch(
       sessionApi.endpoints.getSessionProperties.initiate(undefined, {
         forceRefetch: true,
       }),
     );
+    return response.data;
   },
 );
 

--- a/frontend/src/metabase/redux/settings.unit.spec.tsx
+++ b/frontend/src/metabase/redux/settings.unit.spec.tsx
@@ -1,0 +1,144 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import {
+  sessionApi,
+  useGetSessionPropertiesQuery,
+  useGetSettingsQuery,
+} from "metabase/api";
+import { useSetting } from "metabase/common/hooks";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { getSetting } from "metabase/selectors/settings";
+import { createMockSettings } from "metabase-types/api/mocks";
+import type { State } from "metabase-types/store";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
+import { refreshSiteSettings } from "./settings";
+
+const TestGetComponent = () => {
+  const siteNameFromSelector = useSelector((state: State) =>
+    getSetting(state, "site-name"),
+  );
+  const siteNameFromHook = useSetting("site-name");
+  const { data: settingsFromSessionProperties } =
+    useGetSessionPropertiesQuery();
+  const siteNameFromSessionProperties =
+    settingsFromSessionProperties?.["site-name"];
+
+  // we have a few different ways to access settings state
+  // and we want to make sure they stay in sync
+  return (
+    <div>
+      <div>{siteNameFromSelector}</div>
+      <div>{siteNameFromHook}</div>
+      <div>{siteNameFromSessionProperties}</div>
+    </div>
+  );
+};
+
+const TestComponentWithForceUpdateHook = () => {
+  const { data: settings, isLoading } = useGetSettingsQuery(undefined, {
+    refetchOnMountOrArgChange: true,
+  });
+
+  const siteName = settings?.["site-name"];
+
+  if (isLoading) {
+    return <div>loading</div>;
+  }
+
+  return <div>{siteName}</div>;
+};
+
+const TestUpdateComponent = () => {
+  const [showHiddenComponent, setShowHiddenComponent] = useState(false);
+  const dispatch = useDispatch();
+  const refresh = () => dispatch(refreshSiteSettings());
+  const invalidate = () =>
+    dispatch(sessionApi.util.invalidateTags(["session-properties"]));
+
+  return (
+    <div>
+      <button onClick={() => refresh()}>refresh</button>
+      <button onClick={() => invalidate()}>invalidate</button>
+      <button onClick={() => () => setShowHiddenComponent(true)}>
+        show force update component\
+      </button>
+      <TestGetComponent />
+      {showHiddenComponent && <TestComponentWithForceUpdateHook />}
+    </div>
+  );
+};
+
+const setup = () => {
+  setupPropertiesEndpoints(
+    createMockSettings({ "site-name": "site name from API" }),
+  );
+
+  return renderWithProviders(<TestUpdateComponent />, {
+    storeInitialState: {
+      settings: createMockSettingsState({ "site-name": "initial site name" }),
+    },
+  });
+};
+
+describe("metabase/redux/settings", () => {
+  it("should load settings from initial store", () => {
+    setup();
+    // will be loading if called from the api
+    expect(screen.getAllByText("initial site name")).toHaveLength(2);
+  });
+
+  it("should load settings from API", async () => {
+    setup();
+    await waitFor(() =>
+      expect(screen.getAllByText("site name from API")).toHaveLength(3),
+    );
+  });
+
+  it("settings state should get refreshed by refreshSettings action", async () => {
+    setup();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("site name from API")).toHaveLength(3),
+    );
+
+    setupPropertiesEndpoints(
+      createMockSettings({ "site-name": "updated site name" }),
+    );
+
+    // nothing should have changed
+    expect(screen.getAllByText("site name from API")).toHaveLength(3);
+
+    const refreshButton = screen.getByText("refresh");
+    await userEvent.click(refreshButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("updated site name")).toHaveLength(3),
+    );
+  });
+
+  it("settings state should get refreshed by invalidating tags", async () => {
+    setup();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("site name from API")).toHaveLength(3),
+    );
+
+    setupPropertiesEndpoints(
+      createMockSettings({ "site-name": "updated site name" }),
+    );
+
+    // nothing should have changed
+    expect(screen.getAllByText("site name from API")).toHaveLength(3);
+
+    const invalidateButton = screen.getByText("invalidate");
+    await userEvent.click(invalidateButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("updated site name")).toHaveLength(3),
+    );
+  });
+});

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -376,7 +376,6 @@ export const SessionApi = {
   createWithGoogleAuth: POST("/api/session/google_auth"),
   delete: DELETE("/api/session"),
   slo: POST("/auth/sso/logout"),
-  properties: GET("/api/session/properties"),
   forgot_password: POST("/api/session/forgot_password"),
   reset_password: POST("/api/session/reset_password"),
 };

--- a/frontend/test/__support__/server-mocks/session.ts
+++ b/frontend/test/__support__/server-mocks/session.ts
@@ -3,7 +3,9 @@ import fetchMock from "fetch-mock";
 import type { PasswordResetTokenStatus, Settings } from "metabase-types/api";
 
 export function setupPropertiesEndpoints(settings: Settings) {
-  fetchMock.get("path:/api/session/properties", settings);
+  fetchMock.get("path:/api/session/properties", settings, {
+    overwriteRoutes: true,
+  });
 }
 
 export function setupLoginEndpoint() {


### PR DESCRIPTION
### Description

Use RTK to fetch settings (session/properties), and make sure that RTK api cache stays in sync with the `settings` redux slice and window object where we also rely on settings being present.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
