### PR TITLE
Polishing 2025: Improve spacing in the custom dashboard confirmation modal

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1,4 +1,3 @@
-const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
@@ -8,6 +7,7 @@ import {
 } from "e2e/support/cypress_sample_instance_data";
 import type { CardId, FieldReference } from "metabase-types/api";
 
+const { H } = cy;
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("issue 29943", () => {

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -11,7 +11,7 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
 import { refreshCurrentUser } from "metabase/redux/user";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import { Box, Text } from "metabase/ui";
+import { Stack, Text } from "metabase/ui";
 import type { DashboardId } from "metabase-types/api";
 
 const CUSTOM_HOMEPAGE_SETTING_KEY = "custom-homepage";
@@ -43,18 +43,17 @@ export const CustomHomePageModal = ({
     await dispatch(
       addUndo({
         message: () => (
-          <Box ml="0.5rem" mr="2.5rem">
+          <Stack gap="xs" ml="0.5rem" mr="2.5rem">
             <Text
               span
               c="text-white"
               fw={700}
             >{t`This dashboard has been set as your homepage.`}</Text>
-            <br />
             <Text
               span
               c="text-white"
             >{t`You can change this in Admin > Settings > General.`}</Text>
-          </Box>
+          </Stack>
         ),
         icon: "info",
         timeout: 10000,


### PR DESCRIPTION
Before: 

![improve-spacing-in-custom-dashboard-confirmation-modal--before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/bee72a8c-08fe-48c5-b500-27fc15ce789d.png)

After:

![improve-spacing-in-custom-dashboard-confirmation-modal--after.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/ee405f6a-eba4-49bd-a181-e4e910c67124.png)

