### PR TITLE
Replace ConfirmContent with ConfirmModal

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -1,9 +1,8 @@
 import type { ChangeEvent, ChangeEventHandler } from "react";
 import { t } from "ttag";
 
-import ConfirmContent from "metabase/components/ConfirmContent";
+import { ConfirmModal } from "metabase/components/ConfirmModal";
 import CopyWidget from "metabase/components/CopyWidget";
-import Modal from "metabase/components/Modal";
 import Button from "metabase/core/components/Button";
 import FormField from "metabase/core/components/FormField";
 import TextArea from "metabase/core/components/TextArea";
@@ -161,14 +160,13 @@ const InlineActionSettings = ({
           </CopyWidgetContainer>
         )}
         {isModalOpen && (
-          <Modal>
-            <ConfirmContent
-              title={t`Disable this public link?`}
-              content={t`This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link.`}
-              onAction={handleDisablePublicLink}
-              onClose={closeModal}
-            />
-          </Modal>
+          <ConfirmModal
+            opened
+            title={t`Disable this public link?`}
+            content={t`This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link.`}
+            onConfirm={handleDisablePublicLink}
+            onClose={closeModal}
+          />
         )}
         <FormField title={t`Success message`} htmlFor={`${id}-message`}>
           <TextArea

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -1,3 +1,4 @@
+import { useDisclosure } from "@mantine/hooks";
 import type { ChangeEvent, ChangeEventHandler } from "react";
 import { t } from "ttag";
 
@@ -7,7 +8,6 @@ import Button from "metabase/core/components/Button";
 import FormField from "metabase/core/components/FormField";
 import TextArea from "metabase/core/components/TextArea";
 import Actions from "metabase/entities/actions/actions";
