### PR TITLE
fix: more efficient query for execution stats

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -657,30 +657,38 @@
   (u/prog1 eid-translation/default-counter
     (setting/set-value-of-type! :json :entity-id-translation-counter <>)))
 
-(defn- categorize-query-execution [{:keys [context embedding_client executor_id]}]
-  (cond
-    (= "embedding-sdk-react" embedding_client)                        "sdk_embed"
-    (and (= "embedding-iframe" embedding_client) (some? executor_id)) "interactive_embed"
-    (and (= "embedding-iframe" embedding_client) (nil? executor_id))  "static_embed"
-    (some-> context name (str/starts-with? "public-"))                "public_link"
-    :else                                                             "internal"))
-
 (defn- ->one-day-ago []
   (t/minus (t/offset-date-time) (t/days 1)))
 
 (defn- ->snowplow-grouped-metric-info []
-  (let [qe (t2/select [:model/QueryExecution :embedding_client :context :executor_id :started_at])
+  (let [qe-query [:model/QueryExecution
+                  [(count-case [:= :embedding_client "embedding-sdk-react"]) :sdk_embed]
+                  [(count-case [:and [:= :embedding_client "embedding-iframe"]
+                                [:!= :executor_id nil]])
+                   :interactive_embed]
+                  [(count-case [:and [:= :embedding_client "embedding-iframe"]
+                                [:= :executor_id nil]])
+                   :static_embed]
+                  [(count-case [:and
+                                [:or [:= :embedding_client nil]
+                                 [:!= :embedding_client "embedding-sdk-react"]]
+                                [:or [:= :embedding_client nil]
+                                 [:!= :embedding_client "embedding-iframe"]]
+                                [:like :context "public-%"]])
+                   :public_link]
+                  [(count-case [:and
+                                [:or [:= :embedding_client nil]
+                                 [:!= :embedding_client "embedding-sdk-react"]]
+                                [:or [:= :embedding_client nil]
+                                 [:!= :embedding_client "embedding-iframe"]]
+                                [:not [:like :context "public-%"]]])
+                   :internal]]
+
+        qe          (t2/select-one qe-query)
         one-day-ago (->one-day-ago)
-        ;; reuse the query data:
-        qe-24h (filter (fn [{started-at :started_at}] (t/after? started-at one-day-ago)) qe)]
-    {:query-executions (merge
-                        {"sdk_embed" 0 "interactive_embed" 0 "static_embed" 0 "public_link" 0 "internal" 0}
-                        (-> (group-by categorize-query-execution qe)
-                            (update-vals count)))
-     :query-executions-24h (merge
-                            {"sdk_embed" 0 "interactive_embed" 0 "static_embed" 0 "public_link" 0 "internal" 0}
-                            (-> (group-by categorize-query-execution qe-24h)
-                                (update-vals count)))
+        qe-24h      (t2/select-one qe-query {:where [:> :started_at one-day-ago]})]
+    {:query-executions     qe
+     :query-executions-24h qe-24h
      :eid-translations-24h (get-translation-count)}))
 
 (defn- deep-string-keywords
@@ -689,6 +697,12 @@
   (walk/postwalk
    (fn [x] (if (keyword? x) (-> x u/->snake_case_en name) x))
    data))
+
+(defn- get-query-exeuction-counts
+  [executions]
+  (mapv (fn [qe-group]
+          {:group (str qe-group) :value (get executions qe-group)})
+        [:interactive_embed :internal :public_link :sdk_embed :static_embed]))
 
 (mu/defn- snowplow-grouped-metrics
   :- [:sequential
@@ -702,13 +716,10 @@
     :as _snowplow-grouped-metric-info}]
   (deep-string-keywords
    [{:name :query_executions_by_source
-     :values (mapv (fn [qe-group]
-                     {:group qe-group :value (get query-executions qe-group)})
-                   ["interactive_embed" "internal" "public_link" "sdk_embed" "static_embed"])
+     :values (get-query-exeuction-counts query-executions)
      :tags ["embedding"]}
     {:name :query_executions_by_source_24h
-     :values (mapv (fn [qe-group] {:group qe-group :value (get query-executions-24h qe-group)})
-                   ["interactive_embed" "internal" "public_link" "sdk_embed" "static_embed"])
+     :values (get-query-exeuction-counts query-executions-24h)
      :tags ["embedding"]}
     {:name :entity_id_translations_last_24h
      :values (mapv (fn [[k v]] {:group k :value v}) eid-translations-24h)

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -525,16 +525,46 @@
             "There are never more query executions in the 24h version than all-of-time.")))))
 
 (deftest query-execution-24h-filtering-test
-  (let [before (#'stats/->snowplow-grouped-metric-info)]
-    ;; run 2 internal queries, set one to happen a year ago:
-    (mt/with-temp [:model/QueryExecution _internal-year-ago
-                   (merge query-execution-defaults
-                          {:started_at (-> (t/offset-date-time) (t/minus (t/years 1)))})
-                   :model/QueryExecution _internal-new query-execution-defaults]
+  (let [before (#'stats/->snowplow-grouped-metric-info)
+        one-year-ago-defaults (assoc query-execution-defaults
+                                     :started_at (-> (t/offset-date-time)
+                                                     (t/minus (t/years 1))))]
+    (mt/with-temp [:model/User           u {}
+                   :model/QueryExecution _ one-year-ago-defaults
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-sdk-react")
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc one-year-ago-defaults
+                                                  :embedding_client "embedding-iframe"
+                                                  :executor_id (u/the-id u))
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-question)
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-csv-download)
+                   :model/QueryExecution _ query-execution-defaults
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
+                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
       (let [after (#'stats/->snowplow-grouped-metric-info)
-            before-internal (-> before :query-executions (get "internal"))
-            after-internal (-> after :query-executions (get "internal"))
-            before-24h-internal (-> before :query-executions-24h (get "internal"))
-            after-24h-internal (-> after :query-executions-24h (get "internal"))]
+            before-internal (-> before :query-executions :internal)
+            after-internal (-> after :query-executions :internal)
+            before-24h-internal (-> before :query-executions-24h :internal)
+            after-24h-internal (-> after :query-executions-24h :internal)]
         (is (= 2 (- after-internal before-internal)))
-        (is (= 1 (- after-24h-internal before-24h-internal)))))))
+        (is (= 1 (- after-24h-internal before-24h-internal)))
+        (is (= 2 (- (-> after :query-executions :sdk_embed)
+                    (-> before :query-executions :sdk_embed))))
+        (is (= 4 (- (-> after :query-executions :static_embed)
+                    (-> before :query-executions :static_embed))))
+        (is (= 4 (- (-> after :query-executions :public_link)
+                    (-> before :query-executions :public_link))))
+        (is (= 1 (- (-> after :query-executions :interactive_embed)
+                    (-> before :query-executions :interactive_embed))))
+        (is (= 1 (- (-> after :query-executions-24h :sdk_embed)
+                    (-> before :query-executions-24h :sdk_embed))))
+        (is (= 2 (- (-> after :query-executions-24h :static_embed)
+                    (-> before :query-executions-24h :static_embed))))
+        (is (= 2 (- (-> after :query-executions-24h :public_link)
+                    (-> before :query-executions-24h :public_link))))
+        (is (= 0 (- (-> after :query-executions-24h :interactive_embed)
+                    (-> before :query-executions-24h :interactive_embed))))))))

--- a/test/metabase/public_sharing/api_test.clj
+++ b/test/metabase/public_sharing/api_test.clj
@@ -159,7 +159,7 @@
       (with-temp-public-card [{uuid :public_uuid}]
         (testing "should increment the public link query count when fetching a public Card"
           (let [get-qe-count (fn get-qe-count [] (get-in (#'stats/->snowplow-grouped-metric-info)
-                                                         [:query-executions "public_link"]))
+                                                         [:query-executions :public_link]))
                 qe-count-before (get-qe-count)]
             (client/client :get 202 (str "public/card/" uuid "/query"))
             ;; The qe-count gets incremented asynchronously, so we need to poll until it's updated.


### PR DESCRIPTION
### Description

We see high memory usage when building metabase usage stats. This resolves another place where we spend a lot of time loading models into memory by converting it into two SQL queries one for all-time stats and the other scoped to a single day. 

### How to verify

Hop on a stats repl and trigger the phone home call.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
