### PR TITLE
ci(sdk): Add stable SDK git tags

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     outputs:
-      sdk_version: ${{ steps.new-sdk-version.outputs.result }}
+      sdk_version: ${{ fromJson(steps.new-sdk-version.outputs.result).version }}
+      major_version: ${{ fromJson(steps.new-sdk-version.outputs.result).majorVersion }}
     steps:
       - name: Check out the code using the provided branch
         uses: actions/checkout@v4
@@ -59,19 +60,25 @@ jobs:
         id: new-sdk-version
         uses: actions/github-script@v7
         with:
-          result-encoding: string
           script: |
             const currentVersion = "${{ steps.current-sdk-version.outputs.sdk_current_version }}";
             const [currentVersionWithoutSuffix, suffix] = currentVersion.split("-");
             const versionParts = currentVersionWithoutSuffix.split(".");
             versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
             const newVersion = versionParts.join(".");
+            const [_, majorVersion] = versionParts
 
             if (!suffix) {
-              return newVersion;
+              return {
+                version: newVersion,
+                majorVersion
+              };
             }
 
-            return `${newVersion}-${suffix}`
+            return {
+              version: `${newVersion}-${suffix}`,
+              majorVersion
+            }
 
       - name: Append workflow summary
         run: |
@@ -79,7 +86,8 @@ jobs:
           **Derived inputs:**
 
           - \`current_version\`: "${{ steps.current-sdk-version.outputs.sdk_current_version }}"
-          - \`next_version\`: "${{ steps.new-sdk-version.outputs.result }}"
+          - \`next_version\`: "${{ fromJson(steps.new-sdk-version.outputs.result).version }}"
+          - \`major_version\`: "${{ fromJson(steps.new-sdk-version.outputs.result).majorVersion }}"
           EOF
 
   check-git-tag:
@@ -271,6 +279,7 @@ jobs:
     timeout-minutes: 20
     env:
       tag: embedding-sdk-${{ needs.determine-version.outputs.sdk_version }}
+      stable_tag: embedding-sdk-${{ needs.determine-version.outputs.major_version }}-stable
     steps:
       - name: Check out the code using the provided branch
         uses: actions/checkout@v4
@@ -278,11 +287,13 @@ jobs:
           ref: ${{ inputs.branch }}
 
       # Lightweight tags don't need committer name and email
-      - name: Create a new git tag
+      - name: Create and push SDK version tag
         run: |
           git tag ${{ env.tag }}
-
-      - name: Push the new tag
-        id: push-tag
-        run: |
           git push origin ${{ env.tag }}
+
+      - name: Create and push SDK stable version tag
+        if: ${{ startsWith(inputs.branch, 'release-x.') }}
+        run: |
+          git tag -f ${{ env.stable_tag }}
+          git push origin -f ${{ env.stable_tag }}


### PR DESCRIPTION
Closes EMB-221

[Slack discussion](https://metaboat.slack.com/archives/C063Q3F1HPF/p1740662365193809).

This is to ensure that we have a ref to compare with the release branch to see which commit would be deployed in the new SDK versions.

The stable tag should only be added when publishing SDK from release branches, not from `master`

### How to verify
These runs are made with all the npm related steps disabled. So we're not publishing any packages.

- [`master` run doesn't add and push stable tags](https://github.com/metabase/metabase/actions/runs/13671076668/job/38221435379), the step is skipped
- [53 branch pushes normal tag and stable tag](https://github.com/metabase/metabase/actions/runs/13671370525/job/38222368270)
    <img width="1334" alt="Screenshot 2025-03-05 at 3 20 46 PM" src="https://github.com/user-attachments/assets/4adf0fbb-f5ae-42c8-91ea-4446dedb3d08" />