### PR TITLE
Fix leaving native query editor with parameters

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -1,4 +1,5 @@
 const { H } = cy;
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { IconName } from "metabase/ui";
 
@@ -381,4 +382,39 @@ describe("issues 52811, 52812", () => {
   function clickAway() {
     cy.get("body").click(0, 0);
   }
+});
+
+describe("issue 52806", () => {
+  const questionDetails = {
+    name: "SQL",
+    dataset_query: {
+      database: SAMPLE_DB_ID,
+      type: "native",
+      native: {
+        query: "SELECT * FROM ORDERS WHERE ID = {{id}}",
+        "template-tags": {
+          id: {
+            id: "b22a5ce2-fe1d-44e3-8df4-f8951f7921bc",
+            name: "id",
+            "display-name": "ID",
+            type: "number",
+            default: "1",
+          },
+        },
+      },
+    },
+    visualization_settings: {},
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)", () => {
+    H.visitQuestionAdhoc(questionDetails);
+    cy.findByTestId("main-logo-link").click();
+    H.modal().button("Discard changes").click();
+    cy.location().should(location => expect(location.search).to.eq(""));
+  });
 });

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -665,7 +665,7 @@ class Question {
     return question;
   }
 
-  parameters({ collectionPreview } = {}): ParameterObject[] {
+  private _getParameters = _.memoize((collectionPreview: boolean) => {
     return getCardUiParameters(
       this.card(),
       this.metadata(),
@@ -673,6 +673,10 @@ class Question {
       undefined,
       collectionPreview,
     );
+  });
+
+  parameters({ collectionPreview } = {}): ParameterObject[] {
+    return this._getParameters(collectionPreview);
   }
 
   // predicate function that determines if the question is "dirty" compared to the given question


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/52806

The problem was that `SyncedParameterList` updated the URL when parameters change, and without memoization it was done on every render/tick.

Before:
<img width="891" alt="Screenshot 2025-03-07 at 14 23 56" src="https://github.com/user-attachments/assets/f6aa0287-e172-4892-b6f9-a828d45f75b2" />

After:
<img width="820" alt="Screenshot 2025-03-07 at 14 23 20" src="https://github.com/user-attachments/assets/954ebaf4-29f8-456e-9ae0-207ab5fc83ae" />
