### PR TITLE
Implement database routing

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -745,6 +745,7 @@
    clojurewerkz.quartzite.schedule.cron/schedule                                        macros.quartz/schedule
    clojurewerkz.quartzite.schedule.simple/schedule                                      macros.quartz/simple-schedule
    clojurewerkz.quartzite.triggers/build                                                macros.quartz/build-trigger
+   metabase-enterprise.database-routing.e2e-test/with-temp-dbs!                         macros.metabase-enterprise.database-routing.e2e-test/with-temp-dbs!
    metabase-enterprise.impersonation.util-test/with-impersonations!                     macros.metabase-enterprise.impersonation.util-test/with-impersonations!
    metabase-enterprise.query-reference-validation.api-test/with-test-setup!             macros.metabase-enterprise.query-reference-validation.api-test/with-test-setup!
    metabase-enterprise.sandbox.test-util/with-gtaps!                                    macros.metabase-enterprise.sandbox.test-util/with-gtaps!

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -669,7 +669,7 @@
 
   enterprise/database-routing
   {:api #{metabase-enterprise.database-routing.core metabase-enterprise.database-routing.api}
-   :uses #{analytics api driver events models util premium-features}}
+   :uses #{api events lib models premium-features query-processor util}}
 
   enterprise/enhancements
   {:api  #{metabase-enterprise.enhancements.init}

--- a/.clj-kondo/macros/metabase_enterprise/database_routing/e2e_test.clj
+++ b/.clj-kondo/macros/metabase_enterprise/database_routing/e2e_test.clj
@@ -1,0 +1,5 @@
+(ns macros.metabase-enterprise.database-routing.e2e-test)
+
+(defmacro with-temp-dbs! [bindings & body]
+  `(let [~@(interleave bindings (repeat nil))]
+     ~@body))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -14,7 +14,7 @@
   Database but no current user exists, an exception will be thrown."
   [current-user db-or-id]
   (when-let [attr-name (user-attribute db-or-id)]
-    (let [database-name #p (get #p (:login_attributes @current-user) #p attr-name)]
+    (let [database-name (get (:login_attributes @current-user) attr-name)]
       (cond
         (nil? @current-user)
         (throw (ex-info "Anonymous access to a Router Database is prohibited." {}))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -6,7 +6,7 @@
 (defn- user-attribute
   "Which user attribute should we use for this RouterDB?"
   [db-or-id]
-  (t2/select-one-fn :user_attribute :model/DatabaseRouter :db_id (u/the-id db-or-id)))
+  (t2/select-one-fn :user_attribute :model/DatabaseRouter :database_id (u/the-id db-or-id)))
 
 (defn router-db-or-id->mirror-db-id
   "Given a the current user and a database (or id), returns the ID of the mirror database that the user's query should

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -1,0 +1,30 @@
+(ns metabase-enterprise.database-routing.common
+  (:require
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(defn- user-attribute
+  "Which user attribute should we use for this RouterDB?"
+  [db-or-id]
+  (t2/select-one-fn :user_attribute :model/DatabaseRouter :db_id (u/the-id db-or-id)))
+
+(defn router-db-or-id->mirror-db-id
+  "Given a the current user and a database (or id), returns the ID of the mirror database that the user's query should
+  ultimately be routed to. If the database is not a Router Database, returns `nil`. If the database is a Router
+  Database but no current user exists, an exception will be thrown."
+  [current-user db-or-id]
+  (when-let [attr-name (user-attribute db-or-id)]
+    (let [database-name (get (:login_attributes @current-user) attr-name)]
+      (cond
+        (= database-name "__METABASE_ROUTER__")
+        (u/the-id db-or-id)
+
+        (nil? database-name)
+        (throw (ex-info "Anonymous access to a Router Database is prohibited." {}))
+
+        :else
+        (or (t2/select-one-pk :model/Database
+                              :router_database_id (u/the-id db-or-id)
+                              :name database-name)
+            (throw (ex-info "No MirrorDB found for user attribute" {:database-name database-name
+                                                                    :router-database-id (u/the-id db-or-id)})))))))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -36,10 +36,10 @@
     (if-let [mirror-db-id (:mirror-database/id query)]
       (let [current-database (lib.metadata/database (qp.store/metadata-provider))
             rff* (fn [metadata]
-                   (binding [qp.store/*TESTS-ONLY-allow-replacing-metadata-provider* true]
+                   (binding [qp.store/*DANGER-allow-replacing-metadata-provider* true]
                      (qp.store/with-metadata-provider (u/id current-database)
                        (rff metadata))))]
-        (binding [qp.store/*TESTS-ONLY-allow-replacing-metadata-provider* true]
+        (binding [qp.store/*DANGER-allow-replacing-metadata-provider* true]
           (qp.store/with-metadata-provider mirror-db-id
             (qp query rff*))))
       (qp query rff))))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -1,0 +1,55 @@
+(ns metabase-enterprise.database-routing.middleware
+  "MirrorDBs require two middleware to be executed. The first middleware is a pre-processing middleware that sets a key,
+  `:mirror-database/id`, on the query if a mirror database should be used. The second middleware runs around query
+  execution, and should be THE LAST middleware before we hit the database and query execution actually occurs."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(defn- user-attribute
+  "Which user attribute should we use for this RouterDB?"
+  [db-or-id]
+  (t2/select-one-fn :user_attribute :model/DatabaseRouter :db_id (u/the-id db-or-id)))
+
+(defn router-db-or-id->mirror-db-id
+  [current-user db-or-id]
+  (when-let [attr-name (user-attribute db-or-id)]
+    (let [database-name #p (get (:login_attributes @current-user) attr-name)]
+      (if (= database-name "__METABASE_ROUTER__")
+        (u/the-id db-or-id)
+        (or (t2/select-one-pk :model/Database
+                              :router_database_id (u/the-id db-or-id)
+                              :name database-name)
+            (throw (ex-info "No MirrorDB found for user attribute" {:database-name database-name
+                                                                    :router-database-id (u/the-id db-or-id)})))))))
+
+(defenterprise swap-mirror-db-middleware
+  "Must be the last middleware before we actually hit the database. If a Router Database is specified, swaps out the
+   Metadata Provider for one that has the appropriate mirror database."
+  :feature :database-routing
+  [qp]
+  (fn [query rff]
+    (if-let [mirror-db-id (:mirror-database/id query)]
+      (let [current-database (lib.metadata/database (qp.store/metadata-provider))
+            rff* (fn [metadata]
+                   (binding [qp.store/*TESTS-ONLY-allow-replacing-metadata-provider* true]
+                     (qp.store/with-metadata-provider (u/id current-database)
+                       (rff metadata))))]
+        (binding [qp.store/*TESTS-ONLY-allow-replacing-metadata-provider* true]
+          (qp.store/with-metadata-provider mirror-db-id
+            (qp query rff*))))
+      (qp query rff))))
+
+(defenterprise attach-mirror-db-middleware
+  "Pre-processing middleware. Calculates the mirror database that should be used for this query, e.g. for caching
+  purposes. Does not make any changes to the query besides (possibly) adding a `:mirror-database/id` key."
+  :feature :database-routing
+  [query]
+  (let [database (lib.metadata/database (qp.store/metadata-provider))
+        mirror-db-id (router-db-or-id->mirror-db-id api/*current-user* database)]
+    (cond-> query
+      mirror-db-id (assoc :mirror-database/id mirror-db-id))))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -24,7 +24,7 @@
                        (rff metadata))))]
         (binding [qp.store/*DANGER-allow-replacing-metadata-provider* true]
           (qp.store/with-metadata-provider mirror-db-id
-            (qp (assoc query :database mirror-db-id) rff*))))
+            (qp query rff*))))
       (qp query rff))))
 
 (defenterprise attach-mirror-db-middleware

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -10,7 +10,7 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]))
 
-(defenterprise swap-mirror-db-middleware
+(defenterprise swap-mirror-db
   "Must be the last middleware before we actually hit the database. If a Router Database is specified, swaps out the
    Metadata Provider for one that has the appropriate mirror database."
   :feature :database-routing
@@ -24,7 +24,7 @@
                        (rff metadata))))]
         (binding [qp.store/*DANGER-allow-replacing-metadata-provider* true]
           (qp.store/with-metadata-provider mirror-db-id
-            (qp query rff*))))
+            (qp (assoc query :database mirror-db-id) rff*))))
       (qp query rff))))
 
 (defenterprise attach-mirror-db-middleware

--- a/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
@@ -28,5 +28,5 @@
   "Enterprise version. Returns a hash input that will be used for fields subject to database routing."
   :feature :database-routing
   [field]
-  (when-let [mirror-db-id (some->> field u/the-id field/field-id->database-id (router-db-or-id->mirror-db-id @api/*current-user*))]
+  (when-let [mirror-db-id (some->> field u/the-id field/field-id->database-id (router-db-or-id->mirror-db-id api/*current-user*))]
     {:mirror-db-id mirror-db-id}))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
@@ -1,6 +1,9 @@
 (ns metabase-enterprise.database-routing.model
   (:require
    [metabase.models.interface :as mi]
+   [metabase-enterprise.database-routing.common :refer [router-db-or-id->mirror-db-id]]
+   [metabase.api.common :as api]
+   [metabase.models.field :as field]
    [metabase.premium-features.core :refer [defenterprise]]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -20,3 +23,10 @@
                             :database_id  [:in (map :id databases)]))
    :id
    {:default nil}))
+
+(defenterprise hash-input-for-database-routing
+  "Enterprise version. Returns a hash input that will be used for fields subject to database routing."
+  :feature :database-routing
+  [field]
+  (when-let [mirror-db-id (some->> field u/the-id field/field-id->database-id (router-db-or-id->mirror-db-id @api/*current-user*))]
+    {:mirror-db-id mirror-db-id}))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
@@ -1,10 +1,11 @@
 (ns metabase-enterprise.database-routing.model
   (:require
-   [metabase.models.interface :as mi]
    [metabase-enterprise.database-routing.common :refer [router-db-or-id->mirror-db-id]]
    [metabase.api.common :as api]
    [metabase.models.field :as field]
+   [metabase.models.interface :as mi]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 

--- a/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
@@ -104,13 +104,14 @@
               :else
               role)))))))
 
-(defenterprise hash-key-for-impersonation
+(defenterprise hash-input-for-impersonation
   "Returns a hash-key for FieldValues if the current user uses impersonation for the database."
   :feature :advanced-permissions
-  [field-id]
+  [field]
   ;; Include the role in the hash key, so that we can cache the results of the query for each role.
-  (let [db-id (field/field-id->database-id field-id)]
-    (str (hash [field-id (connection-impersonation-role db-id)]))))
+  (let [db-id (field/field-id->database-id (u/the-id field))]
+    (when-let [role (and api/*current-user-id* (connection-impersonation-role db-id))]
+      {:impersonation-role role})))
 
 (defenterprise set-role-if-supported!
   "Executes a `USE ROLE` or similar statement on the given connection, if connection impersonation is enabled for the

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -79,60 +79,9 @@
                                            [:dimension [:field field-id _]] field-id))]
                     {k (get login-attributes k)})))])))
 
-(defenterprise field-id->field-values-for-current-user
-  "Fetch *existing* FieldValues for a sequence of `field-ids` for the current User. Values are returned as a map of
-    {field-id FieldValues-instance}
-  Returns `nil` if `field-ids` is empty or no matching FieldValues exist."
-  :feature :sandboxes
-  [field-ids]
-  (let [fields                   (when (seq field-ids)
-                                   (t2/hydrate (t2/select :model/Field :id [:in (set field-ids)]) :table))
-        {unsandboxed-fields false
-         sandboxed-fields   true} (group-by (comp boolean field-is-sandboxed?) fields)]
-    (merge
-     ;; use the normal OSS batched implementation for any Fields that aren't subject to sandboxing.
-     (when (seq unsandboxed-fields)
-       (params.field-values/default-field-id->field-values-for-current-user
-        (map u/the-id unsandboxed-fields)))
-     ;; for sandboxed fields, fetch the sandboxed values individually.
-     (into {} (for [{field-id :id, :as field} sandboxed-fields]
-                [field-id (select-keys (params.field-values/get-or-create-advanced-field-values! :sandbox field)
-                                       [:values :human_readable_values :field_id])])))))
-
-(defenterprise get-or-create-field-values-for-current-user!*
-  "Fetch cached FieldValues for a `field`, creating them if needed if the Field should have FieldValues. These
-  should be filtered as appropriate for the current User (currently this only applies to the EE impl)."
+(defenterprise hash-input-for-sandbox
+  "Returns a hash-input for FieldValues if the field is sandboxed."
   :feature :sandboxes
   [field]
-  (cond
-    (field-is-sandboxed? field)
-    (params.field-values/get-or-create-advanced-field-values! :sandbox field)
-
-    ;; Impersonation can have row-level security enforced by the database, so we still need to store field values per-user.
-    ;; TODO: only do this for DBs with impersonation in effect
-    (and api/*current-user-id*
-         (impersonation/impersonated-user?))
-    (params.field-values/get-or-create-advanced-field-values! :impersonation field)
-
-    :else
-    (params.field-values/default-get-or-create-field-values-for-current-user! field)))
-
-(defenterprise hash-key-for-linked-filters
-  "Returns a hash-key for linked-filter FieldValues if the field is sandboxed, otherwise fallback to the OSS impl."
-  :feature :sandboxes
-  [field-id constraints]
-  (let [field (t2/select-one :model/Field :id field-id)]
-    (if (field-is-sandboxed? field)
-      (str (hash (concat [field-id
-                          constraints]
-                         (field->gtap-attributes-for-current-user field))))
-      (field-values/default-hash-key-for-linked-filters field-id constraints))))
-
-(defenterprise hash-key-for-sandbox
-  "Returns a hash-key for FieldValues if the field is sandboxed, otherwise fallback to the OSS impl."
-  :feature :sandboxes
-  [field-id]
-  (let [field (t2/select-one :model/Field :id field-id)]
-    (when (field-is-sandboxed? field)
-      (str (hash (concat [field-id]
-                         (field->gtap-attributes-for-current-user field)))))))
+  (when (field-is-sandboxed? field)
+    {:sandbox-attributes (field->gtap-attributes-for-current-user field)}))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -1,16 +1,12 @@
 (ns metabase-enterprise.sandbox.models.params.field-values
   (:require
-   [metabase-enterprise.impersonation.core :as impersonation]
    [metabase-enterprise.sandbox.api.table :as table]
    [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions
     :as row-level-restrictions]
    [metabase.api.common :as api]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.field :as field]
-   [metabase.models.field-values :as field-values]
-   [metabase.models.params.field-values :as params.field-values]
    [metabase.premium-features.core :refer [defenterprise]]
-   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (comment api/keep-me)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
@@ -20,7 +20,7 @@
             (let [hash-key-1 (str
                               (hash
                                (merge
-                                (params.field-values/hash-input-for-field-values field nil)
+                                (params.field-values/hash-input-for-field-values field)
                                 ;; this is already included above, but we're just making sure.
                                 (impersonation/hash-input-for-impersonation field))))]
               (params.field-values/get-or-create-field-values! field)
@@ -38,7 +38,7 @@
                   (let [hash-key-2 (str
                                     (hash
                                      (merge
-                                      (params.field-values/hash-input-for-field-values field nil)
+                                      (params.field-values/hash-input-for-field-values field)
                                       ;; again, this is already included above, but we're adding it for documentation
                                       (impersonation/hash-input-for-impersonation field))))]
                     (params.field-values/get-or-create-field-values! field)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
@@ -10,31 +10,41 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(deftest get-or-create-advanced-field-values!
+(deftest get-or-create-field-values!-test
   (mt/with-premium-features #{:advanced-permissions}
     (let [field (t2/select-one :model/Field :id (mt/id :categories :id))]
       (try
         (testing "creates new field values for user using impersonation"
           (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                          :attributes     {"impersonation_attr" "impersonation_role"}}
-            (let [hash-key-1 (impersonation/hash-key-for-impersonation (u/the-id field))]
-              (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+            (let [hash-key-1 (str
+                              (hash
+                               (merge
+                                (params.field-values/hash-input-for-field-values field nil)
+                                ;; this is already included above, but we're just making sure.
+                                (impersonation/hash-input-for-impersonation field))))]
+              (params.field-values/get-or-create-field-values! field)
               (is (= #{hash-key-1}
                      (into #{}
-                           (map :hash_key (t2/select :model/FieldValues :field_id (u/the-id field) :type :impersonation)))))
+                           (map :hash_key (t2/select :model/FieldValues :field_id (u/the-id field) :type :advanced)))))
 
               (testing "calling a second time shouldn't create new FieldValues"
-                (params.field-values/get-or-create-advanced-field-values! :impersonation field)
-                (is (= 1 (t2/count :model/FieldValues :field_id (u/the-id field) :type :impersonation))))
+                (params.field-values/get-or-create-field-values! field)
+                (is (= 1 (t2/count :model/FieldValues :field_id (u/the-id field) :type :advanced))))
 
               (testing "changing the impersonation role creates new FieldValues"
                 (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                                :attributes     {"impersonation_attr" "impersonation_role_2"}}
-                  (let [hash-key-2 (impersonation/hash-key-for-impersonation (u/the-id field))]
-                    (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+                  (let [hash-key-2 (str
+                                    (hash
+                                     (merge
+                                      (params.field-values/hash-input-for-field-values field nil)
+                                      ;; again, this is already included above, but we're adding it for documentation
+                                      (impersonation/hash-input-for-impersonation field))))]
+                    (params.field-values/get-or-create-field-values! field)
                     (is (= #{hash-key-1 hash-key-2}
                            (into #{}
-                                 (map :hash_key (t2/select :model/FieldValues :field_id (u/the-id field) :type :impersonation)))))
-                    (is (= 2 (t2/count :model/FieldValues :field_id (u/the-id field) :type :impersonation)))))))))
+                                 (map :hash_key (t2/select :model/FieldValues :field_id (u/the-id field) :type :advanced)))))
+                    (is (= 2 (t2/count :model/FieldValues :field_id (u/the-id field) :type :advanced)))))))))
         (finally
-          (t2/delete! :model/FieldValues :field_id (u/the-id field) :type :impersonation))))))
+          (t2/delete! :model/FieldValues :field_id (u/the-id field) :type :advanced))))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.database-routing.e2e-test
   (:require
    [clojure.java.jdbc :as jdbc]
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer [deftest is]]
    [metabase-enterprise.sandbox.test-util :as sandbox.test-util]
    [metabase.db :as mdb]
    [metabase.driver.h2]
@@ -14,7 +14,7 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(defmacro with-temp-dbs
+(defmacro with-temp-dbs!
   "Creates databases like `mt/with-temp`, but creating an actual underlying H2 database with a single table,
   `my_database_name`, with a single column, `str`."
   [bindings & body]
@@ -51,7 +51,7 @@
           (sandbox.test-util/with-user-attributes!
             :lucky
             {"db_name" "bar"}
-            (with-temp-dbs [router-db mirror-db-1 mirror-db-2]
+            (with-temp-dbs! [router-db mirror-db-1 mirror-db-2]
               ;; configure the Mirror Databases
               (t2/update! :model/Database (u/the-id mirror-db-1) {:name "foo" :router_database_id (u/the-id router-db)})
               (t2/update! :model/Database (u/the-id mirror-db-2) {:name "bar" :router_database_id (u/the-id router-db)})
@@ -80,7 +80,7 @@
       (sandbox.test-util/with-user-attributes!
         :crowberto
         {"db_name" "nonexistent_database_name"}
-        (with-temp-dbs [router-db mirror-db]
+        (with-temp-dbs! [router-db mirror-db]
           (t2/update! :model/Database (u/the-id mirror-db) {:name "my database name" :router_database_id (u/the-id router-db)})
           (sync/sync-database! router-db)
           (mt/with-temp [:model/DatabaseRouter _ {:database_id (u/the-id router-db)
@@ -109,7 +109,7 @@
         (sandbox.test-util/with-user-attributes!
           :rasta
           {"db_name" "mirror database"}
-          (with-temp-dbs [router-db mirror-db]
+          (with-temp-dbs! [router-db mirror-db]
             (t2/update! :model/Database (u/the-id mirror-db) {:name "mirror database" :router_database_id (u/the-id router-db)})
             (sync/sync-database! router-db)
             (execute-statement! router-db "INSERT INTO \"my_database_name\" (str) VALUES ('router')")

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer [deftest is]]
-   [metabase-enterprise.sandbox.test-util :as sandbox.test-util]
+   [metabase-enterprise.test :as met]
    [metabase.db :as mdb]
    [metabase.driver.h2]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -42,19 +42,19 @@
 (deftest mirror-databases-get-used
   (mt/with-premium-features #{:database-routing}
     (binding [metabase.driver.h2/*allow-testing-h2-connections* true]
-      (sandbox.test-util/with-user-attributes!
+      (met/with-user-attributes!
         :crowberto
         {"db_name" "__METABASE_ROUTER__"}
-        (sandbox.test-util/with-user-attributes!
+        (met/with-user-attributes!
           :rasta
-          {"db_name" "foo"}
-          (sandbox.test-util/with-user-attributes!
+          {"db_name" "mirror-db-1"}
+          (met/with-user-attributes!
             :lucky
-            {"db_name" "bar"}
+            {"db_name" "mirror-db-2"}
             (with-temp-dbs! [router-db mirror-db-1 mirror-db-2]
               ;; configure the Mirror Databases
-              (t2/update! :model/Database (u/the-id mirror-db-1) {:name "foo" :router_database_id (u/the-id router-db)})
-              (t2/update! :model/Database (u/the-id mirror-db-2) {:name "bar" :router_database_id (u/the-id router-db)})
+              (t2/update! :model/Database (u/the-id mirror-db-1) {:name "mirror-db-1" :router_database_id (u/the-id router-db)})
+              (t2/update! :model/Database (u/the-id mirror-db-2) {:name "mirror-db-2" :router_database_id (u/the-id router-db)})
               ;; sync the Router database
               (sync/sync-database! router-db)
               ;; Configure the router database and set up a card that uses it.
@@ -77,7 +77,7 @@
 (deftest an-error-is-thrown-if-user-attribute-is-missing-or-no-match
   (mt/with-premium-features #{:database-routing}
     (binding [metabase.driver.h2/*allow-testing-h2-connections* true]
-      (sandbox.test-util/with-user-attributes!
+      (met/with-user-attributes!
         :crowberto
         {"db_name" "nonexistent_database_name"}
         (with-temp-dbs! [router-db mirror-db]
@@ -103,10 +103,10 @@
 (deftest caching-works
   (mt/with-premium-features #{:database-routing}
     (binding [metabase.driver.h2/*allow-testing-h2-connections* true]
-      (sandbox.test-util/with-user-attributes!
+      (met/with-user-attributes!
         :crowberto
         {"db_name" "__METABASE_ROUTER__"}
-        (sandbox.test-util/with-user-attributes!
+        (met/with-user-attributes!
           :rasta
           {"db_name" "mirror database"}
           (with-temp-dbs! [router-db mirror-db]

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -1,0 +1,73 @@
+(ns metabase-enterprise.database-routing.e2e-test
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.test :refer [deftest testing is]]
+   [metabase-enterprise.sandbox.test-util :as sandbox.test-util]
+   [metabase.db :as mdb]
+   [metabase.driver.h2]
+   [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [metabase.test.data :as data]
+   [metabase.test.data.one-off-dbs :as one-off-dbs]
+   [metabase.util :as u]))
+
+(defmacro with-blueberries-dbs [bindings & body]
+  (letfn [(wrap [names body]
+            (prn names body)
+            (if (empty? names)
+              `(do ~@body)
+              `(one-off-dbs/with-blueberries-db
+                 (let [~(first names) (data/db)]
+                   ~(wrap (rest names) body)))))]
+    (wrap bindings body)))
+
+(defn execute-statement! [db statement]
+  (sql-jdbc.execute/do-with-connection-with-options
+   :h2
+   (mdb/spec :h2 (:details db))
+   {:write? true}
+   (fn [^java.sql.Connection conn]
+     (jdbc/execute! {:connection conn} [statement]))))
+
+(deftest mirror-databases-get-used
+  (mt/with-premium-features #{:database-routing}
+    (binding [metabase.driver.h2/*allow-testing-h2-connections* true]
+      (sandbox.test-util/with-user-attributes!
+        :rasta
+        {"db_name" "foo"}
+        (sandbox.test-util/with-user-attributes!
+          :lucky
+          {"db_name" "bar"}
+          (with-blueberries-dbs [router-db mirror-db-1 mirror-db-2]
+            (doseq [db [router-db mirror-db-1 mirror-db-2]]
+              (execute-statement! db "CREATE USER IF NOT EXISTS GUEST PASSWORD 'guest';"))
+            (mt/with-temp [:model/Database router-db {:engine  :h2
+                                                      :details (assoc (:details router-db)
+                                                                      :USER "GUEST")}
+                           :model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                    :user_attribute "db_name"}
+                           :model/Database mirror-db-1 {:name               "foo"
+                                                        :router_database_id (u/the-id router-db)
+                                                        :engine             :h2
+                                                        :details            (assoc (:details mirror-db-1)
+                                                                                   :USER "GUEST")}
+                           :model/Database mirror-db-2 {:name               "bar"
+                                                        :router_database_id (u/the-id router-db)
+                                                        :engine             :h2
+                                                        :details            (assoc (:details mirror-db-2)
+                                                                                   :USER "GUEST")}
+                           :model/Card card {:name          "Some Name"
+                                             :dataset_query {:database (u/the-id router-db)
+                                                             :type     :native
+                                                             :native   {:query "select * from blueberries_consumed"}}}]
+              (sync/sync-database! router-db)
+              (doseq [db [router-db mirror-db-1 mirror-db-2]]
+                (execute-statement! db "CREATE USER IF NOT EXISTS GUEST PASSWORD 'guest';"))
+              (execute-statement! router-db "INSERT INTO blueberries_consumed (str) VALUES ('router')")
+              (execute-statement! mirror-db-1 "INSERT INTO blueberries_consumed (str) VALUES ('mirror-1')")
+              (execute-statement! mirror-db-2 "INSERT INTO blueberries_consumed (str) VALUES ('mirror-2')")
+              (let [response (mt/user-http-request :rasta :post 202 (str "card/" (u/the-id card) "/query"))]
+                (is (= [["mirror-1"]] (mt/rows response))))
+              (let [response (mt/user-http-request :lucky :post 202 (str "card/" (u/the-id card) "/query"))]
+                (is (= [["mirror-2"]] (mt/rows response)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -6,6 +6,7 @@
    [metabase.db :as mdb]
    [metabase.driver.h2]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.query-processor :as qp]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.data :as data]
@@ -13,7 +14,10 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(defmacro with-temp-dbs [bindings & body]
+(defmacro with-temp-dbs
+  "Creates databases like `mt/with-temp`, but creating an actual underlying H2 database with a single table,
+  `my_database_name`, with a single column, `str`."
+  [bindings & body]
   (letfn [(wrap [names body]
             (if (empty? names)
               `(do ~@body)
@@ -48,16 +52,18 @@
             :lucky
             {"db_name" "bar"}
             (with-temp-dbs [router-db mirror-db-1 mirror-db-2]
+              ;; configure the Mirror Databases
               (t2/update! :model/Database (u/the-id mirror-db-1) {:name "foo" :router_database_id (u/the-id router-db)})
               (t2/update! :model/Database (u/the-id mirror-db-2) {:name "bar" :router_database_id (u/the-id router-db)})
+              ;; sync the Router database
               (sync/sync-database! router-db)
+              ;; Configure the router database and set up a card that uses it.
               (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
                                                       :user_attribute "db_name"}
                              :model/Card card {:name          "Some Name"
                                                :dataset_query {:database (u/the-id router-db)
                                                                :type     :query
                                                                :query    {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}}}]
-                (sync/sync-database! router-db)
                 (execute-statement! router-db "INSERT INTO \"my_database_name\" (str) VALUES ('router')")
                 (execute-statement! mirror-db-1 "INSERT INTO \"my_database_name\" (str) VALUES ('mirror-1')")
                 (execute-statement! mirror-db-2 "INSERT INTO \"my_database_name\" (str) VALUES ('mirror-2')")
@@ -67,3 +73,86 @@
                   (is (= [["mirror-2"]] (mt/rows response))))
                 (let [response (mt/user-http-request :crowberto :post 202 (str "card/" (u/the-id card) "/query"))]
                   (is (= [["router"]] (mt/rows response))))))))))))
