### PR TITLE
Distinguish temporal types and add semantic type

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -22,10 +22,12 @@
   [column]
   (let [column (u/normalize-map column)]
     (cond
-      (lib.types.isa/boolean? column)               "boolean"
-      (lib.types.isa/string-or-string-like? column) "string"
-      (lib.types.isa/numeric? column)               "number"
-      (lib.types.isa/temporal? column)              "date")))
+      (lib.types.isa/boolean? column)                "boolean"
+      (lib.types.isa/string-or-string-like? column)  "string"
+      (lib.types.isa/numeric? column)                "number"
+      (isa? (:effective-type column) :type/DateTime) "datetime"
+      (isa? (:effective-type column) :type/Time)     "time"
+      (lib.types.isa/temporal? column)               "date")))
 
 (defn table-field-id-prefix
   "Return the field ID prefix for `table-id`."
@@ -60,11 +62,13 @@
   [query column index-or-columns field-id-prefix]
   (let [pos (if (sequential? index-or-columns)
               (first (find-column-indexes column index-or-columns))
-              index-or-columns)]
+              index-or-columns)
+        semantic-type (:semantic-type column)]
     (-> {:field_id (str field-id-prefix pos)
          :name (lib/display-name query -1 column :long)
          :type (convert-field-type column)}
-        (m/assoc-some :description (get column :description)))))
+        (m/assoc-some :description (get column :description)
+                      :semantic_type (some-> semantic-type name u/->snake_case_en)))))
 
 (defn resolve-column-index
   "Resolve the reference `field_id` to the index of the result columns in the entity with `field-id-prefix`."

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -211,7 +211,7 @@
                                                                {:name "Vendor", :type "string"}
                                                                {:name "Price", :type "number"}
                                                                {:name "Rating", :type "number"}
-                                                               {:name "Created At", :type "date"}])))
+                                                               {:name "Created At", :type "datetime"}])))
                    :conversation_id conversation-id}
                   response)))))))
 
@@ -234,7 +234,7 @@
                                    :query_id string?
                                    :query query
                                    :result_columns
-                                   [{:field_id (str "q" generated-id "/0"), :name "Created At: Week", :type "date"}
+                                   [{:field_id (str "q" generated-id "/0"), :name "Created At: Week", :type "datetime"}
                                     {:field_id (str "q" generated-id "/1"), :name "Average of Rating", :type "number"}]}
                :conversation_id conversation-id}
               ;; normalize query to convert strings like "field" to keywords
@@ -263,7 +263,7 @@
                                           (assoc :id question-id
                                                  :result_columns
                                                  (map-indexed #(assoc %2 :field_id (format "c%d/%d" question-id %1))
-                                                              [{:name "Created At: Week", :type "date"}
+                                                              [{:name "Created At: Week", :type "datetime"}
                                                                {:name "Average of Rating", :type "number"}])))
                    :conversation_id conversation-id}
                   response)))))))
@@ -293,7 +293,7 @@
                                             (assoc :id (str "card__" model-id)
                                                    :fields
                                                    (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-id %1))
-                                                                [{:name "Created At: Week", :type "date"}
+                                                                [{:name "Created At: Week", :type "datetime"}
                                                                  {:name "Average of Rating", :type "number"}])))
                      :conversation_id conversation-id}
                     response))))))))
@@ -311,13 +311,13 @@
           (is (=? {:structured_output {:name "Products"
                                        :id (str table-id)
                                        :fields (map-indexed #(assoc %2 :field_id (format "t%d/%d" table-id %1))
-                                                            [{:name "ID", :type "number"}
+                                                            [{:name "ID", :type "number", :semantic_type "pk"}
                                                              {:name "Ean", :type "string"}
-                                                             {:name "Title", :type "string"}
-                                                             {:name "Category", :type "string"}
-                                                             {:name "Vendor", :type "string"}
+                                                             {:name "Title", :type "string", :semantic_type "title"}
+                                                             {:name "Category", :type "string", :semantic_type "category"}
+                                                             {:name "Vendor", :type "string", :semantic_type "company"}
                                                              {:name "Price", :type "number"}
-                                                             {:name "Rating", :type "number"}
-                                                             {:name "Created At", :type "date"}])}
+                                                             {:name "Rating", :type "number", :semantic_type "score"}
+                                                             {:name "Created At", :type "datetime", :semantic_type "creation_timestamp"}])}
                    :conversation_id conversation-id}
                   response)))))))


### PR DESCRIPTION
Fixes BOT-56.
Depends on BOT-59.

This PR distinguishes `datetime`, `date`, and `time` temporal columns. `date` columns have no time component, `time` columns have no date component, `datetime` columns have both date and time  components.

Fields get a new `semantic_type` property whenever the semantic type is known.