-import { useToggle } from "metabase/hooks/use-toggle";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { connect } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -92,7 +92,8 @@ const InlineActionSettings = ({
   onBack,
 }: ActionSettingsInlineProps) => {
   const id = useUniqueId();
-  const [isModalOpen, { turnOn: openModal, turnOff: closeModal }] = useToggle();
+  const [modalOpened, { open: openModal, close: closeModal }] =
+    useDisclosure(false);
   const hasSharingPermission = isAdmin && isPublicSharingEnabled;
 
   const handleTogglePublic: ChangeEventHandler<HTMLInputElement> = event => {
@@ -111,6 +112,7 @@ const InlineActionSettings = ({
     if (isSavedAction(action)) {
       onDeletePublicLink({ id: action.id });
     }
+    closeModal();
   };
 
   const handleSuccessMessageChange = (
@@ -159,15 +161,13 @@ const InlineActionSettings = ({
             />
           </CopyWidgetContainer>
         )}
-        {isModalOpen && (
-          <ConfirmModal
-            opened
-            title={t`Disable this public link?`}
-            content={t`This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link.`}
-            onConfirm={handleDisablePublicLink}
-            onClose={closeModal}
-          />
-        )}
+        <ConfirmModal
+          opened={modalOpened}
+          title={t`Disable this public link?`}
+          content={t`This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link.`}
+          onConfirm={handleDisablePublicLink}
+          onClose={closeModal}
+        />
         <FormField title={t`Success message`} htmlFor={`${id}-message`}>
           <TextArea
             id={`${id}-message`}

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -2,8 +2,7 @@ import cx from "classnames";
 import PropTypes from "prop-types";
 import { useRef, useState } from "react";
 
-import ConfirmContent from "metabase/components/ConfirmContent";
-import Modal from "metabase/components/Modal";
+import { ConfirmModal } from "metabase/components/ConfirmModal";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import { Tooltip } from "metabase/ui";
@@ -148,13 +147,12 @@ export function PermissionsTable({
       </PermissionsTableRoot>
       {!hasItems && emptyState}
       {confirmations?.length > 0 && (
-        <Modal>
-          <ConfirmContent
-            {...confirmations[0]}
-            onAction={handleConfirm}
-            onCancel={handleCancelConfirm}
-          />
-        </Modal>
+        <ConfirmModal
+          opened
+          {...confirmations[0]}
+          onConfirm={handleConfirm}
+          onClose={handleCancelConfirm}
+        />
       )}
     </>
   );

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -146,14 +146,12 @@ export function PermissionsTable({
         </tbody>
       </PermissionsTableRoot>
       {!hasItems && emptyState}
-      {confirmations?.length > 0 && (
-        <ConfirmModal
-          opened
-          {...confirmations[0]}
-          onConfirm={handleConfirm}
-          onClose={handleCancelConfirm}
-        />
-      )}
+      <ConfirmModal
+        opened={confirmations?.length > 0}
+        {...confirmations[0]}
+        onConfirm={handleConfirm}
+        onClose={handleCancelConfirm}
+      />
     </>
   );
 }

--- a/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
+++ b/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
@@ -7,8 +7,7 @@ import { getDashboard, useUpdateCardMutation } from "metabase/api";
 import { QuestionMoveConfirmModal } from "metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal";
 import type { MoveDestination } from "metabase/collections/types";
 import { canonicalCollectionId } from "metabase/collections/utils";
-import ConfirmContent from "metabase/components/ConfirmContent";
-import Modal from "metabase/components/Modal";
+import { ConfirmModal } from "metabase/components/ConfirmModal";
 import { MoveModal } from "metabase/containers/MoveModal";
 import Dashboards from "metabase/entities/dashboards";
 import { INJECT_RTK_QUERY_QUESTION_VALUE } from "metabase/entities/questions";
@@ -148,83 +147,72 @@ export const MoveQuestionModal = ({
 
   if (confirmMoveState?.type === "dashboard-to-collection") {
     return (
-      <Modal>
-        <ConfirmContent
-          data-testid="dashboard-to-collection-move-confirmation"
-          onAction={() =>
-            handleMove(confirmMoveState?.destination, deleteOldDashcardsState)
-          }
-          onCancel={onClose}
-          onClose={onClose}
-          title={
-            <Title fz="1.25rem" lh={1.5}>
-              {c(
-                "{0} is the dashboard name the question currently has dashcards in",
-              ).jt`Do you still want this question to appear in ${(
-                <>
-                  <Icon
-                    name="dashboard"
-                    style={{ marginBottom: -2 }}
-                    size={20}
-                  />{" "}
-                  <Dashboards.Name id={question.dashboardId()} />
-                </>
-              )}?`}
-            </Title>
-          }
-          message={
-            <>
-              <Box mt="-2rem">
-                {t`It can still appear there even though you’re moving it into a collection.`}
-              </Box>
-              <Radio.Group
-                value={`${!deleteOldDashcardsState}`}
-                onChange={val => setDeleteOldDashcardsState(val !== "true")}
-                mt="2rem"
-              >
-                <Radio
-                  label={t`Yes, it should still appear there`}
-                  value={"true"}
-                />
-                <Radio
-                  mt="md"
-                  label={t`No, remove it from that dashboard`}
-                  value={"false"}
-                />
-              </Radio.Group>
-            </>
-          }
-          confirmButtonPrimary
-          confirmButtonText={t`Done`}
-        />
-      </Modal>
+      <ConfirmModal
+        data-testid="dashboard-to-collection-move-confirmation"
+        opened
+        onConfirm={() => {
+          handleMove(confirmMoveState?.destination, deleteOldDashcardsState);
+          onClose();
+        }}
+        onClose={onClose}
+        title={
+          <Title fz="1.25rem" lh={1.5}>
+            {c(
+              "{0} is the dashboard name the question currently has dashcards in",
+            ).jt`Do you still want this question to appear in ${(
+              <>
+                <Icon name="dashboard" style={{ marginBottom: -2 }} size={20} />{" "}
+                <Dashboards.Name id={question.dashboardId()} />
+              </>
+            )}?`}
+          </Title>
+        }
+        message={
+          <>
+            <Box mt="-2rem">
+              {t`It can still appear there even though you’re moving it into a collection.`}
+            </Box>
+            <Radio.Group
+              value={`${!deleteOldDashcardsState}`}
+              onChange={val => setDeleteOldDashcardsState(val !== "true")}
+              mt="2rem"
+            >
+              <Radio
+                label={t`Yes, it should still appear there`}
+                value={"true"}
+              />
+              <Radio
+                mt="md"
+                label={t`No, remove it from that dashboard`}
+                value={"false"}
+              />
+            </Radio.Group>
+          </>
+        }
+        confirmButtonPrimary
+        confirmButtonText={t`Done`}
+      />
     );
   }
 
   if (confirmMoveState?.type === "dashboard-to-dashboard") {
     return (
-      <Modal>
-        <ConfirmContent
-          data-testid="dashboard-to-dashboard-move-confirmation"
-          onAction={() => handleMove(confirmMoveState.destination, true)}
-          onCancel={onClose}
-          onClose={onClose}
-          title={
-            <Title fz="1.25rem" lh={1.5}>
-              Moving this question to another dashboard will remove it from{" "}
-              <Icon name="dashboard" style={{ marginBottom: -2 }} size={20} />{" "}
-              <Dashboards.Name id={question.dashboardId()} />
-            </Title>
-          }
-          message={
-            <Box mt="-2rem">
-              {t`You can move it to a collection if you want to use it in both dashboards.`}
-            </Box>
-          }
-          confirmButtonPrimary
-          confirmButtonText={t`Okay`}
-        />
-      </Modal>
+      <ConfirmModal
+        opened
+        data-testid="dashboard-to-dashboard-move-confirmation"
+        onConfirm={() => handleMove(confirmMoveState.destination, true)}
+        onClose={onClose}
+        title={
+          <Title fz="1.25rem" lh={1.5}>
+            Moving this question to another dashboard will remove it from{" "}
+            <Icon name="dashboard" style={{ marginBottom: -2 }} size={20} />{" "}
+            <Dashboards.Name id={question.dashboardId()} />
+          </Title>
+        }
+        message={t`You can move it to a collection if you want to use it in both dashboards.`}
+        confirmButtonPrimary
+        confirmButtonText={t`Okay`}
+      />
     );
   }
 


### PR DESCRIPTION
Replaces part of #53814 

Uses the new ConfirmModal component from #54632 and replaces direct usages of `ConfirmContent` with it. `ConfirmContent`  is still used in some other places where it's wrapped in another Component, in hooks or where it is used with a `ModalWithTrigger`. These will be dealt with separately