### PR TITLE
Remove findDOMNode from visualization components

### DIFF
--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import PropTypes from "prop-types";
 import { Component, forwardRef } from "react";
-import ReactDOM from "react-dom";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import { isSameSeries } from "metabase/visualizations/lib/utils";
@@ -15,6 +14,8 @@ class CardRenderer extends Component {
     isEditing: PropTypes.bool,
     isDashboard: PropTypes.bool,
   };
+
+  containerRef = null;
 
   shouldComponentUpdate(nextProps) {
     // a chart only needs re-rendering when the result itself changes OR the chart type is different
@@ -51,7 +52,10 @@ class CardRenderer extends Component {
       return;
     }
 
-    const parent = ReactDOM.findDOMNode(this);
+    const parent = this.containerRef;
+    if (!parent) {
+      return;
+    }
 
     // deregister previous chart:
     this._deregisterChart();
@@ -78,7 +82,17 @@ class CardRenderer extends Component {
       <div
         className={this.props.className}
         style={this.props.style}
-        ref={this.props.forwardedRef}
+        ref={element => {
+          this.containerRef = element;
+
+          if (this.props.forwardedRef) {
+            if (typeof this.props.forwardedRef === "function") {
+              this.props.forwardedRef(element);
+            } else {
+              this.props.forwardedRef.current = element;
+            }
+          }
+        }}
       />
     );
   }

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -1,13 +1,18 @@
 /* eslint-disable react/prop-types */
-/* eslint-disable react/no-string-refs */
 import cx from "classnames";
 import { Component } from "react";
