### PR TITLE
Make expression editor not crash on missing entities

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1385,12 +1385,12 @@ describe("issue 48562", () => {
     H.openNotebook();
     H.getNotebookStep("expression").findByText("CustomColumn").click();
     H.CustomExpressionEditor.get().should("contain.text", "[Unknown Field]");
-    cy.get("body").type("{esc}");
+    cy.realPress("Escape");
     H.getNotebookStep("filter").findByText("[Unknown Segment]").click();
     H.popover().findByText("Custom Expression").click();
     H.CustomExpressionEditor.get().should("contain.text", "[Unknown Segment]");
     cy.button("Cancel").click();
-    cy.get("body").type("{esc}");
+    cy.realPress("Escape");
     H.getNotebookStep("summarize").findByText("[Unknown Metric]").click();
     H.CustomExpressionEditor.get().should("contain.text", "[Unknown Metric]");
   });

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
@@ -25,6 +25,7 @@ import {
 } from "../config";
 import {
   formatDimensionName,
+  formatIdentifier,
   formatMetricName,
   formatSegmentName,
 } from "../identifier";
@@ -164,7 +165,7 @@ function formatDimension(
 
   const column = columns[columnIndex];
   if (!column) {
-    return formatDimensionName(t`Unknown Field`, options);
+    return formatIdentifier(t`Unknown Field`, options);
   }
 
   const info = Lib.displayInfo(query, stageIndex, column);
@@ -186,7 +187,7 @@ function formatMetric(path: AstPath<MetricAgg>, options: FormatOptions): Doc {
   });
 
   if (!metric) {
-    return formatMetricName(t`Unknown Metric`, options);
+    return formatIdentifier(t`Unknown Metric`, options);
   }
 
   const displayInfo = Lib.displayInfo(query, stageIndex, metric);
@@ -212,7 +213,7 @@ function formatSegment(path: AstPath<SegmentFilter>, options: FormatOptions) {
   });
 
   if (!segment) {
-    return formatSegmentName(t`Unknown Segment`, options);
+    return formatIdentifier(t`Unknown Segment`, options);
   }
 
   const displayInfo = Lib.displayInfo(query, stageIndex, segment);

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
@@ -1,6 +1,7 @@
 import type { AstPath, Doc, ParserOptions, Plugin } from "prettier";
 import { builders } from "prettier/doc";
 import { format as pformat } from "prettier/standalone";
+import { t } from "ttag";
 
 import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
@@ -163,7 +164,7 @@ function formatDimension(
 
   const column = columns[columnIndex];
   if (!column) {
-    return "";
+    return formatDimensionName(t`Unknown Field`, options);
   }
 
   const info = Lib.displayInfo(query, stageIndex, column);
@@ -185,7 +186,7 @@ function formatMetric(path: AstPath<MetricAgg>, options: FormatOptions): Doc {
   });
 
   if (!metric) {
-    throw new Error(`metric with ID: ${metricId} does not exist`);
+    return formatMetricName(t`Unknown Metric`, options);
   }
 
   const displayInfo = Lib.displayInfo(query, stageIndex, metric);
@@ -211,7 +212,7 @@ function formatSegment(path: AstPath<SegmentFilter>, options: FormatOptions) {
   });
 
   if (!segment) {
-    throw new Error(`segment with ID does not exist: ${segmentId}`);
+    return formatSegmentName(t`Unknown Segment`, options);
   }
 
   const displayInfo = Lib.displayInfo(query, stageIndex, segment);


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/48562

Instead of crashing, display `[Unknown Field]`, `[Unknown Segment]`, `[Unknown Metric]` in the editor. This was already supported by the lib, only the formatting logic of the expression editor should be modified.

<img width="434" alt="Screenshot 2025-03-05 at 14 27 45" src="https://github.com/user-attachments/assets/57ab160c-6a58-456f-ae74-c083122336d9" />
