### PR TITLE
Fix token unescaping in the expression editor

### DIFF
--- a/e2e/support/helpers/e2e-custom-column-helpers.ts
+++ b/e2e/support/helpers/e2e-custom-column-helpers.ts
@@ -171,7 +171,7 @@ export const CustomExpressionEditor = {
       const unexpanded = part.replaceAll(/→/g, "->");
 
       const alphabet =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789^[]()-,.;_!@#$%&*+=/<>\" ':;";
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789^[]()-,.;_!@#$%&*+=/<>\" ':;\\";
       if (unexpanded.split("").some(char => !alphabet.includes(char))) {
         throw new Error(
           `unknown character in CustomExpressionEditor.type in ${part}`,

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
@@ -106,7 +106,7 @@ function recursiveParse(source) {
     }
 
     // for string literal, remove its enclosing quotes
-    return type === TOKEN.String ? shrink(text) : parseFloat(text);
+    return type === TOKEN.String ? token.value : parseFloat(text);
   };
 
   // Unary ::= Primary |

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
@@ -25,6 +25,7 @@ describe("recursive-parser", () => {
   it("should parse string literals", () => {
     expect(process("'Universe'")).toEqual("Universe");
     expect(process('"answer"')).toEqual("answer");
+    expect(process('"\\""')).toEqual('"');
   });
 
   it("should parse field references", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/53527

How to verify:
- New -> SQL query -> `SELECT 'a"b' AS TEXT` -> Save AS Q1
- New -> Question -> Collections -> Q1 -> Custom column -> `replace([TEXT], "\"", "")` -> Visualize
- Make sure that the quotes were removed