### PR TITLE
Add data-editing configuration checks

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -743,7 +743,7 @@
 
   enterprise/data-editing
   {:api #{}
-   :uses #{api actions util}}
+   :uses #{api actions driver models settings util}}
 
   enterprise/task
   {:api  #{metabase-enterprise.task.truncate-audit-tables}

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -11,8 +11,8 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-(setting/defsetting database-enable-editing
-  (i18n/deferred-tru "Whether to enable data editing for a specific Database.")
+(setting/defsetting database-enable-table-editing
+  (i18n/deferred-tru "Whether to enable table data editing for a specific Database.")
   :default false
   :type :boolean
   :visibility :public
@@ -29,7 +29,7 @@
 
 (defn- check-data-editing-enabled! [{db-id :id db-settings :settings}]
   (binding [setting/*database-local-values* db-settings]
-    (when-not (database-enable-editing)
+    (when-not (database-enable-table-editing)
       (throw (ex-info (i18n/tru "Data editing is not enabled.")
                       {:status-code 400, :database-id db-id})))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -4,14 +4,45 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
+   [metabase.driver.util :as driver.u]
+   [metabase.models.setting :as setting]
+   [metabase.util :as u]
+   [metabase.util.i18n :as i18n]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
+(setting/defsetting database-enable-editing
+  (i18n/deferred-tru "Whether to enable data editing for a specific Database.")
+  :default false
+  :type :boolean
+  :visibility :public
+  :database-local :only
+  :export? true)
+
+(defn- check-driver-support! [{driver :engine, db-id :id, db-name :name :as db}]
+  ;; note for now we reuse the :actions driver feature
+  (when-not (driver.u/supports? driver :actions db)
+    (throw (ex-info (i18n/tru "{0} Database {1} does not support data editing."
+                              (u/qualified-name driver)
+                              (format "%d %s" db-id (pr-str db-name)))
+                    {:status-code 400, :database-id db-id}))))
+
+(defn- check-data-editing-enabled! [{db-id :id db-settings :settings}]
+  (binding [setting/*database-local-values* db-settings]
+    (when-not (database-enable-editing)
+      (throw (ex-info (i18n/tru "Data editing is not enabled.")
+                      {:status-code 400, :database-id db-id})))))
+
 (defn- perform-bulk-action! [action-kw table-id rows]
-  (actions/perform-action! action-kw
-                           {:database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
-                            :table-id table-id
-                            :arg      rows}))
+  (api/check-superuser)
+  (let [db-id (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
+        {:keys [db] :as perform-action-reqs}
+        (actions/prepare-perform-action action-kw {:database db-id
+                                                   :table-id table-id
+                                                   :arg      rows})]
+    (check-driver-support! db)
+    (check-data-editing-enabled! db)
+    (actions/do-perform-action! perform-action-reqs)))
 
 (api.macros/defendpoint :post "/table/:table-id"
   "Insert row(s) into the given table."

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -6,7 +6,12 @@
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (clojure.lang IDeref)
+   (java.io Closeable)))
+
+(set! *warn-on-reflection* true)
 
 (defn- table-rows [table-id]
   (mt/rows
@@ -25,67 +30,135 @@
       (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :put 402 url))
       (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :delete 402 url)))))
 
+(defn- open-test-table!
+  "Sets up an anonymous table in the appdb. Return a box that can be deref'd for the table-id.
+
+  Returned box is java.io.Closeable so you can clean up with `with-open`. Otherwise .close the box to drop the table when finished."
+  ^Closeable []
+  (let [db         (t2/select-one :model/Database (mt/id))
+        driver     :h2
+        table-name (str "temp_table_" (u/lower-case-en (random-uuid)))
+
+        cleanup
+        (fn []
+          (try
+            (driver/drop-table! driver (mt/id) table-name)
+            (catch Exception _)))
+
+        init
+        (fn []
+          (let [_     (driver/create-table! driver
+                                            (mt/id)
+                                            table-name
+                                            {:id   (driver/upload-type->database-type driver :metabase.upload/auto-incrementing-int-pk)
+                                             :name [:text]
+                                             :song  [:text]}
+                                            {:primary-key [:id]})
+                table (sync/create-table! db
+                                          {:name         table-name
+                                           :schema       nil
+                                           :display_name table-name})]
+            (sync/sync-fields-for-table! db table)
+            (:id table)))]
+    (try
+      (let [table-id (init)]
+        (reify Closeable
+          IDeref
+          (deref [_] table-id)
+          (close [_] (cleanup))))
+      (catch Exception e
+        (cleanup)
+        (throw e)))))
+
 (deftest table-operations-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/with-empty-h2-app-db
-      (let [db         (t2/select-one :model/Database (mt/id))
-            driver     :h2
-            table-name (str "temp_table_" (u/lower-case-en (random-uuid)))]
+      (with-open [table-ref (open-test-table!)]
+        (let [table-id @table-ref
+              url      (table-url table-id)]
+          (t2/update! :model/Database (mt/id) {:settings {:database-enable-editing true}})
+          (testing "Initially the table is empty"
+            (is (= [] (table-rows table-id))))
 
-        (mt/with-actions-enabled
-          (try
-            (let [_        (driver/create-table! driver
-                                                 (mt/id)
-                                                 table-name
-                                                 {:id   (driver/upload-type->database-type driver :metabase.upload/auto-incrementing-int-pk)
-                                                  :name [:text]
-                                                  :song  [:text]}
-                                                 {:primary-key [:id]})
-                  table    (sync/create-table! db
-                                               {:name         table-name
-                                                :schema       nil
-                                                :display_name table-name})
-                  _        (sync/sync-fields-for-table! db table)
-                  table-id (:id table)
-                  url      (table-url table-id)]
+          (testing "POST should insert new rows"
+            (is (= {:created-rows [{:id 1 :name "Pidgey"     :song "Car alarms"}
+                                   {:id 2 :name "Spearow"    :song "Hold music"}
+                                   {:id 3 :name "Farfetch'd" :song "The land of lisp"}]}
+                   (mt/user-http-request :crowberto :post 200 url
+                                         {:rows [{:name "Pidgey"     :song "Car alarms"}
+                                                 {:name "Spearow"    :song "Hold music"}
+                                                 {:name "Farfetch'd" :song "The land of lisp"}]})))
 
-              (testing "Initially the table is empty"
-                (is (= [] (table-rows table-id))))
+            (is (= [[1 "Pidgey"     "Car alarms"]
+                    [2 "Spearow"    "Hold music"]
+                    [3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
 
-              (testing "POST should insert new rows"
-                (is (= {:created-rows [{:id 1 :name "Pidgey"     :song "Car alarms"}
-                                       {:id 2 :name "Spearow"    :song "Hold music"}
-                                       {:id 3 :name "Farfetch'd" :song "The land of lisp"}]}
-                       (mt/user-http-request :crowberto :post 200 url
-                                             {:rows [{:name "Pidgey"     :song "Car alarms"}
-                                                     {:name "Spearow"    :song "Hold music"}
-                                                     {:name "Farfetch'd" :song "The land of lisp"}]})))
+          (testing "PUT should update the relevant rows and columns"
+            (is (= {:rows-updated 2}
+                   (mt/user-http-request :crowberto :put 200 url
+                                         {:rows [{:id 1 :song "Join us now and share the software"}
+                                                 {:id 2 :name "Speacolumn"}]})))
 
-                (is (= [[1 "Pidgey"     "Car alarms"]
-                        [2 "Spearow"    "Hold music"]
-                        [3 "Farfetch'd" "The land of lisp"]]
-                       (table-rows table-id))))
+            (is (= [[1 "Pidgey"     "Join us now and share the software"]
+                    [2 "Speacolumn" "Hold music"]
+                    [3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
 
-              (testing "PUT should update the relevant rows and columns"
-                (is (= {:rows-updated 2}
-                       (mt/user-http-request :crowberto :put 200 url
-                                             {:rows [{:id 1 :song "Join us now and share the software"}
-                                                     {:id 2 :name "Speacolumn"}]})))
+          (testing "DELETE should remove the corresponding rows"
+            (is (= {:success true}
+                   (mt/user-http-request :crowberto :delete 200 url
+                                         {:rows [{:id 1}
+                                                 {:id 2}]})))
+            (is (= [[3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id)))))))))
 
-                (is (= [[1 "Pidgey"     "Join us now and share the software"]
-                        [2 "Speacolumn" "Hold music"]
-                        [3 "Farfetch'd" "The land of lisp"]]
-                       (table-rows table-id))))
+(deftest editing-allowed-test
+  (mt/with-premium-features #{:table-data-editing}
+    (mt/with-empty-h2-app-db
+      (testing "40x returned if user/database not configured for editing"
+        (let [test-endpoints
+              (fn [flags]
+                (with-open [table-ref (open-test-table!)]
+                  (let [actions-enabled (:a flags)
+                        editing-enabled (:d flags)
+                        superuser       (:s flags)
+                        url             (table-url @table-ref)
+                        settings        {:database-enable-editing (boolean editing-enabled)
+                                         :database-enable-actions (boolean actions-enabled)}
+                        _               (t2/update! :model/Database (mt/id) {:settings settings})
+                        user            (if superuser :crowberto :rasta)
+                        req             mt/user-http-request-full-response
 
-              (testing "DELETE should remove the corresponding rows"
-                (is (= {:success true}
-                       (mt/user-http-request :crowberto :delete 200 url
-                                             {:rows [{:id 1}
-                                                     {:id 2}]})))
-                (is (= [[3 "Farfetch'd" "The land of lisp"]]
-                       (table-rows table-id)))))
+                        post-response
+                        (req user :post url {:rows [{:name "Pidgey" :song "Car alarms"}]})
 
-            (finally
-              (try
-                (driver/drop-table! driver (mt/id) table-name)
-                (catch Exception _)))))))))
+                        put-response
+                        (req user :put url {:rows [{:id 1 :song "Join us now and share the software"}]})
+
+                        del-response
+                        (req user :delete url {:rows [{:id 1}]})
+
+                        error-or-ok
+                        (fn [{:keys [status body]}]
+                          (if (<= 200 status 299)
+                            :ok
+                            [(:message body body) status]))]
+                    [(error-or-ok post-response)
+                     (error-or-ok put-response)
+                     (error-or-ok del-response)])))]
+          (are [flags response]
+               (= response (frequencies (test-endpoints flags)))
+
+            ;; Shorthand notation
+            ;; :a == action-editing should not affect result
+            ;; :d == data-editing   only allowed to edit if editing enabled
+            ;; :s == super-user     only allowed to edit if a superuser
+
+            #{:a}           {["You don't have permissions to do that." 403] 3}
+            #{:d}           {["You don't have permissions to do that." 403] 3}
+            #{:a :d}        {["You don't have permissions to do that." 403] 3}
+            #{:s}           {["Data editing is not enabled."           400] 3}
+            #{:s :a}        {["Data editing is not enabled."           400] 3}
+            #{:s :d}        {:ok 3}
+            #{:s :a :d}     {:ok 3}))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -76,7 +76,7 @@
       (with-open [table-ref (open-test-table!)]
         (let [table-id @table-ref
               url      (table-url table-id)]
-          (t2/update! :model/Database (mt/id) {:settings {:database-enable-editing true}})
+          (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing true}})
           (testing "Initially the table is empty"
             (is (= [] (table-rows table-id))))
 
@@ -124,8 +124,8 @@
                         editing-enabled (:d flags)
                         superuser       (:s flags)
                         url             (table-url @table-ref)
-                        settings        {:database-enable-editing (boolean editing-enabled)
-                                         :database-enable-actions (boolean actions-enabled)}
+                        settings        {:database-enable-table-editing (boolean editing-enabled)
+                                         :database-enable-actions       (boolean actions-enabled)}
                         _               (t2/update! :model/Database (mt/id) {:settings settings})
                         user            (if superuser :crowberto :rasta)
                         req             mt/user-http-request-full-response

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -19,8 +19,10 @@
  [metabase.actions.actions
   cached-value
   check-actions-enabled!
+  do-perform-action!
   perform-action!
-  perform-action!*]
+  perform-action!*
+  prepare-perform-action]
  [metabase.actions.error
   incorrect-value-type
   violate-foreign-key-constraint

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -238,6 +238,7 @@
   user->id
   user-descriptor
   user-http-request
+  user-http-request-full-response
   user-real-request
   with-group
   with-group-for-user

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -206,6 +206,11 @@
   (partial user-request client/client))
 
 (def ^{:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint
+                    request-options? http-body-map? & {:as query-params}])} user-http-request-full-response
+  "Like user-http-request but uses the full-response client so will return the http response instead of the body"
+  (partial user-request client/client-full-response))
+
+(def ^{:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint
                     request-options? http-body-map? & {:as query-params}])} user-real-request
   "Like [[user-http-request]] but instead of calling the app handler, this makes an actual http request."
   (partial user-request client/real-client))


### PR DESCRIPTION
> *note* we decided to go with https://github.com/metabase/metabase/pull/55104 instead

Adds the configuration behaviour specified in WRK-131.

e.g
- database-enable-editing is required
- database-enable-actions is not required
- superuser is required

Closes WRK-131.

Once merged, data editing will no longer work unless the database-enable-editing is true in `metabase_database.settings`. To be convenient, it might be worth waiting until the frontend toggle is ready before merging.

Had to refactor some of the actions code to allow the policy to vary, otherwise would have need to inject a new flag and branches. I do think in general it is better to seperate and allow callers to define policy around some operation independently of the operation (if we want to maximize reuse, and limit branching in the shared codepaths). On the flip side it has created more noise in the diff here.

Factored out test table setup for reuse. Applied a technique of boxing into a Closeable to handle cleanup for an ad-hoc resource like our table. One can see how to take this further and extract a generic `(closeable thing close-fn)` to be able to use `with-open`, `with-open+` type macros more aggressively, limiting nesting due to try/finally. AFAIK its not just me that uses this pattern, lmk if you hate it!.