### PR TITLE
Add describe-fields query logging

### DIFF
--- a/src/metabase/sync/fetch_metadata.clj
+++ b/src/metabase/sync/fetch_metadata.clj
@@ -72,10 +72,12 @@
   (log-if-error "fields-metadata"
     (let [driver             (driver.u/database->driver database)
           describe-fields-fn (if (driver.u/supports? driver :describe-fields database)
-                               driver/describe-fields
+                               (do (log/debug "Using `describe-fields` (fast sync) to fetch fields metadata.")
+                                   driver/describe-fields)
                                ;; In a future version we may remove [[driver/describe-table]]
                                ;; and we'll just use [[driver/describe-fields]] here
-                               describe-fields-using-describe-table)]
+                               (do (log/debug "Using `describe-table` (legacy sync) to fetch fields metadata.")
+                                   describe-fields-using-describe-table))]
       (cond->> (describe-fields-fn driver database args)
         ;; This is a workaround for the fact that [[mu/defn]] can't check reducible collections yet
         (mu.fn/instrument-ns? *ns*)


### PR DESCRIPTION
This is the first from series of PRs that will attempt to address issues of sync observability discussed [on slack](https://metaboat.slack.com/archives/C05MPF0TM3L/p1739400781937309).

This PR adds debug logging for `describe-fields` query and also logging of whether legacy of newer field sync scheme is used.

Following loggers should be add to log4j2 config:
```
    <Logger name="metabase.driver.sql-jdbc.sync" level="DEBUG"/>
    <Logger name="metabase.sync" level="DEBUG"/>
```