### PR TITLE
don't try to destructure the setting when missing

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
@@ -106,7 +106,6 @@ export function GsheetMenuItem({ onClick }: { onClick: () => void }) {
   const gSheetsSetting = useSetting("gsheets");
   const gSheetsEnabled = useSetting("show-google-sheets-integration");
 
-  const { status } = gSheetsSetting;
   const userIsAdmin = useSelector(getUserIsAdmin);
   const { data: { email: serviceAccountEmail } = {} } =
     useGetServiceAccountQuery();
@@ -119,6 +118,8 @@ export function GsheetMenuItem({ onClick }: { onClick: () => void }) {
   ) {
     return null;
   }
+
+  const { status } = gSheetsSetting;
 
   const handleClick = () => {
     trackSheetConnectionClick({ from: "left-nav" });

--- a/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_sheets/GoogleSheetManagement.tsx
@@ -52,8 +52,6 @@ export function GsheetConnectButton() {
   const { data: { email: serviceAccountEmail } = {} } =
     useGetServiceAccountQuery(shouldGetServiceAccount ? undefined : skipToken);
 
-  const { status } = gSheetsSetting;
-
   if (
     !gSheetsEnabled ||
     !gSheetsSetting ||
@@ -63,6 +61,8 @@ export function GsheetConnectButton() {
   ) {
     return null;
   }
+
+  const { status } = gSheetsSetting;
 
   const buttonText = match(status)
     .with("not-connected", () => t`Connect Google Sheets`)

--- a/enterprise/frontend/src/metabase-enterprise/google_sheets/GsheetsSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_sheets/GsheetsSyncStatus.tsx
@@ -16,7 +16,7 @@ type GsheetsStatus = Settings["gsheets"]["status"];
 type ErrorPayload = { data?: { message: string } };
 
 export const GsheetsSyncStatus = () => {
-  const gsheetsSetting = useSetting("gsheets");
+  const gsheetsSetting = useSetting("gsheets") ?? { status: "not-connected" };
   const { status: settingStatus } = gsheetsSetting;
   const previousSettingStatus = usePrevious(settingStatus);
   const dispatch = useDispatch();


### PR DESCRIPTION
I removed the gsheets setting when the user isn't an admin so we don't leak people's google drive folder to unauthenticated users. I think the frontend always expects it to be there though. So now the frontend makes sure the setting is present before accessing `status` on it.