### PR TITLE
fix(qb): do not cut layout with two sidebars

### DIFF
--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -415,6 +415,42 @@ describe("scenarios > question > native", () => {
       cy.get("@lines").eq(0).should("have.text", "  ");
     },
   );
+
+  it("should be able to handle two sidebars on different screen sizes", () => {
+    const questionDetails = {
+      name: "13332",
+      native: {
+        query: "select * from PRODUCTS limit 5",
+      },
+    };
+
+    H.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.log("open editor on a normal screen size");
+    cy.findByTestId("visibility-toggler").click();
+
+    dataReferenceSidebar().should("be.visible");
+
+    cy.findByTestId("visibility-toggler").click();
+
+    cy.log("open editor on a small screen size");
+    cy.viewport(1279, 800);
+
+    cy.findByTestId("visibility-toggler").click();
+    dataReferenceSidebar().should("not.be.visible");
+
+    cy.log("open visualization settings sidebar, order matters");
+    cy.findByTestId("viz-type-button").click();
+
+    cy.log("open data reference sidebar");
+    cy.findByTestId("native-query-editor-sidebar").icon("reference").click();
+
+    cy.log("set small viewport");
+    cy.viewport(800, 800);
+
+    cy.findByTestId("sidebar-left").invoke("width").should("be.gt", 350);
+    cy.findByTestId("sidebar-right").invoke("width").should("be.gt", 350);
+  });
 });
 
 // causes error in cypress 13

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -135,10 +135,7 @@ interface NativeQueryEditorState {
   isPromptInputVisible: boolean;
 }
 
-export class NativeQueryEditor extends Component<
-  Props,
-  NativeQueryEditorState
-> {
+class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
   resizeBox = createRef<HTMLDivElement & ResizableBox>();
   editor = createRef<CodeMirrorEditorRef>();
 
@@ -472,10 +469,10 @@ export class NativeQueryEditor extends Component<
   }
 }
 
-const NativeQueryEditorRefWrapper = forwardRef<
+const NativeQueryEditorWrapper = forwardRef<
   HTMLDivElement,
   Omit<Props, "toggleEditor">
