### PR TITLE
Fix React console errors on unrecognized props in styled components

### DIFF
--- a/frontend/src/metabase/components/EntityItem/EntityItem.styled.tsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.styled.tsx
@@ -28,7 +28,9 @@ const getItemPadding = (variant?: string) => {
   }
 };
 
-export const EntityIconWrapper = styled(IconButtonWrapper)<{
+export const EntityIconWrapper = styled(IconButtonWrapper, {
+  shouldForwardProp: prop => prop !== "isPinned",
+})<{
   isPinned?: boolean;
   disabled?: boolean;
 }>`

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
@@ -25,9 +25,14 @@ type TableProps = TableHTMLAttributes<HTMLTableElement> & {
   isInDragLayer?: boolean;
 };
 
-export const Table = styled(({ isInDragLayer, ...props }: TableProps) => (
-  <table {...props} className={cx(props.className, AdminS.ContentTable)} />
-))`
+export const Table = styled(
+  (props: TableProps) => (
+    <table {...props} className={cx(props.className, AdminS.ContentTable)} />
+  ),
+  {
+    shouldForwardProp: prop => prop !== "isInDragLayer",
+  },
+)`
   background-color: var(--mb-color-bg-white);
   table-layout: fixed;
   border-collapse: unset;

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
@@ -25,7 +25,7 @@ type TableProps = TableHTMLAttributes<HTMLTableElement> & {
   isInDragLayer?: boolean;
 };
 
-export const Table = styled((props: TableProps) => (
+export const Table = styled(({ isInDragLayer, ...props }: TableProps) => (
   <table {...props} className={cx(props.className, AdminS.ContentTable)} />
 ))`
   background-color: var(--mb-color-bg-white);


### PR DESCRIPTION
Closes EMB-264

Do not forward some styled component props to the underlying components. I mistakenly introduced these in my changes for EMB-215. Sorry about that!

```
React does not recognize the `isPinned` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `ispinned` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

React does not recognize the `isInDragLayer` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isindraglayer` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
````