### PR TITLE
Closes viz-505 incorrect title for new cards

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -64,6 +64,7 @@ export function getInitialStateForCardDataSource(
   state.settings = {
     ...card.visualization_settings,
     ...Object.fromEntries(entries),
+    "card.title": card.name,
   };
 
   return state;

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -1,5 +1,5 @@
 import { registerVisualization } from "metabase/visualizations";
-import Table from "metabase/visualizations/visualizations/Table";
+import Table from "metabase/visualizations/visualizations/Table/Table";
 import {
   createMockCard,
   createMockColumn,
@@ -16,6 +16,7 @@ describe("getInitialStateForCardDataSource", () => {
   const dashCard = createMockDashboardCard({
     card: createMockCard({
       display: "table",
+      name: "TablyMcTableface",
       visualization_settings: {
         "table.cell_column": "avg",
         "table.pivot_column": "CATEGORY",
@@ -52,6 +53,7 @@ describe("getInitialStateForCardDataSource", () => {
       "table.cell_column": "avg",
       "table.pivot_column": "CATEGORY",
       "table.column_formatting": [],
+      "card.title": "TablyMcTableface",
     });
   });
 });


### PR DESCRIPTION
Closes [VIZ-505: Title should have correct default instead of "My new visualization"](https://linear.app/metabase/issue/VIZ-505/title-should-have-correct-default-instead-of-my-new-visualization)

### Description

Initializes new cards with the origin question's title instead of defaulting to "My new visualization".

<img width="1487" alt="image" src="https://github.com/user-attachments/assets/fdcf9f5a-fccd-49a5-acd7-9678206abe15" />
