### PR TITLE
Prevent concurrent init notification and send pulse trigger tasks

### DIFF
--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -44,7 +44,6 @@
    (triggers/with-identity (send-notification-trigger-key subscription-id))
    (triggers/using-job-data {"subscription-id" subscription-id})
    (triggers/for-job send-notification-job-key)
-   (triggers/start-now)
    (triggers/with-schedule
     (cron/schedule
      (cron/cron-schedule cron-schedule)

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -44,6 +44,7 @@
    (triggers/with-identity (send-notification-trigger-key subscription-id))
    (triggers/using-job-data {"subscription-id" subscription-id})
    (triggers/for-job send-notification-job-key)
+   (triggers/start-now)
    (triggers/with-schedule
     (cron/schedule
      (cron/cron-schedule cron-schedule)

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -14,7 +14,7 @@
    [toucan2.core :as t2])
   (:import
    (java.util TimeZone)
-   (org.quartz CronTrigger TriggerKey)))
+   (org.quartz CronTrigger DisallowConcurrentExecution TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -178,7 +178,8 @@
 (jobs/defjob
   ^{:doc
     "Find all notification subscriptions with cron schedules and create a trigger for each.
-    Run once on startup."}
+    Run once on startup."
+    DisallowConcurrentExecution true}
   InitNotificationTriggers
   [_context]
   (log/info "Initializing SendNotification triggers")

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -23,7 +23,7 @@
    [toucan2.core :as t2])
   (:import
    (java.util TimeZone)
-   (org.quartz CronTrigger TriggerKey)))
+   (org.quartz CronTrigger DisallowConcurrentExecution TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -229,7 +229,8 @@
 (jobs/defjob
   ^{:doc
     "Find all active Dashboard Subscriptino channels, group them by pulse-id and schedule time and create a trigger for each.
-    Do this every startup to make sure all active pulse channels are triggered correctly."}
+    Do this every startup to make sure all active pulse channels are triggered correctly."
+    DisallowConcurrentExecution true}
   InitSendPulseTriggers
   [_context]
   (log/info "Initializing SendPulse triggers for dashboard subscriptions")


### PR DESCRIPTION
Putting `DisallowConcurrentExecution` on `InitNotificationTriggers` and `InitSendPulseTriggers` job