### PR TITLE
Add use-toast hook

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
@@ -3,15 +3,14 @@ import { msgid, ngettext, t } from "ttag";
 
 import SettingHeader from "metabase/admin/settings/components/SettingHeader";
 import { ClientSortableTable } from "metabase/common/components/Table";
+import { useToast } from "metabase/common/hooks";
 import {
   BulkActionBar,
   BulkActionButton,
 } from "metabase/components/BulkActionBar";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import Link from "metabase/core/components/Link";
-import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { addUndo } from "metabase/redux/undo";
 import { Box, Button, Checkbox, Flex, Icon, Text } from "metabase/ui";
 import {
   useDeleteUploadTableMutation,
@@ -34,7 +33,7 @@ export function UploadManagementTable() {
   const [selectedItems, setSelectedItems] = useState<Table[]>([]);
   const [deleteTableRequest] = useDeleteUploadTableMutation();
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
-  const dispatch = useDispatch();
+  const [sendToast] = useToast();
 
   // TODO: once we have uploads running through RTK Query, we can remove the force update
   // because we can properly invalidate the tables tag
@@ -110,9 +109,7 @@ export function UploadManagementTable() {
               selectedItems.length,
             );
 
-            dispatch(
-              addUndo({ message, toastColor: "error", icon: "warning" }),
-            );
+            sendToast({ message, toastColor: "error", icon: "warning" });
           } else if (result.length > 0) {
             const message = ngettext(
               msgid`1 table deleted`,
@@ -120,7 +117,7 @@ export function UploadManagementTable() {
               result.length,
             );
 
-            dispatch(addUndo({ message }));
+            sendToast({ message });
           }
           setSelectedItems([]);
         }}

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -107,7 +107,7 @@ export const ModelPersistenceConfiguration = () => {
       ? PersistedModelsApi.enablePersistence()
       : PersistedModelsApi.disablePersistence();
     await resolveWithToasts([promise]);
-    dispatch(refreshSiteSettings({}));
+    dispatch(refreshSiteSettings());
   };
 
   const { url: docsUrl } = useDocsUrl("data-modeling/model-persistence");

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -107,7 +107,7 @@ export const ModelPersistenceConfiguration = () => {
       ? PersistedModelsApi.enablePersistence()
       : PersistedModelsApi.disablePersistence();
     await resolveWithToasts([promise]);
-    dispatch(refreshSiteSettings());
+    dispatch(refreshSiteSettings({}));
   };
 
   const { url: docsUrl } = useDocsUrl("data-modeling/model-persistence");

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -5,4 +5,5 @@ export * from "./use-locale";
 export * from "./use-notification-channels";
 export * from "./use-setting";
 export * from "./use-temp-storage";
+export * from "./use-toast";
 export * from "./use-url-with-utm";

--- a/frontend/src/metabase/common/hooks/use-toast/index.ts
+++ b/frontend/src/metabase/common/hooks/use-toast/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-toast";

--- a/frontend/src/metabase/common/hooks/use-toast/use-toast.ts
+++ b/frontend/src/metabase/common/hooks/use-toast/use-toast.ts
@@ -1,0 +1,14 @@
+import { useDispatch } from "metabase/lib/redux";
+import { addUndo, dismissUndo } from "metabase/redux/undo";
+import type { Undo } from "metabase-types/store/undo";
+
+type ToastArgs = Omit<Undo, "id" | "timeoutId">;
+
+// A handy convenience hook for adding toast/undo notifications
+export const useToast = () => {
+  const dispatch = useDispatch();
+  const sendToast = (toastInfo: ToastArgs) => dispatch(addUndo(toastInfo));
+  const dismissToast = (toastId: number) =>
+    dispatch(dismissUndo({ undoId: toastId }));
+  return [sendToast, dismissToast] as const;
+};

