### PR TITLE
stabilize flaky test

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -14,6 +14,21 @@ describe("command palette", () => {
   });
 
   it("should render a searchable command palette", () => {
+    // we return a list of entities in a specific order to avoid flakiness. "recency" score can sometimes cause the order to change and fail the test
+    cy.intercept(
+      "GET",
+      "**/search?q=Company&context=command-palette&include_dashboard_questions=true&limit=20",
+      req => {
+        req.reply(res => {
+          const orderedNames = ["Products", "Orders", "Reviews", "People"];
+          res.body.data = res.body.data.sort((a, b) => {
+            return orderedNames.indexOf(a.name) - orderedNames.indexOf(b.name);
+          });
+          return res.body;
+        });
+      },
+    );
+
     // //Add a description for a check
     cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
       description: "The best question",


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-364/stabilize-flaky-test-should-render-a-searchable-command-palette

### Description

This was a wild one. The command palette results appear based on different score criteria. One of those criteria is recency. Because of that, backend responds with a different order of results, causing the test to fail.

### Resolution

Since the purpose of this test is not about the order of results, we can mock the results and make sure they appear in a proper order. In fact, we are not even doing mocking, mostly just reordering the order of results to make sure the test doesn’t flake.

### Stress test

https://github.com/metabase/metabase/actions/runs/13697947962
