### PR TITLE
Make react-draggable compatible with React 19 on Metabase 52

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -111,8 +111,17 @@ class TableInteractive extends Component {
       contentWidths: null,
       showDetailShortcut: true,
     };
+
     this.columnHasResized = {};
+
+    /** @type {React.RefObject<HTMLDivElement>[]} */
     this.headerRefs = [];
+
+    /** @type {React.RefObject<HTMLDivElement>[]} */
+    this.resizeHandleRefs = [];
+
+    this._setupColumnHeaderDraggableRefs(props.data);
+
     this.detailShortcutRef = createRef();
 
     this.gridRef = createRef();
@@ -291,6 +300,10 @@ class TableInteractive extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    if (prevProps.data?.cols?.length !== this.props.data?.cols?.length) {
+      this._setupColumnHeaderDraggableRefs(this.props.data);
+    }
+
     if (
       !this.state.contentWidths ||
       prevProps.renderTableHeaderWrapper !== this.props.renderTableHeaderWrapper
@@ -315,6 +328,19 @@ class TableInteractive extends Component {
       this.props.height
     ) {
       this.props.dispatch(setUIControls({ scrollToLastColumn: false }));
+    }
+  }
+
+  _setupColumnHeaderDraggableRefs(data) {
+    const columnCount = data?.cols?.length;
+
+    // Initialize refs for each column headers.
+    // Without this, the draggable components will crash on React 19.
+    // This is because react-draggable uses ReactDOM.findDOMNode
+    // when `nodeRef` is falsey, which no longer exists on React 19.
+    if (columnCount !== undefined) {
+      this.headerRefs = [...Array(columnCount)].map(() => createRef());
+      this.resizeHandleRefs = [...Array(columnCount)].map(() => createRef());
     }
   }
 
@@ -822,8 +848,14 @@ class TableInteractive extends Component {
 
     const columnInfoPopoverTestId = "field-info-popover";
 
+    // Wait for the refs to be set before rendering
+    if (!this.headerRefs[columnIndex] || !this.resizeHandleRefs[columnIndex]) {
+      return null;
+    }
+
     return (
       <TableDraggable
+        nodeRef={this.headerRefs[columnIndex]}
         enableUserSelectHack={false}
         enableCustomUserSelectHack={!isVirtual}
         /* needs to be index+name+counter so Draggable resets after each drag */
@@ -859,7 +891,10 @@ class TableInteractive extends Component {
           } else if (Math.abs(d.x) + Math.abs(d.y) < HEADER_DRAG_THRESHOLD) {
             // in setTimeout since headers will be rerendered due to DRAG_COUNTER changing
             setTimeout(() => {
-              this.onVisualizationClick(clicked, this.headerRefs[columnIndex]);
+              this.onVisualizationClick(
+                clicked,
+                this.headerRefs[columnIndex]?.current,
+              );
             });
           }
           this.setState({
@@ -872,7 +907,13 @@ class TableInteractive extends Component {
         }}
       >
         <Box
-          ref={e => (this.headerRefs[columnIndex] = e)}
+          ref={element => {
+            // We cannot have `null` in `nodeRef` as it will fallback to
+            // `findDOMNode` which no longer exists in React 19.
+            if (element) {
+              this.headerRefs[columnIndex].current = element;
+            }
+          }}
           style={{
             ...style,
             overflow: "visible" /* ensure resize handle is visible */,
@@ -967,8 +1008,16 @@ class TableInteractive extends Component {
               this.onColumnResize(columnIndex, x);
               this.setState({ dragColIndex: null });
             }}
+            nodeRef={this.resizeHandleRefs[columnIndex]}
           >
             <ResizeHandle
+              ref={element => {
+                // We cannot have `null` in `nodeRef` as it will fallback to
+                // `findDOMNode` which no longer exists in React 19.
+                if (element) {
+                  this.resizeHandleRefs[columnIndex].current = element;
+                }
+              }}
               style={{
                 zIndex: 99,
                 position: "absolute",
@@ -1237,7 +1286,9 @@ class TableInteractive extends Component {
                   />
                 )}
                 <Grid
-                  ref={ref => (this.header = ref)}
+                  ref={ref => {
+                    this.header = ref;
+                  }}
                   style={{
                     top: 0,
                     left: 0,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type * as React from "react";
+import * as React from "react";
 import type { ControlPosition, DraggableBounds } from "react-draggable";
 import Draggable from "react-draggable";
 
@@ -61,6 +61,8 @@ export function Cell({
   onResize,
   showTooltip = true,
 }: CellProps) {
+  const resizeHandleRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <PivotTableCell
       data-allow-page-break-after
@@ -104,8 +106,12 @@ export function Cell({
             onStop={(e, { x }) => {
               onResize(x);
             }}
+            nodeRef={resizeHandleRef}
           >
-            <ResizeHandle data-testid="pivot-table-resize-handle" />
+            <ResizeHandle
+              data-testid="pivot-table-resize-handle"
+              ref={resizeHandleRef}
+            />
           </Draggable>
         )}
       </>


### PR DESCRIPTION
Closes EMB-225

Fixes a React 19 compatibility issue on Metabase 52. This PR is backport-only because `master` already got rid of `react-draggable` thanks to Sasha's work on new TableInteractive component in https://github.com/metabase/metabase/pull/54399, but that PR is not backported to 53 or 52.


`react-draggable` is using `ReactDOM.findDOMNode` by default which is removed in React 19, so it is rendering a lot of errors on React 19. This is an issue as `TableInteractive` and `PivotTableCell` relies on them. The API already supports passing `nodeRef` to attach the ref directly, so it doesn't need to invoke `findDOMNode` under the hood.

See this changelog section: https://github.com/react-grid-layout/react-draggable/blob/HEAD/CHANGELOG.md#440-may-12-2020:

> If running in React Strict mode, ReactDOM.findDOMNode() is deprecated. Unfortunately, in order for <Draggable> to work properly, we need raw access to the underlying DOM node. If you want to avoid the warning, pass a nodeRef as in this example

Example stacktrace when used in the SDK with React 19. You can reproduce this on the PoC branch without the changes from this branch:

```
Uncaught TypeError: _reactDom.default.findDOMNode is not a function
    at Draggable.findDOMNode (Draggable.js:210:1)
    at Draggable.componentDidMount (Draggable.js:194:1)
    at react-stack-bottom-frame (react-dom-client.development.js:22451:1)
    at runWithFiberInDEV (react-dom-client.development.js:543:1)
    at commitLayoutEffectOnFiber (react-dom-client.development.js:11436:1)
    at recursivelyTraverseLayoutEffects (react-dom-client.development.js:12412:1)
    at commitLayoutEffectOnFiber (react-dom-client.development.js:11413:1)
    at recursivelyTraverseLayoutEffects (react-dom-client.development.js:12412:1)
    at commitLayoutEffectOnFiber (react-dom-client.development.js:11529:1)
    at recursivelyTraverseLayoutEffects (react-dom-client.development.js:12412:1)
```

### How to test

- Re-arranging column headers in interactive tables should not crash in the main app and in the SDK (using React 18)
- For React 19, I am currently testing in SDK Storybook using the https://github.com/metabase/metabase/pull/54726 PoC branch to ensure it does not crash. Note that dragging the column headers doesn't actually do anything right now (it snaps back into place) but that is the current behavior on the SDK. I'm pretty sure we still have a GitHub Issue open on this.

related: [PR for React 53](https://github.com/metabase/metabase/pull/54902)