### PR TITLE
Fix a case when the template tag's type was changed and the original question was an MBQL query

### DIFF
--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -883,7 +883,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
     SQLFilter.runQuery("cardQuery");
   });
 
-  it("should clear the value type and config when changing the template tag type and restore them when changing the type back", () => {
+  it("should clear the value type and config when changing the template tag type", () => {
     H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
     SQLFilter.openTypePickerFromDefaultFilterType();
@@ -908,11 +908,6 @@ describe("scenarios > filters > sql filters > values source > number parameter",
     SQLFilter.openTypePickerFromSelectedFilterType("Number");
     SQLFilter.chooseType("Field Filter");
     H.setConnectedFieldSource("Orders", "Total");
-
-    SQLFilter.openTypePickerFromSelectedFilterType("Number");
-    SQLFilter.chooseType("Text");
-    cy.get("[data-checked='true']").should("have.text", "Search box");
-    H.checkFilterListSourceHasValue({ values: ["Foo", "Bar"] });
   });
 });
 

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -883,7 +883,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
     SQLFilter.runQuery("cardQuery");
   });
 
-  it("should clear the value type and config when changing the template tag type", () => {
+  it("should clear the value type and config when changing the template tag type and restore them when changing the type back", () => {
     H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
     SQLFilter.openTypePickerFromDefaultFilterType();
@@ -908,6 +908,11 @@ describe("scenarios > filters > sql filters > values source > number parameter",
     SQLFilter.openTypePickerFromSelectedFilterType("Number");
     SQLFilter.chooseType("Field Filter");
     H.setConnectedFieldSource("Orders", "Total");
+
+    SQLFilter.openTypePickerFromSelectedFilterType("Number");
+    SQLFilter.chooseType("Text");
+    cy.get("[data-checked='true']").should("have.text", "Search box");
+    H.checkFilterListSourceHasValue({ values: ["Foo", "Bar"] });
   });
 });
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -98,7 +98,9 @@ class TagEditorParamInner extends Component<Props> {
     }
   }
 
-  getTemplateTagConfig = (newType: TemplateTagType): ParameterValuesConfig => {
+  getTemplateTagConfigAfterTypeChange = (
+    newType: TemplateTagType,
+  ): ParameterValuesConfig => {
     const { tag, parameter, originalQuestion } = this.props;
     if (!parameter || !originalQuestion) {
       return EMPTY_VALUES_CONFIG;
@@ -138,7 +140,7 @@ class TagEditorParamInner extends Component<Props> {
       });
 
       setParameterValue(tag.id, null);
-      setTemplateTagConfig(tag, this.getTemplateTagConfig(type));
+      setTemplateTagConfig(tag, this.getTemplateTagConfigAfterTypeChange(type));
     }
   };
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -5,11 +5,9 @@ import _ from "underscore";
 import { connect } from "metabase/lib/redux";
 import { ValuesSourceSettings } from "metabase/parameters/components/ValuesSourceSettings";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
-import { getOriginalQuestion } from "metabase/query_builder/selectors";
 import { fetchField } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Box } from "metabase/ui";
-import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Field from "metabase-lib/v1/metadata/Field";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
@@ -20,7 +18,6 @@ import {
   getDefaultParameterWidgetType,
   getParameterOptionsForField,
 } from "metabase-lib/v1/parameters/utils/template-tag-options";
-import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type {
   DimensionReference,
   FieldId,
@@ -62,7 +59,6 @@ interface Props {
   databases: Database[];
   databaseFields?: Field[];
   metadata: Metadata;
-  originalQuestion?: Question;
   setTemplateTag: (tag: TemplateTag) => void;
   setTemplateTagConfig: (
     tag: TemplateTag,
@@ -75,7 +71,6 @@ interface Props {
 function mapStateToProps(state: State) {
   return {
     metadata: getMetadata(state),
-    originalQuestion: getOriginalQuestion(state),
   };
 }
 
@@ -93,22 +88,8 @@ class TagEditorParamInner extends Component<Props> {
   }
 
   setType = (type: TemplateTagType) => {
-    const {
-      tag,
-      parameter,
-      setTemplateTag,
-      setParameterValue,
-      setTemplateTagConfig,
-      originalQuestion,
-    } = this.props;
-
-    const originalQuery = originalQuestion?.legacyQuery() as NativeQuery;
-    const originalTag = originalQuery
-      ?.variableTemplateTags()
-      .find((originalTag: TemplateTag) => originalTag.id === tag.id);
-    const originalParameter = originalQuestion
-      ?.parameters()
-      .find(originalParameter => originalParameter.id === parameter?.id);
+    const { tag, setTemplateTag, setParameterValue, setTemplateTagConfig } =
+      this.props;
 
     if (tag.type !== type) {
       setTemplateTag({
@@ -120,23 +101,11 @@ class TagEditorParamInner extends Component<Props> {
       });
 
       setParameterValue(tag.id, null);
-
-      if (!originalTag || originalTag.type !== type) {
-        // clear the values_source_config when changing the type
-        // as the values will most likely not work for the new type.
-        setTemplateTagConfig(tag, {
-          values_source_type: undefined,
-          values_source_config: undefined,
-          values_query_type: undefined,
-        });
-      } else {
-        // reset the original values_source_config when changing the type
-        setTemplateTagConfig(tag, {
-          values_source_type: originalParameter?.values_source_type,
-          values_source_config: originalParameter?.values_source_config,
-          values_query_type: originalParameter?.values_query_type,
-        });
-      }
+      setTemplateTagConfig(tag, {
+        values_source_type: undefined,
+        values_source_config: undefined,
+        values_query_type: undefined,
+      });
     }
   };
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -112,7 +112,7 @@ class TagEditorParamInner extends Component<Props> {
       return EMPTY_VALUES_CONFIG;
     }
 
-    const originalTag = Lib.templateTags(query)[tag.id];
+    const originalTag = Lib.templateTags(query)[tag.name];
     const parameters = originalQuestion.parameters();
     const originalParameter = parameters.find(({ id }) => id === parameter.id);
     if (!originalTag || originalTag.type !== newType || !originalParameter) {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -131,7 +131,7 @@ describe("TagEditorParam", () => {
       });
     });
 
-    it("should not throw when the original question has an mbql query", async () => {
+    it("should not throw when the original question has an mbql query (metabase#50662)", async () => {
       const tag = createMockTemplateTag({
         type: "dimension",
         dimension: ["field", PEOPLE.NAME, null],

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -131,7 +131,7 @@ describe("TagEditorParam", () => {
       });
     });
 
-    it("should not throw when the original question has an mbql query (metabase#50662)", async () => {
+    it("should not throw when the original question is an mbql query (metabase#50662)", async () => {
       const tag = createMockTemplateTag({
         type: "dimension",
         dimension: ["field", PEOPLE.NAME, null],


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/50662

Fix an edge case where `originalQuestion` for a native question was an mbql question. Hard to reproduce with a e2e test, so there is a unit test instead.