### PR TITLE
Closes VIZ-469 Better DND experience for Pie in the visualizer

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -159,7 +159,7 @@ function DashCardActionsPanelInner({
           key="visualizer-button"
           card={series[0].card}
           dashcard={dashcard}
-          columns={series[0].data.cols}
+          columns={series[0].data?.cols ?? []}
         />,
       );
     } else if (!disableSettingsConfig) {

--- a/frontend/src/metabase/visualizer/utils/update-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/update-settings-for-display.ts
@@ -6,14 +6,16 @@ import type {
 } from "metabase-types/api";
 import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
 
+type ColumnValuesMapping = Record<string, VisualizerColumnValueSource[]>;
+
 export function updateSettingsForDisplay(
-  columnValuesMapping: Record<string, VisualizerColumnValueSource[]>,
+  columnValuesMapping: ColumnValuesMapping,
   columns: DatasetColumn[],
   settings: VisualizationSettings,
   sourceDisplay: VisualizationDisplay | null,
   targetDisplay: VisualizationDisplay | null,
 ): {
-  columnValuesMapping: Record<string, VisualizerColumnValueSource[]>;
+  columnValuesMapping: ColumnValuesMapping;
   columns: DatasetColumn[];
   settings: VisualizationSettings;
 } {
@@ -46,9 +48,23 @@ export function updateSettingsForDisplay(
         ...otherSettings
       } = settings;
 
+      const metric = metrics?.[0];
+      const dimension = dimensions?.[0];
+      const newColumns = columns.filter(
+        column => column.name === metric || column.name === dimension,
+      );
+
+      const newColumnValuesMapping: ColumnValuesMapping = {};
+      if (metric) {
+        newColumnValuesMapping[metric] = columnValuesMapping[metric];
+      }
+      if (dimension) {
+        newColumnValuesMapping[dimension] = columnValuesMapping[dimension];
+      }
+
       return {
-        columnValuesMapping,
-        columns,
+        columnValuesMapping: newColumnValuesMapping,
+        columns: newColumns,
         settings: {
           ...otherSettings,
           "pie.metric": metrics?.[0] ?? "",

--- a/frontend/src/metabase/visualizer/utils/update-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/update-settings-for-display.unit.spec.ts
@@ -70,8 +70,8 @@ describe("updateSettingsForDisplay", () => {
 
   it("should work if sourceDisplay is cartesian and targetDisplay is pie", () => {
     const settings = {
-      "graph.metrics": ["count"],
-      "graph.dimensions": ["category"],
+      "graph.metrics": ["COLUMN_2"],
+      "graph.dimensions": ["COLUMN_1"],
     };
     const sourceDisplay = "line";
     const targetDisplay = "pie";
@@ -86,16 +86,48 @@ describe("updateSettingsForDisplay", () => {
       columnValuesMapping,
       columns,
       settings: {
-        "pie.metric": "count",
-        "pie.dimension": "category",
+        "pie.metric": "COLUMN_2",
+        "pie.dimension": "COLUMN_1",
+      },
+    });
+  });
+
+  it("should remove unnecessary columns if sourceDisplay is cartesian and targetDisplay is pie", () => {
+    const settings = {
+      "graph.metrics": ["COLUMN_2"],
+      "graph.dimensions": ["COLUMN_1"],
+    };
+    const sourceDisplay = "line";
+    const targetDisplay = "pie";
+    const result = updateSettingsForDisplay(
+      {
+        ...columnValuesMapping,
+        COLUMN_3: [
+          { sourceId: "card:45", originalName: "category", name: "COLUMN_3" },
+        ],
+      },
+      [
+        ...columns,
+        createMockColumn({ name: "COLUMN_3", display_name: "Category" }),
+      ],
+      settings,
+      sourceDisplay,
+      targetDisplay,
+    );
+    expect(result).toEqual({
+      columnValuesMapping,
+      columns,
+      settings: {
+        "pie.metric": "COLUMN_2",
+        "pie.dimension": "COLUMN_1",
       },
     });
   });
 
   it("should work if sourceDisplay is pie and targetDisplay is cartesian", () => {
     const settings = {
-      "pie.metric": "count",
-      "pie.dimension": "category",
+      "pie.metric": "COLUMN_2",
+      "pie.dimension": "COLUMN_1",
     };
     const sourceDisplay = "pie";
     const targetDisplay = "line";
@@ -110,8 +142,8 @@ describe("updateSettingsForDisplay", () => {
       columnValuesMapping,
       columns,
       settings: {
-        "graph.metrics": ["count"],
-        "graph.dimensions": ["category"],
+        "graph.metrics": ["COLUMN_2"],
+        "graph.dimensions": ["COLUMN_1"],
       },
     });
   });

--- a/frontend/src/metabase/visualizer/visualizations/pie.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.ts
@@ -3,7 +3,6 @@ import type { DragEndEvent } from "@dnd-kit/core";
 import { isNotNull } from "metabase/lib/types";
 import { DROPPABLE_ID } from "metabase/visualizer/constants";
 import {
-  addColumnMapping,
   copyColumn,
   createVisualizerColumnReference,
   extractReferencedColumns,
@@ -41,10 +40,7 @@ export const pieDropHandler = (
     }
 
     if (metricColumnName) {
-      state.columnValuesMapping[metricColumnName] = addColumnMapping(
-        state.columnValuesMapping[metricColumnName],
-        columnRef,
-      );
+      state.columnValuesMapping[metricColumnName] = [columnRef];
     }
   }
 


### PR DESCRIPTION
Closes [VIZ-469: Switching to a pie chart from a multi question viz causes drag and drop issues](https://linear.app/metabase/issue/VIZ-469/switching-to-a-pie-chart-from-a-multi-question-viz-causes-drag-and)

### Description
Addresses two issues:
 - switching to a pie chart from a multi-series cartesian chart is now hadnled more gracefully (i.e. no ghost columns)
 - dnd'ing columns over to a pie chart's metric well actually replaces the current metric (again, no ghost columns)