### PR TITLE
fix: select dataset editor header column after reordering by the corner

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
@@ -387,6 +387,10 @@ const _DatasetEditorInner = props => {
     [setFocusedFieldName],
   );
 
+  const handleHeaderColumnReorder = useCallback(columnName => {
+    setFocusedFieldName(columnName);
+  }, []);
+
   // This value together with focusedFieldIndex is used to
   // horizontally scroll the InteractiveTable to the focused column
   // (via react-virtualized's "scrollToColumn" prop)
@@ -543,6 +547,7 @@ const _DatasetEditorInner = props => {
                 className={CS.spread}
                 noHeader
                 queryBuilderMode="dataset"
+                onHeaderColumnReorder={handleHeaderColumnReorder}
                 isShowingDetailsOnlyColumns={datasetEditorTab === "metadata"}
                 hasMetadataPopovers={false}
                 handleVisualizationClick={handleTableElementClick}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
@@ -387,9 +387,18 @@ const _DatasetEditorInner = props => {
     [setFocusedFieldName],
   );
 
-  const handleHeaderColumnReorder = useCallback(columnName => {
-    setFocusedFieldName(columnName);
-  }, []);
+  const handleHeaderColumnReorder = useCallback(
+    dragColIndex => {
+      const field = fields[dragColIndex];
+
+      if (!field) {
+        return;
+      }
+
+      setFocusedFieldName(field.name);
+    },
+    [fields],
+  );
 
   // This value together with focusedFieldIndex is used to
   // horizontally scroll the InteractiveTable to the focused column

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/TabHintToast/TabHintToast.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/TabHintToast/TabHintToast.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import Card from "metabase/components/Card";
@@ -12,7 +13,10 @@ type Props = {
 
 export function TabHintToast({ className, onClose }: Props) {
   return (
-    <Card className={`${className} ${TabHintToastS.ToastCard}`}>
+    <Card
+      data-testid="tab-hint-toast"
+      className={cx(className, TabHintToastS.ToastCard)}
+    >
       <Icon className={TabHintToastS.TabIcon} name="tab" />
       <Box
         component="span"

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -141,6 +141,7 @@ export default class VisualizationResult extends Component {
             onOpenChartSettings={this.props.onOpenChartSettings}
             onUpdateQuestion={this.props.onUpdateQuestion}
             onUpdateWarnings={this.props.onUpdateWarnings}
+            onHeaderColumnReorder={this.props.onHeaderColumnReorder}
             onUpdateVisualizationSettings={
               this.props.onUpdateVisualizationSettings
             }

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -862,7 +862,7 @@ class TableInteractive extends Component {
             // if the column is dragged, we need to tell DatasetEditor know that
             // this specific column needs to be marked as selected to be able to
             // scroll to it in a virtual table
-            // this.props.onHeaderColumnReorder?.(clicked.column.name);
+            this.props.onHeaderColumnReorder?.(clicked.column.name);
           } else if (Math.abs(d.x) + Math.abs(d.y) < HEADER_DRAG_THRESHOLD) {
             // in setTimeout since headers will be rerendered due to DRAG_COUNTER changing
             setTimeout(() => {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -438,7 +438,7 @@ class TableInteractive extends Component {
     setTimeout(() => this.recomputeGridSize(), 1);
   }
 
-  onColumnReorder(columnIndex, newColumnIndex) {
+  handleColumnReorder(columnIndex, newColumnIndex) {
     const { settings, onUpdateVisualizationSettings } = this.props;
     const columns = settings["table.columns"].slice(); // copy since splice mutates
 
@@ -857,7 +857,7 @@ class TableInteractive extends Component {
             dragColNewIndex != null &&
             dragColIndex !== dragColNewIndex
           ) {
-            this.onColumnReorder(dragColIndex, dragColNewIndex);
+            this.handleColumnReorder(dragColIndex, dragColNewIndex);
 
             // if the column is dragged, we need to tell DatasetEditor know that
             // this specific column needs to be marked as selected to be able to

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -862,7 +862,7 @@ class TableInteractive extends Component {
             // if the column is dragged, we need to tell DatasetEditor know that
             // this specific column needs to be marked as selected to be able to
             // scroll to it in a virtual table
-            this.props.onHeaderColumnReorder?.(clicked.column.name);
+            this.props.onHeaderColumnReorder?.(dragColIndex);
           } else if (Math.abs(d.x) + Math.abs(d.y) < HEADER_DRAG_THRESHOLD) {
             // in setTimeout since headers will be rerendered due to DRAG_COUNTER changing
             setTimeout(() => {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -840,7 +840,7 @@ class TableInteractive extends Component {
           });
           onActionDismissal();
         }}
-        onDrag={(e, data) => {
+        onDrag={(event, data) => {
           const newIndex = this.getDragColNewIndex(data);
           if (newIndex != null && newIndex !== this.state.dragColNewIndex) {
             this.setState({
@@ -849,7 +849,7 @@ class TableInteractive extends Component {
             });
           }
         }}
-        onStop={(e, d) => {
+        onStop={(event, d) => {
           const { dragColIndex, dragColNewIndex } = this.state;
           DRAG_COUNTER++;
           if (
@@ -858,6 +858,11 @@ class TableInteractive extends Component {
             dragColIndex !== dragColNewIndex
           ) {
             this.onColumnReorder(dragColIndex, dragColNewIndex);
+
+            // if the column is dragged, we need to tell DatasetEditor know that
+            // this specific column needs to be marked as selected to be able to
+            // scroll to it in a virtual table
+            // this.props.onHeaderColumnReorder?.(clicked.column.name);
           } else if (Math.abs(d.x) + Math.abs(d.y) < HEADER_DRAG_THRESHOLD) {
             // in setTimeout since headers will be rerendered due to DRAG_COUNTER changing
             setTimeout(() => {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -142,6 +142,7 @@ type VisualizationOwnProps = {
     showSidebarTitle?: boolean;
   }) => void;
   onChangeCardAndRun?: ((opts: OnChangeCardAndRunOpts) => void) | null;
+  onHeaderColumnReorder?: (columnName: string) => void;
   onChangeLocation?: (location: Location) => void;
   onUpdateQuestion?: () => void;
   onUpdateVisualizationSettings?: (
@@ -812,6 +813,7 @@ class Visualization extends PureComponent<
                   onUpdateVisualizationSettings={onUpdateVisualizationSettings}
                   onUpdateWarnings={onUpdateWarnings}
                   onVisualizationClick={this.handleVisualizationClick}
+                  onHeaderColumnReorder={this.props.onHeaderColumnReorder}
                 />
               </div>
             )

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -205,6 +205,8 @@ export type VisualizationPassThroughProps = {
   showAllLegendItems?: boolean;
   onRemoveSeries?: (event: MouseEvent, removedIndex: number) => void;
 
+  onHeaderColumnReorder?: (columnName: string) => void;
+
   // frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.tsx
   isSettings?: boolean;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41419

### Description

When you drag the column header by the corner, internal magic does not fire and virtual table thinks you need to select the first column to be able to use tab navigation.

### How to verify

- new model -> orders -> join products -> visualize -> visualize -> edit metadata -> scroll right -> reorder some column by the edge of the column header

### Demo

### Before


https://github.com/user-attachments/assets/5f8a513a-ee98-4f36-8f58-4ab412f478b3

### After


https://github.com/user-attachments/assets/0e1ab8a7-2944-4ad0-bfa9-b1e82ec1b791




### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<img width="1186" alt="Screenshot 2025-03-05 at 17 08 12" src="https://github.com/user-attachments/assets/ecab9957-4b59-4152-99b2-c5e4d0ed6674" />
