### PR TITLE
Legacy permission and cloud migration modals

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/LegacyPermissionsModal/LegacyPermissionsModal.tsx
+++ b/frontend/src/metabase/admin/permissions/components/LegacyPermissionsModal/LegacyPermissionsModal.tsx
@@ -20,58 +20,54 @@ export const LegacyPermissionsModal = ({
     getDocsUrl(state, { page: "permissions/no-self-service-deprecation" }),
   );
   return (
-    <Modal.Root
+    <Modal
       opened={isOpen && showModal}
+      title={t`Your data permissions may look different, but the access hasn’t changed.`}
       onClose={onClose}
       size="35rem"
       closeOnClickOutside={false}
+      padding="2.5rem"
+      withCloseButton={false}
+      styles={{
+        body: {
+          paddingTop: "2.5rem",
+        },
+      }}
     >
-      <Modal.Overlay />
-      <Modal.Content>
-        <Modal.Header p="2.5rem" pb="1.5rem">
-          <Modal.Title>
-            <Text fz="1.25rem">
-              {t`Your data permissions may look different, but the access hasn’t changed.`}
-            </Text>
-          </Modal.Title>
-        </Modal.Header>
-        <Modal.Body p="2.5rem">
-          <Text mb="1rem">
-            {jt`In Metabase 50, we split our data permissions into two new settings: ${(
-              <Text
-                key="view-data"
-                span
-                color="brand"
-                fw="bold"
-              >{t`View data`}</Text>
-            )} and ${(
-              <Text
-                key="create-queries"
-                span
-                color="brand"
-                fw="bold"
-              >{t`Create queries`}</Text>
-            )}. Having separate settings for what people can view and what they can query makes data permissions more expressive and easier to reason about.`}
-          </Text>
-          <Text mb="1.5rem">
-            {t`Your permissions have been automatically converted to the new settings, with no change in data access for your groups.`}
-          </Text>
-          <Flex justify="space-between">
-            <Button
-              variant="subtle"
-              p={0}
-              component={Link}
-              to={docsUrl}
-              target="_blank"
-            >
-              {t`Learn more`}
-            </Button>
-            <Button onClick={onClose} variant="filled">
-              {t`Got it`}
-            </Button>
-          </Flex>
-        </Modal.Body>
-      </Modal.Content>
-    </Modal.Root>
+      <Text mb="1rem">
+        {jt`In Metabase 50, we split our data permissions into two new settings: ${(
+          <Text
+            key="view-data"
+            component="span"
+            c="brand"
+            fw="bold"
+          >{t`View data`}</Text>
+        )} and ${(
+          <Text
+            key="create-queries"
+            component="span"
+            c="brand"
+            fw="bold"
+          >{t`Create queries`}</Text>
+        )}. Having separate settings for what people can view and what they can query makes data permissions more expressive and easier to reason about.`}
+      </Text>
+      <Text mb="1.5rem">
+        {t`Your permissions have been automatically converted to the new settings, with no change in data access for your groups.`}
+      </Text>
+      <Flex justify="space-between">
+        <Button
+          variant="subtle"
+          p={0}
+          component={Link}
+          to={docsUrl}
+          target="_blank"
+        >
+          {t`Learn more`}
+        </Button>
+        <Button onClick={onClose} variant="filled">
+          {t`Got it`}
+        </Button>
+      </Flex>
+    </Modal>
   );
 };

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationInProgress.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationInProgress.tsx
@@ -110,30 +110,23 @@ export const MigrationInProgress = ({
         </Flex>
       </MigrationCard>
 
-      <Modal.Root
+      <Modal
         opened={isModalOpen}
         onClose={closeModal}
         size="lg"
         data-testid="cancel-cloud-migration-confirmation"
+        title={t`Cancel migration?`}
+        padding="2rem"
       >
-        <Modal.Overlay />
-        <Modal.Content p="1rem">
-          <Modal.Header pt="1rem" px="1rem">
-            <Modal.Title>{t`Cancel migration?`}</Modal.Title>
-            <Modal.CloseButton />
-          </Modal.Header>
-          <Modal.Body mt="md" px="1rem">
-            <Text>{t`We will cancel the migration process. After that, this instance will no longer be read-only.`}</Text>
-            <Flex justify="end" mt="3.5rem">
-              <Button
-                variant="filled"
-                color="error"
-                onClick={handleCancelMigration}
-              >{t`Cancel migration`}</Button>
-            </Flex>
-          </Modal.Body>
-        </Modal.Content>
-      </Modal.Root>
+        <Text mt="md">{t`We will cancel the migration process. After that, this instance will no longer be read-only.`}</Text>
+        <Flex justify="end" mt="3.5rem">
+          <Button
+            variant="filled"
+            color="error"
+            onClick={handleCancelMigration}
+          >{t`Cancel migration`}</Button>
+        </Flex>
+      </Modal>
     </>
   );
 };

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationStart.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationStart.tsx
@@ -23,36 +23,35 @@ export const MigrationStart = ({
         <UpsellCloud onOpenModal={openModal} source="settings-cloud" />
       </Box>
 
-      <Modal.Root
+      <Modal
         opened={isModalOpen}
         onClose={closeModal}
         size="36rem"
         data-testid="new-cloud-migration-confirmation"
+        styles={{
+          body: {
+            padding: 0,
+          },
+        }}
       >
-        <Modal.Overlay />
-        <Modal.Content pt="1rem" pb="4rem">
-          <Modal.Header py="0" px="1rem">
-            <Modal.CloseButton />
-          </Modal.Header>
-          <Modal.Body mt="md" py="0" px="6rem" ta="center">
-            <Icon name="cloud_filled" size="3rem" color="brand" />
-            <Modal.Title mt="1.5rem">{t`Get started with Metabase Cloud`}</Modal.Title>
+        <Box mt="md" pb="4rem" px="6rem" ta="center">
+          <Icon name="cloud_filled" size="3rem" color="brand" />
+          <Modal.Title mt="1.5rem">{t`Get started with Metabase Cloud`}</Modal.Title>
 
-            <Text mt="1.5rem">
-              {t`Just a heads up: your Metabase will be read-only for up to 30
+          <Text mt="1.5rem">
+            {t`Just a heads up: your Metabase will be read-only for up to 30
               minutes while we prep it for migration.`}{" "}
-              <ExternalLink href="https://www.metabase.com/cloud/">{t`Learn More.`}</ExternalLink>
-            </Text>
+            <ExternalLink href="https://www.metabase.com/cloud/">{t`Learn More.`}</ExternalLink>
+          </Text>
 
-            <Button
-              variant="filled"
-              disabled={isStarting}
-              onClick={startNewMigration}
-              mt="2rem"
-            >{t`Migrate now`}</Button>
-          </Modal.Body>
-        </Modal.Content>
-      </Modal.Root>
+          <Button
+            variant="filled"
+            disabled={isStarting}
+            onClick={startNewMigration}
+            mt="2rem"
+          >{t`Migrate now`}</Button>
+        </Box>
+      </Modal>
     </>
   );
 };


### PR DESCRIPTION
Closes ADM-445
Closes ADM-446
Closes ADM-447

### Description
Migrates the legacy permission and Cloud migration modals from composed `<Modal.Root>`  modals to simple `<Modal>` implementations.

### How to verify
No changes to the end user. CI should be green

### Demo
#### After changes
Migartion Start modal:
![image](https://github.com/user-attachments/assets/95d58683-8d13-489e-9c10-ad584c02437d)

Cancel Migration modal (migration in progress):
![image](https://github.com/user-attachments/assets/e354da73-feca-4a3a-8055-47f99e013fd6)

Legacy Permissions:
![image](https://github.com/user-attachments/assets/9bc0ae93-8187-4448-aca0-90e409e492de)


