### PR TITLE
rework filters reset tests to work with real data

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -322,7 +322,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
         H.dashboardParametersPopover().within(() => {
           cy.findByPlaceholderText("Search the list").type(value);
           // select filtered value
-          cy.findAllByRole("checkbox").should("have.length", 1);
+          cy.findAllByRole("checkbox").should("have.length", 2);
           cy.findAllByRole("checkbox").eq(1).click();
           cy.button("Add filter").click();
         });
@@ -332,7 +332,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
         H.dashboardParametersPopover().within(() => {
           cy.findByPlaceholderText("Search the list").type(value);
           // select filtered value
-          cy.findAllByRole("checkbox").should("have.length", 1);
+          cy.findAllByRole("checkbox").should("have.length", 2);
           cy.findAllByRole("checkbox").eq(1).click();
           cy.button("Update filter").click();
         });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -268,7 +268,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
     });
   });
 
-  it.skip("location parameters - multiple values", () => {
+  it("location parameters - multiple values", () => {
     createDashboardWithParameters(PEOPLE_QUESTION, PEOPLE_CITY_FIELD, [
       {
         name: NO_DEFAULT_NON_REQUIRED,
@@ -298,7 +298,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
 
     checkDashboardParameters({
       defaultValueFormatted: "2 selections",
-      otherValue: "{backspace}{backspace}Dike,",
+      otherValue: "{backspace}{backspace}Dike",
       otherValueFormatted: "Dike",
       setValue: (label, value) => {
         filter(label).click();
@@ -314,23 +314,29 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
           cy.button("Update filter").click();
         });
       },
-      // setSidebarValue: (label, value) => {
-      //   filter(label).click();
-      //   H.dashboardParametersPopover().within(() => {
-      //     cy.findByPlaceholderText("Search the list").type(value);
-      //     // select filtered value
-      //     cy.findAllByRole("checkbox").eq(1).click();
-      //     cy.button("Add filter").click();
-      //   });
-      // },
-      // updateSidebarValue: (label, value) => {
-      //   filter(label).click();
-      //   H.dashboardParametersPopover().within(() => {
-      //     cy.findByPlaceholderText("Search the list").type(value);
-      //     cy.findAllByRole("checkbox").eq(1).click();
-      //     cy.button("Update filter").click();
-      //   });
-      // },
+      // we use setSidebarValue here as e2e tests setup shows options
+      // differently than in UI and with a local sample database. Maybe it's a
+      // sign of a bug in setup
+      setSidebarValue: (label, value) => {
+        filter(label).click();
+        H.dashboardParametersPopover().within(() => {
+          cy.findByPlaceholderText("Search the list").type(value);
+          // select filtered value
+          cy.findAllByRole("checkbox").should("have.length", 1);
+          cy.findAllByRole("checkbox").eq(1).click();
+          cy.button("Add filter").click();
+        });
+      },
+      updateSidebarValue: (label, value) => {
+        filter(label).click();
+        H.dashboardParametersPopover().within(() => {
+          cy.findByPlaceholderText("Search the list").type(value);
+          // select filtered value
+          cy.findAllByRole("checkbox").should("have.length", 1);
+          cy.findAllByRole("checkbox").eq(1).click();
+          cy.button("Update filter").click();
+        });
+      },
     });
   });
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -4,7 +4,10 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { checkNotNull } from "metabase/lib/types";
+import type {
+  DashboardDetails,
+  StructuredQuestionDetails,
+} from "e2e/support/helpers";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type { LocalFieldReference } from "metabase-types/api";
 
@@ -43,7 +46,7 @@ const PEOPLE_CITY_FIELD: LocalFieldReference = [
   },
 ];
 
-const ORDERS_COUNT_OVER_TIME: H.StructuredQuestionDetails = {
+const ORDERS_COUNT_OVER_TIME: StructuredQuestionDetails = {
   display: "line",
   query: {
     "source-table": ORDERS_ID,
@@ -52,14 +55,14 @@ const ORDERS_COUNT_OVER_TIME: H.StructuredQuestionDetails = {
   },
 };
 
-const PEOPLE_QUESTION: H.StructuredQuestionDetails = {
+const PEOPLE_QUESTION: StructuredQuestionDetails = {
   query: {
     "source-table": PEOPLE_ID,
     limit: 1,
   },
 };
 
-const ORDERS_QUESTION: H.StructuredQuestionDetails = {
+const ORDERS_QUESTION: StructuredQuestionDetails = {
   query: {
     "source-table": ORDERS_ID,
     limit: 1,
@@ -229,8 +232,8 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
 
     checkDashboardParameters({
       defaultValueFormatted: "Bassett",
-      otherValue: "{backspace}Thomson",
-      otherValueFormatted: "Thomson",
+      otherValue: "{backspace}Dike",
+      otherValueFormatted: "Dike",
       setValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
@@ -245,10 +248,27 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
           cy.button("Update filter").click();
         });
       },
+      setSidebarValue: (label, value) => {
+        filter(label).click();
+        H.dashboardParametersPopover().within(() => {
+          cy.findByPlaceholderText("Search the list").type(value);
+          // select filtered value
+          cy.findByRole("listitem").click();
+          cy.button("Add filter").click();
+        });
+      },
+      updateSidebarValue: (label, value) => {
+        filter(label).click();
+        H.dashboardParametersPopover().within(() => {
+          cy.findByPlaceholderText("Search the list").type(value);
+          cy.findByRole("listitem").click();
+          cy.button("Update filter").click();
+        });
+      },
     });
   });
 
-  it("location parameters - multiple values", () => {
+  it.skip("location parameters - multiple values", () => {
     createDashboardWithParameters(PEOPLE_QUESTION, PEOPLE_CITY_FIELD, [
       {
         name: NO_DEFAULT_NON_REQUIRED,
@@ -278,8 +298,8 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
 
     checkDashboardParameters({
       defaultValueFormatted: "2 selections",
-      otherValue: "{backspace}{backspace}Washington,",
-      otherValueFormatted: "Washington",
+      otherValue: "{backspace}{backspace}Dike,",
+      otherValueFormatted: "Dike",
       setValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
@@ -294,6 +314,23 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
           cy.button("Update filter").click();
         });
       },
+      // setSidebarValue: (label, value) => {
+      //   filter(label).click();
+      //   H.dashboardParametersPopover().within(() => {
+      //     cy.findByPlaceholderText("Search the list").type(value);
+      //     // select filtered value
+      //     cy.findAllByRole("checkbox").eq(1).click();
+      //     cy.button("Add filter").click();
+      //   });
+      // },
+      // updateSidebarValue: (label, value) => {
+      //   filter(label).click();
+      //   H.dashboardParametersPopover().within(() => {
+      //     cy.findByPlaceholderText("Search the list").type(value);
+      //     cy.findAllByRole("checkbox").eq(1).click();
+      //     cy.button("Update filter").click();
+      //   });
+      // },
     });
   });
 
@@ -329,9 +366,9 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
     ]);
 
     checkDashboardParameters({
-      defaultValueFormatted: "1",
+      defaultValueFormatted: "Hudson Borer - 1",
       otherValue: "{backspace}2",
-      otherValueFormatted: "2",
+      otherValueFormatted: "Domenica Williamson - 2",
       setValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
@@ -380,7 +417,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
     checkDashboardParameters({
       defaultValueFormatted: "2 selections",
       otherValue: "{backspace}{backspace}3",
-      otherValueFormatted: "3",
+      otherValueFormatted: "Lina Heaney - 3",
       setValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
@@ -427,9 +464,9 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
     ]);
 
     checkDashboardParameters({
-      defaultValueFormatted: "1",
+      defaultValueFormatted: "Hudson Borer - 1",
       otherValue: "{backspace}2",
-      otherValueFormatted: "2",
+      otherValueFormatted: "Domenica Williamson - 2",
       setValue: (label, value) => {
         filter(label).click();
         H.popover().findByRole("textbox").focus().type(value).blur();
@@ -521,12 +558,14 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "Gadget",
       setValue: (label, value) => {
         filter(label).click();
-        H.popover().findByRole("textbox").type(value);
+        H.popover().findByRole("textbox").type(value).blur();
+        H.popover().findByRole("listitem").eq(0).click();
         H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
         H.popover().findByRole("textbox").type(value);
+        H.popover().findByRole("listitem").eq(0).click();
         H.popover().button("Update filter").click();
       },
     });
@@ -562,16 +601,34 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
 
     checkDashboardParameters({
       defaultValueFormatted: "2 selections",
-      otherValue: "{backspace}{backspace}Doohickey,Widget,",
+      otherValue: "Doohickey,Widget,",
       otherValueFormatted: "2 selections",
       setValue: (label, value) => {
         filter(label).click();
-        H.popover().findByRole("textbox").type(value);
+        H.popover().within(() => {
+          value
+            .split(",")
+            .filter(Boolean)
+            .forEach(value => {
+              cy.findAllByRole("listitem").contains(value).click();
+            });
+        });
+        // H.popover().findByRole("textbox").type(value);
         H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        H.popover().findByRole("textbox").type(value);
+        H.popover().within(() => {
+          cy.findAllByRole("listitem").contains("Select all").click();
+          cy.findAllByRole("listitem").contains("Select none").click();
+
+          value
+            .split(",")
+            .filter(Boolean)
+            .forEach(value => {
+              cy.findAllByRole("listitem").contains(value).click();
+            });
+        });
         H.popover().button("Update filter").click();
       },
     });
@@ -657,23 +714,24 @@ describe("scenarios > dashboard > filters > reset all filters", () => {
 });
 
 function createDashboardWithParameters(
-  questionDetails: H.StructuredQuestionDetails,
+  questionDetails: StructuredQuestionDetails,
   targetField: LocalFieldReference,
-  parameters: H.DashboardDetails["parameters"],
+  parameters: DashboardDetails["parameters"],
 ) {
   H.createQuestionAndDashboard({
     questionDetails,
     dashboardDetails: {
       parameters,
     },
-  }).then(({ body: { dashboard_id, card_id } }) => {
+  }).then(({ body: { dashboard_id }, questionId }) => {
     H.updateDashboardCards({
       dashboard_id,
       cards: [
         {
+          card_id: questionId,
           parameter_mappings: parameters?.map(parameter => ({
             parameter_id: parameter.id,
-            card_id: checkNotNull(card_id),
+            card_id: questionId,
             target: ["dimension", targetField],
           })),
         },
@@ -702,12 +760,16 @@ function checkDashboardParameters<T = string>({
   otherValueFormatted,
   setValue,
   updateValue = setValue,
+  setSidebarValue = setValue,
+  updateSidebarValue = updateValue,
 }: {
   defaultValueFormatted: string;
   otherValue: T;
   otherValueFormatted: string;
   setValue: (label: string, value: T) => void;
   updateValue?: (label: string, value: T) => void;
+  setSidebarValue?: (label: string, value: T) => void;
+  updateSidebarValue?: (label: string, value: T) => void;
 }) {
   cy.log("no default value, non-required, no current value");
   checkStatusIcon(NO_DEFAULT_NON_REQUIRED, "chevron");
@@ -768,6 +830,7 @@ function checkDashboardParameters<T = string>({
   cy.log(
     "has default value, non-required, current value different than default",
   );
+
   updateValue(DEFAULT_NON_REQUIRED, otherValue);
   filter(DEFAULT_NON_REQUIRED).should("have.text", otherValueFormatted);
   checkStatusIcon(DEFAULT_NON_REQUIRED, "reset");
@@ -819,8 +882,8 @@ function checkDashboardParameters<T = string>({
     defaultValueFormatted,
     otherValue,
     otherValueFormatted,
-    setValue,
-    updateValue,
+    setValue: setSidebarValue,
+    updateValue: updateSidebarValue,
   });
 }
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -248,7 +248,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
           cy.button("Update filter").click();
         });
       },
-      setSidebarValue: (label, value) => {
+      setDefaultValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
           cy.findByPlaceholderText("Search the list").type(value);
@@ -257,7 +257,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
           cy.button("Add filter").click();
         });
       },
-      updateSidebarValue: (label, value) => {
+      updateDefaultValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
           cy.findByPlaceholderText("Search the list").type(value);
@@ -314,10 +314,10 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
           cy.button("Update filter").click();
         });
       },
-      // we use setSidebarValue here as e2e tests setup shows options
+      // we use setDefaultValue here as e2e tests setup shows options
       // differently than in UI and with a local sample database. Maybe it's a
       // sign of a bug in setup
-      setSidebarValue: (label, value) => {
+      setDefaultValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
           cy.findByPlaceholderText("Search the list").type(value);
@@ -327,7 +327,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
           cy.button("Add filter").click();
         });
       },
-      updateSidebarValue: (label, value) => {
+      updateDefaultValue: (label, value) => {
         filter(label).click();
         H.dashboardParametersPopover().within(() => {
           cy.findByPlaceholderText("Search the list").type(value);
@@ -766,16 +766,16 @@ function checkDashboardParameters<T = string>({
   otherValueFormatted,
   setValue,
   updateValue = setValue,
-  setSidebarValue = setValue,
-  updateSidebarValue = updateValue,
+  setDefaultValue = setValue,
+  updateDefaultValue = updateValue,
 }: {
   defaultValueFormatted: string;
   otherValue: T;
   otherValueFormatted: string;
   setValue: (label: string, value: T) => void;
   updateValue?: (label: string, value: T) => void;
-  setSidebarValue?: (label: string, value: T) => void;
-  updateSidebarValue?: (label: string, value: T) => void;
+  setDefaultValue?: (label: string, value: T) => void;
+  updateDefaultValue?: (label: string, value: T) => void;
 }) {
   cy.log("no default value, non-required, no current value");
   checkStatusIcon(NO_DEFAULT_NON_REQUIRED, "chevron");
@@ -888,8 +888,8 @@ function checkDashboardParameters<T = string>({
     defaultValueFormatted,
     otherValue,
     otherValueFormatted,
-    setValue: setSidebarValue,
-    updateValue: updateSidebarValue,
+    setValue: setDefaultValue,
+    updateValue: updateDefaultValue,
   });
 }
 


### PR DESCRIPTION
### Description

followup of https://github.com/metabase/metabase/pull/54915

prev tests implementation didn't pass correct value of card_id to BE during PUT request, that's why some assertions were incorrect. This PR passed correct card_id and fixes tests.

`location parameters - multiple values` is skipped intentionally, e2e works differently comparing to local development, I wasn't able to figure out why yet

### How to verify

tests should pass
