### PR TITLE
ci(sdk): Fix mysterious sdk deployment failure on 52

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -360,17 +360,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
-          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-
       - name: Edit PR adding useful information (using Metabase bot app)
         run: |
           gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Auto approve PR (using GitHub Actions account)
         run: |

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -262,8 +262,8 @@ jobs:
         with:
           m2-cache-key: "release-sdk"
 
-      - name: Run unit tests
-        run: yarn embedding-sdk:test-unit
+      # - name: Run unit tests
+      #   run: yarn embedding-sdk:test-unit
 
   build-sdk:
     needs: [test, determine-sdk-version]
@@ -294,17 +294,17 @@ jobs:
         run: |
           yarn embedding-sdk:generate-changelog -o changelog-diff
 
-      - name: Build SDK bundle
-        run: yarn run build-embedding-sdk
+      # - name: Build SDK bundle
+      #   run: yarn run build-embedding-sdk
 
       - name: Generate SDK package.json in the build directory
         run: yarn run embedding-sdk:generate-package
 
-      - name: Upload built SDK package as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: metabase-sdk
-          path: ./resources/embedding-sdk
+      # - name: Upload built SDK package as artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: metabase-sdk
+      #     path: ./resources/embedding-sdk
 
       - name: Upload changelog diff
         uses: actions/upload-artifact@v4
@@ -367,36 +367,36 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      - name: Auto approve PR (using GitHub Actions account)
-        run: |
-          gh pr review --approve
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Auto approve PR (using GitHub Actions account)
+      #   run: |
+      #     gh pr review --approve
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-        run: |
-          gh pr merge --auto --squash
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+      #   run: |
+      #     gh pr merge --auto --squash
+      #   env:
+      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      - name: Retrieve build SDK package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: metabase-sdk
-          path: sdk
+      # - name: Retrieve build SDK package artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: metabase-sdk
+      #     path: sdk
 
-      - name: Publish to NPM
-        working-directory: sdk
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-          # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
+      # - name: Publish to NPM
+      #   working-directory: sdk
+      #   run: |
+      #     echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+      #     # Please keep the value in sync with `inputs.branch`'s release branch
+      #     npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-        if: ${{ inputs.branch == 'release-x.53.x' }}
-        working-directory: sdk
-        run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+      # - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
+      #   if: ${{ inputs.branch == 'release-x.53.x' }}
+      #   working-directory: sdk
+      #   run: |
+      #     npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-sdk-version]
@@ -422,8 +422,8 @@ jobs:
           git tag -a ${{ env.tag }} -m "Tagging SDK version ${{ env.tag }}"
           git push origin ${{ env.tag }}
 
-      - name: Create and push SDK stable version tag
-        if: ${{ startsWith(inputs.branch, 'release-x.') }}
-        run: |
-          git tag -a -f ${{ env.stable_tag }} -m "Tagging SDK stable version ${{ env.stable_tag }}"
-          git push origin -f ${{ env.stable_tag }}
+      # - name: Create and push SDK stable version tag
+      #   if: ${{ startsWith(inputs.branch, 'release-x.') }}
+      #   run: |
+      #     git tag -a -f ${{ env.stable_tag }} -m "Tagging SDK stable version ${{ env.stable_tag }}"
+      #     git push origin -f ${{ env.stable_tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -322,6 +322,7 @@ jobs:
       - name: Check out branch to prepare for a SDK version bump PR
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           # when we created version update PR, it would only have diff from 2 files SDK readme and SDK package.json template
           ref: ${{ inputs.branch}}
 
@@ -408,6 +409,7 @@ jobs:
       - name: Check out the code using the provided branch
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           ref: ${{ inputs.branch }}
 
       # Lightweight tags don't need committer name and email

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -412,14 +412,18 @@ jobs:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           ref: ${{ inputs.branch }}
 
-      # Lightweight tags don't need committer name and email
+      - name: Setup git user
+        run: |
+          git config --global user.email "github-automation@metabase.com"
+          git config --global user.name "Metabase Automation"
+
       - name: Create and push SDK version tag
         run: |
-          git tag ${{ env.tag }}
+          git tag -a ${{ env.tag }} -m "Tagging SDK version ${{ env.tag }}"
           git push origin ${{ env.tag }}
 
       - name: Create and push SDK stable version tag
         if: ${{ startsWith(inputs.branch, 'release-x.') }}
         run: |