-import ReactDOM from "react-dom";
 
 import LegendS from "./Legend.module.css";
 import LegendItem from "./LegendItem";
 
 export default class LegendHorizontal extends Component {
+  constructor(props) {
+    super(props);
+
+    /** @type {Record<number, LegendItem | null>} */
+    this.legendItemRefs = {};
+  }
+
   render() {
     const {
       className,
@@ -28,7 +33,7 @@ export default class LegendHorizontal extends Component {
           const handleMouseEnter = () => {
             onHoverChange?.({
               index,
-              element: ReactDOM.findDOMNode(this.refs["legendItem" + index]),
+              element: this.legendItemRefs[index],
             });
           };
 
@@ -43,7 +48,9 @@ export default class LegendHorizontal extends Component {
               {...(hovered && { "aria-current": !isMuted })}
             >
               <LegendItem
-                ref={this["legendItem" + index]}
+                ref={legendItem => {
+                  this.legendItemRefs[index] = legendItem;
+                }}
                 title={title}
                 color={colors[index % colors.length]}
                 isMuted={isMuted}

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -33,7 +33,7 @@ export default class LegendHorizontal extends Component {
           const handleMouseEnter = () => {
             onHoverChange?.({
               index,
-              element: this.legendItemRefs[index],
+              element: this.legendItemRefs[index]?.getRootElement(),
             });
           };
 

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import PropTypes from "prop-types";
-import { Component } from "react";
+import { Component, createRef } from "react";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
@@ -21,6 +21,9 @@ export default class LegendItem extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {};
+
+    /** @type {React.RefObject<HTMLSpanElement>} */
+    this.rootRef = createRef();
   }
 
   static defaultProps = {
@@ -31,6 +34,10 @@ export default class LegendItem extends Component {
     showTooltip: true,
     showDotTooltip: true,
   };
+
+  getRootElement() {
+    return this.rootRef.current;
+  }
 
   render() {
     const {
@@ -54,6 +61,7 @@ export default class LegendItem extends Component {
 
     return (
       <span
+        ref={this.rootRef}
         data-testid="legend-item"
         className={cx(
           className,

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -91,7 +91,7 @@ export default class LegendVertical extends Component {
           const handleMouseEnter = () => {
             onHoverChange?.({
               index,
-              element: this.legendItemRefs[index],
+              element: this.legendItemRefs[index]?.getRootElement(),
             });
           };
 

--- a/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
@@ -80,11 +80,14 @@ export default class Gauge extends Component {
     }
   }
 
-  state = {
-    mounted: false,
-  };
+  constructor(props) {
+    super(props);
 
-  _label;
+    /** @type {React.RefObject<SVGTextElement>} */
+    this.labelRef = React.createRef();
+
+    this.state = { mounted: false };
+  }
 
   static settings = {
     ...columnSettings({
@@ -141,8 +144,7 @@ export default class Gauge extends Component {
   }
 
   _updateLabelSize() {
-    // TODO: extract this into a component that resizes SVG <text> element to fit bounds
-    const label = this._label && ReactDOM.findDOMNode(this._label);
+    const label = this.labelRef.current;
     if (label) {
       const { width: currentWidth } = label.getBBox();
       // maxWidth currently 95% of inner diameter, could be more intelligent based on text aspect ratio
@@ -323,7 +325,7 @@ export default class Gauge extends Component {
               {/* CENTER LABEL */}
               {/* NOTE: can't be a component because ref doesn't work? */}
               <text
-                ref={label => (this._label = label)}
+                ref={this.labelRef}
                 x={0}
                 y={0}
                 style={{

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -8,8 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { findDOMNode } from "react-dom";
-import { useMount, usePrevious } from "react-use";
+import { usePrevious } from "react-use";
 import type { OnScrollParams } from "react-virtualized";
 import { AutoSizer, Collection, Grid, ScrollSync } from "react-virtualized";
 import { t } from "ttag";
@@ -91,7 +90,6 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
   ) {
     const [viewPortWidth, setViewPortWidth] = useState(width);
     const [shouldOverflow, setShouldOverflow] = useState(false);
-    const [gridElement, setGridElement] = useState<HTMLElement | null>(null);
     const columnWidthSettings = settings["pivot_table.column_widths"];
 
     const theme = useMantineTheme();
@@ -130,9 +128,10 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       ],
     );
 
-    const bodyRef = useRef(null);
-    const leftHeaderRef = useRef(null);
-    const topHeaderRef = useRef(null);
+    const gridRef = useRef<Grid>(null);
+    const gridContainerRef = useRef<HTMLDivElement>(null);
+    const leftHeaderRef = useRef<Collection>(null);
+    const topHeaderRef = useRef<Collection>(null);
 
     const getColumnTitle = useCallback(
       function (columnIndex: number) {
@@ -166,7 +165,7 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       (
         topHeaderRef.current as Collection | null
       )?.recomputeCellSizesAndPositions?.();
-      (bodyRef.current as Grid | null)?.recomputeGridSize?.();
+      (gridRef.current as Grid | null)?.recomputeGridSize?.();
     }, [
       data,
       leftHeaderRef,
@@ -174,10 +173,6 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       leftHeaderWidths,
       valueHeaderWidths,
     ]);
-
-    useMount(() => {
-      setGridElement(bodyRef.current && findDOMNode(bodyRef.current));
-    });
 
     const pivoted = useMemo(() => {
       if (data == null || !data.cols.some(isPivotGroupColumn)) {
@@ -207,13 +202,14 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
     // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
     // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights
     function scrollBarOffsetSize() {
-      if (!gridElement) {
+      if (!gridContainerRef.current) {
         return 0;
       }
       // get the size of the scrollbars
       const scrollBarSize = getScrollBarSize();
       const scrollsHorizontally =
-        gridElement.scrollWidth > parseInt(gridElement.style.width);
+        gridContainerRef.current.scrollWidth >
+        parseInt(gridContainerRef.current.style.width);
 
       if (scrollsHorizontally && scrollBarSize > 0) {
         return scrollBarSize;
@@ -551,7 +547,8 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
                         onScroll={({ scrollLeft, scrollTop }) =>
                           onScroll({ scrollLeft, scrollTop } as OnScrollParams)
                         }
-                        ref={bodyRef}
+                        ref={gridRef}
+                        elementRef={gridContainerRef}
                         scrollTop={scrollTop}
                         scrollLeft={scrollLeft}
                       />

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -165,7 +165,7 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       (
         topHeaderRef.current as Collection | null
       )?.recomputeCellSizesAndPositions?.();
-      (gridRef.current as Grid | null)?.recomputeGridSize?.();
+      gridRef.current?.recomputeGridSize?.();
     }, [
       data,
       leftHeaderRef,

--- a/frontend/src/metabase/visualizations/visualizations/Progress/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress/Progress.jsx
@@ -2,7 +2,6 @@
 import cx from "classnames";
 import Color from "color";
 import { Component, createRef } from "react";
-import ReactDOM from "react-dom";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -29,6 +28,7 @@ export default class Progress extends Component {
   constructor(props) {
     super(props);
 
+    this.rootRef = createRef();
     this.containerRef = createRef();
     this.labelRef = createRef();
     this.pointerRef = createRef();
@@ -88,7 +88,7 @@ export default class Progress extends Component {
   }
 
   componentDidUpdate() {
-    const component = ReactDOM.findDOMNode(this);
+    const root = this.rootRef.current;
     const pointer = this.pointerRef.current;
     const label = this.labelRef.current;
     const container = this.containerRef.current;
@@ -99,7 +99,7 @@ export default class Progress extends Component {
     bar.style.height = 0;
     bar.style.height = computeBarHeight({
       cardHeight: this.props?.gridSize?.height,
-      componentHeight: component.clientHeight,
+      componentHeight: root.clientHeight,
       isMobile: this.props.isMobile,
     });
 
@@ -175,7 +175,10 @@ export default class Progress extends Component {
     };
 
     return (
-      <div className={cx(this.props.className, CS.flex, CS.layoutCentered)}>
+      <div
+        ref={this.rootRef}
+        className={cx(this.props.className, CS.flex, CS.layoutCentered)}
+      >
         <div
           className={cx(
             CS.flexFull,


### PR DESCRIPTION
Closes EMB-213

The following React components under `frontend/src/metabase/visualizations` use `React.findDOMNode` which is removed in React 19:
- CardRenderer.jsx
- LegendHorizontal.jsx
- LegendVertical.jsx
- Gauge.jsx
- PivotTable.jsx
- Progress.jsx

This PR migrates these components to use direct refs instead of findDOMNode.

## Demo

Affected viz remains functional

![CleanShot 2568-03-05 at 14 46 23@2x](https://github.com/user-attachments/assets/ab1bd5a9-70a9-4681-95e2-339abbeb74b9)

![CleanShot 2568-03-05 at 14 46 00@2x](https://github.com/user-attachments/assets/97d77e3b-9db3-4325-a4de-efd69b08b286)

![CleanShot 2568-03-05 at 14 44 21@2x](https://github.com/user-attachments/assets/921ef4d1-47f4-4677-b255-5ce1c442600d)

![CleanShot 2568-03-05 at 14 45 33@2x](https://github.com/user-attachments/assets/a4ea8872-a2ce-4b02-ac33-bfd83d66add3)

![CleanShot 2568-03-05 at 14 44 55@2x](https://github.com/user-attachments/assets/ecd7b19c-1b4a-461b-a4bc-00f66ee619f4)

