### PR TITLE
Add Settings Hooks

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -209,6 +209,7 @@ export const createMockSettings = (
   engines: createMockEngines(),
   "example-dashboard-id": 1,
   gsheets: { status: "not-connected", folder_url: null },
+  "humanization-strategy": "simple",
   "has-user-setup": true,
   "hide-embed-branding?": true,
   "instance-creation": dayjs().toISOString(),

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -370,6 +370,7 @@ interface PublicSettings {
   "has-user-setup": boolean;
   "help-link": HelpLinkSetting;
   "help-link-custom-destination": string;
+  "humanization-strategy": "simple" | "none";
   "hide-embed-branding?": boolean;
   "is-hosted?": boolean;
   "ldap-configured?": boolean;

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -34,3 +34,4 @@ export * from "./timeline";
 export * from "./timeline-event";
 export * from "./user-key-value";
 export * from "./user";
+export * from "./utils";

--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -1,16 +1,58 @@
-import type { SettingKey, SettingValue } from "metabase-types/api";
+import type {
+  SettingDefinition,
+  SettingKey,
+  SettingValue,
+} from "metabase-types/api";
 
 import { Api } from "./api";
+import { invalidateTags, tag } from "./tags";
 
-export const settingApi = Api.injectEndpoints({
+export const settingsApi = Api.injectEndpoints({
   endpoints: builder => ({
-    getSetting: builder.query<SettingValue, SettingKey>({
-      query: settingName => ({
+    // admin-only endpoint that returns all settings with lots of extra metadata
+    getAdminSettingsDetails: builder.query<SettingDefinition[], void>({
+      query: () => ({
         method: "GET",
-        url: `/api/setting/${settingName}`,
+        url: "/api/setting",
       }),
+    }),
+    getSetting: builder.query<SettingValue, SettingKey>({
+      query: name => ({
+        method: "GET",
+        url: `/api/setting/${name}`,
+      }),
+      providesTags: ["session-properties"],
+    }),
+    updateSetting: builder.mutation<
+      void,
+      {
+        key: SettingKey;
+        value: SettingValue;
+      }
+    >({
+      query: ({ key, value }) => ({
+        method: "PUT",
+        url: `/api/setting/${key}`,
+        body: { value },
+      }),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [tag("session-properties")]),
+    }),
+    updateSettings: builder.mutation<void, Record<SettingKey, SettingValue>>({
+      query: settings => ({
+        method: "PUT",
+        url: `/api/setting`,
+        body: settings,
+      }),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [tag("session-properties")]),
     }),
   }),
 });
 
-export const { useGetSettingQuery } = settingApi;
+export const {
+  useGetSettingQuery,
+  useGetAdminSettingsDetailsQuery,
+  useUpdateSettingMutation,
+  useUpdateSettingsMutation,
+} = settingsApi;

--- a/frontend/src/metabase/api/utils/index.ts
+++ b/frontend/src/metabase/api/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./settings";

--- a/frontend/src/metabase/api/utils/readme.md
+++ b/frontend/src/metabase/api/utils/readme.md
@@ -1,0 +1,3 @@
+## API Utils
+
+This is for helpers and utilities to combine APIs and make them more ergonomic, it's not for building feature-specific behavior

--- a/frontend/src/metabase/api/utils/settings.ts
+++ b/frontend/src/metabase/api/utils/settings.ts
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+
+import type { Settings } from "metabase-types/api";
+
+import { useGetSettingsQuery } from "../session";
+import {
+  useGetAdminSettingsDetailsQuery,
+  useUpdateSettingMutation,
+} from "../settings";
+
+/**
+ * One hook to get setting values and mutators for a given setting
+ */
+export const useAdminSetting = <SettingName extends keyof Settings>(
+  settingName: SettingName,
+) => {
+  const {
+    data: settings,
+    isLoading: settingsLoading,
+    ...apiProps
+  } = useGetSettingsQuery();
+  const { data: settingsDetails, isLoading: detailsLoading } =
+    useGetAdminSettingsDetailsQuery();
+  const [updateSetting, updateSettingResult] = useUpdateSettingMutation();
+
+  const settingDetails = useMemo(
+    () => settingsDetails?.find(setting => setting.key === settingName),
+    [settingsDetails, settingName],
+  );
+
+  const settingValue = settings?.[settingName];
+
+  return {
+    value: settingValue,
+    settingDetails,
+    updateSetting,
+    updateSettingResult,
+    isLoading: settingsLoading || detailsLoading,
+    ...apiProps,
+  };
+};

--- a/frontend/src/metabase/api/utils/settings.unit.spec.tsx
+++ b/frontend/src/metabase/api/utils/settings.unit.spec.tsx
@@ -6,7 +6,7 @@ import {
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
-import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import {
   createMockSettingDefinition,
   createMockSettings,
@@ -50,16 +50,15 @@ const setup = async () => {
   ]);
   setupUpdateSettingEndpoint();
   renderWithProviders(<TestComponent />);
-  expect(screen.getByText("Loading...")).toBeInTheDocument();
-  // this makes the act() related errors go away 🙃
-  await act(() => null);
 };
 
 describe("useAdminSetting", () => {
   it("should have loading state", async () => {
     await setup();
-    // the positive loading state assertion is in the setup function
-    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    await waitFor(async () => {
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    });
   });
 
   it("should get setting value", async () => {

--- a/frontend/src/metabase/api/utils/settings.unit.spec.tsx
+++ b/frontend/src/metabase/api/utils/settings.unit.spec.tsx
@@ -1,0 +1,98 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+} from "__support__/server-mocks";
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+
+import { useAdminSetting } from "./settings";
+
+const TestComponent = () => {
+  const { value, settingDetails, updateSetting, isLoading } =
+    useAdminSetting("site-name");
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <div>{JSON.stringify({ value, settingDetails })}</div>
+      <button
+        onClick={async () => {
+          await updateSetting({
+            key: "site-name",
+            value: "New Site Name",
+          });
+        }}
+      >
+        change site name
+      </button>
+    </div>
+  );
+};
+
+const setup = async () => {
+  setupPropertiesEndpoints(createMockSettings({ "site-name": "Metabased" }));
+  setupSettingsEndpoints([
+    createMockSettingDefinition({
+      key: "site-name",
+      is_env_setting: true,
+      env_name: "MB_SPECIAL_SITE_NAME",
+    }),
+  ]);
+  setupUpdateSettingEndpoint();
+  renderWithProviders(<TestComponent />);
+  expect(screen.getByText("Loading...")).toBeInTheDocument();
+  // this makes the act() related errors go away 🙃
+  await act(() => null);
+};
+
+describe("useAdminSetting", () => {
+  it("should have loading state", async () => {
+    await setup();
+    // the positive loading state assertion is in the setup function
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+
+  it("should get setting value", async () => {
+    await setup();
+    expect(await screen.findByText(/Metabased/)).toBeInTheDocument();
+  });
+
+  it("should get setting details", async () => {
+    await setup();
+    expect(
+      await screen.findByText(/"is_env_setting":true/),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/MB_SPECIAL_SITE_NAME/)).toBeInTheDocument();
+  });
+
+  it("should allow setting mutation", async () => {
+    await setup();
+    const updateButton = await screen.findByText("change site name");
+
+    // should update on refetch
+    setupPropertiesEndpoints(
+      createMockSettings({ "site-name": "New Site Name" }),
+    );
+
+    await userEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/New Site Name/)).toBeInTheDocument();
+    });
+
+    const apiCalls = fetchMock.calls();
+    const putCall = apiCalls.find(call => call[1]?.method === "PUT");
+
+    expect(putCall?.[0]).toContain("/api/setting/site-name");
+  });
+});

--- a/frontend/test/__support__/server-mocks/settings.ts
+++ b/frontend/test/__support__/server-mocks/settings.ts
@@ -5,3 +5,7 @@ import type { SettingDefinition } from "metabase-types/api";
 export function setupSettingsEndpoints(settings: SettingDefinition[]) {
   fetchMock.get("path:/api/setting", settings);
 }
+
+export function setupUpdateSettingEndpoint() {
+  fetchMock.put(new RegExp("/api/setting/"), { status: 204 });
+}


### PR DESCRIPTION
## Description

In preparation for moving all admin settings components to use RTKQuery:
- set up all settings api endpoints through RTK, with proper invalidation + typing
- set up a helper hook: `useAdminSetting` that provides a nice interface to three different RTKQuery hooks, all of which are needed to display + update a setting component. (see test for example usage)