-          git tag -f ${{ env.stable_tag }}
+          git tag -a -f ${{ env.stable_tag }} -m "Tagging SDK stable version ${{ env.stable_tag }}"
           git push origin -f ${{ env.stable_tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -262,8 +262,8 @@ jobs:
         with:
           m2-cache-key: "release-sdk"
 
-      # - name: Run unit tests
-      #   run: yarn embedding-sdk:test-unit
+      - name: Run unit tests
+        run: yarn embedding-sdk:test-unit
 
   build-sdk:
     needs: [test, determine-sdk-version]
@@ -294,17 +294,17 @@ jobs:
         run: |
           yarn embedding-sdk:generate-changelog -o changelog-diff
 
-      # - name: Build SDK bundle
-      #   run: yarn run build-embedding-sdk
+      - name: Build SDK bundle
+        run: yarn run build-embedding-sdk
 
       - name: Generate SDK package.json in the build directory
         run: yarn run embedding-sdk:generate-package
 
-      # - name: Upload built SDK package as artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: metabase-sdk
-      #     path: ./resources/embedding-sdk
+      - name: Upload built SDK package as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: metabase-sdk
+          path: ./resources/embedding-sdk
 
       - name: Upload changelog diff
         uses: actions/upload-artifact@v4
@@ -367,36 +367,36 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      # - name: Auto approve PR (using GitHub Actions account)
-      #   run: |
-      #     gh pr review --approve
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto approve PR (using GitHub Actions account)
+        run: |
+          gh pr review --approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-      #   run: |
-      #     gh pr merge --auto --squash
-      #   env:
-      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+        run: |
+          gh pr merge --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
-      # - name: Retrieve build SDK package artifact
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: metabase-sdk
-      #     path: sdk
+      - name: Retrieve build SDK package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: metabase-sdk
+          path: sdk
 
-      # - name: Publish to NPM
-      #   working-directory: sdk
-      #   run: |
-      #     echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-      #     # Please keep the value in sync with `inputs.branch`'s release branch
-      #     npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
+      - name: Publish to NPM
+        working-directory: sdk
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+          # Please keep the value in sync with `inputs.branch`'s release branch
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-      # - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-      #   if: ${{ inputs.branch == 'release-x.53.x' }}
-      #   working-directory: sdk
-      #   run: |
-      #     npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
+        if: ${{ inputs.branch == 'release-x.53.x' }}
+        working-directory: sdk
+        run: |
+          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-sdk-version]
@@ -422,8 +422,8 @@ jobs:
           git tag -a ${{ env.tag }} -m "Tagging SDK version ${{ env.tag }}"
           git push origin ${{ env.tag }}
 
-      # - name: Create and push SDK stable version tag
-      #   if: ${{ startsWith(inputs.branch, 'release-x.') }}
-      #   run: |
-      #     git tag -a -f ${{ env.stable_tag }} -m "Tagging SDK stable version ${{ env.stable_tag }}"
-      #     git push origin -f ${{ env.stable_tag }}
+      - name: Create and push SDK stable version tag
+        if: ${{ startsWith(inputs.branch, 'release-x.') }}
+        run: |
+          git tag -a -f ${{ env.stable_tag }} -m "Tagging SDK stable version ${{ env.stable_tag }}"
+          git push origin -f ${{ env.stable_tag }}


### PR DESCRIPTION
Fixes EMB-238, EMB-169
### Description

Read the [whole ordeal](https://metaboat.slack.com/archives/C063Q3F1HPF/p17410844915160490) here. Ryan found that using a Personal Access Token seems to fix the issue 🥰

This PR achieves 2 things
1. Fix the issue where pushing to GitHub from the release branch 52 is failing consistently and needs, sometimes, more than 10 retries to pass.
2. Remove the step to generate the app token, because we can use the Personal Access Token instead of that.

### How to verify

[See this run](https://github.com/metabase/metabase/actions/runs/13759291336) which was testing using 8bd5d2e07ff0a273098cbc679b084ec17d6593f8 and [(Slack notification)](https://metaboat.slack.com/archives/C06FCQT0KMZ/p1741592330046089), which has certain steps that don't relate to pushing to GitHub disabled.

Also, since we're now using annotated tags, we can read the tag information. (I'll remove the tag after making this PR ready for review because it'll be created by the next deployment)

```sh
git cat-file tag embedding-sdk-0.52.16
object 1f0510681371c8b1b2472942169aeae762b337f4
type commit
tag embedding-sdk-0.52.16
tagger Metabase Automation <github-automation@metabase.com> 1741592699 +0000

Tagging SDK version embedding-sdk-0.52.16
```


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
