### PR TITLE
Add Basic Admin Setting Component

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -25,7 +25,7 @@ type BooleanInputType = "boolean";
 type InputDetails =
   | {
       inputType: TextualInputType;
-      options: never;
+      options?: never;
       placeholder?: string;
     }
   | {
@@ -35,8 +35,8 @@ type InputDetails =
     }
   | {
       inputType: BooleanInputType;
-      options: never;
-      placeholder: never;
+      options?: never;
+      placeholder?: never;
     };
 
 export type AdminSettingInputProps<S extends SettingKey> = {

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -68,7 +68,7 @@ export function AdminSettingInput<SettingName extends SettingKey>({
     value: initialValue,
     updateSetting,
     isLoading,
-    settingDetails: { is_env_setting: setByEnvVar, env_name: envName } = {},
+    settingDetails,
   } = useAdminSetting(name);
 
   const handleChange = (newValue: string | boolean | number) => {
@@ -94,8 +94,8 @@ export function AdminSettingInput<SettingName extends SettingKey>({
   return (
     <Box {...boxProps}>
       <SettingHeader id={name} title={title} description={description} />
-      {setByEnvVar && envName ? (
-        <SetByEnvVar varName={envName} />
+      {settingDetails?.is_env_setting && settingDetails?.env_name ? (
+        <SetByEnvVar varName={settingDetails.env_name} />
       ) : (
         <AdminSettingInputComponent
           name={name}

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -25,7 +25,7 @@ type BooleanInputType = "boolean";
 type InputDetails =
   | {
       inputType: TextualInputType;
-      options?: never;
+      options: never;
       placeholder?: string;
     }
   | {
@@ -35,12 +35,12 @@ type InputDetails =
     }
   | {
       inputType: BooleanInputType;
-      options?: never;
-      placeholder?: never;
+      options: never;
+      placeholder: never;
     };
 
-export type AdminSettingInputProps<SettingName> = {
-  name: SettingName;
+export type AdminSettingInputProps<S extends SettingKey> = {
+  name: S;
   title?: string;
   description?: React.ReactNode;
   hidden?: boolean;
@@ -100,9 +100,9 @@ export function AdminSettingInput<SettingName extends SettingKey>({
         <AdminSettingInputComponent
           name={name}
           value={initialValue}
-          placeholder={placeholder}
           onChange={handleChange}
           options={options}
+          placeholder={placeholder}
           inputType={inputType}
         />
       )}
@@ -114,14 +114,17 @@ export function AdminSettingInputComponent({
   name,
   value,
   onChange,
-  inputType,
-  placeholder,
   options,
+  placeholder,
+  inputType,
 }: {
   name: SettingKey;
   value: any;
   onChange: (newValue: string | boolean | number) => void;
-} & InputDetails) {
+  options?: { label: string; value: string }[];
+  placeholder?: string;
+  inputType: TextualInputType | OptionsInputType | BooleanInputType;
+}) {
   const [localValue, setLocalValue] = useState(value);
 
   useEffect(() => {

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -97,7 +97,7 @@ export function AdminSettingInput<SettingName extends SettingKey>({
       {settingDetails?.is_env_setting && settingDetails?.env_name ? (
         <SetByEnvVar varName={settingDetails.env_name} />
       ) : (
-        <AdminSettingInputComponent
+        <BasicAdminSettingInput
           name={name}
           value={initialValue}
           onChange={handleChange}
@@ -110,7 +110,7 @@ export function AdminSettingInput<SettingName extends SettingKey>({
   );
 }
 
-export function AdminSettingInputComponent({
+export function BasicAdminSettingInput({
   name,
   value,
   onChange,

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useState } from "react";
+import { jt, t } from "ttag";
+
+import { useAdminSetting } from "metabase/api";
+import { useDocsUrl, useToast } from "metabase/common/hooks";
+import ExternalLink from "metabase/core/components/ExternalLink";
+import type { GenericErrorResponse } from "metabase/lib/errors";
+import {
+  Box,
+  type BoxProps,
+  Radio,
+  Select,
+  Switch,
+  TextInput,
+  Textarea,
+} from "metabase/ui";
+import type { SettingKey } from "metabase-types/api";
+
+import { SettingHeader } from "../SettingHeader";
+
+type OptionsInputType = "select" | "radio";
+type TextualInputType = "text" | "number" | "password" | "textarea";
+type BooleanInputType = "boolean";
+
+type InputDetails =
+  | {
+      inputType: TextualInputType;
+      options?: never;
+      placeholder?: string;
+    }
+  | {
+      inputType: OptionsInputType;
+      options: { label: string; value: string }[];
+      placeholder?: string;
+    }
+  | {
+      inputType: BooleanInputType;
+      options?: never;
+      placeholder?: never;
+    };
+
+export type AdminSettingInputProps<SettingName> = {
+  name: SettingName;
+  title?: string;
+  description?: React.ReactNode;
+  hidden?: boolean;
+} & InputDetails &
+  BoxProps;
+
+/**
+ * A simple admin settings component for basic needs, if you need something special,
+ * create a special component (in the widgets/ folder) instead of building one-off
+ * features into this component
+ */
+export function AdminSettingInput<SettingName extends SettingKey>({
+  title,
+  description,
+  name,
+  inputType,
+  hidden,
+  placeholder,
+  options,
+  ...boxProps
+}: AdminSettingInputProps<SettingName>) {
+  const [sendToast] = useToast();
+
+  const {
+    value: initialValue,
+    updateSetting,
+    isLoading,
+    settingDetails: { is_env_setting: setByEnvVar, env_name: envName } = {},
+  } = useAdminSetting(name);
+
+  const handleChange = (newValue: string | boolean | number) => {
+    if (newValue === initialValue) {
+      return;
+    }
+    updateSetting({ key: name, value: newValue }).then(response => {
+      if (response?.error) {
+        const message =
+          (response.error as GenericErrorResponse)?.message ||
+          t`Error saving ${title}`;
+        sendToast({ message, icon: "check", toastColor: "danger" });
+      } else {
+        sendToast({ message: t`${title} changes saved`, icon: "check" });
+      }
+    });
+  };
+
+  if (hidden || isLoading) {
+    return null;
+  }
+
+  return (
+    <Box {...boxProps}>
+      <SettingHeader id={name} title={title} description={description} />
+      {setByEnvVar && envName ? (
+        <SetByEnvVar varName={envName} />
+      ) : (
+        <AdminSettingInputComponent
+          name={name}
+          value={initialValue}
+          placeholder={placeholder}
+          onChange={handleChange}
+          options={options}
+          inputType={inputType}
+        />
+      )}
+    </Box>
+  );
+}
+
+export function AdminSettingInputComponent({
+  name,
+  value,
+  onChange,
+  inputType,
+  placeholder,
+  options,
+}: {
+  name: SettingKey;
+  value: any;
+  onChange: (newValue: string | boolean | number) => void;
+} & InputDetails) {
+  const [localValue, setLocalValue] = useState(value);
+
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const handleChange = (newValue: string | boolean) => {
+    setLocalValue(newValue);
+    onChange(newValue);
+  };
+
+  switch (inputType) {
+    case "select":
+      return (
+        <Select
+          id={name}
+          value={localValue}
+          onChange={handleChange}
+          data={options ?? []}
+        />
+      );
+    case "boolean":
+      return (
+        <Switch
+          id={name}
+          checked={localValue}
+          onChange={e => handleChange(e.target.checked)}
+          label={localValue ? t`Enabled` : t`Disabled`}
+        />
+      );
+    case "radio":
+      return (
+        <Radio.Group id={name} value={localValue} onChange={handleChange}>
+          {options?.map(({ label, value }) => (
+            <Radio key={value} value={value} label={label} />
+          ))}
+        </Radio.Group>
+      );
+    case "textarea":
+      return (
+        <Textarea
+          id={name}
+          value={localValue}
+          onChange={e => setLocalValue(e.target.value)}
+          onBlur={() => onChange(localValue)}
+        />
+      );
+    case "number":
+    case "password":
+    case "text":
+    default:
+      return (
+        <TextInput
+          id={name}
+          value={localValue}
+          placeholder={placeholder}
+          onChange={e => setLocalValue(e.target.value)}
+          onBlur={() => onChange(localValue)}
+          type={inputType ?? "text"}
+        />
+      );
+  }
+}
+
+export const SetByEnvVar = ({ varName }: { varName: string }) => {
+  const { url } = useDocsUrl("configuring-metabase/environment-variables", {
+    anchor: varName?.toLowerCase(),
+  });
+
+  return (
+    <Box data-testid="setting-env-var-message" fw="bold" p="sm">
+      {jt`This has been set by the ${(
+        <ExternalLink key="link" href={url}>
+          {varName}
+        </ExternalLink>
+      )} environment variable.`}
+    </Box>
+  );
+};

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
@@ -1,0 +1,420 @@
+import { userEvent } from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+} from "__support__/server-mocks";
+import {
+  fireEvent,
+  mockScrollIntoView,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "__support__/ui";
+import { UndoListing } from "metabase/containers/UndoListing";
+import type { SettingKey } from "metabase-types/api";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+
+import {
+  AdminSettingInput,
+  type AdminSettingInputProps,
+} from "./AdminSettingInput";
+
+const setup = (props: AdminSettingInputProps<SettingKey>) => {
+  setupPropertiesEndpoints(
+    createMockSettings({
+      "site-name": "Metabased",
+      "site-url": "http://localhost:8675309",
+      "enable-xrays": true,
+      "humanization-strategy": "none",
+      "query-caching-min-ttl": 64,
+      "premium-embedding-token": "super-secret",
+      // @ts-expect-error - this isn't a valid setting
+      "fake-setting": "fake-value",
+    }),
+  );
+
+  setupSettingsEndpoints([
+    createMockSettingDefinition({
+      key: "site-url",
+      is_env_setting: true,
+      env_name: "MB_HARDCODED_URL",
+    }),
+  ]);
+
+  setupUpdateSettingEndpoint();
+  renderWithProviders(
+    <>
+      <AdminSettingInput {...props} />
+      <UndoListing />
+    </>,
+  );
+};
+
+describe("AdminSettingInput", () => {
+  beforeAll(() => {
+    mockScrollIntoView();
+  });
+
+  it("should not allow invalid settings", async () => {
+    setup({
+      title: "Fake Setting",
+      // @ts-expect-error - this isn't a valid setting
+      name: "fake-name",
+    });
+
+    // this is just a test of the types, it shouldn't fail at run time
+    expect(await screen.findByText("Fake Setting")).toBeInTheDocument();
+  });
+
+  it("should render title and description", async () => {
+    setup({
+      title: "Site Name",
+      description: "The name of your site",
+      name: "site-name",
+      inputType: "text",
+    });
+
+    expect(await screen.findByText("Site Name")).toBeInTheDocument();
+    expect(
+      await screen.findByText("The name of your site"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render a text input", async () => {
+    setup({
+      title: "Site Name",
+      description: "The name of your site",
+      name: "site-name",
+      inputType: "text",
+    });
+
+    const input = await screen.findByRole("textbox");
+    expect(input).toHaveAttribute("type", "text");
+    expect(input).toHaveValue("Metabased");
+  });
+
+  it("should render a select input", async () => {
+    setup({
+      title: "Humanization",
+      name: "humanization-strategy",
+      inputType: "select",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+
+    const input = await screen.findByRole("textbox");
+    expect(input).toHaveClass("mb-mantine-Select-input");
+    expect(input).toHaveValue("None");
+  });
+
+  it("should render a boolean input", async () => {
+    setup({
+      title: "Enable X-rays",
+      name: "enable-xrays",
+      inputType: "boolean",
+    });
+
+    const input = await screen.findByRole("switch");
+    expect(input).toHaveClass("mb-mantine-Switch-input");
+    expect(input).toHaveAttribute("data-checked", "true");
+  });
+
+  it("should render a radio input", async () => {
+    setup({
+      title: "Humanization",
+      name: "humanization-strategy",
+      inputType: "radio",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+
+    const inputs = await screen.findAllByRole("radio");
+    expect(inputs).toHaveLength(2);
+
+    // eslint-disable-next-line jest-dom/prefer-to-have-value
+    expect(inputs[0]).toHaveAttribute("value", "none");
+    expect(inputs[0]).toBeChecked();
+
+    // eslint-disable-next-line jest-dom/prefer-to-have-value
+    expect(inputs[1]).toHaveAttribute("value", "simple");
+    expect(inputs[1]).not.toBeChecked();
+  });
+
+  it("should render a number input", async () => {
+    setup({
+      title: "TTL",
+      name: "query-caching-min-ttl",
+      inputType: "number",
+    });
+
+    const input = await screen.findByRole("spinbutton");
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveValue(64);
+  });
+
+  it("should render a password input", async () => {
+    setup({
+      title: "token",
+      name: "premium-embedding-token",
+      inputType: "password",
+    });
+
+    const input = await screen.findByLabelText("token");
+    expect(input).toHaveAttribute("type", "password");
+    expect(input).toHaveValue("super-secret");
+  });
+
+  it("should render a textarea input", async () => {
+    setup({
+      title: "token",
+      name: "premium-embedding-token",
+      inputType: "textarea",
+    });
+
+    const input = await screen.findByRole("textbox");
+    expect(input.nodeName).toBe("TEXTAREA");
+    expect(input).toHaveValue("super-secret");
+  });
+
+  it("should hide an input", async () => {
+    setup({
+      title: "token",
+      name: "premium-embedding-token",
+      hidden: true,
+      inputType: "text",
+    });
+
+    await waitFor(() => {
+      const calls = fetchMock.calls();
+      expect(calls).toHaveLength(2);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should save an updated boolean setting", async () => {
+    setup({
+      title: "Enable X-rays",
+      name: "enable-xrays",
+      inputType: "boolean",
+    });
+
+    const input = await screen.findByRole("switch");
+    await userEvent.click(input);
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/enable-xrays");
+    expect(body).toStrictEqual({ value: false });
+  });
+
+  it("should save an updated text setting", async () => {
+    setup({
+      title: "Site Name",
+      description: "The name of your site",
+      name: "site-name",
+      inputType: "text",
+    });
+
+    const input = await screen.findByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Wigglybase");
+    await fireEvent.blur(input);
+
+    const inputChanged = await screen.findByRole("textbox");
+    expect(inputChanged).toHaveValue("Wigglybase");
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/site-name");
+    expect(body).toStrictEqual({ value: "Wigglybase" });
+  });
+
+  it("should save an updated number setting", async () => {
+    setup({
+      title: "ttl",
+      name: "query-caching-min-ttl",
+      inputType: "number",
+    });
+
+    const input = await screen.findByRole("spinbutton");
+    await userEvent.clear(input);
+    await userEvent.type(input, "33");
+    await fireEvent.blur(input);
+
+    const inputChanged = await screen.findByRole("spinbutton");
+    expect(inputChanged).toHaveValue(33);
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/query-caching-min-ttl");
+    expect(body).toStrictEqual({ value: "33" });
+  });
+
+  it("should save an updated select setting", async () => {
+    setup({
+      title: "Humanization",
+      name: "humanization-strategy",
+      inputType: "select",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+
+    const input = await screen.findByRole("textbox");
+    await userEvent.click(input);
+    const option = await screen.findByText("Simple");
+    await userEvent.click(option);
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/humanization-strategy");
+    expect(body).toStrictEqual({ value: "simple" });
+  });
+
+  it("should save an updated radio setting", async () => {
+    setup({
+      title: "Humanization",
+      name: "humanization-strategy",
+      inputType: "radio",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+
+    const option = await screen.findByText("Simple");
+    await userEvent.click(option);
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/humanization-strategy");
+    expect(body).toStrictEqual({ value: "simple" });
+  });
+
+  it("should save an updated textarea setting", async () => {
+    setup({
+      title: "Site Name",
+      description: "The name of your site",
+      name: "site-name",
+      inputType: "textarea",
+    });
+
+    const input = await screen.findByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Wigglybase");
+    await fireEvent.blur(input);
+
+    const inputChanged = await screen.findByRole("textbox");
+    expect(inputChanged).toHaveValue("Wigglybase");
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/site-name");
+    expect(body).toStrictEqual({ value: "Wigglybase" });
+  });
+
+  it("should save an updated password setting", async () => {
+    setup({
+      title: "token",
+      name: "premium-embedding-token",
+      inputType: "password",
+    });
+
+    const input = await screen.findByLabelText("token");
+    await userEvent.clear(input);
+    await userEvent.type(input, "new-secret-stuff");
+    await fireEvent.blur(input);
+
+    const inputChanged = await screen.findByLabelText("token");
+    expect(inputChanged).toHaveValue("new-secret-stuff");
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/premium-embedding-token");
+    expect(body).toStrictEqual({ value: "new-secret-stuff" });
+  });
+
+  it("should show a success toast on save success", async () => {
+    setup({
+      title: "Humanization Strategy",
+      name: "humanization-strategy",
+      inputType: "select",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+
+    const input = await screen.findByRole("textbox");
+    await userEvent.click(input);
+    const option = await screen.findByText("Simple");
+    await userEvent.click(option);
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/humanization-strategy");
+    expect(body).toStrictEqual({ value: "simple" });
+
+    const toast = await screen.findByText(
+      "Humanization Strategy changes saved",
+    );
+    expect(toast).toBeInTheDocument();
+  });
+
+  it("should show an error toast on save failure", async () => {
+    setup({
+      title: "Humanization Strategy",
+      name: "humanization-strategy",
+      inputType: "select",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+    setupUpdateSettingEndpoint({ status: 500 });
+
+    const input = await screen.findByRole("textbox");
+    await userEvent.click(input);
+    const option = await screen.findByText("Simple");
+    await userEvent.click(option);
+
+    const [putUrl, body] = await findPut();
+    expect(putUrl).toContain("/api/setting/humanization-strategy");
+    expect(body).toStrictEqual({ value: "simple" });
+
+    const toast = await screen.findByText("Error saving Humanization Strategy");
+    expect(toast).toBeInTheDocument();
+  });
+
+  it("should display a notice isntead of input when a setting is set by an environment variable", async () => {
+    setup({
+      title: "url",
+      name: "site-url",
+      inputType: "text",
+    });
+
+    expect(
+      await screen.findByText(/This has been set by the/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("MB_HARDCODED_URL")).toBeInTheDocument();
+    expect(screen.getByText(/environment variable./)).toBeInTheDocument();
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});
+
+async function findPut() {
+  const calls = fetchMock.calls();
+  const [putUrl, putDetails] =
+    calls.find(call => call[1]?.method === "PUT") ?? [];
+
+  const body = ((await putDetails?.body) as string) ?? "{}";
+
+  return [putUrl, JSON.parse(body)];
+}

--- a/frontend/test/__support__/server-mocks/settings.ts
+++ b/frontend/test/__support__/server-mocks/settings.ts
@@ -6,6 +6,12 @@ export function setupSettingsEndpoints(settings: SettingDefinition[]) {
   fetchMock.get("path:/api/setting", settings);
 }
 
-export function setupUpdateSettingEndpoint() {
-  fetchMock.put(new RegExp("/api/setting/"), { status: 204 });
+export function setupUpdateSettingEndpoint(
+  { status }: { status?: number } = { status: 204 },
+) {
+  fetchMock.put(
+    new RegExp("/api/setting/"),
+    { status },
+    { overwriteRoutes: true },
+  );
 }


### PR DESCRIPTION
This is basically a replacement for the existing `SettingSetting` input component that forms the basis of most of the inputs in admin settings. It has a few key differences though

1. Uses RTKQuery hooks
2. Is in Typescript
3. Is extensively unit tested
4. Uses Mantine components
5. Has a lot fewer magical options

. | .
--|--
Text | ![Screenshot 2025-03-12 at 5 01 34 PM](https://github.com/user-attachments/assets/1c8f298f-e01a-4105-bf57-70f9e870c764)
Textarea | ![Screenshot 2025-03-12 at 5 01 44 PM](https://github.com/user-attachments/assets/e06827e2-7dd1-497e-89e8-4da136b5c67f)
Dropdown | ![Screenshot 2025-03-12 at 5 01 38 PM](https://github.com/user-attachments/assets/e8ab094d-c417-4af6-9e5c-90fd12afe851)
Switch | ![Screenshot 2025-03-12 at 5 01 41 PM](https://github.com/user-attachments/assets/a19a370e-67ba-49a7-aaf5-73d421aff079)

(also supports radios, passwords, and numbers)
