### PR TITLE
Sync nullable, generated, default attributes for fields

### DIFF
--- a/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc_test.clj
+++ b/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc_test.clj
@@ -33,6 +33,8 @@
                             :database-type "TIMESTAMP",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable false
                             :base-type :type/DateTime,
                             :database-position 0,
                             :json-unfolding false}
@@ -40,6 +42,8 @@
                             :database-type "BIGINT",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/BigInteger,
                             :database-position 10,
                             :json-unfolding false}
@@ -47,6 +51,8 @@
                             :database-type "BIGINT",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/BigInteger,
                             :database-position 1,
                             :json-unfolding false}
@@ -54,6 +60,8 @@
                             :database-type "COMPLEX<hyperUnique>",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/DruidHyperUnique,
                             :database-position 11,
                             :json-unfolding false}
@@ -61,6 +69,8 @@
                             :database-type "VARCHAR",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/Text,
                             :database-position 2,
                             :json-unfolding false}
@@ -68,6 +78,8 @@
                             :database-type "VARCHAR",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/Text,
                             :database-position 3,
                             :json-unfolding false}
@@ -75,6 +87,8 @@
                             :database-type "VARCHAR",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/Text,
                             :database-position 4,
                             :json-unfolding false}
@@ -82,6 +96,8 @@
                             :database-type "VARCHAR",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/Text,
                             :database-position 5,
                             :json-unfolding false}
@@ -89,6 +105,8 @@
                             :database-type "DOUBLE",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/Float,
                             :database-position 6,
                             :json-unfolding false}
@@ -96,6 +114,8 @@
                             :database-type "DOUBLE",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/Float,
                             :database-position 7,
                             :json-unfolding false}
@@ -103,6 +123,8 @@
                             :database-type "VARCHAR",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/Text,
                             :database-position 8,
                             :json-unfolding false}
@@ -110,6 +132,8 @@
                             :database-type "BIGINT",
                             :database-required false,
                             :database-is-auto-increment false,
+                            :database-is-generated false
+                            :database-is-nullable true
                             :base-type :type/BigInteger,
                             :database-position 9,
                             :json-unfolding false}}}

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -414,6 +414,8 @@
                          :pk?               true
                          :database-position 0
                          :database-is-auto-increment true
+                         :database-is-generated false
+                         :database-is-nullable false
                          :database-required false
                          :json-unfolding    false}
                         {:name              "name"
@@ -421,6 +423,8 @@
                          :base-type         :type/Text
                          :database-position 1
                          :database-is-auto-increment false
+                         :database-is-generated false
+                         :database-is-nullable false
                          :database-required true
                          :json-unfolding    false}}}
              (driver/describe-table :snowflake (assoc (mt/db) :name "ABC") (t2/select-one :model/Table :id (mt/id :categories))))))))

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -144,7 +144,9 @@
                                    :database-position          0
                                    :database-required          false
                                    :json-unfolding             false
-                                   :database-is-auto-increment false}}}
+                                   :database-is-auto-increment false
+                                   :database-is-generated      false
+                                   :database-is-nullable       true}}}
                        (driver/describe-table driver db (t2/select-one :model/Table :id (mt/id :timestamp_table)))))))))))))
 
 (deftest select-query-datetime

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10833,6 +10833,53 @@ databaseChangeLog:
               - column:
                   name: key_hashed
             indexName: idx_core_session_key_hashed
+  - changeSet:
+      id: v54.2025-03-13T16:14:34
+      author: wotbrew
+      comment: Add metabase_field.database_is_nullable
+      preConditions:
+      changes:
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: database_is_nullable
+                  type: ${boolean.type}
+                  remarks: "Indicates whether the column is nullable"
+                  constraints:
+                    nullable: false
+                  defaultValue: false
+  - changeSet:
+      id: v54.2025-03-13T16:14:35
+      author: wotbrew
+      comment: Add metabase_field.database_is_generated
+      preConditions:
+      changes:
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: database_is_generated
+                  type: ${boolean.type}
+                  remarks: "Indicates whether the column is generated/computed"
+                  constraints:
+                    nullable: false
+                  defaultValue: false
+  - changeSet:
+      id: v54.2025-03-13T16:14:36
+      author: wotbrew
+      comment: Add metabase_field.database_default
+      preConditions:
+      changes:
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: database_default
+                  type: ${text.type}
+                  remarks: "The columns DEFAULT expression as a dialect specific SQL string."
+                  constraints:
+                    nullable: true
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -314,10 +314,15 @@
                         [:and [:!= :column_default nil] [:like :column_default [:inline "%nextval(%"]]]
                         [:!= :is_identity [:inline "NO"]]]]]
                 :database-required]
