### PR TITLE
fix: bump saml20 library for assertion sig fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -96,7 +96,7 @@
   lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "4.1.0"
+  metabase/saml20-clj                       {:mvn/version "4.2.0"
                                              :exclusions [; EE SAML integration TODO: bump version when we release the library
                                                           org.bouncycastle/bcpkix-jdk15on
                                                           org.bouncycastle/bcprov-jdk15on


### PR DESCRIPTION
### Description

Bumps the version of the saml library in order to pull in the fix for messages without top-level signatures, but with assertion signatures.

### Checklist

- [NA] Tests have been added/updated to cover changes in this PR
