### PR TITLE
Remove dashboardActions and dashboardProps spreading in favor of explicit props

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -9,6 +9,42 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
+import {
+  addCardToDashboard,
+  addHeadingDashCardToDashboard,
+  addLinkDashCardToDashboard,
+  addMarkdownDashCardToDashboard,
+  cancelFetchDashboardCardData,
+  closeDashboard,
+  closeSidebar,
+  fetchDashboard,
+  fetchDashboardCardData,
+  hideAddParameterPopover,
+  initialize,
+  navigateToNewCardFromDashboard,
+  onReplaceAllDashCardVisualizationSettings,
+  onUpdateDashCardColumnSettings,
+  onUpdateDashCardVisualizationSettings,
+  removeParameter,
+  reset,
+  setDashboardAttributes,
+  setEditingDashboard,
+  setParameterDefaultValue,
+  setParameterFilteringParameters,
+  setParameterIsMultiSelect,
+  setParameterName,
+  setParameterQueryType,
+  setParameterRequired,
+  setParameterSourceConfig,
+  setParameterSourceType,
+  setParameterTemporalUnits,
+  setParameterType,
+  setSharing,
+  setSidebar,
+  showAddParameterPopover,
+  toggleSidebar,
+  updateDashboardAndCards,
+} from "metabase/dashboard/actions";
 import { Dashboard } from "metabase/dashboard/components/Dashboard/Dashboard";
 import { DashboardLeaveConfirmationModal } from "metabase/dashboard/components/DashboardLeaveConfirmationModal";
 import {
@@ -35,7 +71,6 @@ import {
 import type { DashboardId } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-import * as dashboardActions from "../../actions";
 import { DASHBOARD_SLOW_TIMEOUT } from "../../constants";
 import {
   getClickBehaviorSidebarDashcard,
@@ -96,9 +131,40 @@ const mapStateToProps = (state: State) => {
 };
 
 const mapDispatchToProps = {
-  ...dashboardActions,
+  initialize,
+  cancelFetchDashboardCardData,
+  addCardToDashboard,
+  addHeadingDashCardToDashboard,
+  addMarkdownDashCardToDashboard,
+  addLinkDashCardToDashboard,
+  setEditingDashboard,
+  setDashboardAttributes,
+  setSharing,
+  toggleSidebar,
+  closeSidebar,
   closeNavbar,
   setErrorPage,
+  setParameterName,
+  setParameterType,
+  navigateToNewCardFromDashboard,
+  setParameterDefaultValue,
+  setParameterRequired,
+  setParameterTemporalUnits,
+  setParameterIsMultiSelect,
+  setParameterQueryType,
+  setParameterSourceType,
+  setParameterSourceConfig,
+  setParameterFilteringParameters,
+  showAddParameterPopover,
+  removeParameter,
+  onReplaceAllDashCardVisualizationSettings,
+  onUpdateDashCardVisualizationSettings,
+  onUpdateDashCardColumnSettings,
+  updateDashboardAndCards,
+  setSidebar,
+  hideAddParameterPopover,
+  fetchDashboard,
+  fetchDashboardCardData,
   onChangeLocation: push,
 };
 
@@ -118,15 +184,60 @@ const DashboardApp = (props: DashboardAppProps) => {
     isDirty,
     route,
     router,
-  } = props;
-
-  const {
     documentTitle: _documentTitle,
     isRunning: _isRunning,
     isLoadingComplete: _isLoadingComplete,
-    children,
     location,
-    ...dashboardProps
+    canManageSubscriptions,
+    isAdmin,
+    isNavbarOpen,
+    isSharing,
+    dashboardBeforeEditing,
+    isEditingParameter,
+    slowCards,
+    parameterValues,
+    loadingStartTime,
+    clickBehaviorSidebarDashcard,
+    isAddParameterPopoverOpen,
+    sidebar,
+    isHeaderVisible,
+    isAdditionalInfoVisible,
+    selectedTabId,
+    isNavigatingBackToDashboard,
+    initialize,
+    cancelFetchDashboardCardData,
+    addCardToDashboard,
+    addHeadingDashCardToDashboard,
+    addMarkdownDashCardToDashboard,
+    addLinkDashCardToDashboard,
+    setEditingDashboard,
+    setDashboardAttributes,
+    setSharing,
+    toggleSidebar,
+    closeSidebar,
+    closeNavbar,
+    setErrorPage,
+    setParameterName,
+    setParameterType,
+    navigateToNewCardFromDashboard,
+    setParameterDefaultValue,
+    setParameterRequired,
+    setParameterTemporalUnits,
+    setParameterIsMultiSelect,
+    setParameterQueryType,
+    setParameterSourceType,
+    setParameterSourceConfig,
+    setParameterFilteringParameters,
+    showAddParameterPopover,
+    removeParameter,
+    onReplaceAllDashCardVisualizationSettings,
+    onUpdateDashCardVisualizationSettings,
+    onUpdateDashCardColumnSettings,
+    updateDashboardAndCards,
+    setSidebar,
+    hideAddParameterPopover,
+    fetchDashboard,
+    fetchDashboardCardData,
   } = props;
 
   const parameterQueryParams = location.query;
@@ -141,8 +252,8 @@ const DashboardApp = (props: DashboardAppProps) => {
   const { requestPermission, showNotification } = useWebNotification();
 
   useUnmount(() => {
-    dispatch(dashboardActions.reset());
-    dispatch(dashboardActions.closeDashboard());
+    dispatch(reset());
+    dispatch(closeDashboard());
   });
 
   const slowToastId = useUniqueId();
@@ -238,7 +349,63 @@ const DashboardApp = (props: DashboardAppProps) => {
         onFullscreenChange={onFullscreenChange}
         onRefreshPeriodChange={onRefreshPeriodChange}
         parameterQueryParams={parameterQueryParams}
-        {...dashboardProps}
+        canManageSubscriptions={canManageSubscriptions}
+        isAdmin={isAdmin}
+        isNavbarOpen={isNavbarOpen}
+        isEditing={isEditing}
+        isSharing={isSharing}
+        dashboardBeforeEditing={dashboardBeforeEditing}
+        isEditingParameter={isEditingParameter}
+        isDirty={isDirty}
+        dashboard={dashboard}
+        slowCards={slowCards}
+        parameterValues={parameterValues}
+        loadingStartTime={loadingStartTime}
+        clickBehaviorSidebarDashcard={clickBehaviorSidebarDashcard}
+        isAddParameterPopoverOpen={isAddParameterPopoverOpen}
+        sidebar={sidebar}
+        isHeaderVisible={isHeaderVisible}
+        isAdditionalInfoVisible={isAdditionalInfoVisible}
+        selectedTabId={selectedTabId}
+        isNavigatingBackToDashboard={isNavigatingBackToDashboard}
+        initialize={initialize}
+        cancelFetchDashboardCardData={cancelFetchDashboardCardData}
+        addCardToDashboard={addCardToDashboard}
+        addHeadingDashCardToDashboard={addHeadingDashCardToDashboard}
+        addMarkdownDashCardToDashboard={addMarkdownDashCardToDashboard}
+        addLinkDashCardToDashboard={addLinkDashCardToDashboard}
+        setEditingDashboard={setEditingDashboard}
+        setDashboardAttributes={setDashboardAttributes}
+        setSharing={setSharing}
+        toggleSidebar={toggleSidebar}
+        closeSidebar={closeSidebar}
+        closeNavbar={closeNavbar}
+        setErrorPage={setErrorPage}
+        setParameterName={setParameterName}
+        setParameterType={setParameterType}
+        navigateToNewCardFromDashboard={navigateToNewCardFromDashboard}
+        setParameterDefaultValue={setParameterDefaultValue}
+        setParameterRequired={setParameterRequired}
+        setParameterTemporalUnits={setParameterTemporalUnits}
+        setParameterIsMultiSelect={setParameterIsMultiSelect}
+        setParameterQueryType={setParameterQueryType}
+        setParameterSourceType={setParameterSourceType}
+        setParameterSourceConfig={setParameterSourceConfig}
+        setParameterFilteringParameters={setParameterFilteringParameters}
+        showAddParameterPopover={showAddParameterPopover}
+        removeParameter={removeParameter}
+        onReplaceAllDashCardVisualizationSettings={
+          onReplaceAllDashCardVisualizationSettings
+        }
+        onUpdateDashCardVisualizationSettings={
+          onUpdateDashCardVisualizationSettings
+        }
+        onUpdateDashCardColumnSettings={onUpdateDashCardColumnSettings}
+        updateDashboardAndCards={updateDashboardAndCards}
+        setSidebar={setSidebar}
+        hideAddParameterPopover={hideAddParameterPopover}
+        fetchDashboard={fetchDashboard}
+        fetchDashboardCardData={fetchDashboardCardData}
       />
       {/* For rendering modal urls */}
       {props.children}


### PR DESCRIPTION
Removes the `dashboardActions` spreading in the `DashboardApp` in favor of explicit props.

I'm playing around with a small, super rough PoC of a Dashboard context for the embedding SDK in my spare time and ended up doing this. Feel free to take it or leave it, but I feel like it's better to have these explicit imports instead of having `dashboardActions`. We can then make improvements to the organization of this code since it's all laid out