### PR TITLE
Allow single argument between parameters on the backend

### DIFF
--- a/test/metabase/driver/common/parameters/operators_test.clj
+++ b/test/metabase/driver/common/parameters/operators_test.clj
@@ -105,10 +105,19 @@
                 (catch Exception e
                   (ex-data e))))]
       (doseq [[op values] [[:number/>= [2 4]]
-                           [:number/between [1]]
                            [:number/between [1 2 3]]]]
         (is (=? {:param-type  op
                  :param-value values
                  :field-id    pos-int?
                  :type        qp.error-type/invalid-parameter}
                 (f op values)))))))
+
+(deftest ^:parallel to-clause-test-7
+  (testing "between normalization"
+    (are [values op] (= [op [:field 26 {:source-field 5}] 1]
+                        (params.ops/to-clause {:type   :number/between
+                                               :target [:dimension [:field 26 {:source-field 5}]]
+                                               :value  values}))
+      [1]     :>=
+      [1 nil] :>=
+      [nil 1] :<=)))


### PR DESCRIPTION
Fixes #54364

### Description

Convert `:number/between` parameters with single numeric argument to `:number/>=` or `:number/<=` parameters.

### How to verify

Try the steps from #54364 with a single number either as a lower bound or as an upper bound.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
