### PR TITLE
Modify the API - don't care about database routers

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -669,7 +669,7 @@
 
   enterprise/database-routing
   {:api #{metabase-enterprise.database-routing.core metabase-enterprise.database-routing.api}
-   :uses #{analytics api driver events util}}
+   :uses #{analytics api driver events util premium-features}}
 
   enterprise/enhancements
   {:api  #{metabase-enterprise.enhancements.init}

--- a/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
@@ -1,5 +1,7 @@
 (ns metabase-enterprise.database-routing.model
   (:require
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -7,3 +9,9 @@
 
 (doto :model/DatabaseRouter
   (derive :metabase/model))
+
+(defenterprise router-user-attribute
+  "Enterprise implementation. Returns the user attribute, if set, that will be used for the DB routing feature for this database."
+  :feature :database-routing
+  [db-or-id]
+  (t2/select-one-fn :user_attribute :model/DatabaseRouter :database_id (u/the-id db-or-id)))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -385,6 +385,7 @@
   "Get a single Database with `id`."
   [db {:keys [include include-editable-data-model?]}]
   (cond-> db
+    true                         (assoc :router_user_attribute (database/router-user-attribute db))
     true                         add-expanded-schedules
     true                         (get-database-hydrate-include include)
     true                         add-can-upload

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -494,3 +494,9 @@
                   :updated-at    true}
    :search-terms [:name :description]
    :render-terms {:initial-sync-status true}})
+
+(defenterprise router-user-attribute
+  "OSS implementation. Returns the user attribute, if set, that will be used for the DB routing feature."
+  metabase-enterprise.database-routing.model
+  [_db-id]
+  nil)

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -628,7 +628,7 @@
 
 (deftest ^:parallel fetch-database-metadata-test
   (testing "GET /api/database/:id/metadata"
-    (is (= (merge (dissoc (db-details) :details)
+    (is (= (merge (dissoc (db-details) :details :router_user_attribute)
                   {:engine        "h2"
                    :name          "test-data (h2)"
                    :features      (map u/qualified-name (driver.u/features :h2 (mt/db)))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -81,10 +81,11 @@
     (mt/object-defaults :model/Database)
     (select-keys db [:created_at :id :entity_id :details :updated_at :timezone :name :dbms_version
                      :metadata_sync_schedule :cache_field_values_schedule :uploads_enabled])
-    {:engine               (u/qualified-name (:engine db))
-     :settings             {}
-     :features             (map u/qualified-name (driver.u/features driver db))
-     :initial_sync_status "complete"})))
+    {:engine                (u/qualified-name (:engine db))
+     :settings              {}
+     :features              (map u/qualified-name (driver.u/features driver db))
+     :initial_sync_status   "complete"
+     :router_user_attribute nil})))
 
 (defn- table-details [table]
   (-> (merge (mt/obj->json->obj (mt/object-defaults :model/Table))


### PR DESCRIPTION
Add a `router_user_attribute` to the `GET /api/database/:id` API endpoint.

Modifies the database routing API to address only by the database ID. There's now just two endpoints:

- POST /ee/database-routing/mirror-database to create a mirror database

- PUT /ee/database-routing/router-database/:id to change the `user_attribute` used for routing an existing database. Can be set to `null` to turn of database routing for the database.
