### PR TITLE
[CI] Fix e2e admin database page flakes

### DIFF
--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -226,7 +226,7 @@ describe("admin > database > add", () => {
           expect(request.body.details.user).to.equal("metabase");
         });
 
-        cy.url().should("match", /\/admin\/databases\/\d\?created=true$/);
+        cy.url().should("match", /\/admin\/databases\/\d/);
 
         waitForDbSync();
       });
@@ -306,7 +306,7 @@ describe("admin > database > add", () => {
 
         cy.wait("@createDatabase");
 
-        cy.url().should("match", /\/admin\/databases\/\d\?created=true$/);
+        cy.url().should("match", /\/admin\/databases\/\d/);
 
         cy.findByRole("dialog").within(() => {
           cy.findByText(
@@ -370,7 +370,7 @@ describe("admin > database > add", () => {
 
         cy.wait("@createDatabase");
 
-        cy.url().should("match", /\/admin\/databases\/\d\?created=true$/);
+        cy.url().should("match", /\/admin\/databases\/\d/);
 
         cy.findByRole("dialog").within(() => {
           cy.findByText(
@@ -418,7 +418,7 @@ describe("admin > database > add", () => {
 
       cy.wait("@createDatabase");
 
-      cy.url().should("match", /\/admin\/databases\/\d\?created=true$/);
+      cy.url().should("match", /\/admin\/databases\/\d/);
 
       cy.findByRole("dialog").within(() => {
         cy.findByText(


### PR DESCRIPTION

### Description

This PR removes e2e checks for the `created` query param when navigating to `/admin/databases/:id` after database creation. The query param triggers a permissions modal to display, but recent UI improvements now consume this param immediately to prevent the modal from reappearing as you go forward/backward in browser history. The quick removal of this query param causes a race condition in our e2e tests and is the source of [flakes like this](https://github.com/metabase/metabase/actions/runs/13833823151/job/38706086836).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
