### PR TITLE
Use actual time zone marker (Z) when parsing offset times

### DIFF
--- a/src/metabase/util/time/impl.cljs
+++ b/src/metabase/util/time/impl.cljs
@@ -358,13 +358,11 @@
   {:offset-date-time {:regex   common/offset-datetime-regex
                       :formats #js ["YYYY-MM-DDTHH:mm:ss.SSSZ"
                                     "YYYY-MM-DDTHH:mm:ssZ"
-                                    "YYYY-MM-DDTHH:mmZ"
-                                    "YYYY-MM-DDTHHZ"]}
+                                    "YYYY-MM-DDTHH:mmZ"]}
    :local-date-time  {:regex   common/local-datetime-regex
                       :formats #js ["YYYY-MM-DDTHH:mm:ss.SSS"
                                     "YYYY-MM-DDTHH:mm:ss"
-                                    "YYYY-MM-DDTHH:mm"
-                                    "YYYY-MM-DDTHH"]}
+                                    "YYYY-MM-DDTHH:mm"]}
    :local-date       {:regex   common/local-date-regex
                       :formats #js ["YYYY-MM-DD"
                                     "YYYY-MM"
@@ -372,13 +370,11 @@
    :offset-time      {:regex   common/offset-time-regex
                       :formats #js ["HH:mm:ss.SSSZ"
                                     "HH:mm:ssZ"
-                                    "HH:mmZ"
-                                    "HHZ"]}
+                                    "HH:mmZ"]}
    :local-time       {:regex   common/local-time-regex
                       :formats #js ["HH:mm:ss.SSS"
                                     "HH:mm:ss"
-                                    "HH:mm"
-                                    "HH"]}})
+                                    "HH:mm"]}})
 
 (defn- iso-8601->moment+type
   [s]

--- a/src/metabase/util/time/impl.cljs
+++ b/src/metabase/util/time/impl.cljs
@@ -151,7 +151,7 @@
   (.local value))
 
 (def ^:private parse-time-formats
-  #js ["HH:mm:ss.SSS[Z]"
+  #js ["HH:mm:ss.SSSZ"
        "HH:mm:ss.SSS"
        "HH:mm:ss"
        "HH:mm"])
@@ -356,10 +356,10 @@
 
 (def ^:private temporal-formats
   {:offset-date-time {:regex   common/offset-datetime-regex
-                      :formats #js ["YYYY-MM-DDTHH:mm:ss.SSS[Z]"
-                                    "YYYY-MM-DDTHH:mm:ss[Z]"
-                                    "YYYY-MM-DDTHH:mm[Z]"
-                                    "YYYY-MM-DDTHH[Z]"]}
+                      :formats #js ["YYYY-MM-DDTHH:mm:ss.SSSZ"
+                                    "YYYY-MM-DDTHH:mm:ssZ"
+                                    "YYYY-MM-DDTHH:mmZ"
+                                    "YYYY-MM-DDTHHZ"]}
    :local-date-time  {:regex   common/local-datetime-regex
                       :formats #js ["YYYY-MM-DDTHH:mm:ss.SSS"
                                     "YYYY-MM-DDTHH:mm:ss"
@@ -370,10 +370,10 @@
                                     "YYYY-MM"
                                     "YYYY"]}
    :offset-time      {:regex   common/offset-time-regex
-                      :formats #js ["HH:mm:ss.SSS[Z]"
-                                    "HH:mm:ss[Z]"
-                                    "HH:mm[Z]"
-                                    "HH[Z]"]}
+                      :formats #js ["HH:mm:ss.SSSZ"
+                                    "HH:mm:ssZ"
+                                    "HH:mmZ"
+                                    "HHZ"]}
    :local-time       {:regex   common/local-time-regex
                       :formats #js ["HH:mm:ss.SSS"
                                     "HH:mm:ss"
@@ -388,6 +388,22 @@
               (when (.isValid parsed)
                 [parsed value-type]))))
         temporal-formats))
+
+(comment
+  (moment "01:49:10.858Z" "HH:mm:ss.SSSZ")
+
+  (let [s "1982-03-16T01:49:10.858Z"
+        formats #js ["YYYY-MM-DDTHH:mm:ss.SSS[Z]"]
+        formatz #js ["YYYY-MM-DDTHH:mm:ss.SSSZ"]
+        s-parsed (moment/parseZone s formats #_strict? true)
+        z-parsed (moment/parseZone s formatz #_strict? true)]
+    {:tz (.. (js/Intl.DateTimeFormat) resolvedOptions -timeZone)
+     :tzo (.getTimezoneOffset (js/Date.)) #_mins
+     :s s-parsed
+     :z z-parsed
+     :fz (.format z-parsed "YYYY-MM-DDTHH:mm:ss.SSSZ")
+     :fs (.format z-parsed "YYYY-MM-DDTHH:mm:ss.SSS[Z]")})
+  -)
 
 (defmulti ^:private moment+type->iso-8601
   {:arglists '([moment+type])}


### PR DESCRIPTION
Fixes #53724

### How to verify

Make sure you have a REPL with a non-zero offset time zone, pick a datetime for which the local and the GMT dates differ and try parsing with the different format strings in the Rich comment.