### PR TITLE
Add constraints to key

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.spec.alpha :as s]
    [metabase-enterprise.advanced-config.file.interface :as advanced-config.file.i]
+   [metabase.models.api-key :as api-key]
    [metabase.models.user :as user]
    [metabase.permissions.core :as perms]
    [metabase.util :as u]
@@ -58,7 +59,7 @@
     ;; Validate key format
     (when-not (and (string? key)
                    (>= (count key) 8)
-                   (.startsWith key "mb_"))
+                   (.startsWith ^String key "mb_"))
       (throw (ex-info (format "API key must start with 'mb_' and be at least 8 characters long: %s" (pr-str name))
                       {:name name})))
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -18,7 +18,7 @@
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/key
   (s/and string?
-         #(re-matches #"mb_.{5,}.*" %)
+         (re-matches #"mb_.*" %)
          #(>= (count %) 8)))
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/creator

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -14,7 +14,9 @@
   string?)
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/key
-  string?)
+  (s/and string?
+         #(re-matches #"mb_.{5,}.*" %)
+         #(>= (count %) 8)))
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/creator
   string?)
@@ -50,37 +52,44 @@
 
 (defn- init-from-config-file!
   [api-key-config]
-  (let [{:keys [name key group creator]} api-key-config
-        group-id (case group
-                   "admin" (u/the-id (perms/admin-group))
-                   "all-users" (u/the-id (perms/all-users-group)))
-        unhashed-key (u.secret/secret key)
-        creator (get-admin-user-by-email creator)]
+  (let [{:keys [name key group creator]} api-key-config]
+    ;; Validate key format
+    (when-not (and (string? key)
+                   (>= (count key) 8)
+                   (.startsWith key "mb_"))
+      (throw (ex-info (format "API key must start with 'mb_' and be at least 8 characters long: %s" (pr-str name))
+                      {:name name})))
 
-    (if-let [existing-api-key (select-api-key name)]
-      (do
-        (log/info (u/format-color :blue "API key with name %s already exists, skipping" (pr-str name)))
-        existing-api-key)
-      (do
-        (log/info (u/format-color :green "Creating new API key %s" (pr-str name)))
-        ;; Create a user for the API key
-        (let [email (format "api-key-user-%s@api-key.invalid" (random-uuid))
-              user (first
-                    (t2/insert-returning-instances! :model/User
-                                                    {:email      email
-                                                     :first_name name
-                                                     :last_name  ""
-                                                     :type       :api-key
-                                                     :password   (str (random-uuid))}))]
-          ;; Set permissions groups for the user
-          (user/set-permissions-groups! user [(perms/all-users-group) {:id group-id}])
-          ;; Create the API key
-          (t2/insert-returning-instance! :model/ApiKey
-                                         {:user_id      (u/the-id user)
-                                          :name         name
-                                          :unhashed_key unhashed-key
-                                          :creator_id   (u/the-id creator)
-                                          :updated_by_id (u/the-id creator)}))))))
+    (let [group-id (case group
+                     "admin" (u/the-id (perms/admin-group))
+                     "all-users" (u/the-id (perms/all-users-group)))
+          unhashed-key (u.secret/secret key)
+          creator (get-admin-user-by-email creator)]
+
+      (if-let [existing-api-key (select-api-key name)]
+        (do
+          (log/info (u/format-color :blue "API key with name %s already exists, skipping" (pr-str name)))
+          existing-api-key)
+        (do
+          (log/info (u/format-color :green "Creating new API key %s" (pr-str name)))
+          ;; Create a user for the API key
+          (let [email (format "api-key-user-%s@api-key.invalid" (random-uuid))
+                user (first
+                      (t2/insert-returning-instances! :model/User
+                                                      {:email      email
+                                                       :first_name name
+                                                       :last_name  ""
+                                                       :type       :api-key
+                                                       :password   (str (random-uuid))}))]
+            ;; Set permissions groups for the user
+            (user/set-permissions-groups! user [(perms/all-users-group) {:id group-id}])
+            ;; Create the API key
+            (t2/insert-returning-instance! :model/ApiKey
+                                           {:user_id      (u/the-id user)
+                                            :name         name
+                                            :unhashed_key unhashed-key
+                                            :creator_id   (u/the-id creator)
+                                            :updated_by_id (u/the-id creator)})))))))
 
 (defmethod advanced-config.file.i/initialize-section! :api-keys
   [_section-name api-keys]

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -18,7 +18,7 @@
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/key
   (s/and string?
-         (re-matches #"mb_.*" %)
+         #(re-matches #"mb_.*" %)
          #(>= (count %) 8)))
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/creator

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -10,6 +10,8 @@
    [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/name
   string?)
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -66,7 +66,13 @@
                      "admin" (u/the-id (perms/admin-group))
                      "all-users" (u/the-id (perms/all-users-group)))
           unhashed-key (u.secret/secret key)
+          prefix (api-key/prefix (u.secret/expose unhashed-key))
           creator (get-admin-user-by-email creator)]
+
+      ;; Check if there's an existing API key with the same prefix
+      (when (t2/exists? :model/ApiKey :key_prefix prefix)
+        (throw (ex-info (format "API key with prefix '%s' already exists. Keys must have unique prefixes." prefix)
+                        {:name name :prefix prefix})))
 
       (if-let [existing-api-key (select-api-key name)]
         (do

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -18,8 +18,8 @@
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/key
   (s/and string?
-         #(re-matches #"mb_.*" %)
-         #(>= (count %) 8)))
+         #(<= 11 (count %) 254)
+         #(re-matches #"mb_[A-Za-z0-9+/=]+" %)))
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/creator
   string?)
@@ -56,12 +56,6 @@
 (defn- init-from-config-file!
   [api-key-config]
   (let [{:keys [name key group creator]} api-key-config]
-    ;; Validate key format
-    (when-not (and (string? key)
-                   (>= (count key) 8)
-                   (.startsWith ^String key "mb_"))
-      (throw (ex-info (format "API key must start with 'mb_' and be at least 8 characters long: %s" (pr-str name))
-                      {:name name})))
 
     (let [group-id (case group
                      "admin" (u/the-id (perms/admin-group))

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -91,7 +91,7 @@
                                           :name         name
                                           :unhashed_key unhashed-key
                                           :creator_id   (u/the-id creator)
-                                          :updated_by_id (u/the-id creator)})))))
+                                          :updated_by_id (u/the-id creator)}))))))
 
 (defmethod advanced-config.file.i/initialize-section! :api-keys
   [_section-name api-keys]

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -50,11 +50,11 @@
                                  :group "all-users"}]}})
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "test_api_key_123"
+                                                               :key "mb_test_api_key_123"
                                                                :creator "admin@test.com"
                                                                :group "admin"}
                                                               {:name "All Users API Key"
-                                                               :key "different_api_key_456"
+                                                               :key "mb_different_api_key_456"
                                                                :creator "admin@test.com"
                                                                :group "all-users"}]}}]
             (is (= :ok (config.file/initialize!)))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -41,11 +41,11 @@
           (write-config!
            {:version 1
             :config {:api-keys [{:name "Test API Key"
-                                 :key "test_api_key_123"
+                                 :key "mb_test_api_key_123"
                                  :creator "admin@test.com"
                                  :group "admin"}
                                 {:name "All Users API Key"
-                                 :key "different_api_key_456"
+                                 :key "mb_different_api_key_456"
                                  :creator "admin@test.com"
                                  :group "all-users"}]}})
           (binding [config.file/*config* {:version 1
@@ -74,7 +74,7 @@
                                         :is_superuser false}]
             (binding [config.file/*config* {:version 1
                                             :config {:api-keys [{:name "Test API Key"
-                                                                 :key "test_api_key_123"
+                                                                 :key "mb_test_api_key_123"
                                                                  :creator "regular@test.com"
                                                                  :group "admin"}]}}]
               (is (thrown-with-msg?
@@ -88,7 +88,7 @@
         (try
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "test_api_key_123"
+                                                               :key "mb_test_api_key_123"
                                                                :creator "nonexistent@test.com"
                                                                :group "admin"}]}}]
             (is (thrown-with-msg?
@@ -102,7 +102,7 @@
         (try
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "test_api_key_123"
+                                                               :key "mb_test_api_key_123"
                                                                :creator "admin@test.com"
                                                                :group "admin"}]}}]
             (config.file/initialize!)
@@ -117,7 +117,7 @@
         (try
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "test_api_key_123"
+                                                               :key "mb_test_api_key_123"
                                                                :creator "admin@test.com"
                                                                :group "invalid-group"}]}}]
             (is (thrown? clojure.lang.ExceptionInfo

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -68,34 +68,6 @@
           (finally
             (cleanup-config!))))
 
-      (testing "should fail if API keys have the same prefix"
-        (try
-          (write-config!
-           {:version 1
-            :config {:api-keys [{:name "First API Key"
-                                 :key "mb_same_prefix_123"
-                                 :creator "admin@test.com"
-                                 :group "admin"}]}})
-          (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "First API Key"
-                                                               :key "mb_same_prefix_123"
-                                                               :creator "admin@test.com"
-                                                               :group "admin"}]}}]
-            (config.file/initialize!)
-
-            ;; Try to create another key with the same prefix
-            (binding [config.file/*config* {:version 1
-                                            :config {:api-keys [{:name "Second API Key"
-                                                                 :key "mb_same_prefix_456"
-                                                                 :creator "admin@test.com"
-                                                                 :group "admin"}]}}]
-              (is (thrown-with-msg?
-                   clojure.lang.ExceptionInfo
-                   #"API key with prefix 'mb_same' already exists"
-                   (config.file/initialize!)))))
-          (finally
-            (cleanup-config!))))
-
       (testing "should fail if creator is not an admin"
         (try
           (mt/with-temp [:model/User _ {:email "regular@test.com"

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -41,20 +41,20 @@
           (write-config!
            {:version 1
             :config {:api-keys [{:name "Test API Key"
-                                 :key "mb_test_api_key_123"
+                                 :key "mb_testapikey123"
                                  :creator "admin@test.com"
                                  :group "admin"}
                                 {:name "All Users API Key"
-                                 :key "mb_different_api_key_456"
+                                 :key "mb_differentapikey456"
                                  :creator "admin@test.com"
                                  :group "all-users"}]}})
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_test_api_key_123"
+                                                               :key "mb_testapikey123"
                                                                :creator "admin@test.com"
                                                                :group "admin"}
                                                               {:name "All Users API Key"
-                                                               :key "mb_different_api_key_456"
+                                                               :key "mb_differentapikey456"
                                                                :creator "admin@test.com"
                                                                :group "all-users"}]}}]
             (is (= :ok (config.file/initialize!)))
@@ -72,16 +72,16 @@
           (write-config!
            {:version 1
             :config {:api-keys [{:name "First API Key"
-                                 :key "mb_same_prefix_123"
+                                 :key "mb_sameprefix_123"
                                  :creator "admin@test.com"
                                  :group "admin"}]}})
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "First API Key"
-                                                               :key "mb_same_prefix_123"
+                                                               :key "mb_sameprefix123"
                                                                :creator "admin@test.com"
                                                                :group "admin"}
                                                               {:name "Second API Key"
-                                                               :key "mb_same_prefix_456"
+                                                               :key "mb_sameprefix456"
                                                                :creator "admin@test.com"
                                                                :group "admin"}]}}]
             (is (thrown-with-msg?
@@ -98,7 +98,7 @@
                                         :is_superuser false}]
             (binding [config.file/*config* {:version 1
                                             :config {:api-keys [{:name "Test API Key"
-                                                                 :key "mb_1test_api_key_123"
+                                                                 :key "mb_1testapikey123"
                                                                  :creator "regular@test.com"
                                                                  :group "admin"}]}}]
               (is (thrown-with-msg?
@@ -112,7 +112,7 @@
         (try
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_2test_api_key_123"
+                                                               :key "mb_2testapikey123"
                                                                :creator "nonexistent@test.com"
                                                                :group "admin"}]}}]
             (is (thrown-with-msg?
@@ -126,14 +126,14 @@
         (try
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_3test_api_key_123"
+                                                               :key "mb_3testapikey123"
                                                                :creator "admin@test.com"
                                                                :group "admin"}]}}]
             (config.file/initialize!)
             (let [first-key (t2/select-one :model/ApiKey :name "Test API Key")
                   _ (binding [config.file/*config* {:version 1
                                                     :config {:api-keys [{:name "Test API Key"
-                                                                         :key "mb_4test_api_key_123"
+                                                                         :key "mb_4testapikey123"
                                                                          :creator "admin@test.com"
                                                                          :group "admin"}]}}]
                       (config.file/initialize!))
@@ -146,7 +146,7 @@
         (try
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_5test_api_key_123"
+                                                               :key "mb_5testapikey123"
                                                                :creator "admin@test.com"
                                                                :group "invalid-group"}]}}]
             (is (thrown? clojure.lang.ExceptionInfo


### PR DESCRIPTION
Implemented validation that ensures API keys when created with config.yml:
Start with the `mb_` prefix
Have a minimum length of 12 characters and max 254
Prefix (first 7 characters) must be unique
String must be Base64

"mb_$(openssl rand -base64 32)"