### PR TITLE
hide empty tooltips with empty hints in PermissionsSelectOption

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.jsx
@@ -36,7 +36,7 @@ export function PermissionsSelectOption({
       onMouseEnter={() => setShouldShowTooltip(true)}
       onMouseLeave={() => setShouldShowTooltip(false)}
     >
-      <Tooltip label={hint} opened={shouldShowTooltip}>
+      <Tooltip label={hint} disabled={!hint} opened={shouldShowTooltip}>
         <IconContainer color={iconColor}>
           <Icon name={icon} />
         </IconContainer>


### PR DESCRIPTION
### Description
Small PR that disables tooltips on Permssion Option Selects when the hint is empty

### How to verify

1. Admin -> Permissions -> Collections
2. Select a collection. However over Admin and see the tooltips
3. Hover over other things and see there are no tooltips

### Demo
Before:
<img width="297" alt="image" src="https://github.com/user-attachments/assets/764880e7-5fd9-47d4-8ef6-d876b6acab60" />
After: (mouse is hovering over the option, trust me haha)
<img width="465" alt="image" src="https://github.com/user-attachments/assets/aed4dc26-6dce-4cd5-a77f-7840d0f0537b" />
