### PR TITLE
Fix Custom Expression snippet completion when error occurs

### DIFF
--- a/e2e/support/helpers/e2e-custom-column-helpers.ts
+++ b/e2e/support/helpers/e2e-custom-column-helpers.ts
@@ -95,9 +95,11 @@ export const CustomExpressionEditor = {
     {
       allowFastSet = false,
       focus = true,
+      delay = 0,
     }: {
       focus?: boolean;
       allowFastSet?: boolean;
+      delay?: number;
     } = {},
   ) {
     if (focus) {
@@ -116,6 +118,7 @@ export const CustomExpressionEditor = {
     const parts = text.replaceAll("{{", "{{}{{}").split(/(\{[^}]+\})/);
 
     parts.forEach(part => {
+      cy.wait(delay);
       switch (part.toLowerCase()) {
         case "":
           return;
@@ -186,7 +189,7 @@ export const CustomExpressionEditor = {
         );
       }
 
-      cy.realType(unexpanded);
+      cy.realType(unexpanded, { delay });
     });
     return CustomExpressionEditor;
   },

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -769,6 +769,38 @@ describe("scenarios > question > custom column", () => {
     cy.focused().should("have.attr", "class").and("contains", "cm-content");
   });
 
+  it("should be possible to use the suggestion snippet arguments", () => {
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
+
+    H.CustomExpressionEditor.type("coalesc{tab}[Tax]{tab}[User ID]", {
+      delay: 50,
+    });
+    H.CustomExpressionEditor.value().should(
+      "equal",
+      "coalesce([Tax], [User ID])",
+    );
+  });
+
+  it("should be possible to use the suggestion templates", () => {
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
+
+    H.CustomExpressionEditor.type("coalesc{tab}", { delay: 50 });
+
+    // Wait for error check to render, it should not affect the state of the snippets
+    cy.wait(1300);
+
+    H.CustomExpressionEditor.type("[Tax]{tab}[User ID]", {
+      focus: false,
+      delay: 50,
+    });
+    H.CustomExpressionEditor.value().should(
+      "equal",
+      "coalesce([Tax], [User ID])",
+    );
+  });
+
   // TODO: fixme!
   it.skip("should render custom expression helper near the custom expression field", () => {
     H.openOrdersTable({ mode: "notebook" });

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -160,7 +160,6 @@ function useExpression<S extends StartRule = "expression">({
   expressionIndex,
   metadata,
   onChange,
-  error: prevError,
 }: EditorProps<S> & {
   metadata: Metadata;
 }) {
@@ -168,6 +167,7 @@ function useExpression<S extends StartRule = "expression">({
   const [initialSource, setInitialSource] = useState("");
   const [isFormatting, setIsFormatting] = useState(true);
   const [isValidated, setIsValidated] = useState(false);
+  const errorRef = useRef<ErrorWithMessage | null>(null);
 
   const formatExpression = useCallback(
     ({ initial = false }: { initial?: boolean }) => {
@@ -205,6 +205,7 @@ function useExpression<S extends StartRule = "expression">({
   const handleChange = useCallback<typeof onChange>(
     (clause, error) => {
       setIsValidated(true);
+      errorRef.current = error;
       onChange(clause, error);
     },
     [onChange],
@@ -234,7 +235,7 @@ function useExpression<S extends StartRule = "expression">({
         metadata,
         name,
       });
-      if (immediate || prevError) {
+      if (immediate || errorRef.current) {
         debouncedOnChange.cancel();
         handleChange(clause, error);
       } else {
@@ -250,7 +251,7 @@ function useExpression<S extends StartRule = "expression">({
       expressionIndex,
       handleChange,
       debouncedOnChange,
-      prevError,
+      // prevError,
     ],
   );
 


### PR DESCRIPTION
Fixes a bug in the multiline custom expression editor that prevented snippets from being tabbed through when the error renders.

### To verify
1. New question > Orders > Custom Column
2. Type `coale{tab}`
3. Wait for about ~1s for the error message to render
4. Try typing or tabbing trough the snippet fields, it should be possible


#### Before 
https://github.com/user-attachments/assets/7f19f1c3-3f99-414f-b31c-48ecd86e7730


#### After 
https://github.com/user-attachments/assets/1c4267b9-8218-4634-82ef-1c3e3d947be4

