### PR TITLE
support: More logging for field sync.

### DIFF
--- a/src/metabase/sync/sync_metadata/fields/sync_instances.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_instances.clj
@@ -222,6 +222,10 @@
    ;; syncing the active instances makes important changes to `our-metadata` that need to be passed to recursive
    ;; calls, such as adding new Fields or making inactive ones active again. Keep updated version returned by
    ;; `sync-active-instances!`
+   (log/tracef "Syncing field instances for %s DB: %s, Existing: %s"
+               (sync-util/name-for-logging table)
+               (pr-str (sort (map common/canonical-name db-metadata)))
+               (pr-str (sort (map common/canonical-name our-metadata))))
    (let [{:keys [num-updates our-metadata]} (sync-active-instances! table db-metadata our-metadata parent-id)]
      (+ num-updates
         (retire-fields! table db-metadata our-metadata)


### PR DESCRIPTION
Part of #54559

This adds `trace` level logging to:
- `metabase.driver.athena`
- `metabase.sync.sync-metadata.fields.sync-instances`

That should help us diagnose sync issues where describe-fields and fingerprinting seem to be out of sync.
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/7068e899-145c-4298-a508-19a87f895c8f" />
