### PR TITLE
feat(sdk): Ensure that all dashboards use entity ID the same way

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
@@ -36,7 +36,7 @@ const DefaultErrorMessage = ({ message }: SdkErrorComponentProps) => (
 );
 
 interface ResourceNotFoundErrorProps {
-  id: string | number | null | undefined;
+  id: string | number;
 }
 
 const ResourceNotFoundError = ({

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -129,7 +129,7 @@ export const CollectionBrowserInner = ({
 };
 
 const CollectionBrowserWrapper = ({
-  collectionId,
+  collectionId = "personal",
   ...restProps
 }: CollectionBrowserProps) => {
   const { id, isLoading } = useValidatedEntityId<

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
@@ -1,14 +1,9 @@
 import type { Query } from "history";
-import { type ComponentType, type FC, useEffect } from "react";
+import type { ComponentType, FC } from "react";
 import type { ConnectedProps } from "react-redux";
 import _ from "underscore";
 
 import type { MetabasePluginsConfig } from "embedding-sdk";
-import {
-  DashboardNotFoundError,
-  SdkLoader,
-} from "embedding-sdk/components/private/PublicComponentWrapper";
-import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import * as dashboardActions from "metabase/dashboard/actions";
 import type { NavigateToNewCardFromDashboardOpts } from "metabase/dashboard/components/DashCard/types";
 import { Dashboard } from "metabase/dashboard/components/Dashboard/Dashboard";
@@ -43,7 +38,7 @@ import { connect } from "metabase/lib/redux";
 import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
 import { useDashboardLoadHandlers } from "metabase/public/containers/PublicOrEmbeddedDashboard/use-dashboard-load-handlers";
 import { closeNavbar, setErrorPage } from "metabase/redux/app";
-import { getErrorPage, getIsNavbarOpen } from "metabase/selectors/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 import {
   canManageSubscriptions,
   getUserIsAdmin,
@@ -130,22 +125,4 @@ const ConnectedDashboardInner = ({
 
 export const ConnectedDashboard = connector<
   ComponentType<ConnectedDashboardProps & ReduxProps>
->(({ dashboardId, isLoading, ...rest }) => {
-  const errorPage = useSdkSelector(getErrorPage);
-  const dispatch = useSdkDispatch();
-  useEffect(() => {
-    if (dashboardId) {
-      dispatch(setErrorPage(null));
-    }
-  }, [dispatch, dashboardId]);
-
-  if (isLoading) {
-    return <SdkLoader />;
-  }
-
-  if (!dashboardId || errorPage?.status === 404) {
-    return <DashboardNotFoundError id={dashboardId} />;
-  }
-
-  return <ConnectedDashboardInner dashboardId={dashboardId} {...rest} />;
-}) as FC<ConnectedDashboardProps>;
+>(ConnectedDashboardInner) as FC<ConnectedDashboardProps>;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
@@ -39,7 +39,6 @@ import type {
   DashboardLoaderWrapperProps,
   DashboardRefreshPeriodControls,
 } from "metabase/dashboard/types";
-import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { connect } from "metabase/lib/redux";
 import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
 import { useDashboardLoadHandlers } from "metabase/public/containers/PublicOrEmbeddedDashboard/use-dashboard-load-handlers";
@@ -91,6 +90,7 @@ type ReduxProps = ConnectedProps<typeof connector>;
 
 type ConnectedDashboardProps = {
   dashboardId: DashboardId;
+  isLoading: boolean;
   parameterQueryParams: Query;
 
   downloadsEnabled?: boolean;
@@ -130,29 +130,22 @@ const ConnectedDashboardInner = ({
 
 export const ConnectedDashboard = connector<
   ComponentType<ConnectedDashboardProps & ReduxProps>
->(({ dashboardId: initialDashboardId, ...rest }) => {
-  const { id: resolvedDashboardId, isLoading } = useValidatedEntityId({
-    type: "dashboard",
-    id: initialDashboardId,
-  });
-
+>(({ dashboardId, isLoading, ...rest }) => {
   const errorPage = useSdkSelector(getErrorPage);
   const dispatch = useSdkDispatch();
   useEffect(() => {
-    if (resolvedDashboardId) {
+    if (dashboardId) {
       dispatch(setErrorPage(null));
     }
-  }, [dispatch, resolvedDashboardId]);
+  }, [dispatch, dashboardId]);
 
   if (isLoading) {
     return <SdkLoader />;
   }
 
-  if (!resolvedDashboardId || errorPage?.status === 404) {
-    return <DashboardNotFoundError id={initialDashboardId} />;
+  if (!dashboardId || errorPage?.status === 404) {
+    return <DashboardNotFoundError id={dashboardId} />;
   }
 
-  return (
-    <ConnectedDashboardInner dashboardId={resolvedDashboardId} {...rest} />
-  );
+  return <ConnectedDashboardInner dashboardId={dashboardId} {...rest} />;
 }) as FC<ConnectedDashboardProps>;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
@@ -1,19 +1,25 @@
-import type { CSSProperties } from "react";
+import { type CSSProperties, useEffect } from "react";
 
 import type { MetabasePluginsConfig } from "embedding-sdk";
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
+import {
+  DashboardNotFoundError,
+  SdkLoader,
+} from "embedding-sdk/components/private/PublicComponentWrapper";
 import { StyledPublicComponentWrapper } from "embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.styled";
 import {
   type SdkDashboardDisplayProps,
   useSdkDashboardParams,
 } from "embedding-sdk/hooks/private/use-sdk-dashboard-params";
-import { useSdkSelector } from "embedding-sdk/store";
+import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import {
   DASHBOARD_EDITING_ACTIONS,
   SDK_DASHBOARD_VIEW_ACTIONS,
 } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/constants";
 import { getIsEditing } from "metabase/dashboard/selectors";
 import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
+import { setErrorPage } from "metabase/redux/app";
+import { getErrorPage } from "metabase/selectors/app";
 
 import { ConnectedDashboard } from "./ConnectedDashboard";
 import { InteractiveDashboardProvider } from "./context";
@@ -68,6 +74,22 @@ export const EditableDashboard = ({
   const dashboardActions = isEditing
     ? DASHBOARD_EDITING_ACTIONS
     : SDK_DASHBOARD_VIEW_ACTIONS;
+
+  const errorPage = useSdkSelector(getErrorPage);
+  const dispatch = useSdkDispatch();
+  useEffect(() => {
+    if (dashboardId) {
+      dispatch(setErrorPage(null));
+    }
+  }, [dispatch, dashboardId]);
+
+  if (isLoading) {
+    return <SdkLoader />;
+  }
+
+  if (!dashboardId || errorPage?.status === 404) {
+    return <DashboardNotFoundError id={dashboardId} />;
+  }
 
   return (
     <StyledPublicComponentWrapper className={className} style={style} ref={ref}>

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
@@ -28,7 +28,7 @@ export type EditableDashboardProps = {
   PublicOrEmbeddedDashboardEventHandlersProps;
 
 export const EditableDashboard = ({
-  dashboardId,
+  dashboardId: initialDashboardId,
   initialParameters = {},
   withDownloads = false,
   drillThroughQuestionHeight,
@@ -45,8 +45,10 @@ export const EditableDashboard = ({
     refreshPeriod,
     onRefreshPeriodChange,
     setRefreshElapsedHook,
-  } = useSdkDashboardParams({
+    isLoading,
     dashboardId,
+  } = useSdkDashboardParams({
+    dashboardId: initialDashboardId,
     withDownloads,
     withTitle: true,
     hiddenParameters: undefined,
@@ -85,6 +87,7 @@ export const EditableDashboard = ({
         >
           <ConnectedDashboard
             dashboardId={dashboardId}
+            isLoading={isLoading}
             parameterQueryParams={initialParameters}
             refreshPeriod={refreshPeriod}
             onRefreshPeriodChange={onRefreshPeriodChange}

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
@@ -88,7 +88,7 @@ export const EditableDashboard = ({
   }
 
   if (!dashboardId || errorPage?.status === 404) {
-    return <DashboardNotFoundError id={dashboardId} />;
+    return <DashboardNotFoundError id={initialDashboardId} />;
   }
 
   return (

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/use-common-dashboard-params.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/use-common-dashboard-params.tsx
@@ -47,7 +47,7 @@ export const useCommonDashboardParams = ({
       const state = store.getState();
       const metadata = getMetadata(state);
       const { dashboards, parameterValues } = state.dashboard;
-      const dashboard = dashboards[dashboardId];
+      const dashboard = dashboardId && dashboards[dashboardId];
 
       if (dashboard) {
         const url = getNewCardUrl({

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/use-common-dashboard-params.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/use-common-dashboard-params.tsx
@@ -17,7 +17,7 @@ import type { DashboardId, QuestionDashboardCard } from "metabase-types/api";
 export const useCommonDashboardParams = ({
   dashboardId,
 }: {
-  dashboardId: DashboardId;
+  dashboardId: DashboardId | null;
 }) => {
   const dispatch = useSdkDispatch();
   const store = useSdkStore();

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
@@ -9,6 +9,7 @@ import {
   useRefreshDashboard,
 } from "metabase/dashboard/hooks";
 import type { EmbedDisplayParams } from "metabase/dashboard/types";
+import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { isNotNull } from "metabase/lib/types";
 import type { DashboardId } from "metabase-types/api";
 
@@ -25,13 +26,18 @@ export type SdkDashboardDisplayProps = {
 };
 
 export const useSdkDashboardParams = ({
-  dashboardId,
+  dashboardId: initialDashboardId,
   withDownloads,
   withTitle,
   withFooter,
   hiddenParameters,
   initialParameters = {},
 }: SdkDashboardDisplayProps) => {
+  const { id: dashboardId, isLoading } = useValidatedEntityId({
+    type: "dashboard",
+    id: initialDashboardId,
+  });
+
   // temporary name until we change `hideDownloadButton` to `downloads`
   const hideDownloadButton = !withDownloads;
 
@@ -66,5 +72,7 @@ export const useSdkDashboardParams = ({
     onRefreshPeriodChange,
     refreshPeriod,
     setRefreshElapsedHook,
+    dashboardId,
+    isLoading,
   };
 };


### PR DESCRIPTION
Moves the `dashboardId` entity ID logic into `useSdkDashboardParams` to simplify the code within the three dashboard components. This will be the first step in simplifying the dashboard code. It also adds entity IDs to `EditableDashboard`, which it was missing for some reason

To test: there are e2e tests for each of these components for entity IDs, so they should still pass.

You can manually test these by using `yarn run storybook-embedding-sdk`, and selecting `InteractiveDashboard`, `EditableDashboard`, and `StaticDashboard`. Go into the controls, and select `Entity ID` in the `dashboardId` dropdown:

![image](https://github.com/user-attachments/assets/55edaeea-e0fa-4c20-b971-b9075e3e31ef)

everything should continue to work.