### PR TITLE
Polishing 2025: Fix width of model persistence toggle

### DIFF
--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -137,16 +137,18 @@ export const ModelPersistenceConfiguration = () => {
           error={null}
           loading={modelPersistenceEnabled === undefined}
         >
-          <Switch
-            mt="sm"
-            label={
-              <Text fw="bold">
-                {modelPersistenceEnabled ? t`Enabled` : t`Disabled`}
-              </Text>
-            }
-            onChange={onSwitchChanged}
-            checked={modelPersistenceEnabled}
-          />
+          <Stack align="flex-start">
+            <Switch
+              mt="sm"
+              label={
+                <Text fw="bold">
+                  {modelPersistenceEnabled ? t`Enabled` : t`Disabled`}
+                </Text>
+              }
+              onChange={onSwitchChanged}
+              checked={modelPersistenceEnabled}
+            />
+          </Stack>
         </DelayedLoadingAndErrorWrapper>
       </Box>
       {/* modelCachingSchedule is sometimes undefined but TS thinks it is always a string */}


### PR DESCRIPTION
In Admin / Performance / Model persistence, don't allow the toggle to fill the width of the page or clicking several inches to the right of it will trigger it, making misclicks too easy.

Before:

![admin-performance-model-persistene--make-toggle-smaller--before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/d6e125b1-efec-43ba-93ab-b7a98746a418.png)

After

![admin-performance-model-persistene--make-toggle-smaller--after.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/03287263-1b60-43d2-9ea8-f48e49acc89e.png)

