### PR TITLE
Don't allow a migrate down if you are running an old version of metabase

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -61,7 +61,7 @@
 ;; Command implementations
 
 (defn ^:command migrate
-  "Run database migrations. Valid options for `direction` are `up`, `force`, `down`, `print`, or `release-locks`."
+  "Run database migrations. Valid options for `direction` are `up`, `force`, `down`, `down-force`, `print`, or `release-locks`."
   [direction]
   (classloader/require 'metabase.cmd.migrate)
   ((resolve 'metabase.cmd.migrate/migrate!) direction))

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -486,7 +486,7 @@
        (.getDatabaseChangeLog)
        (.getChangeSets)
        last
-       (.getId)
+       (^ChangeSet .getId)
        extract-numbers
        first))
 

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -486,7 +486,7 @@
        (.getDatabaseChangeLog)
        (.getChangeSets)
        last
-       (^ChangeSet .getId)
+       (#(.getId ^ChangeSet %))
        extract-numbers
        first))
 

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -479,6 +479,26 @@
   [s]
   (map #(Integer/parseInt %) (re-seq #"\d+" s)))
 
+(defn latest-available-major-version
+  "Get the latest version that Liquibase would apply if we ran migrations right now."
+  [^Liquibase liquibase]
+  (->> liquibase
+       (.getDatabaseChangeLog)
+       (.getChangeSets)
+       (map #(.getId ^ChangeSet %))
+       last
+       extract-numbers
+       first))
+
+(defn latest-applied-major-version
+  "Gets the latest version applied to the database."
+  [conn ^Database database]
+  (when-not (fresh-install? conn database)
+    (let [changeset-query (format "SELECT id FROM %s WHERE id LIKE 'v%%' ORDER BY ORDEREXECUTED DESC LIMIT 1"
+                                  (.getDatabaseChangeLogTableName database))
+          changeset-id (last (map :id (jdbc/query {:connection conn} [changeset-query])))]
+      (some-> changeset-id extract-numbers first))))
+
 (defn rollback-major-version
   "Roll back migrations later than given Metabase major version"
   ;; default rollback to previous version
@@ -498,31 +518,11 @@
            changeset-ids   (map :id (jdbc/query {:connection conn} [changeset-query]))
            ;; IDs in changesets do not include the leading 0/1 digit, so the major version is the first number
            ids-to-drop     (drop-while #(not= (inc target-version) (first (extract-numbers %))) changeset-ids)
-           latest-version (apply max (map #(-> % extract-numbers first) ids-to-drop))
-           current-version (config/current-major-version)]
-       (when (and current-version (> latest-version current-version))
+           latest-available (latest-available-major-version liquibase)
+           latest-applied   (latest-applied-major-version conn (.getDatabase liquibase))]
+       (when (> latest-applied latest-available)
          (throw (IllegalArgumentException.
                  (format "Cannot downgrade a database at version %d from Metabase version %d. You must run 'migrate down' from Metabase version >= %d."
-                         latest-version (config/current-major-version) latest-version))))
+                         latest-applied latest-available latest-applied))))
        (log/infof "Rolling back app database schema to version %d" target-version)
        (.rollback liquibase (count ids-to-drop) "")))))
-
-(defn latest-applied-major-version
-  "Gets the latest version applied to the database."
-  [conn ^Database database]
-  (when-not (fresh-install? conn database)
-    (let [changeset-query (format "SELECT id FROM %s WHERE id LIKE 'v%%' ORDER BY ORDEREXECUTED DESC LIMIT 1"
-                                  (.getDatabaseChangeLogTableName database))
-          changeset-id (last (map :id (jdbc/query {:connection conn} [changeset-query])))]
-      (some-> changeset-id extract-numbers first))))
-
-(defn latest-available-major-version
-  "Get the latest version that Liquibase would apply if we ran migrations right now."
-  [^Liquibase liquibase]
-  (->> liquibase
-       (.getDatabaseChangeLog)
-       (.getChangeSets)
-       (map #(.getId ^ChangeSet %))
-       last
-       extract-numbers
-       first))

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -61,7 +61,8 @@
 
   *  `:up`            - Migrate up
   *  `:force`         - Force migrate up, ignoring locks and any DDL statements that fail.
-  *  `:down`          - Rollback to the previous major version schema
+  *  `:down`          - Rollback to the previous major version schema.
+  *  `:down-force`    - Rollback to the previous major version schema, ignoring any validation checks.
   *  `:print`         - Just print the SQL for running the migrations, don't actually run them.
   *  `:release-locks` - Manually release migration locks left by an earlier failed migration.
                         (This shouldn't be necessary now that we run migrations inside a transaction, but is
@@ -87,7 +88,8 @@
         (case direction
           :up            (liquibase/migrate-up-if-needed! liquibase data-source)
           :force         (liquibase/force-migrate-up-if-needed! liquibase data-source)
-          :down          (apply liquibase/rollback-major-version conn liquibase args)
+          :down          (apply liquibase/rollback-major-version conn liquibase false args)
+          :down-force    (apply liquibase/rollback-major-version conn liquibase true args)
           :print         (print-migrations-and-quit-if-needed! liquibase data-source)
           :release-locks (liquibase/force-release-locks! liquibase))
        ;; Migrations were successful; commit everything and re-enable auto-commit

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -116,7 +116,7 @@
             (log/info "rolling back to version" version)
             (t2.conn/with-connection [conn]
               (liquibase/with-liquibase [liquibase conn]
-                (liquibase/rollback-major-version conn liquibase version))))
+                (liquibase/rollback-major-version conn liquibase false version))))
           (log/info "creating dump" filename)
           ;; this migrates the DB back to the newest and creates a dump
           (dump-to-h2/dump-to-h2! filename)

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.db.liquibase-test
+(ns ^:mb/driver-tests metabase.db.liquibase-test
   (:require
    [clojure.java.io :as io]
    [clojure.set :as set]
@@ -15,6 +15,7 @@
    [next.jdbc :as next.jdbc]
    [toucan2.core :as t2])
   (:import
+   (clojure.lang ExceptionInfo)
    (liquibase Liquibase)
    (liquibase.lockservice LockServiceFactory)))
 
