### PR TITLE
fix(sdk): Popovers not working on Safari

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -20,8 +20,6 @@ const PublicComponentStylesWrapperInner = styled.div`
   width: 100%;
   height: 100%;
 
-  position: relative;
-
   font-size: ${({ theme }) => theme.other.fontSize};
 
   font-weight: 400;


### PR DESCRIPTION
Fixes popovers on Safari. It looks like the `position: relative` wasn't working with Safari, and we'll need to do something else in terms of resets here