### PR TITLE
fix(sdk): mark all react-dom dependency requests as external for React 19 compatibility

### DIFF
--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -117,13 +117,21 @@ module.exports = env => {
       ],
     },
 
-    externals: {
-      ...mainConfig.externals,
-      react: "react",
-      "react-dom": "react-dom",
-      "react-dom/client": "react-dom/client",
-      "react/jsx-runtime": "react/jsx-runtime",
-    },
+    externals: [
+      {
+        ...mainConfig.externals,
+        react: "react",
+        "react/jsx-runtime": "react/jsx-runtime",
+      },
+      ({ request }, callback) => {
+        // Every react-dom dependency request must be external
+        if (/^react-dom($|\/)/.test(request)) {
+          return callback(null, request);
+        }
+
+        callback();
+      },
+    ],
 
     optimization: {
       // The default `moduleIds: 'named'` setting breaks Cypress tests when `development` mode is enabled,

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -117,20 +117,16 @@ module.exports = env => {
       ],
     },
 
+    // Prevent these dependencies from being included in the JavaScript bundle.
     externals: [
-      {
-        ...mainConfig.externals,
-        react: "react",
-        "react/jsx-runtime": "react/jsx-runtime",
-      },
-      ({ request }, callback) => {
-        // Every react-dom dependency request must be external
-        if (/^react-dom($|\/)/.test(request)) {
-          return callback(null, request);
-        }
+      mainConfig.externals,
 
-        callback();
-      },
+      // We intend to support multiple React versions in the SDK,
+      // so the SDK itself should not pre-bundle react and react-dom
+      "react",
+      /^react\//i,
+      "react-dom",
+      /^react-dom\//i,
     ],
 
     optimization: {


### PR DESCRIPTION
Closes EMB-256

The SDK crashed when on React 19 due to `Uncaught TypeError: i2.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED is undefined`. See this deploy preview: https://shoppy-e234ucpy7-embedding-c312e713.vercel.app - it simply crashes.

On development builds on Firefox:

```js
Uncaught TypeError: ReactSharedInternals is undefined
```

On development builds on Chrome:

```js
Uncaught TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')
    at @metabase_embedding-sdk-react.js?v=c038baae:978649:65
    at Object.__webpack_modules__ (@metabase_embedding-sdk-react.js?v=c038baae:981051:15)
    at __webpack_require__ (@metabase_embedding-sdk-react.js?v=c038baae:1021852:39)
    at Object.__webpack_modules__ (@metabase_embedding-sdk-react.js?v=c038baae:975680:17)
    at __webpack_require__ (@metabase_embedding-sdk-react.js?v=c038baae:1021852:39)
    at Module.__webpack_modules__ (@metabase_embedding-sdk-react.js?v=c038baae:975600:63)
    at __webpack_require__ (@metabase_embedding-sdk-react.js?v=c038baae:1021852:39)
    at Module.__webpack_modules__ (@metabase_embedding-sdk-react.js?v=c038baae:970351:103)
    at __webpack_require__ (@metabase_embedding-sdk-react.js?v=c038baae:1021852:39)
    at Module.__webpack_modules__ (@metabase_embedding-sdk-react.js?v=c038baae:901945:70)
```

The error specifically happens because of the SDK trying to reference bundled react-dom code which is React 18 only. 
```js
var ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
```

We can fix this by marking every `react-dom` dependency requests as "external" so they do not get accidentally included in the bundle. These dependency requests are made during development:

```
      "react-dom/server": "react-dom/server",
      "react-dom/server.browser": "react-dom/server.browser",
      "react-dom/server-legacy.browser": "react-dom/server-legacy.browser",
      "react-dom/cjs/react-dom-server-legacy.browser.development":
        "react-dom/cjs/react-dom-server-legacy.browser.development",
```

But just hard-coding all dependency requests is brittle as there's also `production` variants and so on. This PR uses regex to mark all react-dom requests as external instead.

### How to test

- Do a production build locally with `yarn build-embedding-sdk`
- Link it to your app that runs on React 19 (I use Shoppy's `react-19-demo` branch which updates Shoppy to React 19)
- The app should no longer crash. There is a couple of known console errors and bugs (e.g. `Error getting setting graph.other_category_aggregation_fn TypeError: Cannot read properties of undefined (reading 'name')` when drilling), but that will be fixed separately.