### PR TITLE
Add reproduction for "Documentation link does not work"

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1445,3 +1445,27 @@ describe("issue 54638", () => {
     });
   });
 });
+
+describe("issue #54722", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.openOrdersTable({ mode: "notebook" });
+  });
+
+  it("should focus the editor when opening it #54722", () => {
+    cy.button("Custom column").click();
+    cy.focused().should("have.attr", "class").and("contains", "cm-content");
+    H.expressionEditorWidget().button("Cancel").click();
+
+    cy.button("Filter").click();
+    H.popover().findByText("Custom Expression").click();
+    cy.focused().should("have.attr", "class").and("contains", "cm-content");
+    H.expressionEditorWidget().button("Cancel").click();
+
+    cy.button("Summarize").click();
+    H.popover().findByText("Custom Expression").click();
+    cy.focused().should("have.attr", "class").and("contains", "cm-content");
+    H.expressionEditorWidget().button("Cancel").click();
+  });
+});

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1415,3 +1415,33 @@ describe("issue 48562", () => {
     H.CustomExpressionEditor.value().should("contain", "[Unknown Metric]");
   });
 });
+
+describe("issue 54638", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.openOrdersTable({ mode: "notebook" });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Custom column").click();
+  });
+
+  it("should be possible to click documentation links in the expression editor help text popover (metabase#54638)", () => {
+    H.CustomExpressionEditor.type("case(");
+    H.CustomExpressionEditor.helpText().within(() => {
+      cy.findByText("Learn more")
+        .should("be.visible")
+        .then($a => {
+          expect($a).to.have.attr("target", "_blank");
+          // Update attr to open in same tab, since Cypress does not support
+          // testing in multiple tabs.
+          $a.attr("target", "_self");
+        })
+        .click();
+      cy.url().should(
+        "equal",
+        "https://www.metabase.com/docs/latest/questions/query-builder/expressions/case.html",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54638

The issue was solved in https://github.com/metabase/metabase/pull/54084, this is just adds the reproduction.