### PR TITLE
Increase stage limit to 1000 and clarify error message.

### DIFF
--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -491,8 +491,8 @@
       (empty? stages)
       graph
 
-      (> stages-visited 50)
-      (throw (ex-info (i18n/tru "The chain of dependencies is too long to save card.") {}))
+      (> stages-visited 1000)
+      (throw (ex-info (i18n/tru "There are too many stages (>1000) to save card.") {}))
 
       :else
       (let [[stage & stages] stages]


### PR DESCRIPTION
Closes https://discourse.metabase.com/t/error-the-chain-of-dependencies-is-too-long-to-save-card/212085/2

### Description

We were limiting the number of stages in a card's query (including referenced queries) in order to avoid infinite recursion. Unfortunately, the limit was 50, which was too low. Setting it now to 1000, which we hope is high enough to never be reached but still prevent infinite recursion.
