### PR TITLE
docs: update some other docs about e2e for the sdk

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -181,11 +181,9 @@ Cypress._.times(N, () => {
 
 ### Embedding SDK tests
 
-Tests located in `e2e/test/scenarios/embedding-sdk` are used to run automated checks for the Embedding SDK.
+Tests located in `e2e/test-component/scenarios/embedding-sdk/` are used to run automated checks for the Embedding SDK.
 
-Embedding SDK is a library, and not an application. We use Storybook to host public components, and we run tests against it.
-
-In order to run stories used for tests locally, please check [storybook setup docs](https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/embedding-sdk/README.md#storybook)
+In order to run the tests locally, see [sdk docs about e2e](../../enterprise/frontend/src/embedding-sdk/dev.md#e2e-tests)
 
 ## DB Snapshots
 

--- a/enterprise/frontend/src/embedding-sdk/dev.md
+++ b/enterprise/frontend/src/embedding-sdk/dev.md
@@ -52,13 +52,14 @@ CYPRESS_ALL_FEATURES_TOKEN=  ${usual token from password manager}
 CYPRESS_NO_FEATURES_TOKEN=  ${usual token from password manager}
 ```
 
-And then run:
+Cypress will use the built package, so you'll have to build the sdk first (see above).
+We recommend running either the dev or the watch command to have shorter a feedback loop.
+
+To start the cypress for the e2e tests:
 
 ```bash
 TEST_SUITE="component" yarn test-cypress
 ```
-
-Cypress will use the built package, so we recommend running it together with either the watch or dev command.
 
 ## Use the local build in a project
 


### PR DESCRIPTION
Some parts of the docs were not up to date, as reported by Sasha: https://metaboat.slack.com/archives/C063Q3F1HPF/p1741109842353749?thread_ts=1741106835.862209&cid=C063Q3F1HPF