### PR TITLE
ci: decrease build job timeout

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -11,22 +11,22 @@ on:
       # config files
       - ".**"
       # documentation
-      - 'docs/**'
+      - "docs/**"
       - "**.md"
       # this covers both BE and FE unit tests, as well as E2E tests
-      - '**test/**'
+      - "**test/**"
       - "**_test.clj"
       - "**/frontend/**.unit.*"
   workflow_dispatch:
     inputs:
       commit:
-        description: 'Optional full-length commit SHA-1 hash'
+        description: "Optional full-length commit SHA-1 hash"
 
 jobs:
   build:
     name: Build MB ${{ matrix.edition }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: 15
     strategy:
       matrix:
         edition: [ee, oss]
@@ -34,23 +34,23 @@ jobs:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
     steps:
-    - name: Check out the code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.inputs.commit }}
-    - name: Prepare front-end environment
-      uses: ./.github/actions/prepare-frontend
-    - name: Prepare back-end environment
-      uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: uberjar
-        java-version: 21
-    - name: Build
-      run: ./bin/build.sh
-    - name: Prepare uberjar artifact
-      uses: ./.github/actions/prepare-uberjar-artifact
-      with:
-        name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit }}
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: uberjar
+          java-version: 21
+      - name: Build
+        run: ./bin/build.sh
+      - name: Prepare uberjar artifact
+        uses: ./.github/actions/prepare-uberjar-artifact
+        with:
+          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
 
   check_jar_health:
     runs-on: ubuntu-22.04
@@ -62,22 +62,22 @@ jobs:
         edition: [ee, oss]
         java-version: [21]
     steps:
-    - name: Prepare JRE (Java Run-time Environment)
-      uses: actions/setup-java@v4
-      with:
-        java-package: jre
-        java-version: ${{ matrix.java-version }}
-        distribution: 'temurin'
-    - run: java -version
-    - uses: actions/download-artifact@v4
-      name: Retrieve uberjar artifact
-      with:
-        name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
-    - name: Launch uberjar
-      run: >-
-        java --add-opens java.base/java.nio=ALL-UNNAMED -jar ./target/uberjar/metabase.jar &
-    - name: Wait for Metabase to start
-      run: while ! curl 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      - name: Prepare JRE (Java Run-time Environment)
+        uses: actions/setup-java@v4
+        with:
+          java-package: jre
+          java-version: ${{ matrix.java-version }}
+          distribution: "temurin"
+      - run: java -version
+      - uses: actions/download-artifact@v4
+        name: Retrieve uberjar artifact
+        with:
+          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
+      - name: Launch uberjar
+        run: >-
+          java --add-opens java.base/java.nio=ALL-UNNAMED -jar ./target/uberjar/metabase.jar &
+      - name: Wait for Metabase to start
+        run: while ! curl 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
 
   containerize_test_and_push_container:
     runs-on: ubuntu-22.04
