### PR TITLE
Make postcss-modules eslint plugin conditional to fix VS Code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,10 @@
 // can use this flag to enable it. This is set to true in CI
 const shouldLintCssModules =
   process.env.LINT_CSS_MODULES === "true" || process.env.CI;
+const plugins = ["react", "no-only-tests"];
+if (shouldLintCssModules) {
+  plugins.push("postcss-modules");
+}
 
 module.exports = {
   rules: {
@@ -134,7 +138,7 @@ module.exports = {
     "jest/globals": true,
   },
   parser: "babel-eslint",
-  plugins: ["react", "no-only-tests", "postcss-modules"],
+  plugins,
   extends: [
     "eslint:recommended",
     "plugin:react/recommended",


### PR DESCRIPTION
### Description
The VS Code ESLint integration was failing because the `postcss-modules` plugin was always being loaded, even when CSS module linting was not enabled. This caused issues in local development environments where the plugin might not be properly configured.

### Changes
- Created a dynamic `plugins` array with the base plugins and added conditional logic to only push the `postcss-modules` plugin to the array when `shouldLintCssModules` is true.

### How to verify
1. Open the project in VS Code with ESLint extension enabled
2. Verify that the editor highlights ESLint errors correctly
3. Verify that no ESLint errors related to missing plugins appear

### Demo
#### Before
<img width="519" alt="image" src="https://github.com/user-attachments/assets/23bf2a16-c5b9-4ff3-b17a-4e85f6449ed5" />

<img width="970" alt="image" src="https://github.com/user-attachments/assets/42e3d734-6e1b-4319-8055-a88e0a6df7ce" />

#### After
<img width="809" alt="Screenshot 2025-03-11 at 17 00 21" src="https://github.com/user-attachments/assets/50485c14-b832-4eb5-9648-2f105199bc5f" />

<img width="972" alt="image" src="https://github.com/user-attachments/assets/5fa29a6c-66c9-4014-8e02-652df6410cfc" />

