### PR TITLE
Create search index within transaction

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -167,12 +167,13 @@
 (defn create-table!
   "Create an index table with the given name. Should fail if it already exists."
   [table-name]
-  (-> (sql.helpers/create-table table-name)
-      (sql.helpers/with-columns (specialization/table-schema base-schema))
-      t2/query)
-  (let [table-name (name table-name)]
-    (doseq [stmt (specialization/post-create-statements table-name table-name)]
-      (t2/query stmt))))
+  (t2/with-transaction [_]
+    (-> (sql.helpers/create-table table-name)
+        (sql.helpers/with-columns (specialization/table-schema base-schema))
+        t2/query)
+    (let [table-name (name table-name)]
+      (doseq [stmt (specialization/post-create-statements table-name table-name)]
+        (t2/query stmt)))))
 
 (defn maybe-create-pending!
   "Create a search index table if one doesn't exist. Record and return the name of the table, regardless."


### PR DESCRIPTION
Not all drivers will actually do DDL statements transactionally, but it doesn't hurt to try.