### PR TITLE
fix examples for mage cljfmt-files

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -130,6 +130,13 @@
    ;; map of ports.
    :data       {:a [:b :c] :b [:d]}}
 
+  -test {:doc "run all mage tests"
+         :requires [[mage.core-test]
+                    [mage.examples-test :as examples-test]]
+         :task (do
+                 (mage.core-test/run-tests)
+                 (examples-test/run-example-tests))}
+
   -test-examples
   {:doc      "Runs every example and checks that it exits with 0"
    :requires [[mage.examples-test :as examples-test]]

--- a/bb.edn
+++ b/bb.edn
@@ -18,9 +18,9 @@
   cljfmt-files
   {:doc      "Runs cljfmt on the given files/directories"
    :requires [[mage.format :as format]]
-   :examples [["./bin/mage format-file src/metabase/events.clj" "Format events.clj"]
-              ["./bin/mage format-file src" "Format all files in src"]
-              ["./bin/mage format-file -c src" "Check all files in src"]]
+   :examples [["./bin/mage cljfmt-files src/metabase/events.clj" "Format events.clj"]
+              ["./bin/mage cljfmt-files src" "Format all files in src"]
+              ["./bin/mage cljfmt-files -c src" "Check all files in src"]]
    :options  [["-c" "--force-check" "Check staged files"]]
    :args     [:sequential [:string {:description "Files or directories to format."}]]
    :task     (format/files (cli/parse! (current-task)))}

--- a/bin/mage
+++ b/bin/mage
@@ -8,9 +8,18 @@
 
 (ns mage
   (:require
+   [babashka.tasks :as bt]
    [mage.color :as c]
    [mage.shell :as sh]
    [mage.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+(defn lolcat [f]
+  (if (try (u/sh "command -v lolcat")
+           (catch Exception _ false))
+    (bt/shell (str "lolcat " f))
+    (println (slurp f))))
 
 (defn invalid-task? []
   (let [task-name (first *command-line-args*)]
@@ -18,17 +27,30 @@
       (println (c/red (str "Unknown task: " task-name)))
       true)))
 
+(defn- print-help []
+  (do
+    (lolcat "./mage/resource.txt")
+    (flush)
+    (println (c/bold " ✨ Metabase Automation Genius Engine ✨"))
+    (println "")
+    (println (u/sh "bb tasks"))))
+
 (defn -main [& _]
-  (if (or (nil? *command-line-args*) ;; forgot to pass args
-          (= *command-line-args* ["-h"]) ;; trying to get help
-          (= *command-line-args* ["--help"])
-          (invalid-task?))
-    (do
-      (print (slurp "./mage/resource.txt"))
-      (flush)
-      (println (c/bold " ✨ Metabase Automation Genius Engine ✨"))
-      (println "")
-      (println (u/sh "bb tasks")))
+  (cond
+    ;; help
+    (or
+     (= *command-line-args* ["-h"])
+     (= *command-line-args* ["--help"]))
+    (print-help)
+
+    ;; errors
+    (or
+     (nil? *command-line-args*)
+     (invalid-task?))
+    (do (print-help) (System/exit 1))
+
+
+    :else
     (apply sh/sh (into ["bb"] *command-line-args*))))
 
 (when (= *file* (System/getProperty "babashka.file"))

--- a/bin/mage
+++ b/bin/mage
@@ -39,16 +39,14 @@
   (cond
     ;; help
     (or
+     (nil? *command-line-args*)
      (= *command-line-args* ["-h"])
      (= *command-line-args* ["--help"]))
     (print-help)
 
     ;; errors
-    (or
-     (nil? *command-line-args*)
-     (invalid-task?))
+    (invalid-task?)
     (do (print-help) (System/exit 1))
-
 
     :else
     (apply sh/sh (into ["bb"] *command-line-args*))))


### PR DESCRIPTION
`mage -test-examples` test was broken because we weren't returning a 1 exit code when failing to pass a valid task! 😱 
