### PR TITLE
Support google_sheets in POST /api/ee/gsheets/folder

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -40,7 +40,7 @@
 ;;   - user copies their Google Drive share link into MB form and hits submit
 ;; - FE sends :post "api/ee/gsheets/folder" w/ folder url string as `request.body.url`
 ;;   - BE forwards request to :post "/api/v2/mb/connections" w/ body:
-;;     `{:type "gdrive" :secret {:resources ["the-url"]}}`
+;;     `{:type "[gdrive|google_spreadsheet]" :secret {:resources ["the-url"]}}`
 ;;     - on unexceptional status:
 ;;       - BE sets `gsheets.status` to `"loading"`
 ;;       - BE returns the gsheets shape: `{:status "loading" :folder_url "the-url" :folder-upload-time <epoch-time> :gdrive/conn-id <uuid>}}`
@@ -125,7 +125,7 @@
 (mr/def :gdrive/connection
   [:map {:description "A Harbormaster Gdrive Connection"}
    [:id :string]
-   [:type [:= "gdrive"]]
+   [:type [:enum "gdrive" "google_spreadsheet"]]
    [:status [:enum "initializing" "syncing" "active" "error"]]
    [:last-sync-at [:maybe :time/zoned-date-time]]
    [:last-sync-started-at [:maybe :time/zoned-date-time]]
@@ -134,7 +134,7 @@
 
 (defn- is-gdrive?
   "Is this connection a gdrive connection?"
-  [{:keys [type] :as _conn}] (= "gdrive" type))
+  [{:keys [type] :as _conn}] (or (= "google_spreadsheet" type) (= "gdrive" type)))
 
 (defn- normalize-gdrive-conn
   "Normalize the gdrive connection shape from harbormaster, mostly parsing times."
@@ -180,10 +180,21 @@
     (throw (ex-info "Cannot fetch Google Drive connection: ID is nil" {})))
   (hm.client/make-request :get (str "/api/v2/mb/connections/" id)))
 
