### PR TITLE
closes viz-517 pie well styling

### DIFF
--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/PieVerticalWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/PieVerticalWell.tsx
@@ -2,6 +2,7 @@ import { useDroppable } from "@dnd-kit/core";
 import { useMemo } from "react";
 import { t } from "ttag";
 
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { Box, Stack, Text } from "metabase/ui";
 import { DROPPABLE_ID } from "metabase/visualizer/constants";
@@ -54,14 +55,16 @@ function PieMetricWell() {
 
   return (
     <Box mt="lg">
-      <Text>{t`Pie chart metric`}</Text>
+      <Text>{t`Metric`}</Text>
       <WellBox isHighlighted={isHighlighted} isOver={isOver} ref={setNodeRef}>
         <Stack>
-          <WellItem onRemove={metric && handleRemoveMetric}>
-            <Text>
-              {metric?.display_name ?? t`Drop your chart Metric here`}
-            </Text>
-          </WellItem>
+          {metric && (
+            <WellItem onRemove={metric && handleRemoveMetric}>
+              <Ellipsified style={{ flex: 1 }}>
+                {metric.display_name}
+              </Ellipsified>
+            </WellItem>
+          )}
         </Stack>
       </WellBox>
     </Box>
@@ -95,22 +98,20 @@ function PieDimensionWell() {
 
   return (
     <Box mt="lg">
-      <Text>{t`Pie chart dimensions`}</Text>
+      <Text>{t`Dimensions`}</Text>
       <WellBox isHighlighted={isHighlighted} isOver={isOver} ref={setNodeRef}>
-        {dimensions.length > 0 ? (
-          <Stack>
-            {dimensions.map(dimension => (
-              <WellItem
-                key={dimension.id}
-                onRemove={() => handleRemoveDimension(dimension)}
-              >
+        <Stack>
+          {dimensions.map(dimension => (
+            <WellItem
+              key={dimension.id}
+              onRemove={() => handleRemoveDimension(dimension)}
+            >
+              <Ellipsified style={{ flex: 1 }}>
                 {dimension.display_name}
-              </WellItem>
-            ))}
-          </Stack>
-        ) : (
-          <Text>{t`Drop your chart Dimensions here`}</Text>
-        )}
+              </Ellipsified>
+            </WellItem>
+          ))}
+        </Stack>
       </WellBox>
     </Box>
   );

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/WellBox.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/WellBox.tsx
@@ -18,7 +18,7 @@ export const WellBox = forwardRef<HTMLDivElement, WellBoxProps>(
         bg={isHighlighted ? "var(--mb-color-brand-light)" : "bg-light"}
         p="sm"
         mih="120px"
-        w="300px"
+        w="150px"
         style={{
           borderRadius: "var(--default-border-radius)",
           border: `1px solid ${borderColor}`,


### PR DESCRIPTION
Closes [VIZ-517: Different styling for pie chart wells](https://linear.app/metabase/issue/VIZ-517/different-styling-for-pie-chart-wells)

### Description

Avoids ridiculously large pie wells, and labels more consistent with other visualizations
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/9333fdc3-cf4d-4881-acd7-ec1876b77dbf" />
