### PR TITLE
WRK-129: Add 'by the minute' option to Schedule

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -82,7 +82,12 @@ export interface ScheduleSettings {
   schedule_minute?: number | null;
 }
 
-export type ScheduleType = "hourly" | "daily" | "weekly" | "monthly";
+export type ScheduleType =
+  | "minutely"
+  | "hourly"
+  | "daily"
+  | "weekly"
+  | "monthly";
 
 export type ScheduleDayType =
   | "sun"

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -83,7 +83,7 @@ export interface ScheduleSettings {
 }
 
 export type ScheduleType =
-  | "minutely"
+  | "every_n_minutes"
   | "hourly"
   | "daily"
   | "weekly"

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -61,7 +61,7 @@ export const scheduleSettingsToCron = (settings: ScheduleSettings): string => {
   let dayOfMonth: string = settings.schedule_day
     ? Cron.NoSpecificValue
     : Cron.AllValues;
-  if (settings.schedule_type === "minutely") {
+  if (settings.schedule_type === "every_n_minutes") {
     minute = everyToCronSyntax(minute);
   } else if (settings.schedule_type === "monthly" && settings.schedule_frame) {
     // There are two kinds of monthly schedule:
@@ -117,7 +117,7 @@ export const cronToScheduleSettings_unmemoized = (
   if (dayOfMonth === Cron.AllValues) {
     if (weekday === Cron.AllValues) {
       if (hour === Cron.AllValues) {
-        schedule_type = isRepeatingEvery(minute) ? "minutely" : "hourly";
+        schedule_type = isRepeatingEvery(minute) ? "every_n_minutes" : "hourly";
       } else {
         schedule_type = "daily";
       }

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -24,6 +24,12 @@ import type { PerformanceTabId, StrategyData, StrategyLabel } from "./types";
 const AM = 0;
 const PM = 1;
 
+const everyToCronSyntax = (every: number | string) =>
+  `${Cron.EveryPrefix}${every}`;
+const isRepeatingEvery = (every: string) => every.startsWith(Cron.EveryPrefix);
+const cronUnitToNumber = (unit: string) =>
+  parseInt(unit.replace(Cron.EveryPrefix, ""));
+
 const dayToCron = (day: ScheduleSettings["schedule_day"]) => {
   const { weekdays } = getScheduleStrings();
   const index = weekdays.findIndex(o => o.value === day);
@@ -46,7 +52,7 @@ const frameFromCron = (frameInCronFormat: string) =>
 
 export const scheduleSettingsToCron = (settings: ScheduleSettings): string => {
   const second = "0";
-  const minute = settings.schedule_minute?.toString() ?? Cron.AllValues;
+  let minute = settings.schedule_minute?.toString() ?? Cron.AllValues;
   const hour = settings.schedule_hour?.toString() ?? Cron.AllValues;
   let weekday = settings.schedule_day
     ? dayToCron(settings.schedule_day).toString()
@@ -55,7 +61,9 @@ export const scheduleSettingsToCron = (settings: ScheduleSettings): string => {
   let dayOfMonth: string = settings.schedule_day
     ? Cron.NoSpecificValue
     : Cron.AllValues;
-  if (settings.schedule_type === "monthly" && settings.schedule_frame) {
+  if (settings.schedule_type === "minutely") {
+    minute = everyToCronSyntax(minute);
+  } else if (settings.schedule_type === "monthly" && settings.schedule_frame) {
     // There are two kinds of monthly schedule:
     // - weekday-based (e.g. "on the first Monday of the month")
     // - date-based (e.g. "on the 15th of the month")
@@ -108,7 +116,11 @@ export const cronToScheduleSettings_unmemoized = (
   let schedule_type: ScheduleType | undefined;
   if (dayOfMonth === Cron.AllValues) {
     if (weekday === Cron.AllValues) {
-      schedule_type = hour === Cron.AllValues ? "hourly" : "daily";
+      if (hour === Cron.AllValues) {
+        schedule_type = isRepeatingEvery(minute) ? "minutely" : "hourly";
+      } else {
+        schedule_type = "daily";
+      }
     } else {
       // If the weekday part of the cron expression is something like '1#1' (first Monday),
       // or '2L' (last Tuesday), then the frequency is monthly
@@ -153,8 +165,9 @@ export const cronToScheduleSettings_unmemoized = (
     }
   }
 
-  const scheduleMinute = minute === Cron.AllValues ? null : parseInt(minute);
-  const scheduleHour = hour === Cron.AllValues ? null : parseInt(hour);
+  const scheduleMinute =
+    minute === Cron.AllValues ? null : cronUnitToNumber(minute);
+  const scheduleHour = hour === Cron.AllValues ? null : cronUnitToNumber(hour);
   return {
     schedule_type,
     schedule_minute: scheduleMinute,

--- a/frontend/src/metabase/admin/performance/utils.unit.spec.ts
+++ b/frontend/src/metabase/admin/performance/utils.unit.spec.ts
@@ -13,6 +13,16 @@ import {
 } from "./utils";
 
 describe("scheduleSettingsToCron", () => {
+  it("converts every_n_minutes schedule to cron", () => {
+    const settings: ScheduleSettings = {
+      schedule_type: "every_n_minutes",
+      schedule_minute: 10,
+      schedule_hour: null,
+    };
+    const cron = scheduleSettingsToCron(settings);
+    expect(cron).toEqual("0 0/10 * * * ?");
+  });
+
   it("converts hourly schedule to cron", () => {
     const settings: ScheduleSettings = {
       schedule_type: "hourly",
@@ -103,6 +113,13 @@ describe("cronToScheduleSettings", () => {
   });
 
   describe("schedule type determination", () => {
+    it('sets schedule type to "every_n_minutes" when minute is "0/15"', () => {
+      const cron = `0 0/15 * * * ?`;
+      expect(cronToScheduleSettings(cron)?.schedule_type).toBe(
+        "every_n_minutes",
+      );
+    });
+
     it('sets schedule type to "hourly" when hour is "*" and both dayOfMonth and dayOfWeek are "*"', () => {
       const cron = "0 30 * * * *";
       expect(cronToScheduleSettings(cron)?.schedule_type).toBe("hourly");
@@ -191,6 +208,19 @@ describe("cronToScheduleSettings", () => {
         expect.objectContaining({
           schedule_minute: 20,
           schedule_hour: 3,
+        }),
+      );
+    });
+  });
+
+  describe("every n minutes schedule determination", () => {
+    it('sets schedule type to "every_n_minutes" when minute is "0/15"', () => {
+      const cron = `0 0/15 * * * ?`;
+      expect(cronToScheduleSettings(cron)).toEqual(
+        expect.objectContaining({
+          schedule_type: "every_n_minutes",
+          schedule_minute: 15,
+          schedule_hour: null,
         }),
       );
     });

--- a/frontend/src/metabase/components/Schedule/AutoWidthSelect.tsx
+++ b/frontend/src/metabase/components/Schedule/AutoWidthSelect.tsx
@@ -31,6 +31,7 @@ export const AutoWidthSelect = <Value extends string>({
     <Select
       styles={{
         wrapper: { width },
+        root: { flexShrink: 0 },
       }}
       value={value}
       {...props}

--- a/frontend/src/metabase/components/Schedule/GroupControlsTogether.tsx
+++ b/frontend/src/metabase/components/Schedule/GroupControlsTogether.tsx
@@ -1,5 +1,7 @@
 import { Children, type ReactNode, isValidElement } from "react";
 
+import { Text } from "metabase/ui";
+
 import S from "./Schedule.module.css";
 import { combineConsecutiveStrings } from "./utils";
 
@@ -41,11 +43,31 @@ export const GroupControlsTogether = ({
 
   const compactChildren = combineConsecutiveStrings(childNodes);
 
-  compactChildren.forEach((child, index) => {
+  for (let index = 0; index < compactChildren.length; index++) {
+    const child = compactChildren[index];
     if (isValidElement(child)) {
       currentGroup.push(child);
 
-      if (!isValidElement(compactChildren[index + 1])) {
+      const nextIndex = index + 1;
+      if (!isValidElement(compactChildren[nextIndex])) {
+        // If next child is the last string, add it to the current group
+        // to prevent it from being left hanging on the last line.
+        if (nextIndex === compactChildren.length - 1) {
+          const nextChild = compactChildren[nextIndex];
+          if (typeof nextChild === "string" && !!nextChild.trim()) {
+            currentGroup.push(
+              <Text key={`node-${nextIndex}`} ml="0.5rem">
+                {nextChild}
+              </Text>,
+            );
+          }
+          groupedNodes.push(
+            <div className={S.ControlGroup} key={`node-${index}`}>
+              {currentGroup}
+            </div>,
+          );
+          break;
+        }
         // Flush current group
         groupedNodes.push(
           <div className={S.ControlGroup} key={`node-${index}`}>
@@ -76,7 +98,7 @@ export const GroupControlsTogether = ({
         </div>,
       );
     }
-  });
+  }
 
   return <>{groupedNodes}</>;
 };

--- a/frontend/src/metabase/components/Schedule/Schedule.module.css
+++ b/frontend/src/metabase/components/Schedule/Schedule.module.css
@@ -2,25 +2,33 @@
   line-height: 2.5rem;
   display: grid;
   grid-template-columns: fit-content(100%) auto;
-  gap: 0.5rem;
-  row-gap: 0.35rem;
+  gap: var(--schedule-grid-gap, 0.5rem);
+  row-gap: var(--schedule-row-gap, 0.35rem);
+  font-weight: var(--schedule-font-weight, normal);
 }
 
 .ControlGroup {
   display: flex;
   gap: 0.25rem;
-  flex-flow: row wrap;
+  flex-flow: row nowrap;
+  flex-shrink: 0;
   grid-column: 2;
+  align-items: center;
 }
 
 .TextInFirstColumn {
   display: flex;
   flex-flow: row wrap;
-  justify-content: flex-end;
   align-items: flex-start;
+  font-weight: var(--schedule-first-column-font-weight, normal);
 }
 
 .TextInSecondColumn {
   line-height: 1.5rem;
   grid-column: 2;
+  font-weight: var(--schedule-second-column-font-weight, normal);
+}
+
+.CompactLabels .TextInFirstColumn {
+  justify-content: flex-end;
 }

--- a/frontend/src/metabase/components/Schedule/Schedule.stories.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.stories.tsx
@@ -124,7 +124,7 @@ export const HourlyOnSpecificMinute = {
   args: {
     schedule: {
       schedule_type: "hourly",
-      shedule_hour: null,
+      schedule_hour: null,
       schedule_minute: 10,
     },
     longVerb: false,

--- a/frontend/src/metabase/components/Schedule/Schedule.stories.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.stories.tsx
@@ -50,7 +50,13 @@ const Template: StoryFn<typeof Schedule> = args => {
   const [
     {
       schedule,
-      scheduleOptions = ["hourly", "daily", "weekly", "monthly"],
+      scheduleOptions = [
+        "every_n_minutes",
+        "hourly",
+        "daily",
+        "weekly",
+        "monthly",
+      ],
       timezone = "UTC",
       locale = "en",
       longVerb = false,
@@ -97,5 +103,32 @@ export const LongVerb = {
     schedule: defaultSchedule,
     longVerb: true,
     locale: "en",
+  },
+};
+
+export const EveryNMinutes = {
+  render: Template,
+  args: {
+    schedule: {
+      schedule_type: "every_n_minutes",
+      shedule_hour: null,
+      schedule_minute: 15,
+    },
+    longVerb: false,
+    locale: "en",
+  },
+};
+
+export const HourlyOnSpecificMinute = {
+  render: Template,
+  args: {
+    schedule: {
+      schedule_type: "hourly",
+      shedule_hour: null,
+      schedule_minute: 10,
+    },
+    longVerb: false,
+    locale: "en",
+    minutesOnHourPicker: true,
   },
 };

--- a/frontend/src/metabase/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.tsx
@@ -158,13 +158,12 @@ export const Schedule = ({
       .with(
         "minutely",
         () =>
+          // Converting to lowercase here, because 'minute` is used without pluralization on the backend,
+          // and it's impossible to have both pluralized and single form for the same string.
           c(
             "{0} is a verb like 'Check', {1} is an adverb like 'by the minute', {2} is a number of minutes.",
-          ).jt`${verb} ${selectFrequency} every ${selectEveryMinute} ${ngettext(
-            msgid`minute`,
-            "minutes",
-            schedule_minute as number,
-          )}`,
+          )
+            .jt`${verb} ${selectFrequency} every ${selectEveryMinute} ${ngettext(msgid`Minute`, "Minutes", schedule_minute as number).toLocaleLowerCase()}`,
       )
       .with("hourly", () => {
         return minutesOnHourPicker ? (

--- a/frontend/src/metabase/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.tsx
@@ -156,7 +156,7 @@ export const Schedule = ({
 
     return match(schedule_type)
       .with(
-        "minutely",
+        "every_n_minutes",
         () =>
           // Converting to lowercase here, because 'minute` is used without pluralization on the backend,
           // and it's impossible to have both pluralized and single form for the same string.

--- a/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
@@ -1,4 +1,7 @@
-import { screen } from "__support__/ui";
+import { within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { mockScrollIntoView, screen } from "__support__/ui";
 import { setup } from "metabase/components/Schedule/test-utils";
 
 const getInputValues = () => {
@@ -8,6 +11,10 @@ const getInputValues = () => {
 };
 
 describe("Schedule", () => {
+  beforeAll(() => {
+    mockScrollIntoView();
+  });
+
   it("shows time when schedule is daily", () => {
     setup();
     expect(getInputValues()).toEqual(["daily", "12:00"]);
@@ -35,5 +42,50 @@ describe("Schedule", () => {
       },
     });
     expect(getInputValues()).toEqual(["monthly", "first", "Monday", "8:00"]);
+  });
+
+  it("shows 10 minutes by default for minutely schedule", () => {
+    setup({
+      schedule: { schedule_type: "minutely" },
+    });
+    // screen.debug(undefined, 1000000);
+    expect(getInputValues()).toEqual(["by the minute", "10"]);
+    expect(screen.getByText("minutes")).toBeInTheDocument();
+  });
+
+  it("shows proper single noun for minutely schedule", () => {
+    setup({
+      schedule: { schedule_type: "minutely", schedule_minute: 1 },
+    });
+    expect(getInputValues()).toEqual(["by the minute", "1"]);
+    expect(screen.getByText("minute")).toBeInTheDocument();
+  });
+
+  it("shows proper plural noun for minutely schedule", () => {
+    setup({
+      schedule: { schedule_type: "minutely", schedule_minute: 5 },
+    });
+    expect(getInputValues()).toEqual(["by the minute", "5"]);
+    expect(screen.getByText("minutes")).toBeInTheDocument();
+  });
+
+  it("does not allow 0 minutes option for minutely schedule", async () => {
+    setup({
+      schedule: { schedule_type: "minutely" },
+    });
+
+    const minuteInput = screen.getByTestId("select-minute");
+    expect(minuteInput).toBeInTheDocument();
+
+    await userEvent.click(minuteInput);
+
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+
+    const options = within(listbox).getAllByRole("option");
+    const optionValues = options.map(option => option.getAttribute("value"));
+
+    expect(optionValues).not.toContain("0");
+    expect(Math.min(...optionValues.map(Number))).toBe(1);
   });
 });

--- a/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
@@ -44,34 +44,33 @@ describe("Schedule", () => {
     expect(getInputValues()).toEqual(["monthly", "first", "Monday", "8:00"]);
   });
 
-  it("shows 10 minutes by default for minutely schedule", () => {
+  it("shows 10 minutes by default for every_n_minutes schedule", () => {
     setup({
-      schedule: { schedule_type: "minutely" },
+      schedule: { schedule_type: "every_n_minutes" },
     });
-    // screen.debug(undefined, 1000000);
     expect(getInputValues()).toEqual(["by the minute", "10"]);
     expect(screen.getByText("minutes")).toBeInTheDocument();
   });
 
-  it("shows proper single noun for minutely schedule", () => {
+  it("shows proper single noun for every_n_minutes schedule", () => {
     setup({
-      schedule: { schedule_type: "minutely", schedule_minute: 1 },
+      schedule: { schedule_type: "every_n_minutes", schedule_minute: 1 },
     });
     expect(getInputValues()).toEqual(["by the minute", "1"]);
     expect(screen.getByText("minute")).toBeInTheDocument();
   });
 
-  it("shows proper plural noun for minutely schedule", () => {
+  it("shows proper plural noun for every_n_minutes schedule", () => {
     setup({
-      schedule: { schedule_type: "minutely", schedule_minute: 5 },
+      schedule: { schedule_type: "every_n_minutes", schedule_minute: 5 },
     });
     expect(getInputValues()).toEqual(["by the minute", "5"]);
     expect(screen.getByText("minutes")).toBeInTheDocument();
   });
 
-  it("does not allow 0 minutes option for minutely schedule", async () => {
+  it("does not allow 0 minutes option for every_n_minutes schedule", async () => {
     setup({
-      schedule: { schedule_type: "minutely" },
+      schedule: { schedule_type: "every_n_minutes" },
     });
 
     const minuteInput = screen.getByTestId("select-minute");

--- a/frontend/src/metabase/components/Schedule/components.tsx
+++ b/frontend/src/metabase/components/Schedule/components.tsx
@@ -225,16 +225,18 @@ export const SelectWeekdayOfMonth = ({
 export const SelectMinute = ({
   schedule_minute,
   updateSchedule,
+  range = minutes,
 }: {
   schedule_minute: ScheduleSettings["schedule_minute"];
   updateSchedule: UpdateSchedule;
+  range?: typeof minutes;
 }) => {
   const minuteOfHour = isNaN(schedule_minute as number) ? 0 : schedule_minute;
   const label = useMemo(() => getScheduleComponentLabel("minute"), []);
   return (
     <AutoWidthSelect
       value={(minuteOfHour || 0).toString()}
-      data={minutes}
+      data={range}
       onChange={(value: string) =>
         updateSchedule("schedule_minute", Number(value))
       }

--- a/frontend/src/metabase/components/Schedule/strings.ts
+++ b/frontend/src/metabase/components/Schedule/strings.ts
@@ -59,7 +59,7 @@ export const getScheduleStrings = () => {
     // The context is needed because 'hourly' can be an adjective ('hourly
     // rate') or adverb ('update hourly'). Same with 'daily', 'weekly', and
     // 'monthly'.
-    minutely: c("adverb").t`by the minute`,
+    every_n_minutes: c("adverbial phrase").t`by the minute`,
     hourly: c("adverb").t`hourly`,
     daily: c("adverb").t`daily`,
     weekly: c("adverb").t`weekly`,

--- a/frontend/src/metabase/components/Schedule/strings.ts
+++ b/frontend/src/metabase/components/Schedule/strings.ts
@@ -8,6 +8,8 @@ export const minutes = _.times(60, n => ({
   label: n.toString(),
   value: n.toString(),
 }));
+// 1-59 minutes
+export const minuteIntervals = minutes.slice(1);
 
 export const getHours = () => {
   const localizedHours = [
@@ -57,6 +59,7 @@ export const getScheduleStrings = () => {
     // The context is needed because 'hourly' can be an adjective ('hourly
     // rate') or adverb ('update hourly'). Same with 'daily', 'weekly', and
     // 'monthly'.
+    minutely: c("adverb").t`by the minute`,
     hourly: c("adverb").t`hourly`,
     daily: c("adverb").t`daily`,
     weekly: c("adverb").t`weekly`,
@@ -151,6 +154,7 @@ export enum Cron {
   AllValues = "*",
   NoSpecificValue = "?",
   NoSpecificValue_Escaped = "\\?",
+  EveryPrefix = "0/",
 }
 
 export type ScheduleComponentType =

--- a/frontend/src/metabase/components/Schedule/test-utils.tsx
+++ b/frontend/src/metabase/components/Schedule/test-utils.tsx
@@ -28,6 +28,7 @@ const mockSchedule: ScheduleSettings = {
   schedule_minute: 0,
 };
 const mockScheduleOptions: ScheduleType[] = [
+  "minutely",
   "hourly",
   "daily",
   "weekly",

--- a/frontend/src/metabase/components/Schedule/test-utils.tsx
+++ b/frontend/src/metabase/components/Schedule/test-utils.tsx
@@ -28,7 +28,7 @@ const mockSchedule: ScheduleSettings = {
   schedule_minute: 0,
 };
 const mockScheduleOptions: ScheduleType[] = [
-  "minutely",
+  "every_n_minutes",
   "hourly",
   "daily",
   "weekly",

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -71,6 +71,12 @@ export const getScheduleDefaults = (
   schedule: ScheduleSettings,
 ): ScheduleSettings => {
   return match<ScheduleSettings>(schedule)
+    .with({ schedule_type: "minutely" }, () => ({
+      schedule_day: null,
+      schedule_frame: null,
+      schedule_hour: null,
+      schedule_minute: 10,
+    }))
     .with({ schedule_type: "hourly" }, () => ({
       schedule_day: null,
       schedule_frame: null,

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -71,7 +71,7 @@ export const getScheduleDefaults = (
   schedule: ScheduleSettings,
 ): ScheduleSettings => {
   return match<ScheduleSettings>(schedule)
-    .with({ schedule_type: "minutely" }, () => ({
+    .with({ schedule_type: "every_n_minutes" }, () => ({
       schedule_day: null,
       schedule_frame: null,
       schedule_hour: null,

--- a/frontend/src/metabase/components/SchedulePicker/SchedulePicker.tsx
+++ b/frontend/src/metabase/components/SchedulePicker/SchedulePicker.tsx
@@ -32,6 +32,7 @@ import {
 } from "./SchedulePicker.styled";
 
 const optionNameTranslations = {
+  minutely: t`By the minute`,
   hourly: t`Hourly`,
   daily: t`Daily`,
   weekly: t`Weekly`,

--- a/frontend/src/metabase/components/SchedulePicker/SchedulePicker.tsx
+++ b/frontend/src/metabase/components/SchedulePicker/SchedulePicker.tsx
@@ -31,8 +31,7 @@ import {
   ScheduleDescriptionContainer,
 } from "./SchedulePicker.styled";
 
-const optionNameTranslations = {
-  minutely: t`By the minute`,
+const optionNameTranslations: Partial<Record<ScheduleType, string>> = {
   hourly: t`Hourly`,
   daily: t`Daily`,
   weekly: t`Weekly`,

--- a/frontend/src/metabase/lib/notifications.ts
+++ b/frontend/src/metabase/lib/notifications.ts
@@ -244,7 +244,7 @@ export const formatNotificationCheckSchedule = ({
   const options = MetabaseSettings.formattingOptions();
 
   switch (schedule_type) {
-    case "minutely":
+    case "every_n_minutes":
       // Converting to lowercase here, because 'minute` is used without pluralization on the backend.
       // and it's impossible to have both pluralized and single form for the same string.
       return t`Check every ${ngettext(msgid`Minute`, `${schedule_minute} Minutes`, schedule_minute || 0).toLocaleLowerCase()}`;

--- a/frontend/src/metabase/lib/notifications.ts
+++ b/frontend/src/metabase/lib/notifications.ts
@@ -1,4 +1,4 @@
-import { msgid, ngettext, t } from "ttag";
+import { c, msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
 import type { NotificationListItem } from "metabase/account/notifications/types";
@@ -293,7 +293,7 @@ export const formatNotificationScheduleDescription = ({
     case "monthly": {
       if (schedule_hour != null) {
         const ampm = formatTimeWithUnit(schedule_hour, "hour-of-day");
-        return t`at ${ampm}`;
+        return c("time with AM/PM label").t`at ${ampm}`;
       }
       break;
     }

--- a/frontend/src/metabase/lib/notifications.ts
+++ b/frontend/src/metabase/lib/notifications.ts
@@ -245,7 +245,9 @@ export const formatNotificationCheckSchedule = ({
 
   switch (schedule_type) {
     case "minutely":
-      return t`Check every ${schedule_minute} ${ngettext(msgid`minute`, `minutes`, schedule_minute || 0)} `;
+      // Converting to lowercase here, because 'minute` is used without pluralization on the backend.
+      // and it's impossible to have both pluralized and single form for the same string.
+      return t`Check every ${ngettext(msgid`Minute`, `${schedule_minute} Minutes`, schedule_minute || 0).toLocaleLowerCase()}`;
     case "hourly":
       return t`Check hourly`;
     case "daily": {

--- a/frontend/src/metabase/lib/notifications.ts
+++ b/frontend/src/metabase/lib/notifications.ts
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
 import type { NotificationListItem } from "metabase/account/notifications/types";
@@ -236,6 +236,7 @@ export const formatNotificationSchedule = (
 
 export const formatNotificationCheckSchedule = ({
   schedule_type,
+  schedule_minute,
   schedule_hour,
   schedule_day,
   schedule_frame,
@@ -243,6 +244,8 @@ export const formatNotificationCheckSchedule = ({
   const options = MetabaseSettings.formattingOptions();
 
   switch (schedule_type) {
+    case "minutely":
+      return t`Check every ${schedule_minute} ${ngettext(msgid`minute`, `minutes`, schedule_minute || 0)} `;
     case "hourly":
       return t`Check hourly`;
     case "daily": {
@@ -265,21 +268,34 @@ export const formatNotificationCheckSchedule = ({
       break;
     }
     case "monthly": {
-      if (
-        schedule_hour != null &&
-        schedule_day != null &&
-        schedule_frame != null
-      ) {
+      if (schedule_hour != null && schedule_frame != null) {
         const ampm = formatTimeWithUnit(schedule_hour, "hour-of-day", options);
-        const day = formatDateTimeWithUnit(
-          schedule_day,
-          "day-of-week",
-          options,
-        );
+        const day = schedule_day
+          ? formatDateTimeWithUnit(schedule_day, "day-of-week", options)
+          : t`day`;
         const frame = formatFrame(schedule_frame);
         return t`Check monthly on the ${frame} ${day} at ${ampm}`;
       }
       break;
     }
+  }
+};
+
+export const formatNotificationScheduleDescription = ({
+  schedule_type,
+  schedule_hour,
+}: ScheduleSettings) => {
+  switch (schedule_type) {
+    case "daily":
+    case "weekly":
+    case "monthly": {
+      if (schedule_hour != null) {
+        const ampm = formatTimeWithUnit(schedule_hour, "hour-of-day");
+        return t`at ${ampm}`;
+      }
+      break;
+    }
+    default:
+      return "";
   }
 };

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -76,7 +76,7 @@ const ALERT_TRIGGER_OPTIONS_MAP: Record<
 };
 
 const ALERT_SCHEDULE_OPTIONS: ScheduleType[] = [
-  "minutely",
+  "every_n_minutes",
   "hourly",
   "daily",
   "weekly",

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/AlertModalSettingsBlock/AlertModalSettingsBlock.module.css
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/AlertModalSettingsBlock/AlertModalSettingsBlock.module.css
@@ -1,0 +1,10 @@
+.contentContainer {
+  padding: var(
+    --alert-modal-content-padding,
+    var(--mantine-spacing-lg) var(--mantine-spacing-xl)
+  );
+
+  background-color: var(--mb-base-color-orion-5);
+  overflow: hidden;
+  border-radius: var(--mantine-radius-md);
+}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/AlertModalSettingsBlock/AlertModalSettingsBlock.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/AlertModalSettingsBlock/AlertModalSettingsBlock.tsx
@@ -1,29 +1,26 @@
 import type { ReactNode } from "react";
 
-import { Box, Stack, Text } from "metabase/ui";
+import { Box, Stack, type StackProps, Text } from "metabase/ui";
+
+import styles from "./AlertModalSettingsBlock.module.css";
 
 type AlertModalSettingsBlockProps = {
   title: string;
   children: ReactNode;
-};
+} & StackProps;
 
 export const AlertModalSettingsBlock = ({
   title,
   children,
+  className,
+  ...stackProps
 }: AlertModalSettingsBlockProps) => {
   return (
-    <Stack gap="0.75rem">
+    <Stack gap="0.75rem" {...stackProps}>
       <Text size="lg" lineClamp={1}>
         {title}
       </Text>
-      <Box
-        bg="var(--mb-color-background-info)"
-        px="2rem"
-        py="1.5rem"
-        style={{ borderRadius: "0.5rem" }}
-      >
-        {children}
-      </Box>
+      <Box className={styles.contentContainer}>{children}</Box>
     </Stack>
   );
 };

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.module.css
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.module.css
@@ -1,0 +1,13 @@
+.scheduleContainer {
+  background-color: var(--mb-base-color-orion-5);
+  padding: var(
+    --notification-schedule-padding,
+    var(--mantine-spacing-lg) var(--mantine-spacing-xl)
+  );
+}
+
+.schedule {
+  --schedule-grid-gap: 1.5rem;
+  --schedule-row-gap: 1rem;
+  --schedule-first-column-font-weight: bold;
+}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
@@ -6,7 +6,6 @@ import {
   scheduleSettingsToCron,
 } from "metabase/admin/performance/utils";
 import { Schedule } from "metabase/components/Schedule/Schedule";
-import type { ScheduleChangeProp } from "metabase/components/Schedule/types";
 import { formatNotificationScheduleDescription } from "metabase/lib/notifications";
 import { useSelector } from "metabase/lib/redux";
 import { DEFAULT_ALERT_SCHEDULE } from "metabase/notifications/utils";

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
@@ -6,6 +6,7 @@ import {
   scheduleSettingsToCron,
 } from "metabase/admin/performance/utils";
 import { Schedule } from "metabase/components/Schedule/Schedule";
+import type { ScheduleChangeProp } from "metabase/components/Schedule/types";
 import { formatNotificationScheduleDescription } from "metabase/lib/notifications";
 import { useSelector } from "metabase/lib/redux";
 import { DEFAULT_ALERT_SCHEDULE } from "metabase/notifications/utils";

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
@@ -86,7 +86,7 @@ export const NotificationSchedule = ({
   );
 };
 
-const UNSAFE_SCHEDULE_TYPES = ["minutely", "cron"];
+const UNSAFE_SCHEDULE_TYPES = ["every_n_minutes", "cron"];
 const WARNING_THRESHOLD_MINS = 10;
 function showWarning(schedule: ScheduleSettings) {
   if (
@@ -102,7 +102,7 @@ function showWarning(schedule: ScheduleSettings) {
 }
 
 // No description is necessary for schedule types, which recur periodically.
-const PERIODIC_SCHEDULE_TYPES = ["minutely", "hourly"];
+const PERIODIC_SCHEDULE_TYPES = ["every_n_minutes", "hourly"];
 function useScheduleDescription(
   schedule: ScheduleSettings,
   timezone: string,

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
@@ -1,0 +1,125 @@
+import { type HTMLAttributes, useCallback, useMemo } from "react";
+import { c, t } from "ttag";
+
+import {
+  cronToScheduleSettings,
+  scheduleSettingsToCron,
+} from "metabase/admin/performance/utils";
+import { Schedule } from "metabase/components/Schedule/Schedule";
+import { formatNotificationScheduleDescription } from "metabase/lib/notifications";
+import { useSelector } from "metabase/lib/redux";
+import { DEFAULT_ALERT_SCHEDULE } from "metabase/notifications/utils";
+import { getSetting } from "metabase/selectors/settings";
+import { getApplicationName } from "metabase/selectors/whitelabel";
+import { Box, type BoxProps, Flex, Text } from "metabase/ui";
+import type {
+  NotificationCronSubscription,
+  ScheduleSettings,
+  ScheduleType,
+} from "metabase-types/api";
+
+import styles from "./NotificationSchedule.module.css";
+import { NotificationScheduleWarning } from "./NotificationScheduleWarning";
+
+export interface NotificationScheduleProps {
+  subscription?: NotificationCronSubscription;
+  scheduleOptions: ScheduleType[];
+  onScheduleChange: (subscription: NotificationCronSubscription) => void;
+}
+
+export const NotificationSchedule = ({
+  subscription,
+  scheduleOptions,
+  onScheduleChange,
+  ...boxProps
+}: NotificationScheduleProps & BoxProps & HTMLAttributes<HTMLDivElement>) => {
+  const timezone = useSelector(state =>
+    getSetting(state, "report-timezone-short"),
+  );
+
+  const scheduleSettings = useMemo(() => {
+    return (
+      cronToScheduleSettings(subscription?.cron_schedule) ||
+      DEFAULT_ALERT_SCHEDULE
+    );
+  }, [subscription?.cron_schedule]);
+
+  const handleScheduleChange = useCallback(
+    (nextSchedule: ScheduleSettings) => {
+      if (nextSchedule.schedule_type && subscription) {
+        const newCronSchedule = scheduleSettingsToCron(nextSchedule);
+        onScheduleChange({
+          ...subscription,
+          cron_schedule: newCronSchedule,
+        });
+      }
+    },
+    [onScheduleChange, subscription],
+  );
+
+  const actionText = t`Alerts will be sent at`;
+  const scheduleDescription = useScheduleDescription(
+    scheduleSettings,
+    timezone,
+    actionText,
+  );
+
+  return (
+    <Box {...boxProps}>
+      <Flex className={styles.scheduleContainer} direction="column" gap="md">
+        <Schedule
+          className={styles.schedule}
+          schedule={scheduleSettings}
+          scheduleOptions={scheduleOptions}
+          labelAlignment="left"
+          minutesOnHourPicker
+          onScheduleChange={handleScheduleChange}
+          verb={c("A verb in the imperative mood").t`Check`}
+          aria-label={t`Describe how often the alert notification should be sent`}
+        />
+        {scheduleDescription && (
+          <Text c="var(--mb-color-text-secondary)">{scheduleDescription}</Text>
+        )}
+      </Flex>
+      {showWarning(scheduleSettings) && <NotificationScheduleWarning />}
+    </Box>
+  );
+};
+
+const UNSAFE_SCHEDULE_TYPES = ["minutely", "cron"];
+const WARNING_THRESHOLD_MINS = 10;
+function showWarning(schedule: ScheduleSettings) {
+  if (
+    !schedule.schedule_type ||
+    !UNSAFE_SCHEDULE_TYPES.includes(schedule.schedule_type)
+  ) {
+    return false;
+  }
+  return (
+    typeof schedule.schedule_minute === "number" &&
+    schedule.schedule_minute < WARNING_THRESHOLD_MINS
+  );
+}
+
+// No description is necessary for schedule types, which recur periodically.
+const PERIODIC_SCHEDULE_TYPES = ["minutely", "hourly"];
+function useScheduleDescription(
+  schedule: ScheduleSettings,
+  timezone: string,
+  actionText: string,
+) {
+  const applicationName = useSelector(getApplicationName);
+
+  if (PERIODIC_SCHEDULE_TYPES.includes(schedule.schedule_type as string)) {
+    return null;
+  }
+
+  const scheduleDescription = formatNotificationScheduleDescription(schedule);
+  if (!scheduleDescription) {
+    return null;
+  }
+
+  const timezoneLabel = t`${timezone}, your ${applicationName} timezone.`;
+
+  return `${actionText} ${scheduleDescription} ${timezoneLabel}`;
+}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
@@ -1,0 +1,43 @@
+import { screen } from "__support__/ui";
+
+import { setup } from "./setup";
+
+describe("NotificationSchedule", () => {
+  it("should show warning when notification schedule is set to less than 10 minutes", () => {
+    setup({
+      subscription: {
+        id: 1,
+        notification_id: 1,
+        type: "notification-subscription/cron",
+        event_name: null,
+        cron_schedule: "0 0/5 * * * ?", // every 5 minutes
+        created_at: "2025-03-14T16:11:12Z",
+      },
+    });
+
+    expect(
+      screen.getByText(
+        /If an alert is still in progress when the next one is scheduled, the next alert will be skipped/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should not show warning when notification schedule is set to 10 or more minutes", () => {
+    setup({
+      subscription: {
+        id: 1,
+        notification_id: 1,
+        type: "notification-subscription/cron",
+        event_name: null,
+        cron_schedule: "0 0/10 * * * ?", // every 10 minutes
+        created_at: "2025-03-14T16:11:12Z",
+      },
+    });
+
+    expect(
+      screen.queryByText(
+        /If an alert is still in progress when the next one is scheduled, the next alert will be skipped/,
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.module.css
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.module.css
@@ -1,7 +1,13 @@
 .warningContainer {
   width: 100%;
-  background-color: var(--notification-warning-bg, var(--mb-base-color-orion-10));
-  padding: var(--notification-warning-padding, var(--mantine-spacing-md) var(--mantine-spacing-xl));
+  background-color: var(
+    --notification-warning-bg,
+    var(--mb-base-color-orion-10)
+  );
+  padding: var(
+    --notification-warning-padding,
+    var(--mantine-spacing-md) var(--mantine-spacing-xl)
+  );
 }
 
 .warningText {

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.module.css
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.module.css
@@ -1,0 +1,11 @@
+.warningContainer {
+  width: 100%;
+  background-color: var(--notification-warning-bg, var(--mb-base-color-orion-10));
+  padding: var(--notification-warning-padding, var(--mantine-spacing-md) var(--mantine-spacing-xl));
+}
+
+.warningText {
+  color: var(--notification-warning-text-color, var(--mb-color-text-secondary));
+  line-height: var(--mantine-line-height-sm);
+  font-family: var(--mantine-font-family);
+}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.module.css
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.module.css
@@ -13,5 +13,4 @@
 .warningText {
   color: var(--notification-warning-text-color, var(--mb-color-text-secondary));
   line-height: var(--mantine-line-height-sm);
-  font-family: var(--mantine-font-family);
 }

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationScheduleWarning.tsx
@@ -1,0 +1,15 @@
+import { t } from "ttag";
+
+import { Box, Text } from "metabase/ui";
+
+import styles from "./NotificationScheduleWarning.module.css";
+
+export const NotificationScheduleWarning = () => {
+  return (
+    <Box className={styles.warningContainer}>
+      <Text className={styles.warningText}>
+        {t`If an alert is still in progress when the next one is scheduled, the next alert will be skipped. This may result in fewer alerts than expected.`}
+      </Text>
+    </Box>
+  );
+};

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/setup.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/setup.tsx
@@ -1,6 +1,9 @@
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
-import type { NotificationCronSubscription, ScheduleType } from "metabase-types/api";
+import type {
+  NotificationCronSubscription,
+  ScheduleType,
+} from "metabase-types/api";
 import { createMockState } from "metabase-types/store/mocks";
 
 import { NotificationSchedule } from "./NotificationSchedule";

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/setup.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/setup.tsx
@@ -13,7 +13,7 @@ interface SetupOpts {
 }
 
 const mockScheduleOptions: ScheduleType[] = [
-  "minutely",
+  "every_n_minutes",
   "hourly",
   "daily",
   "weekly",

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/setup.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/setup.tsx
@@ -1,0 +1,40 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders } from "__support__/ui";
+import type { NotificationCronSubscription, ScheduleType } from "metabase-types/api";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { NotificationSchedule } from "./NotificationSchedule";
+
+interface SetupOpts {
+  subscription?: NotificationCronSubscription;
+}
+
+const mockScheduleOptions: ScheduleType[] = [
+  "minutely",
+  "hourly",
+  "daily",
+  "weekly",
+  "monthly",
+];
+
+const mockOnScheduleChange = jest.fn();
+
+export const setup = ({ subscription }: SetupOpts = {}) => {
+  const state = createMockState({
+    settings: mockSettings({
+      "report-timezone-short": "UTC",
+    }),
+  });
+
+  const props = {
+    scheduleOptions: mockScheduleOptions,
+    onScheduleChange: mockOnScheduleChange,
+    subscription,
+  };
+
+  renderWithProviders(<NotificationSchedule {...props} />, {
+    storeInitialState: state,
+  });
+
+  return props;
+};


### PR DESCRIPTION
Closes [WRK-129](https://linear.app/metabase/issue/WRK-129/add-by-minute-option-to-schedule-component)

This PR introduces a new "by the minute" scheduling option for alerts and enhances the notification scheduling UI:

### Changes
- Added a new granular "by the minute" option to the `Schedule` component for more precise alert timing.
- Refactored `Schedule` component to improve customization possibilities to conform to design, but to keep existing usage in Admin Settings untouched.

<img width="634" alt="image" src="https://github.com/user-attachments/assets/2692675f-38a9-42f3-88f9-abfe7ada62ab" />

- Created a new `NotificationSchedule` component encapsulating alerts-specific logic, such as displaying a warning message, to reuse later with Subscriptions. We can integrate it inside the Schedule component later, but for now it seems too specific and was left outside of it.
- Added proper pluralization for scheduling interface

<img width="633" alt="image" src="https://github.com/user-attachments/assets/e2de59b7-4521-4463-b3de-8d34e9e106a4" />

- Fixed a bug with monthly alerts formatting
 
<img width="667" alt="image" src="https://github.com/user-attachments/assets/d2395487-0cda-407e-8cb3-454e0ced851f" />

<img width="644" alt="image" src="https://github.com/user-attachments/assets/2583f638-80ae-4797-beb9-4dc01c99e811" />

- Updated `Schedule` stories to show new functionality

### How to verify
Navigate to any question in the dashboard.
Click "Sharing - Edit Alerts".
In the alert creation modal:
Verify that "by the minute" option is available in the schedule dropdown.
Confirm that pluralization is correct for different time intervals.
Create alerts with different minute-based schedules to verify they're saved and triggered correctly.

### Demo
https://www.loom.com/share/78ddb63cacf74d1e99ed04dbdae5c391?sid=77087de0-0135-4834-b558-848ec8358346

### Checklist
[x] Tests have been added/updated to cover changes in this PR