### PR TITLE
feat(sdk): Add stable IDs for SaveQuestion / InteractiveQuestion

### DIFF
--- a/frontend/src/metabase/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
@@ -13,6 +13,7 @@ import { useListRecentsQuery } from "metabase/api";
 import { useGetDefaultCollectionId } from "metabase/collections/hooks";
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
 import { FormProvider } from "metabase/forms";
+import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { useSelector } from "metabase/lib/redux";
 import { isNotNull } from "metabase/lib/types";
 import type Question from "metabase-lib/v1/Question";
@@ -71,10 +72,16 @@ export const SaveQuestionProvider = ({
   );
 
   const currentUser = useSelector(getCurrentUser);
+  const { id: collectionId } = useValidatedEntityId({
+    type: "collection",
+    id: userTargetCollection,
+  });
+
   const targetCollection =
-    currentUser && userTargetCollection === "personal"
+    collectionId ||
+    (currentUser && userTargetCollection === "personal"
       ? currentUser.personal_collection_id
-      : userTargetCollection;
+      : userTargetCollection);
 
   const [hasLoadedRecentItems, setHasLoadedRecentItems] = useState(false);
   const { data: recentItems, isLoading } = useListRecentsQuery(


### PR DESCRIPTION
Adds ability to use collection stable IDs with `targetCollection`/`saveToCollection` of the `InteractiveQuestion`

This one is relatively simple since it sits in the `SaveQuestion` component. Let me know if you think there is a better way to do this, but keep in mind that we have to ensure that the `SaveQuestion` components are independent of the interactive question components. 

_Maybe_ we can do a check in the provider but I don't want to muddy up the provider with more logic than is already there right now