### PR TITLE
Use grid + transitions for visualizer modal

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -34,6 +34,7 @@ export const BaseChartSettings = ({
   widgets,
   chartSettings,
   transformedSeries,
+  className,
   ...stackProps
 }: BaseChartSettingsProps) => {
   const {
@@ -194,7 +195,7 @@ export const BaseChartSettings = ({
         data-testid="chartsettings-sidebar"
         h="100%"
         gap={0}
-        className={CS.overflowHidden}
+        className={`${CS.overflowHidden} ${className}`}
         {...stackProps}
       >
         {showSectionPicker && (

--- a/frontend/src/metabase/visualizations/components/ChartSettings/QuestionChartSettings/QuestionChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/QuestionChartSettings/QuestionChartSettings.tsx
@@ -14,7 +14,8 @@ export const QuestionChartSettings = ({
   onChange,
   computedSettings,
   initial,
-}: QuestionChartSettingsProps) => {
+  className,
+}: QuestionChartSettingsProps & { className?: string }) => {
   const { chartSettings, handleChangeSettings, transformedSeries } =
     useChartSettingsState({ series, onChange });
 
@@ -39,6 +40,7 @@ export const QuestionChartSettings = ({
       chartSettings={chartSettings}
       transformedSeries={transformedSeries}
       widgets={widgets}
+      className={className}
       w="100%"
     />
   );

--- a/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
+++ b/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
@@ -17,7 +17,7 @@ import { VisualizationPicker } from "../VisualizationPicker";
 
 import S from "./Footer.module.css";
 
-export function Footer() {
+export function Footer({ className }: { className?: string }) {
   const dispatch = useDispatch();
   const display = useSelector(getVisualizationType);
   const datasets = useSelector(getDatasets);
@@ -30,7 +30,7 @@ export function Footer() {
     [dispatch],
   );
   return (
-    <Flex className={S.footer} px="xl" py="md">
+    <Flex className={`${S.footer} ${className}`} px="xl" py="md">
       <VisualizationPicker value={display} onChange={handleChangeDisplay} />
       {hasDatasets && (
         <Button

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -22,12 +22,14 @@ interface HeaderProps {
   onSave?: (visualization: VisualizerHistoryItem) => void;
   saveLabel?: string;
   allowSaveWhenPristine?: boolean;
+  className?: string;
 }
 
 export function Header({
   onSave,
   saveLabel,
   allowSaveWhenPristine = false,
+  className,
 }: HeaderProps) {
   const { canUndo, canRedo, undo, redo } = useVisualizerHistory();
 
@@ -49,7 +51,7 @@ export function Header({
   );
 
   return (
-    <Flex p="md" pb="sm" align="center">
+    <Flex p="md" pb="sm" align="center" className={className}>
       <ActionIcon onClick={() => dispatch(toggleFullscreenMode())}>
         <Icon name="sidebar_open" />
       </ActionIcon>

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/FunnelVerticalWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/FunnelVerticalWell.tsx
@@ -2,7 +2,7 @@ import { useDroppable } from "@dnd-kit/core";
 import { useMemo } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { Text } from "metabase/ui";
+import { Flex, Text } from "metabase/ui";
 import { DROPPABLE_ID } from "metabase/visualizer/constants";
 import {
   getVisualizerComputedSettings,
@@ -50,14 +50,25 @@ export function FunnelVerticalWell() {
       isOver={isOver}
       ref={setNodeRef}
     >
-      {!!metric && (
-        <WellItem
-          onRemove={handleRemoveMetric}
-          style={{ position: "absolute", transform: "rotate(-90deg)" }}
-        >
-          <Text truncate>{metric.display_name}</Text>
-        </WellItem>
-      )}
+      <Flex
+        align="center"
+        pos="relative"
+        gap="sm"
+        style={{
+          height: "100%",
+          overflow: "auto",
+          writingMode: "sideways-lr",
+        }}
+      >
+        {!!metric && (
+          <WellItem
+            onRemove={handleRemoveMetric}
+            style={{ position: "absolute", transform: "rotate(-90deg)" }}
+          >
+            <Text truncate>{metric.display_name}</Text>
+          </WellItem>
+        )}
+      </Flex>
     </SimpleVerticalWell>
   );
 }

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.module.css
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.module.css
@@ -2,8 +2,8 @@
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  grid-template-rows: auto 1fr minmax(auto, 42px);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) minmax(auto, 42px);
   grid-template-areas:
     "left main top-right"
     "left main ."

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
@@ -29,7 +29,7 @@ import { StartFromViz } from "./StartFromViz";
 import { VerticalWell } from "./VerticalWell";
 import Styles from "./VisualizationCanvas.module.css";
 
-export function VisualizationCanvas() {
+export function VisualizationCanvas({ className }: { className?: string }) {
   const [isTabularPreviewOpen, setTabularPreviewOpen] = useState(false);
 
   const display = useSelector(getVisualizationType);
@@ -40,7 +40,7 @@ export function VisualizationCanvas() {
 
   if (!display && !isLoading) {
     return (
-      <Center h="100%" w="100%" mx="auto">
+      <Center h="100%" w="100%" mx="auto" className={className}>
         <StartFromViz />
       </Center>
     );
@@ -48,7 +48,7 @@ export function VisualizationCanvas() {
 
   if (!display || rawSeries.length === 0) {
     return (
-      <Center h="100%" w="100%" mx="auto">
+      <Center h="100%" w="100%" mx="auto" className={className}>
         {isLoading ? (
           <Loader size="lg" />
         ) : (
@@ -60,7 +60,7 @@ export function VisualizationCanvas() {
 
   return (
     <>
-      <Box className={Styles.Container} ref={setNodeRef}>
+      <Box className={`${Styles.Container} ${className}`} ref={setNodeRef}>
         <Box style={{ gridArea: "left" }}>
           <VerticalWell display={display} />
         </Box>

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.module.css
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.module.css
@@ -1,8 +1,61 @@
+.Container {
+  display: grid;
+
+  --sidebar-width: 320px;
+  --left: var(--sidebar-width);
+  --right: 0;
+
+  grid-template-columns: var(--left) 1fr var(--right);
+  grid-template-rows: auto 1fr auto;
+  height: 100%;
+  grid-template-areas:
+    "dataSidebar Header settingsSidebar"
+    "dataSidebar Canvas settingsSidebar"
+    "dataSidebar Footer settingsSidebar";
+  transition: 100ms;
+}
+
+.Container.fullscreen {
+  --left: 0px;
+}
+
+.Container.vizSettingsOpen {
+  --right: var(--sidebar-width);
+}
+
 .dataSidebar {
+  grid-area: dataSidebar;
+  overflow: hidden;
+  min-width: 0;
   background-color: var(--mb-color-bg-light);
+}
+
+.Header {
+  grid-area: Header;
+  border-left: 1px solid var(--mb-color-border);
+  border-right: 1px solid var(--mb-color-border);
+}
+
+.Canvas {
+  grid-area: Canvas;
+  overflow: hidden;
+  padding: var(--mantine-spacing-lg);
+  border-left: 1px solid var(--mb-color-border);
+  border-right: 1px solid var(--mb-color-border);
+}
+
+.Footer {
+  grid-area: Footer;
+  border-left: 1px solid var(--mb-color-border);
   border-right: 1px solid var(--mb-color-border);
 }
 
 .settingsSidebar {
-  border-left: 1px solid var(--mb-color-border);
+  min-width: 0;
+  grid-area: settingsSidebar;
+  overflow: hidden;
+}
+
+.settingsSidebarContent {
+  min-width: var(--sidebar-width);
 }

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -139,6 +139,15 @@ export const Visualizer = (props: VisualizerProps) => {
     [dispatch],
   );
 
+  const classNames = [
+    S.Container,
+    isFullscreen ? S.fullscreen : undefined,
+    isVizSettingsSidebarOpen ? S.vizSettingsOpen : undefined,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <DndContext
       sensors={[canvasSensor]}
@@ -152,49 +161,42 @@ export const Visualizer = (props: VisualizerProps) => {
         },
       }}
     >
-      <Flex className={className} direction="column">
-        <Flex style={{ overflow: "hidden", flexGrow: 1 }}>
-          {!isFullscreen && (
-            <Flex direction="column" miw={320} p="md" className={S.dataSidebar}>
-              <Box h="50%" p={10} pr={0} style={{ overflowY: "hidden" }}>
-                <DataImporter />
-              </Box>
-              <Box h="50%" pl={10} pb={10} style={{ overflowY: "auto" }}>
-                <DataManager />
-              </Box>
-            </Flex>
-          )}
-
-          <Flex direction="column" w="100%">
-            <Header
-              onSave={onSave}
-              saveLabel={saveLabel}
-              allowSaveWhenPristine={allowSaveWhenPristine}
-            />
-            <Flex
-              flex={1}
-              direction="column"
-              bg="white"
-              style={{
-                overflowY: "hidden",
-              }}
-            >
-              <Box px="xl" mb="lg" flex={1}>
-                <VisualizationCanvas />
-              </Box>
-              <Footer />
-            </Flex>
+      {/* main container */}
+      <Box className={classNames}>
+        {/* left side bar */}
+        <Box className={S.dataSidebar}>
+          <Flex direction="column" miw={320} p="md" h="100%">
+            <Box h="50%" p={10} pr={0} style={{ overflowY: "hidden" }}>
+              <DataImporter />
+            </Box>
+            <Box h="50%" pl={10} pb={10} style={{ overflowY: "auto" }}>
+              <DataManager />
+            </Box>
           </Flex>
-          {!isFullscreen && isVizSettingsSidebarOpen && (
-            <Flex direction="column" miw={320} className={S.settingsSidebar}>
-              <VizSettingsSidebar />
-            </Flex>
-          )}
-        </Flex>
+        </Box>
+
+        {/* top header bar */}
+        <Header
+          onSave={onSave}
+          saveLabel={saveLabel}
+          allowSaveWhenPristine={allowSaveWhenPristine}
+        />
+
+        {/* main area */}
+        <VisualizationCanvas className={S.Canvas} />
+
+        {/* footer */}
+        <Footer className={S.Footer} />
+
+        {/* right side bar */}
+        <Box className={S.settingsSidebar}>
+          <VizSettingsSidebar className={S.settingsSidebarContent} />
+        </Box>
+
         <DragOverlay dropAnimation={null}>
           {draggedItem && <VisualizerDragOverlay item={draggedItem} />}
         </DragOverlay>
-      </Flex>
+      </Box>
     </DndContext>
   );
 };

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -180,6 +180,7 @@ export const Visualizer = (props: VisualizerProps) => {
           onSave={onSave}
           saveLabel={saveLabel}
           allowSaveWhenPristine={allowSaveWhenPristine}
+          className={S.Header}
         />
 
         {/* main area */}

--- a/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
+++ b/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
@@ -11,7 +11,7 @@ import { updateSettings } from "metabase/visualizer/visualizer.slice";
 import Question from "metabase-lib/v1/Question";
 import type { VisualizationSettings } from "metabase-types/api";
 
-export function VizSettingsSidebar() {
+export function VizSettingsSidebar({ className }: { className?: string }) {
   const series = useSelector(getVisualizerRawSeries);
   const settings = useSelector(getVisualizerComputedSettings);
   const metadata = useSelector(getMetadata);
@@ -39,6 +39,7 @@ export function VizSettingsSidebar() {
       series={series}
       computedSettings={settings}
       onChange={handleChangeSettings}
+      className={className}
     />
   );
 }

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -343,9 +343,6 @@ const visualizerSlice = createSlice({
     },
     toggleFullscreenMode: state => {
       state.isFullscreen = !state.isFullscreen;
-      if (!state.isFullscreen) {
-        state.isVizSettingsSidebarOpen = false;
-      }
     },
     turnOffFullscreenMode: state => {
       state.isFullscreen = false;


### PR DESCRIPTION
Kind of a followup to [VIZ-496: Restructure header + sidebar](https://linear.app/metabase/issue/VIZ-496/restructure-header-sidebar)

This PRs makes the visualizer modal layout clearer and hopefully easier to maintain, while also making it possible to have nice transitions when opening/closing sidebars.

https://www.loom.com/share/95252786077a43548ff60d57aa624f32