### PR TITLE
Scrap the ability to resolve table names, just use ids

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -14,8 +14,6 @@
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.events :as events]
-   [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.card :as card]
@@ -29,9 +27,6 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.public-settings :as public-settings]
-   [metabase.query-processor :as qp]
-   [metabase.query-processor.store :as qp.store]
-   [metabase.query-processor.streaming :as qp.streaming]
    [metabase.request.core :as request]
    [metabase.sample-data :as sample-data]
    [metabase.server.streaming-response]
@@ -47,7 +42,6 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.quick-task :as quick-task]
-   [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -733,55 +727,6 @@
                                                 (str schema "." table-name)
                                                 table-name))})))
       (first tables))))
-
-(defn- resolve-table [db-id table-identifier]
-  (let [[schema table-name] (let [parts (str/split table-identifier #"\.")]
-                              (case (count parts)
-                                1 [nil (first parts)]
-                                2 parts
-                                nil))]
-    (api/check table-name 400 "Invalid table identifier")
-    (api/check-404
-     (or (if schema
-           ;; Sometimes we get duplicate records, but bypass that if we have a fully qualified exact match.
-           ;; See: https://github.com/metabase/metabase/issues/53868
-           (t2/select-one :model/Table :db_id db-id :name table-name :schema schema)
-           (check-unique (t2/select :model/Table :db_id db-id :name table-name)))
-         (check-unique (t2/select :model/Table
-                                  :db_id db-id
-                                  :%lower.name (u/lower-case-en table-name)
-                                  (cond-> {}
-                                    schema (assoc :where {:%lower.schema (u/lower-case-en schema)}))))))))
-
-(api.macros/defendpoint :get "/:db-id/table/:table-identifier/data"
-  "Get the data for the given table"
-  [{:keys [db-id table-identifier]} :- [:map
-                                        [:db-id ms/PositiveInt]
-                                        [:table-identifier ms/NonBlankString]]]
-  (api/read-check (t2/select-one :model/Database :id db-id))
-  (qp.store/with-metadata-provider db-id
-    (let [mp    (qp.store/metadata-provider)
-          table-id (:id (resolve-table db-id table-identifier))
-          query (-> (lib/query mp (lib.metadata/table mp table-id))
-                    (update-in [:middleware :js-int-to-string?] (fnil identity true))
-                    qp/userland-query-with-default-constraints
-                    (update :info merge {:executed-by api/*current-user-id*
-                                         :context     :table-grid
-                                         :card-id     nil}))]
-      (events/publish-event! :event/table-read {:object  (t2/select-one :model/Table :id table-id)
-                                                :user-id api/*current-user-id*})
-      (span/with-span!
-        {:name "query-table-async"}
-        (qp.streaming/streaming-response [rff :api]
-          (qp/process-query query
-                           ;; For now, doing this transformation here makes it easy to iterate on our payload shape.
-                           ;; In the future, we might want to implement a new export-type, say `:api/table`, instead.
-                           ;; Then we can avoid building non-relevant fields, only to throw them away again.
-                            (qp.streaming/transforming-query-response
-                             rff
-                             (fn [response]
-                               (-> (assoc response :table_id table-id)
-                                   (dissoc :json_query :context :cached :average_execution_time))))))))))
 
 ;;; ----------------------------------------------- POST /api/database -----------------------------------------------
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -714,20 +714,6 @@
              (filter field-perm-check (-> (database/pk-fields {:id id})
                                           (t2/hydrate :table))))))
 
-;;; ----------------------------------------- GET /api/database/:id/table/:fqn ---------------------------------------
-
-(defn- check-unique [tables]
-  (when (seq tables)
-    (let [unique-combos (distinct (map (juxt :schema :name) tables))]
-      (when (> (count unique-combos) 1)
-        (throw (ex-info "Ambiguous table identifier"
-                        {:status-code       300
-                         :potential-matches (for [[schema table-name] unique-combos]
-                                              (if schema
-                                                (str schema "." table-name)
-                                                table-name))})))
-      (first tables))))
-
 ;;; ----------------------------------------------- POST /api/database -----------------------------------------------
 
 (defn test-database-connection

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -95,8 +95,7 @@
                               (qp.streaming/transforming-query-response
                                rff
                                (fn [response]
-                                 (-> (assoc response :table_id table-id)
-                                     (dissoc :json_query :context :cached :average_execution_time)))))))))))
+                                 (dissoc response :json_query :context :cached :average_execution_time))))))))))
 
 (mu/defn ^:private update-table!*
   "Takes an existing table and the changes, updates in the database and optionally calls `table/update-field-positions!`

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -9,11 +9,16 @@
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.events :as events]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.field-values :as field-values]
    [metabase.models.interface :as mi]
    [metabase.models.table :as table]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.streaming :as qp.streaming]
    [metabase.request.core :as request]
    [metabase.sync.core :as sync]
    [metabase.types :as types]
@@ -25,6 +30,7 @@
    [metabase.util.malli.schema :as ms]
    [metabase.util.quick-task :as quick-task]
    [metabase.xrays.core :as xrays]
+   [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -62,6 +68,35 @@
     (-> (api-perm-check-fn :model/Table id)
         (t2/hydrate :db :pk_field)
         fix-schema)))
+
+(api.macros/defendpoint :get "/:table-id/data"
+  "Get the data for the given table"
+  [{:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]]
+  (let [table (t2/select-one :model/Table :id table-id)
+        db-id (:db_id table)]
+    (api/read-check table)
+    (qp.store/with-metadata-provider db-id
+      (let [mp       (qp.store/metadata-provider)
+            query    (-> (lib/query mp (lib.metadata/table mp table-id))
+                         (update-in [:middleware :js-int-to-string?] (fnil identity true))
+                         qp/userland-query-with-default-constraints
+                         (update :info merge {:executed-by api/*current-user-id*
+                                              :context     :table-grid
+                                              :card-id     nil}))]
+        (events/publish-event! :event/table-read {:object  (t2/select-one :model/Table :id table-id)
+                                                  :user-id api/*current-user-id*})
+        (span/with-span!
+          {:name "query-table-async"}
+          (qp.streaming/streaming-response [rff :api]
+            (qp/process-query query
+             ;; For now, doing this transformation here makes it easy to iterate on our payload shape.
+             ;; In the future, we might want to implement a new export-type, say `:api/table`, instead.
+             ;; Then we can avoid building non-relevant fields, only to throw them away again.
+                              (qp.streaming/transforming-query-response
+                               rff
+                               (fn [response]
+                                 (-> (assoc response :table_id table-id)
+                                     (dissoc :json_query :context :cached :average_execution_time)))))))))))
 
 (mu/defn ^:private update-table!*
   "Takes an existing table and the changes, updates in the database and optionally calls `table/update-field-positions!`

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -83,7 +83,7 @@
                          (update :info merge {:executed-by api/*current-user-id*
                                               :context     :table-grid
                                               :card-id     nil}))]
-        (events/publish-event! :event/table-read {:object  (t2/select-one :model/Table :id table-id)
+        (events/publish-event! :event/table-read {:object  table
                                                   :user-id api/*current-user-id*})
         (span/with-span!
           {:name "query-table-async"}

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -41,7 +41,6 @@
    [ring.util.codec :as codec]
    [toucan2.core :as t2])
   (:import
-   (clojure.lang ExceptionInfo)
    (java.sql Connection)
    (org.quartz JobDetail TriggerKey)))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.api.database-test
   "Tests for /api/database endpoints."
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojurewerkz.quartzite.scheduler :as qs]
@@ -13,7 +12,6 @@
    [metabase.driver.h2 :as h2]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.util :as driver.u]
-   [metabase.events :as events]
    [metabase.http-client :as client]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.audit-log :as audit-log]
@@ -734,56 +732,6 @@
                                          #"Invalid table identifier"
                                          (resolve-table db-id "a.b.c")))]
             (is (= 400 (:status-code (ex-data ex))))))))))
-
-(deftest api-database-table-endpoint-test
-  (testing "GET /api/database/:id/table/:table-identifier/data"
-    (mt/dataset test-data
-      (let [db-id (mt/id)
-            published-events (atom [])]
-        (mt/with-dynamic-fn-redefs [events/publish-event! (fn [& args] (swap! published-events conj args))]
-          (testing "returns dataset in same format as POST /api/dataset"
-            (let [response (mt/user-http-request :rasta :get 202 (format "database/%d/table/public.orders/data" db-id))]
-              (is (contains? response :data))
-              (is (contains? response :row_count))
-              (is (contains? response :status))
-              (is (= #{"Created At"
-                       "Discount"
-                       "ID"
-                       "Product ID"
-                       "Quantity"
-                       "Subtotal"
-                       "Tax"
-                       "Total"
-                       "User ID"}
-                     (into #{} (map :display_name) (:cols (:data response)))))
-              (is (seq (:rows (:data response))))
-              (is (empty? (set/intersection #{:json_query :context :cached :average_execution_time} (set (keys response)))))
-              (is (= (mt/id :orders) (:table_id response)))))
-          (testing "we track a table-read event"
-            (is (= [["public" "orders"]]
-                   (->> @published-events
-                        (filter (comp #{:event/table-read} first))
-                        (map (comp #(mapv u/lower-case-en %)
-                                   (juxt :schema :name)
-                                   :object
-                                   second)))))))
-
-        (testing "resolves case-insensitive table references"
-          (mt/user-http-request :rasta :get 202 (format "database/%d/table/PUBLIC.ORDERS/data" db-id)))
-
-        (testing "handles ambiguous references"
-          (mt/with-temp [:model/Table _ {:db_id db-id :schema "app" :name "ORDERS"}]
-            (mt/with-test-user :rasta
-              (let [response (mt/user-http-request :rasta :get 300 (format "database/%d/table/orders/data" db-id))]
-                (is (contains? response :potential-matches))
-                (is (= #{"PUBLIC.ORDERS" "app.ORDERS"}
-                       (set (:potential-matches response))))))))
-
-        (testing "returns 404 for tables that don't exist"
-          (mt/user-http-request :rasta :get 404 (format "database/%d/table/nonexistent/data" db-id)))
-
-        (testing "validates table identifier format"
-          (mt/user-http-request :rasta :get 400 (format "database/%d/table/a.b.c/data" db-id)))))))
 
 (deftest fetch-database-metadata-include-hidden-test
   ;; NOTE: test for the exclude_uneditable parameter lives in metabase-enterprise.advanced-permissions.common-test

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -221,8 +221,7 @@
                        "User ID"}
                      (into #{} (map :display_name) (:cols (:data response)))))
               (is (seq (:rows (:data response))))
-              (is (empty? (set/intersection #{:json_query :context :cached :average_execution_time} (set (keys response)))))
-              (is (= (mt/id :orders) (:table_id response)))))
+              (is (empty? (set/intersection #{:json_query :context :cached :average_execution_time} (set (keys response)))))))
           (testing "we track a table-read event"
             (is (= [["public" "orders"]]
                    (->> @published-events

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -201,8 +201,7 @@
 (deftest api-database-table-endpoint-test
   (testing "GET /api/table/:table-id/data"
     (mt/dataset test-data
-      (let [db-id (mt/id)
-            table-id (mt/id :orders)
+      (let [table-id (mt/id :orders)
             published-events (atom [])]
         (mt/with-dynamic-fn-redefs [events/publish-event! (fn [& args] (swap! published-events conj args))]
           (testing "returns dataset in same format as POST /api/dataset"


### PR DESCRIPTION
Closes WRK-130

Friendship ended with `/api/database/4/table/PUBLIC/ORDERS/data`

Now `/api/table/12/data` is new best friend.