### PR TITLE
Repro for "Add column popover is cut off"

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -332,3 +332,26 @@ describe("issue 53404", () => {
     });
   });
 });
+
+describe("issue 53170", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it(
+    "should correctly position the add column popover (metabase#53170)",
+    { viewportWidth: 480, viewportHeight: 800 },
+    () => {
+      H.openOrdersTable();
+      cy.findByLabelText("Add column").click();
+      H.popover().within(() => {
+        cy.findByText("Combine columns").click();
+        cy.button("Done").then($button => {
+          const buttonRight = $button[0].getBoundingClientRect().right;
+          cy.window().its("innerWidth").should("be.gt", buttonRight);
+        });
+      });
+    },
+  );
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/53170

The issue was fixed with mantine v7. Now the popover is positioned correctly.

<img width="510" alt="Screenshot 2025-03-05 at 13 14 11" src="https://github.com/user-attachments/assets/28dc0660-1a36-42ad-8f83-fe204a28ddac" />
