### PR TITLE
fix(sdk): mark react-dom/client as external to fix warnings in React 19

### DIFF
--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -121,6 +121,7 @@ module.exports = env => {
       ...mainConfig.externals,
       react: "react",
       "react-dom": "react-dom",
+      "react-dom/client": "react-dom/client",
       "react/jsx-runtime": "react/jsx-runtime",
     },
 


### PR DESCRIPTION
Closes EMB-242

Marks `react-dom/client` as external in our Embedding SDK webpack configuration to fix the below error. We never imported `createRoot` from `react-dom` anywhere in the codebase. Marking `react-dom/client` as external does the trick.

```
Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client". Component Stack: 
node_modules @metabase_embedding-sdk-react.js:186260
    a10 ExplicitSize.tsx:82
    node_modules @metabase_embedding-sdk-react.js:179573
    _VG @metabase_embedding-sdk-react.js:186429
    div unknown:0
    div unknown:0
    node_modules @metabase_embedding-sdk-react.js:16086
    erx ErrorBoundary.tsx:25
    ear Visualization.tsx:236
    a10 ExplicitSize.tsx:82
    u3 Redux
```

## How to test

- Build the SDK on this branch
- Install the SDK on a project that uses React 19
- Render an InteractiveQuestion component
- There should no longer be a `You are importing createRoot from "react-dom" which is not supported` warning in the console