### PR TITLE
Modal.Stack with Create modals and entity picker modals

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -27,7 +27,9 @@ export function menu() {
 export function modal() {
   const MODAL_SELECTOR = ".mb-mantine-Modal-content[role='dialog']";
   const LEGACY_MODAL_SELECTOR = "[data-testid=modal]";
-  return cy.get([MODAL_SELECTOR, LEGACY_MODAL_SELECTOR].join(","));
+  return cy
+    .get([MODAL_SELECTOR, LEGACY_MODAL_SELECTOR].join(","))
+    .filter(":visible");
 }
 
 export function tooltip() {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -50,9 +50,7 @@ describe("scenarios > dashboard", () => {
       );
       H.modal().findByTestId("collection-picker-button").click();
       H.entityPickerModal().findByText("Select a collection");
-      // cy.realPress("Escape");
-      // TODO: Fix this:
-      H.entityPickerModal().button("Cancel").click();
+      cy.realPress("Escape");
       H.modal().findByText("New dashboard").should("be.visible");
 
       cy.log("Create a new dashboard");

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -178,20 +178,19 @@ const EditSandboxingModal = ({
             >
               {policyCard?.name ?? t`Select a question`}
             </Button>
-            {showPickerModal && (
-              <QuestionPickerModal
-                value={
-                  policyCard && policy.card_id != null
-                    ? getQuestionPickerValue(policyCard)
-                    : undefined
-                }
-                onChange={newCard => {
-                  setPolicy({ ...policy, card_id: newCard.id });
-                  hideModal();
-                }}
-                onClose={hideModal}
-              />
-            )}
+            <QuestionPickerModal
+              opened={showPickerModal}
+              value={
+                policyCard && policy.card_id != null
+                  ? getQuestionPickerValue(policyCard)
+                  : undefined
+              }
+              onChange={newCard => {
+                setPolicy({ ...policy, card_id: newCard.id });
+                hideModal();
+              }}
+              onClose={hideModal}
+            />
           </div>
         )}
         {(!shouldUseSavedQuestion || policy.card_id != null) &&

--- a/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
@@ -171,19 +171,19 @@ export const QueryValidator = () => {
           emptyBody={<QueryValidatorEmpty />}
         />
       </Box>
-      {collectionPickerOpen && (
-        <CollectionPickerModal
-          title={t`Select a collection`}
-          value={{ id: collectionId, model: "collection" }}
-          onChange={handleCollectionChange}
-          onClose={() => setCollectionPickerOpen(false)}
-          options={{
-            hasRecents: false,
-            showRootCollection: true,
-            showPersonalCollections: true,
-          }}
-        />
-      )}
+
+      <CollectionPickerModal
+        opened={collectionPickerOpen}
+        title={t`Select a collection`}
+        value={{ id: collectionId, model: "collection" }}
+        onChange={handleCollectionChange}
+        onClose={() => setCollectionPickerOpen(false)}
+        options={{
+          hasRecents: false,
+          showRootCollection: true,
+          showPersonalCollections: true,
+        }}
+      />
     </>
   ) : (
     <Flex justify="center" p="1rem">

--- a/frontend/src/metabase/archive/components/ArchivedEntityBanner/ArchivedEntityBanner.tsx
+++ b/frontend/src/metabase/archive/components/ArchivedEntityBanner/ArchivedEntityBanner.tsx
@@ -81,21 +81,21 @@ export const ArchivedEntityBanner = ({
           )}
         </Flex>
       </Box>
-      {modal === "move" && (
-        <CollectionPickerModal
-          title={`Move ${name}`}
-          value={{ id: "root", model: "collection" }}
-          onChange={collection => onMove?.(collection)}
-          options={{
-            showSearch: true,
-            hasConfirmButtons: true,
-            showRootCollection: true,
-            showPersonalCollections: true,
-            confirmButtonText: t`Move`,
-          }}
-          onClose={() => setModal(null)}
-        />
-      )}
+      <CollectionPickerModal
+        opened={modal === "move"}
+        title={`Move ${name}`}
+        value={{ id: "root", model: "collection" }}
+        onChange={collection => onMove?.(collection)}
+        options={{
+          showSearch: true,
+          hasConfirmButtons: true,
+          showRootCollection: true,
+          showPersonalCollections: true,
+          confirmButtonText: t`Move`,
+        }}
+        onClose={() => setModal(null)}
+      />
+
       {modal === "delete" && (
         <ConfirmModal
           opened

--- a/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
@@ -46,20 +46,22 @@ function CreateCollectionModal({
   );
 
   return (
-    <Modal
-      opened
-      onClose={onClose}
-      size="lg"
-      data-testid="new-collection-modal"
-      padding="40px"
-      title={t`New collection`}
-    >
-      <CreateCollectionForm
-        {...props}
-        onCreate={handleCreate}
-        onCancel={onClose}
-      />
-    </Modal>
+    <Modal.Stack>
+      <Modal
+        opened
+        onClose={onClose}
+        size="lg"
+        data-testid="new-collection-modal"
+        padding="40px"
+        title={t`New collection`}
+      >
+        <CreateCollectionForm
+          {...props}
+          onCreate={handleCreate}
+          onCancel={onClose}
+        />
+      </Modal>
+    </Modal.Stack>
   );
 }
 

--- a/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
@@ -15,6 +15,7 @@ import { CreateCollectionForm } from "../components/CreateCollectionForm";
 interface CreateCollectionModalOwnProps
   extends Omit<CreateCollectionFormOwnProps, "onCancel"> {
   onClose: () => void;
+  opened: boolean;
 }
 
 interface CreateCollectionModalDispatchProps {
@@ -31,6 +32,7 @@ function CreateCollectionModal({
   onCreate,
   onChangeLocation,
   onClose,
+  opened,
   ...props
 }: Props) {
   const handleCreate = useCallback(
@@ -48,7 +50,7 @@ function CreateCollectionModal({
   return (
     <Modal.Stack>
       <Modal
-        opened
+        opened={opened}
         onClose={onClose}
         size="lg"
         data-testid="new-collection-modal"

--- a/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
@@ -49,20 +49,22 @@ function CreateCollectionModal({
 
   return (
     <Modal.Stack>
-      <Modal
-        opened={opened}
-        onClose={onClose}
-        size="lg"
-        data-testid="new-collection-modal"
-        padding="40px"
-        title={t`New collection`}
-      >
-        <CreateCollectionForm
-          {...props}
-          onCreate={handleCreate}
-          onCancel={onClose}
-        />
-      </Modal>
+      {opened && (
+        <Modal
+          opened={opened}
+          onClose={onClose}
+          size="lg"
+          data-testid="new-collection-modal"
+          padding="40px"
+          title={t`New collection`}
+        >
+          <CreateCollectionForm
+            {...props}
+            onCreate={handleCreate}
+            onCancel={onClose}
+          />
+        </Modal>
+      )}
     </Modal.Stack>
   );
 }

--- a/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
@@ -241,16 +241,15 @@ export function FormCollectionAndDashboardPicker({
           )}
         </Button>
       </FormField>
-      {isPickerOpen && (
-        <CollectionPickerModal
-          title={pickerTitle}
-          value={pickerValue}
-          onChange={handleChange}
-          onClose={handleModalClose}
-          options={options}
-          {...collectionPickerModalProps}
-        />
-      )}
+      <CollectionPickerModal
+        opened={isPickerOpen}
+        title={pickerTitle}
+        value={pickerValue}
+        onChange={handleChange}
+        onClose={handleModalClose}
+        options={options}
+        {...collectionPickerModalProps}
+      />
     </>
   );
 }

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -146,16 +146,16 @@ function FormCollectionPicker({
           )}
         </Button>
       </FormField>
-      {isPickerOpen && (
-        <CollectionPickerModal
-          title={t`Select a collection`}
-          value={{ id: value, model: "collection" }}
-          onChange={handleChange}
-          onClose={() => setIsPickerOpen(false)}
-          options={options}
-          {...collectionPickerModalProps}
-        />
-      )}
+
+      <CollectionPickerModal
+        opened={isPickerOpen}
+        title={t`Select a collection`}
+        value={{ id: value, model: "collection" }}
+        onChange={handleChange}
+        onClose={() => setIsPickerOpen(false)}
+        options={options}
+        {...collectionPickerModalProps}
+      />
     </>
   );
 }

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { useToggle } from "metabase/hooks/use-toggle";
-import { Button, Icon } from "metabase/ui";
+import { Button, Icon, Modal, useModalStackContext } from "metabase/ui";
 import type { RecentItem, SearchResult } from "metabase-types/api";
 
 import { NewDashboardDialog } from "../../DashboardPicker/components/NewDashboardDialog";
@@ -201,7 +201,7 @@ export const CollectionPickerModal = ({
     }
   }, [selectedItem, value]);
 
-  return (
+  const modal = (
     <>
       <EntityPickerModal
         title={title}
@@ -236,4 +236,12 @@ export const CollectionPickerModal = ({
       />
     </>
   );
+
+  const modalCtx = useModalStackContext();
+
+  if (modalCtx) {
+    return modal;
+  } else {
+    return <Modal.Stack>{modal}</Modal.Stack>;
+  }
 };

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -31,6 +31,7 @@ export interface CollectionPickerModalProps {
   searchResultFilter?: (searchResults: SearchResult[]) => SearchResult[];
   recentFilter?: (recentItems: RecentItem[]) => RecentItem[];
   models?: CollectionPickerModel[];
+  opened: boolean;
 }
 
 const canSelectItem = (
@@ -51,6 +52,7 @@ const searchFilter = (searchResults: SearchResult[]): SearchResult[] => {
 
 export const CollectionPickerModal = ({
   title = t`Choose a collection`,
+  opened,
   onChange,
   onClose,
   value,
@@ -204,6 +206,7 @@ export const CollectionPickerModal = ({
   const modal = (
     <>
       <EntityPickerModal
+        opened={opened}
         title={title}
         onItemSelect={handleItemSelect}
         canSelectItem={

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
@@ -224,6 +224,7 @@ const setupModal = async ({
 
   renderWithProviders(
     <DashboardPickerModal
+      opened
       onChange={onChange}
       value={initialValue}
       onClose={jest.fn()}

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -3,7 +3,7 @@ import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { useToggle } from "metabase/hooks/use-toggle";
-import { Button, Icon } from "metabase/ui";
+import { Button, Icon, Modal, useModalStackContext } from "metabase/ui";
 import type { RecentItem, SearchResult } from "metabase-types/api";
 
 import type { EntityPickerTab } from "../../EntityPicker";
@@ -188,7 +188,7 @@ export const DashboardPickerModal = ({
 
   const parentCollectionId = getCollectionId(selectedItem || value);
 
-  return (
+  const modal = (
     <>
       <EntityPickerModal
         title={title}
@@ -223,4 +223,12 @@ export const DashboardPickerModal = ({
       />
     </>
   );
+
+  const modalCtx = useModalStackContext();
+
+  if (modalCtx) {
+    return modal;
+  } else {
+    return <Modal.Stack>{modal}</Modal.Stack>;
+  }
 };

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -29,6 +29,7 @@ import { NewDashboardDialog } from "./NewDashboardDialog";
 
 export interface DashboardPickerModalProps {
   title?: string;
+  opened: boolean;
   onChange: (item: DashboardPickerValueItem) => void;
   onClose: () => void;
   options?: DashboardPickerOptions;
@@ -76,6 +77,7 @@ const mergeOptions = (
 
 export const DashboardPickerModal = ({
   title = t`Choose a dashboard`,
+  opened,
   onChange,
   onClose,
   value = { model: "collection", id: "root" },
@@ -192,6 +194,7 @@ export const DashboardPickerModal = ({
     <>
       <EntityPickerModal
         title={title}
+        opened={opened}
         onItemSelect={handleItemSelect}
         canSelectItem={
           !isCreateDialogOpen &&

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -43,6 +43,7 @@ interface Props {
    */
   databaseId?: DatabaseId;
   title: string;
+  opened: boolean;
   value: DataPickerValue | undefined;
   models?: DataPickerValue["model"][];
   onChange: (value: TableId) => void;
@@ -70,6 +71,7 @@ const options: DataPickerModalOptions = {
 
 export const DataPickerModal = ({
   databaseId,
+  opened,
   title,
   value,
   models = ["table", "card", "dataset"],
@@ -227,6 +229,7 @@ export const DataPickerModal = ({
 
   return (
     <EntityPickerModal
+      opened={opened}
       canSelectItem
       defaultToRecentTab={false}
       initialValue={value}

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.unit.spec.tsx
@@ -1,8 +1,9 @@
 import {
+  setupDatabasesEndpoints,
   setupRecentViewsAndSelectionsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import { mockScrollBy, renderWithProviders, screen } from "__support__/ui";
 import type { DatabaseId, RecentItem, SearchResult } from "metabase-types/api";
 import {
   createMockRecentCollectionItem,
@@ -35,6 +36,7 @@ function setup({
 
   setupRecentViewsAndSelectionsEndpoints(recentItems, ["selections"]);
   setupSearchEndpoints(searchItems);
+  setupDatabasesEndpoints([]);
 
   renderWithProviders(
     <DataPickerModal
@@ -48,6 +50,8 @@ function setup({
 
   return { onChange, onClose };
 }
+
+mockScrollBy();
 
 describe("DataPickerModal", () => {
   describe("recents", () => {

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.unit.spec.tsx
@@ -41,6 +41,7 @@ function setup({
   renderWithProviders(
     <DataPickerModal
       title={title}
+      opened
       value={value}
       databaseId={databaseId}
       onChange={onChange}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntitityPickerModal.module.css
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntitityPickerModal.module.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  padding: 0;
 }
 
 .singlePickerView {

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -1,4 +1,3 @@
-import { useWindowEvent } from "@mantine/hooks";
 import {
   type ReactNode,
   useCallback,
@@ -12,7 +11,6 @@ import { t } from "ttag";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { useListRecentsQuery, useSearchQuery } from "metabase/api";
 import { useModalOpen } from "metabase/hooks/use-modal-open";
-import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { Box, Flex, Icon, Modal, Skeleton, TextInput } from "metabase/ui";
 import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
 import type {
@@ -330,24 +328,12 @@ export function EntityPickerModal<
     setSelectedTabId(initialTabId);
   }, [initialTabId]);
 
-  useWindowEvent(
-    "keydown",
-    event => {
-      if (event.key === "Escape") {
-        event.stopPropagation();
-        onClose();
-      }
-    },
-    { capture: true, once: true },
-  );
-
-  const titleId = useUniqueId("entity-picker-modal-title-");
-
   return (
-    <Modal.Root
+    <Modal
       opened={open}
       onClose={onClose}
       data-testid="entity-picker-modal"
+      title={title}
       /**
        * Both children of this component have "position: fixed" so the element's height is 0 by default.
        * This makes the following assertion to fail in Cypress:
@@ -357,82 +343,77 @@ export function EntityPickerModal<
       h="100vh"
       w="100vw"
       trapFocus={trapFocus}
-      closeOnEscape={false} // we're doing this manually in useWindowEvent
+      closeOnEscape
       yOffset="10dvh"
+      classNames={{
+        content: S.modalContent,
+        body: S.modalBody,
+      }}
+      styles={{
+        inner: {
+          display: "flex",
+          flexDirection: "column",
+        },
+        content: {
+          width: "57.5rem",
+        },
+      }}
     >
-      <Modal.Overlay />
-      <Modal.Content
-        className={S.modalContent}
-        aria-labelledby={titleId}
-        w="57.5rem"
-      >
-        <Modal.Header
-          px="2.5rem"
-          pt="1rem"
-          pb={hasTabs ? "1rem" : "1.5rem"}
-          bg="var(--mb-color-background)"
-        >
-          <Modal.Title id={titleId} lh="2.5rem">
-            {title}
-          </Modal.Title>
-          <Modal.CloseButton size={21} pos="relative" top="1px" />
-        </Modal.Header>
-        <Modal.Body className={S.modalBody} p="0">
-          {hydratedOptions.showSearch && (
-            <Box px="2.5rem" mb="1.5rem">
-              <TextInput
-                classNames={{ input: S.textInput }}
-                data-autofocus
-                type="search"
-                leftSection={<Icon name="search" size={16} />}
-                miw={400}
-                placeholder={getSearchInputPlaceholder(selectedFolder)}
-                value={searchQuery}
-                onChange={e => handleQueryChange(e.target.value ?? "")}
-              />
-            </Box>
-          )}
-          {!isLoadingTabs && !isLoadingRecentItems ? (
-            <ErrorBoundary>
-              {hasTabs ? (
-                <TabsView
-                  selectedTabId={selectedTabId}
-                  tabs={tabs}
-                  onItemSelect={handleSelectItem}
-                  onTabChange={handleTabChange}
-                />
-              ) : (
-                <div
-                  className={S.singlePickerView}
-                  data-testid="single-picker-view"
-                >
-                  {tabs[0]?.render({
-                    onItemSelect: item => handleSelectItem(item, tabs[0].id),
-                  }) ?? null}
-                </div>
-              )}
-              {!!hydratedOptions.hasConfirmButtons && onConfirm && (
-                <ButtonBar
-                  onConfirm={onConfirm}
-                  onCancel={onClose}
-                  canConfirm={canSelectItem}
-                  actionButtons={showActionButtons ? actionButtons : []}
-                  confirmButtonText={
-                    typeof options?.confirmButtonText === "function"
-                      ? options.confirmButtonText(selectedItem?.model)
-                      : options?.confirmButtonText
-                  }
-                  cancelButtonText={options?.cancelButtonText}
-                />
-              )}
-            </ErrorBoundary>
+      {hydratedOptions.showSearch && (
+        <Box px="2.5rem" mb="1.5rem">
+          <TextInput
+            classNames={{ input: S.textInput }}
+            data-autofocus
+            type="search"
+            leftSection={<Icon name="search" size={16} />}
+            miw={400}
+            placeholder={getSearchInputPlaceholder(selectedFolder)}
+            value={searchQuery}
+            onChange={e => handleQueryChange(e.target.value ?? "")}
+          />
+        </Box>
+      )}
+      {!isLoadingTabs && !isLoadingRecentItems ? (
+        <ErrorBoundary>
+          {hasTabs ? (
+            <TabsView
+              selectedTabId={selectedTabId}
+              tabs={tabs}
+              onItemSelect={handleSelectItem}
+              onTabChange={handleTabChange}
+            />
           ) : (
-            <EntityPickerLoadingSkeleton />
+            <div
+              className={S.singlePickerView}
+              data-testid="single-picker-view"
+            >
+              {tabs[0]?.render({
+                onItemSelect: item => handleSelectItem(item, tabs[0].id),
+              }) ?? null}
+            </div>
           )}
-          {children}
-        </Modal.Body>
-      </Modal.Content>
-    </Modal.Root>
+          {!!hydratedOptions.hasConfirmButtons && onConfirm && (
+            <ButtonBar
+              onConfirm={onConfirm}
+              onCancel={onClose}
+              canConfirm={canSelectItem}
+              actionButtons={showActionButtons ? actionButtons : []}
+              confirmButtonText={
+                typeof options?.confirmButtonText === "function"
+                  ? options.confirmButtonText(selectedItem?.model)
+                  : options?.confirmButtonText
+              }
+              cancelButtonText={options?.cancelButtonText}
+            />
+          )}
+        </ErrorBoundary>
+      ) : (
+        <EntityPickerLoadingSkeleton />
+      )}
+      {children}
+      {/* </Modal.Body>
+      </Modal.Content> */}
+    </Modal>
   );
 }
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -10,7 +10,6 @@ import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { useListRecentsQuery, useSearchQuery } from "metabase/api";
-import { useModalOpen } from "metabase/hooks/use-modal-open";
 import { Box, Flex, Icon, Modal, Skeleton, TextInput } from "metabase/ui";
 import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
 import type {
@@ -75,6 +74,7 @@ export interface EntityPickerModalProps<
   Item extends TypeWithModel<Id, Model>,
 > {
   title?: string;
+  opened: boolean;
   selectedItem: Item | null;
   initialValue?: Partial<Item>;
   canSelectItem: boolean;
@@ -104,6 +104,7 @@ export function EntityPickerModal<
   Item extends TypeWithModel<Id, Model>,
 >({
   title = t`Choose an item`,
+  opened,
   canSelectItem,
   selectedItem,
   initialValue,
@@ -161,8 +162,6 @@ export function EntityPickerModal<
   );
 
   assertValidProps(hydratedOptions, onConfirm);
-
-  const { open } = useModalOpen();
 
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
   useDebounce(() => setDebouncedSearchQuery(searchQuery), 200, [searchQuery]);
@@ -330,7 +329,7 @@ export function EntityPickerModal<
 
   return (
     <Modal
-      opened={open}
+      opened={opened}
       onClose={onClose}
       data-testid="entity-picker-modal"
       title={title}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -110,6 +110,7 @@ const setup = ({
 
   renderWithProviders(
     <EntityPickerModal
+      opened
       title={title}
       onItemSelect={onItemSelect}
       canSelectItem={true}

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -337,6 +337,7 @@ const setupModal = async ({
   renderWithProviders(
     <QuestionPickerModal
       onChange={onChange}
+      opened
       value={initialValue}
       onClose={jest.fn()}
       models={models}

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -25,6 +25,7 @@ import {
 
 interface QuestionPickerModalProps {
   title?: string;
+  opened: boolean;
   onChange: (item: QuestionPickerValueItem) => void;
   onClose: () => void;
   options?: QuestionPickerOptions;
@@ -51,6 +52,7 @@ const defaultOptions: QuestionPickerOptions = {
 
 export const QuestionPickerModal = ({
   title = t`Choose a question or model`,
+  opened,
   onChange,
   onClose,
   value = { model: "collection", id: "root" },
@@ -160,6 +162,7 @@ export const QuestionPickerModal = ({
 
   return (
     <EntityPickerModal
+      opened={opened}
       title={title}
       onItemSelect={handleItemSelect}
       canSelectItem={canSelectItem(selectedItem)}

--- a/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
+++ b/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
@@ -34,25 +34,24 @@ export const DashboardSelector = ({
       <DashboardPickerButton onClick={() => setIsOpen(true)}>
         {dashboard?.name || t`Select a dashboard`}
       </DashboardPickerButton>
-      {isOpen && (
-        <DashboardPickerModal
-          title={t`Choose a dashboard`}
-          value={
-            dashboard?.id ? { model: "dashboard", id: dashboard.id } : undefined
-          }
-          onChange={(dashboard: DashboardPickerValueItem) => {
-            onChange(dashboard.id);
-            setIsOpen(false);
-          }}
-          onClose={() => setIsOpen(false)}
-          options={{
-            showPersonalCollections: false,
-            showRootCollection: true,
-            allowCreateNew: false,
-            hasConfirmButtons: false,
-          }}
-        />
-      )}
+      <DashboardPickerModal
+        opened={isOpen}
+        title={t`Choose a dashboard`}
+        value={
+          dashboard?.id ? { model: "dashboard", id: dashboard.id } : undefined
+        }
+        onChange={(dashboard: DashboardPickerValueItem) => {
+          onChange(dashboard.id);
+          setIsOpen(false);
+        }}
+        onClose={() => setIsOpen(false)}
+        options={{
+          showPersonalCollections: false,
+          showRootCollection: true,
+          allowCreateNew: false,
+          hasConfirmButtons: false,
+        }}
+      />
     </Flex>
   );
 };

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
@@ -95,6 +95,7 @@ export const AddToDashSelectDashModal = ({
 
   return (
     <DashboardPickerModal
+      opened
       title={getTitle(card)}
       onChange={onDashboardSelected}
       onClose={onClose}

--- a/frontend/src/metabase/containers/MoveModal.tsx
+++ b/frontend/src/metabase/containers/MoveModal.tsx
@@ -118,6 +118,7 @@ export const MoveModal = ({
 
   return (
     <CollectionPickerModal
+      opened
       title={title}
       value={{
         id: initialCollectionId,
@@ -188,6 +189,7 @@ export const BulkMoveModal = ({
 
   return (
     <CollectionPickerModal
+      opened
       title={title}
       value={{
         id: initialCollectionId,

--- a/frontend/src/metabase/css/core/overlays/OverlaysDemo.tsx
+++ b/frontend/src/metabase/css/core/overlays/OverlaysDemo.tsx
@@ -318,6 +318,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
       ))}
       {Array.from({ length: entityPickerCount }).map((_value, index) => (
         <EntityPickerModal
+          opened
           key={`entity-picker-${index}`}
           title={`Entity Picker content`}
           selectedItem={null}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -299,22 +299,21 @@ export function LinkedEntityPicker({
         onClick={() => setIsPickerOpen(true)}
         onCancel={handleResetLinkTargetType}
       />
-      {isPickerOpen && (
-        <PickerComponent
-          title={getModalTitle()}
-          value={initialPickerValue as any} // typescript isn't smart enough to know which picker we're using
-          onChange={newTarget => {
-            handleSelectLinkTargetEntityId(newTarget.id);
-            setIsPickerOpen(false);
-          }}
-          onClose={() => setIsPickerOpen(false)}
-          options={{
-            showPersonalCollections: filterPersonalCollections !== "exclude",
-            showRootCollection: true,
-            hasConfirmButtons: false,
-          }}
-        />
-      )}
+      <PickerComponent
+        opened={isPickerOpen}
+        title={getModalTitle()}
+        value={initialPickerValue as any} // typescript isn't smart enough to know which picker we're using
+        onChange={newTarget => {
+          handleSelectLinkTargetEntityId(newTarget.id);
+          setIsPickerOpen(false);
+        }}
+        onClose={() => setIsPickerOpen(false)}
+        options={{
+          showPersonalCollections: filterPersonalCollections !== "exclude",
+          showRootCollection: true,
+          hasConfirmButtons: false,
+        }}
+      />
 
       {isDashboard && dashboardTabs.length > 1 && (
         <Select

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -466,6 +466,7 @@ class DashboardGridInner extends Component<
 
     return (
       <QuestionPickerModal
+        opened={hasValidDashCard}
         title={t`Pick what you want to replace this with`}
         value={
           replaceCardModalDashCard.card.id

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -37,20 +37,22 @@ export const CreateDashboardModal = ({
   );
 
   return (
-    <Modal
-      title={t`New dashboard`}
-      onClose={() => onClose?.()}
-      data-testid="new-dashboard-modal"
-      size="lg"
-      {...modalProps}
-    >
-      <CreateDashboardForm
-        onCreate={handleCreate}
-        onCancel={onClose}
-        initialValues={initialValues}
-        filterPersonalCollections={filterPersonalCollections}
-        collectionId={collectionId}
-      />
-    </Modal>
+    <Modal.Stack>
+      <Modal
+        title={t`New dashboard`}
+        onClose={() => onClose?.()}
+        data-testid="new-dashboard-modal"
+        size="lg"
+        {...modalProps}
+      >
+        <CreateDashboardForm
+          onCreate={handleCreate}
+          onCancel={onClose}
+          initialValues={initialValues}
+          filterPersonalCollections={filterPersonalCollections}
+          collectionId={collectionId}
+        />
+      </Modal>
+    </Modal.Stack>
   );
 };

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -21,6 +21,7 @@ export const CreateDashboardModal = ({
   initialValues,
   filterPersonalCollections,
   collectionId,
+  opened,
   ...modalProps
 }: CreateDashboardModalProps & Omit<ModalProps, "onClose">) => {
   const dispatch = useDispatch();
@@ -38,21 +39,24 @@ export const CreateDashboardModal = ({
 
   return (
     <Modal.Stack>
-      <Modal
-        title={t`New dashboard`}
-        onClose={() => onClose?.()}
-        data-testid="new-dashboard-modal"
-        size="lg"
-        {...modalProps}
-      >
-        <CreateDashboardForm
-          onCreate={handleCreate}
-          onCancel={onClose}
-          initialValues={initialValues}
-          filterPersonalCollections={filterPersonalCollections}
-          collectionId={collectionId}
-        />
-      </Modal>
+      {opened && (
+        <Modal
+          title={t`New dashboard`}
+          onClose={() => onClose?.()}
+          data-testid="new-dashboard-modal"
+          size="lg"
+          opened={opened}
+          {...modalProps}
+        >
+          <CreateDashboardForm
+            onCreate={handleCreate}
+            onCancel={onClose}
+            initialValues={initialValues}
+            filterPersonalCollections={filterPersonalCollections}
+            collectionId={collectionId}
+          />
+        </Modal>
+      )}
     </Modal.Stack>
   );
 };

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -233,8 +233,41 @@ describe("CreateDashboardModal", () => {
       await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
       await userEvent.click(newCollBtn());
-      await screen.findByTestId("create-collection-on-the-go"),
-        await screen.findByText("Give it a name");
+      await screen.findByTestId("create-collection-on-the-go");
+      await screen.findByText("Give it a name");
+    });
+
+    it("allow you to use esc to close modals", async () => {
+      setup();
+      const name = "my dashboard";
+      await userEvent.type(nameField(), name);
+      await userEvent.click(collDropdown());
+      await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
+      await userEvent.click(newCollBtn());
+      await screen.findByTestId("create-collection-on-the-go");
+
+      //Both parent modals should be hidden
+      expect(
+        await screen.findByRole("dialog", { name: "Select a collection" }),
+      ).toHaveAttribute("data-hidden", "true");
+      expect(
+        await screen.findByRole("dialog", { name: "New dashboard" }),
+      ).toHaveAttribute("data-hidden", "true");
+      userEvent.keyboard("{Escape}");
+
+      // Back to entity picker
+      expect(
+        await screen.findByRole("dialog", { name: "Select a collection" }),
+      ).not.toHaveAttribute("data-hidden", "true");
+      expect(
+        await screen.findByRole("dialog", { name: "New dashboard" }),
+      ).toHaveAttribute("data-hidden", "true");
+      userEvent.keyboard("{Escape}");
+
+      // Back to create dashboard modal
+      expect(
+        await screen.findByRole("dialog", { name: "New dashboard" }),
+      ).not.toHaveAttribute("data-hidden", "true");
     });
   });
 });

--- a/frontend/src/metabase/models/containers/FormModelPicker/FormModelPicker.tsx
+++ b/frontend/src/metabase/models/containers/FormModelPicker/FormModelPicker.tsx
@@ -64,18 +64,17 @@ export function FormModelPicker({
           {isModelSelected ? model?.name : placeholder}
         </Button>
       </FormField>
-      {isPickerOpen && (
-        <QuestionPickerModal
-          models={["dataset"]}
-          title={t`Select a model`}
-          value={model?.id ? getQuestionPickerValue(model) : undefined}
-          onChange={newModel => {
-            setValue(newModel.id);
-            setIsPickerOpen(false);
-          }}
-          onClose={() => setIsPickerOpen(false)}
-        />
-      )}
+      <QuestionPickerModal
+        opened={isPickerOpen}
+        models={["dataset"]}
+        title={t`Select a model`}
+        value={model?.id ? getQuestionPickerValue(model) : undefined}
+        onChange={newModel => {
+          setValue(newModel.id);
+          setIsPickerOpen(false);
+        }}
+        onClose={() => setIsPickerOpen(false)}
+      />
     </>
   );
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -1,5 +1,5 @@
 import type { LocationDescriptor } from "history";
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo } from "react";
 import _ from "underscore";
 
 import {
@@ -7,12 +7,10 @@ import {
   useListCollectionsTreeQuery,
 } from "metabase/api";
 import { logout } from "metabase/auth/actions";
-import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 import {
   currentUserPersonalCollections,
   nonPersonalOrArchivedCollection,
 } from "metabase/collections/utils";
-import Modal from "metabase/components/Modal";
 import Bookmarks, { getOrderedBookmarks } from "metabase/entities/bookmarks";
 import type { CollectionTreeItem } from "metabase/entities/collections";
 import Collections, {
@@ -21,8 +19,8 @@ import Collections, {
   getCollectionIcon,
 } from "metabase/entities/collections";
 import Databases from "metabase/entities/databases";
-import { connect } from "metabase/lib/redux";
-import * as Urls from "metabase/lib/urls";
+import { connect, useDispatch } from "metabase/lib/redux";
+import { setOpenModal } from "metabase/redux/ui";
 import { getHasDataAccess } from "metabase/selectors/data";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -34,8 +32,6 @@ import { NavbarLoadingView } from "../NavbarLoadingView";
 import type { MainNavbarProps, SelectedItem } from "../types";
 
 import { MainNavbarView } from "./MainNavbarView";
-
-type NavbarModal = "MODAL_NEW_COLLECTION" | null;
 
 function mapStateToProps(state: State, { databases = [] }: DatabaseProps) {
   return {
@@ -87,7 +83,7 @@ function MainNavbarContainer({
   onReorderBookmarks,
   ...props
 }: Props) {
-  const [modal, setModal] = useState<NavbarModal>(null);
+  const dispatch = useDispatch();
 
   const {
     data: trashCollection,
@@ -150,25 +146,8 @@ function MainNavbarContainer({
   );
 
   const onCreateNewCollection = useCallback(() => {
-    setModal("MODAL_NEW_COLLECTION");
-  }, []);
-
-  const closeModal = useCallback(() => setModal(null), []);
-
-  const renderModalContent = useCallback(() => {
-    if (modal === "MODAL_NEW_COLLECTION") {
-      return (
-        <CreateCollectionModal
-          onClose={closeModal}
-          onCreate={(collection: Collection) => {
-            closeModal();
-            onChangeLocation(Urls.collection(collection));
-          }}
-        />
-      );
-    }
-    return null;
-  }, [modal, closeModal, onChangeLocation]);
+    dispatch(setOpenModal("collection"));
+  }, [dispatch]);
 
   const allError = props.allError || !!error;
   if (allError) {
@@ -196,8 +175,6 @@ function MainNavbarContainer({
         handleCloseNavbar={closeNavbar}
         handleLogout={logout}
       />
-
-      {modal && <Modal onClose={closeModal}>{renderModalContent()}</Modal>}
     </>
   );
 }

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -32,34 +32,28 @@ export const NewModals = withRouter((props: WithRouterProps) => {
   const handleModalClose = useCallback(() => {
     dispatch(closeModal());
   }, [dispatch]);
+  return (
+    <>
+      <CreateCollectionModal
+        opened={currentNewModal === "collection"}
+        onClose={handleModalClose}
+        collectionId={collectionId}
+      />
 
-  switch (currentNewModal) {
-    case "collection":
-      return (
-        <CreateCollectionModal
-          onClose={handleModalClose}
-          collectionId={collectionId}
-        />
-      );
+      <CreateDashboardModal
+        opened={currentNewModal === "dashboard"}
+        onClose={handleModalClose}
+        collectionId={collectionId}
+      />
 
-    case "dashboard":
-      return (
-        <CreateDashboardModal
-          opened
-          onClose={handleModalClose}
-          collectionId={collectionId}
-        />
-      );
-    case "action":
-      return (
+      {currentNewModal === "action" && (
         <Modal wide onClose={handleModalClose} enableTransition={false}>
           <ActionCreator
             onClose={handleModalClose}
             onSubmit={handleActionCreated}
           />
         </Modal>
-      );
-    default:
-      return null;
-  }
+      )}
+    </>
+  );
 });

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
@@ -40,6 +40,7 @@ export const ValuesSourceCardModal = ({
 
   return (
     <QuestionPickerModal
+      opened
       title={t`Selectable values for ${parameter.name}`}
       value={initialValue}
       onChange={handleSubmit}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -181,16 +181,15 @@ function ModernDataPicker({
           onAuxClick={handleAuxClick}
         />
       </Tooltip>
-      {isOpened && (
-        <DataPickerModal
-          title={title}
-          value={tableValue}
-          databaseId={canChangeDatabase ? undefined : databaseId}
-          models={modelList}
-          onChange={onChange}
-          onClose={() => setIsOpened(false)}
-        />
-      )}
+      <DataPickerModal
+        opened={isOpened}
+        title={title}
+        value={tableValue}
+        databaseId={canChangeDatabase ? undefined : databaseId}
+        models={modelList}
+        onChange={onChange}
+        onClose={() => setIsOpened(false)}
+      />
     </>
   );
 }

--- a/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
@@ -68,15 +68,14 @@ export function DataStep({
           {tableInfo?.displayName}
         </Text>
       )}
-      {isOpened && (
-        <DataPickerModal
-          title={t`Select a table`}
-          models={["table"]}
-          value={tableValue}
-          onChange={handleChange}
-          onClose={() => setIsOpened(false)}
-        />
-      )}
+      <DataPickerModal
+        opened={isOpened}
+        title={t`Select a table`}
+        models={["table"]}
+        value={tableValue}
+        onChange={handleChange}
+        onClose={() => setIsOpened(false)}
+      />
     </ClauseStep>
   );
 }

--- a/frontend/src/metabase/timelines/common/components/MoveTimelineModal/MoveTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/MoveTimelineModal/MoveTimelineModal.tsx
@@ -37,6 +37,7 @@ const MoveTimelineModal = ({
 
   return (
     <CollectionPickerModal
+      opened
       value={{ id: timeline.collection_id ?? "root", model: "collection" }}
       title={t`Move ${getTimelineName(timeline)}`}
       onClose={onClose}

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.config.tsx
@@ -18,7 +18,7 @@ export const modalOverrides = {
     classNames: {
       root: Styles.root,
       title: Styles.title,
-      overlay: cx(Styles.overlay, ZIndex.Overlay, Animation.fadeIn),
+      overlay: cx(Styles.overlay, ZIndex.Overlay),
       content: cx(Styles.content, ZIndex.Overlay, Animation.popInFromBottom),
       inner: cx(ZIndex.Overlay, Animation.popInFromBottom),
       header: Styles.header,

--- a/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
@@ -2,18 +2,37 @@ import {
   Modal as MantineModal,
   type ModalProps,
   type ModalRootProps,
+  useModalStackContext,
 } from "@mantine/core";
+import { useState } from "react";
+import { useUnmount } from "react-use";
 
+import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { PreventEagerPortal } from "metabase/ui";
 
 export type { ModalProps } from "@mantine/core";
+export { useModalStackContext } from "@mantine/core";
 
 export * from "./Modal.config";
+
+const _Modal = (props: ModalProps) => {
+  const ctx = useModalStackContext();
+  const identifier = useUniqueId("modal-");
+  const [_stackId] = useState(props.stackId ?? identifier);
+
+  useUnmount(() => {
+    if (ctx) {
+      ctx?.removeModal(_stackId);
+    }
+  });
+
+  return <MantineModal {...props} stackId={_stackId} />;
+};
 
 export const Modal = (props: ModalProps) => {
   return (
     <PreventEagerPortal {...props}>
-      <MantineModal {...props} />
+      <_Modal {...props} />
     </PreventEagerPortal>
   );
 };
@@ -31,4 +50,5 @@ Modal.CloseButton = MantineModal.CloseButton;
 Modal.Header = MantineModal.Header;
 Modal.Title = MantineModal.Title;
 Modal.Body = MantineModal.Body;
+Modal.Stack = MantineModal.Stack;
 // Modal.NativeScrollArea = MantineModal.NativeScrollArea;

--- a/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
@@ -8,13 +8,14 @@ import { useState } from "react";
 import { useUnmount } from "react-use";
 
 import { useUniqueId } from "metabase/hooks/use-unique-id";
+import { PreventEagerPortal } from "metabase/ui";
 
 export type { ModalProps } from "@mantine/core";
 export { useModalStackContext } from "@mantine/core";
 
 export * from "./Modal.config";
 
-const _Modal = (props: ModalProps) => {
+export const Modal = (props: ModalProps) => {
   const ctx = useModalStackContext();
   const identifier = useUniqueId("modal-");
   const [_stackId] = useState(props.stackId ?? identifier);
@@ -25,14 +26,24 @@ const _Modal = (props: ModalProps) => {
     }
   });
 
-  return <MantineModal {...props} stackId={_stackId} />;
+  const modal = <MantineModal {...props} stackId={_stackId} />;
+
+  if (ctx) {
+    return modal;
+  }
+
+  return (
+    <PreventEagerPortal {...props}>
+      <MantineModal {...props} stackId={_stackId} />
+    </PreventEagerPortal>
+  );
 };
 
-export const Modal = (props: ModalProps) => {
-  return <_Modal {...props} />;
-};
-
-const ModalRoot = (props: ModalRootProps) => <MantineModal.Root {...props} />;
+const ModalRoot = (props: ModalRootProps) => (
+  <PreventEagerPortal>
+    <MantineModal.Root {...props} />
+  </PreventEagerPortal>
+);
 
 Modal.Root = ModalRoot;
 Modal.Overlay = MantineModal.Overlay;

--- a/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
@@ -8,7 +8,6 @@ import { useState } from "react";
 import { useUnmount } from "react-use";
 
 import { useUniqueId } from "metabase/hooks/use-unique-id";
-import { PreventEagerPortal } from "metabase/ui";
 
 export type { ModalProps } from "@mantine/core";
 export { useModalStackContext } from "@mantine/core";
@@ -30,18 +29,10 @@ const _Modal = (props: ModalProps) => {
 };
 
 export const Modal = (props: ModalProps) => {
-  return (
-    <PreventEagerPortal {...props}>
-      <_Modal {...props} />
-    </PreventEagerPortal>
-  );
+  return <_Modal {...props} />;
 };
 
-const ModalRoot = (props: ModalRootProps) => (
-  <PreventEagerPortal>
-    <MantineModal.Root {...props} />
-  </PreventEagerPortal>
-);
+const ModalRoot = (props: ModalRootProps) => <MantineModal.Root {...props} />;
 
 Modal.Root = ModalRoot;
 Modal.Overlay = MantineModal.Overlay;

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -56,22 +56,21 @@ function DashCardPlaceholderInner({
           >{t`Select question`}</Button>
         )}
       </Flex>
-      {isQuestionPickerOpen && (
-        <QuestionPickerModal
-          title={t`Pick what you want to replace this with`}
-          value={
-            dashboard.collection_id
-              ? {
-                  id: dashboard.collection_id,
-                  model: "collection",
-                }
-              : undefined
-          }
-          models={["card", "dataset", "metric"]}
-          onChange={handleSelectQuestion}
-          onClose={() => setQuestionPickerOpen(false)}
-        />
-      )}
+      <QuestionPickerModal
+        opened={isQuestionPickerOpen}
+        title={t`Pick what you want to replace this with`}
+        value={
+          dashboard.collection_id
+            ? {
+                id: dashboard.collection_id,
+                model: "collection",
+              }
+            : undefined
+        }
+        models={["card", "dataset", "metric"]}
+        onChange={handleSelectQuestion}
+        onClose={() => setQuestionPickerOpen(false)}
+      />
     </>
   );
 }


### PR DESCRIPTION
Closes ADM-460

### Description
Uses `<Modal.Stack>` and a modal wrapper to leverage Mantine's built in modal management for known flows where modals render other modals. This does change things so that only 1 modal is rendered at a time on the screen, but pressing esc will only dismiss the current modal, not the whole stack. 

The particular approach of wrapping the `<Modal>` component (again) is due to the fact that we use a pattern throughout the app where we mount and unmount modals, where Mantine expects us to be mounting the modals and updating the value of `opened`. This meant that when working with a `<Modal.Stack>`, we were never removing the modal from the stack when unmounting. 

### How to verify

1. New question -> Collection -> Open Collection Picker
2. Click Create new Collection
3. Press esc, and you should be back to the entity picker
4. press esc again, and you should be back to the create modal form.

Interactions like these can be found in other places, such as creating dashboards, adding question to dashboards, moving questions / dashboards, etc.

### Demo

https://www.loom.com/share/3942352473ff4e69a4f5a25b23c1dc4a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
