### PR TITLE
fix(sdk): remove react-router console error in LegendLabel when in React 19

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
@@ -9,6 +9,9 @@ import {
 import type { LinkProps } from "react-router";
 import { Link } from "react-router";
 
+import { isEmbeddingSdk } from "metabase/env";
+import { Box } from "metabase/ui";
+
 import S from "./LegendLabel.module.css";
 
 interface Props {
@@ -50,6 +53,21 @@ export const LegendLabel = ({
       >
         {children}
       </div>
+    );
+  }
+
+  // If we are in the Embedding SDK, we should not be using the
+  // Link component, as internal links would be inaccessible.
+  if (isEmbeddingSdk) {
+    return (
+      <Box
+        className={cx(S.text, S.link, className)}
+        onClick={handleLinkClick}
+        onFocus={onFocus}
+        onMouseEnter={onMouseEnter}
+      >
+        {children}
+      </Box>
     );
   }
 


### PR DESCRIPTION
Closes EMB-241

We should not render `<Link />` when in SDK Embedding (or even when in static embedding), so we should cleanup those usages. When `react-router` is rendered on React 19 it causes tons of React errors. In particular, the following  `getDefaultProps` error on `<LegendLabel />` is the most spammy as it logs 98 errors in a single render:

```
Warning: getDefaultProps is only used on classic React.createClass definitions. Use a static property named `defaultProps` instead. Component Stack: 
    erF LegendLabel.tsx:30
    node_modules @metabase_embedding-sdk-react.js:16089
    div unknown:0
    node_modules @metabase_embedding-sdk-react.js:16089
    erK LegendCaption.tsx:53
    node_modules @metabase_embedding-sdk-react.js:16089
    erZ ChartCaption.tsx:32
    div unknown:0
```

For reference, these clickable dashcard titles uses the `LegendLabel` component. The SDK used to render this with `react-router` Link which does not make sense as it may lead to an internal question, which could potentially allow break out of embedding if users right click on the link.

![CleanShot 2568-03-11 at 01 34 06@2x](https://github.com/user-attachments/assets/ffb4767c-b350-41f3-81bc-507cd52bae68)

### How to reproduce

- Install the SDK on a React 19 project
- Render an intetractive dashboard (which uses `LegendLabel`)
- It should no longer render the `react-router` Link component
- We should no longer get a huge spam of `getDefaultProps` error

### Demo

Before applying the fix

![CleanShot 2568-03-11 at 01 25 54@2x](https://github.com/user-attachments/assets/a04b90bc-ec2c-495c-9568-d03a040a28b4)

After applying the fix, the console error is gone.

![CleanShot 2568-03-11 at 01 27 15@2x](https://github.com/user-attachments/assets/06c168d4-e3f4-42cb-8e3c-183b139f2a51)

### Tests

We already have interactive dashboard tests that covers clicking/drilling on dashboard cards. You can cause the test to fail if you remove the click handlers from the `<Box>`.