### PR TITLE
fix(sdk): don't set the color scheme on the host app

### DIFF
--- a/patches/@mantine+core+7.17.0.patch
+++ b/patches/@mantine+core+7.17.0.patch
@@ -25,7 +25,7 @@ index 79fe05c..29f5854 100644
    theme,
    children,
 diff --git a/node_modules/@mantine/core/styles.css b/node_modules/@mantine/core/styles.css
-index 2bd5e32..2a011a3 100644
+index 2bd5e32..3e64622 100644
 --- a/node_modules/@mantine/core/styles.css
 +++ b/node_modules/@mantine/core/styles.css
 @@ -1,34 +1,4 @@
@@ -42,7 +42,7 @@ index 2bd5e32..2a011a3 100644
 -select {
 -  font: inherit;
 -}
- 
+-
 -button,
 -select {
 -  text-transform: none;
@@ -56,10 +56,19 @@ index 2bd5e32..2a011a3 100644
 -  line-height: var(--mantine-line-height);
 -  background-color: var(--mantine-color-body);
 -  color: var(--mantine-color-text);
--
+ 
 -  -webkit-font-smoothing: var(--mantine-webkit-font-smoothing);
 -  -moz-osx-font-smoothing: var(--mantine-moz-font-smoothing);
 -}
  @media screen and (max-device-width: 31.25em) {
  body {
      -webkit-text-size-adjust: 100%
+@@ -79,8 +49,6 @@ fieldset:disabled .mantine-active:active {
+ /* ----- Default CSS variables ----- */
+ 
+ :root {
+-  color-scheme: var(--mantine-color-scheme);
+-
+   --mantine-z-index-app: 100;
+   --mantine-z-index-modal: 200;
+   --mantine-z-index-popover: 300;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #54835
fixes EMB-234

This pr patches the css of mantine by removing 
`color-scheme: var(--mantine-color-scheme);`
from `:root`, which is a side effect on host app that we should not be doing as an sdk.

I tried another approach with getRootElement ([fix(sdk): use getRootElement](https://github.com/metabase/metabase/pull/55041)) but it was causing issues that I don't have time to properly investigate at the moment.


## How to reproduce and verify
- create a vite app and use the sdk on it (I used [npretto/sdk-compare](https://github.com/npretto/sdk-compare))
- set your mac to dark mode
- notice that without the sdk loaded, scrollbars and native html inputs are in dark mode
- embed the sdk, notice that they're now white without this fix

Pre mantine v7: (notice the scrollbars and the select are correctly dark)
<img width="717" alt="image" src="https://github.com/user-attachments/assets/3a0dd650-e5cd-4ab5-bb50-b6068be45524" />


Master:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/55428d7e-e555-4296-b455-a472972bc70d" />


This branch:

<img width="729" alt="image" src="https://github.com/user-attachments/assets/1f5f1deb-45ad-49be-98a5-b7fd33c5052f" />

