### PR TITLE
fix model reproductions and filters flakes

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -290,6 +290,44 @@ export const moveDnDKitElement = (
     .wait(200);
 };
 
+export const moveDnDKitElementByAlias = (
+  alias,
+  { horizontal = 0, vertical = 0 } = {},
+) => {
+  // This function queries alias before triggering every event to avoid running into "element was removed from the DOM"
+  // error caused by node remounting https://on.cypress.io/element-has-detached-from-dom
+  cy.get(alias)
+    .trigger("pointerdown", 0, 0, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200);
+  // This initial move needs to be greater than the activation constraint
+  // of the pointer sensor
+  cy.get(alias)
+    .trigger("pointermove", 20, 20, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200);
+  cy.get(alias)
+    .trigger("pointermove", horizontal, vertical, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200);
+  cy.get(alias)
+    .trigger("pointerup", horizontal, vertical, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200);
+};
+
 export const queryBuilderMain = () => {
   return cy.findByTestId("query-builder-main");
 };

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -216,10 +216,10 @@ describe("issue 18770", { tags: "@flaky" }, () => {
 
     cy.findAllByTestId("cell-data")
       .filter(":contains(4,784)")
-      .should("have.length", 1)
-      .as("targetCell");
+      .should("have.length", 1);
+
     // Querying the cell again to ensure the dom node stability
-    cy.get("@targetCell").click();
+    H.tableInteractiveBody().findByText("4,784").click();
     H.popover().within(() => {
       cy.findByText("Filter by this value").should("be.visible");
       cy.findAllByRole("button")

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -201,39 +201,37 @@ describe("issue 18770", { tags: "@flaky" }, () => {
     H.createQuestion(questionDetails, { visitQuestion: true });
   });
 
-  it(
-    "post-aggregation filter shouldn't affect the drill-through options (metabase#18770)",
-    { tags: "@flaky" },
-    () => {
-      H.openNotebook();
-      // It is important to manually trigger "visualize" in order to generate the `result_metadata`
-      // Otherwise, we might get false negative even when this issue gets resolved.
-      // In order to do that, we have to change the breakout field first or it will never generate and send POST /api/dataset request.
-      cy.findAllByTestId("notebook-cell-item")
-        .contains(/Products? → Title/)
-        .click();
-      H.popover().findByText("Category").click();
-      cy.findAllByTestId("notebook-cell-item").contains(/Products? → Category/);
+  it("post-aggregation filter shouldn't affect the drill-through options (metabase#18770)", () => {
+    H.openNotebook();
+    // It is important to manually trigger "visualize" in order to generate the `result_metadata`
+    // Otherwise, we might get false negative even when this issue gets resolved.
+    // In order to do that, we have to change the breakout field first or it will never generate and send POST /api/dataset request.
+    cy.findAllByTestId("notebook-cell-item")
+      .contains(/Products? → Title/)
+      .click();
+    H.popover().findByText("Category").click();
+    cy.findAllByTestId("notebook-cell-item").contains(/Products? → Category/);
 
-      H.visualize();
+    H.visualize();
 
-      cy.findAllByTestId("cell-data")
-        .filter(":contains(4,784)")
-        .should("have.length", 1)
-        .click();
-      H.popover().within(() => {
-        cy.findByText("Filter by this value").should("be.visible");
-        cy.findAllByRole("button")
-          .should("have.length", 6)
-          .and("contain", "See these Orders")
-          .and("contain", "Break out by")
-          .and("contain", "<")
-          .and("contain", ">")
-          .and("contain", "=")
-          .and("contain", "≠");
-      });
-    },
-  );
+    cy.findAllByTestId("cell-data")
+      .filter(":contains(4,784)")
+      .should("have.length", 1)
+      .as("targetCell");
+    // Querying the cell again to ensure the dom node stability
+    cy.get("@targetCell").click();
+    H.popover().within(() => {
+      cy.findByText("Filter by this value").should("be.visible");
+      cy.findAllByRole("button")
+        .should("have.length", 6)
+        .and("contain", "See these Orders")
+        .and("contain", "Break out by")
+        .and("contain", "<")
+        .and("contain", ">")
+        .and("contain", "=")
+        .and("contain", "≠");
+    });
+  });
 });
 
 describe("issue 20551", () => {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -1395,30 +1395,27 @@ describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
-  it(
-    "should allow to run the model query after changing custom columns (metabase#29951)",
-    { tags: "@flaky" },
-    () => {
-      H.createQuestion(questionDetails).then(({ body: { id } }) => {
-        cy.visit(`/model/${id}/query`);
-      });
+  it("should allow to run the model query after changing custom columns (metabase#29951)", () => {
+    H.createQuestion(questionDetails).then(({ body: { id } }) => {
+      cy.visit(`/model/${id}/query`);
+    });
 
-      removeExpression("CC2");
-      // The UI shows us the "play" icon, indicating we should refresh the query,
-      // but the point of this repro is to save without refreshing
-      cy.button("Get Answer").should("be.visible");
-      H.saveMetadataChanges();
+    removeExpression("CC2");
+    // The UI shows us the "play" icon, indicating we should refresh the query,
+    // but the point of this repro is to save without refreshing
+    cy.button("Get Answer").should("be.visible");
+    H.saveMetadataChanges();
 
-      // eslint-disable-next-line no-unsafe-element-filtering
-      cy.findAllByTestId("header-cell").last().should("have.text", "CC1");
-      H.moveDnDKitElement(H.tableHeaderColumn("ID"), { horizontal: 100 });
+    // eslint-disable-next-line no-unsafe-element-filtering
+    cy.findAllByTestId("header-cell").last().should("have.text", "CC1");
+    H.tableHeaderColumn("ID").as("idHeader");
+    H.moveDnDKitElementByAlias("@idHeader", { horizontal: 100 });
 
-      cy.findByTestId("qb-header").button("Refresh").click();
-      cy.wait("@dataset");
-      cy.get("[data-testid=cell-data]").should("contain", "37.65");
-      cy.findByTestId("view-footer").should("contain", "Showing 2 rows");
-    },
-  );
+    cy.findByTestId("qb-header").button("Refresh").click();
+    cy.wait("@dataset");
+    cy.get("[data-testid=cell-data]").should("contain", "37.65");
+    cy.findByTestId("view-footer").should("contain", "Showing 2 rows");
+  });
 });
 
 describe("issue 31309", () => {


### PR DESCRIPTION
Closes [DEV-367](https://linear.app/metabase/issue/DEV-367/flaky-test-e2e-should-allow-to-run-the-model-query-after-changing) 

closes https://linear.app/metabase/issue/DEV-369/flaky-test-e2e-post-aggregation-filter-shouldnt-affect-the-drill

With the new table implementation reordering of columns may cause flakes due the dragged header element is being remounted when order changes so we need to query the element before triggering every event.

Stress tests:
- `e2e/test/scenarios/models/reproductions.cy.spec.js` [link](https://github.com/metabase/metabase/actions/runs/13794321903)
- `e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js` [link](https://github.com/metabase/metabase/actions/runs/13796173804/job/38588248533)
