### PR TITLE
Closes VIZ-291: axis labels are no longer forcibly disabled

### DIFF
--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
@@ -1,4 +1,5 @@
 import { useDroppable } from "@dnd-kit/core";
+import produce from "immer";
 import { useState } from "react";
 import { t } from "ttag";
 
@@ -13,6 +14,7 @@ import {
   Text,
   Tooltip,
 } from "metabase/ui";
+import { isCartesianChart } from "metabase/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
 import { DROPPABLE_ID } from "metabase/visualizer/constants";
 import {
@@ -20,6 +22,7 @@ import {
   getVisualizationType,
   getVisualizerRawSeries,
 } from "metabase/visualizer/selectors";
+import type { RawSeries } from "metabase-types/api";
 
 import { TabularPreviewModal } from "../TabularPreviewModal";
 
@@ -29,11 +32,29 @@ import { StartFromViz } from "./StartFromViz";
 import { VerticalWell } from "./VerticalWell";
 import Styles from "./VisualizationCanvas.module.css";
 
+function disableAxisLabels(rawSeries: RawSeries) {
+  return produce(rawSeries, draft => {
+    const settings = draft[0]?.card.visualization_settings;
+
+    if (!settings) {
+      return draft;
+    }
+
+    settings["graph.x_axis.labels_enabled"] = false;
+    settings["graph.y_axis.labels_enabled"] = false;
+    draft[0].card.visualization_settings = settings;
+  });
+}
+
 export function VisualizationCanvas({ className }: { className?: string }) {
   const [isTabularPreviewOpen, setTabularPreviewOpen] = useState(false);
 
   const display = useSelector(getVisualizationType);
-  const rawSeries = useSelector(getVisualizerRawSeries);
+  let rawSeries = useSelector(getVisualizerRawSeries);
+  if (display && isCartesianChart(display)) {
+    rawSeries = disableAxisLabels(rawSeries);
+  }
+
   const isLoading = useSelector(getIsLoading);
 
   const { setNodeRef } = useDroppable({ id: DROPPABLE_ID.CANVAS_MAIN });

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -125,7 +125,7 @@ export const Visualizer = (props: VisualizerProps) => {
             data: {
               current: event.active.data.current,
             },
-          }),
+          } as DraggedItem),
         );
       }
     },

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -9,7 +9,12 @@ import {
 } from "metabase/visualizations";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
-import type { Card, DatasetData, RawSeries } from "metabase-types/api";
+import type {
+  Card,
+  DatasetData,
+  RawSeries,
+  SingleSeries,
+} from "metabase-types/api";
 import type {
   VisualizerHistoryItem,
   VisualizerState,
@@ -32,21 +37,6 @@ const getCurrentHistoryItem = (state: State) => state.visualizer.present;
 const getCards = (state: State) => state.visualizer.cards;
 
 const getRawSettings = (state: State) => getCurrentHistoryItem(state).settings;
-
-const getSettings = createSelector(
-  [getVisualizationType, getRawSettings],
-  (display, rawSettings) => {
-    if (display && isCartesianChart(display)) {
-      // Visualizer wells display labels
-      return {
-        ...rawSettings,
-        "graph.x_axis.labels_enabled": false,
-        "graph.y_axis.labels_enabled": false,
-      };
-    }
-    return rawSettings;
-  },
-);
 
 const getVisualizationColumns = (state: State) =>
   getCurrentHistoryItem(state).columns;
@@ -132,7 +122,7 @@ const getVisualizerDatasetData = createSelector(
       columnValuesMapping,
       datasets,
       dataSources,
-    }),
+    }) as DatasetData,
 );
 
 export const getVisualizerDatasetColumns = createSelector(
@@ -144,7 +134,7 @@ export const getVisualizerRawSeries = createSelector(
   [
     getVisualizationType,
     getVisualizerColumnValuesMapping,
-    getSettings,
+    getRawSettings,
     getVisualizerDatasetData,
   ],
   (display, columnValuesMapping, settings, data): RawSeries => {
@@ -163,7 +153,7 @@ export const getVisualizerRawSeries = createSelector(
         // Certain visualizations memoize settings computation based on series keys
         // This guarantees a visualization always rerenders on changes
         started_at: new Date().toISOString(),
-      },
+      } as SingleSeries,
     ];
 
     if (isCartesianChart(display)) {


### PR DESCRIPTION
Closes [VIZ-291: Visualizer created dashcard not creating axis labels](https://linear.app/metabase/issue/VIZ-291/visualizer-created-dashcard-not-creating-axis-labels)

### Description
These guys now do their job properly:
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/44ac7f71-1800-407e-8745-f0771e7aaa5b" />
