### PR TITLE
run only previously failed tests when rerunning pipeline

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -98,6 +98,18 @@ jobs:
         id: cypress-prep
         uses: ./.github/actions/prepare-cypress
 
+      - name: Download failed test artifacts
+        uses: actions/download-artifact@v4
+        if: github.run_attempt != '1'
+        continue-on-error: true
+        id: failed-specs
+        with:
+          name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
+
+      - name: Get failed specs
+        if: github.run_attempt != '1'
+        run: echo "specs=$(cat failed-specs)" >> $GITHUB_ENV
+
       - name: Run Snowplow micro
         uses: ./.github/actions/run-snowplow-micro
 
@@ -117,19 +129,25 @@ jobs:
           SPLIT_TIME_THRESHOLD: 5.0
           # do not write cypress-split summary to github
           SPLIT_SUMMARY: false
+          SPEC_PATH: ${{ env.specs || inputs.specs }}
         shell: bash
         run: |
+          echo "Running tests with specs: $SPEC_PATH"
           node e2e/runner/run_cypress_ci.js e2e \
             --env grepTags="-@mongo+-@flaky+-@OSS --@quarantine",grepOmitFiltered=true \
+            --spec "$SPEC_PATH" \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
         if: ${{ inputs.specs }}
         shell: bash
+        env:
+          SPEC_PATH: ${{ env.specs || inputs.specs }}
         run: |
+          echo "Running tests with specs: $SPEC_PATH"
           node e2e/runner/run_cypress_ci.js e2e \
           --env grepTags="${{inputs.tags}} --@quarantine",grepOmitFiltered=true \
-          --spec '${{ inputs.specs }}' \
+          --spec "$SPEC_PATH" \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 
       - name: Upload Test Results
@@ -153,6 +171,13 @@ jobs:
             ./cypress
             ./logs/test.log
           if-no-files-found: ignore
+
+      - name: Upload Failed Tests
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
+          path: ./cypress/test-results
 
       - name: Publish Summary
         if: failure()

--- a/e2e/support/collectFailedTests.js
+++ b/e2e/support/collectFailedTests.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+
+const path = require("path");
+
+/**
+ * Collects failed test specs from the most recent Cypress test run
+ *
+ * After each run, a file will store failed spec paths as a comma-separated list
+ * This format matches what's needed by the GitHub workflow for retrying tests
+ *
+ * @param {*} on
+ * @param {*} config
+ * @returns
+ */
+const collectFailingTests = (on, config) => {
+  on("after:run", async results => {
+    const failedSpecs = results.runs
+      .filter(run => run.stats.failures > 0)
+      .map(run => run.spec.relative);
+
+    if (failedSpecs.length > 0) {
+      const failedTestFilePath = "../../cypress/test-results/";
+      fs.mkdirSync(failedTestFilePath, { recursive: true });
+      fs.writeFileSync(
+        path.join(failedTestFilePath, "failed-specs"),
+        failedSpecs.join(","),
+      );
+    }
+  });
+
+  return collectFailingTests;
+};
+
+export { collectFailingTests };

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -4,6 +4,7 @@ import path from "node:path";
 import installLogsPrinter from "cypress-terminal-report/src/installLogsPrinter";
 
 import * as ciTasks from "./ci_tasks";
+import { collectFailingTests } from "./collectFailedTests";
 import {
   removeDirectory,
   verifyDownloadTasks,
@@ -146,6 +147,7 @@ const defaultConfig = {
 
     if (isCI) {
       cypressSplit(on, config, getSplittableSpecs);
+      collectFailingTests(on, config);
     }
 
     // this is an official workaround to keep recordings of the failed specs only


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #51359
Closes https://linear.app/metabase/issue/DEV-109/auto-re-run-only-failed-e2e-tests-in-ci

### Description

The logic goes as follows.
1. all failed tests are collected using `after:run` step and saved to `cypress/test-results`
2. this is saved as an artifact
3. e2e-test workflow now has an additional step that will check for any failed test artifacts
4. if none are found, everything runs as before, but if files are found, the previously failed tests will run

### Test
I obviously tried this countless times, but you can look at how it works here:
[First run](https://github.com/metabase/metabase/actions/runs/13831362889/attempts/1?pr=54900)
[Second run ](https://github.com/metabase/metabase/actions/runs/13831362889/attempts/2?pr=54900)
[Third run](https://github.com/metabase/metabase/actions/runs/13831362889/attempts/3?pr=54900)




