### PR TITLE
Patch 52 deps one more fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -109,7 +109,7 @@
   net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"}              ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
   net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
                                              :exclusions  [org.slf4j/slf4j-api]}
-  net.sf.cssbox/cssbox                      {:mvn/version "5.0.1"               ; HTML / CSS rendering
+  net.sf.cssbox/cssbox                      {:mvn/version "5.0.2"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api
                                                            junit/junit]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20240207"} ; Java implementation of the JQ json query language

--- a/deps.edn
+++ b/deps.edn
@@ -193,7 +193,9 @@
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   user-agent/user-agent                     {:mvn/version "0.1.1"}              ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}}             ; Dependency graphs and topological sorting
+  weavejester/dependency                    {:mvn/version "0.2.1"}              ; Dependency graphs and topological sorting
+  xerces/xercesImpl                         {:mvn/version "2.12.2"}             ; SAX2 parser, transient dependency of batik
+  }
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ;; !!         PLEASE KEEP NEW DEPENDENCIES ABOVE ALPHABETICALLY ORGANIZED AND ADD COMMENTS EXPLAINING THEM.         !!

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -10,5 +10,5 @@
                                                         ;; netty is updated because of CVE
                                                         io.netty/netty-common
                                                         io.netty/netty-buffer]}
-  io.netty/netty-common                  {:mvn/version "4.1.115.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.1.115.Final"}}}
+  io.netty/netty-common                  {:mvn/version "4.1.118.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.1.118.Final"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.20.0"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.22.0"}}}


### PR DESCRIPTION
~~bump~~ include xerces

It's a "provided" dep of `org.htmlunit/neko-htmlunit 4.6.0` which comes along from css box bump

https://www.htmlunit.org/dependencies.html

5.0.1
```
net.sf.cssbox/cssbox 5.0.1
  . org.codelibs/nekohtml 2.0.2 <----
    . org.codelibs.xerces/xercesImpl 2.12.0-sp1
    . xml-apis/xml-apis 1.4.01
```

5.0.2:

```
net.sf.cssbox/cssbox 5.0.2
  . org.htmlunit/neko-htmlunit 4.6.0 <---- different lib for neko and doesn't bring xerces
  . net.sf.cssbox/jstyleparser 4.0.1
    . org.antlr/antlr4-runtime 4.13.2
    X org.slf4j/slf4j-api 1.7.25 :excluded
    . org.unbescape/unbescape 1.1.6.RELEASE
```