### PR TITLE
fix(sdk):  wrong icon on visualization selector

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/ChartTypeSelectorList/ChartTypeDropdown.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/ChartTypeSelectorList/ChartTypeDropdown.tsx
@@ -67,7 +67,7 @@ export const ChartTypeDropdown = (menuProps: MenuProps) => {
           variant="default"
           px={undefined}
           pr="md"
-          leftSection={<Icon ml="xs" size={10} name="chevrondown" />}
+          rightSection={<Icon ml="xs" size={10} name="chevrondown" />}
           className={ToolbarButtonS.PrimaryToolbarButton}
         />
       </Menu.Target>


### PR DESCRIPTION
Fixes EMB-201

Before:
<img width="281" alt="image" src="https://github.com/user-attachments/assets/9ac767a3-467e-47e4-991c-e8e1c8ac3250" />


After:
<img width="273" alt="image" src="https://github.com/user-attachments/assets/3016b035-9c9f-484b-8aa4-79c0802a6511" />
