### PR TITLE
Polishing 2025: Improve spacing in Admin / Settings / Appearance / Logo

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageUpload/ImageUpload.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageUpload/ImageUpload.jsx
@@ -2,16 +2,16 @@
 import cx from "classnames";
 
 import { SettingInput } from "metabase/admin/settings/components/widgets/SettingInput";
-import Button from "metabase/core/components/Button";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
+import { Button, Flex, Icon } from "metabase/ui";
 
 import { FileInput } from "./ImageUpload.styled";
 
 export const ImageUpload = ({ id, setting, onChange, ...props }) => {
   const imageSource = setting.value;
   return (
-    <div>
+    <Flex align="center">
       {imageSource && (
         <div className={CS.mb1}>
           {/* Preview of icon as it will appear in the nav bar */}
@@ -43,7 +43,16 @@ export const ImageUpload = ({ id, setting, onChange, ...props }) => {
       ) : (
         <SettingInput setting={setting} onChange={onChange} {...props} />
       )}
-      <Button onlyIcon icon="close" onClick={() => onChange(undefined)} />
-    </div>
+      {imageSource && (
+        <Button
+          p="xs"
+          c="text-dark"
+          variant="subtle"
+          onClick={() => onChange(undefined)}
+        >
+          <Icon name="close" />
+        </Button>
+      )}
+    </Flex>
   );
 };


### PR DESCRIPTION
On master, in Admin / Settings / Appearance, the logo removal icon was visible even when no logo has been chosen:

![improve-spacing-in-admin-settings-appearance-logo--before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/eea66cf7-1c5e-4e79-aa77-58452554d306.png)

In this branch:

![improve-spacing-in-admin-settings-appearance-logo--after.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/1dd8edf1-1376-4e7a-aba6-539683a3bc1c.png)

The icon appears when a logo is selected:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/30ff1a17-0483-4b6a-b660-92d2bf8d496a.png)

