### PR TITLE
Make pivot tables draggable compatible with React 19

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type * as React from "react";
+import * as React from "react";
 import type { ControlPosition, DraggableBounds } from "react-draggable";
 import Draggable from "react-draggable";
 
@@ -61,6 +61,8 @@ export function Cell({
   onResize,
   showTooltip = true,
 }: CellProps) {
+  const resizeHandleRef = React.useRef<HTMLDivElement | null>(null);
+
   return (
     <PivotTableCell
       data-allow-page-break-after
@@ -104,8 +106,14 @@ export function Cell({
             onStop={(e, { x }) => {
               onResize(x);
             }}
+            nodeRef={resizeHandleRef}
           >
-            <ResizeHandle data-testid="pivot-table-resize-handle" />
+            <ResizeHandle
+              data-testid="pivot-table-resize-handle"
+              ref={element => {
+                resizeHandleRef.current = element;
+              }}
+            />
           </Draggable>
         )}
       </>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -110,9 +110,7 @@ export function Cell({
           >
             <ResizeHandle
               data-testid="pivot-table-resize-handle"
-              ref={element => {
-                resizeHandleRef.current = element;
-              }}
+              ref={resizeHandleRef}
             />
           </Draggable>
         )}


### PR DESCRIPTION
Closes EMB-225

`react-draggable` is using `ReactDOM.findDOMNode` by default which is removed in React 19, so it is rendering a lot of errors on React 19. This is an issue as `PivotTableCell` relies on them. The API already supports passing `nodeRef` to attach the ref directly, so it doesn't need to invoke `findDOMNode` under the hood.

See this changelog section: https://github.com/react-grid-layout/react-draggable/blob/HEAD/CHANGELOG.md#440-may-12-2020:

> If running in React Strict mode, ReactDOM.findDOMNode() is deprecated. Unfortunately, in order for <Draggable> to work properly, we need raw access to the underlying DOM node. If you want to avoid the warning, pass a nodeRef as in this example

Example stacktrace when used in the SDK with React 19. You can reproduce this on the PoC branch without the changes from this branch:

```
Uncaught TypeError: _reactDom.default.findDOMNode is not a function
    at Draggable.findDOMNode (Draggable.js:210:1)
    at Draggable.componentDidMount (Draggable.js:194:1)
    at react-stack-bottom-frame (react-dom-client.development.js:22451:1)
    at runWithFiberInDEV (react-dom-client.development.js:543:1)
    at commitLayoutEffectOnFiber (react-dom-client.development.js:11436:1)
    at recursivelyTraverseLayoutEffects (react-dom-client.development.js:12412:1)
    at commitLayoutEffectOnFiber (react-dom-client.development.js:11413:1)
    at recursivelyTraverseLayoutEffects (react-dom-client.development.js:12412:1)
    at commitLayoutEffectOnFiber (react-dom-client.development.js:11529:1)
    at recursivelyTraverseLayoutEffects (react-dom-client.development.js:12412:1)
```

## This PR does not need to be backported

Because `TableInteractive` no longer uses `react-draggable` thanks to https://github.com/metabase/metabase/pull/54399, only `PivotTableCell` uses them in `master`, we have a separate fix for 52 and 53 which includes this change already:

- 52: https://github.com/metabase/metabase/pull/54901
- 53: https://github.com/metabase/metabase/pull/54902

## How to test

- Pivot tables should not crash in the main app and in the SDK (using React 18)
  - For React 19, I am currently testing in SDK Storybook using the https://github.com/metabase/metabase/pull/54726 PoC branch to ensure pivot tables does not crash.