### PR TITLE
Replace ConfirmContent in DatabaseDangerZone

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseDangerZoneSection/DatabaseDangerZoneSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseDangerZoneSection/DatabaseDangerZoneSection.tsx
@@ -63,7 +63,6 @@ export const DatabaseDangerZoneSection = ({
               color="danger"
             >{t`Discard saved field values`}</Button>
             <ConfirmModal
-              data-testid="modal"
               opened={discardModalOpened}
               title={t`Discard saved field values`}
               onClose={closeDiscardModal}

--- a/frontend/src/metabase/admin/databases/components/DatabaseDangerZoneSection/DatabaseDangerZoneSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseDangerZoneSection/DatabaseDangerZoneSection.tsx
@@ -63,6 +63,7 @@ export const DatabaseDangerZoneSection = ({
               color="danger"
             >{t`Discard saved field values`}</Button>
             <ConfirmModal
+              data-testid="modal"
               opened={discardModalOpened}
               title={t`Discard saved field values`}
               onClose={closeDiscardModal}

--- a/frontend/src/metabase/admin/databases/components/DatabaseDangerZoneSection/DatabaseDangerZoneSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseDangerZoneSection/DatabaseDangerZoneSection.tsx
@@ -1,9 +1,10 @@
+import { useDisclosure } from "@mantine/hooks";
 import { useCallback, useRef } from "react";
 import { t } from "ttag";
 
 import DeleteDatabaseModal from "metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal";
 import { useDiscardDatabaseFieldValuesMutation } from "metabase/api";
-import ConfirmContent from "metabase/components/ConfirmContent";
+import { ConfirmModal } from "metabase/components/ConfirmModal";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import { isSyncCompleted } from "metabase/lib/syncing";
 import { Button, Flex } from "metabase/ui";
@@ -21,14 +22,13 @@ export const DatabaseDangerZoneSection = ({
   database: Database;
   deleteDatabase: (databaseId: DatabaseId) => Promise<void>;
 }) => {
-  const discardSavedFieldValuesModal = useRef<any>();
+  const [
+    discardModalOpened,
+    { close: closeDiscardModal, open: openDiscardModal },
+  ] = useDisclosure();
   const deleteDatabaseModal = useRef<any>();
 
   const [discardDatabaseFieldValues] = useDiscardDatabaseFieldValuesMutation();
-
-  const handleSavedFieldsModalClose = useCallback(() => {
-    discardSavedFieldValuesModal.current.close();
-  }, []);
 
   const handleDeleteDatabaseModalClose = useCallback(() => {
     deleteDatabaseModal.current.close();
@@ -56,21 +56,22 @@ export const DatabaseDangerZoneSection = ({
     >
       <Flex gap="sm" wrap="wrap">
         {isSyncCompleted(database) && (
-          <ModalWithTrigger
-            triggerElement={
-              <Button
-                variant="filled"
-                color="danger"
-              >{t`Discard saved field values`}</Button>
-            }
-            ref={discardSavedFieldValuesModal}
-          >
-            <ConfirmContent
+          <>
+            <Button
+              onClick={openDiscardModal}
+              variant="filled"
+              color="danger"
+            >{t`Discard saved field values`}</Button>
+            <ConfirmModal
+              opened={discardModalOpened}
               title={t`Discard saved field values`}
-              onClose={handleSavedFieldsModalClose}
-              onAction={() => discardDatabaseFieldValues(database.id)}
+              onClose={closeDiscardModal}
+              onConfirm={() => {
+                discardDatabaseFieldValues(database.id);
+                closeDiscardModal();
+              }}
             />
-          </ModalWithTrigger>
+          </>
         )}
         {isAdmin && (
           <ModalWithTrigger


### PR DESCRIPTION
Replaces part of https://github.com/metabase/metabase/pull/53814

Uses the new ConfirmModal from https://github.com/metabase/metabase/pull/54632 inside `DatabaseDangerZoneSection` and replaces the `ModalWithTrigger` with `useDisclosure` hook