### PR TITLE
Fix type logic for datetimeDiff() for days on postgres

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -623,8 +623,7 @@
 
 (defmethod sql.qp/datetime-diff [:postgres :day]
   [_driver _unit x y]
-  (let [interval (h2x/- (date-trunc :day y) (date-trunc :day x))]
-    (h2x/->integer (extract :day interval))))
+  (h2x/- (date-trunc :day y) (date-trunc :day x)))
 
 (defmethod sql.qp/datetime-diff [:postgres :hour]
   [driver _unit x y]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -623,7 +623,7 @@
 
 (defmethod sql.qp/datetime-diff [:postgres :day]
   [_driver _unit x y]
-  (h2x/- (date-trunc :day y) (date-trunc :day x)))
+  (h2x/- (h2x/cast :DATE y) (h2x/cast :DATE x)))
 
 (defmethod sql.qp/datetime-diff [:postgres :hour]
   [driver _unit x y]


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/54654

### Description

The problem was that datetimeDiff() on days was assuming it needed extra work to extract the day and convert it to an integer, when subtraction on dates already returns an integer number of days.

### How to verify

1. New question -> Sample dataset (postgres) -> People
2. Add custom field `datetimeDiff([Birth Date], [Birth Date], "day")`
3. visualize. It should show the table. (in the issue it showed an error)

The sql view shows this now:

```sql
(
    CAST(
      TRUNC(
        extract(
          epoch
          from
            "public"."people"."birth_date"
        ) - extract(
          epoch
          from
            "public"."people"."birth_date"
        )
      ) AS integer
    ) / 3600
  ) AS "DAYDIFF"
```