### PR TITLE
VIZ-522 no crash for unknown columns

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -1,0 +1,70 @@
+import { isNotNull } from "metabase/lib/types";
+import { getColumnVizSettings } from "metabase/visualizations";
+import type { Card, DatasetColumn } from "metabase-types/api";
+import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
+
+import {
+  copyColumn,
+  createVisualizerColumnReference,
+  extractReferencedColumns,
+} from "./column";
+import { createDataSource } from "./data-source";
+
+export function getInitialStateForCardDataSource(
+  card: Card,
+  columns: DatasetColumn[],
+): VisualizerHistoryItem {
+  const state: VisualizerHistoryItem = {
+    display: card.display,
+    columns: [],
+    columnValuesMapping: {},
+    settings: {},
+  };
+  const dataSource = createDataSource("card", card.id, card.name);
+
+  columns.forEach(column => {
+    const columnRef = createVisualizerColumnReference(
+      dataSource,
+      column,
+      extractReferencedColumns(state.columnValuesMapping),
+    );
+    state.columns.push(copyColumn(columnRef.name, column));
+    state.columnValuesMapping[columnRef.name] = [columnRef];
+  });
+
+  const entries = getColumnVizSettings(card.display)
+    .map(setting => {
+      const originalValue = card.visualization_settings[setting];
+
+      if (!originalValue) {
+        return null;
+      }
+
+      if (Array.isArray(originalValue)) {
+        return [
+          setting,
+          originalValue.map(originalColumnName => {
+            const index = columns.findIndex(
+              col => col.name === originalColumnName,
+            );
+            return state.columns[index].name;
+          }),
+        ];
+      } else {
+        const index = columns.findIndex(col => col.name === originalValue);
+        if (!state.columns[index]) {
+          return;
+        }
+
+        return [setting, state.columns[index]?.name];
+      }
+    })
+    .filter(isNotNull);
+
+  state.settings = {
+    ...card.visualization_settings,
+    ...Object.fromEntries(entries),
+  };
+
+  return state;
+}

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -1,0 +1,57 @@
+import { registerVisualization } from "metabase/visualizations";
+import Table from "metabase/visualizations/visualizations/Table";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDashboardCard,
+} from "metabase-types/api/mocks";
+
+import { getInitialStateForCardDataSource } from "./get-initial-state-for-card-data-source";
+
+// Not registering all visualizations here for perf reasons
+// @ts-expect-error -- TODO fix this error?
+registerVisualization(Table);
+
+describe("getInitialStateForCardDataSource", () => {
+  const dashCard = createMockDashboardCard({
+    card: createMockCard({
+      display: "table",
+      visualization_settings: {
+        "table.cell_column": "avg",
+        "table.pivot_column": "CATEGORY",
+        "table.column_formatting": [],
+      },
+    }),
+  });
+
+  it("should not try to replace unknown columns in the settings", () => {
+    const initialState = getInitialStateForCardDataSource(dashCard.card, [
+      createMockColumn({ name: "Foo" }),
+      createMockColumn({ name: "Bar" }),
+    ]);
+
+    expect(initialState.columns).toHaveLength(2);
+    expect(initialState.columnValuesMapping).toEqual({
+      COLUMN_1: [
+        {
+          name: "COLUMN_1",
+          originalName: "Foo",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "Bar",
+          sourceId: "card:1",
+        },
+      ],
+    });
+
+    expect(initialState.settings).toEqual({
+      "table.cell_column": "avg",
+      "table.pivot_column": "CATEGORY",
+      "table.column_formatting": [],
+    });
+  });
+});

--- a/frontend/src/metabase/visualizer/utils/index.ts
+++ b/frontend/src/metabase/visualizer/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./column";
 export * from "./dashboard-card-supports-visualizer";
 export * from "./data-source";
 export * from "./drag-and-drop";
+export * from "./get-initial-state-for-card-data-source";
 export * from "./is-visualizer-dashboard-card";
 export * from "./merge-data";
 export * from "./misc";


### PR DESCRIPTION
Closes [VIZ-522: "Visualize a different way" on certain table cards crashes dashboard](https://linear.app/metabase/issue/VIZ-522/visualize-a-different-way-on-certain-table-cards-crashes-dashboard)

This happens when trying to "Visualize another way" a question that has a reference to an unknown column in its settings, likely because of some staleness.