### PR TITLE
fix: unify popover width between firefox and chrome

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
@@ -3,6 +3,7 @@
   /*
   firefox has a known issue about overflow: auto, adding additional horizontal
   scrollbar so we have to pass separately overflow-x: hidden to prevent this
+  https://bugzilla.mozilla.org/show_bug.cgi?id=764076
   */
   overflow-y: auto;
   overflow-x: hidden;

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.module.css
@@ -1,6 +1,11 @@
 .dropdown {
   padding: 0;
-  overflow: auto;
+  /*
+  firefox has a known issue about overflow: auto, adding additional horizontal
+  scrollbar so we have to pass separately overflow-x: hidden to prevent this
+  */
+  overflow-y: auto;
+  overflow-x: hidden;
   background: var(--mb-color-background);
   border-color: var(--mb-color-border);
   color: var(--mb-color-text-primary);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48016

### Description

Firefox has an unresolved bug with `overflow: auto`, which adds unnecessary horizontal scrollbar.
https://bugzilla.mozilla.org/show_bug.cgi?id=764076

Specifying overflow-x and overflow-y separately addressed this problem, but it can cut text horizontally

### How to verify

1. New question -> Sample Dataset -> Orders -> open all possible pickers and verify their length and there is no horizontal scrollbar in firefox

### Demo

https://github.com/user-attachments/assets/be7ef53f-c237-4a64-8289-77f8130de0b6






