### PR TITLE
Closes VIZ-528: no longer crashes when using implicit columns as metrics

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -8,7 +8,7 @@ import type { VisualizerColumnValueSource } from "metabase-types/store/visualize
 
 type ColumnValuesMapping = Record<string, VisualizerColumnValueSource[]>;
 
-export function updateSettingsForDisplay(
+export function getUpdatedSettingsForDisplay(
   columnValuesMapping: ColumnValuesMapping,
   columns: DatasetColumn[],
   settings: VisualizationSettings,
@@ -43,32 +43,32 @@ export function updateSettingsForDisplay(
     // cartesian -> pie
     if (targetDisplay === "pie") {
       const {
-        "graph.metrics": metrics,
-        "graph.dimensions": dimensions,
+        "graph.metrics": metrics = [],
+        "graph.dimensions": dimensions = [],
         ...otherSettings
       } = settings;
 
-      const metric = metrics?.[0];
-      const dimension = dimensions?.[0];
+      const metric = metrics[0];
       const newColumns = columns.filter(
-        column => column.name === metric || column.name === dimension,
+        column => column.name === metric || dimensions.includes(column.name),
       );
 
       const newColumnValuesMapping: ColumnValuesMapping = {};
       if (metric) {
         newColumnValuesMapping[metric] = columnValuesMapping[metric];
       }
-      if (dimension) {
+
+      dimensions.forEach(dimension => {
         newColumnValuesMapping[dimension] = columnValuesMapping[dimension];
-      }
+      });
 
       return {
         columnValuesMapping: newColumnValuesMapping,
         columns: newColumns,
         settings: {
           ...otherSettings,
-          "pie.metric": metrics?.[0] ?? "",
-          "pie.dimension": dimensions?.[0] ?? "",
+          "pie.metric": metric,
+          "pie.dimension": dimensions.length === 1 ? dimensions[0] : dimensions,
         },
       };
     }


### PR DESCRIPTION
Closes [VIZ-528: Visualizer closes automatically when selecting viz type](https://linear.app/metabase/issue/VIZ-528/visualizer-closes-automatically-when-selecting-viz-type)

### Description

In the code that handles converting one type of chart into another (when using the visualization picker within the visualizer modal), we needed to account for certain visualization settinsg being implicit, in this case it was the pie metric.