### PR TITLE
Fix visualizer column mapping and funnel issues

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -29,6 +29,7 @@ import {
   dashboardCardSupportsVisualizer,
   isVisualizerDashboardCard,
   mergeVisualizerData,
+  shouldSplitVisualizerSeries,
   splitVisualizerSeries,
 } from "metabase/visualizer/utils";
 import Question from "metabase-lib/v1/Question";
@@ -209,7 +210,11 @@ export function DashCardVisualization({
       },
     ];
 
-    if (display && isCartesianChart(display)) {
+    if (
+      display &&
+      isCartesianChart(display) &&
+      shouldSplitVisualizerSeries(columnValuesMapping, settings)
+    ) {
       return splitVisualizerSeries(series, columnValuesMapping);
     }
 

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -34,7 +34,7 @@ type State = { visualizer: VisualizerState };
 
 const getCurrentHistoryItem = (state: State) => state.visualizer.present;
 
-const getCards = (state: State) => state.visualizer.cards;
+export const getCards = (state: State) => state.visualizer.cards;
 
 const getRawSettings = (state: State) => getCurrentHistoryItem(state).settings;
 

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -25,6 +25,7 @@ import {
   extractReferencedColumns,
   getDefaultVisualizationName,
   mergeVisualizerData,
+  shouldSplitVisualizerSeries,
   splitVisualizerSeries,
 } from "./utils";
 
@@ -156,7 +157,10 @@ export const getVisualizerRawSeries = createSelector(
       } as SingleSeries,
     ];
 
