### PR TITLE
fix empty tooltip on the help menu item

### DIFF
--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
@@ -117,7 +117,7 @@ const LinkMenuItem = ({
   children,
   onClose,
 }: LinkMenuItemProps): JSX.Element => (
-  <Tooltip label={tooltip} position="right">
+  <Tooltip label={tooltip} disabled={tooltip == null} position="right">
     {externalLink ? (
       <MenuExternalLink
         href={link}

--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.unit.spec.js
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.unit.spec.js
@@ -1,4 +1,7 @@
+import userEvent from "@testing-library/user-event";
+
 import { fireEvent, getIcon, render, screen } from "__support__/ui";
+import { delay } from "__support__/utils";
 import EntityMenuItem from "metabase/components/EntityMenuItem";
 
 describe("EntityMenuItem", () => {
@@ -37,6 +40,40 @@ describe("EntityMenuItem", () => {
         );
 
         expect(screen.getByTestId("entity-menu-link")).toBeInTheDocument();
+      });
+
+      it("should show tooltip when tooltip prop is provided", async () => {
+        render(
+          <EntityMenuItem
+            title="Link with tooltip"
+            icon="pencil"
+            link="https://example.com"
+            externalLink
+            tooltip="Tooltip text"
+          />,
+        );
+
+        await userEvent.hover(await screen.findByText("Link with tooltip"));
+        const tooltip = await screen.findByRole("tooltip");
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip).toHaveTextContent("Tooltip text");
+      });
+
+      it("should not show tooltip when tooltip prop is not provided", async () => {
+        render(
+          <EntityMenuItem
+            title="Link without tooltip"
+            icon="pencil"
+            link="https://example.com"
+            externalLink
+          />,
+        );
+
+        await userEvent.hover(await screen.findByText("Link without tooltip"));
+        // Wait enough time for the tooltip to appear if it was going to appear
+        await delay(100);
+        const tooltip = screen.queryByRole("tooltip");
+        expect(tooltip).not.toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55082

### Description

Fixes "Help" item has an empty tooltip. Caused by https://github.com/metabase/metabase/pull/53447
<img width="398" alt="Screenshot 2025-03-14 at 1 34 09 PM" src="https://github.com/user-attachments/assets/24645796-4fe8-4a3a-8df1-93e204d74b24" />

### How to verify

- Click on the menu button in the top right corner
- Hover "Help" and ensure there is no tooltip

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
