### PR TITLE
ci(sdk): Send SDK release notification to Slack

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -37,6 +37,38 @@ jobs:
           triggered by: @${{ github.event.sender.login }}
           EOF
 
+  send-slack-notification-start:
+    name: "Send Slack notification: SDK release started"
+    needs: determine-sdk-version
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+
+      - name: Send build start message
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { mentionUserByGithubLogin, sendSlackMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const sdkVersion = "${{ needs.determine-sdk-version.outputs.sdk_version }}";
+
+            const title = `:rocket: *SDK release: ${sdkVersion}* :rocket:`
+            const body = `run by ${mentionUserByGithubLogin("${{ github.event.sender.login }}")}`
+            const sendSlackMessageResponse = await sendSlackMessage({
+              channelName: process.env.SLACK_RELEASE_CHANNEL,
+              message: `${title}\n${body}`,
+            });
+
+            console.log('sendSlackMessageResponse')
+            console.log(sendSlackMessageResponse)
+
   determine-sdk-version:
     runs-on: ubuntu-22.04
     timeout-minutes: 20

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -117,7 +117,43 @@ jobs:
             const sdkVersion = "${{ needs.determine-sdk-version.outputs.sdk_version }}";
 
             const runLink = githubRunLink(
-              `:x: ${sdkVersion} release has failed`,
+              `:x: ${sdkVersion} Release has failed`,
+              context.runId,
+              context.repo.owner,
+              context.repo.repo,
+            );
+            sendSlackReply({
+              channelName: 'bot-testing',
+              message: runLink,
+              messageId: ${{ env.slackMessageId}},
+              broadcast: true
+            });
+
+  send-slack-notification-successful:
+    name: "Send Slack notification: SDK release successful"
+    needs: ["determine-sdk-version", "send-slack-notification-start"]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    env:
+      slackMessageId: ${{ needs.send-slack-notification-start.outputs.slackMessageId }}
+    steps:
+      - name: Retrieve build scripts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-scripts
+          path: release/dist/
+
+      - name: Send build successful message
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { githubRunLink, sendSlackReply } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const sdkVersion = "${{ needs.determine-sdk-version.outputs.sdk_version }}";
+
+            const runLink = githubRunLink(
+              `:partydeploy: ${sdkVersion} Release is complete :partydeploy:`,
               context.runId,
               context.repo.owner,
               context.repo.repo,

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -42,6 +42,8 @@ jobs:
     needs: determine-sdk-version
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    outputs:
+      slackMessageId: ${{ steps.send-slack-message-start.outputs.result }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,24 +52,82 @@ jobs:
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
 
+      - name: Cache build scripts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-scripts
+          path: release/dist/index.cjs
+
       - name: Send build start message
+        id: send-slack-message-start
         uses: actions/github-script@v7
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
+          result-encoding: string
           script: | # js
-            const { mentionUserByGithubLogin, sendSlackMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { mentionUserByGithubLogin, sendSlackMessage, githubRunLink } = require('${{ github.workspace }}/release/dist/index.cjs');
             const sdkVersion = "${{ needs.determine-sdk-version.outputs.sdk_version }}";
 
             const title = `:rocket: *SDK release: ${sdkVersion}* :rocket:`
-            const body = `run by ${mentionUserByGithubLogin("${{ github.event.sender.login }}")}`
+            const runLink = githubRunLink(
+              `:building_construction: _CI Run_ :building_construction:`,
+              context.runId,
+              context.repo.owner,
+              context.repo.repo,
+            );
+            const body = `${runLink} - run by ${mentionUserByGithubLogin("${{ github.event.sender.login }}")}`
             const sendSlackMessageResponse = await sendSlackMessage({
               channelName: process.env.SLACK_RELEASE_CHANNEL,
               message: `${title}\n${body}`,
             });
 
-            console.log('sendSlackMessageResponse')
-            console.log(sendSlackMessageResponse)
+            return sendSlackMessageResponse.message.ts
+
+  # Technically this should be placed last, since it runs after other jobs, but I want to co-locate all Slack jobs
+  send-slack-notification-failure:
+    name: "Send Slack notification: SDK release failed"
+    needs: [
+        "determine-sdk-version",
+        "send-slack-notification-start",
+        # "check-git-tag",
+        # "test",
+        # "build-sdk",
+        # "publish-npm",
+        # "git-tag",
+      ]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    env:
+      slackMessageId: ${{ needs.send-slack-notification-start.outputs.slackMessageId }}
+    steps:
+      - name: Retrieve build scripts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-scripts
+          path: release/dist/
+
+      - name: Send build failure message
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { githubRunLink, sendSlackReply } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const sdkVersion = "${{ needs.determine-sdk-version.outputs.sdk_version }}";
+
+            const runLink = githubRunLink(
+              `:x: ${sdkVersion} release has failed`,
+              context.runId,
+              context.repo.owner,
+              context.repo.repo,
+            );
+            sendSlackReply({
+              channelName: 'bot-testing',
+              message: runLink,
+              messageId: ${{ env.slackMessageId}},
+              broadcast: true
+            });
 
   determine-sdk-version:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -262,6 +262,9 @@ jobs:
         with:
           m2-cache-key: "release-sdk"
 
+      - name: You shall not pass!!!
+        run: exit 1
+
       # - name: Run unit tests
       #   run: yarn embedding-sdk:test-unit
 

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -262,11 +262,8 @@ jobs:
         with:
           m2-cache-key: "release-sdk"
 
-      - name: You shall not pass!!!
-        run: exit 1
-
-      # - name: Run unit tests
-      #   run: yarn embedding-sdk:test-unit
+      - name: Run unit tests
+        run: yarn embedding-sdk:test-unit
 
   build-sdk:
     needs: [test, determine-sdk-version]
@@ -297,17 +294,17 @@ jobs:
         run: |
           yarn embedding-sdk:generate-changelog -o changelog-diff
 
-      # - name: Build SDK bundle
-      #   run: yarn run build-embedding-sdk
+      - name: Build SDK bundle
+        run: yarn run build-embedding-sdk
 
       - name: Generate SDK package.json in the build directory
         run: yarn run embedding-sdk:generate-package
 
-      # - name: Upload built SDK package as artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: metabase-sdk
-      #     path: ./resources/embedding-sdk
+      - name: Upload built SDK package as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: metabase-sdk
+          path: ./resources/embedding-sdk
 
       - name: Upload changelog diff
         uses: actions/upload-artifact@v4
@@ -351,60 +348,60 @@ jobs:
           cat changelog-diff enterprise/frontend/src/embedding-sdk/CHANGELOG.md > new-changelog
           mv new-changelog enterprise/frontend/src/embedding-sdk/CHANGELOG.md
 
-      # - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
-      #   run: |
-      #     git checkout -b update-sdk-version-${{ env.sdk_version }}
-      #     git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
-      #     git push origin HEAD
-      #     gh pr create --base ${{ inputs.branch }}\
-      #                  --assignee "${GITHUB_ACTOR}"\
-      #                  --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
-      #                  --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
-      #   env:
-      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
+        run: |
+          git checkout -b update-sdk-version-${{ env.sdk_version }}
+          git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
+          git push origin HEAD
+          gh pr create --base ${{ inputs.branch }}\
+                       --assignee "${GITHUB_ACTOR}"\
+                       --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
+                       --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      # - uses: actions/create-github-app-token@v1
-      #   id: app-token
-      #   with:
-      #     app-id: ${{ secrets.METABASE_BOT_APP_ID }}
-      #     private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
 
-      # - name: Edit PR adding useful information (using Metabase bot app)
-      #   run: |
-      #     gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Edit PR adding useful information (using Metabase bot app)
+        run: |
+          gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      # - name: Auto approve PR (using GitHub Actions account)
-      #   run: |
-      #     gh pr review --approve
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto approve PR (using GitHub Actions account)
+        run: |
+          gh pr review --approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-      #   run: |
-      #     gh pr merge --auto --squash
-      #   env:
-      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+        run: |
+          gh pr merge --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      # - name: Retrieve build SDK package artifact
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: metabase-sdk
-      #     path: sdk
+      - name: Retrieve build SDK package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: metabase-sdk
+          path: sdk
 
-      # - name: Publish to NPM
-      #   working-directory: sdk
-      #   run: |
-      #     echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-      #     # Please keep the value in sync with `inputs.branch`'s release branch
-      #     npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
+      - name: Publish to NPM
+        working-directory: sdk
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+          # Please keep the value in sync with `inputs.branch`'s release branch
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-      # - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-      #   if: ${{ inputs.branch == 'release-x.53.x' }}
-      #   working-directory: sdk
-      #   run: |
-      #     npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
+        if: ${{ inputs.branch == 'release-x.53.x' }}
+        working-directory: sdk
+        run: |
+          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-sdk-version]
@@ -420,13 +417,13 @@ jobs:
           ref: ${{ inputs.branch }}
 
       # Lightweight tags don't need committer name and email
-      # - name: Create and push SDK version tag
-      #   run: |
-      #     git tag ${{ env.tag }}
-      #     git push origin ${{ env.tag }}
+      - name: Create and push SDK version tag
+        run: |
+          git tag ${{ env.tag }}
+          git push origin ${{ env.tag }}
 
-      # - name: Create and push SDK stable version tag
-      #   if: ${{ startsWith(inputs.branch, 'release-x.') }}
-      #   run: |
-      #     git tag -f ${{ env.stable_tag }}
-      #     git push origin -f ${{ env.stable_tag }}
+      - name: Create and push SDK stable version tag
+        if: ${{ startsWith(inputs.branch, 'release-x.') }}
+        run: |
+          git tag -f ${{ env.stable_tag }}
+          git push origin -f ${{ env.stable_tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -121,210 +121,210 @@ jobs:
           - \`major_version\`: "${{ fromJson(steps.new-sdk-version.outputs.result).majorVersion }}"
           EOF
 
-  check-git-tag:
-    needs: determine-sdk-version
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    env:
-      tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
-    steps:
-      - name: Check out the code using the provided branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
-          fetch-depth: 0
-          fetch-tags: true
+  # check-git-tag:
+  #   needs: determine-sdk-version
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 20
+  #   env:
+  #     tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
+  #   steps:
+  #     - name: Check out the code using the provided branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.branch }}
+  #         fetch-depth: 0
+  #         fetch-tags: true
 
-      - name: check tags
-        run: |
-          if [ $(git tag -l | grep $tag$) ]
-          then
-            echo "::error::Tag '${{ env.tag }}' already exists. If you expect to run this workflow with the same tag, please remove the tag first and rerun this workflow again."
-            exit 1
-          else
-            exit 0
-          fi
+  #     - name: check tags
+  #       run: |
+  #         if [ $(git tag -l | grep $tag$) ]
+  #         then
+  #           echo "::error::Tag '${{ env.tag }}' already exists. If you expect to run this workflow with the same tag, please remove the tag first and rerun this workflow again."
+  #           exit 1
+  #         else
+  #           exit 0
+  #         fi
 
-  test:
-    needs: check-git-tag
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    steps:
-      - name: Check out the code using the provided branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
+  # test:
+  #   needs: check-git-tag
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 20
+  #   steps:
+  #     - name: Check out the code using the provided branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.branch }}
 
-      - name: Prepare front-end environment
-        uses: ./.github/actions/prepare-frontend
+  #     - name: Prepare front-end environment
+  #       uses: ./.github/actions/prepare-frontend
 
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "release-sdk"
+  #     - name: Prepare back-end environment
+  #       uses: ./.github/actions/prepare-backend
+  #       with:
+  #         m2-cache-key: "release-sdk"
 
-      - name: Run unit tests
-        run: yarn embedding-sdk:test-unit
+  #     - name: Run unit tests
+  #       run: yarn embedding-sdk:test-unit
 
-  build-sdk:
-    needs: [test, determine-sdk-version]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    steps:
-      - name: Check out the code using the provided branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
-          fetch-depth: 0
-          fetch-tags: true
+  # build-sdk:
+  #   needs: [test, determine-sdk-version]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 20
+  #   steps:
+  #     - name: Check out the code using the provided branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.branch }}
+  #         fetch-depth: 0
+  #         fetch-tags: true
 
-      - name: Prepare front-end environment
-        uses: ./.github/actions/prepare-frontend
+  #     - name: Prepare front-end environment
+  #       uses: ./.github/actions/prepare-frontend
 
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "release-sdk"
+  #     - name: Prepare back-end environment
+  #       uses: ./.github/actions/prepare-backend
+  #       with:
+  #         m2-cache-key: "release-sdk"
 
-      - name: Bump published npm package version
-        # NOTE: this should happen before "Build SDK bundle" as we inject SDK version into the code during build step
-        run: |
-          ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ needs.determine-sdk-version.outputs.sdk_version }}
+  #     - name: Bump published npm package version
+  #       # NOTE: this should happen before "Build SDK bundle" as we inject SDK version into the code during build step
+  #       run: |
+  #         ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ needs.determine-sdk-version.outputs.sdk_version }}
 
-      - name: Update changelog
-        run: |
-          yarn embedding-sdk:generate-changelog -o changelog-diff
+  #     - name: Update changelog
+  #       run: |
+  #         yarn embedding-sdk:generate-changelog -o changelog-diff
 
-      - name: Build SDK bundle
-        run: yarn run build-embedding-sdk
+  #     - name: Build SDK bundle
+  #       run: yarn run build-embedding-sdk
 
-      - name: Generate SDK package.json in the build directory
-        run: yarn run embedding-sdk:generate-package
+  #     - name: Generate SDK package.json in the build directory
+  #       run: yarn run embedding-sdk:generate-package
 
-      - name: Upload built SDK package as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: metabase-sdk
-          path: ./resources/embedding-sdk
+  #     - name: Upload built SDK package as artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: metabase-sdk
+  #         path: ./resources/embedding-sdk
 
-      - name: Upload changelog diff
-        uses: actions/upload-artifact@v4
-        with:
-          name: sdk-changelog-diff
-          path: ./changelog-diff
+  #     - name: Upload changelog diff
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: sdk-changelog-diff
+  #         path: ./changelog-diff
 
-  publish-npm:
-    needs: [build-sdk, determine-sdk-version]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    env:
-      sdk_version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
-    steps:
-      - name: Check out branch to prepare for a SDK version bump PR
-        uses: actions/checkout@v4
-        with:
-          # when we created version update PR, it would only have diff from 2 files SDK readme and SDK package.json template
-          ref: ${{ inputs.branch}}
+  # publish-npm:
+  #   needs: [build-sdk, determine-sdk-version]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 20
+  #   env:
+  #     sdk_version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
+  #   steps:
+  #     - name: Check out branch to prepare for a SDK version bump PR
+  #       uses: actions/checkout@v4
+  #       with:
+  #         # when we created version update PR, it would only have diff from 2 files SDK readme and SDK package.json template
+  #         ref: ${{ inputs.branch}}
 
-      - name: Setup git user
-        run: |
-          git config --global user.email "github-automation@metabase.com"
-          git config --global user.name "Metabase Automation"
+  #     - name: Setup git user
+  #       run: |
+  #         git config --global user.email "github-automation@metabase.com"
+  #         git config --global user.name "Metabase Automation"
 
-      - name: Update readme
-        run: |
-          bash ./bin/embedding-sdk/release_utils.bash update_readme ${{ env.sdk_version }}
+  #     - name: Update readme
+  #       run: |
+  #         bash ./bin/embedding-sdk/release_utils.bash update_readme ${{ env.sdk_version }}
 
-      - name: Bump published npm package version
-        run: |
-          bash ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ env.sdk_version }}
+  #     - name: Bump published npm package version
+  #       run: |
+  #         bash ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ env.sdk_version }}
 
-      - name: Retrieve SDK changelog diff
-        uses: actions/download-artifact@v4
-        with:
-          name: sdk-changelog-diff
+  #     - name: Retrieve SDK changelog diff
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: sdk-changelog-diff
 
-      - name: Update changelog
-        run: |
-          cat changelog-diff enterprise/frontend/src/embedding-sdk/CHANGELOG.md > new-changelog
-          mv new-changelog enterprise/frontend/src/embedding-sdk/CHANGELOG.md
+  #     - name: Update changelog
+  #       run: |
+  #         cat changelog-diff enterprise/frontend/src/embedding-sdk/CHANGELOG.md > new-changelog
+  #         mv new-changelog enterprise/frontend/src/embedding-sdk/CHANGELOG.md
 
-      - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
-        run: |
-          git checkout -b update-sdk-version-${{ env.sdk_version }}
-          git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
-          git push origin HEAD
-          gh pr create --base ${{ inputs.branch }}\
-                       --assignee "${GITHUB_ACTOR}"\
-                       --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
-                       --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+  #     - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
+  #       run: |
+  #         git checkout -b update-sdk-version-${{ env.sdk_version }}
+  #         git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
+  #         git push origin HEAD
+  #         gh pr create --base ${{ inputs.branch }}\
+  #                      --assignee "${GITHUB_ACTOR}"\
+  #                      --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
+  #                      --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
+  #       env:
+  #         GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
-          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+  #     - uses: actions/create-github-app-token@v1
+  #       id: app-token
+  #       with:
+  #         app-id: ${{ secrets.METABASE_BOT_APP_ID }}
+  #         private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
 
-      - name: Edit PR adding useful information (using Metabase bot app)
-        run: |
-          gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+  #     - name: Edit PR adding useful information (using Metabase bot app)
+  #       run: |
+  #         gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
+  #       env:
+  #         GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Auto approve PR (using GitHub Actions account)
-        run: |
-          gh pr review --approve
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Auto approve PR (using GitHub Actions account)
+  #       run: |
+  #         gh pr review --approve
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-        run: |
-          gh pr merge --auto --squash
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+  #     - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+  #       run: |
+  #         gh pr merge --auto --squash
+  #       env:
+  #         GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      - name: Retrieve build SDK package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: metabase-sdk
-          path: sdk
+  #     - name: Retrieve build SDK package artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: metabase-sdk
+  #         path: sdk
 
-      - name: Publish to NPM
-        working-directory: sdk
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-          # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
+  #     - name: Publish to NPM
+  #       working-directory: sdk
+  #       run: |
+  #         echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+  #         # Please keep the value in sync with `inputs.branch`'s release branch
+  #         npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-        if: ${{ inputs.branch == 'release-x.53.x' }}
-        working-directory: sdk
-        run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+  #     - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
+  #       if: ${{ inputs.branch == 'release-x.53.x' }}
+  #       working-directory: sdk
+  #       run: |
+  #         npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
-  git-tag:
-    needs: [publish-npm, determine-sdk-version]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    env:
-      tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
-      stable_tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.major_version }}-stable
-    steps:
-      - name: Check out the code using the provided branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
+  # git-tag:
+  #   needs: [publish-npm, determine-sdk-version]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 20
+  #   env:
+  #     tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
+  #     stable_tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.major_version }}-stable
+  #   steps:
+  #     - name: Check out the code using the provided branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.branch }}
 
-      # Lightweight tags don't need committer name and email
-      - name: Create and push SDK version tag
-        run: |
-          git tag ${{ env.tag }}
-          git push origin ${{ env.tag }}
+  #     # Lightweight tags don't need committer name and email
+  #     - name: Create and push SDK version tag
+  #       run: |
+  #         git tag ${{ env.tag }}
+  #         git push origin ${{ env.tag }}
 
-      - name: Create and push SDK stable version tag
-        if: ${{ startsWith(inputs.branch, 'release-x.') }}
-        run: |
-          git tag -f ${{ env.stable_tag }}
-          git push origin -f ${{ env.stable_tag }}
+  #     - name: Create and push SDK stable version tag
+  #       if: ${{ startsWith(inputs.branch, 'release-x.') }}
+  #       run: |
+  #         git tag -f ${{ env.stable_tag }}
+  #         git push origin -f ${{ env.stable_tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -37,8 +37,7 @@ jobs:
           triggered by: @${{ github.event.sender.login }}
           EOF
 
-  determine-version:
-    name: Determine SDK version
+  determine-sdk-version:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     outputs:
@@ -91,11 +90,11 @@ jobs:
           EOF
 
   check-git-tag:
-    needs: determine-version
+    needs: determine-sdk-version
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
-      tag: embedding-sdk-${{ needs.determine-version.outputs.sdk_version }}
+      tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
     steps:
       - name: Check out the code using the provided branch
         uses: actions/checkout@v4
@@ -136,7 +135,7 @@ jobs:
         run: yarn embedding-sdk:test-unit
 
   build-sdk:
-    needs: [test, determine-version]
+    needs: [test, determine-sdk-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -158,7 +157,7 @@ jobs:
       - name: Bump published npm package version
         # NOTE: this should happen before "Build SDK bundle" as we inject SDK version into the code during build step
         run: |
-          ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ needs.determine-version.outputs.sdk_version }}
+          ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ needs.determine-sdk-version.outputs.sdk_version }}
 
       - name: Update changelog
         run: |
@@ -183,11 +182,11 @@ jobs:
           path: ./changelog-diff
 
   publish-npm:
-    needs: [build-sdk, determine-version]
+    needs: [build-sdk, determine-sdk-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
-      sdk_version: ${{ needs.determine-version.outputs.sdk_version }}
+      sdk_version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
     steps:
       - name: Check out branch to prepare for a SDK version bump PR
         uses: actions/checkout@v4
@@ -274,12 +273,12 @@ jobs:
           npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
-    needs: [publish-npm, determine-version]
+    needs: [publish-npm, determine-sdk-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
-      tag: embedding-sdk-${{ needs.determine-version.outputs.sdk_version }}
-      stable_tag: embedding-sdk-${{ needs.determine-version.outputs.major_version }}-stable
+      tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
+      stable_tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.major_version }}-stable
     steps:
       - name: Check out the code using the provided branch
         uses: actions/checkout@v4

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -262,8 +262,8 @@ jobs:
         with:
           m2-cache-key: "release-sdk"
 
-      - name: Run unit tests
-        run: yarn embedding-sdk:test-unit
+      # - name: Run unit tests
+      #   run: yarn embedding-sdk:test-unit
 
   build-sdk:
     needs: [test, determine-sdk-version]
@@ -294,17 +294,17 @@ jobs:
         run: |
           yarn embedding-sdk:generate-changelog -o changelog-diff
 
-      - name: Build SDK bundle
-        run: yarn run build-embedding-sdk
+      # - name: Build SDK bundle
+      #   run: yarn run build-embedding-sdk
 
       - name: Generate SDK package.json in the build directory
         run: yarn run embedding-sdk:generate-package
 
-      - name: Upload built SDK package as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: metabase-sdk
-          path: ./resources/embedding-sdk
+      # - name: Upload built SDK package as artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: metabase-sdk
+      #     path: ./resources/embedding-sdk
 
       - name: Upload changelog diff
         uses: actions/upload-artifact@v4
@@ -348,60 +348,60 @@ jobs:
           cat changelog-diff enterprise/frontend/src/embedding-sdk/CHANGELOG.md > new-changelog
           mv new-changelog enterprise/frontend/src/embedding-sdk/CHANGELOG.md
 
-      - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
-        run: |
-          git checkout -b update-sdk-version-${{ env.sdk_version }}
-          git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
-          git push origin HEAD
-          gh pr create --base ${{ inputs.branch }}\
-                       --assignee "${GITHUB_ACTOR}"\
-                       --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
-                       --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      # - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
+      #   run: |
+      #     git checkout -b update-sdk-version-${{ env.sdk_version }}
+      #     git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
+      #     git push origin HEAD
+      #     gh pr create --base ${{ inputs.branch }}\
+      #                  --assignee "${GITHUB_ACTOR}"\
+      #                  --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
+      #                  --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
+      #   env:
+      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
-          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+      # - uses: actions/create-github-app-token@v1
+      #   id: app-token
+      #   with:
+      #     app-id: ${{ secrets.METABASE_BOT_APP_ID }}
+      #     private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
 
-      - name: Edit PR adding useful information (using Metabase bot app)
-        run: |
-          gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      # - name: Edit PR adding useful information (using Metabase bot app)
+      #   run: |
+      #     gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Auto approve PR (using GitHub Actions account)
-        run: |
-          gh pr review --approve
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Auto approve PR (using GitHub Actions account)
+      #   run: |
+      #     gh pr review --approve
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-        run: |
-          gh pr merge --auto --squash
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+      #   run: |
+      #     gh pr merge --auto --squash
+      #   env:
+      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      - name: Retrieve build SDK package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: metabase-sdk
-          path: sdk
+      # - name: Retrieve build SDK package artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: metabase-sdk
+      #     path: sdk
 
-      - name: Publish to NPM
-        working-directory: sdk
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-          # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
+      # - name: Publish to NPM
+      #   working-directory: sdk
+      #   run: |
+      #     echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+      #     # Please keep the value in sync with `inputs.branch`'s release branch
+      #     npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-        if: ${{ inputs.branch == 'release-x.53.x' }}
-        working-directory: sdk
-        run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+      # - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
+      #   if: ${{ inputs.branch == 'release-x.53.x' }}
+      #   working-directory: sdk
+      #   run: |
+      #     npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-sdk-version]
@@ -417,13 +417,13 @@ jobs:
           ref: ${{ inputs.branch }}
 
       # Lightweight tags don't need committer name and email
-      - name: Create and push SDK version tag
-        run: |
-          git tag ${{ env.tag }}
-          git push origin ${{ env.tag }}
+      # - name: Create and push SDK version tag
+      #   run: |
+      #     git tag ${{ env.tag }}
+      #     git push origin ${{ env.tag }}
 
-      - name: Create and push SDK stable version tag
-        if: ${{ startsWith(inputs.branch, 'release-x.') }}
-        run: |
-          git tag -f ${{ env.stable_tag }}
-          git push origin -f ${{ env.stable_tag }}
+      # - name: Create and push SDK stable version tag
+      #   if: ${{ startsWith(inputs.branch, 'release-x.') }}
+      #   run: |
+      #     git tag -f ${{ env.stable_tag }}
+      #     git push origin -f ${{ env.stable_tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -78,7 +78,7 @@ jobs:
             );
             const body = `${runLink} - run by ${mentionUserByGithubLogin("${{ github.event.sender.login }}")}`
             const sendSlackMessageResponse = await sendSlackMessage({
-              channelName: process.env.SLACK_RELEASE_CHANNEL,
+              channelName: 'proj-embedding-sdk',
               message: `${title}\n${body}`,
             });
 
@@ -125,7 +125,7 @@ jobs:
               context.repo.repo,
             );
             sendSlackReply({
-              channelName: 'bot-testing',
+              channelName: 'proj-embedding-sdk',
               message: runLink,
               messageId: ${{ env.slackMessageId}},
               broadcast: true
@@ -162,7 +162,7 @@ jobs:
               context.repo.repo,
             );
             sendSlackReply({
-              channelName: 'bot-testing',
+              channelName: 'proj-embedding-sdk',
               message: runLink,
               messageId: ${{ env.slackMessageId}},
               broadcast: true

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -87,19 +87,21 @@ jobs:
   # Technically this should be placed last, since it runs after other jobs, but I want to co-locate all Slack jobs
   send-slack-notification-failure:
     name: "Send Slack notification: SDK release failed"
-    needs: [
+    needs:
+      [
         "determine-sdk-version",
         "send-slack-notification-start",
-        # "check-git-tag",
-        # "test",
-        # "build-sdk",
-        # "publish-npm",
-        # "git-tag",
+        "check-git-tag",
+        "test",
+        "build-sdk",
+        "publish-npm",
+        "git-tag",
       ]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     env:
       slackMessageId: ${{ needs.send-slack-notification-start.outputs.slackMessageId }}
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Retrieve build scripts
         uses: actions/download-artifact@v4
@@ -131,7 +133,8 @@ jobs:
 
   send-slack-notification-successful:
     name: "Send Slack notification: SDK release successful"
-    needs: ["determine-sdk-version", "send-slack-notification-start"]
+    needs:
+      ["determine-sdk-version", "send-slack-notification-start", "publish-npm"]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     env:
@@ -217,210 +220,210 @@ jobs:
           - \`major_version\`: "${{ fromJson(steps.new-sdk-version.outputs.result).majorVersion }}"
           EOF
 
-  # check-git-tag:
-  #   needs: determine-sdk-version
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 20
-  #   env:
-  #     tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
-  #   steps:
-  #     - name: Check out the code using the provided branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.branch }}
-  #         fetch-depth: 0
-  #         fetch-tags: true
+  check-git-tag:
+    needs: determine-sdk-version
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
+    steps:
+      - name: Check out the code using the provided branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+          fetch-tags: true
 
-  #     - name: check tags
-  #       run: |
-  #         if [ $(git tag -l | grep $tag$) ]
-  #         then
-  #           echo "::error::Tag '${{ env.tag }}' already exists. If you expect to run this workflow with the same tag, please remove the tag first and rerun this workflow again."
-  #           exit 1
-  #         else
-  #           exit 0
-  #         fi
+      - name: check tags
+        run: |
+          if [ $(git tag -l | grep $tag$) ]
+          then
+            echo "::error::Tag '${{ env.tag }}' already exists. If you expect to run this workflow with the same tag, please remove the tag first and rerun this workflow again."
+            exit 1
+          else
+            exit 0
+          fi
 
-  # test:
-  #   needs: check-git-tag
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 20
-  #   steps:
-  #     - name: Check out the code using the provided branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.branch }}
+  test:
+    needs: check-git-tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out the code using the provided branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
-  #     - name: Prepare front-end environment
-  #       uses: ./.github/actions/prepare-frontend
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
 
-  #     - name: Prepare back-end environment
-  #       uses: ./.github/actions/prepare-backend
-  #       with:
-  #         m2-cache-key: "release-sdk"
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "release-sdk"
 
-  #     - name: Run unit tests
-  #       run: yarn embedding-sdk:test-unit
+      - name: Run unit tests
+        run: yarn embedding-sdk:test-unit
 
-  # build-sdk:
-  #   needs: [test, determine-sdk-version]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 20
-  #   steps:
-  #     - name: Check out the code using the provided branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.branch }}
-  #         fetch-depth: 0
-  #         fetch-tags: true
+  build-sdk:
+    needs: [test, determine-sdk-version]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out the code using the provided branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+          fetch-tags: true
 
-  #     - name: Prepare front-end environment
-  #       uses: ./.github/actions/prepare-frontend
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
 
-  #     - name: Prepare back-end environment
-  #       uses: ./.github/actions/prepare-backend
-  #       with:
-  #         m2-cache-key: "release-sdk"
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "release-sdk"
 
-  #     - name: Bump published npm package version
-  #       # NOTE: this should happen before "Build SDK bundle" as we inject SDK version into the code during build step
-  #       run: |
-  #         ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ needs.determine-sdk-version.outputs.sdk_version }}
+      - name: Bump published npm package version
+        # NOTE: this should happen before "Build SDK bundle" as we inject SDK version into the code during build step
+        run: |
+          ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ needs.determine-sdk-version.outputs.sdk_version }}
 
-  #     - name: Update changelog
-  #       run: |
-  #         yarn embedding-sdk:generate-changelog -o changelog-diff
+      - name: Update changelog
+        run: |
+          yarn embedding-sdk:generate-changelog -o changelog-diff
 
-  #     - name: Build SDK bundle
-  #       run: yarn run build-embedding-sdk
+      - name: Build SDK bundle
+        run: yarn run build-embedding-sdk
 
-  #     - name: Generate SDK package.json in the build directory
-  #       run: yarn run embedding-sdk:generate-package
+      - name: Generate SDK package.json in the build directory
+        run: yarn run embedding-sdk:generate-package
 
-  #     - name: Upload built SDK package as artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: metabase-sdk
-  #         path: ./resources/embedding-sdk
+      - name: Upload built SDK package as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: metabase-sdk
+          path: ./resources/embedding-sdk
 
-  #     - name: Upload changelog diff
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: sdk-changelog-diff
-  #         path: ./changelog-diff
+      - name: Upload changelog diff
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-changelog-diff
+          path: ./changelog-diff
 
-  # publish-npm:
-  #   needs: [build-sdk, determine-sdk-version]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 20
-  #   env:
-  #     sdk_version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
-  #   steps:
-  #     - name: Check out branch to prepare for a SDK version bump PR
-  #       uses: actions/checkout@v4
-  #       with:
-  #         # when we created version update PR, it would only have diff from 2 files SDK readme and SDK package.json template
-  #         ref: ${{ inputs.branch}}
+  publish-npm:
+    needs: [build-sdk, determine-sdk-version]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      sdk_version: ${{ needs.determine-sdk-version.outputs.sdk_version }}
+    steps:
+      - name: Check out branch to prepare for a SDK version bump PR
+        uses: actions/checkout@v4
+        with:
+          # when we created version update PR, it would only have diff from 2 files SDK readme and SDK package.json template
+          ref: ${{ inputs.branch}}
 
-  #     - name: Setup git user
-  #       run: |
-  #         git config --global user.email "github-automation@metabase.com"
-  #         git config --global user.name "Metabase Automation"
+      - name: Setup git user
+        run: |
+          git config --global user.email "github-automation@metabase.com"
+          git config --global user.name "Metabase Automation"
 
-  #     - name: Update readme
-  #       run: |
-  #         bash ./bin/embedding-sdk/release_utils.bash update_readme ${{ env.sdk_version }}
+      - name: Update readme
+        run: |
+          bash ./bin/embedding-sdk/release_utils.bash update_readme ${{ env.sdk_version }}
 
-  #     - name: Bump published npm package version
-  #       run: |
-  #         bash ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ env.sdk_version }}
+      - name: Bump published npm package version
+        run: |
+          bash ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ env.sdk_version }}
 
-  #     - name: Retrieve SDK changelog diff
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: sdk-changelog-diff
+      - name: Retrieve SDK changelog diff
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-changelog-diff
 
-  #     - name: Update changelog
-  #       run: |
-  #         cat changelog-diff enterprise/frontend/src/embedding-sdk/CHANGELOG.md > new-changelog
-  #         mv new-changelog enterprise/frontend/src/embedding-sdk/CHANGELOG.md
+      - name: Update changelog
+        run: |
+          cat changelog-diff enterprise/frontend/src/embedding-sdk/CHANGELOG.md > new-changelog
+          mv new-changelog enterprise/frontend/src/embedding-sdk/CHANGELOG.md
 
-  #     - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
-  #       run: |
-  #         git checkout -b update-sdk-version-${{ env.sdk_version }}
-  #         git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
-  #         git push origin HEAD
-  #         gh pr create --base ${{ inputs.branch }}\
-  #                      --assignee "${GITHUB_ACTOR}"\
-  #                      --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
-  #                      --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
-  #       env:
-  #         GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
+        run: |
+          git checkout -b update-sdk-version-${{ env.sdk_version }}
+          git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
+          git push origin HEAD
+          gh pr create --base ${{ inputs.branch }}\
+                       --assignee "${GITHUB_ACTOR}"\
+                       --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
+                       --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-  #     - uses: actions/create-github-app-token@v1
-  #       id: app-token
-  #       with:
-  #         app-id: ${{ secrets.METABASE_BOT_APP_ID }}
-  #         private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
 
-  #     - name: Edit PR adding useful information (using Metabase bot app)
-  #       run: |
-  #         gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
-  #       env:
-  #         GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Edit PR adding useful information (using Metabase bot app)
+        run: |
+          gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-  #     - name: Auto approve PR (using GitHub Actions account)
-  #       run: |
-  #         gh pr review --approve
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto approve PR (using GitHub Actions account)
+        run: |
+          gh pr review --approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-  #       run: |
-  #         gh pr merge --auto --squash
-  #       env:
-  #         GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+        run: |
+          gh pr merge --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-  #     - name: Retrieve build SDK package artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: metabase-sdk
-  #         path: sdk
+      - name: Retrieve build SDK package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: metabase-sdk
+          path: sdk
 
-  #     - name: Publish to NPM
-  #       working-directory: sdk
-  #       run: |
-  #         echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-  #         # Please keep the value in sync with `inputs.branch`'s release branch
-  #         npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
+      - name: Publish to NPM
+        working-directory: sdk
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+          # Please keep the value in sync with `inputs.branch`'s release branch
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-  #     - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-  #       if: ${{ inputs.branch == 'release-x.53.x' }}
-  #       working-directory: sdk
-  #       run: |
-  #         npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
+        if: ${{ inputs.branch == 'release-x.53.x' }}
+        working-directory: sdk
+        run: |
+          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
-  # git-tag:
-  #   needs: [publish-npm, determine-sdk-version]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 20
-  #   env:
-  #     tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
-  #     stable_tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.major_version }}-stable
-  #   steps:
-  #     - name: Check out the code using the provided branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.branch }}
+  git-tag:
+    needs: [publish-npm, determine-sdk-version]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.sdk_version }}
+      stable_tag: embedding-sdk-${{ needs.determine-sdk-version.outputs.major_version }}-stable
+    steps:
+      - name: Check out the code using the provided branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
-  #     # Lightweight tags don't need committer name and email
-  #     - name: Create and push SDK version tag
-  #       run: |
-  #         git tag ${{ env.tag }}
-  #         git push origin ${{ env.tag }}
+      # Lightweight tags don't need committer name and email
+      - name: Create and push SDK version tag
+        run: |
+          git tag ${{ env.tag }}
+          git push origin ${{ env.tag }}
 
-  #     - name: Create and push SDK stable version tag
-  #       if: ${{ startsWith(inputs.branch, 'release-x.') }}
-  #       run: |
-  #         git tag -f ${{ env.stable_tag }}
-  #         git push origin -f ${{ env.stable_tag }}
+      - name: Create and push SDK stable version tag
+        if: ${{ startsWith(inputs.branch, 'release-x.') }}
+        run: |
+          git tag -f ${{ env.stable_tag }}
+          git push origin -f ${{ env.stable_tag }}

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -195,7 +195,7 @@ async function getExistingSlackMessage(version: string, channelName: string) {
   };
 }
 
-async function sendSlackReply({ channelName, message, messageId, broadcast }: {channelName: string, message: string, messageId?: string, broadcast?: boolean}) {
+export async function sendSlackReply({ channelName, message, messageId, broadcast }: {channelName: string, message: string, messageId?: string, broadcast?: boolean}) {
   const channelId = await getSlackChannelId(channelName);
   if (!channelId) {
     throw new Error(`Could not find channel ${channelName}`);
@@ -216,7 +216,7 @@ export function slackLink(text: string, url: string) {
   return `<${url}|${text}>`;
 }
 
-function githubRunLink(
+export function githubRunLink(
   text: string,
   runId: string,
   owner: string,

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -156,7 +156,7 @@ export async function sendPreReleaseStatus({
   });
 }
 
-function sendSlackMessage({ channelName = SLACK_CHANNEL_NAME, message }: { channelName?: string, message: string }) {
+export function sendSlackMessage({ channelName = SLACK_CHANNEL_NAME, message }: { channelName?: string, message: string }) {
   return slack.chat.postMessage({
     channel: channelName,
     text: message,


### PR DESCRIPTION
Closes EMB-222, EMB-164

### Description

Send notification status to Slack when releasing the SDK
- A notification when the release has been started
- A status when the release has been published
- A status when the release is complete

### How to verify
See these runs
- [Mock successful run](https://github.com/metabase/metabase/actions/runs/13677791183), [Slack message](https://metaboat.slack.com/archives/C01BWAZJE0N/p1741183536078189)
- [Mock failed run](https://github.com/metabase/metabase/actions/runs/13677959403/job/38242847724), [Slack message](https://metaboat.slack.com/archives/C01BWAZJE0N/p1741184026637769)

### Demo
<img width="430" alt="image" src="https://github.com/user-attachments/assets/7c123679-9cd6-44df-af29-79d34fceebeb" />