+
+(deftest an-error-is-thrown-if-user-attribute-is-missing-or-no-match
+  (mt/with-premium-features #{:database-routing}
+    (binding [metabase.driver.h2/*allow-testing-h2-connections* true]
+      (sandbox.test-util/with-user-attributes!
+        :crowberto
+        {"db_name" "nonexistent_database_name"}
+        (with-temp-dbs [router-db mirror-db]
+          (t2/update! :model/Database (u/the-id mirror-db) {:name "my database name" :router_database_id (u/the-id router-db)})
+          (sync/sync-database! router-db)
+          (mt/with-temp [:model/DatabaseRouter _ {:database_id (u/the-id router-db)
+                                                  :user_attribute "db_name"}]
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Anonymous access to a Router Database is prohibited."
+                                  (qp/process-query {:database (u/the-id router-db)
+                                                     :type :query
+                                                     :query {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}})))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"No Mirror Database found for user attribute"
+                                  (mt/with-test-user :crowberto
+                                    (qp/process-query {:database (u/the-id router-db)
+                                                       :type :query
+                                                       :query {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}}))))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"User attribute missing"
+                                  (mt/with-test-user :rasta
+                                    (qp/process-query {:database (u/the-id router-db)
+                                                       :type :query
+                                                       :query {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}}))))))))))
+
+(deftest caching-works
+  (mt/with-premium-features #{:database-routing}
+    (binding [metabase.driver.h2/*allow-testing-h2-connections* true]
+      (sandbox.test-util/with-user-attributes!
+        :crowberto
+        {"db_name" "__METABASE_ROUTER__"}
+        (sandbox.test-util/with-user-attributes!
+          :rasta
+          {"db_name" "mirror database"}
+          (with-temp-dbs [router-db mirror-db]
+            (t2/update! :model/Database (u/the-id mirror-db) {:name "mirror database" :router_database_id (u/the-id router-db)})
+            (sync/sync-database! router-db)
+            (execute-statement! router-db "INSERT INTO \"my_database_name\" (str) VALUES ('router')")
+            (execute-statement! mirror-db "INSERT INTO \"my_database_name\" (str) VALUES ('mirror')")
+            (mt/with-temp [:model/DatabaseRouter _ {:database_id (u/the-id router-db)
+                                                    :user_attribute "db_name"}]
+
+              (mt/with-test-user :crowberto
+                (is (= [["router"]]
+                       (-> (qp/process-query {:database (u/the-id router-db)
+                                              :type :query
+                                              :query {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}
+                                              :cache-strategy {:type             :ttl
+                                                               :multiplier       60
+                                                               :avg-execution-ms 1000
+                                                               :min-duration-ms  1}})
+                           :data
+                           :rows))))
+              (mt/with-test-user :crowberto
+                (is (=? {:cache/details {:cached true}
+                         :data {:rows [["router"]]}}
+                        (qp/process-query {:database (u/the-id router-db)
+                                           :type :query
+                                           :query {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}
+                                           :cache-strategy {:type             :ttl
+                                                            :multiplier       60
+                                                            :avg-execution-ms 1000
+                                                            :min-duration-ms  1}}))))
+              (mt/with-test-user :rasta
+                (is (=? {:data {:rows [["mirror"]]}}
+                        (qp/process-query {:database (u/the-id router-db)
+                                           :type :query
+                                           :query {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}
+                                           :cache-strategy {:type             :ttl
+                                                            :multiplier       60
+                                                            :avg-execution-ms 1000
+                                                            :min-duration-ms  1}})))
+                (is (=? {:cache/details {:cached true}
+                         :data {:rows [["mirror"]]}}
+                        (qp/process-query {:database (u/the-id router-db)
+                                           :type :query
+                                           :query {:source-table (t2/select-one-pk :model/Table :db_id (u/the-id router-db))}
+                                           :cache-strategy {:type             :ttl
+                                                            :multiplier       60
+                                                            :avg-execution-ms 1000
+                                                            :min-duration-ms  1}})))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
@@ -153,7 +153,7 @@
           (is (some? (:values (mt/user-http-request :rasta :get 200 (str "field/" (:id field) "/values")))))
           (is (= 1 (t2/count :model/FieldValues
                              :field_id (:id field)
-                             :type :sandbox)))))
+                             :type :advanced)))))
 
       (testing "Do different users has different sandbox FieldValues"
         (let [password (mt/random-name)]
@@ -166,7 +166,7 @@
               ;; create another one for the new user
               (is (= 2 (t2/count :model/FieldValues
                                  :field_id (:id field)
-                                 :type :sandbox)))))))
+                                 :type :advanced)))))))
 
       (testing "Do we invalidate the cache when full FieldValues change"
         (try
@@ -189,11 +189,11 @@
         (#'field-values/clear-advanced-field-values-for-field! field)
         ;; make sure we have a cache
         (mt/user-http-request :rasta :get 200 (str "field/" (:id field) "/values"))
-        (let [old-sandbox-fv-id (t2/select-one-pk :model/FieldValues :field_id (:id field) :type :sandbox)]
+        (let [old-sandbox-fv-id (t2/select-one-pk :model/FieldValues :field_id (:id field) :type :advanced)]
           (with-redefs [field-values/advanced-field-values-expired? (fn [fv]
                                                                       (= (:id fv) old-sandbox-fv-id))]
             (mt/user-http-request :rasta :get 200 (str "field/" (:id field) "/values"))
             ;; did the old one get deleted?
             (is (not (t2/exists? :model/FieldValues :id old-sandbox-fv-id)))
             ;; make sure we created a new one
-            (is (= 1 (t2/count :model/FieldValues :field_id (:id field) :type :sandbox)))))))))
+            (is (= 1 (t2/count :model/FieldValues :field_id (:id field) :type :advanced)))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
@@ -17,7 +17,7 @@
           (is (= {:values          [["African"] ["American"]]
                   :has_more_values false}
                  (mt/$ids (chain-filter/chain-filter %categories.name nil))))
-          (is (= 1 (t2/count :model/FieldValues :field_id (mt/id :categories :name) :type :sandbox))))
+          (is (= 1 (t2/count :model/FieldValues :field_id (mt/id :categories :name) :type :advanced))))
 
         (testing "search"
           (is (= {:values          [["African"] ["American"]]
@@ -31,11 +31,11 @@
                       :has_more_values false}
                      (mt/$ids (chain-filter/chain-filter %categories.name
                                                          [{:field-id %categories.id :op := :value 3}])))))
-            (is (= 1 (t2/count :model/FieldValues :field_id (mt/id :categories :name) :type :linked-filter))))
+            (is (= 2 (t2/count :model/FieldValues :field_id (mt/id :categories :name) :type :advanced))))
 
           (testing "creates another linked-filter FieldValues if sandboxed"
             (is (= {:values          []
                     :has_more_values false}
                    (mt/$ids (chain-filter/chain-filter %categories.name
                                                        [{:field-id %categories.id :op := :value 3}]))))
-            (is (= 2 (t2/count :model/FieldValues :field_id (mt/id :categories :name) :type :linked-filter)))))))))
+            (is (= 3 (t2/count :model/FieldValues :field_id (mt/id :categories :name) :type :advanced)))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -13,107 +13,93 @@
 (set! *warn-on-reflection* true)
 
 (deftest get-or-create-advanced-field-values!-test
-  (doseq [fv-type [:sandbox :linked-filter]]
-    (testing "create a new field values and fix up the human readable values"
-      (met/with-gtaps! {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:and
-                                                                                        [:> $id 3]
-                                                                                        [:< $id 6]]})}}}
-        ;; the categories-id doesn't have a field values, we fake it with a full fieldvalues to make it easier to test
-        (t2/insert! :model/FieldValues {:type                  :full
-                                        :field_id              (mt/id :categories :id)
-                                        :values                (range 10)
-                                        :human_readable_values (map #(str "id_" %) (range 10))})
-        (let [categories-id (mt/id :categories :id)
-              f             (t2/select-one :model/Field :id (mt/id :categories :id))
-              card-id       (-> f :table_id (#'ee-params.field-values/table-id->gtap) :card :id)
-              fv            (params.field-values/get-or-create-advanced-field-values! fv-type f)]
-          (is (= [(range 4 6)]
+  (testing "create a new field values and fix up the human readable values"
+    (met/with-gtaps! {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:and
+                                                                                      [:> $id 3]
+                                                                                      [:< $id 6]]})}}}
+      ;; the categories-id doesn't have a field values, we fake it with a full fieldvalues to make it easier to test
+      (t2/insert! :model/FieldValues {:type                  :full
+                                      :field_id              (mt/id :categories :id)
+                                      :values                (range 10)
+                                      :human_readable_values (map #(str "id_" %) (range 10))})
+      (let [categories-id (mt/id :categories :id)
+            f             (t2/select-one :model/Field :id (mt/id :categories :id))
+            card-id       (-> f :table_id (#'ee-params.field-values/table-id->gtap) :card :id)
+            fv            (params.field-values/get-or-create-field-values! f)]
+        (is (= [(range 4 6)]
+               (t2/select-fn-vec :values :model/FieldValues
+                                 :field_id categories-id :type :advanced
+                                 {:order-by [:id]})))
+        (is (= [4 5] (:values fv)))
+        (is (= ["id_4" "id_5"] (:human_readable_values fv)))
+        (is (some? (:hash_key fv)))
+
+        (testing "call second time shouldn't create a new FieldValues"
+          (params.field-values/get-or-create-field-values!
+           (t2/select-one :model/Field :id (mt/id :categories :id)))
+          (is (= 1 (t2/count :model/FieldValues :field_id categories-id :type :advanced))))
+
+        (testing "after changing the question, should create new FieldValues"
+          (let [new-query (mt/mbql-query categories
+                            {:filter [:and [:> $id 1] [:< $id 4]]})]
+            (Thread/sleep 1)
+            (t2/update! :model/Card card-id {:dataset_query new-query
+                                             :updated_at    (t/local-date-time)}))
+          (params.field-values/get-or-create-field-values!
+           (t2/select-one :model/Field :id (mt/id :categories :id)))
+          (is (= [(range 4 6)
+                  (range 2 4)]
                  (t2/select-fn-vec :values :model/FieldValues
-                                   :field_id categories-id :type fv-type
-                                   {:order-by [:id]})))
-          (is (= [4 5] (:values fv)))
-          (is (= ["id_4" "id_5"] (:human_readable_values fv)))
-          (is (some? (:hash_key fv)))
-
-          (testing "call second time shouldn't create a new FieldValues"
-            (params.field-values/get-or-create-advanced-field-values!
-             fv-type
-             (t2/select-one :model/Field :id (mt/id :categories :id)))
-            (is (= 1 (t2/count :model/FieldValues :field_id categories-id :type fv-type))))
-
-          (testing "after changing the question, should create new FieldValues"
-            (let [new-query (mt/mbql-query categories
-                              {:filter [:and [:> $id 1] [:< $id 4]]})]
-              (Thread/sleep 1)
-              (t2/update! :model/Card card-id {:dataset_query new-query
-                                               :updated_at    (t/local-date-time)}))
-            (params.field-values/get-or-create-advanced-field-values!
-             fv-type
-             (t2/select-one :model/Field :id (mt/id :categories :id)))
-            (is (= [(range 4 6)
-                    (range 2 4)]
-                   (t2/select-fn-vec :values :model/FieldValues
-                                     :field_id categories-id :type fv-type
-                                     {:order-by [:id]})))))))
-
-    (testing "make sure the Fieldvalues respect [field-values/*total-max-length*]"
-      (met/with-gtaps! {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:and
-                                                                                        [:> $id 3]
-                                                                                        [:< $id 6]]})}}}
-        (binding [field-values/*total-max-length* 5]
-          (is (= ["Asian"]
-                 (:values (params.field-values/get-or-create-advanced-field-values!
-                           fv-type
-                           (t2/select-one :model/Field :id (mt/id :categories :name)))))))))))
+                                   :field_id categories-id :type :advanced
+                                   {:order-by [:id]}))))))))
 
 (deftest advanced-field-values-hash-test
   (mt/with-premium-features #{:sandboxes}
     ;; copy at top level so that `with-gtaps-for-user!` does not have to create a new copy every time it gets called
     (mt/with-temp-copy-of-db
       (testing "gtap with remappings"
-        (letfn [(hash-for-user-id [user-id login-attributes field-id]
-                  (met/with-gtaps-for-user! user-id
-                    {:gtaps      {:categories {:remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}}
-                     :attributes login-attributes}
-                    (ee-params.field-values/hash-key-for-sandbox field-id)))]
+        (let [hash-input-for-user-id (fn [user-id login-attributes field]
+                                       (met/with-gtaps-for-user! user-id
+                                         {:gtaps      {:categories {:remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}}
+                                          :attributes login-attributes}
+                                         (ee-params.field-values/hash-input-for-sandbox field)))
+              field (t2/select-one :model/Field (mt/id :categories :name))]
           (mt/with-temp [:model/User {user-id-1 :id} {}
                          :model/User {user-id-2 :id} {}]
 
             (testing "2 users with the same attribute"
               (testing "should have the same hash for the same field"
-                (is (= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
-                       (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :name)))))
-              (testing "should have different hash for different fields"
-                (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :id)))))
+                (is (= (hash-input-for-user-id user-id-1 {"State" "CA"} field)
+                       (hash-input-for-user-id user-id-2 {"State" "CA"} field))))
               (testing "having extra login attributes won't effect the hash"
-                (is (= (hash-for-user-id user-id-1 {"State" "CA"
-                                                    "City"  "San Jose"} (mt/id :categories :name))
-                       (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :name))))))
+                (is (= (hash-input-for-user-id user-id-1 {"State" "CA"
+                                                          "City"  "San Jose"} field)
+                       (hash-input-for-user-id user-id-2 {"State" "CA"} field)))))
 
             (testing "2 users with the same attribute should have the different hash for different "
-              (is (= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
-                     (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :name)))))
+              (is (= (hash-input-for-user-id user-id-1 {"State" "CA"} field)
+                     (hash-input-for-user-id user-id-2 {"State" "CA"} field))))
 
             (testing "same users but the login_attributes change should have different hash"
-              (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
-                        (hash-for-user-id user-id-1 {"State" "NY"} (mt/id :categories :name)))))
+              (is (not= (hash-input-for-user-id user-id-1 {"State" "CA"} field)
+                        (hash-input-for-user-id user-id-1 {"State" "NY"} field))))
 
             (testing "2 users with different login_attributes should have different hash"
-              (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
-                        (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name))))
-              (is (not= (hash-for-user-id user-id-1 {} (mt/id :categories :name))
-                        (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name)))))))))))
+              (is (not= (hash-input-for-user-id user-id-1 {"State" "CA"} field)
+                        (hash-input-for-user-id user-id-2 {"State" "NY"} field)))
+              (is (not= (hash-input-for-user-id user-id-1 {} field)
+                        (hash-input-for-user-id user-id-2 {"State" "NY"} field))))))))))
 
 (deftest advanced-field-values-hash-test-2
   (mt/with-premium-features #{:sandboxes}
     (testing "gtap with card and remappings"
       ;; hack so that we don't have to setup all the sandbox permissions the table
       (with-redefs [ee-params.field-values/field-is-sandboxed? (constantly true)]
-        (letfn [(hash-for-user-id-with-attributes [user-id login_attributes field-id]
-                  (mt/with-temp-vals-in-db :model/User user-id {:login_attributes login_attributes}
-                    (request/with-current-user user-id
-                      (ee-params.field-values/hash-key-for-sandbox field-id))))]
+        (let [field (t2/select-one :model/Field (mt/id :categories :name))
+              hash-input-for-user-id-with-attributes (fn [user-id login-attributes field]
+                                                       (mt/with-temp-vals-in-db :model/User user-id {:login_attributes login-attributes}
+                                                         (request/with-current-user user-id
+                                                           (ee-params.field-values/hash-input-for-sandbox field))))]
           (testing "2 users in the same group"
             (mt/with-temp
               [:model/Card                       {card-id :id} {}
@@ -130,100 +116,92 @@
                                                     :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
 
               (testing "with same attributes, the hash should be the same field"
-                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
-
-              (testing "with same attributes, the hash should different for different fields"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
+                (is (= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                       (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field))))
 
               (testing "with different attributes, the hash should be the different"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
+                (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                          (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field))))))
 
-          (testing "gtap with native question"
-            (mt/with-temp
-              [:model/Card                       {card-id :id} {:query_type :native
-                                                                :name "A native query"
-                                                                :dataset_query
-                                                                {:type :native
-                                                                 :database (mt/id)
-                                                                 :native
-                                                                 {:query "SELECT * FROM People WHERE state = {{STATE}}"
-                                                                  :template-tags
-                                                                  {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
-                                                                            :name "STATE"
-                                                                            :display-name "STATE"
-                                                                            :type "text"}}}}}
-               :model/PermissionsGroup           {group-id :id} {}
-               :model/User                       {user-id :id} {}
-               :model/PermissionsGroupMembership _ {:group_id group-id
-                                                    :user_id user-id}
-               :model/GroupTableAccessPolicy     _ {:card_id card-id
-                                                    :group_id group-id
-                                                    :table_id (mt/id :categories)
-                                                    :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]
-              (testing "same users but if the login_attributes change, they should have different hash (#24966)"
-                (is (not= (hash-for-user-id-with-attributes user-id {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id {"State" "NY"} (mt/id :categories :name)))))))
+            (testing "gtap with native question"
+              (mt/with-temp
+                [:model/Card                       {card-id :id} {:query_type :native
+                                                                  :name "A native query"
+                                                                  :dataset_query
+                                                                  {:type :native
+                                                                   :database (mt/id)
+                                                                   :native
+                                                                   {:query "SELECT * FROM People WHERE state = {{STATE}}"
+                                                                    :template-tags
+                                                                    {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
+                                                                              :name "STATE"
+                                                                              :display-name "STATE"
+                                                                              :type "text"}}}}}
+                 :model/PermissionsGroup           {group-id :id} {}
+                 :model/User                       {user-id :id} {}
+                 :model/PermissionsGroupMembership _ {:group_id group-id
+                                                      :user_id user-id}
+                 :model/GroupTableAccessPolicy     _ {:card_id card-id
+                                                      :group_id group-id
+                                                      :table_id (mt/id :categories)
+                                                      :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]
+                (testing "same users but if the login_attributes change, they should have different hash (#24966)"
+                  (is (not= (hash-input-for-user-id-with-attributes user-id {"State" "CA"} field)
+                            (hash-input-for-user-id-with-attributes user-id {"State" "NY"} field))))))
 
-          (testing "2 users in different groups but gtaps use the same card"
-            (mt/with-temp
-              [:model/Card                       {card-id :id} {}
+            (testing "2 users in different groups but gtaps use the same card"
+              (mt/with-temp
+                [:model/Card                       {card-id :id} {}
 
-               ;; user 1 in group 1
-               :model/User                       {user-id-1 :id} {}
-               :model/PermissionsGroup           {group-id-1 :id} {}
-               :model/PermissionsGroupMembership _ {:group_id group-id-1
-                                                    :user_id user-id-1}
-               :model/GroupTableAccessPolicy     _ {:card_id card-id
-                                                    :group_id group-id-1
-                                                    :table_id (mt/id :categories)
-                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
-               ;; user 2 in group 2 with gtap using the same card
-               :model/User                       {user-id-2 :id} {}
-               :model/PermissionsGroup           {group-id-2 :id} {}
-               :model/PermissionsGroupMembership _ {:group_id group-id-2
-                                                    :user_id user-id-2}
-               :model/GroupTableAccessPolicy     _ {:card_id card-id
-                                                    :group_id group-id-2
-                                                    :table_id (mt/id :categories)
-                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
-              (testing "with the same attributes, the hash should be the same"
-                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
+                 ;; user 1 in group 1
+                 :model/User                       {user-id-1 :id} {}
+                 :model/PermissionsGroup           {group-id-1 :id} {}
+                 :model/PermissionsGroupMembership _ {:group_id group-id-1
+                                                      :user_id user-id-1}
+                 :model/GroupTableAccessPolicy     _ {:card_id card-id
+                                                      :group_id group-id-1
+                                                      :table_id (mt/id :categories)
+                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
+                 ;; user 2 in group 2 with gtap using the same card
+                 :model/User                       {user-id-2 :id} {}
+                 :model/PermissionsGroup           {group-id-2 :id} {}
+                 :model/PermissionsGroupMembership _ {:group_id group-id-2
+                                                      :user_id user-id-2}
+                 :model/GroupTableAccessPolicy     _ {:card_id card-id
+                                                      :group_id group-id-2
+                                                      :table_id (mt/id :categories)
+                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+                (testing "with the same attributes, the hash should be the same"
+                  (is (= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                         (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field))))
 
-              (testing "with same attributes, the hash should different for different fields"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
+                (testing "with different attributes, the hash should be the different"
+                  (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                            (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field))))))
 
-              (testing "with different attributes, the hash should be the different"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
-
-          (testing "2 users in different groups and gtaps use 2 different cards"
-            (mt/with-temp
-              [:model/Card                       {card-id-1 :id} {}
-               :model/User                       {user-id-1 :id} {}
-               :model/PermissionsGroup           {group-id-1 :id} {}
-               :model/PermissionsGroupMembership _ {:group_id group-id-1
-                                                    :user_id user-id-1}
-               :model/GroupTableAccessPolicy     _ {:card_id card-id-1
-                                                    :group_id group-id-1
-                                                    :table_id (mt/id :categories)
-                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
-               ;; user 2 in group 2 with gtap using card 2
-               :model/Card                       {card-id-2 :id} {}
-               :model/User                       {user-id-2 :id} {}
-               :model/PermissionsGroup           {group-id-2 :id} {}
-               :model/PermissionsGroupMembership _ {:group_id group-id-2
-                                                    :user_id user-id-2}
-               :model/GroupTableAccessPolicy     _ {:card_id card-id-2
-                                                    :group_id group-id-2
-                                                    :table_id (mt/id :categories)
-                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
-              (testing "the hash are different even though they have the same attribute"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name))))
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name))))))))))))
+            (testing "2 users in different groups and gtaps use 2 different cards"
+              (mt/with-temp
+                [:model/Card                       {card-id-1 :id} {}
+                 :model/User                       {user-id-1 :id} {}
+                 :model/PermissionsGroup           {group-id-1 :id} {}
+                 :model/PermissionsGroupMembership _ {:group_id group-id-1
+                                                      :user_id user-id-1}
+                 :model/GroupTableAccessPolicy     _ {:card_id card-id-1
+                                                      :group_id group-id-1
+                                                      :table_id (mt/id :categories)
+                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
+                 ;; user 2 in group 2 with gtap using card 2
+                 :model/Card                       {card-id-2 :id} {}
+                 :model/User                       {user-id-2 :id} {}
+                 :model/PermissionsGroup           {group-id-2 :id} {}
+                 :model/PermissionsGroupMembership _ {:group_id group-id-2
+                                                      :user_id user-id-2}
+                 :model/GroupTableAccessPolicy     _ {:card_id card-id-2
+                                                      :group_id group-id-2
+                                                      :table_id (mt/id :categories)
+                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+                (testing "the hash are different even though they have the same attribute"
+                  (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                            (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field)))
+                  (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                            (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -4,7 +4,6 @@
    [java-time.api :as t]
    [metabase-enterprise.sandbox.models.params.field-values :as ee-params.field-values]
    [metabase-enterprise.test :as met]
-   [metabase.models.field-values :as field-values]
    [metabase.models.params.field-values :as params.field-values]
    [metabase.request.core :as request]
    [metabase.test :as mt]
@@ -123,85 +122,85 @@
                 (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
                           (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field))))))
 
-            (testing "gtap with native question"
-              (mt/with-temp
-                [:model/Card                       {card-id :id} {:query_type :native
-                                                                  :name "A native query"
-                                                                  :dataset_query
-                                                                  {:type :native
-                                                                   :database (mt/id)
-                                                                   :native
-                                                                   {:query "SELECT * FROM People WHERE state = {{STATE}}"
-                                                                    :template-tags
-                                                                    {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
-                                                                              :name "STATE"
-                                                                              :display-name "STATE"
-                                                                              :type "text"}}}}}
-                 :model/PermissionsGroup           {group-id :id} {}
-                 :model/User                       {user-id :id} {}
-                 :model/PermissionsGroupMembership _ {:group_id group-id
-                                                      :user_id user-id}
-                 :model/GroupTableAccessPolicy     _ {:card_id card-id
-                                                      :group_id group-id
-                                                      :table_id (mt/id :categories)
-                                                      :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]
-                (testing "same users but if the login_attributes change, they should have different hash (#24966)"
-                  (is (not= (hash-input-for-user-id-with-attributes user-id {"State" "CA"} field)
-                            (hash-input-for-user-id-with-attributes user-id {"State" "NY"} field))))))
+          (testing "gtap with native question"
+            (mt/with-temp
+              [:model/Card                       {card-id :id} {:query_type :native
+                                                                :name "A native query"
+                                                                :dataset_query
+                                                                {:type :native
+                                                                 :database (mt/id)
+                                                                 :native
+                                                                 {:query "SELECT * FROM People WHERE state = {{STATE}}"
+                                                                  :template-tags
+                                                                  {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
+                                                                            :name "STATE"
+                                                                            :display-name "STATE"
+                                                                            :type "text"}}}}}
+               :model/PermissionsGroup           {group-id :id} {}
+               :model/User                       {user-id :id} {}
+               :model/PermissionsGroupMembership _ {:group_id group-id
+                                                    :user_id user-id}
+               :model/GroupTableAccessPolicy     _ {:card_id card-id
+                                                    :group_id group-id
+                                                    :table_id (mt/id :categories)
+                                                    :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]
+              (testing "same users but if the login_attributes change, they should have different hash (#24966)"
+                (is (not= (hash-input-for-user-id-with-attributes user-id {"State" "CA"} field)
+                          (hash-input-for-user-id-with-attributes user-id {"State" "NY"} field))))))
 
-            (testing "2 users in different groups but gtaps use the same card"
-              (mt/with-temp
-                [:model/Card                       {card-id :id} {}
+          (testing "2 users in different groups but gtaps use the same card"
+            (mt/with-temp
+              [:model/Card                       {card-id :id} {}
 
                  ;; user 1 in group 1
-                 :model/User                       {user-id-1 :id} {}
-                 :model/PermissionsGroup           {group-id-1 :id} {}
-                 :model/PermissionsGroupMembership _ {:group_id group-id-1
-                                                      :user_id user-id-1}
-                 :model/GroupTableAccessPolicy     _ {:card_id card-id
-                                                      :group_id group-id-1
-                                                      :table_id (mt/id :categories)
-                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
+               :model/User                       {user-id-1 :id} {}
+               :model/PermissionsGroup           {group-id-1 :id} {}
+               :model/PermissionsGroupMembership _ {:group_id group-id-1
+                                                    :user_id user-id-1}
+               :model/GroupTableAccessPolicy     _ {:card_id card-id
+                                                    :group_id group-id-1
+                                                    :table_id (mt/id :categories)
+                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
                  ;; user 2 in group 2 with gtap using the same card
-                 :model/User                       {user-id-2 :id} {}
-                 :model/PermissionsGroup           {group-id-2 :id} {}
-                 :model/PermissionsGroupMembership _ {:group_id group-id-2
-                                                      :user_id user-id-2}
-                 :model/GroupTableAccessPolicy     _ {:card_id card-id
-                                                      :group_id group-id-2
-                                                      :table_id (mt/id :categories)
-                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
-                (testing "with the same attributes, the hash should be the same"
-                  (is (= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
-                         (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field))))
+               :model/User                       {user-id-2 :id} {}
+               :model/PermissionsGroup           {group-id-2 :id} {}
+               :model/PermissionsGroupMembership _ {:group_id group-id-2
+                                                    :user_id user-id-2}
+               :model/GroupTableAccessPolicy     _ {:card_id card-id
+                                                    :group_id group-id-2
+                                                    :table_id (mt/id :categories)
+                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+              (testing "with the same attributes, the hash should be the same"
+                (is (= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                       (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field))))
 
-                (testing "with different attributes, the hash should be the different"
-                  (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
-                            (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field))))))
+              (testing "with different attributes, the hash should be the different"
+                (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                          (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field))))))
 
-            (testing "2 users in different groups and gtaps use 2 different cards"
-              (mt/with-temp
-                [:model/Card                       {card-id-1 :id} {}
-                 :model/User                       {user-id-1 :id} {}
-                 :model/PermissionsGroup           {group-id-1 :id} {}
-                 :model/PermissionsGroupMembership _ {:group_id group-id-1
-                                                      :user_id user-id-1}
-                 :model/GroupTableAccessPolicy     _ {:card_id card-id-1
-                                                      :group_id group-id-1
-                                                      :table_id (mt/id :categories)
-                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
+          (testing "2 users in different groups and gtaps use 2 different cards"
+            (mt/with-temp
+              [:model/Card                       {card-id-1 :id} {}
+               :model/User                       {user-id-1 :id} {}
+               :model/PermissionsGroup           {group-id-1 :id} {}
+               :model/PermissionsGroupMembership _ {:group_id group-id-1
+                                                    :user_id user-id-1}
+               :model/GroupTableAccessPolicy     _ {:card_id card-id-1
+                                                    :group_id group-id-1
+                                                    :table_id (mt/id :categories)
+                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}
                  ;; user 2 in group 2 with gtap using card 2
-                 :model/Card                       {card-id-2 :id} {}
-                 :model/User                       {user-id-2 :id} {}
-                 :model/PermissionsGroup           {group-id-2 :id} {}
-                 :model/PermissionsGroupMembership _ {:group_id group-id-2
-                                                      :user_id user-id-2}
-                 :model/GroupTableAccessPolicy     _ {:card_id card-id-2
-                                                      :group_id group-id-2
-                                                      :table_id (mt/id :categories)
-                                                      :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
-                (testing "the hash are different even though they have the same attribute"
-                  (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
-                            (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field)))
-                  (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
-                            (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field)))))))))))
+               :model/Card                       {card-id-2 :id} {}
+               :model/User                       {user-id-2 :id} {}
+               :model/PermissionsGroup           {group-id-2 :id} {}
+               :model/PermissionsGroupMembership _ {:group_id group-id-2
+                                                    :user_id user-id-2}
+               :model/GroupTableAccessPolicy     _ {:card_id card-id-2
+                                                    :group_id group-id-2
+                                                    :table_id (mt/id :categories)
+                                                    :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+              (testing "the hash are different even though they have the same attribute"
+                (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                          (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field)))
+                (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
+                          (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field)))))))))))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -257,9 +257,10 @@
                     CommandInterface/CALL} cmd-type-nums)
           (nil? remaining-sql)))))
 
-(defn- check-read-only-statements [{:keys [database] {:keys [query]} :native}]
+(defn- check-read-only-statements [{{:keys [query]} :native}]
   (when query
-    (let [query-classification (classify-query database query)]
+    (let [query-classification (classify-query (lib.metadata/database (qp.store/metadata-provider))
+                                               query)]
       (when-not (read-only-statements? query-classification)
         (throw (ex-info "Only SELECT statements are allowed in a native query."
                         {:classification query-classification}))))))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -142,8 +142,7 @@
 (defn should-sync?
   "Should this database be synced?"
   [db]
-  (and (not (is-destination? db))
-       (not= audit/audit-db-id (:id db))))
+  (not (is-destination? db)))
 
 (defn- check-and-schedule-tasks-for-db!
   "(Re)schedule sync operation tasks for `database`. (Existing scheduled tasks will be deleted first.)"
@@ -215,16 +214,6 @@
     ((requiring-resolve 'metabase.sync.task.sync-databases/unschedule-tasks-for-db!) database)
     (catch Throwable e
       (log/error e "Error unscheduling tasks for DB."))))
-
-(defn- is-destination?
-  "Is this database a destination database for some router database?"
-  [db]
-  (boolean (:router_database_id db)))
-
-(defn should-sync?
-  "Should this database be synced?"
-  [db]
-  (not (is-destination? db)))
 
 ;; TODO -- consider whether this should live HERE or inside the `permissions` module.
 (defn- set-new-database-permissions!

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -519,6 +519,3 @@
   "Batch hydrate `Tables` for the given `Database`."
   [_model k databases]
   (hydrate-router-user-attribute k databases))
-
-(defn should-sync? [db]
-  (nil? (:router_database_id db)))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -493,6 +493,7 @@
                   :created-at    true
                   :updated-at    true}
    :search-terms [:name :description]
+   :where        [:= :router_database_id nil]
    :render-terms {:initial-sync-status true}})
 
 (defenterprise hydrate-router-user-attribute

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -216,22 +216,33 @@
     (catch Throwable e
       (log/error e "Error unscheduling tasks for DB."))))
 
+(defn- is-destination?
+  "Is this database a destination database for some router database?"
+  [db]
+  (boolean (:router_database_id db)))
+
+(defn should-sync?
+  "Should this database be synced?"
+  [db]
+  (not (is-destination? db)))
+
 ;; TODO -- consider whether this should live HERE or inside the `permissions` module.
 (defn- set-new-database-permissions!
   [database]
-  (t2/with-transaction [_conn]
-    (let [all-users-group  (perms/all-users-group)
-          non-magic-groups (perms/non-magic-groups)
-          non-admin-groups (conj non-magic-groups all-users-group)]
-      (if (:is_audit database)
-        (doseq [group non-admin-groups]
-          (perms/set-database-permission! group database :perms/view-data :unrestricted)
-          (perms/set-database-permission! group database :perms/create-queries :no)
-          (perms/set-database-permission! group database :perms/download-results :one-million-rows)
-          (perms/set-database-permission! group database :perms/manage-table-metadata :no)
-          (perms/set-database-permission! group database :perms/manage-database :no))
-        (doseq [group non-admin-groups]
-          (perms/set-new-database-permissions! group database))))))
+  (when-not (is-destination? database)
+    (t2/with-transaction [_conn]
+      (let [all-users-group  (perms/all-users-group)
+            non-magic-groups (perms/non-magic-groups)
+            non-admin-groups (conj non-magic-groups all-users-group)]
+        (if (:is_audit database)
+          (doseq [group non-admin-groups]
+            (perms/set-database-permission! group database :perms/view-data :unrestricted)
+            (perms/set-database-permission! group database :perms/create-queries :no)
+            (perms/set-database-permission! group database :perms/download-results :one-million-rows)
+            (perms/set-database-permission! group database :perms/manage-table-metadata :no)
+            (perms/set-database-permission! group database :perms/manage-database :no))
+          (doseq [group non-admin-groups]
+            (perms/set-new-database-permissions! group database)))))))
 
 (t2/define-after-insert :model/Database
   [database]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -324,6 +324,12 @@
   [_field]
   nil)
 
+(defenterprise hash-input-for-database-routing
+  "Returns a hash input that will be used for fields subject to database routing"
+  metabase-enterprise.database-routing.model
+  [_field]
+  nil)
+
 (defn hash-input-for-linked-filters
   "Return a hash-key that will be used for linked-filters fieldvalues."
   [_field constraints]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -87,7 +87,8 @@
   "A class of fieldvalues that has additional constraints/filters."
   #{:sandbox         ;; field values filtered by sandbox permissions
     :impersonation   ;; field values with connection impersonation enforced (db-level roles)
-    :linked-filter}) ;; field values with constraints from other linked parameters on dashboard/embedding
+    :linked-filter
+    :advanced}) ;; field values with constraints from other linked parameters on dashboard/embedding
 
 (def ^:private field-values-types
   "All FieldValues type."
@@ -311,29 +312,23 @@
   {:pre [(advanced-field-values-types (:type fv))]}
   (u.date/older-than? (:created_at fv) advanced-field-values-max-age))
 
-(defenterprise hash-key-for-sandbox
+(defenterprise hash-input-for-sandbox
   "Return a hash-key that will be used for sandboxed fieldvalues."
   metabase-enterprise.sandbox.models.params.field-values
-  [_field-id]
+  [_field]
   nil)
 
-(defenterprise hash-key-for-impersonation
+(defenterprise hash-input-for-impersonation
   "Return a hash-key that will be used for impersonated fieldvalues."
   metabase-enterprise.impersonation.driver
-  [_field-id]
+  [_field]
   nil)
 
-(defn default-hash-key-for-linked-filters
-  "OSS impl of [[hash-key-for-linked-filters]]."
-  [field-id constraints]
-  (str (hash [field-id
-              constraints])))
-
-(defenterprise hash-key-for-linked-filters
+(defn hash-input-for-linked-filters
   "Return a hash-key that will be used for linked-filters fieldvalues."
-  metabase-enterprise.sandbox.models.params.field-values
-  [field-id constraints]
-  (default-hash-key-for-linked-filters field-id constraints))
+  [_field constraints]
+  (when (seq constraints)
+    {:constraints constraints}))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                    CRUD fns                                                    |

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -659,22 +659,22 @@
        :has_more_values false}))
 
 (defn- search-cached-field-values? [field-id constraints]
-  (and (use-cached-field-values? field-id)
-       (isa? (t2/select-one-fn :base_type :model/Field :id field-id) :type/Text)
-       (apply t2/exists? :model/FieldValues (mapcat
-                                             identity
-                                             (merge {:field_id field-id, :values [:not= nil], :human_readable_values nil}
+  (let [field (t2/select-one :model/Field :id field-id)]
+    (and (use-cached-field-values? field-id)
+         (isa? (:base_type field) :type/Text)
+         (apply t2/exists? :model/FieldValues (mapcat
+                                               identity
+                                               (merge {:field_id field-id, :values [:not= nil], :human_readable_values nil}
                                                       ;; if we are doing a search, make sure we only use field values
                                                       ;; when we're certain the fieldvalues we stored are all the possible values.
                                                       ;; otherwise, we should search directly from DB
-                                                    {:has_more_values false}
-                                                    (if-not (empty? constraints)
-                                                      {:type     "linked-filter"
-                                                       :hash_key (params.field-values/hash-key-for-advanced-field-values :linked-filter field-id constraints)}
-                                                      (if-let [hash-key (params.field-values/hash-key-for-advanced-field-values :sandbox field-id nil)]
-                                                        {:type    "sandbox"
-                                                         :hash_key hash-key}
-                                                        {:type "full"})))))))
+                                                      {:has_more_values false}
+                                                      (let [hash-input (params.field-values/hash-input-for-field-values field constraints)
+                                                            hash-key (str (hash hash-input))]
+                                                        (if (not= hash-input {:field-id field-id})
+                                                          {:type "advanced"
+                                                           :hash_key hash-key}
+                                                          {:type "full"}))))))))
 
 (defn- cached-field-values-search
   [field-id query constraints {:keys [limit]}]

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -7,20 +7,15 @@
    [metabase.models.field-values :as field-values]
    [metabase.models.interface :as mi]
    [metabase.plugins.classloader :as classloader]
-   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(defn default-get-or-create-field-values-for-current-user!
-  "OSS implementation; used as a fallback for the EE implementation if the field isn't sandboxed."
-  [field]
-  (field-values/get-or-create-full-field-values! field))
+(declare get-or-create-field-values!)
 
-(defenterprise get-or-create-field-values-for-current-user!*
+(defn get-or-create-field-values-for-current-user!*
   "Fetch cached FieldValues for a `field`, creating them if needed if the Field should have FieldValues."
-  metabase-enterprise.sandbox.models.params.field-values
   [field]
-  (default-get-or-create-field-values-for-current-user! field))
+  (get-or-create-field-values! field))
 
 (defn current-user-can-fetch-field-values?
   "Whether the current User has permissions to fetch FieldValues for a `field`."
@@ -52,23 +47,32 @@
         (update-vals (field-values/batched-get-latest-full-field-values field-ids)
                      #(select-keys % [:field_id :human_readable_values :values]))))))
 
-(defenterprise field-id->field-values-for-current-user
+(defn field-id->field-values-for-current-user
   "Fetch *existing* FieldValues for a sequence of `field-ids` for the current User. Values are returned as a map of
     {field-id FieldValues-instance}
   Returns `nil` if `field-ids` is empty of no matching FieldValues exist."
-  metabase-enterprise.sandbox.models.params.field-values
   [field-ids]
-  (default-field-id->field-values-for-current-user field-ids))
+  (let [fields                 (when (seq field-ids)
+                                 (t2/hydrate (t2/select :model/Field :id [:in (set field-ids)]) :table))
+        {normal-fields   false
+         advanced-fields true} (group-by requires-advanced-field-value? fields)]
+    (merge
+     ;; use the normal OSS batched implementation for any Fields that aren't subject to sandboxing.
+     (when (seq normal-fields)
+       (default-field-id->field-values-for-current-user
+        (map u/the-id normal-fields)))
+     ;; for sandboxed (or otherwise advanced) fields, fetch the sandboxed values individually.
+     (into {} (for [{field-id :id, :as field} advanced-fields]
+                [field-id (select-keys (get-or-create-field-values! field)
+                                       [:values :human_readable_values :field_id])])))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             Advanced FieldValues                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- fetch-advanced-field-values
-  [fv-type field constraints]
-  {:pre [(field-values/advanced-field-values-types fv-type)]}
-  (case fv-type
-    :linked-filter
+  [field constraints]
+  (if (seq constraints)
     (do
       (classloader/require 'metabase.models.params.chain-filter)
       (let [{:keys [values has_more_values]} ((resolve 'metabase.models.params.chain-filter/unremapped-chain-filter)
@@ -81,63 +85,59 @@
          :has_more_values (or (> (count values)
                                  (count limited-values))
                               has_more_values)}))
-
     (field-values/distinct-values field)))
-
-(defn hash-key-for-advanced-field-values
-  "Returns hash-key for Advanced FieldValues by types."
-  [fv-type field-id constraints]
-  (case fv-type
-    :linked-filter
-    (field-values/hash-key-for-linked-filters field-id constraints)
-
-    :sandbox
-    (field-values/hash-key-for-sandbox field-id)
-
-    :impersonation
-    (field-values/hash-key-for-impersonation field-id)))
 
 (defn prepare-advanced-field-values
   "Fetch and construct the FieldValues for `field` with type `fv-type`. This does not do any insertion.
    The human_readable_values of Advanced FieldValues will be automatically fixed up based on the
    list of values and human_readable_values of the full FieldValues of the same field."
-  [fv-type field hash-key constraints]
+  [field hash-key constraints]
   (when-let [{wrapped-values :values :keys [has_more_values]}
-             (fetch-advanced-field-values fv-type field constraints)]
+             (fetch-advanced-field-values field constraints)]
     (let [;; each value in `wrapped-values` is a 1-tuple, so unwrap the raw values for storage
           values                (map first wrapped-values)
           ;; If the full FieldValues of this field have human-readable-values, ensure that we reuse them
           full-field-values     (field-values/get-latest-full-field-values (:id field))
           human-readable-values (field-values/fixup-human-readable-values full-field-values values)]
       {:field_id              (:id field)
-       :type                  fv-type
+       :type                  :advanced
        :hash_key              hash-key
        :has_more_values       has_more_values
        :human_readable_values human-readable-values
        :values                values})))
 
-(defn get-or-create-advanced-field-values!
-  "Fetch an Advanced FieldValues with type `fv-type` for a `field`, creating them if needed.
-  If the fetched FieldValues is expired, we delete them then try to create it."
-  ([fv-type field]
-   (get-or-create-advanced-field-values! fv-type field nil))
+(defn hash-input-for-field-values [field constraints]
+  (merge
+   {:field-id (u/the-id field)}
+   (field-values/hash-input-for-sandbox field)
+   (field-values/hash-input-for-impersonation field)
+   (field-values/hash-input-for-linked-filters field constraints)))
 
-  ([fv-type field constraints]
-   (let [hash-key   (hash-key-for-advanced-field-values fv-type (:id field) constraints)
-         select-kvs {:field_id (:id field) :type fv-type :hash_key hash-key}
-         fv         (mdb.query/select-or-insert! :model/FieldValues select-kvs
-                                                 #(prepare-advanced-field-values fv-type field hash-key constraints))]
-     (cond
-       (nil? fv) nil
+(defn- requires-advanced-field-value?
+  "Given a field, returns falsey if this field should use the normal batched implementation to get field values."
+  [field]
+  (not= (hash-input-for-field-values field nil)
+        {:field-id (u/the-id field)}))
 
-       ;; If it's expired, delete then try to re-create it
-       (field-values/advanced-field-values-expired? fv)
-       (do
-         ;; It's possible another process has already recalculated this, but spurious recalculations are OK.
-         (t2/delete! :model/FieldValues :id (:id fv))
-         (recur fv-type field constraints))
-
-       :else fv))))
+(defn get-or-create-field-values!
+  "Gets or creates field values."
+  ([field] (get-or-create-field-values! field nil))
+  ([field constraints]
+   (let [hash-input (hash-input-for-field-values field constraints)
+         advanced-field-value? (not= hash-input {:field-id (u/the-id field)})]
+     (if advanced-field-value?
+       (let [hash-key (str (hash hash-input))
+             select-kvs {:field_id (:id field) :type :advanced :hash_key hash-key}
+             fv (mdb.query/select-or-insert! :model/FieldValues select-kvs
+                                             #(prepare-advanced-field-values field hash-key constraints))]
+         ;; If it's expired, delete then try to re-create it
+         (if (some-> fv field-values/advanced-field-values-expired?)
+           (do
+             ;; It's possible another process has already recalculated this, but spurious recalculations are OK.
+             (t2/delete! :model/FieldValues :id (:id fv))
+             (recur field constraints))
+           fv))
+       (field-values/get-or-create-full-field-values! field)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Public functions                                                 |
@@ -172,5 +172,5 @@
      :field_id         field-id
      :has_field_values boolean}"
   [field constraints]
-  (-> (get-or-create-advanced-field-values! :linked-filter field constraints)
+  (-> (get-or-create-field-values! field constraints)
       (postprocess-field-values field)))

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -111,7 +111,8 @@
    {:field-id (u/the-id field)}
    (field-values/hash-input-for-sandbox field)
    (field-values/hash-input-for-impersonation field)
-   (field-values/hash-input-for-linked-filters field constraints)))
+   (field-values/hash-input-for-linked-filters field constraints)
+   (field-values/hash-input-for-database-routing field)))
 
 (defn- requires-advanced-field-value?
   "Given a field, returns falsey if this field should use the normal batched implementation to get field values."

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -320,5 +320,6 @@
    :where        [:and
                   :active
                   [:= :visibility_type nil]
+                  [:= :db.router_database_id nil]
                   [:not= :db_id [:inline audit/audit-db-id]]]
    :joins        {:db [:model/Database [:= :db.id :this.db_id]]}})

--- a/src/metabase/query_processor/execute.clj
+++ b/src/metabase/query_processor/execute.clj
@@ -43,7 +43,8 @@
   e.g.
 
     (f (f query rff)) -> (f query rff)"
-  [#'update-used-cards/update-used-cards!
+  [#'qp.middleware.enterprise/swap-mirror-db-middleware
+   #'update-used-cards/update-used-cards!
    #'add-native-form-to-result-metadata
    #'add-preprocessed-query-to-result-metadata-for-userland-query
    #'cache/maybe-return-cached-results

--- a/src/metabase/query_processor/middleware/enterprise.clj
+++ b/src/metabase/query_processor/middleware/enterprise.clj
@@ -14,6 +14,13 @@
 
 ;;; (f query) => query
 
+(defenterprise attach-mirror-db-middleware
+  "Pre-processing middleware. Calculates the mirror database that should be used for this query, e.g. for caching
+  purposes. Does not make any changes to the query besides (possibly) adding a `:mirror-database/id` key."
+  metabase-enterprise.database-routing.middleware
+  [query]
+  query)
+
 (defenterprise apply-sandboxing
   "Pre-processing middleware. Replaces source tables a User was querying against with source queries that (presumably)
   restrict the rows returned, based on presence of sandboxes."
@@ -38,6 +45,13 @@
 ;;;; Execution middleware
 
 ;;; (f qp) => qp
+
+(defenterprise swap-mirror-db-middleware
+  "Must be the last middleware before we actually hit the database. If a Router Database is specified, swaps out the
+   Metadata Provider for one that has the appropriate mirror database."
+  metabase-enterprise.database-routing.middleware
+  [qp]
+  qp)
 
 (defenterprise check-download-permissions
   "Middleware for queries that generate downloads, which checks that the user has permissions to download the results

--- a/src/metabase/query_processor/middleware/enterprise.clj
+++ b/src/metabase/query_processor/middleware/enterprise.clj
@@ -46,12 +46,18 @@
 
 ;;; (f qp) => qp
 
-(defenterprise swap-mirror-db-middleware
+(defenterprise swap-mirror-db
   "Must be the last middleware before we actually hit the database. If a Router Database is specified, swaps out the
    Metadata Provider for one that has the appropriate mirror database."
   metabase-enterprise.database-routing.middleware
   [qp]
   qp)
+
+(defn swap-mirror-db-middleware
+  "Helper middleware wrapper for [[swap-mirror-db]] to make sure we do [[defenterprise]] dispatch correctly on each QP run rather than just once when we combine all of the QP middleware"
+  [qp]
+  (fn [query rff]
+    ((swap-mirror-db qp) query rff)))
 
 (defenterprise check-download-permissions
   "Middleware for queries that generate downloads, which checks that the user has permissions to download the results

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -117,6 +117,7 @@
    (ensure-legacy #'reconcile-bucketing/reconcile-breakout-and-order-by-bucketing)
    (ensure-legacy #'qp.add-source-metadata/add-source-metadata-for-source-queries)
    (ensure-pmbql #'qp.middleware.enterprise/apply-impersonation)
+   (ensure-pmbql #'qp.middleware.enterprise/attach-mirror-db-middleware)
    (ensure-legacy #'qp.middleware.enterprise/apply-sandboxing)
    (ensure-legacy #'qp.persistence/substitute-persisted-query)
    (ensure-legacy #'qp.add-implicit-clauses/add-implicit-clauses)

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -99,7 +99,13 @@
   (This is done so irrelevant info or options that don't affect query results doesn't result in the same query
   producing different hashes.)"
   [query :- [:maybe :map]]
-  (let [{:keys [constraints parameters], :as query} (select-keys query [:database :lib/type :stages :parameters :constraints :impersonation/role])]
+  (let [{:keys [constraints parameters], :as query} (select-keys query [:database
+                                                                        :lib/type
+                                                                        :stages
+                                                                        :parameters
+                                                                        :constraints
+                                                                        :mirror-database/id
+                                                                        :impersonation/role])]
     (cond-> query
       (empty? constraints) (dissoc :constraints)
       true                 (update :parameters sort-parameter-values)

--- a/src/metabase/query_processor/writeback.clj
+++ b/src/metabase/query_processor/writeback.clj
@@ -4,6 +4,7 @@
    [metabase.driver :as driver]
    [metabase.query-processor :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.query-processor.middleware.enterprise :as qp.enterprise]
    [metabase.query-processor.middleware.parameters :as parameters]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.preprocess :as qp.preprocess]
@@ -16,7 +17,8 @@
   "Middleware that happens after compilation, AROUND query execution itself. Has the form
 
     (f (f query rff)) -> (f query rff)"
-  [#'qp.perms/check-query-action-permissions])
+  [#'qp.enterprise/swap-mirror-db-middleware
+   #'qp.perms/check-query-action-permissions])
 
 (defn- apply-middleware [qp middleware-fns]
   (reduce

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -499,7 +499,8 @@
 
 (defmethod search-query-for-model "database"
   [model search-ctx]
-  (base-query-for-model model search-ctx))
+  (-> (base-query-for-model model search-ctx)
+      (sql.helpers/where [:= :router_database_id nil])))
 
 (defmethod search-query-for-model "dashboard"
   [model search-ctx]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -271,10 +271,10 @@
 (deftest ^:parallel check-read-only-test
   (testing "read only statements should pass"
     (are [query] (nil?
-                  (#'h2/check-read-only-statements
-                   {:database (u/the-id (mt/db))
-                    :engine :h2
-                    :native {:query query}}))
+                  (mt/with-metadata-provider (mt/id)
+                    (#'h2/check-read-only-statements
+                     {:engine :h2
+                      :native {:query query}})))
       "select * from orders"
       "select 1; select 2;"
       "explain select * from orders"
@@ -290,11 +290,11 @@
     (are [query] (thrown?
                   clojure.lang.ExceptionInfo
                   #"Only SELECT statements are allowed in a native query."
-                  (#'h2/check-read-only-statements
-                   {:database (u/the-id (mt/db))
-                    :engine :h2
-                    :native {:query query}}))
-      "update venues set name = 'bill'"
+                  (mt/with-metadata-provider (mt/id)
+                    (#'h2/check-read-only-statements
+                     {:engine :h2
+                      :native {:query query}}))
+                  "update venues set name = 'bill'")
       "insert into venues (name) values ('bill')"
       "delete venues"
       "select 1; update venues set name = 'bill'; delete venues;"

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -495,7 +495,7 @@
             (is (= {:values          [["Japanese"] ["Steakhouse"]]
                     :has_more_values false}
                    (chain-filter categories.name {venues.price 4})))
-            (is (= 1 (t2/count :model/FieldValues :field_id field-id :type :linked-filter)))))
+            (is (= 1 (t2/count :model/FieldValues :field_id field-id :type :advanced)))))
 
         (testing "should search with the cached FieldValues when search without constraints"
           (mt/with-temp
@@ -515,11 +515,11 @@
           (testing "should create a linked-filter FieldValues"
             ;; warm up the cache
             (chain-filter categories.name {venues.price 4})
-            (is (= 1 (t2/count :model/FieldValues :field_id field-id :type "linked-filter"))))
+            (is (= 1 (t2/count :model/FieldValues :field_id field-id :type :advanced))))
 
           (testing "should search for the values of linked-filter FieldValues"
             (t2/update! :model/FieldValues {:field_id field-id
-                                            :type     "linked-filter"}
+                                            :type     :advanced}
                         {:values (json/encode ["Good" "Bad"])
                          ;; HACK: currently this is hardcoded to true for linked-filter
                          ;; in [[params.field-values/fetch-advanced-field-values]]
@@ -530,7 +530,7 @@
                    (chain-filter-search categories.name {venues.price 4} "o")))
             (testing "Shouldn't use cached FieldValues if has_more_values=true"
               (t2/update! :model/FieldValues {:field_id field-id
-                                              :type     "linked-filter"}
+                                              :type     :advanced}
                           {:has_more_values true})
               (is (= {:values          [["Steakhouse"]]
                       :has_more_values false}

--- a/test/metabase/query_processor/middleware/remove_inactive_field_refs_test.clj
+++ b/test/metabase/query_processor/middleware/remove_inactive_field_refs_test.clj
@@ -106,7 +106,7 @@
           ;; running the actual tests
           (try
             (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
-              (binding [qp.store/*TESTS-ONLY-allow-replacing-metadata-provider* true]
+              (binding [qp.store/*DANGER-allow-replacing-metadata-provider* true]
                 (qp.store/with-metadata-provider mp
                   ;; running these questions after fields have been removed from the database
                   ;; and the change has been detected by syncing

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -102,7 +102,7 @@
                                 #{:active :description :schema :name :id :db_id :initial_sync_status :display_name
                                   :visibility_type :view_count :created_at :updated_at}
                                 :where        [:= :updated.id :this.id]}},
-                 :Database   #{{:search-model "table", :fields #{:name}, :where [:= :updated.id :this.db_id]}}
+                 :Database   #{{:search-model "table", :fields #{:name :router_database_id}, :where [:= :updated.id :this.db_id]}}
                  :Segment    #{{:search-model "segment"
                                 :fields       #{:description :archived :table_id :name :id :updated_at}
                                 :where        [:= :updated.id :this.id]}}

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -105,25 +105,25 @@
                                      (t2/table-name :model/FieldValues)
                                      [;; expired sandbox fieldvalues
                                       {:field_id   field-id
-                                       :type       "sandbox"
+                                       :type       "advanced"
                                        :hash_key   "random-hash"
                                        :created_at expired-created-at
                                        :updated_at expired-created-at}
                                        ;; expired linked-filter fieldvalues
                                       {:field_id   field-id
-                                       :type       "linked-filter"
+                                       :type       "advanced"
                                        :hash_key   "random-hash"
                                        :created_at expired-created-at
                                        :updated_at expired-created-at}
                                        ;; valid sandbox fieldvalues
                                       {:field_id   field-id
-                                       :type       "sandbox"
+                                       :type       "advanced"
                                        :hash_key   "random-hash"
                                        :created_at now
                                        :updated_at now}
                                        ;; valid linked-filter fieldvalues
                                       {:field_id   field-id
-                                       :type       "linked-filter"
+                                       :type       "advanced"
                                        :hash_key   "random-hash"
                                        :created_at now
                                        :updated_at now}
@@ -165,7 +165,7 @@
 
     ;; Manually add an advanced field values to test whether or not it got deleted later
     (t2/insert! :model/FieldValues {:field_id (mt/id :blueberries_consumed :str)
-                                    :type :sandbox
+                                    :type :advanced
                                     :hash_key "random-key"})
 
     (testing "We mark the field values as :has_more_values when it grows too big."
@@ -226,7 +226,7 @@
                (t2/select-one-fn :has_more_values :model/FieldValues :field_id (mt/id :blueberries_consumed :str)))))
       ;; Manually add an advanced field values to test whether or not it got deleted later
       (t2/insert! :model/FieldValues {:field_id (mt/id :blueberries_consumed :str)
-                                      :type :sandbox
+                                      :type :advanced
                                       :hash_key "random-key"})
       (testing "adding more values even if it's exceed our cardinality limit, "
         (one-off-dbs/insert-rows-and-sync! (one-off-dbs/range-str 50 (+ 100 field-values/*absolute-max-distinct-values-limit*)))


### PR DESCRIPTION
Implements database routing. The high level description of what's going on:

- there are two new enterprise only middlewares for database routing. 
  - One, a preprocessing middleware that just tags the query with the ID of the Destination DB (in this PR, it's called the "Mirror DB", this will change in an upcoming PR though).
  - Two, a postprocessing middleware that actually swaps in the database into the query processor's store. (The QP store is what drivers use to obtain the data needed to connect to the database itself.)
- Caching has been modified to include the mirror database in the cache key.
- Advanced FieldValues needed a bit of a refactor. Previously we could have FieldValues have the type `linked_filter`, `sandbox`, or `impersonation`. This is a pain because some FieldValues are orthogonal - you can have a `linked_filter` that is also for a sandboxed user. We worked around this before by having the definition of `hash-key-for-linked-filter` actually call the `hash-key-for-sandbox` function if necessary, but this gets more and more painful as we add more orthogonal ways to distinguish between different types of FieldValues. As a refactor, I turned `hash-key-for-*` into `hash-input-for-*`, which returns either a map of the relevant information or `nil` if it's not applicable, and then we just merge all the maps together and hash the result. This means that if someone is sandboxed and the database has DB routing on and we're looking at a linked filter, the correct hash is generated.
- syncing is turned off for Mirror Databases