### PR TITLE
[Notification] Handle description for new schedule types

### DIFF
--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -358,7 +358,9 @@
         (format "Run weekly on %s at %s %s"
                 (schedule-day-text schedule)
                 (schedule-hour-text schedule)
-                (schedule-timezone))))))
+                (schedule-timezone))
+
+        "dont know"))))
 
 (defn- send-email!
   "Sends an email on a background thread, returning a future."

--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -12,7 +12,6 @@
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.template.core :as channel.template]
    [metabase.db.query :as mdb.query]
-   [metabase.driver :as driver]
    [metabase.lib.util :as lib.util]
    [metabase.models.collection :as collection]
    [metabase.permissions.core :as perms]
@@ -20,7 +19,6 @@
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util :as u]
-   [metabase.util.cron :as u.cron]
    [metabase.util.date-2 :as u.date]
    [metabase.util.encryption :as encryption]
    [metabase.util.i18n :as i18n :refer [trs tru]]
@@ -28,10 +26,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.urls :as urls]
-   [toucan2.core :as t2])
-  (:import
-   (java.time LocalTime)
-   (java.time.format DateTimeFormatter)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -296,71 +291,6 @@
       :meets
       :below)
     :rows))
-
-(defn- first-card
-  "Alerts only have a single card, so the alerts API accepts a `:card` key, while pulses have `:cards`. Depending on
-  whether the data comes from the alert API or pulse tasks, the card could be under `:card` or `:cards`"
-  [alert]
-  (or (:card alert)
-      (first (:cards alert))))
-
-(defn common-alert-context
-  "Template context that is applicable to all alert templates, including alert management templates
-  (e.g. the subscribed/unsubscribed emails)"
-  ([alert]
-   (common-alert-context alert nil))
-  ([alert alert-condition-map]
-   (let [{card-id :id, card-name :name} (first-card alert)]
-     (merge (common-context)
-            {:emailType                 "alert"
-             :questionName              card-name
-             :questionURL               (urls/card-url card-id)
-             :sectionStyle              (channel.render/section-style)}
-            (when alert-condition-map
-              {:alertCondition (get alert-condition-map (pulse->alert-condition-kwd alert))})))))
-
-(defn- schedule-hour-text
-  [{hour :schedule_hour}]
-  (.format (LocalTime/of hour 0)
-           (DateTimeFormatter/ofPattern "h a")))
-
-(defn- schedule-day-text
-  [{day :schedule_day}]
-  (get {"sun" "Sunday"
-        "mon" "Monday"
-        "tue" "Tuesday"
-        "wed" "Wednesday"
-        "thu" "Thursday"
-        "fri" "Friday"
-        "sat" "Saturday"}
-       day))
-
-(defn- schedule-timezone
-  []
-  (or (driver/report-timezone) "UTC"))
-
-(defn notification-card-schedule-text
-  "Given cron notification subscription return a human-readable description of the schedule."
-  [{:keys [cron_schedule type] :as _subscription}]
-  (when (= :notification-subscription/cron type)
-    ;; TODO consider using https://github.com/grahamar/cron-parser
-    (let [schedule (u.cron/cron-string->schedule-map cron_schedule)]
-      (case (keyword (:schedule_type schedule))
-        :hourly
-        "Run hourly"
-
-        :daily
-        (format "Run daily at %s %s"
-                (schedule-hour-text schedule)
-                (schedule-timezone))
-
-        :weekly
-        (format "Run weekly on %s at %s %s"
-                (schedule-day-text schedule)
-                (schedule-hour-text schedule)
-                (schedule-timezone))
-
-        "dont know"))))
 
 (defn- send-email!
   "Sends an email on a background thread, returning a future."

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -23,7 +23,11 @@
    [metabase.util.markdown :as markdown]
    [metabase.util.ui-logic :as ui-logic]
    [metabase.util.urls :as urls]
-   [ring.util.codec :as codec]))
+   [ring.util.codec :as codec])
+  (:import
+   (net.redhogs.cronparser CronExpressionDescriptor Options)))
+
+(set! *warn-on-reflection* true)
 
 (def ^:private EmailMessage
   [:map
@@ -195,7 +199,7 @@
                                                :icon_cid        (:content-id icon-attachment)
                                                :content         html-content
                                                ;; UI only allow one subscription per card notification
-                                               :alert_schedule  (messages/notification-card-schedule-text (first subscriptions))
+                                               :alert_schedule  (some-> subscriptions first :cron_schedule channel.shared/friendly-cron-description)
                                                :goal_value      goal
                                                :management_text (if (nil? non-user-email)
                                                                   "Manage your subscriptions"

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -23,9 +23,7 @@
    [metabase.util.markdown :as markdown]
    [metabase.util.ui-logic :as ui-logic]
    [metabase.util.urls :as urls]
-   [ring.util.codec :as codec])
-  (:import
-   (net.redhogs.cronparser CronExpressionDescriptor Options)))
+   [ring.util.codec :as codec]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/channel/shared.clj
+++ b/src/metabase/channel/shared.clj
@@ -12,6 +12,8 @@
   (:import
    (net.redhogs.cronparser CronExpressionDescriptor Options)))
 
