### PR TITLE
Convert `cardId` to `questionId` for consistency

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -43,7 +43,7 @@ const mapEntityTypeFilterToDataPickerModels = (
 };
 
 export const InteractiveQuestionProvider = ({
-  cardId: initialQuestionId,
+  questionId: initialQuestionId,
   options = DEFAULT_OPTIONS,
   deserializedCard,
   componentPlugins,
@@ -57,7 +57,7 @@ export const InteractiveQuestionProvider = ({
   initialSqlParameters,
 }: InteractiveQuestionProviderProps) => {
   const {
-    id: cardId,
+    id: questionId,
     isLoading: isLoadingValidatedId,
     isError: isCardIdError,
   } = useValidatedEntityId({
@@ -115,7 +115,7 @@ export const InteractiveQuestionProvider = ({
     updateQuestion,
     navigateToNewCard,
   } = useLoadQuestion({
-    cardId,
+    questionId,
     options,
     deserializedCard,
     initialSqlParameters,

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProviderWithLocation.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProviderWithLocation.tsx
@@ -10,14 +10,14 @@ export const InteractiveQuestionProviderWithLocation = ({
   ...props
 }: InteractiveQuestionProviderWithLocationProps) => {
   // If we cannot extract an entity ID from the slug, assume we are creating a new question.
-  const cardId = Urls.extractEntityId(params.slug) ?? "new";
+  const questionId = Urls.extractEntityId(params.slug) ?? "new";
 
   const { options, serializedCard } = parseHash(location.hash);
   const deserializedCard = serializedCard && deserializeCard(serializedCard);
 
   return (
     <InteractiveQuestionProvider
-      cardId={cardId}
+      questionId={questionId}
       options={options}
       deserializedCard={deserializedCard}
       {...props}

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -48,8 +48,8 @@ export type InteractiveQuestionId = CardId | "new" | (string & {});
 
 export type InteractiveQuestionProviderProps = PropsWithChildren<
   InteractiveQuestionConfig &
-    Omit<LoadSdkQuestionParams, "cardId"> & {
-      cardId: InteractiveQuestionId;
+    Omit<LoadSdkQuestionParams, "questionId"> & {
+      questionId: InteractiveQuestionId;
     }
 >;
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -33,7 +33,7 @@ import { withPublicComponentWrapper } from "embedding-sdk/components/private/Pub
 import type { SDKCollectionReference } from "embedding-sdk/store/collections";
 
 export type InteractiveQuestionProps = PropsWithChildren<{
-  questionId: InteractiveQuestionProviderProps["cardId"];
+  questionId: InteractiveQuestionProviderProps["questionId"];
   plugins?: InteractiveQuestionProviderProps["componentPlugins"];
   /**
    * When this is defined, the collection picker will be hidden and
@@ -71,7 +71,7 @@ export const _InteractiveQuestion = ({
   InteractiveQuestionResultProps &
   FlexibleSizeProps): JSX.Element | null => (
   <InteractiveQuestionProvider
-    cardId={questionId}
+    questionId={questionId}
     componentPlugins={plugins}
     onBeforeSave={onBeforeSave}
     onSave={onSave}

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-question.ts
@@ -49,7 +49,7 @@ export interface LoadQuestionHookResult {
 }
 
 export function useLoadQuestion({
-  cardId,
+  questionId,
   options,
   // Passed when navigating from `InteractiveDashboard` or `EditableDashboard`
   deserializedCard,
@@ -80,7 +80,7 @@ export function useLoadQuestion({
   // Avoid re-running the query if the parameters haven't changed.
   const sqlParameterKey = getParameterDependencyKey(initialSqlParameters);
 
-  const shouldLoadQuestion = cardId != null || deserializedCard != null;
+  const shouldLoadQuestion = questionId != null || deserializedCard != null;
   const [isQuestionLoading, setIsQuestionLoading] =
     useState(shouldLoadQuestion);
 
@@ -92,7 +92,7 @@ export function useLoadQuestion({
       loadQuestionSdk({
         options,
         deserializedCard,
-        cardId,
+        questionId: questionId,
         initialSqlParameters,
       }),
     ).finally(() => {
@@ -110,7 +110,7 @@ export function useLoadQuestion({
     mergeQuestionState(results);
 
     return { ...results, originalQuestion };
-  }, [dispatch, options, deserializedCard, cardId, sqlParameterKey]);
+  }, [dispatch, options, deserializedCard, questionId, sqlParameterKey]);
 
   const [runQuestionState, queryQuestion] = useAsyncFn(async () => {
     if (!question) {

--- a/enterprise/frontend/src/embedding-sdk/lib/interactive-question/load-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/interactive-question/load-question.ts
@@ -12,7 +12,7 @@ export const loadQuestionSdk =
   ({
     options = {},
     deserializedCard,
-    cardId,
+    questionId: cardId,
     initialSqlParameters,
   }: LoadSdkQuestionParams) =>
   async (

--- a/enterprise/frontend/src/embedding-sdk/lib/interactive-question/load-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/interactive-question/load-question.ts
@@ -12,7 +12,7 @@ export const loadQuestionSdk =
   ({
     options = {},
     deserializedCard,
-    questionId: cardId,
+    questionId,
     initialSqlParameters,
   }: LoadSdkQuestionParams) =>
   async (
@@ -20,7 +20,7 @@ export const loadQuestionSdk =
     getState: GetState,
   ): Promise<{ question: Question; originalQuestion?: Question }> => {
     const { card, originalCard } = await resolveCards({
-      cardId: cardId ?? undefined,
+      cardId: questionId ?? undefined,
       options,
       dispatch,
       getState,

--- a/enterprise/frontend/src/embedding-sdk/types/question.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/question.ts
@@ -16,7 +16,7 @@ export interface SdkQuestionState {
 export interface LoadSdkQuestionParams {
   options?: QueryParams;
   deserializedCard?: Card;
-  cardId?: CardId | null;
+  questionId?: CardId | null;
   initialSqlParameters?: ParameterValues;
 }
 


### PR DESCRIPTION
I'm fixing some types and this is just one thing to start with to keep consistency in our internal code terminology