### PR TITLE
feat(sdk): do not setup sandboxing and show user switcher if using a sample database

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -100,6 +100,17 @@ export const SETUP_PRO_LICENSE_MESSAGE = `
   If you skip this step, the setup will continue without multi-tenancy or SSO.
 `;
 
+export const SETUP_PRO_LICENSE_MESSAGE_WITH_SAMPLE_DATABASE = `
+  You've chosen to use a sample database to explore Metabase.
+  This tool can also set up permissions for multi-tenancy, but you will need to provide your own database for that.
+
+  For now, this tool can create a mock back-end server that signs people into Metabase,
+  so you can see how different tenants experience the dashboard embedded in your app when you connect your data.
+
+  To set up multi-tenancy and SSO with JWT, you'll need a Pro license.
+  Skipping this step will not affect how your Metabase instance is set up.
+`;
+
 export const SDK_LEARN_MORE_MESSAGE = `All done! 🚀 Learn more about the SDK here: ${green(
   SDK_DOCS_LINK,
 )}`;

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -102,13 +102,12 @@ export const SETUP_PRO_LICENSE_MESSAGE = `
 
 export const SETUP_PRO_LICENSE_MESSAGE_WITH_SAMPLE_DATABASE = `
   You've chosen to use a sample database to explore Metabase.
-  This tool can also set up permissions for multi-tenancy, but you will need to provide your own database for that.
 
-  For now, this tool can create a mock back-end server that signs people into Metabase,
-  so you can see how different tenants experience the dashboard embedded in your app when you connect your data.
-
-  To set up multi-tenancy and SSO with JWT, you'll need a Pro license.
-  Skipping this step will not affect how your Metabase instance is set up.
+  If you want to use this tool to set up permissions for multi-tenancy with JWT SSO,
+  you'll need to select your own database.
+  
+  With the sample database selected, this tool will simply create a mock back-end server 
+  that signs people into Metabase, without setting up JWT SSO.
 `;
 
 export const SDK_LEARN_MORE_MESSAGE = `All done! 🚀 Learn more about the SDK here: ${green(

--- a/enterprise/frontend/src/embedding-sdk/cli/run.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/run.ts
@@ -63,6 +63,7 @@ export const CLI_STEPS: CliStepConfig[] = [
 
     // We need at least one table with a tenancy column to set up sandboxing.
     runIf: state =>
+      !state.useSampleDatabase &&
       hasValidLicense(state) &&
       Object.keys(state.tenancyColumnNames ?? {}).length > 0,
   },

--- a/enterprise/frontend/src/embedding-sdk/cli/run.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/run.ts
@@ -55,7 +55,7 @@ export const CLI_STEPS: CliStepConfig[] = [
   {
     id: "askForTenancyColumns",
     executeStep: askForTenancyColumns,
-    runIf: hasValidLicense,
+    runIf: state => !state.useSampleDatabase && hasValidLicense(state),
   },
   {
     id: "setupPermissions",

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/generate-component-files.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/generate-component-files.ts
@@ -60,9 +60,9 @@ export const generateReactComponentFiles: CliStepMethod = async state => {
     dashboards,
     isNextJs,
 
-    // Enable user switching only when a valid license is present,
-    // as JWT requires a valid license.
-    userSwitcherEnabled: !!token,
+    // Enable user switching only when a valid license is present
+    // as JWT requires a valid license, and using a sample database.
+    userSwitcherEnabled: !!token && !state.useSampleDatabase,
   });
 
   const isInTypeScriptProject = await checkIsInTypeScriptProject();

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/generate-component-files.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/generate-component-files.ts
@@ -61,7 +61,7 @@ export const generateReactComponentFiles: CliStepMethod = async state => {
     isNextJs,
 
     // Enable user switching only when a valid license is present
-    // as JWT requires a valid license, and using a sample database.
+    // as JWT requires a valid license, and does not use a sample database.
     userSwitcherEnabled: !!token && !state.useSampleDatabase,
   });
 

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/setup-license.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/setup-license.ts
@@ -6,7 +6,10 @@ import ora from "ora";
 
 import type { CliStepMethod } from "embedding-sdk/cli/types/cli";
 
-import { SETUP_PRO_LICENSE_MESSAGE } from "../constants/messages";
+import {
+  SETUP_PRO_LICENSE_MESSAGE,
+  SETUP_PRO_LICENSE_MESSAGE_WITH_SAMPLE_DATABASE,
+} from "../constants/messages";
 import { printEmptyLines, printWithPadding } from "../utils/print";
 import { propagateErrorResponse } from "../utils/propagate-error-response";
 
@@ -18,7 +21,11 @@ const VISIT_STORE_MESSAGE = `Please visit ${chalk.blue(
 )} to get a license key.`;
 
 export const setupLicense: CliStepMethod = async state => {
-  printWithPadding(SETUP_PRO_LICENSE_MESSAGE);
+  const setupMessage = state.useSampleDatabase
+    ? SETUP_PRO_LICENSE_MESSAGE_WITH_SAMPLE_DATABASE
+    : SETUP_PRO_LICENSE_MESSAGE;
+
+  printWithPadding(setupMessage);
 
   const shouldSetupLicense = await toggle({
     message: "Do you want to set up a Pro license?",


### PR DESCRIPTION
Closes EMB-257

The sample databases does not have sandboxing configured (as our sample data is tricky to setup multi-tenancy) so it does not make sense to show the user switcher when using sample databases. Let's not set up sandboxing / user switcher if they are using sample databases.

See this Loom video for more context: https://www.loom.com/share/b0843903d64c4ed8a06ec37f2f2ac1e6?sid=f836b57e-bef6-4640-9453-7866392b8af2

### How to test

- Run the CLI
- Use the sample database by choosing _I don't have a database_
- Choose to setup a Pro license
- It should not ask for tenancy columns
- It should not setup sandboxing/permissions
- It should not generate the user switcher component
- If should still generate an Express.js server with `const USERS` in it, but it is not surfaced in the UI.