### PR TITLE
use whitelabel colors in the static viz

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -23,6 +23,8 @@ runs:
       run: yarn build-static-viz
       shell: bash
       if: ${{ inputs.build-static-viz == 'true' }}
+      env:
+        MB_EDITION: ee
     - name: Test database driver
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -19,6 +19,8 @@ jobs:
           m2-cache-key: "cloverage"
       - name: Build static viz frontend
         run: yarn build-static-viz
+        env:
+          MB_EDITION: ee
       - name: Collect the test coverage
         run: clojure -X:dev:ci:ee:ee-dev:test:cloverage
       - name: Upload coverage to codecov.io

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -135,6 +135,8 @@ jobs:
       - name: Build static-viz frontend
         if: ${{ matrix.job.build-static-viz == 'true' && !inputs.skip }}
         run: yarn build-static-viz
+        env:
+          MB_EDITION: ${{ matrix.job.edition }}
       - name: Download Static Viz Bundle Artifact
         if: ${{ matrix.job.build-static-viz == 'true' && !inputs.skip }}
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,6 +43,8 @@ jobs:
           m2-cache-key: "files-changed"
       - name: Build static-viz frontend
         run: yarn build-static-viz
+        env:
+          MB_EDITION: ee
       - name: Upload Static Viz Bundle Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/enterprise/frontend/src/metabase-enterprise/static-viz-overrides.js
+++ b/enterprise/frontend/src/metabase-enterprise/static-viz-overrides.js
@@ -1,0 +1,5 @@
+import { applyWhitelabelOverride } from "./whitelabel/static-viz-overrides";
+
+export default function apply() {
+  applyWhitelabelOverride();
+}

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/static-viz-overrides.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/static-viz-overrides.js
@@ -1,0 +1,8 @@
+import { hasPremiumFeature } from "metabase-enterprise/settings";
+import { updateColors } from "metabase-enterprise/whitelabel/lib/whitelabel";
+
+export function applyWhitelabelOverride() {
+  if (hasPremiumFeature("whitelabel")) {
+    updateColors();
+  }
+}

--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -4,6 +4,8 @@ import "fast-text-encoding";
 import { setPlatformAPI } from "echarts/core";
 import ReactDOMServer from "react-dom/server";
 
+// eslint-disable-next-line import/order
+import enterpriseOverrides from "ee-overrides";
 import "metabase/lib/dayjs";
 
 import { updateStartOfWeek } from "metabase/lib/i18n";
@@ -45,12 +47,20 @@ function getRawSeriesWithDashcardSettings(rawSeries, dashcardSettings) {
 }
 
 export function RenderChart(rawSeries, dashcardSettings, options) {
+  MetabaseSettings.set("token-features", options.tokenFeatures);
+  MetabaseSettings.set("application-colors", options.applicationColors);
+
+  if (typeof enterpriseOverrides === "function") {
+    enterpriseOverrides();
+  }
+
+  MetabaseSettings.set("custom-formatting", options.customFormatting);
+
   const renderingContext = createStaticRenderingContext(
     options.applicationColors,
   );
 
   updateStartOfWeek(options.startOfWeek);
-  MetabaseSettings.set("custom-formatting", options.customFormatting);
 
   const rawSeriesWithDashcardSettings = getRawSeriesWithDashcardSettings(
     rawSeries,

--- a/rspack.static-viz.config.js
+++ b/rspack.static-viz.config.js
@@ -10,6 +10,8 @@ const CLJS_SRC_PATH_DEV = __dirname + "/target/cljs_dev";
 const LIB_SRC_PATH = __dirname + "/frontend/src/metabase-lib";
 const TYPES_SRC_PATH = __dirname + "/frontend/src/metabase-types";
 const SDK_SRC_PATH = __dirname + "/enterprise/frontend/src/embedding-sdk";
+const ENTERPRISE_SRC_PATH =
+  __dirname + "/enterprise/frontend/src/metabase-enterprise";
 
 const WEBPACK_BUNDLE = process.env.WEBPACK_BUNDLE || "development";
 const devMode = WEBPACK_BUNDLE !== "production";
@@ -109,11 +111,16 @@ module.exports = env => {
       alias: {
         assets: ASSETS_PATH,
         metabase: SRC_PATH,
+        "metabase-enterprise": ENTERPRISE_SRC_PATH,
         cljs: devMode ? CLJS_SRC_PATH_DEV : CLJS_SRC_PATH,
         "metabase-lib": LIB_SRC_PATH,
         "metabase-types": TYPES_SRC_PATH,
         "embedding-sdk": SDK_SRC_PATH,
         "process/browser": require.resolve("process/browser"),
+        "ee-overrides":
+          process.env.MB_EDITION === "ee"
+            ? ENTERPRISE_SRC_PATH + "/static-viz-overrides"
+            : SRC_PATH + "/lib/noop",
       },
       fallback: {
         crypto: require.resolve("crypto-browserify"),

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -165,7 +165,8 @@
                                                        (json/encode dashcard-viz-settings)
                                                        (json/encode {:applicationColors (public-settings/application-colors)
                                                                      :startOfWeek (public-settings/start-of-week)
-                                                                     :customFormatting (public-settings/custom-formatting)})))]
+                                                                     :customFormatting (public-settings/custom-formatting)
+                                                                     :tokenFeatures (public-settings/token-features)})))]
     (-> response
         json/decode+kw
         (update :type (fnil keyword "unknown")))))

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -1031,3 +1031,21 @@
                               first)]
               (testing "Renders with correct day of week first"
                 (is (= "2017/1" label))))))))))
+
+(deftest render-correct-whitelabel-colors
+  (testing "The static-viz respects custom whitelabel colors"
+    (mt/with-temporary-setting-values [public-settings/application-colors {:accent0 "#0005FF"}, public-settings/token-features {:whitelabel true}]
+      (mt/dataset test-data
+        (let [q    (mt/mbql-query products
+                     {:aggregation [[:count]]
+                      :breakout    [!month.created_at]})
+              card {:name                   "bar-test"
+                    :display                :bar
+                    :dataset_query          q
+                    :visualization_settings {:graph.dimensions ["CREATED_AT"]
+                                             :graph.metrics ["count"]}}]
+          (mt/with-temp [:model/Card {card-id :id} card]
+            (let [doc    (render.tu/render-card-as-hickory! card-id)
+                  svg    (html doc)]
+              (testing "Renders with custom whitelabel color"
+                (is (str/includes? svg "#0005FF"))))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47644

### Description

Fixes static viz chart do not use whitelabel colors when defined.

### How to verify

- Build static viz with `MB_EDITION=ee yarn build-static-viz`
- Run Metabase EE
- Go to Admin settings -> [Appearance](http://localhost:3000/admin/settings/whitelabel)
- Change "Chart colors"
- Create any line/area/bar chart. **Do not to change series colors**, the bug is about assigned by default colors.
- Send a test dashboard subscription with the chart, ensure it has custom colors

### Demo

Dashboard

<img width="846" alt="Screenshot 2025-03-14 at 11 48 25 PM" src="https://github.com/user-attachments/assets/4f9a78e8-9551-4773-9abb-478a66b06c1b" />

Static viz

<img width="635" alt="Screenshot 2025-03-14 at 11 48 46 PM" src="https://github.com/user-attachments/assets/d2d7c8b8-42d6-44d8-88a7-8970fd792c1c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
