### PR TITLE
Use PAT for git tagging

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -269,12 +269,15 @@ jobs:
     needs: check-version
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     strategy:
       matrix:
         edition: ${{ fromJson(needs.check-version.outputs.edition_matrix) }}
     steps:
     - uses: actions/checkout@v4
       with:
+        token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         fetch-depth: 0 # we want all branches and tags
         fetch-tags: true
     - name: Add and push git tag for nightly/beta/latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,7 @@ jobs:
     - name: Tag Release
       uses: actions/github-script@v7
       with:
+        github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         result-encoding: string
         script: | # js
           const { tagRelease } = require('${{ github.workspace }}/release/dist/index.cjs');


### PR DESCRIPTION
Our releases have run into cyptic git and github api errors when pushing git tags to older release branches (v51 and v52). This release code worked fine for over a year, and errors only started appearing int he past month or so. This tries to use a PAT to see if there's some kind of permissions problem on github token.

see [thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1741084491516049)