### PR TITLE
Fix - Wrong padding of field name in Model metadata editing

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -254,9 +254,6 @@ function DatasetFieldMetadataSidebar({
                       },
                     },
                     input: {
-                      paddingTop: "1.375rem",
-                      paddingBottom: "0.5rem",
-                      height: "auto",
                       fontWeight: "bold",
                     },
                   }}


### PR DESCRIPTION
Fixes #54898

### Demo

[before](https://github.com/user-attachments/assets/56138be7-e7f1-4b77-8640-1185e35d3c52) vs [after](https://github.com/user-attachments/assets/58e71655-0859-4e91-b59b-2691f90f9e8b) vs [v52 (before Mantine 7)](https://github.com/user-attachments/assets/5c53eabe-2233-45d0-977b-dcc3b3a1d3a0)