@@ -97,181 +97,181 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - name: Extract and clean branch name
-      shell: bash
-      run: echo "branch=$(echo $GITHUB_REF_NAME | sed 's/[^-._a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
-      id: extract_branch
-    - name: Verify the intended tag of the container image
-      run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
-    - name: Check out the code (Dockerfile needed)
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.inputs.commit }}
-    - name: Download uploaded artifacts to insert into container
-      if: ${{ matrix.edition != 'ee-extra' }}
-      uses: actions/download-artifact@v4
-      with:
-        name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
-        path: bin/docker/
-    - name: Download uploaded artifacts to insert into container
-      if: ${{ matrix.edition == 'ee-extra' }}
-      uses: actions/download-artifact@v4
-      with:
-        name: metabase-ee-${{ github.sha }}-uberjar
-        path: bin/docker/
-    - name: Move the ${{ matrix.edition }} uberjar to the context dir
-      run: mv bin/docker/target/uberjar/metabase.jar bin/docker/.
-    - name: Add partner drivers to the container
-      if: ${{ matrix.edition == 'ee-extra' }}
-      uses: ./.github/actions/build-ee-extra
-      with:
-        iam-role: ${{ secrets.METABASE_EE_EXTRA_IAM_ROLE }}
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2.5.0
-      with:
-        driver-opts: network=host
-    - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v3
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}
-        build-args: |
-          GIT_COMMIT_SHA=${{ github.sha }}
-        no-cache: true
-        push: true
-    - name: Launch ${{ matrix.edition }} container
-      run: docker run --rm -dp 3000:3000 localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}
-      timeout-minutes: 5
-    - name: Is Docker running?
-      run: docker ps
-    - name: Wait for Metabase to start and reach 100% health
-      run: while ! curl 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract and clean branch name
+        shell: bash
+        run: echo "branch=$(echo $GITHUB_REF_NAME | sed 's/[^-._a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Verify the intended tag of the container image
+        run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
+      - name: Check out the code (Dockerfile needed)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit }}
+      - name: Download uploaded artifacts to insert into container
+        if: ${{ matrix.edition != 'ee-extra' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
+          path: bin/docker/
+      - name: Download uploaded artifacts to insert into container
+        if: ${{ matrix.edition == 'ee-extra' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: metabase-ee-${{ github.sha }}-uberjar
+          path: bin/docker/
+      - name: Move the ${{ matrix.edition }} uberjar to the context dir
+        run: mv bin/docker/target/uberjar/metabase.jar bin/docker/.
+      - name: Add partner drivers to the container
+        if: ${{ matrix.edition == 'ee-extra' }}
+        uses: ./.github/actions/build-ee-extra
+        with:
+          iam-role: ${{ secrets.METABASE_EE_EXTRA_IAM_ROLE }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          driver-opts: network=host
+      - name: Build ${{ matrix.edition }} container
+        uses: docker/build-push-action@v3
+        with:
+          context: bin/docker/.
+          platforms: linux/amd64,linux/arm64
+          network: host
+          tags: localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
+          no-cache: true
+          push: true
+      - name: Launch ${{ matrix.edition }} container
+        run: docker run --rm -dp 3000:3000 localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}
+        timeout-minutes: 5
+      - name: Is Docker running?
+        run: docker ps
+      - name: Wait for Metabase to start and reach 100% health
+        run: while ! curl 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+        timeout-minutes: 3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Retag and push images if master (ee) - should be cached at this point
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-      uses: docker/build-push-action@v3
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: ${{ github.repository_owner }}/metabase-enterprise-head:latest
-        build-args: |
-          GIT_COMMIT_SHA=${{ github.sha }}
-        no-cache: false
-        push: true
+      - name: Retag and push images if master (ee) - should be cached at this point
+        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: bin/docker/.
+          platforms: linux/amd64,linux/arm64
+          network: host
+          tags: ${{ github.repository_owner }}/metabase-enterprise-head:latest
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
+          no-cache: false
+          push: true
 
-    # TODO: remove when we're done testing metabot
-    - name: Retag and push images if metabot-v3-second-try (ee) - should be cached at this point
-      if: ${{ (github.ref_name == 'metabot-v3-second-try') && matrix.edition == 'ee' }}
-      uses: docker/build-push-action@v3
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: ${{ github.repository_owner }}/metabase-enterprise-head:metabot
-        build-args: |
-          GIT_COMMIT_SHA=${{ github.sha }}
-        no-cache: false
-        push: true
+      # TODO: remove when we're done testing metabot
+      - name: Retag and push images if metabot-v3-second-try (ee) - should be cached at this point
+        if: ${{ (github.ref_name == 'metabot-v3-second-try') && matrix.edition == 'ee' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: bin/docker/.
+          platforms: linux/amd64,linux/arm64
+          network: host
+          tags: ${{ github.repository_owner }}/metabase-enterprise-head:metabot
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
+          no-cache: false
+          push: true
 
-    - name: Retag and push images if master (oss) - should be cached at this point
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
-      uses: docker/build-push-action@v3
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: ${{ github.repository_owner }}/metabase-head:latest
-        build-args: |
-          GIT_COMMIT_SHA=${{ github.sha }}
-        no-cache: false
-        push: true
+      - name: Retag and push images if master (oss) - should be cached at this point
+        if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: bin/docker/.
+          platforms: linux/amd64,linux/arm64
+          network: host
+          tags: ${{ github.repository_owner }}/metabase-head:latest
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
+          no-cache: false
+          push: true
 
-    - name: Retag and push images if master (ee-extra) - should be cached at this point
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee-extra' }}
-      uses: docker/build-push-action@v3
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: ${{ secrets.METABASE_EE_EXTRA_CONTAINER_REGISTRY }}/metabase-enterprise-head:latest
-        build-args: |
-          GIT_COMMIT_SHA=${{ github.sha }}
-        no-cache: false
-        push: true
+      - name: Retag and push images if master (ee-extra) - should be cached at this point
+        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee-extra' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: bin/docker/.
+          platforms: linux/amd64,linux/arm64
+          network: host
+          tags: ${{ secrets.METABASE_EE_EXTRA_CONTAINER_REGISTRY }}/metabase-enterprise-head:latest
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
+          no-cache: false
+          push: true
 
-    - name: Retag and push images if dev branch - should be cached at this point
-      if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee-extra' }}
-      uses: docker/build-push-action@v3
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: ${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
-        build-args: |
-          GIT_COMMIT_SHA=${{ github.sha }}
-        no-cache: false
-        push: true
+      - name: Retag and push images if dev branch - should be cached at this point
+        if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee-extra' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: bin/docker/.
+          platforms: linux/amd64,linux/arm64
+          network: host
+          tags: ${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
+          no-cache: false
+          push: true
 
-    - name: Run Trivy vulnerability scanner if master (ee)
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-      uses: aquasecurity/trivy-action@0.29.0
-      env:
-        TRIVY_OFFLINE_SCAN: true
-      with:
-        image-ref: docker.io/${{ github.repository_owner }}/metabase-enterprise-head:latest
-        format: sarif
-        output: trivy-results.sarif
-        version: "v0.57.1"
+      - name: Run Trivy vulnerability scanner if master (ee)
+        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
+        uses: aquasecurity/trivy-action@0.29.0
+        env:
+          TRIVY_OFFLINE_SCAN: true
+        with:
+          image-ref: docker.io/${{ github.repository_owner }}/metabase-enterprise-head:latest
+          format: sarif
+          output: trivy-results.sarif
+          version: "v0.57.1"
 
-    - name: Run Trivy vulnerability scanner if master (oss)
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
-      uses: aquasecurity/trivy-action@0.29.0
-      env:
-        TRIVY_OFFLINE_SCAN: true
-      with:
-        image-ref: docker.io/${{ github.repository_owner }}/metabase-head:latest
-        format: sarif
-        output: trivy-results.sarif
-        version: "v0.57.1"
+      - name: Run Trivy vulnerability scanner if master (oss)
+        if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
+        uses: aquasecurity/trivy-action@0.29.0
+        env:
+          TRIVY_OFFLINE_SCAN: true
+        with:
+          image-ref: docker.io/${{ github.repository_owner }}/metabase-head:latest
+          format: sarif
+          output: trivy-results.sarif
+          version: "v0.57.1"
 
-    - name: Run Trivy vulnerability scanner if dev branch
-      if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
-      uses: aquasecurity/trivy-action@0.29.0
-      env:
-        TRIVY_OFFLINE_SCAN: true
-      with:
-        version: "v0.57.1"
-        image-ref: docker.io/${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
-        format: sarif
-        output: trivy-results.sarif
+      - name: Run Trivy vulnerability scanner if dev branch
+        if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
+        uses: aquasecurity/trivy-action@0.29.0
+        env:
+          TRIVY_OFFLINE_SCAN: true
+        with:
+          version: "v0.57.1"
+          image-ref: docker.io/${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
+          format: sarif
+          output: trivy-results.sarif
 
-    - name: Upload Trivy scan results to GitHub Security tab if master (ee)
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab if master (ee)
+        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
 
-    - name: Upload Trivy scan results to GitHub Security tab if master (oss)
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab if master (oss)
+        if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
 
-    - name: Upload Trivy scan results to GitHub Security tab if dev branch
-      if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab if dev branch
+        if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
 
   containerize_multi_arch:
     runs-on: ubuntu-22.04
@@ -307,7 +307,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: 'arm64'
+          platforms: "arm64"
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2.5.0
@@ -345,7 +345,7 @@ jobs:
         if: ${{ github.ref_name == 'master' }}
         uses: regclient/actions/regctl-installer@main
         with:
-          release: 'v0.4.7'
+          release: "v0.4.7"
       - name: Switch regctl to point to localhost:5000 via http
         if: ${{ github.ref_name == 'master' }}
         run: regctl registry set --tls disabled localhost:5000


### PR DESCRIPTION
rspack still gets stuck in some cases, so let's not wait for 40min, when job usually takes 7min

decrease timeout from 40min to 15 min for uberjar building

we need to fail earlier, last failure example https://github.com/metabase/metabase/actions/runs/13900566429/job/38891013891 


### For reviewers

hide whitespaces to simplify review

<img width="952" alt="image" src="https://github.com/user-attachments/assets/ca4fec75-bd35-41af-a76f-fe28b981cfb1" />
