### PR TITLE
Fix drill through for "empty" pie chart slices

### DIFF
--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -68,6 +68,10 @@ export function getKeyFromDimensionValue(dimensionValue: RowValue) {
   return String(dimensionValue);
 }
 
+export function getValueFromDimensionKey(key: string) {
+  return key === NULL_DISPLAY_VALUE ? null : key;
+}
+
 export function getAggregatedRows(
   rows: RowValues[],
   dimensionIndex: number,

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/use-chart-events.ts
@@ -21,6 +21,7 @@ import {
   getMarkerColorClass,
   useClickedStateTooltipSync,
 } from "metabase/visualizations/echarts/tooltip";
+import { getValueFromDimensionKey } from "metabase/visualizations/shared/settings/pie";
 import type {
   ClickObject,
   VisualizationProps,
@@ -152,7 +153,7 @@ function handleClick(
     column: chartModel.colDescs.metricDesc.column,
     data,
     dimensions: nodes.map(node => ({
-      value: node.key,
+      value: getValueFromDimensionKey(node.key),
       column: checkNotNull(node.column),
     })),
     settings,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #49737

### To reproduce

1. New > Question > Accounts
2. Count by Source
3. Set visualization to "pie"
4. Click on the "empty" slice
5. Click "See these Accounts"
6. Ensure you can see filtered accounts instead of an error / empty state

### Demo

**Before**

https://github.com/user-attachments/assets/1dad8ffc-8019-4c72-be0c-3fb0011dd600

**After**

https://github.com/user-attachments/assets/96cdf83c-8f71-4756-9e33-bf288e2a323a

