### PR TITLE
dev: just warn if can't watch UserKeyValue schemas

### DIFF
--- a/src/metabase/user_key_value/models/user_key_value/types.clj
+++ b/src/metabase/user_key_value/models/user_key_value/types.clj
@@ -165,4 +165,7 @@
   (load-all-schemas-prod! types-dir)
   ;; in dev, watch both types directories for changes
   (when config/is-dev?
-    (watch-directory! (io/file (io/resource types-dir)) handle-file-change!)))
+    (try
+      (watch-directory! (io/file (io/resource types-dir)) handle-file-change!)
+      (catch Exception e
+        (log/warn e "Could not watch UserKeyValue schema directory!")))))


### PR DESCRIPTION
If you run an uberjar with `MB_RUN_MODE=dev`, you get an exception because you try to run the `watch-directory!` bit (which only works for actual files) in an uberjar environment.

Let's just print a warning but continue along.