### PR TITLE
update gsheets setting visibility

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/gsheets/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/settings.clj
@@ -65,7 +65,7 @@
   (deferred-tru "Information about Google Sheets Integration")
   :encryption :when-encryption-key-set
   :export? true
-  :visibility :public
+  :visibility :admin
   :type :json
   :getter (fn [] (or
                   ;; This NEEDS to be up to date between instances on a cluster, so:


### PR DESCRIPTION
This setting's value should actually only show up for admins.

As it is now, unauthenticated users can see your instance's gdrive setting (including the folder url).
