### PR TITLE
adds cljfmt-updated task

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -16,14 +16,14 @@
    :task     (format/staged (cli/parse! (current-task)))}
 
   cljfmt-files
-  {:doc      "Runs cljfmt on the given files/directories"
-   :requires [[mage.format :as format]]
-   :examples [["./bin/mage cljfmt-files src/metabase/events.clj" "Format events.clj"]
-              ["./bin/mage cljfmt-files src" "Format all files in src"]
-              ["./bin/mage cljfmt-files -c src" "Check all files in src"]]
-   :options  [["-c" "--force-check" "Check staged files"]]
-   :args     [:sequential [:string {:description "Files or directories to format."}]]
-   :task     (format/files (cli/parse! (current-task)))}
+  {:doc        "Runs cljfmt on the given files/directories"
+   :requires   [[mage.format :as format]]
+   :examples   [["./bin/mage cljfmt-files src/metabase/events.clj" "Format events.clj"]
+                ["./bin/mage cljfmt-files src" "Format all files in src"]
+                ["./bin/mage cljfmt-files -c src" "Check all files in src"]]
+   :options    [["-c" "--force-check" "Check staged files"]]
+   :arg-schema [:sequential [:string {:description "Files or directories to format."}]]
+   :task       (format/files (cli/parse! (current-task)))}
 
   cljfmt-all
   {:doc      "Runs cljfmt on all (clojure) files"
@@ -31,6 +31,15 @@
    :examples [["./bin/mage cljfmt-all" "Format all files"]]
    :options  [["-c" "--force-check" "Check staged files"]]
    :task     (format/all (cli/parse! (current-task)))}
+
+  cljfmt-updated
+  {:doc        "Runs cljfmt on all (Clojure) files relative to a git ref (default HEAD)"
+   :requires   [[mage.format :as format]]
+   :examples   [["./bin/mage cljfmt-updated" "Format updated files relative to HEAD"]
+                ["./bin/mage cljfmt-updated master" "Format updated files relative to master"]]
+   :options    [["-c" "--force-check" "Check staged files"]]
+   :arg-schema [:or [:tuple] [:tuple :string]]
+   :task       (format/updated (cli/parse! (current-task)))}
 
   kondo
   {:doc      "Runs Kondo against a file, directory, or everything we usually lint"
@@ -110,7 +119,7 @@
                 ["./bin/mage -example-calculator 100 - 99" "evaluates to 1"]]
    ;; The task is the actual code that runs when you run the task.
    :task       (let [{:keys [arguments data]} (cli/parse! (current-task))
-                     [a op b] arguments]
+                     [a op b]                 arguments]
                  (println a (name op) b "=" (c/blue (({:+ + :- -} op) a b))))
    ;; (optional) `:require` lazily libraries for just your task:
    :requires   [[mage.color :as c]]
@@ -130,12 +139,12 @@
    ;; map of ports.
    :data       {:a [:b :c] :b [:d]}}
 
-  -test {:doc "run all mage tests"
+  -test {:doc      "run all mage tests"
          :requires [[mage.core-test]
                     [mage.examples-test :as examples-test]]
-         :task (do
-                 (mage.core-test/run-tests)
-                 (examples-test/run-example-tests))}
+         :task     (do
+                     (mage.core-test/run-tests)
+                     (examples-test/run-example-tests))}
 
   -test-examples
   {:doc      "Runs every example and checks that it exits with 0"

--- a/mage/mage/format.clj
+++ b/mage/mage/format.clj
@@ -21,6 +21,11 @@
       (println "Running: " cmd)
       (try (u/sh cmd) (catch Exception _e nil)))))
 
+(defn updated
+  "Formats or checks all updated clojure files with cljfmt."
+  [parsed]
+  (files (assoc parsed :arguments (u/updated-files))))
+
 (defn staged
   "Formats or checks all staged clojure files with cljfmt."
   [{{force-check? :force-check} :options}]

--- a/mage/mage/kondo.clj
+++ b/mage/mage/kondo.clj
@@ -72,19 +72,9 @@
   [cli-args]
   (kondo* cli-args))
 
-(defn- updated-files
-  "Sequence of filenames that have changes in Git relative to `diff-target`."
-  [diff-target]
-  (->> (shell/sh {:quiet? true}
-                 "git" "diff" "--name-only" diff-target
-                 "--" "*.clj" "*.cljc" "*.cljs" ":!/.clj-kondo" ":!/dev")
-       ;; filter out any files that have been deleted/moved
-       (filter (fn [filename]
-                 (.exists (io/file (str u/project-root-directory "/" filename)))))))
-
 (defn- kondo-updated* [diff-target]
   (let [diff-target   (or diff-target "HEAD")
-        updated-files (updated-files diff-target)]
+        updated-files (u/updated-files diff-target)]
     (when (empty? updated-files)
       (println "No updated Clojure source files.")
       (System/exit 0))

--- a/mage/mage/util.clj
+++ b/mage/mage/util.clj
@@ -89,3 +89,16 @@
                       :tasks
                       keys)]
     (mapv str (remove #{:requires} task-keys))))
+
+(defn updated-files
+  "Sequence of filenames that have changes in Git relative to `diff-target`."
+  ([] (updated-files "HEAD"))
+  ([diff-target]
+   (->> (shell {:out :string :dir project-root-directory}
+               "git" "diff" "--name-only" diff-target
+               "--" "*.clj" "*.cljc" "*.cljs" ":!/.clj-kondo" ":!/dev")
+        :out
+        (str/split-lines)
+        ;; filter out any files that have been deleted/moved
+        (filter (fn [filename]
+                  (.exists (io/file (str project-root-directory "/" filename))))))))


### PR DESCRIPTION
```
$ mage cljfmt-updated -h
Task Name: cljfmt-updated
 Runs cljfmt on all (Clojure) files relative to a git ref (default HEAD)
Usages:
  -c, --force-check  Check staged files

Examples:

 ./bin/mage cljfmt-updated
 - Format updated files relative to HEAD

 ./bin/mage cljfmt-updated master
 - Format updated files relative to master
 ```