### PR TITLE
Adm 464 disabled input text color

### DIFF
--- a/frontend/src/metabase/reference/components/Formula.module.css
+++ b/frontend/src/metabase/reference/components/Formula.module.css
@@ -22,22 +22,3 @@
 .formulaDefinition {
   overflow: hidden;
 }
-
-.formulaDefinitionEnter {
-  max-height: 0;
-}
-
-.formulaDefinitionEnter.formulaDefinitionEnterActive {
-  /* using 100% max-height breaks the transition */
-  max-height: 150px;
-  transition: max-height 300ms ease-out;
-}
-
-.formulaDefinitionExit {
-  max-height: 150px;
-}
-
-.formulaDefinitionExit.formulaDefinitionExitActive {
-  max-height: 0;
-  transition: max-height 300ms ease-out;
-}

--- a/frontend/src/metabase/reference/components/Formula.tsx
+++ b/frontend/src/metabase/reference/components/Formula.tsx
@@ -1,9 +1,8 @@
 import cx from "classnames";
-import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { t } from "ttag";
 
 import { QueryDefinition } from "metabase/admin/datamodel/components/QueryDefinition";
-import { Icon } from "metabase/ui";
+import { Icon, Transition, type TransitionProps } from "metabase/ui";
 import type { Segment } from "metabase-types/api";
 
 import S from "./Formula.module.css";
@@ -17,6 +16,16 @@ type FormulaProps = FormulaEntityProps & {
   isExpanded: boolean;
   expandFormula: () => void;
   collapseFormula: () => void;
+};
+
+const TRANSITION: TransitionProps["transition"] = {
+  in: {
+    maxHeight: "150px",
+  },
+  out: {
+    maxHeight: "0px",
+  },
+  transitionProperty: "max-height",
 };
 
 export const Formula = ({
@@ -34,30 +43,16 @@ export const Formula = ({
       <Icon name="beaker" size={24} />
       <span className={S.formulaTitle}>{t`View the ${type} formula`}</span>
     </div>
-    <TransitionGroup>
-      {isExpanded && (
-        <CSSTransition
-          key="formulaDefinition"
-          classNames={{
-            enter: S.formulaDefinitionEnter,
-            enterActive: S.formulaDefinitionEnterActive,
-            exit: S.formulaDefinitionExit,
-            exitActive: S.formulaDefinitionExitActive,
-          }}
-          timeout={{
-            enter: 300,
-            exit: 300,
-          }}
-        >
-          <div className={S.formulaDefinition}>
-            <QueryDefinition
-              className={S.formulaDefinitionInner}
-              definition={entity.definition}
-              tableId={entity.table_id}
-            />
-          </div>
-        </CSSTransition>
+    <Transition mounted={isExpanded} duration={300} transition={TRANSITION}>
+      {styles => (
+        <div className={S.formulaDefinition} style={styles}>
+          <QueryDefinition
+            className={S.formulaDefinitionInner}
+            definition={entity.definition}
+            tableId={entity.table_id}
+          />
+        </div>
       )}
-    </TransitionGroup>
+    </Transition>
   </div>
 );

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
@@ -18,6 +18,7 @@
 
   &:disabled {
     background-color: var(--mb-color-background-disabled);
+    color: var(--mb-color-text-disabled);
   }
 
   &[data-size="xs"] {


### PR DESCRIPTION
Closes ADM-464

### Description
Sets the color of disabled inputs to `--mb-colors-text-disabled`. This was surfaced in SCIM configuration and viewing API keys

### How to verify
1. Go to Admin -> Authentication
2. Click User Provisioning and enabled it
3. Get through the modal and check the SCIM endpoint input. The endpoint should be visible


### Demo
<img width="681" alt="image" src="https://github.com/user-attachments/assets/a79ed379-c1b3-4e22-a2fa-c7c81b272924" />
<img width="504" alt="image" src="https://github.com/user-attachments/assets/c7865ec8-8a25-4c3a-b4ef-93252b6eaf70" />