--- a/frontend/src/metabase/common/hooks/use-toast/use-toast.ts
+++ b/frontend/src/metabase/common/hooks/use-toast/use-toast.ts
@@ -1,3 +1,5 @@
+import { useCallback } from "react";
+
 import { useDispatch } from "metabase/lib/redux";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
 import type { Undo } from "metabase-types/store/undo";
@@ -7,8 +9,13 @@ type ToastArgs = Omit<Undo, "id" | "timeoutId">;
 // A handy convenience hook for adding toast/undo notifications
 export const useToast = () => {
   const dispatch = useDispatch();
-  const sendToast = (toastInfo: ToastArgs) => dispatch(addUndo(toastInfo));
-  const dismissToast = (toastId: number) =>
-    dispatch(dismissUndo({ undoId: toastId }));
+  const sendToast = useCallback(
+    (toastInfo: ToastArgs) => dispatch(addUndo(toastInfo)),
+    [dispatch],
+  );
+  const dismissToast = useCallback(
+    (toastId: number) => dispatch(dismissUndo({ undoId: toastId })),
+    [dispatch],
+  );
   return [sendToast, dismissToast] as const;
 };

--- a/frontend/src/metabase/common/hooks/use-toast/use-toast.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-toast/use-toast.unit.spec.tsx
@@ -1,0 +1,57 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { UndoListing } from "metabase/containers/UndoListing";
+
+import { useToast } from "./use-toast";
+
+const TEST_TOAST_ID = 8675309;
+
+const TestComponent = () => {
+  const [sendToast, removeToast] = useToast();
+  return (
+    <div>
+      <button
+        onClick={() =>
+          sendToast({
+            // @ts-expect-error - we shouldn't hardcode ids in application code
+            id: TEST_TOAST_ID,
+            message: "Yeah Toast!",
+            icon: "check",
+            timeout: 9000,
+          })
+        }
+      >
+        Send Toast
+      </button>
+      <button onClick={() => removeToast(TEST_TOAST_ID)}>Remove Toast</button>
+      <UndoListing />
+    </div>
+  );
+};
+
+const setup = async () => {
+  await renderWithProviders(<TestComponent />, { storeInitialState: {} });
+};
+
+describe("useToast hook", () => {
+  it("should send a toast", async () => {
+    setup();
+
+    const sendButton = screen.getByText("Send Toast");
+    await userEvent.click(sendButton);
+    expect(await screen.findByText("Yeah Toast!")).toBeInTheDocument();
+  });
+
+  it("should remove a toast", async () => {
+    setup();
+
+    const sendButton = screen.getByText("Send Toast");
+    await userEvent.click(sendButton);
+    expect(await screen.findByText("Yeah Toast!")).toBeInTheDocument();
+
+    const removeButton = screen.getByText("Remove Toast");
+    await userEvent.click(removeButton);
+    expect(screen.queryByText("Yeah Toast!")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

This simply adds some much-needed ergonomics to our existing toast system by adding a nice little hook to wrap some redux actions.
- this should be easier to find because it uses the word "toast" - which someone might be able to find more easily than "undo".
- also adds some nice test coverage
- also properly types it, the current redux payload is just `any`

![Screenshot 2025-03-06 at 2 23 10 PM](https://github.com/user-attachments/assets/0573fe72-6091-44a7-beb8-6b876c236ca0)

This also converts a couple pages to using it.

### Before
```ts
import { useDispatch } from "metabase/lib/redux";
import { addUndo, dismissUndo } from "metabase/redux/undo";

function MyComponent() {
  const dispatch = useDispatch();

  return (
    <button
      onClick={() => {
        dispatch(addUndo({ message: "Hello world" }));
      }}
    >
      Do The Thing
    </button>
  );
}
```


### After

```ts
import { useToast } from "metabase/common/hooks";

function MyNewComponent() {
  const [sendToast, removeToast] = useToast();

  return (
    <button
      onClick={() => {
        sendToast({ message: "Hello world" });
      }}
    >
      Do The Thing
    </button>
  );
}
```

Not ground-breaking, but I've wanted to use this via a hook for a long time, and abstract some of the redux implementation details away.
