### PR TITLE
fix(sdk): Improve _.compose type + fix SDK type

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.stories.tsx
@@ -24,11 +24,7 @@ export default {
 };
 
 const Template: StoryFn<ComponentProps<typeof CreateDashboardModal>> = args => (
-  <CreateDashboardModal
-    onClose={action("onClose")}
-    onCreate={action("onCreate")}
-    {...args}
-  />
+  <CreateDashboardModal {...args} />
 );
 
 export const Default = {

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -13,7 +13,7 @@ import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 export interface CreateDashboardModalProps {
-  initialCollectionId: SDKCollectionReference;
+  initialCollectionId?: SDKCollectionReference;
   isOpen?: boolean;
   onCreate: (dashboard: Dashboard) => void;
   onClose?: () => void;
@@ -49,6 +49,6 @@ const CreateDashboardModalCoreWithLoading = _.compose(
   }),
 )(CreateDashboardModalCore);
 
-export const CreateDashboardModal = _.compose(withPublicComponentWrapper)(
+export const CreateDashboardModal = withPublicComponentWrapper(
   CreateDashboardModalInner,
 );

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -114,7 +114,7 @@ describe("CreateDashboardModal", () => {
 
     expect(screen.queryByText("New dashboard")).not.toBeInTheDocument();
 
-    rerender(<CreateDashboardModal isOpen />);
+    rerender(<CreateDashboardModal isOpen onCreate={jest.fn()} />);
 
     expect(screen.getByText("New dashboard")).toBeInTheDocument();
   });
@@ -123,12 +123,15 @@ describe("CreateDashboardModal", () => {
 function setup({ props }: { props?: Partial<CreateDashboardModalProps> } = {}) {
   setupCollectionByIdEndpoint({ collections: COLLECTIONS });
 
-  return renderWithSDKProviders(<CreateDashboardModal {...props} />, {
-    sdkProviderProps: {
-      authConfig: createMockAuthProviderUriConfig(),
+  return renderWithSDKProviders(
+    <CreateDashboardModal onCreate={jest.fn()} {...props} />,
+    {
+      sdkProviderProps: {
+        authConfig: createMockAuthProviderUriConfig(),
+      },
+      storeInitialState: {
+        currentUser: CURRENT_USER,
+      },
     },
-    storeInitialState: {
-      currentUser: CURRENT_USER,
-    },
-  });
+  );
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/ModerationReviewIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/ModerationReviewIcon.tsx
@@ -2,12 +2,14 @@ import _ from "underscore";
 
 import { connect } from "metabase/lib/redux";
 import { getUser } from "metabase/selectors/user";
+import type { User } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 import ModerationReviewIcon from "../../components/ModerationReviewIcon";
 
 const mapStateToProps = (state: State) => ({
-  currentUser: getUser(state),
+  // user would already be loaded when rendering this component.
+  currentUser: getUser(state) as User,
 });
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { withRouter } from "react-router";
 import { t } from "ttag";
-import _ from "underscore";
 import * as Yup from "yup";
 
 import { useGetDashboardQuery } from "metabase/api";
@@ -47,7 +46,7 @@ export interface CopyDashboardFormProperties {
 }
 
 export interface CopyDashboardFormProps {
-  onSubmit?: (values: CopyDashboardFormProperties) => Dashboard;
+  onSubmit: (values: CopyDashboardFormProperties) => Promise<Dashboard>;
   onSaved?: (dashboard?: Dashboard) => void;
   onClose?: () => void;
   initialValues?: CopyDashboardFormProperties | null;
@@ -155,5 +154,4 @@ function CopyDashboardForm({
   );
 }
 
-export const CopyDashboardFormConnected =
-  _.compose(withRouter)(CopyDashboardForm);
+export const CopyDashboardFormConnected = withRouter(CopyDashboardForm);

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
@@ -3,7 +3,10 @@ import { t } from "ttag";
 
 import { useGetDefaultCollectionId } from "metabase/collections/hooks";
 import ModalContent from "metabase/components/ModalContent";
-import { CopyDashboardFormConnected } from "metabase/dashboard/containers/CopyDashboardForm";
+import {
+  CopyDashboardFormConnected,
+  type CopyDashboardFormProperties,
+} from "metabase/dashboard/containers/CopyDashboardForm";
 import { CopyQuestionForm } from "metabase/questions/components/CopyQuestionForm";
 
 interface EntityCopyModalProps {
@@ -14,7 +17,7 @@ interface EntityCopyModalProps {
   onClose: () => void;
   onSaved: (newEntityObject?: any) => void;
   overwriteOnInitialValuesChange?: boolean;
-  onValuesChange?: (values: Record<string, unknown>) => void;
+  onValuesChange?: (values: CopyDashboardFormProperties) => void;
   form?: any;
 }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -164,5 +164,13 @@ function maybeGetCollectionId(
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default _.compose(connect(mapStateToProps, mapDispatchToProps))(
-  MainNavbar,
+  /**
+   * Previously the `_.compose` type was broken, so it wasn't checking for type compatibility, and would
+   * return the composed function type as `any`. Now that it works better, legit errors are surfacing.
+   * But I don't have time, or enough context to fix this one.
+   *
+   * It seems the error came from the mismatch of the `dashboard` type, where the component expects
+   * a dashboard response, but the injected prop is from the redux store which has a different type.
+   */
+  MainNavbar as any,
 );

--- a/frontend/src/types/underscore.d.ts
+++ b/frontend/src/types/underscore.d.ts
@@ -53,7 +53,7 @@ declare module _ {
       f2: (a: R1) => R2,
       f1: (...args: TArgs) => R1,
     ): (...args: TArgs) => R7;
-    // fallback overload if number of composed functions greater than 7
+    // fallback overload if the number of composed functions is greater than 7
     compose<TArgs extends any[], R1, R2, R3, R4, R5, R6, R7, TResult>(
       ...func: [
         fnLast: (a: any) => TResult,

--- a/frontend/src/types/underscore.d.ts
+++ b/frontend/src/types/underscore.d.ts
@@ -1,26 +1,71 @@
-// https://stackoverflow.com/a/73082627/5742640
+// https://github.com/ramda/types/blob/develop/types/compose.d.ts
 
 declare module _ {
   interface UnderscoreStatic {
-    compose<Fns extends readonly UnaryFunction[]>(
-      ...functions: Composable<Fns>
-    ): (arg: ComposeParams<Fns>) => ComposeReturn<Fns>;
+    compose<TArgs extends any[], R1>(
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R1;
+    compose<TArgs extends any[], R1, R2>(
+      f2: (a: R1) => R2,
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R2;
+    compose<TArgs extends any[], R1, R2, R3>(
+      f3: (a: R2) => R3,
+      f2: (a: R1) => R2,
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R3;
+    compose<TArgs extends any[], R1, R2, R3, R4>(
+      f4: (a: R3) => R4,
+      f3: (a: R2) => R3,
+      f2: (a: R1) => R2,
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R4;
+    compose<TArgs extends any[], R1, R2, R3, R4, R5>(
+      f5: (a: R4) => R5,
+      f4: (a: R3) => R4,
+      f3: (a: R2) => R3,
+      f2: (a: R1) => R2,
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R5;
+    compose<TArgs extends any[], R1, R2, R3, R4, R5, R6>(
+      f6: (a: R5) => R6,
+      f5: (a: R4) => R5,
+      f4: (a: R3) => R4,
+      f3: (a: R2) => R3,
+      f2: (a: R1) => R2,
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R6;
+    compose<TArgs extends any[], R1, R2, R3, R4, R5, R6, R7>(
+      f7: (a: R6) => R7,
+      f6: (a: R5) => R6,
+      f5: (a: R4) => R5,
+      f4: (a: R3) => R4,
+      f3: (a: R2) => R3,
+      f2: (a: R1) => R2,
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R7;
+    compose<TArgs extends any[], R1, R2, R3, R4, R5, R6, R7>(
+      f7: (a: R6) => R7,
+      f6: (a: R5) => R6,
+      f5: (a: R4) => R5,
+      f4: (a: R3) => R4,
+      f3: (a: R2) => R3,
+      f2: (a: R1) => R2,
+      f1: (...args: TArgs) => R1,
+    ): (...args: TArgs) => R7;
+    // fallback overload if number of composed functions greater than 7
+    compose<TArgs extends any[], R1, R2, R3, R4, R5, R6, R7, TResult>(
+      ...func: [
+        fnLast: (a: any) => TResult,
+        ...func: Array<(a: any) => any>,
+        f7: (a: R6) => R7,
+        f6: (a: R5) => R6,
+        f5: (a: R4) => R5,
+        f4: (a: R3) => R4,
+        f3: (a: R2) => R3,
+        f2: (a: R1) => R2,
+        f1: (...args: TArgs) => R1,
+      ]
+    ): (...args: TArgs) => TResult;
   }
 }
-
-type UnaryFunction = (arg: any) => any;
-
-type Composable<Fn> = Fn extends readonly [UnaryFunction]
-  ? Fn
-  : Fn extends readonly [any, ...infer Rest extends readonly UnaryFunction[]]
-    ? readonly [(arg: ComposeReturn<Rest>) => any, ...Composable<Rest>]
-    : never;
-
-type ComposeReturn<Fns extends readonly UnaryFunction[]> = ReturnType<Fns[0]>;
-
-type ComposeParams<Fns> = Fns extends readonly [
-  ...any[],
-  infer Last extends UnaryFunction,
-]
-  ? Parameters<Last>[0]
-  : never;

--- a/frontend/src/types/underscore.d.ts
+++ b/frontend/src/types/underscore.d.ts
@@ -67,6 +67,11 @@ declare module _ {
         f1: (...args: TArgs) => R1,
       ]
     ): (...args: TArgs) => TResult;
+    /**
+     * This last overload is added to handle the case where passing a function with `any` type to `_.compose`,
+     * without this overload, the returned composed function type would be `unknown` rather than `any` which is
+     * expected.
+     */
     compose<T>(...funcs: T[]): any;
   }
 }

--- a/frontend/src/types/underscore.d.ts
+++ b/frontend/src/types/underscore.d.ts
@@ -55,7 +55,7 @@ declare module _ {
     ): (...args: TArgs) => R7;
     // fallback overload if the number of composed functions is greater than 7
     compose<TArgs extends any[], R1, R2, R3, R4, R5, R6, R7, TResult>(
-      ...func: [
+      ...funcs: [
         fnLast: (a: any) => TResult,
         ...func: Array<(a: any) => any>,
         f7: (a: R6) => R7,
@@ -67,5 +67,6 @@ declare module _ {
         f1: (...args: TArgs) => R1,
       ]
     ): (...args: TArgs) => TResult;
+    compose<T>(...funcs: T[]): any;
   }
 }

--- a/frontend/src/types/underscore.d.ts
+++ b/frontend/src/types/underscore.d.ts
@@ -1,4 +1,7 @@
-// https://github.com/ramda/types/blob/develop/types/compose.d.ts
+/**
+ * The original types could be found at https://github.com/ramda/types/blob/13d36d597c51793627a7b0dc0d83c62f1236029b/types/compose.d.ts
+ * This version rearranges and the type in a logical way and adds an extra overrides to handle a case where we pass `any` type to `_.compose`.
+ */
 
 declare module _ {
   interface UnderscoreStatic {

--- a/frontend/src/types/underscore.d.ts
+++ b/frontend/src/types/underscore.d.ts
@@ -1,0 +1,26 @@
+// https://stackoverflow.com/a/73082627/5742640
+
+declare module _ {
+  interface UnderscoreStatic {
+    compose<Fns extends readonly UnaryFunction[]>(
+      ...functions: Composable<Fns>
+    ): (arg: ComposeParams<Fns>) => ComposeReturn<Fns>;
+  }
+}
+
+type UnaryFunction = (arg: any) => any;
+
+type Composable<Fn> = Fn extends readonly [UnaryFunction]
+  ? Fn
+  : Fn extends readonly [any, ...infer Rest extends readonly UnaryFunction[]]
+    ? readonly [(arg: ComposeReturn<Rest>) => any, ...Composable<Rest>]
+    : never;
+
+type ComposeReturn<Fns extends readonly UnaryFunction[]> = ReturnType<Fns[0]>;
+
+type ComposeParams<Fns> = Fns extends readonly [
+  ...any[],
+  infer Last extends UnaryFunction,
+]
+  ? Parameters<Last>[0]
+  : never;


### PR DESCRIPTION
Closes EMB-235

### Description

This improve the `_.compose` type. It does work really well with higher order functions without generics. When there are generics, the output types are still wrong, but it's an improvement over the current version which doesn't output any function signature at all.

There is one SDK type fix, which I'm not quite sure is suitable to be included in this PR, let me know what you think @npretto 

### How to verify

`yarn type-check` passes