+               [:column_default :database-default]
                [[:or
                  [:and [:!= :column_default nil] [:like :column_default [:inline "%nextval(%"]]]
                  [:!= :is_identity [:inline "NO"]]]
-                :database-is-auto-increment]]
+                :database-is-auto-increment]
+               [[:= :is_nullable [:inline "YES"]]
+                :database-is-nullable]
+               [[:= :is_generated "ALWAYS"]
+                :database-is-generated]]
       :from [[:information_schema.columns :c]]
       :left-join [[{:select [:tc.table_schema
                              :tc.table_name
@@ -351,7 +356,10 @@
                [false :pk?]
                [nil :field-comment]
                [false :database-required]
-               [false :database-is-auto-increment]]
+               [nil :database-default]
+               [false :database-is-auto-increment]
+               [false :database-is-nullable]
+               [false :database-is-generated]]
       :from [[:pg_catalog.pg_class :pc]]
       :join [[:pg_catalog.pg_namespace :pn] [:= :pn.oid :pc.relnamespace]
              [:pg_catalog.pg_attribute :pa] [:= :pa.attrelid :pc.oid]

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -127,7 +127,7 @@
         (merge
          {:name                       column-name
           :database-type              (.getString rs "TYPE_NAME")
-          :database-default           default
+          :database-default           (not-empty default) ; druid returns "" if no DEFAULT
           :database-is-auto-increment auto-increment?
           :database-is-generated      generated?
           :database-is-nullable       nullable?

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -116,17 +116,21 @@
      #(let [default            (.getString rs "COLUMN_DEF")
             no-default?        (contains? #{nil "NULL" "null"} default)
             nullable           (.getInt rs "NULLABLE")
-            not-nullable?      (= 0 nullable)
+            nullable?          (= 1 nullable)
              ;; IS_AUTOINCREMENT could return nil
             auto-increment     (.getString rs "IS_AUTOINCREMENT")
             auto-increment?    (= "YES" auto-increment)
             no-auto-increment? (= "NO" auto-increment)
             column-name        (.getString rs "COLUMN_NAME")
-            required?          (and no-default? not-nullable? no-auto-increment?)]
+            required?          (and no-default? (not nullable?) no-auto-increment?)
+            generated?         (= "YES" (.getString rs "IS_GENERATEDCOLUMN"))]
         (merge
          {:name                       column-name
           :database-type              (.getString rs "TYPE_NAME")
+          :database-default           default
           :database-is-auto-increment auto-increment?
+          :database-is-generated      generated?
+          :database-is-nullable       nullable?
           :database-required          required?}
          (when-let [remarks (.getString rs "REMARKS")]
            (when-not (str/blank? remarks)
@@ -185,7 +189,10 @@
                                         :database-type
                                         :field-comment
                                         :database-required
-                                        :database-is-auto-increment])
+                                        :database-default
+                                        :database-is-auto-increment
+                                        :database-is-nullable
+                                        :database-is-generated])
             {:table-schema      (:table-schema col) ;; can be nil
              :base-type         base-type
              ;; json-unfolding is true by default for JSON fields, but this can be overridden at the DB level

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -393,7 +393,8 @@
 
 (defmethod serdes/make-spec "Field" [_model-name opts]
   {:copy      [:active :base_type :caveats :coercion_strategy :custom_position :database_indexed
-               :database_is_auto_increment :database_partitioned :database_position :database_required :database_type
+               :database_is_auto_increment :database_is_generated :database_is_nullable :database_default
+               :database_partitioned :database_position :database_required :database_type
                :description :display_name :effective_type :entity_id :has_field_values :is_defective_duplicate
                :json_unfolding :name :nfc_path :points_of_interest :position :preview_display :semantic_type :settings
                :unique_field_helper :visibility_type]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.h2-test
   (:require
    [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -415,3 +416,49 @@
            (sql-jdbc.actions/maybe-parse-sql-error
             :h2 actions.error/violate-foreign-key-constraint {:id 1} :row/update
             "Referential integrity constraint violation: \"USER_GROUP-ID_GROUP_-159406530: PUBLIC.\"\"USER\"\" FOREIGN KEY(\"\"GROUP-ID\"\") REFERENCES PUBLIC.\"\"GROUP\"\"(ID) (CAST(999 AS BIGINT))\"; SQL statement:\nINSERT INTO \"PUBLIC\".\"USER\" (\"NAME\", \"GROUP-ID\") VALUES (CAST(? AS VARCHAR), CAST(? AS INTEGER)) [23506-214]")))))
+
+(deftest column-attributes-test
+  (mt/test-driver :h2
+    (mt/with-empty-db
+      (let [spec (mdb/spec :h2 (:details (mt/db)))
+            describe
+            (fn [column-defs]
+              (jdbc/execute! spec ["DROP TABLE IF EXISTS TEST_TABLE"])
+              (jdbc/execute! spec [(->> (map #(format "col%d %s" %1 %2) (range) column-defs)
+                                        (str/join ",")
+                                        (format "CREATE TABLE TEST_TABLE (%s)"))])
+              (->> (driver/describe-table :h2 (mt/db) {:name "TEST_TABLE"})
+                   :fields
+                   (sort-by :database-position)
+                   (mapv #(-> (select-keys % [:database-is-generated :database-is-nullable :database-default])
+                              ;; shorthand
+                              (set/rename-keys {:database-is-generated :g
+                                                :database-is-nullable  :n
+                                                :database-default      :d})))))
+            do-test
+            (fn [& test-cases]
+              (let [test-cases' (partition 2 test-cases)
+                    results (describe (map first test-cases'))]
+                (is (= (count test-cases) (* 2 (count results))))
+                (doseq [[[col-def expected] result] (map vector test-cases' results)]
+                  (testing col-def
+                    (is (= expected result))))))]
+        (do-test
+         "SERIAL"
+         {:g false, :n false}
+
+         "INT"
+         {:g false, :n true}
+
+         "INT AS (col0 + 1)"
+         {:g true,  :n true}
+
+         ;; note, like postgres - h2 rewrites the expression supplied by the user.
+         "INT DEFAULT EXTRACT(EPOCH FROM NOW())"
+         {:g false, :n true, :d "EXTRACT(EPOCH FROM LOCALTIMESTAMP)"}
+
+         "INT NULL"
+         {:g false, :n true}
+
+         "INT NOT NULL"
+         {:g false, :n false})))))

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -58,6 +58,8 @@
                :pk?                        true
                :database-required          false
                :database-is-auto-increment true
+               :database-is-generated      false
+               :database-is-nullable       false
                :json-unfolding             false}
               {:name                       "NAME"
                :database-type              "CHARACTER VARYING"
@@ -65,6 +67,8 @@
                :database-position          1
                :database-required          false
                :database-is-auto-increment false
+               :database-is-generated      false
+               :database-is-nullable       true
                :json-unfolding             false}
               {:name                       "CATEGORY_ID"
                :database-type              "INTEGER"
@@ -72,6 +76,8 @@
                :database-position          2
                :database-required          false
                :database-is-auto-increment false
+               :database-is-generated      false
+               :database-is-nullable       true
                :json-unfolding             false}
               {:name                       "LATITUDE"
                :database-type              "DOUBLE PRECISION"
@@ -79,6 +85,8 @@
                :database-position          3
                :database-required          false
                :database-is-auto-increment false
+               :database-is-generated      false
+               :database-is-nullable       true
                :json-unfolding             false}
               {:name                       "LONGITUDE"
                :database-type              "DOUBLE PRECISION"
@@ -86,6 +94,8 @@
                :database-position          4
                :database-required          false
                :database-is-auto-increment false
+               :database-is-generated      false
+               :database-is-nullable       true
                :json-unfolding             false}
               {:name                       "PRICE"
                :database-type              "INTEGER"
@@ -93,6 +103,8 @@
                :database-position          5
                :database-required          false
                :database-is-auto-increment false
+               :database-is-generated      false
+               :database-is-nullable       true
                :json-unfolding             false}}}
            (driver/describe-table :h2 (mt/db) {:name "VENUES"})))))
 
@@ -109,28 +121,34 @@
                          "GRANT ALL ON \"employee_counter\" TO GUEST;"]]
         (jdbc/execute! one-off-dbs/*conn* [statement]))
       (sync/sync-database! (mt/db))
-      (is (= {:fields #{{:base-type                 :type/Integer
+      (is (= {:fields #{{:base-type                  :type/Integer
                          :database-is-auto-increment true
-                         :database-position         0
-                         :database-required         false
-                         :database-type             "INTEGER"
-                         :name                      "id"
-                         :pk?                       true
-                         :json-unfolding            false}
-                        {:base-type                 :type/Integer
+                         :database-is-generated      false
+                         :database-is-nullable       false
+                         :database-position          0
+                         :database-required          false
+                         :database-type              "INTEGER"
+                         :name                       "id"
+                         :pk?                        true
+                         :json-unfolding             false}
+                        {:base-type                  :type/Integer
                          :database-is-auto-increment true
-                         :database-position         1
-                         :database-required         false
-                         :database-type             "INTEGER"
-                         :name                      "count"
-                         :json-unfolding            false}
-                        {:base-type                 :type/Integer
+                         :database-is-generated      false
+                         :database-is-nullable       false
+                         :database-position          1
+                         :database-required          false
+                         :database-type              "INTEGER"
+                         :name                       "count"
+                         :json-unfolding             false}
+                        {:base-type                  :type/Integer
                          :database-is-auto-increment false
-                         :database-position         2
-                         :database-required         true
-                         :database-type             "INTEGER"
-                         :name                      "rank"
-                         :json-unfolding            false}}
+                         :database-is-generated      false
+                         :database-is-nullable       false
+                         :database-position          2
+                         :database-required          true
+                         :database-type              "INTEGER"
+                         :name                       "rank"
+                         :json-unfolding             false}}
               :name "employee_counter"}
              (sql-jdbc.describe-table/describe-table :h2 (mt/id) {:name "employee_counter"}))))))
 

--- a/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/fields/Some Field.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/fields/Some Field.yaml
@@ -35,6 +35,9 @@ serdes/meta:
   model: Table
 - id: Some Field
   model: Field
+database_default: null
 database_indexed: null
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: Ov5wwh7fYOdhiUFxS4ihN

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: sBsHx24gA7l-4ghDzlzhF

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/NAME.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: NAME
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: jEZf_v-4ewNSY1QEWw0Se

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/DATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/DATE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: DATE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: RP5HLhoqRvCi2Y7tt6SiJ

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: cY9GKjimt9fkbwSmq3s2D

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/USER_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/USER_ID.yaml
@@ -41,6 +41,9 @@ serdes/meta:
   model: Table
 - id: USER_ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: aPH5xec5UYszHtsFWpmel

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/VENUE_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/VENUE_ID.yaml
@@ -41,6 +41,9 @@ serdes/meta:
   model: Table
 - id: VENUE_ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: PCwnRlLbnPF8R4hzXmNGR

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/CREATED_AT.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: CREATED_AT
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 9ntDoLGY3AF3C4gD2TEzy

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/DISCOUNT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/DISCOUNT.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: DISCOUNT
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: bJZMPrTpKh9du7t-BG67z

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: IiIFClKQXRxRxACobQ0Hb

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/PRODUCT_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/PRODUCT_ID.yaml
@@ -41,6 +41,9 @@ serdes/meta:
   model: Table
 - id: PRODUCT_ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: HcBNIyo38ID7k3zRiaZZ7

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/QUANTITY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/QUANTITY.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: QUANTITY
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 0wAi4F3QofJo3rKLN0Tmc

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/SUBTOTAL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/SUBTOTAL.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: SUBTOTAL
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: Hk8HG908-1Yk3eatFXpqM

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TAX.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TAX.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: TAX
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: T8PChksd3ig-4V3cmUkX1

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TOTAL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TOTAL.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: TOTAL
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: OzPJltpWAbCXnqBRDXETi

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/USER_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/USER_ID.yaml
@@ -41,6 +41,9 @@ serdes/meta:
   model: Table
 - id: USER_ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: rNoeK7kIBWVuk-q-GXeXe

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ADDRESS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ADDRESS.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ADDRESS
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 95on8mqct2RznafaiUYYN

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/BIRTH_DATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/BIRTH_DATE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: BIRTH_DATE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: QTEhFM69RUzvOmN54uzW3

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CITY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CITY.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: CITY
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 9B2UPC2I7yRIUQiJuZNrO

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CREATED_AT.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: CREATED_AT
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: kVPl9EyIl3cKVtJT2boYc

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/EMAIL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/EMAIL.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: EMAIL
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: NAoZKcsK9zzQ_vx6E9ioB

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: qrQZFu3wq_jquvdj9Cykl

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LATITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LATITUDE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: LATITUDE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 4g80DtZISRLp5SCVUFdOw

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LONGITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LONGITUDE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: LONGITUDE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: hZ92SH5RvNXAgQDTWhUaD

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/NAME.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: NAME
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: hyZGfYofxZluz3zEY06z1

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/PASSWORD.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/PASSWORD.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: PASSWORD
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: H3sKKUFQJZjLnpv6Qzv4E

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/SOURCE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/SOURCE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: SOURCE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 2hnPlZ9z5Riq4qv_VSeTv

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/STATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/STATE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: STATE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: sCwbkjXDJgQIAX3D3rbV5

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ZIP.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ZIP.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ZIP
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 1dXHzmeh3xHHuQC1y51Dj

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CATEGORY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CATEGORY.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: CATEGORY
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: khmQ5iqqybZ9RL7rP7DVH

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CREATED_AT.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: CREATED_AT
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: tlG2LL84pkkAcc6FLQhWU

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/EAN.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/EAN.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: EAN
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: MLCr2IuH9utdQxlXlH3hp

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: pIVx08kb89oxIvq9ewtm_

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/PRICE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/PRICE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: PRICE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: Zsxl1zcPTMPPJoHpaFMwC

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/RATING.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/RATING.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: RATING
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: lVeIH8wHGn6hBtTWcgvwV

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/TITLE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/TITLE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: TITLE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: KcDM8frKUWvd0mC1KPJ-G

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/VENDOR.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/VENDOR.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: VENDOR
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: plKu8ko8uSEu8t8rSyTNb

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/BODY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/BODY.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: BODY
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: nZQyMvxGygYomxrBfzoQk

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/CREATED_AT.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: CREATED_AT
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: VHTQLIUwNEI0PoLRogT8W

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: LUbennMbPNtPzL9tKb8W9

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/PRODUCT_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/PRODUCT_ID.yaml
@@ -41,6 +41,9 @@ serdes/meta:
   model: Table
 - id: PRODUCT_ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: SSid-McZJwdk9QqJQbQ5a

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/RATING.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/RATING.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: RATING
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: i9kgOCMWRj9Zy8gXDioh-

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/REVIEWER.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/REVIEWER.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: REVIEWER
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: s5SzrmXlHrLNSSU0pchfo

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: b4rF_gcpmPwMBS1fEul7x

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/LAST_LOGIN.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/LAST_LOGIN.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: LAST_LOGIN
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: qELQSWKJkRMHmPZNn8-80

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/NAME.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: NAME
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: hYN1x8_S3RWiV9gyLlW8R

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/PASSWORD.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/PASSWORD.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: PASSWORD
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: hT0OPv0YdJd3l56rFPYLy

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/CATEGORY_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/CATEGORY_ID.yaml
@@ -41,6 +41,9 @@ serdes/meta:
   model: Table
 - id: CATEGORY_ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 6d-rbYLMiBcMKBFBO3z2O

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/ID.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: ID
   model: Field
+database_default: null
 database_indexed: true
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 5Ni7ZdMvZ5yqmbaRYVQ-q

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LATITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LATITUDE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: LATITUDE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: EPdF1g_aQzDZ0Z4cozcxg

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LONGITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LONGITUDE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: LONGITUDE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: 9rX_BZ6VY24FA6H6qFuCs

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/NAME.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: NAME
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: cMgpuvb_X4Jkvf8_e0lp5

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/PRICE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/PRICE.yaml
@@ -37,6 +37,9 @@ serdes/meta:
   model: Table
 - id: PRICE
   model: Field
+database_default: null
 database_indexed: false
+database_is_generated: false
+database_is_nullable: false
 database_partitioned: null
 entity_id: lqd08dVvYfpeB73LxjbQz


### PR DESCRIPTION
Adds the following columns to `metabase_field`

- `database_is_nullable` (not nullable boolean)
- `database_is_generated` (not nullable boolean)
- `database_default` (nullable `text.type`)

Closes WRK-74

The `database_` prefix is chosen as I saw it used to qualify existing names such as `database_is_auto_increment`.

`database_is_nullable` / `database_is_generated` are pretty straightforward. One thing of note is we do not distinguish between virtual/stored or any other dimension of generated columns. This is because we only care _that_ the column is generated, not its expr or properties.

`database_default` returns the dialect/driver specific expression string associated with the column as its `DEFAULT`. Note this is not necessarily the same string that appears in the column definition - as the added H2/Postgres test cases demonstrate.

Possible controversies:
- I've only added explicit tests for H2/Postgres. This is ok for `internal-tools` but probably not for `master`.
- The `database_is_nullable`, `database_is_generated` columns are themselves not nullable, there is no sentinel value for 'unknown' or 'not supported'

If we want to merge this into master at some point we might want to work on / consider more deeply the above points.