### PR TITLE
ci: improve memory management in cypress in chromium based browsers

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -188,6 +188,7 @@ const mainConfig = {
     : {}),
   projectId: "ywjy9z",
   numTestsKeptInMemory: process.env["CI"] ? 1 : 50,
+  experimentalMemoryManagement: true,
   reporter: "cypress-multi-reporters",
   reporterOptions: {
     configFile: false,


### PR DESCRIPTION
### Description

one of the reasons of chrome crashing during local development which was discussed during last eng review meeting can be the size of memory, we can try to enable a special flag to improve the state of local development

### Before
<img width="1450" alt="Screenshot 2025-03-17 at 15 43 34" src="https://github.com/user-attachments/assets/25560936-2005-4cae-8350-64a54bd10bcd" />


### After
<img width="1473" alt="Screenshot 2025-03-17 at 15 51 51" src="https://github.com/user-attachments/assets/7bbde63c-babc-48d4-bb4c-d6afbf0f5a13" />
