### PR TITLE
Fixing select dropdown in append data modal collection view

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -1,6 +1,7 @@
 const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { FIXTURE_PATH } from "e2e/support/helpers";
 
 const { NOSQL_GROUP, ALL_USERS_GROUP } = USER_GROUPS;
 
@@ -223,6 +224,42 @@ H.describeWithSnowplow(
         });
       });
     });
+
+    it("should allow you to choose a model to append to if there are multiple (metabase#53824)", () => {
+      H.restore("postgres-writable");
+      cy.signInAsAdmin();
+      H.enableTracking();
+
+      H.enableUploads("postgres");
+      H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[0]);
+      H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[1]);
+
+      H.visitCollection(FIRST_COLLECTION_ID);
+
+      cy.fixture(`${FIXTURE_PATH}/${H.VALID_CSV_FILES[2].fileName}`).then(
+        file => {
+          cy.get("#upload-input").selectFile(
+            {
+              contents: Cypress.Buffer.from(file),
+              fileName: H.VALID_CSV_FILES[2].fileName,
+              mimeType: "text/csv",
+            },
+            { force: true },
+          );
+        },
+      );
+
+      cy.findByRole("radio", { name: /Append to a model/ }).click();
+
+      cy.findByRole("textbox", { name: "Select a model" })
+        .should("contain.value", H.VALID_CSV_FILES[1].humanName)
+        .click();
+
+      H.popover().findByText(H.VALID_CSV_FILES[0].humanName).click();
+      cy.findByRole("textbox", { name: "Select a model" })
+        .should("have.value", H.VALID_CSV_FILES[0].humanName)
+        .click();
+    });
   },
 );
 
@@ -360,14 +397,14 @@ describe("Upload Table Cleanup/Management", { tags: "@external" }, () => {
   });
 });
 
-function uploadFileToCollection(testFile) {
+function uploadFileToCollection(testFile, viewModel = true) {
   cy.get("@collectionId").then(collectionId =>
     cy.visit(`/collection/${collectionId}`),
   );
 
   H.uploadFile("#upload-input", "Uploads Collection", testFile);
 
-  if (testFile.valid) {
+  if (testFile.valid && viewModel) {
     cy.get("main").within(() => cy.findByText("Uploads Collection"));
 
     cy.findByTestId("collection-table").within(() => {

--- a/frontend/src/metabase/collections/components/ModelUploadModal.tsx
+++ b/frontend/src/metabase/collections/components/ModelUploadModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { useSearchListQuery } from "metabase/common/hooks";
+import { useListCollectionItemsQuery } from "metabase/api";
 import {
   Button,
   Flex,
@@ -45,19 +45,17 @@ export function ModelUploadModal({
 }) {
   const [uploadMode, setUploadMode] = useState<UploadMode>(UploadMode.create);
   const [tableId, setTableId] = useState<TableId | null>(null);
-  const models = useSearchListQuery({
-    query: {
-      collection: collectionId,
-      models: ["dataset"],
-    },
+
+  const { data, isLoading } = useListCollectionItemsQuery({
+    id: collectionId,
+    models: ["dataset"],
   });
 
   const uploadableModels = useMemo(
-    () => models.data?.filter(model => !!model.based_on_upload),
-    [models],
+    () => data?.data?.filter(model => !!model.based_on_upload),
+    [data],
   );
-  const hasNoUploadableModels =
-    models.isLoaded && uploadableModels?.length === 0;
+  const hasNoUploadableModels = !isLoading && uploadableModels?.length === 0;
 
   useEffect(
     function setDefaultTableId() {
@@ -79,7 +77,7 @@ export function ModelUploadModal({
 
       return onUpload({
         tableId: Number(tableId),
-        modelId: modelForTableId?.id,
+        modelId: modelForTableId?.id as number,
         uploadMode: uploadMode,
       });
     }
@@ -143,6 +141,7 @@ export function ModelUploadModal({
         </Radio.Group>
         {uploadMode !== UploadMode.create && (
           <Select
+            aria-label="Select a model"
             leftSection={<Icon name="model" />}
             placeholder="Select a model"
             value={tableId ? String(tableId) : ""}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53824

### Description
Issue was caused by unstable reference from old entity hook. This updates the modal to use RTK Query, and adds an e2e test for this scenario

### How to verify

1. Go to a collection with at least 2 models
2. Choose a CSV to upload, and in the modal choose "Append to model"
3. In the select dropdown, you should be able to choose any item and it should persist

### Demo
https://github.com/user-attachments/assets/de323c36-70ef-456e-86e9-b2cac6eb003e

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
