### PR TITLE
Avoid ref on fn component error in console

### DIFF
--- a/frontend/src/metabase/components/EntityMenuTrigger/EntityMenuTrigger.styled.tsx
+++ b/frontend/src/metabase/components/EntityMenuTrigger/EntityMenuTrigger.styled.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
+import { forwardRef } from "react";
 
 import Button, { type ButtonProps } from "metabase/core/components/Button";
 
@@ -13,15 +14,21 @@ export interface EntityMenuIconButtonProps extends ButtonProps {
   "data-testid"?: string;
 }
 
-export const EntityMenuIconButton = styled(
-  (props: EntityMenuIconButtonProps) => (
+const EntityMenuIconButtonInner = forwardRef<
+  HTMLButtonElement,
+  EntityMenuIconButtonProps
+>(function EntityMenuIconButtonInner(props, ref) {
+  return (
     <Button
       {...props}
+      ref={ref}
       iconSize={props.iconSize ?? 16}
       onlyIcon={props.onlyIcon ?? true}
     />
-  ),
-)`
+  );
+});
+
+export const EntityMenuIconButton = styled(EntityMenuIconButtonInner)`
   width: 36px;
   height: 36px;
 


### PR DESCRIPTION
Closes nothing, avoids this error in the console:
<img width="1488" alt="image" src="https://github.com/user-attachments/assets/0704ec34-50d3-43f6-b47a-6f50d30834aa" />