+(set! *warn-on-reflection* true)
+
 (defn validate-channel-details
   "Validate a value against a schema and throw an exception if it's invalid.
   The :errors key are used on the UI to display field-specific error messages."

--- a/src/metabase/channel/shared.clj
+++ b/src/metabase/channel/shared.clj
@@ -64,7 +64,7 @@
 (defn friendly-cron-description
   "Convert a cron string to a human-readable description."
   [cron-string]
-  (let [[seconds minutes hours day-of-month month day-of-week _] (str/split cron-string #"\s+")
+  (let [[seconds minutes hours day-of-month month day-of-week year] (str/split cron-string #"\s+")
         timezone (schedule-timezone)]
     (cond
       ;; Hourly pattern
@@ -72,6 +72,7 @@
        (= seconds "0")
        (= minutes "0")
        (= hours "*")
+       (or (nil? year) (= year "*"))
        (not= day-of-month "?")
        (not= month "?"))
       (format "Run hourly %s" timezone)
@@ -81,6 +82,7 @@
        (= seconds "0")
        (re-matches #"\d+" minutes)
        (= hours "*")
+       (or (nil? year) (= year "*"))
        (not= day-of-month "?")
        (not= month "?"))
       (format "Run hourly at %d minutes past the hour %s"
@@ -92,6 +94,7 @@
        (= seconds "0")
        (re-matches #"\d+" minutes)
        (re-matches #"\d+" hours)
+       (or (nil? year) (= year "*"))
        (= day-of-month "*")
        (= month "*"))
       (format "Run daily at %s %s"
@@ -103,6 +106,7 @@
        (= seconds "0")
        (re-matches #"\d+" minutes)
        (re-matches #"\d+" hours)
+       (or (nil? year) (= year "*"))
        (= day-of-month "?")
        (= month "*")
        (re-matches #"\d+" day-of-week))

--- a/src/metabase/channel/shared.clj
+++ b/src/metabase/channel/shared.clj
@@ -1,10 +1,16 @@
 (ns metabase.channel.shared
   "Shared functions for channel implementations."
   (:require
+   [clojure.string :as str]
    [malli.error :as me]
    [medley.core :as m]
+   [metabase.driver :as driver]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.log :as log]
+   [metabase.util.malli.registry :as mr])
+  (:import
+   (net.redhogs.cronparser CronExpressionDescriptor Options)))
 
 (defn validate-channel-details
   "Validate a value against a schema and throw an exception if it's invalid.
@@ -25,3 +31,88 @@
   [part]
   (when part
     (m/update-existing-in part [:result :data :rows] maybe-deref)))
+
+(defn- schedule-timezone
+  []
+  (or (driver/report-timezone) "UTC"))
+
+(defn- format-time
+  "Format hour and minute into a 12-hour time string with AM/PM."
+  [hour minute]
+  (let [hour-12 (cond
+                  (zero? hour) 12
+                  (> hour 12) (- hour 12)
+                  :else hour)
+        am-pm (if (< hour 12) "AM" "PM")]
+    (if-not (zero? minute)
+      (format "%d:%02d %s" hour-12 minute am-pm)
+      (format "%d %s" hour-12 am-pm))))
+
+(defn- cron-description
+  [cron-string]
+  (try
+    (let [s (CronExpressionDescriptor/getDescription ^String cron-string
+                                                     (doto (Options.)
+                                                       (.setZeroBasedDayOfWeek false)))
+          s (str (u/lower-case-en (subs s 0 1))
+                 (subs s 1))]
+      (format "Run %s %s" s (schedule-timezone)))
+    (catch Exception e
+      (log/errorf e "Failed to parse cron expression: %s" cron-string)
+      nil)))
+
+(defn friendly-cron-description
+  "Convert a cron string to a human-readable description."
+  [cron-string]
+  (let [[seconds minutes hours day-of-month month day-of-week _] (str/split cron-string #"\s+")
+        timezone (schedule-timezone)]
+    (cond
+      ;; Hourly pattern
+      (and
+       (= seconds "0")
+       (= minutes "0")
+       (= hours "*")
+       (not= day-of-month "?")
+       (not= month "?"))
+      (format "Run hourly %s" timezone)
+
+      ;; Hourly pattern with specific minutes
+      (and
+       (= seconds "0")
+       (re-matches #"\d+" minutes)
+       (= hours "*")
+       (not= day-of-month "?")
+       (not= month "?"))
+      (format "Run hourly at %d minutes past the hour %s"
+              (Integer/parseInt minutes)
+              timezone)
+
+      ;; Daily pattern
+      (and
+       (= seconds "0")
+       (re-matches #"\d+" minutes)
+       (re-matches #"\d+" hours)
+       (= day-of-month "*")
+       (= month "*"))
+      (format "Run daily at %s %s"
+              (format-time (Integer/parseInt hours) (Integer/parseInt minutes))
+              timezone)
+
+      ;; Weekly pattern
+      (and
+       (= seconds "0")
+       (re-matches #"\d+" minutes)
+       (re-matches #"\d+" hours)
+       (= day-of-month "?")
+       (= month "*")
+       (re-matches #"\d+" day-of-week))
+      (let [day-name (["Sunday" "Monday" "Tuesday" "Wednesday" "Thursday" "Friday" "Saturday"]
+                      (dec (Integer/parseInt day-of-week)))]
+        (format "Run weekly on %s at %s %s"
+                day-name
+                (format-time (Integer/parseInt hours) (Integer/parseInt minutes))
+                timezone))
+
+      ;; Default case
+      :else
+      (cron-description cron-string))))

--- a/src/metabase/util/cron.clj
+++ b/src/metabase/util/cron.clj
@@ -9,7 +9,6 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms])
   (:import
-   (net.redhogs.cronparser CronExpressionDescriptor)
    (org.quartz CronExpression)))
 
 (set! *warn-on-reflection* true)
@@ -159,8 +158,3 @@
      :schedule_frame  (cron-day-of-week+day-of-month->frame day-of-week day-of-month)
      :schedule_hour   (cron->digit hours)
      :schedule_type   (cron->schedule-type hours day-of-month day-of-week)}))
-
-(mu/defn describe-cron-string :- ms/NonBlankString
-  "Return a human-readable description of a cron expression, localized for the current User."
-  [^String cron-string :- CronScheduleString]
-  (CronExpressionDescriptor/getDescription cron-string (i18n/user-locale)))

--- a/test/metabase/channel/email/messages_test.clj
+++ b/test/metabase/channel/email/messages_test.clj
@@ -47,36 +47,6 @@
               (get-in [0 :body 0 :content])
               (str/includes? "deactivated"))))))
 
-(deftest alert-schedule-text-test
-  (let [schedule-text (fn [cron-string]
-                        (-> cron-string
-                            u.cron/schedule-map->cron-string
-                            ((fn [cron-string] {:type :notification-subscription/cron
-                                                :cron_schedule cron-string}))
-                            (@#'messages/notification-card-schedule-text)))]
-    (testing "Alert schedules can be described as English strings, with the timezone included"
-      (tu/with-temporary-setting-values [report-timezone "America/Pacific"]
-        (is (= "Run hourly"
-               (schedule-text {:schedule_type "hourly"})))
-        (is (= "Run daily at 12 AM America/Pacific"
-               (schedule-text {:schedule_type "daily"
-                               :schedule_hour 0})))
-        (is (= "Run daily at 5 AM America/Pacific"
-               (schedule-text {:schedule_type "daily"
-                               :schedule_hour 5})))
-        (is (= "Run daily at 6 PM America/Pacific"
-               (schedule-text {:schedule_type "daily"
-                               :schedule_hour 18})))
-        (is (= "Run weekly on Monday at 8 AM America/Pacific"
-               (schedule-text {:schedule_type "weekly"
-                               :schedule_day  "mon"
-                               :schedule_hour 8})))))
-    (testing "If report-timezone is not set, falls back to UTC"
-      (tu/with-temporary-setting-values [report-timezone nil]
-        (is (= "Run daily at 12 AM UTC"
-               (schedule-text {:schedule_type "daily"
-                               :schedule_hour 0})))))))
-
 #_(deftest render-pulse-email-test
     (testing "Email with few rows and columns can be rendered when tracing (#21166)"
       (mt/with-log-level [metabase.channel.email :trace]

--- a/test/metabase/channel/email/messages_test.clj
+++ b/test/metabase/channel/email/messages_test.clj
@@ -8,7 +8,6 @@
    [metabase.models.api-key :as api-key]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
-   [metabase.util.cron :as u.cron]
    [metabase.util.retry :as retry]
    [metabase.util.retry-test :as rt])
   (:import

--- a/test/metabase/channel/shared_test.clj
+++ b/test/metabase/channel/shared_test.clj
@@ -1,0 +1,33 @@
+(ns metabase.channel.shared-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.channel.shared :as channel.shared]
+   [metabase.test :as mt]))
+
+(deftest cron-to-friendly-description-test
+  (mt/with-dynamic-fn-redefs [channel.shared/schedule-timezone (constantly "UTC")]
+    (testing "converts cron expressions to human-readable descriptions"
+      (are [cron expected] (= expected (channel.shared/friendly-cron-description cron))
+        ;; Hourly patterns
+        "0 0 * * * ?"    "Run hourly UTC"
+        "0 30 * * * ?"   "Run hourly at 30 minutes past the hour UTC"
+
+        ;; Daily patterns
+        "0 0 12 * * ?"   "Run daily at 12 PM UTC"
+        "0 30 9 * * ?"   "Run daily at 9:30 AM UTC"
+        "0 15 17 * * ?"  "Run daily at 5:15 PM UTC"
+        "0 0 0 * * ?"    "Run daily at 12 AM UTC"
+
+        ;; Weekly patterns
+        "0 0 9 ? * 2"    "Run weekly on Monday at 9 AM UTC"
+        "0 30 17 ? * 6"  "Run weekly on Friday at 5:30 PM UTC"
+        "0 0 0 ? * 1"    "Run weekly on Sunday at 12 AM UTC"
+        "0 45 14 ? * 4"  "Run weekly on Wednesday at 2:45 PM UTC"))
+
+    (testing "falls back to cron->description for complex patterns"
+      (are [cron expected] (= expected (channel.shared/friendly-cron-description cron))
+        "0 0 12 1-15 * ?"  "Run at 12:00 pm, between day 1 and 15 of the month UTC"
+        "0 0/15 * * * ?"   "Run every 15 minutes UTC"
+        "0 0 12 ? * 2,4,6" "Run at 12:00 pm, only on Monday, Wednesday and Friday UTC"
+        "0 0 12 L * ?"     "Run at 12:00 pm, on the last day of the month UTC"
+        "0 0 12 ? * 2#1"   "Run at 12:00 pm, on the first Monday of the month UTC"))))

--- a/test/metabase/channel/shared_test.clj
+++ b/test/metabase/channel/shared_test.clj
@@ -10,16 +10,19 @@
       (are [cron expected] (= expected (channel.shared/friendly-cron-description cron))
         ;; Hourly patterns
         "0 0 * * * ?"    "Run hourly UTC"
+        "0 0 * * * ? *"  "Run hourly UTC"
         "0 30 * * * ?"   "Run hourly at 30 minutes past the hour UTC"
 
         ;; Daily patterns
         "0 0 12 * * ?"   "Run daily at 12 PM UTC"
+        "0 0 12 * * ? *" "Run daily at 12 PM UTC"
         "0 30 9 * * ?"   "Run daily at 9:30 AM UTC"
         "0 15 17 * * ?"  "Run daily at 5:15 PM UTC"
         "0 0 0 * * ?"    "Run daily at 12 AM UTC"
 
         ;; Weekly patterns
         "0 0 9 ? * 2"    "Run weekly on Monday at 9 AM UTC"
+        "0 0 9 ? * 2 *"  "Run weekly on Monday at 9 AM UTC"
         "0 30 17 ? * 6"  "Run weekly on Friday at 5:30 PM UTC"
         "0 0 0 ? * 1"    "Run weekly on Sunday at 12 AM UTC"
         "0 45 14 ? * 4"  "Run weekly on Wednesday at 2:45 PM UTC"))
@@ -30,4 +33,8 @@
         "0 0/15 * * * ?"   "Run every 15 minutes UTC"
         "0 0 12 ? * 2,4,6" "Run at 12:00 pm, only on Monday, Wednesday and Friday UTC"
         "0 0 12 L * ?"     "Run at 12:00 pm, on the last day of the month UTC"
-        "0 0 12 ? * 2#1"   "Run at 12:00 pm, on the first Monday of the month UTC"))))
+        "0 0 12 ? * 2#1"   "Run at 12:00 pm, on the first Monday of the month UTC")))
+
+  (mt/with-dynamic-fn-redefs [channel.shared/schedule-timezone (constantly "Asia/Ho_Chi_Minh")]
+    (testing "with timezone Asia/Ho_Chi_Minh"
+      (is (= "Run hourly Asia/Ho_Chi_Minh" (channel.shared/friendly-cron-description "0 0 * * * ?"))))))


### PR DESCRIPTION
In the email template for alert, we have a text to describe the schedule like: "Run daily at 9AM".
As we're working on new options for the alert schedule:
- minute level
- monthly
- custom cron

The current implementation of cron description does not support all variants, this PR add support for the rest.

See tests for example.

Closes https://linear.app/metabase/issue/WRK-161/fix-alert-failed-to-send-to-email-when-using-minute-level-schedule