### PR TITLE
[sync-metadata] Use equalsIgnoreCase to match fields instead of lowercasing

### DIFF
--- a/test/metabase/sync/sync_metadata/fields/common_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/common_test.clj
@@ -1,0 +1,17 @@
+(ns metabase.sync.sync-metadata.fields.common-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.sync.sync-metadata.fields.common :as common]))
+
+(deftest canonical-names-equal?-test
+  (are [s1 s2 result] (= result (#'common/canonical-names-equal? {:name s1} {:name s2}))
+    "id"     "ID"     true
+    "Id"     "id"     true
+    "id"     "id"     true
+    "FoObAr" "FOOBAR" true
+    "foo"    "bar"    false
+    ;; Turkish character handling is one of the reasons why this function is important.
+    "ıd"     "id"     true
+    "ıd"     "ID"     true
+    "ıD"     "Id"     true
+    "ıD"     "yd"     false))


### PR DESCRIPTION
If a table contains a lot of fields (think tens or hundreds of thousands), lowecasing each field over and over brings a lot of allocation and runtime overhead. I propose to use `equalsIgnoreCase` instead which is mostly allocation-free and achieves the same result. From what I've found, `equalsIgnoreCase` is locale-insensitive, so Turkish-locale issues shouldn't happen there (see e.g. https://bugs.openjdk.org/browse/JDK-8049038). I've also verified with he Turkish locale locally; the method appears to work correctly.

Diffgraph with a huge difference in allocations when importing a new database with 10k fields: https://flamebin.dev/xbBrak.