+(defn- url-type [url]
+  (cond
+    (re-matches #"^https://docs.google.com/spreadsheets/.*" url)
+    "google_spreadsheet"
+
+    (re-matches #"^https://drive.google.com/drive/.*" url)
+    "gdrive"
+
+    :else
+    (throw (ex-info (tru "Invalid URL: {0}" url) {:status-code 400}))))
+
 (mu/defn- hm-create-gdrive-conn! :- :hm-client/http-reply
-  "Creating a gdrive connection on HM starts the sync w/ drive folder."
-  [drive-folder-url]
-  (hm.client/make-request :post "/api/v2/mb/connections" {:type "gdrive" :secret {:resources [drive-folder-url]}}))
+  "Creating a gdrive connection on HM starts the sync w/ drive folder or sheet."
+  [resource-url]
+  (hm.client/make-request :post "/api/v2/mb/connections" {:type (url-type resource-url) :secret {:resources [resource-url]}}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; FE <-> MB APIs

--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -182,10 +182,10 @@
 
 (defn- url-type [url]
   (cond
-    (re-matches #".*docs.google.com/spreadsheets/.*" url)
+    (re-matches #"^(https|http)://docs.google.com/spreadsheets/.*" url)
     "google_spreadsheet"
 
-    (re-matches #".*drive.google.com/drive/.*" url)
+    (re-matches #"^(https|http)://drive.google.com/drive/.*" url)
     "gdrive"
 
     :else

--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -182,10 +182,10 @@
 
 (defn- url-type [url]
   (cond
-    (re-matches #"^https://docs.google.com/spreadsheets/.*" url)
+    (re-matches #".*docs.google.com/spreadsheets/.*" url)
     "google_spreadsheet"
 
-    (re-matches #"^https://drive.google.com/drive/.*" url)
+    (re-matches #".*drive.google.com/drive/.*" url)
     "gdrive"
 
     :else

--- a/enterprise/backend/test/metabase_enterprise/api/gsheets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/gsheets_test.clj
@@ -225,5 +225,7 @@
 
 (deftest url-type
   (is (= "gdrive" (#'gsheets.api/url-type "https://drive.google.com/drive/abc")))
+  (is (= "gdrive" (#'gsheets.api/url-type "http://drive.google.com/drive/abc")))
   (is (= "google_spreadsheet" (#'gsheets.api/url-type "https://docs.google.com/spreadsheets/abc")))
+  (is (= "google_spreadsheet" (#'gsheets.api/url-type "http://docs.google.com/spreadsheets/abc")))
   (is (thrown-with-msg? Exception #"Invalid URL: https://not.google.com/file" (#'gsheets.api/url-type "https://not.google.com/file"))))

--- a/enterprise/backend/test/metabase_enterprise/api/gsheets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/gsheets_test.clj
@@ -118,7 +118,12 @@
 (def ^:private
   gdrive-link
   "nb: if you change this, change it in test_resources/gsheets/mock_hm_responses.edn"
-  "<expected-gdrive-link>")
+  "https://drive.google.com/drive/expected-gdrive-link")
+
+(def ^:private
+  gsheet-link
+  "nb: if you change this, change it in test_resources/gsheets/mock_hm_responses.edn"
+  "https://docs.google.com/spreadsheets/expected-sheet-link")
 
 (defmacro with-sample-db-as-dwh [& body]
   "We need an attached dwh for these tests, so let's have the sample db fill in for us:"
@@ -134,6 +139,14 @@
         (is (partial=
              {:status "loading", :folder_url gdrive-link}
              (mt/user-http-request :crowberto :post 200 "ee/gsheets/folder" {:url gdrive-link})))))))
+
+(deftest post-sheet-test
+  (with-sample-db-as-dwh
+    (mt/with-premium-features #{:etl-connections :attached-dwh :hosting}
+      (with-redefs [hm.client/make-request (partial mock-make-request happy-responses)]
+        (is (partial=
+             {:status "loading", :folder_url gsheet-link}
+             (mt/user-http-request :crowberto :post 200 "ee/gsheets/folder" {:url gsheet-link})))))))
 
 (deftest post-folder-syncing-test
   (mt/with-premium-features #{:etl-connections :attached-dwh :hosting}
@@ -209,3 +222,8 @@
       (with-redefs [hm.client/make-request (partial mock-make-request (+failed-delete-response happy-responses))]
         (= {:status "not-connected"}
            (mt/user-http-request :crowberto :delete 200 "ee/gsheets/folder"))))))
+
+(deftest url-type
+  (is (= "gdrive" (#'gsheets.api/url-type "https://drive.google.com/drive/abc")))
+  (is (= "google_spreadsheet" (#'gsheets.api/url-type "https://docs.google.com/spreadsheets/abc")))
+  (is (thrown-with-msg? Exception #"Invalid URL: https://not.google.com/file" (#'gsheets.api/url-type "https://not.google.com/file"))))

--- a/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
@@ -241,10 +241,15 @@ function GoogleSheetsConnectModal({
     event.preventDefault();
     setErrorMessage("");
 
-    const validationRegex = /(https|http)\:\/\/drive\.google\.com\/.+/;
+    const folderValidationRegex = /(https|http)\:\/\/drive\.google\.com\/.+/;
+    const sheetValidationRegex =
+      /(https|http)\:\/\/docs\.google\.com\/spreadsheets\/.+/;
 
-    if (!validationRegex.test(folderLink.trim())) {
-      setErrorMessage(t`Invalid Google Drive folder link`);
+    if (
+      !folderValidationRegex.test(folderLink.trim()) &&
+      !sheetValidationRegex.test(folderLink.trim())
+    ) {
+      setErrorMessage(t`Invalid Google link`);
       return;
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
@@ -241,9 +241,9 @@ function GoogleSheetsConnectModal({
     event.preventDefault();
     setErrorMessage("");
 
-    const folderValidationRegex = /(https|http)\:\/\/drive\.google\.com\/.+/;
+    const folderValidationRegex = /^(https|http):\/\/drive\.google\.com\/.+/;
     const sheetValidationRegex =
-      /(https|http)\:\/\/docs\.google\.com\/spreadsheets\/.+/;
+      /^(https|http):\/\/docs\.google\.com\/spreadsheets\/.+/;
 
     if (
       !folderValidationRegex.test(folderLink.trim()) &&

--- a/test_resources/gsheets/mock_hm_responses.edn
+++ b/test_resources/gsheets/mock_hm_responses.edn
@@ -94,7 +94,7 @@
        :trace-redirects []}]
  {:method :post,
   :url "/api/v2/mb/connections",
-  :body {:type "gdrive", :secret {:resources ["<expected-gdrive-link>"]}}}
+  :body {:type "gdrive", :secret {:resources ["https://drive.google.com/drive/expected-gdrive-link"]}}}
  [:ok {:cached nil,
        :request-time 1941,
        :repeatable? false,
@@ -121,6 +121,54 @@
         :last-sync-at nil,
         :error-detail nil,
         :type "gdrive",
+        :hosted-instance-resource
+        {:updated-at "2025-01-27T18:43:02Z",
+         :shared-resource-id nil,
+         :resource-id
+         "arn:aws:secretsmanager:us-west-2:373519213707:secret:hosting/development/instance/f390ec19-bd44-48ae-991c-66817182a376/conn-secret/049f3007-2146-4083-be38-f160c526aca7-C6UvyD",
+         :type "conn-secret",
+         :hosted-instance-id "f390ec19-bd44-48ae-991c-66817182a376",
+         :deleted-at nil,
+         :region "us-west-2",
+         :id 7,
+         :created-at "2025-01-27T18:43:02Z",
+         :provider "k8s"},
+        :hosted-instance-id "f390ec19-bd44-48ae-991c-66817182a376",
+        :last-sync-started-at nil,
+        :status "initializing",
+        :id "049f3007-2146-4083-be38-f160c526aca7",
+        :created-at "2025-01-27T18:43:02Z"},
+       :trace-redirects []}]
+
+ {:method :post,
+  :url "/api/v2/mb/connections",
+  :body {:type "google_spreadsheet", :secret {:resources ["https://docs.google.com/spreadsheets/expected-sheet-link"]}}}
+ [:ok {:cached nil,
+       :request-time 1941,
+       :repeatable? false,
+       :protocol-version {:name "HTTP", :major 1, :minor 1},
+       :streaming? true,
+       ;; :http-client #object[org.apache.http.impl.client.InternalHttpClient 0x5b19fc1e "org.apache.http.impl.client.InternalHttpClient@5b19fc1e"],
+       :chunked? false,
+       :reason-phrase "OK",
+       :headers
+       {"Date" "Mon, 27 Jan 2025 18:43:02 GMT",
+        "Connection" "close",
+        "Content-Type" "application/json;charset=utf-8",
+        "X-Frame-Options" "SAMEORIGIN",
+        "X-Content-Type-Options" "nosniff",
+        "Strict-Transport-Security" "max-age=31536000; includeSubDomains",
+        "Content-Length" "779",
+        "Server" "Jetty(11.0.24)"},
+       :orig-content-encoding nil,
+       :status 200,
+       :length 779,
+       :body
+       {:updated-at "2025-01-27T18:43:02Z",
+        :hosted-instance-resource-id 7,
+        :last-sync-at nil,
+        :error-detail nil,
+        :type "google_spreadsheet",
         :hosted-instance-resource
         {:updated-at "2025-01-27T18:43:02Z",
          :shared-resource-id nil,


### PR DESCRIPTION
### Description

Allows `POST /api/ee/gsheets/folder` to recognize a URL as being to a specific rather than to a folder and calls the harbormaster with the correct `type` argument

### How to verify

1. Enter a shared google sheet URL in the "connect to google sheets" dialog
2. See that the tabs within the sheet show in the attached datawarehouse

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
