### PR TITLE
[refs] Put `:ident`s on column lists returned by MBQL lib

### DIFF
--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -4,6 +4,7 @@
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.schema :as lib.schema]
@@ -41,7 +42,8 @@
    (some->> (breakouts query stage-number)
             (mapv (fn [field-ref]
                     (-> (lib.metadata.calculation/metadata query stage-number field-ref)
-                        (assoc :lib/source :source/breakouts)))))))
+                        (assoc :lib/source :source/breakouts
+                               :ident      (lib.options/ident field-ref))))))))
 
 (mu/defn breakout :- ::lib.schema/query
   "Add a new breakout on an expression, presumably a Field reference. Ignores attempts to add a duplicate breakout."

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -66,6 +66,7 @@
           :display-name        (lib.metadata.calculation/display-name query stage-number expression-ref-clause)
           :base-type           (lib.metadata.calculation/type-of query stage-number expression-ref-clause)
           :lib/source          :source/expressions}
+         {:ident (lib.options/ident (resolve-expression query stage-number expression-name))}
          (when-let [unit (lib.temporal-bucket/raw-temporal-bucket expression-ref-clause)]
            {:metabase.lib.field/temporal-unit unit})
          (when lib.metadata.calculation/*propagate-binning-and-bucketing*
@@ -333,7 +334,8 @@
                       :lib/source-column-alias :lib/source-uuid :lib/type])
         (assoc :lib/source   :source/expressions
                :name         expression-name
-               :display-name expression-name))))
+               :display-name expression-name
+               :ident        (lib.options/ident expression-definition)))))
 
 (mu/defn expressions-metadata :- [:maybe [:sequential ::lib.schema.metadata/column]]
   "Get metadata about the expressions in a given stage of a `query`."

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -68,7 +68,8 @@
                                       (when (or (:source-card  stage)
                                                 (:source-table stage)
                                                 (:expressions  stage)
-                                                (:fields       stage))
+                                                (:fields       stage)
+                                                (pos-int? previous-stage-number))
                                         (lib.metadata.calculation/visible-columns query stage-number stage))
                                       (log/warnf "Cannot resolve column %s: stage has no metadata"
                                                  (pr-str column-name)))]
@@ -177,7 +178,9 @@
   [query
    stage-number
    metadata
-   [_tag {source-uuid :lib/uuid :keys [base-type binning effective-type join-alias source-field temporal-unit], :as opts} :as field-ref]]
+   [_tag {source-uuid :lib/uuid
+          :keys [base-type binning effective-type ident join-alias source-field temporal-unit], :as opts}
+    :as field-ref]]
   (let [metadata (merge
                   {:lib/type        :metadata/column}
                   metadata
@@ -190,7 +193,8 @@
       temporal-unit  (assoc ::temporal-unit temporal-unit)
       binning        (assoc ::binning binning)
       source-field   (assoc :fk-field-id source-field)
-      join-alias     (lib.join/with-join-alias join-alias))))
+      join-alias     (lib.join/with-join-alias join-alias)
+      ident          (assoc :ident ident))))
 
 ;;; TODO -- effective type should be affected by `temporal-unit`, right?
 (defmethod lib.metadata.calculation/metadata-method :field

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -506,7 +506,11 @@
     options        :- [:maybe ReturnedColumnsOptions]]
    (let [options (merge (default-returned-columns-options) options)]
      (binding [*propagate-binning-and-bucketing* true]
-       (returned-columns-method query stage-number x options)))))
+       (u/prog1 (returned-columns-method query stage-number x options)
+         (lib.metadata.ident/assert-idents-present! <> {:query        query
+                                                        :stage-number stage-number
+                                                        :target       x
+                                                        :options      options}))))))
 
 (def VisibleColumnsOptions
   "Schema for options passed to [[visible-columns]] and [[visible-columns-method]]."
@@ -590,7 +594,11 @@
     x
     options        :- [:maybe VisibleColumnsOptions]]
    (let [options (merge (default-visible-columns-options) options)]
-     (visible-columns-method query stage-number x options))))
+     (u/prog1 (visible-columns-method query stage-number x options)
+       (lib.metadata.ident/assert-idents-present! <> {:query        query
+                                                      :stage-number stage-number
+                                                      :target       x
+                                                      :options      options})))))
 
 (mu/defn primary-keys :- [:sequential ::lib.schema.metadata/column]
   "Returns a list of primary keys for the source table of this query."

--- a/src/metabase/lib/metadata/ident.cljc
+++ b/src/metabase/lib/metadata/ident.cljc
@@ -10,7 +10,41 @@
 
 (defn explicitly-joined-ident
   "Returns the ident for an explicitly joined column, given the idents of the join clause and the target column.
-
   Remember that `:ident` strings should never be parsed - they are opaque, but should be legible during debugging."
   [target-ident join-ident]
   (str "join__" join-ident "__" target-ident))
+
+(defn model-ident
+  "Returns the `:ident` for this column on a model.
+
+  Needs the `entity_id` for the model's card and the column's `:ident`."
+  [target-ident card-entity-id]
+  (str "model__" card-entity-id "__" target-ident))
+
+(defn native-ident
+  "Returns the `:ident` for a given field name on a native query.
+
+  Requires the `entity_id` of the card and the name of the column."
+  [column-name card-entity-id]
+  (str "native__" card-entity-id "__" column-name))
+
+(def ^:dynamic *enforce-idents-present*
+  "The [[assert-idents-present!]] check is sometimes too zealous; this dynamic var can be overridden whe we know the
+  query is in a broken state, such as during the cleanup of dangling references in `remove-clause`.
+
+  Defaults to false in production, true in dev and test."
+  ;; TODO: Enable this in tests once the QP is adding `:ident`s to `result_metadata`.
+  false
+  #_#?(:clj      (not config/is-prod?)
+       :cljs-dev true
+       :default  false))
+
+(defn assert-idents-present!
+  "Given a list of columns and map of data for [[ex-info]], throw if any columns in the output lack `:ident`s.
+
+  Return nil if there's no trouble."
+  [columns ex-map]
+  (when *enforce-idents-present*
+    (when-let [missing (seq (remove :ident columns))]
+      (throw (ex-info "Some columns are missing :idents"
+                      (assoc ex-map :missing-ident missing))))))

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -9,6 +9,7 @@
    [metabase.lib.join :as lib.join]
    [metabase.lib.join.util :as lib.join.util]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
@@ -125,44 +126,46 @@
 
 (defn- remove-replace-location
   [query stage-number unmodified-query-for-stage location target-clause remove-replace-fn]
-  (let [result (lib.util/update-query-stage query stage-number
-                                            remove-replace-fn location target-clause)
-        target-uuid (lib.options/uuid target-clause)]
-    (if (not= query result)
-      (lib.util.match/match-one location
-        [:expressions]
-        (-> result
-            (remove-local-references
-             stage-number
-             unmodified-query-for-stage
-             :expression
-             {}
-             (lib.util/expression-name target-clause))
-            (remove-stage-references stage-number unmodified-query-for-stage target-uuid)
-            (update-stale-references stage-number unmodified-query-for-stage))
+  ;; We may see missing idents during the remove/replace process, so disable the assertions.
+  (binding [lib.metadata.ident/*enforce-idents-present* false]
+    (let [result (lib.util/update-query-stage query stage-number
+                                              remove-replace-fn location target-clause)
+          target-uuid (lib.options/uuid target-clause)]
+      (if (not= query result)
+        (lib.util.match/match-one location
+          [:expressions]
+          (-> result
+              (remove-local-references
+               stage-number
+               unmodified-query-for-stage
+               :expression
+               {}
+               (lib.util/expression-name target-clause))
+              (remove-stage-references stage-number unmodified-query-for-stage target-uuid)
+              (update-stale-references stage-number unmodified-query-for-stage))
 
-        [:aggregation]
-        (-> result
-            (remove-local-references
-             stage-number
-             unmodified-query-for-stage
-             :aggregation
-             {}
-             target-uuid)
-            (remove-stage-references stage-number unmodified-query-for-stage target-uuid)
-            (update-stale-references stage-number unmodified-query-for-stage))
+          [:aggregation]
+          (-> result
+              (remove-local-references
+               stage-number
+               unmodified-query-for-stage
+               :aggregation
+               {}
+               target-uuid)
+              (remove-stage-references stage-number unmodified-query-for-stage target-uuid)
+              (update-stale-references stage-number unmodified-query-for-stage))
 
-        #_{:clj-kondo/ignore [:invalid-arity]}
-        (:or
-         [:breakout]
-         [:fields]
-         [:joins _ :fields])
-        (-> (remove-stage-references result stage-number unmodified-query-for-stage target-uuid)
-            (update-stale-references stage-number unmodified-query-for-stage))
+          #_{:clj-kondo/ignore [:invalid-arity]}
+          (:or
+           [:breakout]
+           [:fields]
+           [:joins _ :fields])
+          (-> (remove-stage-references result stage-number unmodified-query-for-stage target-uuid)
+              (update-stale-references stage-number unmodified-query-for-stage))
 
-        _
-        result)
-      result)))
+          _
+          result)
+        result))))
 
 (defn- remove-local-references [query stage-number unmodified-query-for-stage target-op target-opts target-ref-id]
   (let [stage (lib.util/query-stage query stage-number)

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -11,6 +11,7 @@
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]))
@@ -143,32 +144,37 @@
    (lib/metadata query stage clause)))
 
 (deftest ^:parallel col-info-for-aggregation-clause-test
-  (are [clause expected] (=? expected
-                             (col-info-for-aggregation-clause clause))
-    ;; :count, no field
-    [:/ {} [:count {}] 2]
-    {:base-type    :type/Float
-     :name         "expression"
-     :display-name "Count ÷ 2"}
+  (let [ident (u/generate-nano-id)]
+    (are [clause expected] (=? expected
+                               (col-info-for-aggregation-clause clause))
+      ;; :count, no field
+      [:/ {:ident ident} [:count {}] 2]
+      {:base-type    :type/Float
+       :name         "expression"
+       :ident        ident
+       :display-name "Count ÷ 2"}
 
-    ;; :sum
-    [:sum {} [:+ {} (lib.tu/field-clause :venues :price) 1]]
-    {:base-type    :type/Integer
-     :name         "sum"
-     :display-name "Sum of Price + 1"}
+      ;; :sum
+      [:sum {:ident ident} [:+ {} (lib.tu/field-clause :venues :price) 1]]
+      {:base-type    :type/Integer
+       :name         "sum"
+       :ident        ident
+       :display-name "Sum of Price + 1"}
 
-    ;; options map
-    [:sum
-     {:name "sum_2", :display-name "My custom name", :base-type :type/BigInteger}
-     (lib.tu/field-clause :venues :price)]
-    {:base-type    :type/BigInteger
-     :name         "sum_2"
-     :display-name "My custom name"}))
+      ;; options map
+      [:sum
+       {:name "sum_2", :display-name "My custom name", :base-type :type/BigInteger, :ident ident}
+       (lib.tu/field-clause :venues :price)]
+      {:base-type    :type/BigInteger
+       :name         "sum_2"
+       :ident        ident
+       :display-name "My custom name"})))
 
 (deftest ^:parallel col-info-named-aggregation-test
   (testing "col info for an `expression` aggregation w/ a named expression should work as expected"
     (is (=? {:base-type    :type/Integer
              :name         "sum"
+             :ident        string?
              :display-name "Sum of double-price"}
             (col-info-for-aggregation-clause
              (lib.tu/venues-query-with-last-stage
@@ -179,7 +185,8 @@
                               (lib.tu/field-clause :venues :price {:base-type :type/Integer})
                               2]]})
              [:sum
-              {:lib/uuid (str (random-uuid))}
+              {:lib/uuid (str (random-uuid))
+               :ident    (u/generate-nano-id)}
               [:expression {:base-type :type/Integer, :lib/uuid (str (random-uuid))} "double-price"]])))))
 
 (deftest ^:parallel aggregate-test
@@ -782,23 +789,17 @@
                           (lib/expression "Total of Zero" (lib/coalesce (meta/field-metadata :orders :total) 0)))
           converted-query (lib/query meta/metadata-provider
                                      (lib.convert/->pMBQL
-                                      {:database (meta/id)
-                                       :type :query
-                                       :query {:source-table (meta/id :orders) ,
-                                               :expressions {"Zero" [:+ 0 0]
-                                                             "Total of Zero" [:coalesce
-                                                                              [:field
-                                                                               (meta/id :orders :total) ,
-                                                                               nil],
-                                                                              0]}}}))]
-      (is (= (->> built-query
-                  lib/available-aggregation-operators
-                  (m/find-first #(= (:short %) :sum))
-                  lib/aggregation-operator-columns)
-             (->> converted-query
-                  lib/available-aggregation-operators
-                  (m/find-first #(= (:short %) :sum))
-                  lib/aggregation-operator-columns))))))
+                                      (lib.tu.macros/mbql-query orders
+                                        {:expressions {"Zero"          [:+ 0 0]
+                                                       "Total of Zero" [:coalesce $total 0]}})))
+          clean (fn [query]
+                  (->> query
+                       lib/available-aggregation-operators
+                       (m/find-first #(= (:short %) :sum))
+                       lib/aggregation-operator-columns
+                       (map #(dissoc % :ident))))]
+      (is (= (clean built-query)
+             (clean converted-query))))))
 
 (deftest ^:parallel aggregation-at-index-test
   (let [query (-> (lib.tu/venues-query)

--- a/test/metabase/lib/drill_thru/test_util/canned.cljc
+++ b/test/metabase/lib/drill_thru/test_util/canned.cljc
@@ -178,7 +178,7 @@
                                    {:columns (->> (meta/fields :products)
                                                   (map #(meta/field-metadata :products %))
                                                   (sort-by :position)
-                                                  (map #(select-keys % [:lib/type :name :display-name :field-ref
+                                                  (map #(select-keys % [:lib/type :name :display-name :field-ref :ident
                                                                         :base-type :effective-type :semantic-type])))}))
      :native?        true
      :row            {"ID"         "3"

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -14,6 +14,7 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.lib.test-util.metadata-providers.mock :as providers.mock]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
@@ -197,11 +198,9 @@
           metric-card {:description "Orders with a subtotal of $100 or more."
                        :lib/type :metadata/card
                        :type :metric
-                       :dataset-query {:type     :query
-                                       :database (meta/id)
-                                       :query    {:source-table (meta/id :orders)
-                                                  :aggregation  [[:count]]
-                                                  :filter       [:>= [:field (meta/id :orders :subtotal) nil] 100]}}
+                       :dataset-query (lib.tu.macros/mbql-query orders
+                                        {:aggregation  [[:count]]
+                                         :filter       [:>= $subtotal 100]})
                        :database-id (meta/id)
                        :name "Large orders"
                        :id metric-id}

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -17,6 +17,7 @@
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.lib.test-util.mocks-31368 :as lib.tu.mocks-31368]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
@@ -523,11 +524,9 @@
   (testing ":field refs with string names should work if the Field comes from a :join"
     (let [metadata-provider (lib.tu/metadata-provider-with-cards-for-queries
                              meta/metadata-provider
-                             [{:database (meta/id)
-                               :type     :query
-                               :query    {:source-table (meta/id :checkins)
-                                          :aggregation  [[:count]]
-                                          :breakout     [[:field (meta/id :checkins :user-id) nil]]}}])
+                             [(lib.tu.macros/mbql-query checkins
+                                {:aggregation [[:count]]
+                                 :breakout    [$user-id]})])
           cols  (->> (lib.metadata/card metadata-provider 1)
                      (lib/query metadata-provider)
                      lib/returned-columns
@@ -631,8 +630,9 @@
                                                    :database 1
                                                    :stages   [{:lib/type     :mbql.stage/mbql
                                                                :source-table 2}]}
-                                 :result-metadata [{:id   4
-                                                    :name "Field 4"}]}]})
+                                 :result-metadata [{:id    4
+                                                    :ident "ybTElkkGoYYBAyDRTIiUe"
+                                                    :name  "Field 4"}]}]})
           query    (lib/query provider {:lib/type :mbql/query
                                         :database 1
                                         :stages   [{:lib/type    :mbql.stage/mbql
@@ -642,6 +642,7 @@
                :effective-type           :type/*
                :id                       4
                :name                     "Field 4"
+               :ident                    "ybTElkkGoYYBAyDRTIiUe"
                :fk-target-field-id       nil
                :lib/source               :source/card
                :lib/card-id              3
@@ -653,6 +654,7 @@
               :effective-type          :type/Text
               :id                      4
               :name                    "Field 4"
+              :ident                   "ybTElkkGoYYBAyDRTIiUe"
               :fk-target-field-id      nil
               :display-name            "Field 4"
               :lib/card-id             3
@@ -1594,11 +1596,13 @@
 (deftest ^:parallel resolve-field-metadata-test
   (testing "Make sure fallback name for a Field ref makes sense"
     (mu/disable-enforcement
-      (is (=? {:lib/type        :metadata/column
-               :lib/source-uuid string?
-               :name            "12345"
-               :display-name    "12345"}
-              (lib.metadata.calculation/metadata (lib.tu/venues-query) -1 [:field {:lib/uuid (str (random-uuid))} 12345]))))))
+      (binding [lib.metadata.ident/*enforce-idents-present* false]
+        (is (=? {:lib/type        :metadata/column
+                 :lib/source-uuid string?
+                 :name            "12345"
+                 :display-name    "12345"}
+                (lib.metadata.calculation/metadata (lib.tu/venues-query) -1
+                                                   [:field {:lib/uuid (str (random-uuid))} 12345])))))))
 
 (deftest ^:parallel field-values-search-info-test
   (testing "type/PK field remapped to a type/Name field within the same table"
@@ -1691,6 +1695,7 @@
                            {:lib/type :metadata/column
                             :id 1
                             :name "search"
+                            :ident "pu_Pfm-Oe2cnFTsRgmYM3"
                             :display-name "Search"
                             :base-type :type/Text})
                 lib/visible-columns
@@ -1702,6 +1707,7 @@
                            {:lib/type :metadata/column
                             :id 1
                             :name "num"
+                            :ident "pu_Pfm-Oe2cnFTsRgmYM3"
                             :display-name "Random number"
                             :base-type :type/Integer})
                 lib/visible-columns

--- a/test/metabase/lib/segment_test.cljc
+++ b/test/metabase/lib/segment_test.cljc
@@ -6,18 +6,19 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-util :as lib.tu]))
+   [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.test-util.macros :as lib.tu.macros]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (def ^:private segment-id 100)
 
 (def ^:private segment-definition
-  {:source-table (meta/id :venues)
-   :aggregation  [[:count]]
-   :filter       [:and
-                  [:> [:field (meta/id :venues :id) nil] [:* [:field (meta/id :venues :price) nil] 11]]
-                  [:contains [:field (meta/id :venues :name) nil] "BBQ" {:case-sensitive true}]]})
+  (:query (lib.tu.macros/mbql-query venues
+            {:aggregation [[:count]]
+             :filter      [:and
+                           [:> $id [:* $price 11]]
+                           [:contains $name "BBQ" {:case-sensitive true}]]})))
 
 (def ^:private segments-db
   {:segments [{:id          segment-id

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -43,19 +43,9 @@
 (deftest ^:parallel deduplicate-expression-names-in-aggregations-test
   (testing "make sure multiple expressions come back with deduplicated names"
     (testing "expressions in aggregations"
-      (let [query (lib.tu/venues-query-with-last-stage
-                   {:aggregation [[:*
-                                   {:lib/uuid (str (random-uuid))}
-                                   0.8
-                                   [:avg
-                                    {:lib/uuid (str (random-uuid))}
-                                    (lib.tu/field-clause :venues :price)]]
-                                  [:*
-                                   {:lib/uuid (str (random-uuid))}
-                                   0.8
-                                   [:avg
-                                    {:lib/uuid (str (random-uuid))}
-                                    (lib.tu/field-clause :venues :price)]]]})]
+      (let [query (-> (lib.tu/venues-query)
+                      (lib/aggregate (lib/* 0.8 (lib/avg (meta/field-metadata :venues :price))))
+                      (lib/aggregate (lib/* 0.8 (lib/avg (meta/field-metadata :venues :price)))))]
         (is (=? [{:base-type                :type/Float
                   :name                     "expression"
                   :display-name             "0.8 × Average of Price"

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -8,6 +8,7 @@
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.test-metadata :as meta]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -306,38 +307,39 @@
 
 (deftest nested-models-with-expressions-pivot-breakout-names-test
   (testing "#43993 again - breakouts on an expression from the inner model should pass"
-    (mt/with-temp [:model/Card model1 {:type :model
-                                       :dataset_query
-                                       (mt/mbql-query products
-                                         {:source-table $$products
-                                          :expressions  {"Rating Bucket" [:floor $products.rating]}})}
-                   :model/Card model2 {:type :model
-                                       :dataset_query
-                                       (mt/mbql-query orders
-                                         {:source-table $$orders
-                                          :joins        [{:source-table (str "card__" (u/the-id model1))
-                                                          :alias        "model A - Product"
-                                                          :fields       :all
-                                                          :condition    [:= $orders.product_id
-                                                                         [:field %products.id
-                                                                          {:join-alias "model A - Product"}]]}]})}]
-      (testing "Column aliasing works when joining an expression in an inner model"
-        (let [query        (mt/mbql-query
-                             orders {:source-table (str "card__" (u/the-id model2))
-                                     :aggregation  [[:sum [:field "SUBTOTAL" {:base-type :type/Number}]]]
-                                     :breakout     [[:field "Rating Bucket" {:base-type  :type/Number
-                                                                             :join-alias "model A - Product"}]]})
-              viz-settings {:pivot_table.column_split
-                            {:columns ["Rating Bucket"]}}]
-          (testing "for a regular query"
-            (is (=? {:status :completed}
-                    (qp/process-query query))))
-          (testing "and a pivot query"
-            (is (=? {:status    :completed
-                     :row_count 6}
-                    (-> query
-                        (assoc :info {:visualization-settings viz-settings})
-                        qp.pivot/run-pivot-query)))))))))
+    (binding [lib.metadata.ident/*enforce-idents-present* false]
+      (mt/with-temp [:model/Card model1 {:type :model
+                                         :dataset_query
+                                         (mt/mbql-query products
+                                           {:source-table $$products
+                                            :expressions  {"Rating Bucket" [:floor $products.rating]}})}
+                     :model/Card model2 {:type :model
+                                         :dataset_query
+                                         (mt/mbql-query orders
+                                           {:source-table $$orders
+                                            :joins        [{:source-table (str "card__" (u/the-id model1))
+                                                            :alias        "model A - Product"
+                                                            :fields       :all
+                                                            :condition    [:= $orders.product_id
+                                                                           [:field %products.id
+                                                                            {:join-alias "model A - Product"}]]}]})}]
+        (testing "Column aliasing works when joining an expression in an inner model"
+          (let [query        (mt/mbql-query
+                               orders {:source-table (str "card__" (u/the-id model2))
+                                       :aggregation  [[:sum [:field "SUBTOTAL" {:base-type :type/Number}]]]
+                                       :breakout     [[:field "Rating Bucket" {:base-type  :type/Number
+                                                                               :join-alias "model A - Product"}]]})
+                viz-settings {:pivot_table.column_split
+                              {:columns ["Rating Bucket"]}}]
+            (testing "for a regular query"
+              (is (=? {:status :completed}
+                      (qp/process-query query))))
+            (testing "and a pivot query"
+              (is (=? {:status    :completed
+                       :row_count 6}
+                      (-> query
+                          (assoc :info {:visualization-settings viz-settings})
+                          qp.pivot/run-pivot-query))))))))))
 
 (deftest ^:parallel dont-return-too-many-rows-test
   (testing "Make sure pivot queries don't return too many rows (#14329)"

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -14,7 +14,8 @@
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (comment h2/keep-me)
 
@@ -819,10 +820,11 @@
               (#'add/matching-field-in-join-at-this-level source-query field-clause))))))
 
 (defn- metadata-provider-with-two-models []
-  (let [result-metadata-for (fn [column-name]
+  (let [result-metadata-for (fn [card-eid column-name]
                               {:display_name   column-name
                                :field_ref      [:field column-name {:base-type :type/Integer}]
                                :name           column-name
+                               :ident          (str "native__" card-eid "__" column-name)
                                :base_type      :type/Integer
                                :effective_type :type/Integer
                                :semantic_type  nil
@@ -832,24 +834,28 @@
     (lib/composed-metadata-provider
      meta/metadata-provider
      (providers.mock/mock-metadata-provider
-      {:cards [{:name            "Model A"
-                :id              1
-                :database-id     (meta/id)
-                :type            :model
-                :dataset-query   {:database (mt/id)
-                                  :type     :native
-                                  :native   {:template-tags {} :query "select 1 as a1, 2 as a2;"}}
-                :result-metadata [(result-metadata-for "A1")
-                                  (result-metadata-for "A2")]}
-               {:name            "Model B"
-                :id              2
-                :database-id     (meta/id)
-                :type            :model
-                :dataset-query   {:database (mt/id)
-                                  :type     :native
-                                  :native   {:template-tags {} :query "select 1 as b1, 2 as b2;"}}
-                :result-metadata [(result-metadata-for "B1")
-                                  (result-metadata-for "B2")]}
+      {:cards [(let [eid (u/generate-nano-id)]
+                 {:name            "Model A"
+                  :id              1
+                  :entity-id       eid
+                  :database-id     (meta/id)
+                  :type            :model
+                  :dataset-query   {:database (mt/id)
+                                    :type     :native
+                                    :native   {:template-tags {} :query "select 1 as a1, 2 as a2;"}}
+                  :result-metadata [(result-metadata-for eid "A1")
+                                    (result-metadata-for eid "A2")]})
+               (let [eid (u/generate-nano-id)]
+                 {:name            "Model B"
+                  :id              2
+                  :entity-id       eid
+                  :database-id     (meta/id)
+                  :type            :model
+                  :dataset-query   {:database (mt/id)
+                                    :type     :native
+                                    :native   {:template-tags {} :query "select 1 as b1, 2 as b2;"}}
+                  :result-metadata [(result-metadata-for eid "B1")
+                                    (result-metadata-for eid "B2")]})
                {:name            "Joined"
                 :id              3
                 :database-id     (meta/id)

--- a/test/metabase/query_processor_test/drill_thru_e2e_test.clj
+++ b/test/metabase/query_processor_test/drill_thru_e2e_test.clj
@@ -5,12 +5,14 @@
    [metabase.lib.core :as lib]
    [metabase.lib.field :as lib.field]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
    [metabase.query-processor.store :as qp.store]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (deftest ^:parallel quick-filter-on-bucketed-date-test
   (testing "a quick-filter drill on a bucketed DATE should produce valid results (#18769)"
@@ -50,7 +52,9 @@
       (let [metadata-provider  (lib.metadata.jvm/application-database-metadata-provider (mt/id))
             card-query         (lib/native-query metadata-provider "SELECT * FROM PEOPLE ORDER BY ID DESC LIMIT 100;")
             results            (qp/process-query card-query)
-            results-metadata   (get-in results [:data :results_metadata :columns])
+            card-eid           (u/generate-nano-id)
+            results-metadata   (for [col (get-in results [:data :results_metadata :columns])]
+                                 (assoc col :ident (lib.metadata.ident/native-ident (:name col) card-eid)))
             _                  (is (seq results-metadata))
             metadata-provider  (lib.tu/mock-metadata-provider
                                 metadata-provider


### PR DESCRIPTION
Closes [QUE-700](https://linear.app/metabase/issue/QUE-700/test-every-column-on-a-query-gets-an-ident).

### Description

I enforced this by checking the return values of `visible-columns` and
`returned-columns`. I want to check that in (for dev and test only) but
it fails tests currently.

The trouble is that cards don't have `:ident` in their `result_metadata`.
That's coming later, so the enforcement flag is disabled for now.

I fixed several cases in the library where we were not including `:ident` in the metadata
even though it was available.


### How to verify

Enable the flag `metabase.lib.metadata.ident/*enforce-idents-present*` by dropping the
`(and false ...)` around it, and see what tests are passing.

Tests that use the QP currently fail this, so I can't check in the test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
