### PR TITLE
fix: default saml to use http-post binding

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -96,9 +96,7 @@
   lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:git/sha "d7dd536976b07f52ab3cdb86b29ef03eb769a1bd"
-                                             :git/url "http://github.com/metabase/saml20-clj"
-                                             ;;:mvn/version "4.0.0"
+  metabase/saml20-clj                       {:mvn/version "4.1.0"
                                              :exclusions [; EE SAML integration TODO: bump version when we release the library
                                                           org.bouncycastle/bcpkix-jdk15on
                                                           org.bouncycastle/bcprov-jdk15on

--- a/deps.edn
+++ b/deps.edn
@@ -96,7 +96,9 @@
   lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "4.0.0"
+  metabase/saml20-clj                       {:git/sha "d7dd536976b07f52ab3cdb86b29ef03eb769a1bd"
+                                             :git/url "http://github.com/metabase/saml20-clj"
+                                             ;;:mvn/version "4.0.0"
                                              :exclusions [; EE SAML integration TODO: bump version when we release the library
                                                           org.bouncycastle/bcpkix-jdk15on
                                                           org.bouncycastle/bcprov-jdk15on

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -143,13 +143,14 @@
     (try
       (let [idp-url      (sso-settings/saml-identity-provider-uri)
             relay-state  (u/encode-base64 redirect-url)]
-        (saml/idp-redirect-response {:request-id  (str "id-" (random-uuid))
-                                     :sp-name     (sso-settings/saml-application-name)
-                                     :issuer      (sso-settings/saml-application-name)
-                                     :acs-url     (acs-url)
-                                     :idp-url     idp-url
-                                     :credential  (sp-cert-keystore-details)
-                                     :relay-state relay-state}))
+        (saml/idp-redirect-response {:request-id       (str "id-" (random-uuid))
+                                     :sp-name          (sso-settings/saml-application-name)
+                                     :issuer           (sso-settings/saml-application-name)
+                                     :acs-url          (acs-url)
+                                     :idp-url          idp-url
+                                     :credential       (sp-cert-keystore-details)
+                                     :relay-state      relay-state
+                                     :protocol-binding :post}))
       (catch Throwable e
         (let [msg (trs "Error generating SAML request")]
           (log/error e msg)

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -216,7 +216,7 @@
                             " ID=\"id-419507d5-1d2a-43c4-bcde-3e5b9746bb47\""
                             " IsPassive=\"false\""
                             " IssueInstant=\"2020-09-30T17:53:32.000Z\""
-                            " ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\""
+                            " ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\""
                             " ProviderName=\"Metabase\""
                             " Version=\"2.0\""
                             " xmlns:saml2p=\"urn:oasis:names:tc:SAML:2.0:protocol\">"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55007

### Description

Microsoft Entra will only respond to AuthnRequests that ask for the HTTP-Post binding, which was our previous default setting. This defaults metabase to requesting that binding on AuthnRequests. In the future this should be determined by IdP metadata. 

### How to verify

On an instance with microsoft entra SAML configured, attempt to login via sso.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