@@ -153,3 +154,42 @@
           (liquibase/with-liquibase [liquibase3 data-source]
             ;; This will fail if the com.github.blagerweij/liquibase-sessionlock dep is not present
             (is (lock liquibase3) "Can acquire session lock when conn closed without lock release")))))))
+
+(deftest latest-available-major-version
+  (mt/test-drivers #{:h2}
+    (mt/with-temp-empty-app-db [conn driver/*driver*]
+      (liquibase/with-liquibase [liquibase conn]
+        (is (< 52 (liquibase/latest-available-major-version liquibase)))))))
+
+(deftest latest-applied-major-version
+  (mt/test-drivers #{:h2 :mysql :postgres}
+    (mt/with-temp-empty-app-db [conn driver/*driver*]
+      (liquibase/with-liquibase [liquibase conn]
+        (is (nil? (liquibase/latest-applied-major-version conn (.getDatabase liquibase))))
+        (.update liquibase "")
+        (is (< 52 (liquibase/latest-applied-major-version conn (.getDatabase liquibase))))))))
+
+(deftest rollback-major-version
+  (mt/test-drivers #{:h2 :mysql :rollback}
+    (mt/with-temp-empty-app-db [conn driver/*driver*]
+      (liquibase/with-liquibase [liquibase conn]
+        (.update liquibase "")
+
+        (let [actual-latest-applied-version (liquibase/latest-applied-major-version conn (.getDatabase liquibase))
+              actual-latest-available-version (liquibase/latest-available-major-version liquibase)]
+          (testing "Can downgrade and re-upgrade version"
+            (liquibase/rollback-major-version conn liquibase false (dec actual-latest-available-version))
+            (is (= (dec actual-latest-applied-version) (liquibase/latest-applied-major-version conn (.getDatabase liquibase))))
+
+            (liquibase/rollback-major-version conn liquibase false (- actual-latest-available-version 2))
+            (is (= (- actual-latest-available-version 2) (liquibase/latest-applied-major-version conn (.getDatabase liquibase))))
+
+            (.update liquibase "")
+            (is (= actual-latest-applied-version (liquibase/latest-applied-major-version conn (.getDatabase liquibase)))))
+
+          (testing "Cannot downgrade when there are changests from a newer version already ran which are not in the changelog file"
+            (with-redefs [liquibase/latest-applied-major-version (constantly (inc actual-latest-applied-version))]
+              (is (thrown-with-msg? ExceptionInfo #"Cannot downgrade.*"
+                                    (liquibase/rollback-major-version conn liquibase false (dec actual-latest-available-version))))
+              (testing "CAN downgrade if forced"
+                (liquibase/rollback-major-version conn liquibase true (dec actual-latest-available-version))))))))))


### PR DESCRIPTION
### Description

Prevents the database from getting in an invalid state when running `migrate down` from a Metabase version that is less than what was previously ran against the database.

Liquibase does a rollback based on the changelog file it has in the Metabase version you are running. So when you do a rollback from a 52 container against a 53 database, it rolls back the 52 changes and leaves the 53 changes because the 52 container code doesn't have them to know what to do.

It is a general problem, but in an example of rolling back a v53 database from a v52 Metabase, one of the v52 changesets rolled back was "create the notification table" so it drops that. But one of the v53 changesets that was not rolled back was "add the notification.internal_id column"

This leaves the database in a bad spot where if you go back to 53, the v52 "create" changeset is re-ran but liquibase never thought it rolled back the v53 "add the column" changeset so it doesn't try to re-run that and you end up with the table missing the column.

Furthermore: we determine the number of changests to roll back based on doing a count of changesets in the database > the version to roll back to. But which changesets are actually rolled back is based on what is in the changelog file. So if there are 10 changesets in the database from v52 and 20 from v53, if you run "migrate down" from a v52 metabase without those v53 changesets, it still roll back 30 changesets -- the 10 from v52 and 20 more from v51 and before. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run `migrate down` from a metabase version that is at least one major version lower than what had ran against the appdb before
2. See that it fails with an error like `Cannot downgrade a database at version 53 from Metabase version 52. You must run 'migrate down' from a Metabase version >= 53.`

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
