### PR TITLE
Add support for temporal extraction filters

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -254,7 +254,9 @@
       (metabot-v3.tools.u/handle-agent-error ex))))
 
 (comment
-  (toucan2.core/select :model/Field)
+  (require '[metabase.query-processor :as qp]
+           '[toucan2.core :as t2])
+  (t2/select :model/Field)
   (binding [api/*current-user-permissions-set* (delay #{"/"})
             api/*current-user-id* 2
             api/*is-superuser?* true]
@@ -267,5 +269,5 @@
                      :bucket "month-of-year"
                      :field_id "t1/3"
                      :value #_"2020-01-01" 1}]})
-        :structured-output :query metabase.query-processor/process-query :data :native_form :query))
+        :structured-output :query qp/process-query :data :native_form :query))
   -)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -57,6 +57,7 @@
                          {:field_id "q2a/3", :operation "equals", :values ["3" "4"]}
                          {:field_id "q2a/5", :operation "not-equals", :values [3 4]}
                          {:field_id "q2a/6", :operation "month-equals", :values [4 5 9]}
+                         {:field_id "c2a/6", :bucket "week-of-year" :operation "not-equals", :values [14 15 19]}
                          {:field_id "q2a/6", :operation "year-equals", :value 2008}]
                 response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/filter-records"
                                                {:request-options {:headers {"x-metabase-session" ai-token}}}
@@ -149,6 +150,8 @@
                        {:field_id "c2/3", :operation "equals", :values ["3" "4"]}
                        {:field_id "c2/5", :operation "not-equals", :values [3 4]}
                        {:field_id "c2/6", :operation "month-equals", :values [4 5 9]}
+                       {:field_id "c2/6", :bucket "day-of-month" :operation "not-equals", :values [14 15 19]}
+                       {:field_id "c2/6", :bucket "day-of-week" :operation "equals", :values [1 7]}
                        {:field_id "c2/6", :operation "year-equals", :value 2008}]
               breakouts [{:field_id "c2/4", :field_granularity "week"}
                          {:field_id "c2/6", :field_granularity "day"}]


### PR DESCRIPTION
Fixes BOT-60.

Actually, both extraction and bucketing is supported. The following values can be provided in the filter's `bucket` property:

```
millisecond
second
minute
hour
day
week
month
quarter
year
second-of-minute
minute-of-hour
hour-of-day
day-of-week
day-of-month
day-of-year
week-of-year
month-of-year
quarter-of-year
year-of-era
```

The values of the form x-of-y result in extraction, the other result in truncation. The extractions `week-of-year` and `day-of-week` have ISO semantics.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
