### PR TITLE
setup discouraged-tag linting for #p

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -298,6 +298,8 @@
    honeysql.types         {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
    honeysql.util          {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}}
 
+  :discouraged-tag {p {:message "You can use it, but don't commit it." }}
+
   :unresolved-var
   {:exclude
    [colorize.core]}

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -152,3 +152,5 @@
     (catch Exception e
       {:success false
        :error (.getMessage e)})))
+
+#p [::hi]

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -152,5 +152,3 @@
     (catch Exception e
       {:success false
        :error (.getMessage e)})))
-
-#p [::hi]


### PR DESCRIPTION
We don't want to allow `#p` to leak into prod code.

We are running CI with the :dev alias, which includes hashp, but we shouldn't let it get into production code. Hence the linter