### PR TITLE
Override type of date fields for CH upload tables

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -787,7 +787,7 @@
               ;; See https://github.com/metabase/metabase/issues/55199
               ch-type-hack       (fn [upload-type]
                                    (if (and (= ::upload-types/offset-datetime upload-type)
-                                            (= driver :clickhouse))
+                                            (= :clickhouse driver))
                                      ::upload-types/datetime
                                      upload-type))
               old-types          (map (comp ch-type-hack upload-types/base-type->upload-type :base_type name->field) column-names)


### PR DESCRIPTION
See #55199 

Underlying problem is that the latest CH driver reads the `:type/DateTime` column we create as a `:type/DateTimeWithTZ`. 

Either the driver will need to revert the change in how it categorizes columns, or we will need to update our Upload logic to track this. Even if we take the latter approach, there is some clean up we'd need to do in the driver so that its upload specific logic is consistent.

An advantage with this hotfix versus a fix in the driver is that it will fix the problem immediately, without needing the database to be re-sync'd.

Update: some more context about this fix and why it will be fairly robust.

**We made a design decision in both Metabase and the Driver when implementing Uploads to NOT support zoned datetimes, and to treat anything with a zone as a string. Other parts of the Driver has since changed to treat ALL dates as zoned, so there is a fundamental internal contradiction that results in this bug.**

See: https://github.com/ClickHouse/metabase-clickhouse-driver/blob/b84e70c1b5725c83bb0e5398c21e9642cb454ffe/src/metabase/driver/clickhouse.clj#L194-L196