### PR TITLE
polish tanstack tableinteractive implementation

### DIFF
--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -73,6 +73,7 @@ function newNativeCardHash(
     query = "",
     collection_id = null,
     display = "scalar",
+    visualization_settings = {},
   } = {},
 ) {
   const card = {
@@ -84,7 +85,7 @@ function newNativeCardHash(
     },
     display,
     parameters: [],
-    visualization_settings: {},
+    visualization_settings,
     type,
   };
 

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -85,6 +85,45 @@ describe("scenarios > visualizations > table", () => {
     headerCells().contains("QUANTITY").should("not.exist");
   });
 
+  it("should preserve set widths after reordering (VIZ-439)", () => {
+    H.startNewNativeQuestion({
+      query: 'select 1 "first_column", 2 "second_column"',
+      display: "table",
+      visualization_settings: { "table.column_widths": [600, 150] },
+    });
+
+    cy.findByTestId("native-query-editor-container").icon("play").click();
+
+    H.tableHeaderColumn("first_column").invoke("outerWidth").as("firstWidth");
+    H.tableHeaderColumn("second_column").invoke("outerWidth").as("secondWidth");
+
+    H.moveDnDKitElement(H.tableHeaderColumn("first_column"), {
+      horizontal: 100,
+    });
+
+    const assertUnchangedWidths = () => {
+      cy.get("@firstWidth").then(firstWidth => {
+        H.tableHeaderColumn("first_column")
+          .invoke("outerWidth")
+          .should("eq", firstWidth);
+      });
+
+      cy.get("@secondWidth").then(secondWidth => {
+        H.tableHeaderColumn("second_column")
+          .invoke("outerWidth")
+          .should("eq", secondWidth);
+      });
+    };
+
+    assertUnchangedWidths();
+    cy.reload();
+
+    cy.findByTestId("native-query-editor-container").icon("play").click();
+    // Wait for column widths to be set
+    cy.wait(100);
+    assertUnchangedWidths();
+  });
+
   it("should allow to display any column as link with extrapolated url and text", () => {
     H.openPeopleTable({ limit: 2 });
 

--- a/frontend/src/metabase/data-grid/components/AddColumnButton/AddColumnButton.module.css
+++ b/frontend/src/metabase/data-grid/components/AddColumnButton/AddColumnButton.module.css
@@ -18,10 +18,10 @@
 }
 
 .button {
-  background-color: var(--mb-base-color-brand-10) !important;
+  transition: background-color 200ms;
+  background-color: var(--mb-base-color-brand-10);
 }
 
 .button:hover {
-  background-color: var(--mb-base-color-brand-20) !important;
-  transition: background-color 200ms;
+  background: var(--mb-base-color-brand-20) !important;
 }

--- a/frontend/src/metabase/data-grid/components/AddColumnButton/AddColumnButton.module.css
+++ b/frontend/src/metabase/data-grid/components/AddColumnButton/AddColumnButton.module.css
@@ -16,3 +16,12 @@
   right: 0;
   border-left: 1px solid var(--mb-color-border);
 }
+
+.button {
+  background-color: var(--mb-base-color-brand-10) !important;
+}
+
+.button:hover {
+  background-color: var(--mb-base-color-brand-20) !important;
+  transition: background-color 200ms;
+}

--- a/frontend/src/metabase/data-grid/components/AddColumnButton/AddColumnButton.tsx
+++ b/frontend/src/metabase/data-grid/components/AddColumnButton/AddColumnButton.tsx
@@ -8,17 +8,25 @@ import S from "./AddColumnButton.module.css";
 
 interface AddColumnButtonProps extends HTMLAttributes<HTMLButtonElement> {
   isSticky?: boolean;
+  marginRight?: number;
 }
 
 export const AddColumnButton = memo(function AddColumnButton({
   isSticky,
+  marginRight,
   onClick,
 }: AddColumnButtonProps) {
   return (
-    <div className={cx(S.root, { [S.sticky]: isSticky })}>
+    <div
+      className={cx(S.root, { [S.sticky]: isSticky })}
+      style={{ marginRight }}
+    >
       <Button
-        variant="outline"
+        className={S.button}
+        variant="subtle"
         size="compact-md"
+        w={23}
+        h={23}
         leftSection={<Icon name="add" />}
         title={t`Add column`}
         aria-label={t`Add column`}

--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
@@ -20,6 +20,7 @@ import {
 import { DataGridThemeProvider } from "metabase/data-grid/hooks/use-table-theme";
 import type { DataGridInstance, DataGridTheme } from "metabase/data-grid/types";
 import { useForceUpdate } from "metabase/hooks/use-force-update";
+import { getScrollBarSize } from "metabase/lib/dom";
 
 import S from "./DataGrid.module.css";
 
@@ -76,16 +77,28 @@ export const DataGrid = function DataGrid<TData>({
     table.getTotalSize() >=
     (gridRef.current?.offsetWidth ?? Infinity) - ADD_COLUMN_BUTTON_WIDTH;
 
+  const addColumnMarginRight =
+    virtualGrid.rowVirtualizer.getTotalSize() >=
+    (gridRef.current?.offsetHeight ?? Infinity)
+      ? getScrollBarSize()
+      : 0;
+
   const hasAddColumnButton = onAddColumnClick != null;
   const addColumnButton = useMemo(
     () =>
       hasAddColumnButton ? (
         <AddColumnButton
+          marginRight={addColumnMarginRight}
           isSticky={isAddColumnButtonSticky}
           onClick={onAddColumnClick}
         />
       ) : null,
-    [hasAddColumnButton, isAddColumnButtonSticky, onAddColumnClick],
+    [
+      hasAddColumnButton,
+      isAddColumnButtonSticky,
+      onAddColumnClick,
+      addColumnMarginRight,
+    ],
   );
 
   const isEmpty = table.getRowModel().rows.length === 0;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -281,19 +281,21 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
 
   const handleColumnReordering = useCallback(
     (columnsOrder: string[]) => {
-      const result = settings["table.columns"]?.slice() ?? [];
+      const newColumns = settings["table.columns"]?.slice() ?? [];
 
-      const enabledIndices = result
+      const enabledIndices = newColumns
         .map((col, index) => (col.enabled ? index : -1))
         .filter(index => index !== -1);
 
       columnsOrder.forEach((columnName, orderIndex) => {
-        const sourceIndex = result.findIndex(col => col.name === columnName);
+        const sourceIndex = newColumns.findIndex(
+          col => col.name === columnName,
+        );
         if (sourceIndex !== -1) {
           const targetIndex = enabledIndices[orderIndex];
 
-          const [column] = result.splice(sourceIndex, 1);
-          result.splice(targetIndex, 0, column);
+          const [column] = newColumns.splice(sourceIndex, 1);
+          newColumns.splice(targetIndex, 0, column);
 
           if (sourceIndex > targetIndex) {
             for (let i = orderIndex + 1; i < enabledIndices.length; i++) {
@@ -303,13 +305,22 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
         }
       });
 
+      const newEnabledColumns = newColumns.filter(col => col.enabled);
+      const savedWidths = settings["table.column_widths"];
+      const newWidths =
+        Array.isArray(savedWidths) &&
+        savedWidths.length === newEnabledColumns.length
+          ? newEnabledColumns.map(c => columnSizingMap[c.name])
+          : undefined;
+
       const settingsUpdate = {
-        "table.columns": result,
+        "table.columns": newColumns,
+        "table.column_widths": newWidths,
       };
 
       onUpdateVisualizationSettings(settingsUpdate);
     },
-    [onUpdateVisualizationSettings, settings],
+    [onUpdateVisualizationSettings, settings, columnSizingMap],
   );
 
   const handleAddColumnButtonClick = useMemo(() => {


### PR DESCRIPTION
Closes [VIZ-439](https://linear.app/metabase/issue/VIZ-439/sorting-on-a-column-resizes-truncates-others-in-unexpected-ways)
Closes [VIZ-424](https://linear.app/metabase/issue/VIZ-424/make-add-column-button-style-similar-to-column-headers)
Closes [VIZ-415](https://linear.app/metabase/issue/VIZ-415/table-header-overlaps-on-top-of-vertical-scrollbar)

### Description

Fixes a few non-blocking bugs in the new table.

1. Column reordering after resizing now preserves correct widths [VIZ-439](https://linear.app/metabase/issue/VIZ-439/sorting-on-a-column-resizes-truncates-others-in-unexpected-ways)
https://github.com/user-attachments/assets/bf8b9279-e9aa-4161-af00-d9b0d8f8989e

2. Add column header button has matching style with headers [VIZ-424](https://linear.app/metabase/issue/VIZ-424/make-add-column-button-style-similar-to-column-headers)

<img width="527" alt="Screenshot 2025-03-04 at 10 01 06 PM" src="https://github.com/user-attachments/assets/31ee73f2-df86-4f50-b055-dce67dc3ab2a" />

3. Table header does not overlap with vertical scroll bar anymore [VIZ-415](https://linear.app/metabase/issue/VIZ-415/table-header-overlaps-on-top-of-vertical-scrollbar)
<img width="164" alt="Screenshot 2025-03-04 at 10 01 25 PM" src="https://github.com/user-attachments/assets/6f0d8cdd-c10b-4b8a-b6c9-9b34a268d9ee" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
