### PR TITLE
Feature visualizer hot fixes

### DIFF
--- a/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
+++ b/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
@@ -30,6 +30,10 @@ export function VizSettingsSidebar({ className }: { className?: string }) {
   );
 
   const widgets = useMemo(() => {
+    if (transformedSeries.length === 0) {
+      return [];
+    }
+
     const widgets = getSettingsWidgetsForSeries(
       transformedSeries,
       handleChangeSettings,

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -14,32 +14,21 @@ export function getUpdatedSettingsForDisplay(
   settings: VisualizationSettings,
   sourceDisplay: VisualizationDisplay | null,
   targetDisplay: VisualizationDisplay | null,
-): {
-  columnValuesMapping: ColumnValuesMapping;
-  columns: DatasetColumn[];
-  settings: VisualizationSettings;
-} {
+):
+  | {
+      columnValuesMapping: ColumnValuesMapping;
+      columns: DatasetColumn[];
+      settings: VisualizationSettings;
+    }
+  | undefined {
   if (!sourceDisplay || !targetDisplay) {
-    return {
-      columnValuesMapping,
-      columns,
-      settings,
-    };
+    return undefined;
   }
 
   const sourceIsCartesian = isCartesianChart(sourceDisplay);
   const targetIsCartesian = isCartesianChart(targetDisplay);
 
   if (sourceIsCartesian) {
-    // cartesian -> cartesian
-    if (targetIsCartesian) {
-      return {
-        columnValuesMapping,
-        columns,
-        settings,
-      };
-    }
-
     // cartesian -> pie
     if (targetDisplay === "pie") {
       const {
@@ -92,19 +81,6 @@ export function getUpdatedSettingsForDisplay(
           "graph.dimensions": [dimensions].filter(Boolean) as string[],
         },
       };
-    } else {
-      // pie -> pie
-      return {
-        columnValuesMapping,
-        columns,
-        settings,
-      };
     }
   }
-
-  return {
-    columnValuesMapping,
-    columns,
-    settings,
-  };
 }

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -51,7 +51,7 @@ describe("updateSettingsForDisplay", () => {
     }),
   ];
 
-  it("should return the same settings if sourceDisplay or targetDisplay is null", () => {
+  it("should return undefined if sourceDisplay or targetDisplay is null", () => {
     const settings = {};
     const sourceDisplay = null;
     const targetDisplay = null;
@@ -62,10 +62,10 @@ describe("updateSettingsForDisplay", () => {
       sourceDisplay,
       targetDisplay,
     );
-    expect(result).toEqual({ columnValuesMapping, columns, settings });
+    expect(result).toBeUndefined();
   });
 
-  it("should return the same settings if sourceDisplay and targetDisplay are cartesian", () => {
+  it("should return undefined if sourceDisplay and targetDisplay are cartesian", () => {
     const settings = {};
     const sourceDisplay = "bar";
     const targetDisplay = "bar";
@@ -76,11 +76,7 @@ describe("updateSettingsForDisplay", () => {
       sourceDisplay,
       targetDisplay,
     );
-    expect(result).toEqual({
-      columnValuesMapping,
-      columns,
-      settings,
-    });
+    expect(result).toBeUndefined();
   });
 
   describe("cartesian -> pie", () => {

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -255,18 +255,21 @@ const visualizerHistoryItemSlice = createSlice({
     builder
       .addCase(setDisplay.fulfilled, (state, action) => {
         const { display, computedSettings } = action.payload;
-        const { columnValuesMapping, columns, settings } =
-          getUpdatedSettingsForDisplay(
-            state.columnValuesMapping,
-            state.columns,
-            computedSettings,
-            state.display,
-            display,
-          );
+        const updatedSettings = getUpdatedSettingsForDisplay(
+          state.columnValuesMapping,
+          state.columns,
+          computedSettings,
+          state.display,
+          display,
+        );
 
-        state.columnValuesMapping = columnValuesMapping;
-        state.columns = columns;
-        state.settings = settings;
+        if (updatedSettings) {
+          const { columnValuesMapping, columns, settings } = updatedSettings;
+          state.columnValuesMapping = columnValuesMapping;
+          state.columns = columns;
+          state.settings = settings;
+        }
+
         state.display = display;
       })
       .addCase(initializeVisualizer.fulfilled, (state, action) => {


### PR DESCRIPTION
Closes nothing, fixes two issues introduced respectively by #54784 and the mix of #54760 and #54794:
 - impossible to change the display of a cartesian visualizer card to another cartesian chart
 - impossible to edit a visualizer dash card