### PR TITLE
make sdk not error on type error

### DIFF
--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -171,6 +171,8 @@ module.exports = env => {
             memoryLimit: 4096,
           },
         }),
+      // we don't want to fail the build on type errors, we have a dedicated type check step for that
+      new TypescriptConvertErrorsToWarnings(),
       shouldAnalyzeBundles &&
         new BundleAnalyzerPlugin({
           analyzerMode: "static",
@@ -195,3 +197,14 @@ module.exports = env => {
 
   return config;
 };
+
+// https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/232#issuecomment-1322651312
+class TypescriptConvertErrorsToWarnings {
+  apply(compiler) {
+    const hooks = ForkTsCheckerWebpackPlugin.getCompilerHooks(compiler);
+
+    hooks.issues.tap("TypeScriptWarnOnlyWebpackPlugin", issues =>
+      issues.map(issue => ({ ...issue, severity: "warning" })),
+    );
+  }
+}


### PR DESCRIPTION
Closes EMB-245
https://metaboat.slack.com/archives/C063Q3F1HPF/p1741648894985879

This aligns the sdk with the core app, the build should not stop/fail for a type error, so that we can see the still see e2e test results.

[should fail](https://github.com/metabase/metabase/pull/54963) is an example branch where the build should still succeed, but the type check should fail:
- [e2e started](https://github.com/metabase/metabase/actions/runs/13785319379/job/38552333191?pr=54963)
- [type check failed](https://github.com/metabase/metabase/actions/runs/13785319342/job/38551924120?pr=54963)