### PR TITLE
closes viz-516: allow all letters in viz titles, even the letter z

### DIFF
--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -104,8 +104,8 @@ export const Visualizer = (props: VisualizerProps) => {
   });
 
   useKeyPressEvent("z", event => {
-    event.preventDefault();
     if (event.ctrlKey || event.metaKey) {
+      event.preventDefault();
       if (event.shiftKey) {
         if (canRedo) {
           redo();

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -86,7 +86,8 @@ export const getIsFullscreenModeEnabled = (state: State) =>
 export const getIsVizSettingsSidebarOpen = (state: State) =>
   state.visualizer.isVizSettingsSidebarOpen;
 
-export const getCanUndo = (state: State) => state.visualizer.past.length > 0;
+// #0 is state before its actually initialized, hence the > 1
+export const getCanUndo = (state: State) => state.visualizer.past.length > 1;
 export const getCanRedo = (state: State) => state.visualizer.future.length > 0;
 
 export const getReferencedColumns = createSelector(


### PR DESCRIPTION
Closes [VIZ-516: Can't type the letter "z" in your dashcard titles](https://linear.app/metabase/issue/VIZ-516/cant-type-the-letter-z-in-your-dashcard-titles)

### Description

Only prevent keyboard event propagation when CMD/CTRL Z has been pressed, not when Z all alone because we sometimes use it when writing things, even if it lives with the other goth letters down there in the alphabet.