### PR TITLE
[mongodb] Optimize post-processing of Mongo queries

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -109,13 +109,14 @@
 (defn- row->vec [row-col-names]
   (fn [^org.bson.Document row]
     (mapv (fn [col-name]
-            (let [col-parts (str/split col-name #"\.")
-                  val       (reduce
-                             (fn [^org.bson.Document object ^String part-name]
-                               (when object
-                                 (.get object part-name)))
-                             row
-                             col-parts)]
+            (let [val (if (str/includes? col-name ".")
+                        (reduce
+                         (fn [^org.bson.Document object ^String part-name]
+                           (when object
+                             (.get object part-name)))
+                         row
+                         (str/split col-name #"\."))
+                        (.get row col-name))]
               (mongo.conversion/from-document val {:keywordize true})))
           row-col-names)))
 


### PR DESCRIPTION
This PR adds a pretty simple optimization to post-processing in Mongo driver. If the column (field) doesn't contain a period, we can avoid attempting to split it by a a period.

The savings come from not running the regex machinery for it. For example, when performing fingerprinting of a sample Mongo database, this patch cuts allocations by ~5% (and CPU time by the same amount). Diffgraph: https://flamebin.dev/3Y3g7Q.
