### PR TITLE
Fix bug in env var url component

### DIFF
--- a/frontend/src/metabase/admin/settings/utils.js
+++ b/frontend/src/metabase/admin/settings/utils.js
@@ -16,8 +16,7 @@ export const settingToFormField = setting => ({
 export const settingToFormFieldId = setting => `setting-${setting.key}`;
 
 export const useGetEnvVarDocsUrl = envName => {
-  return useDocsUrl(
-    "configuring-metabase/environment-variables",
-    envName?.toLowerCase(),
-  );
+  return useDocsUrl("configuring-metabase/environment-variables", {
+    anchor: envName?.toLowerCase(),
+  });
 };


### PR DESCRIPTION
Because this component wasn't in typescript, the hook was used incorrectly and always produced broken anchor tag links like this:

```
https://www.metabase.com/docs/latest/configuring-metabase/environment-variables.html#function%20anchor()%20{%20[native%20code]%20}
```

Ran across this while converting some settings code to typescript (coming soon to a review queue near you)