### PR TITLE
Hide upload config when data warehouse is attached

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1343,3 +1343,56 @@ describe("admin > settings > updates", () => {
     });
   });
 });
+
+describe("admin > upload settings", () => {
+  describe("scenarios > admin > uploads (OSS)", { tags: "@OSS" }, () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+    });
+
+    it("should show the uploads settings page", () => {
+      cy.visit("/admin/settings/uploads");
+      cy.findByTestId("admin-list-settings-items").findByText("Uploads");
+      cy.findByLabelText("Upload Settings Form").findByText(
+        "Database to use for uploads",
+      );
+    });
+  });
+
+  describe("scenarios > admin > uploads (EE)", () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.setTokenFeatures("all");
+    });
+
+    it("without attached-dwh should show the uploads settings page", () => {
+      H.mockSessionPropertiesTokenFeatures({
+        hosting: false,
+        attached_dwh: false,
+        upload_management: true,
+      });
+      cy.visit("/admin/settings/uploads");
+      cy.findByTestId("admin-list-settings-items").findByText("Uploads");
+      cy.findByLabelText("Upload Settings Form").findByText(
+        "Database to use for uploads",
+      );
+      cy.findByTestId("upload-tables-table").findByText("Uploaded Tables");
+    });
+
+    it("with attached-dwh should not show the uploads settings page", () => {
+      H.mockSessionPropertiesTokenFeatures({
+        hosting: true,
+        attached_dwh: true,
+        upload_management: true,
+      });
+      cy.visit("/admin/settings/uploads");
+      cy.findByTestId("admin-list-settings-items")
+        .findByText("Uploads")
+        .should("not.exist");
+
+      cy.findByTestId("upload-tables-table").findByText("Uploaded Tables");
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -1,4 +1,5 @@
 import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
+import PluginPlaceholder from "metabase/plugins/components/PluginPlaceholder";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import {
@@ -15,6 +16,7 @@ if (hasPremiumFeature("upload_management")) {
 }
 
 if (hasPremiumFeature("hosting") && hasPremiumFeature("attached_dwh")) {
+  PLUGIN_UPLOAD_MANAGEMENT.UploadSettings = PluginPlaceholder;
   PLUGIN_UPLOAD_MANAGEMENT.GsheetConnectionModal = GsheetConnectionModal;
   PLUGIN_UPLOAD_MANAGEMENT.GsheetMenuItem = GsheetMenuItem;
   PLUGIN_UPLOAD_MANAGEMENT.GsheetsSyncStatus = GsheetsSyncStatus;

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -2,13 +2,11 @@ import { UpsellUploads } from "metabase/admin/upsells";
 import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
 import { Flex } from "metabase/ui";
 
-import { UploadSettingsForm } from "./UploadSettingsForm";
-
 export const UploadSettings = () => {
   return (
     <>
       <Flex justify="space-between" align="flex-start" gap="md">
-        <UploadSettingsForm />
+        <PLUGIN_UPLOAD_MANAGEMENT.UploadSettings />
         <UpsellUploads source="settings-uploads" />
       </Flex>
       <PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable />

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -24,6 +24,7 @@ import {
   type PermissionSubject,
 } from "metabase/admin/permissions/types";
 import { InteractiveEmbeddingSettings } from "metabase/admin/settings/components/EmbeddingSettings/InteractiveEmbeddingSettings";
+import { UploadSettingsForm } from "metabase/admin/settings/components/UploadSettings/UploadSettingsForm";
 import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors";
 import type {
   MetricFilterControlsProps,
@@ -576,6 +577,7 @@ type GsheetConnectionModalProps = {
 };
 
 export const PLUGIN_UPLOAD_MANAGEMENT = {
+  UploadSettings: UploadSettingsForm,
   UploadManagementTable: PluginPlaceholder,
   GsheetsSyncStatus: PluginPlaceholder,
   GsheetConnectionModal:

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -965,6 +965,8 @@ See [fonts](../configuring-metabase/fonts.md).")
                    :table_prefix (:uploads_table_prefix db)}))
   :setter     (fn [{:keys [db_id schema_name table_prefix]}]
                 (cond
+                  (premium-features/has-feature? :attached-dwh)
+                  (api/throw-403)
                   (nil? db_id)
                   (t2/update! :model/Database :uploads_enabled true {:uploads_enabled      false
                                                                      :uploads_schema_name  nil

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -224,6 +224,75 @@
       (is (= "123456"
              (models.setting-test/test-sensitive-setting))))))
 
+(deftest fetch-conditionally-read-only-setting-test
+  (testing "GET requests are unaffected by the conditional read-only status"
+    (testing "GET /api/session/properties with attached-dwh"
+      (mt/with-premium-features #{:attached-dwh}
+        (is (=? {:db_id        nil
+                 :schema_name  nil
+                 :table_prefix nil}
+                (:uploads-settings (mt/user-http-request :crowberto :get 200 "session/properties"))))))
+    (testing "GET /api/setting with attached-dwh"
+      (mt/with-premium-features #{:attached-dwh}
+        (is (=? {:db_id        nil
+                 :schema_name  nil
+                 :table_prefix nil}
+                (:value (first (filter (comp #{"uploads-settings"} :key)
+                                       (mt/user-http-request :crowberto :get 200 "setting"))))))))
+    (testing "GET /api/setting/uploads-settings with attached-dwh"
+      (mt/with-premium-features #{:attached-dwh}
+        (is (=? {:db_id        nil
+                 :schema_name  nil
+                 :table_prefix nil}
+                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings")))))
+    (testing "GET /api/session/properties without attached-dwh"
+      (is (=? {:db_id        nil
+               :schema_name  nil
+               :table_prefix nil}
+              (:uploads-settings (mt/user-http-request :crowberto :get 200 "session/properties")))))
+    (testing "GET /api/setting without attached-dwh"
+      (is (=? {:db_id        nil
+               :schema_name  nil
+               :table_prefix nil}
+              (:value (first (filter (comp #{"uploads-settings"} :key)
+                                     (mt/user-http-request :crowberto :get 200 "setting")))))))
+    (testing "GET /api/setting/uploads-settings without attached-dwh"
+      (is (=? {:db_id        nil
+               :schema_name  nil
+               :table_prefix nil}
+              (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))))
+
+(deftest set-conditionally-read-only-setting-test
+  (testing "PUT requests are rejected with attached-dwh but permitted without"
+    (mt/with-temp [:model/Database {:keys [id]} {:engine :postgres
+                                                 :name   "The Chosen One"}]
+      (testing "PUT /api/setting with attached-dwh"
+        (mt/with-premium-features #{:attached-dwh}
+          (mt/user-http-request :crowberto :put 403 "setting" {:uploads-settings {:db_id id}}))
+        (is (=? {:db_id        nil
+                 :schema_name  nil
+                 :table_prefix nil}
+                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))
+      (testing "PUT /api/setting/uploads-settings with attached-dwh"
+        (mt/with-premium-features #{:attached-dwh}
+          (mt/user-http-request :crowberto :put 403 "setting/uploads-settings" {:value {:db_id id}}))
+        (is (=? {:db_id        nil
+                 :schema_name  nil
+                 :table_prefix nil}
+                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))
+      (testing "PUT /api/setting without attached-dwh"
+        (mt/user-http-request :crowberto :put 204 "setting" {:uploads-settings {:db_id id}})
+        (is (=? {:db_id        id
+                 :schema_name  nil
+                 :table_prefix nil}
+                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))
+      (testing "PUT /api/setting/uploads-settings without attached-dwh"
+        (mt/user-http-request :crowberto :put 204 "setting/uploads-settings" {:value {:db_id id}})
+        (is (=? {:db_id        id
+                 :schema_name  nil
+                 :table_prefix nil}
+                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings")))))))
+
 ;; there are additional tests for this functionality in [[metabase.models.models.setting-test/set-many!-test]], since
 ;; this API endpoint is just a thin wrapper around that function
 (deftest update-multiple-settings-test


### PR DESCRIPTION
== Goal ==

Prevent admins of Metabase Cloud instances with Metabase Cloud Storage
from accidentally breaking their upload configuration, since in this
scenario that is automatically managed by Metabase Cloud to use the
attached data warehouse.

== How to test ==

On a subscription with Metabase Cloud Storage:
* The "Uploads" section in the left sidebar of `/admin/settings` is
  shown
* Opening the "Uploads" section, or opening `/admin/settings/uploads`
  directly, shows only the "Manage Uploads" part of the page, while the
  "Uploads Settings" part is hidden
* `PUT /api/setting` with an `uploads-settings` field in the body fails
  with `403 Forbidden` and the setting is not changed
* `PUT /api/setting/uploads-settings` fails with `403 Forbidden` and
  the setting is not changed
* `GET /api/setting` contains an element with `key: "uploads-settings"`
  and a value
* `GET /api/setting/uploads-settings` responds with the value
* `GET /api/session/properties` contains the `uploads-settings` field

Closes: https://linear.app/metabase/issue/ADM-119/you-can-turn-off-csv-uploads-for-metabase-cloud-storage-and-cannot-re
References: fbaf58ad032afd3283baa3d6c7fb056ac6a23b8a
References: 7ff0ab3dff8306c6f5b9d996a1b7b2adf1ad9bcf