-    if (isCartesianChart(display)) {
+    if (
+      isCartesianChart(display) &&
+      shouldSplitVisualizerSeries(columnValuesMapping, settings)
+    ) {
       return splitVisualizerSeries(series, columnValuesMapping);
     }
 

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -1,10 +1,19 @@
-import { isCartesianChart } from "metabase/visualizations";
+import _ from "underscore";
+
+import { isNotNull } from "metabase/lib/types";
+import {
+  getMaxDimensionsSupported,
+  getMaxMetricsSupported,
+  isCartesianChart,
+} from "metabase/visualizations";
 import type {
   DatasetColumn,
   VisualizationDisplay,
   VisualizationSettings,
 } from "metabase-types/api";
 import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
+
+import { isScalarFunnel } from "../visualizations/funnel";
 
 type ColumnValuesMapping = Record<string, VisualizerColumnValueSource[]>;
 
@@ -29,58 +38,196 @@ export function getUpdatedSettingsForDisplay(
   const targetIsCartesian = isCartesianChart(targetDisplay);
 
   if (sourceIsCartesian) {
-    // cartesian -> pie
-    if (targetDisplay === "pie") {
-      const {
-        "graph.metrics": metrics = [],
-        "graph.dimensions": dimensions = [],
-        ...otherSettings
-      } = settings;
-
-      const metric = metrics[0];
-      const newColumns = columns.filter(
-        column => column.name === metric || dimensions.includes(column.name),
+    if (targetIsCartesian) {
+      return cartesianToCartesian(
+        columnValuesMapping,
+        columns,
+        settings,
+        targetDisplay,
       );
-
-      const newColumnValuesMapping: ColumnValuesMapping = {};
-      if (metric) {
-        newColumnValuesMapping[metric] = columnValuesMapping[metric];
-      }
-
-      dimensions.forEach(dimension => {
-        newColumnValuesMapping[dimension] = columnValuesMapping[dimension];
-      });
-
-      return {
-        columnValuesMapping: newColumnValuesMapping,
-        columns: newColumns,
-        settings: {
-          ...otherSettings,
-          "pie.metric": metric,
-          "pie.dimension": dimensions.length === 1 ? dimensions[0] : dimensions,
-        },
-      };
+    }
+    if (targetDisplay === "pie") {
+      return cartesianToPie(columnValuesMapping, columns, settings);
     }
   }
 
   if (sourceDisplay === "pie") {
-    // pie -> cartesian
     if (targetIsCartesian) {
-      const {
-        "pie.metric": metric,
-        "pie.dimension": dimensions,
-        ...otherSettings
-      } = settings;
-
-      return {
+      return pieToCartesian(
         columnValuesMapping,
         columns,
-        settings: {
-          ...otherSettings,
-          "graph.metrics": [metric].filter(Boolean) as string[],
-          "graph.dimensions": [dimensions].filter(Boolean) as string[],
-        },
-      };
+        settings,
+        targetDisplay,
+      );
     }
   }
+
+  if (sourceDisplay === "funnel") {
+    if (isScalarFunnel({ display: "funnel", settings })) {
+      return {
+        settings: _.pick(settings, "card.title"),
+        columns: [],
+        columnValuesMapping: {},
+      };
+    }
+    if (targetIsCartesian) {
+      return funnelToCartesian(columnValuesMapping, columns, settings);
+    }
+    if (targetDisplay === "pie") {
+      return funnelToPie(columnValuesMapping, columns, settings);
+    }
+  }
+
+  return {
+    columns,
+    columnValuesMapping,
+    settings: _.pick(settings, "card.title"),
+  };
 }
+
+const cartesianToCartesian = (
+  columnValuesMapping: ColumnValuesMapping,
+  columns: DatasetColumn[],
+  settings: VisualizationSettings,
+  targetDisplay: VisualizationDisplay,
+) => {
+  const maxMetrics = getMaxMetricsSupported(targetDisplay);
+  const maxDimensions = getMaxDimensionsSupported(targetDisplay);
+
+  const {
+    "graph.metrics": metrics = [],
+    "graph.dimensions": dimensions = [],
+    ...otherSettings
+  } = settings;
+
+  const nextMetrics = metrics.slice(0, maxMetrics);
+  const removedMetrics = metrics.slice(maxMetrics);
+
+  const nextDimensions = dimensions.slice(0, maxDimensions);
+  const removedDimensions = dimensions.slice(maxDimensions);
+
+  const removedColumns = [...removedMetrics, ...removedDimensions];
+
+  return {
+    columns: columns.filter(column => !removedColumns.includes(column.name)),
+    columnValuesMapping: _.omit(columnValuesMapping, removedColumns),
+    settings: {
+      ...otherSettings,
+      "graph.metrics": nextMetrics,
+      "graph.dimensions": nextDimensions,
+    },
+  };
+};
+
+const cartesianToPie = (
+  columnValuesMapping: ColumnValuesMapping,
+  columns: DatasetColumn[],
+  settings: VisualizationSettings,
+) => {
+  const {
+    "graph.metrics": metrics = [],
+    "graph.dimensions": dimensions = [],
+    ...otherSettings
+  } = settings;
+
+  const metric = metrics[0];
+  const newColumns = columns.filter(
+    column => column.name === metric || dimensions.includes(column.name),
+  );
+
+  const newColumnValuesMapping: ColumnValuesMapping = {};
+  if (metric) {
+    newColumnValuesMapping[metric] = columnValuesMapping[metric];
+  }
+
+  dimensions.forEach(dimension => {
+    newColumnValuesMapping[dimension] = columnValuesMapping[dimension];
+  });
+
+  return {
+    columnValuesMapping: newColumnValuesMapping,
+    columns: newColumns,
+    settings: {
+      ...otherSettings,
+      "pie.metric": metric,
+      "pie.dimension": dimensions.length === 1 ? dimensions[0] : dimensions,
+    },
+  };
+};
+
+const pieToCartesian = (
+  columnValuesMapping: ColumnValuesMapping,
+  columns: DatasetColumn[],
+  settings: VisualizationSettings,
+  targetDisplay: VisualizationDisplay,
+) => {
+  const maxDimensions = getMaxDimensionsSupported(targetDisplay);
+
+  const {
+    "pie.metric": metric,
+    "pie.dimension": dimensions,
+    ...otherSettings
+  } = settings;
+
+  let nextDimensions = Array.isArray(dimensions)
+    ? dimensions.filter(isNotNull)
+    : [dimensions].filter(isNotNull);
+
+  if (nextDimensions.length > maxDimensions) {
+    nextDimensions = nextDimensions.slice(0, maxDimensions);
+  }
+
+  return {
+    columns,
+    columnValuesMapping,
+    settings: {
+      ...otherSettings,
+      "graph.metrics": [metric].filter(isNotNull),
+      "graph.dimensions": nextDimensions,
+    },
+  };
+};
+
+const funnelToCartesian = (
+  columnValuesMapping: ColumnValuesMapping,
+  columns: DatasetColumn[],
+  settings: VisualizationSettings,
+) => {
+  const {
+    "funnel.metric": metric,
+    "funnel.dimension": dimension,
+    ...otherSettings
+  } = settings;
+
+  return {
+    columns,
+    columnValuesMapping,
+    settings: {
+      ...otherSettings,
+      "graph.metrics": [metric].filter(isNotNull),
+      "graph.dimensions": [dimension].filter(isNotNull),
+    },
+  };
+};
+
+const funnelToPie = (
+  columnValuesMapping: ColumnValuesMapping,
+  columns: DatasetColumn[],
+  settings: VisualizationSettings,
+) => {
+  const {
+    "funnel.metric": metric,
+    "funnel.dimension": dimension,
+    ...otherSettings
+  } = settings;
+
+  return {
+    columns,
+    columnValuesMapping,
+    settings: {
+      ...otherSettings,
+      "pie.metric": metric,
+      "pie.dimensions": dimension,
+    },
+  };
+};

--- a/frontend/src/metabase/visualizer/utils/split-series.ts
+++ b/frontend/src/metabase/visualizer/utils/split-series.ts
@@ -2,10 +2,29 @@ import _ from "underscore";
 
 import { isNotNull } from "metabase/lib/types";
 import { isCartesianChart } from "metabase/visualizations";
-import type { RawSeries } from "metabase-types/api";
+import type { RawSeries, VisualizationSettings } from "metabase-types/api";
 import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
 
 import { isDataSourceNameRef } from "./data-source";
+
+export function shouldSplitVisualizerSeries(
+  columnValuesMapping: Record<string, VisualizerColumnValueSource[]>,
+  settings: VisualizationSettings,
+) {
+  const dimensions = settings["graph.dimensions"] ?? [];
+  const dimensionDataSources = _.uniq(
+    dimensions
+      .map(columnName => {
+        const mapping = columnValuesMapping[columnName];
+        if (isDataSourceNameRef(mapping[0])) {
+          return;
+        }
+        return mapping[0]?.sourceId;
+      })
+      .filter(isNotNull),
+  );
+  return dimensionDataSources.length > 1;
+}
 
 export function splitVisualizerSeries(
   series: RawSeries,

--- a/frontend/src/metabase/visualizer/visualizations/funnel.ts
+++ b/frontend/src/metabase/visualizer/visualizations/funnel.ts
@@ -230,7 +230,9 @@ function createDimensionColumn(name: string): DatasetColumn {
   };
 }
 
-export function isScalarFunnel(state: VisualizerHistoryItem) {
+export function isScalarFunnel(
+  state: Pick<VisualizerHistoryItem, "display" | "settings">,
+) {
   return (
     state.display === "funnel" &&
     state.settings["funnel.metric"] === "METRIC" &&

--- a/frontend/src/metabase/visualizer/visualizations/funnel.ts
+++ b/frontend/src/metabase/visualizer/visualizations/funnel.ts
@@ -9,9 +9,14 @@ import {
   extractReferencedColumns,
   isDraggedColumnItem,
 } from "metabase/visualizer/utils";
-import { isNumeric } from "metabase-lib/v1/types/utils/isa";
+import {
+  isDimension,
+  isMetric,
+  isNumeric,
+} from "metabase-lib/v1/types/utils/isa";
 import type { Card, Dataset, DatasetColumn } from "metabase-types/api";
 import type {
+  VisualizerColumnReference,
   VisualizerDataSource,
   VisualizerHistoryItem,
 } from "metabase-types/store/visualizer";
@@ -137,6 +142,69 @@ export function addScalarToFunnel(
   );
 }
 
+export function addColumnToFunnel(
+  state: VisualizerHistoryItem,
+  column: DatasetColumn,
+  columnRef: VisualizerColumnReference,
+  dataSource: VisualizerDataSource,
+  dataset: Dataset,
+  card?: Card,
+) {
+  const isEmpty = state.columns.length === 0;
+
+  if (
+    (isEmpty || isScalarFunnel(state)) &&
+    card &&
+    canCombineCardWithFunnel(card, dataset)
+  ) {
+    addScalarToFunnel(state, dataSource, dataset.data.cols[0]);
+    return;
+  }
+
+  if (!isScalarFunnel(state)) {
+    state.columns.push(column);
+    state.columnValuesMapping[column.name] = [columnRef];
+
+    const metric = state.settings["funnel.metric"];
+    if (!metric && isMetric(column)) {
+      state.settings["funnel.metric"] = column.name;
+    }
+
+    const dimension = state.settings["funnel.dimension"];
+    if (!dimension && isDimension(column) && !isMetric(column)) {
+      state.settings["funnel.dimension"] = column.name;
+    }
+  }
+}
+
+export function removeColumnFromFunnel(
+  state: VisualizerHistoryItem,
+  columnName: string,
+) {
+  if (isScalarFunnel(state)) {
+    if (columnName === "METRIC") {
+      state.columns = [];
+      state.columnValuesMapping = {};
+      state.settings = {};
+    } else {
+      const index = state.columnValuesMapping.METRIC.findIndex(
+        mapping => typeof mapping !== "string" && mapping.name === columnName,
+      );
+      if (index >= 0) {
+        state.columnValuesMapping.METRIC.splice(index, 1);
+        state.columnValuesMapping.DIMENSION.splice(index, 1);
+      }
+    }
+  } else {
+    if (state.settings["funnel.metric"] === columnName) {
+      delete state.settings["funnel.metric"];
+    }
+    if (state.settings["funnel.dimension"] === columnName) {
+      delete state.settings["funnel.dimension"];
+    }
+  }
+}
+
 function createMetricColumn(
   name: string,
   type = "type/Integer",
@@ -162,33 +230,10 @@ function createDimensionColumn(name: string): DatasetColumn {
   };
 }
 
-export function removeColumnFromFunnel(
-  state: VisualizerHistoryItem,
-  columnName: string,
-) {
-  const isMadeOfScalars = state.columnValuesMapping.METRIC?.length >= 1;
-
-  if (isMadeOfScalars) {
-    if (columnName === "METRIC") {
-      state.columns = [];
-      state.columnValuesMapping = {};
-      state.settings = {};
-      return;
-    }
-
-    const index = state.columnValuesMapping.METRIC.findIndex(
-      mapping => typeof mapping !== "string" && mapping.name === columnName,
-    );
-    if (index >= 0) {
-      state.columnValuesMapping.METRIC.splice(index, 1);
-      state.columnValuesMapping.DIMENSION.splice(index, 1);
-    }
-  } else {
-    if (state.settings["funnel.metric"] === columnName) {
-      delete state.settings["funnel.metric"];
-    }
-    if (state.settings["funnel.dimension"] === columnName) {
-      delete state.settings["funnel.dimension"];
-    }
-  }
+export function isScalarFunnel(state: VisualizerHistoryItem) {
+  return (
+    state.display === "funnel" &&
+    state.settings["funnel.metric"] === "METRIC" &&
+    state.settings["funnel.dimension"] === "DIMENSION"
+  );
 }

--- a/frontend/src/metabase/visualizer/visualizations/pie.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.ts
@@ -8,7 +8,12 @@ import {
   extractReferencedColumns,
   isDraggedColumnItem,
 } from "metabase/visualizer/utils";
-import { isNumeric } from "metabase-lib/v1/types/utils/isa";
+import {
+  isDimension,
+  isMetric,
+  isNumeric,
+} from "metabase-lib/v1/types/utils/isa";
+import type { DatasetColumn } from "metabase-types/api";
 import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
 
 export const pieDropHandler = (
@@ -72,6 +77,21 @@ export const pieDropHandler = (
     };
   }
 };
+
+export function addColumnToPieChart(
+  state: VisualizerHistoryItem,
+  column: DatasetColumn,
+) {
+  const metric = state.settings["pie.metric"];
+  if (!metric && isMetric(column)) {
+    state.settings["pie.metric"] = column.name;
+  }
+
+  if (isDimension(column) && !isMetric(column)) {
+    const dimensions = state.settings["pie.dimension"] ?? [];
+    state.settings["pie.dimension"] = [...dimensions, column.name];
+  }
+}
 
 export function removeColumnFromPieChart(
   state: VisualizerHistoryItem,


### PR DESCRIPTION
Fixes [VIZ-531: Data manager + wells + chart differences for funnel](https://linear.app/metabase/issue/VIZ-531/data-manager-wells-chart-differences-for-funnel)
Fixes [VIZ-513: Column auto-mapping not always working](https://linear.app/metabase/issue/VIZ-513/column-auto-mapping-not-always-working)
Fixes [VIZ-512: Data manager and wells out of sync when clicking, not dragging](https://linear.app/metabase/issue/VIZ-512/data-manager-and-wells-out-of-sync-when-clicking-not-dragging)

Fixes a group of issues around column mapping in the visualizer and several issues around funnels:

- extracts common mapping functions like `addColumnToCartesianChart`, `addColumnToFunnel`, etc. and calls them with `addColumn` action
- extends `getUpdatedSettingsForDisplay` to handle more cases
- fixes funnel support for regular way to plot data and fixes some bugs around how artificial "METRIC" and "DIMENSION" columns (used to populate data with values from scalar cards) were recycled
- splits cartesian series conditionally only if a chart uses dimensions from different data sources