### PR TITLE
Truncate slack header titles and links if the exceed block limits

### DIFF
--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -36,9 +36,9 @@
         (str "…"))
     mrkdwn))
 
-(def ^:private header-text-limit 150)
-(def ^:private block-text-length-limit 3000)
-(def ^:private attachment-text-length-limit 2000)
+(def header-text-limit       "Header block character limit"    150)
+(def block-text-length-limit "Section block character limit"   3000)
+(def ^:private attachment-text-length-limit                    2000)
 
 (defn- text->markdown-block
   [text]

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -82,28 +82,27 @@
   (let [mock-upload-file!
         (fn [_bytes attachment-name]
           {:url (str "http://uploaded/" attachment-name)
-           :id (str "ID_" attachment-name)})]
-    (testing "Uploads files"
-      (let [attachments [{:title           "&amp;a"
-                          :title_link      "a.com"
-                          :attachment-name "a.png"
-                          :rendered-info   {:attachments nil
-                                            :content     [:div "hi"]}}
-                         {:title           "> click <https://c.com|here>"
-                          :title_link      "b.com"
-                          :attachment-name "b.png"
-                          :rendered-info   {:attachments nil
-                                            :content     [:div "hi again"]
-                                            :render/text "hi again"}}]
-            processed   (with-redefs [slack/upload-file! mock-upload-file!]
-                          (mapv #'channel.slack/create-and-upload-slack-attachment! attachments))]
-        (is (= [{:blocks [{:type "section"
-                           :text {:type "mrkdwn", :text "<a.com|&amp;amp;a>", :verbatim true}}
-                          {:type "image"
-                           :alt_text "&amp;a",
-                           :slack_file {:id "ID_a.png"}}]}
-                {:blocks [{:type "section"
-                           :text {:text "<b.com|&gt; click &lt;https://c.com|here&gt;>", :type "mrkdwn", :verbatim true}}
-                          {:type "section"
-                           :text {:type "plain_text", :text "hi again"}}]}]
-               processed))))))
+           :id (str "ID_" attachment-name)})
+        attachments [{:title           "&amp;a"
+                      :title_link      "a.com"
+                      :attachment-name "a.png"
+                      :rendered-info   {:attachments nil
+                                        :content     [:div "hi"]}}
+                     {:title           "> click <https://c.com|here>"
+                      :title_link      "b.com"
+                      :attachment-name "b.png"
+                      :rendered-info   {:attachments nil
+                                        :content     [:div "hi again"]
+                                        :render/text "hi again"}}]
+        processed   (with-redefs [slack/upload-file! mock-upload-file!]
+                      (mapv #'channel.slack/create-and-upload-slack-attachment! attachments))]
+    (is (= [{:blocks [{:type "section"
+                       :text {:type "mrkdwn", :text "<a.com|&amp;amp;a>", :verbatim true}}
+                      {:type "image"
+                       :alt_text "&amp;a",
+                       :slack_file {:id "ID_a.png"}}]}
+            {:blocks [{:type "section"
+                       :text {:text "<b.com|&gt; click &lt;https://c.com|here&gt;>", :type "mrkdwn", :verbatim true}}
+                      {:type "section"
+                       :text {:type "plain_text", :text "hi again"}}]}]
+           processed))))

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -343,7 +343,7 @@
                    [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
                               {:type "section", :fields [{:type "mrkdwn", :text (str "<https://testmb.com/dashboard/"
                                                                                      dashboard-id
-                                                                                     " | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
+                                                                                     "|*Sent from Metabase Test by Rasta Toucan*>")}]}]}
                     {:title           pulse.test-util/card-name
                      :rendered-info   {:attachments false
                                        :content     true}
@@ -392,7 +392,7 @@
                  [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
                             {:type "section", :fields [{:type "mrkdwn", :text (str "<https://testmb.com/dashboard/"
                                                                                    dashboard-id
-                                                                                   " | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
+                                                                                   "|*Sent from Metabase Test by Rasta Toucan*>")}]}]}
                   {:title           pulse.test-util/card-name
                    :rendered-info   {:attachments false, :content true, :render/text true},
                    :title_link      (str "https://testmb.com/question/" card-id)
@@ -437,7 +437,7 @@
                                                         :text
                                                         (str "<https://testmb.com/dashboard/"
                                                              dashboard-id
-                                                             " | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
+                                                             "|*Sent from Metabase Test by Rasta Toucan*>")}]}]}
                   {:title           pulse.test-util/card-name
                    :rendered-info   {:attachments false, :content true, :render/text true},
                    :title_link      (str "https://testmb.com/question/" card-id)
@@ -483,7 +483,7 @@
                               {:type "section", :fields [{:type "mrkdwn", :text
                                                           (str "<https://testmb.com/dashboard/"
                                                                dashboard-id
-                                                               "?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021 | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
+                                                               "?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021|*Sent from Metabase Test by Rasta Toucan*>")}]}]}
 
                     {:title           pulse.test-util/card-name
                      :rendered-info   {:attachments false, :content true, :render/text true},
@@ -551,7 +551,7 @@
                      {:type "mrkdwn", :text "*Quarter and Year*\nQ1, 2021"}]}
                    {:type "section", :fields [{:type "mrkdwn",
                                                :text
-                                               #"<https://testmb\.com/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\ \| \*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
+                                               #"<https://testmb\.com/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\|\*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
 
                  {:title "Test card",
                   :rendered-info {:attachments false, :content true, :render/text true},
@@ -960,7 +960,7 @@
                     [{:type "mrkdwn", :text "*State*\nCA, NY, and NJ"}
                      {:type "mrkdwn", :text "*Quarter and Year*\nQ1, 2021"}]}
                    {:type "section", :fields [{:type "mrkdwn"
-                                               :text #"<https://testmb\.com/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021 \| \*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
+                                               :text #"<https://testmb\.com/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\|\*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
 
                  {:blocks [{:type "section", :text {:type "mrkdwn", :text "*The first tab*"}}]}
                  {:title "Test card",


### PR DESCRIPTION
After merging the PR dropping slack images support [#54276](https://github.com/metabase/metabase/pull/54276), we noticed large question and dashboard titles could cause header lengths to be exceeded. 

This PR adds some new truncation behaviours:

- Card/dashboard header blocks are kept under 150 characters
   * we could replace the block type to mkdwn to get a higher limit, but it would change the formatting.
- mdkwn links we generate also apply truncation to the label and URL if needed.
   - the limit is 3000 chars, so unlikely to be hit in practice (previously we were not truncating these)
   - we prefer to keep the URL and therefore the link, but if the URL itself exceeds the limit, or would cause under 10 characters of the label to be displayed we add a `(URL exceeds slack limits)` qualifier and render as much of the label possible.