->(function _NativeQueryEditorRefWrapper(props, ref) {
+>(function NativeQueryEditorWrapper(props, ref) {
   const screenSize = useNotebookScreenSize();
   const dispatch = useDispatch();
   const { isNativeEditorOpen } = props;
@@ -506,4 +503,4 @@ export default _.compose(
   Snippets.loadList({ loadingAndErrorWrapper: false }),
   SnippetCollections.loadList({ loadingAndErrorWrapper: false }),
   ExplicitSize(),
-)(NativeQueryEditorRefWrapper);
+)(NativeQueryEditorWrapper);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -1,5 +1,11 @@
 import cx from "classnames";
-import { Component, type ForwardedRef, createRef, forwardRef } from "react";
+import {
+  Component,
+  type ForwardedRef,
+  createRef,
+  forwardRef,
+  useCallback,
+} from "react";
 import { ResizableBox, type ResizableBoxProps } from "react-resizable";
 import _ from "underscore";
 
@@ -8,8 +14,14 @@ import Modal from "metabase/components/Modal";
 import Databases from "metabase/entities/databases";
 import SnippetCollections from "metabase/entities/snippet-collections";
 import Snippets from "metabase/entities/snippets";
+import { useDispatch } from "metabase/lib/redux";
+import {
+  setIsNativeEditorOpen,
+  setUIControls,
+} from "metabase/query_builder/actions";
 import SnippetFormModal from "metabase/query_builder/components/template_tags/SnippetFormModal";
 import type { QueryModalType } from "metabase/query_builder/constants";
+import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
 import { Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -76,6 +88,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
 
   editorContext?: "question";
 
+  toggleEditor: () => void;
   handleResize: () => void;
   setDatasetQuery: (query: NativeQuery) => Promise<Question>;
   runQuestionQuery: (opts?: {
@@ -233,10 +246,6 @@ export class NativeQueryEditor extends Component<
     this.editor.current?.focus();
   }
 
-  toggleEditor = () => {
-    this.props.setIsNativeEditorOpen?.(!this.props.isNativeEditorOpen);
-  };
-
   // Change the Database we're currently editing a query for.
   setDatabaseId = (databaseId: DatabaseId) => {
     const { query, setDatasetQuery, question, onSetDatabaseId } = this.props;
@@ -392,7 +401,7 @@ export class NativeQueryEditor extends Component<
                 <VisibilityToggler
                   isOpen={isNativeEditorOpen}
                   readOnly={!!readOnly}
-                  toggleEditor={this.toggleEditor}
+                  toggleEditor={this.props.toggleEditor}
                 />
               )}
           </Flex>
@@ -463,11 +472,33 @@ export class NativeQueryEditor extends Component<
   }
 }
 
-const NativeQueryEditorRefWrapper = forwardRef<HTMLDivElement, Props>(
-  function _NativeQueryEditorRefWrapper(props, ref) {
-    return <NativeQueryEditor {...props} forwardedRef={ref} />;
-  },
-);
+const NativeQueryEditorRefWrapper = forwardRef<
+  HTMLDivElement,
+  Omit<Props, "toggleEditor">
+>(function _NativeQueryEditorRefWrapper(props, ref) {
+  const screenSize = useNotebookScreenSize();
+  const dispatch = useDispatch();
+  const { isNativeEditorOpen } = props;
+
+  /**
+   * do not show reference sidebar on small screens automatically
+   */
+  const toggleEditor = useCallback(() => {
+    if (screenSize === "small") {
+      dispatch(setUIControls({ isNativeEditorOpen: !isNativeEditorOpen }));
+    } else {
+      dispatch(setIsNativeEditorOpen(!isNativeEditorOpen));
+    }
+  }, [dispatch, isNativeEditorOpen, screenSize]);
+
+  return (
+    <NativeQueryEditor
+      toggleEditor={toggleEditor}
+      {...props}
+      forwardedRef={ref}
+    />
+  );
+});
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default _.compose(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/index.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/index.ts
@@ -1,3 +1,2 @@
-export * from "./NativeQueryEditor";
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./NativeQueryEditor";

--- a/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.module.css
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.module.css
@@ -11,8 +11,9 @@
 .QueryBuilderMain {
   display: flex;
   flex-direction: column;
-  flex: 1 0 auto;
-  flex-basis: 0;
+  flex: 1;
+  /* editor can be wider than a container */
+  overflow: hidden;
 
   @media screen and (max-width: 40em) {
     position: relative;

--- a/frontend/src/metabase/query_builder/components/view/View/ViewRightSidebarContainer/ViewRightSidebarContainer.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewRightSidebarContainer/ViewRightSidebarContainer.jsx
@@ -28,7 +28,9 @@ export const ViewRightSidebarContainer = props => {
 
   const { isNative } = Lib.queryDisplayInfo(question.query());
 
-  return !isNative ? (
+  return isNative ? (
+    <NativeQueryRightSidebar {...props} />
+  ) : (
     <StructuredQueryRightSidebar
       deselectTimelineEvents={deselectTimelineEvents}
       hideTimelineEvents={hideTimelineEvents}
@@ -50,7 +52,5 @@ export const ViewRightSidebarContainer = props => {
       visibleTimelineEventIds={visibleTimelineEventIds}
       xDomain={xDomain}
     />
-  ) : (
-    <NativeQueryRightSidebar {...props} />
   );
 };


### PR DESCRIPTION
[context](https://metaboat.slack.com/archives/C0645JP1W81/p1741869363500959)

### Description

1. original report was about sidebars which weren't fully visible on the screen with opened editor. It turned out the problem is visible on mid to small screen
2. we agreed to implement a similar logic to [what we already have in the notebook editor](https://github.com/metabase/metabase/issues/48170#issuecomment-2682652581), so right sidebar with DataReference is not opened automatically on small screens (less than 1280px width) when you click "Editor" button, but you're still able to open DataReference manually by clicking on the icon

related PRs
- https://github.com/metabase/metabase/pull/54438
- https://github.com/metabase/metabase/pull/54267

### How to verify

Describe the steps to verify that the changes are working as expected.

1. create a new native question with parameters (or create a new question from orders, count, created at and convert to native)
4. add parameters e.g. by adding `[[ where {{param1}} and {{param2}} ]]`
5. click on "editor" icon and click on "visualization options" button
6. change screen width by dragging right border to the left, verify that sidebars are not cropped

### Demo

https://github.com/user-attachments/assets/3d169760-c931-4db3-84a0-b3a1c1dbbff6


### Checklist

example of a failing test
<img width="1040" alt="Screenshot 2025-03-14 at 20 47 26" src="https://github.com/user-attachments/assets/d2cafbcc-b167-4eac-9d67-c457b8c4a634" />
