### PR TITLE
skip actions when duplicating a dashboard

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -371,7 +371,7 @@
             {:reference {}
              :copy {}
              :discard []}
-            dashcards)))
+            (filter :card_id dashcards))))
 
 (defn- maybe-duplicate-cards
   "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries as necessary.
@@ -418,8 +418,11 @@
                     dashcards)]
     (keep (fn [dashboard-card]
             (cond
+              (:action_id dashboard-card)
+              nil
+
               ;; text cards need no manipulation
-              (nil? (:card_id dashboard-card))
+              (some-> dashboard-card :visualization_settings :virtual_card :display #{"text" "heading"})
               dashboard-card
 
               ;; referenced cards need no manipulation

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1534,7 +1534,9 @@
 (deftest cards-to-copy-test
   (testing "Identifies all cards to be copied"
     (let [dashcards [{:card_id 1 :card (card-model {:id 1}) :series [(card-model {:id 2})]}
-                     {:card_id 3 :card (card-model {:id 3})}]]
+                     {:card_id 3 :card (card-model {:id 3})}
+                     ;; this guy does not even reach the discard pile
+                     {:action_id 123}]]
       (binding [*readable-card-ids* #{1 2 3}]
         (is (= {:copy {1 {:id 1} 2 {:id 2} 3 {:id 3}}
                 :reference {}
@@ -1636,6 +1638,18 @@
                                                       [:field 63 nil]]}]}]
                (api.dashboard/update-cards-for-copy dashcards
                                                     {1 {:id 2}}
+                                                    nil
+                                                    nil)))))
+    (testing "Does not think action cards are text cards"
+      (let [dashcards [{:card_id 1 :card {:id 1}}
+                       {:visualization_settings {:virtual_card {:display "text"}
+                                                 :text         "whatever"}}
+                       {:visualization_settings {:virtual_card {:display "heading"}
+                                                 :text         "keep me!"}}
+                       {:action_id 123}]]
+        (is (= (butlast dashcards)
+               (api.dashboard/update-cards-for-copy dashcards
+                                                    {1 {:id 1}}
                                                     nil
                                                     nil)))))))
 


### PR DESCRIPTION
They rise an exception right now

Ideally, we'd copy them too, but we need to decide if we should duplicate them or not (do a deep or shallow copy) is a too hard to make immediately, and this at least will unblock people being unable to duplicate dashboard with actions defined.

somewhat improves on #38224
