### PR TITLE
Closes VIZ-508: cannot save card when pristine

### DIFF
--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -178,6 +178,7 @@ export function QuestionList({
             setVisualizerModalCardId(null);
           }}
           onClose={() => setVisualizerModalCardId(null)}
+          allowSaveWhenPristine
         />
       )}
     </>

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -21,9 +21,14 @@ import S from "./Header.module.css";
 interface HeaderProps {
   onSave?: (visualization: VisualizerHistoryItem) => void;
   saveLabel?: string;
+  allowSaveWhenPristine?: boolean;
 }
 
-export function Header({ onSave, saveLabel }: HeaderProps) {
+export function Header({
+  onSave,
+  saveLabel,
+  allowSaveWhenPristine = false,
+}: HeaderProps) {
   const { canUndo, canRedo, undo, redo } = useVisualizerHistory();
 
   const visualization = useSelector(getCurrentVisualizerState);
@@ -65,7 +70,11 @@ export function Header({ onSave, saveLabel }: HeaderProps) {
             <Icon name="chevronright" />
           </ActionIcon>
         </Tooltip>
-        <Button variant="filled" disabled={!isDirty} onClick={handleSave}>
+        <Button
+          variant="filled"
+          disabled={!isDirty && !allowSaveWhenPristine}
+          onClick={handleSave}
+        >
           {saveLabel ?? t`Add to dashboard`}
         </Button>
       </Flex>

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -42,10 +42,11 @@ interface VisualizerProps {
   className?: string;
   onSave?: (visualization: VisualizerHistoryItem) => void;
   saveLabel?: string;
+  allowSaveWhenPristine?: boolean;
 }
 
 export const Visualizer = (props: VisualizerProps) => {
-  const { className, onSave, saveLabel } = props;
+  const { className, onSave, saveLabel, allowSaveWhenPristine } = props;
   const { canUndo, canRedo, undo, redo } = useVisualizerHistory();
 
   const draggedItem = useSelector(getDraggedItem);
@@ -128,7 +129,11 @@ export const Visualizer = (props: VisualizerProps) => {
           )}
 
           <Flex direction="column" w="100%">
-            <Header onSave={onSave} saveLabel={saveLabel} />
+            <Header
+              onSave={onSave}
+              saveLabel={saveLabel}
+              allowSaveWhenPristine={allowSaveWhenPristine}
+            />
             <Flex
               flex={1}
               direction="column"

--- a/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { type ComponentProps, useCallback, useEffect } from "react";
 import { usePrevious } from "react-use";
 import { t } from "ttag";
 
@@ -22,17 +22,14 @@ interface VisualizerModalProps {
     state?: Partial<VisualizerHistoryItem>;
     extraDataSources?: VisualizerDataSourceId[];
   };
-  onSave: (visualization: VisualizerHistoryItem) => void;
   onClose: () => void;
-  saveLabel?: string;
 }
 
 export function VisualizerModal({
   initialState,
-  onSave,
   onClose,
-  saveLabel,
-}: VisualizerModalProps) {
+  ...otherProps
+}: VisualizerModalProps & ComponentProps<typeof Visualizer>) {
   const { open } = useModalOpen();
   const wasOpen = usePrevious(open);
   const dispatch = useDispatch();
@@ -71,11 +68,7 @@ export function VisualizerModal({
         onClose={onModalClose}
         padding={0}
       >
-        <Visualizer
-          className={S.VisualizerRoot}
-          onSave={onSave}
-          saveLabel={saveLabel}
-        />
+        <Visualizer className={S.VisualizerRoot} {...otherProps} />
       </Modal>
       {modalContent}
     </>


### PR DESCRIPTION
Closes [VIZ-508: You can't "Save" or "Add to dashboard" when no changes have been made](https://linear.app/metabase/issue/VIZ-508/you-cant-save-or-add-to-dashboard-when-no-changes-have-been-made)

### Description

When adding a card through the question list by clicking on "Visualize another way", if the user doesn't change anythign the card isn't considered as "dirty" and therefore the "Add to dashboard" button is disabled. This makes sense when editing a card, but not when adding one. This PR fixes this.