### PR TITLE
feat: add malli schema, test converage to ldap api

### DIFF
--- a/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
@@ -78,11 +78,23 @@ describe(
       getLdapCard().findByText("Set up").should("exist");
     });
 
-    it("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
+    it("should not reset previously populated fields when schema validation fails for just one of them", () => {
       cy.visit("/admin/settings/authentication/ldap");
 
       enterLdapSettings();
       enterLdapPort("0");
+      cy.button("Save and enable").click();
+      cy.wait("@updateLdapSettings");
+
+      cy.findAllByText("Nullable integer greater than 0").should("exist");
+      cy.findByDisplayValue("localhost").should("exist");
+    });
+
+    it("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
+      cy.visit("/admin/settings/authentication/ldap");
+
+      enterLdapSettings();
+      enterLdapPort("1");
       cy.button("Save and enable").click();
       cy.wait("@updateLdapSettings");
 

--- a/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
@@ -86,7 +86,7 @@ describe(
       cy.button("Save and enable").click();
       cy.wait("@updateLdapSettings");
 
-      cy.findAllByText("Nullable integer greater than 0").should("exist");
+      cy.findAllByText("nullable integer greater than 0").should("exist");
       cy.findByDisplayValue("localhost").should("exist");
     });
 

--- a/src/metabase/sso/api/ldap.clj
+++ b/src/metabase/sso/api/ldap.clj
@@ -21,14 +21,20 @@
 
 (api.macros/defendpoint :put "/settings"
   "Update LDAP related settings. You must be a superuser to do this."
-  ;; TODO -- add `:ldap-port` and `:ldap-password` to the body schema and use Malli decoding for `:ldap-port`
   [_route-params
    _query-params
-   settings :- :map]
+   settings :- [:map
+                [:ldap-port    {:optional true} [:maybe
+                                                 ;; treat empty string as nil
+                                                 {:decode/api (fn [x]
+                                                                (when-not (= x "")
+                                                                  x))}
+                                                 pos-int?]]
+                [:ldap-password {:optional true} [:maybe :string]]
+                [:ldap-host {:optional true} [:maybe :string]]
+                [:ldap-enabled {:optional true} [:maybe :boolean]]]]
   (api/check-superuser)
   (let [ldap-settings (-> settings
-                          (assoc :ldap-port (when-let [^String ldap-port (not-empty (str (:ldap-port settings)))]
-                                              (Long/parseLong ldap-port)))
                           (update :ldap-password update-password-if-needed)
                           (dissoc :ldap-enabled))
         ldap-details  (set/rename-keys ldap-settings ldap/mb-settings->ldap-details)


### PR DESCRIPTION
### Description

Restores the malli schema that was causing e2e tests to fail on the first attempt and updates those e2e tests to look for the new error message returned when the api request is rejected due to schema validation issues.

Expand test cases around ldap connection testing errors so those messages can be caught on future api changes.

### How to verify

1. Navigate to the LDAP settings on metabase.
2. Attempt to enter 0 as the port number
3. Click save
4. See a message indicating this value is not allowed
5. Attempt to enter 1 as the port number
6. Click save
7. See a message indicating that the the wrong host or port was used to connect

### Demo
<img width="588" alt="Screenshot 2025-03-13 at 3 08 01 PM" src="https://github.com/user-attachments/assets/8a051177-79a6-4617-9f35-2d73bad2f011" />
<img width="579" alt="Screenshot 2025-03-13 at 3 08 09 PM" src="https://github.com/user-attachments/assets/233bd213-f057-4e54-8706-05e71d545769" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
