### PR TITLE
Remove `source-table` being accessed directly in the QB

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -60,7 +60,6 @@ interface Props {
   embeddedParameterVisibility?: EmbeddingParameterVisibility | null;
   database?: Database | null;
   databases: Database[];
-  databaseFields?: Field[];
   metadata: Metadata;
   originalQuestion?: Question;
   setTemplateTag: (tag: TemplateTag) => void;

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -9,7 +9,6 @@ import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
-import type Field from "metabase-lib/v1/metadata/Field";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type {
   Card,
@@ -34,7 +33,6 @@ interface TagEditorSidebarProps {
   card: Card;
   query: NativeQuery;
   databases: Database[];
-  databaseFields: Field[];
   question: Question;
   sampleDatabaseId: DatabaseId;
   setDatasetQuery: (query: NativeDatasetQuery) => void;
@@ -64,7 +62,6 @@ export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
   render() {
     const {
       databases,
-      databaseFields,
       sampleDatabaseId,
       setDatasetQuery,
       query,
@@ -130,7 +127,6 @@ export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
             <SettingsPane
               tags={tags}
               parametersById={parametersById}
-              databaseFields={databaseFields}
               database={database}
               databases={databases}
               setTemplateTag={setTemplateTag}
@@ -156,7 +152,6 @@ interface SettingsPaneProps {
   tags: TemplateTag[];
   database?: Database | null;
   databases: Database[];
-  databaseFields: Field[];
   parametersById: Record<ParameterId, Parameter>;
   setTemplateTag: (tag: TemplateTag) => void;
   setTemplateTagConfig: (
@@ -170,7 +165,6 @@ interface SettingsPaneProps {
 const SettingsPane = ({
   tags,
   parametersById,
-  databaseFields,
   database,
   databases,
   setTemplateTag,
@@ -190,7 +184,6 @@ const SettingsPane = ({
               ? getEmbeddedParameterVisibility(parametersById[tag.id].slug)
               : null
           }
-          databaseFields={databaseFields}
           database={database}
           databases={databases}
           setTemplateTag={setTemplateTag}

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -41,7 +41,6 @@ import { VISUALIZATION_SLOW_TIMEOUT } from "../constants";
 import {
   getCard,
   getDataReferenceStack,
-  getDatabaseFields,
   getDatabasesList,
   getDocumentTitle,
   getEmbeddedParameterVisibility,
@@ -168,7 +167,6 @@ const mapStateToProps = (state: State, props: EntityListLoaderMergedProps) => {
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
 
     parameters: getParameters(state),
-    databaseFields: getDatabaseFields(state),
     sampleDatabaseId: getSampleDatabaseId(state),
 
     isRunnable: getIsRunnable(state),

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -79,7 +79,6 @@ import {
   getSnippetCollectionId,
   getTableForeignKeyReferences,
   getTableForeignKeys,
-  getTables,
   getTimeseriesXDomain,
   getUiControls,
   getVisibleTimelineEventIds,
@@ -136,7 +135,6 @@ const mapStateToProps = (state: State, props: EntityListLoaderMergedProps) => {
     card: getCard(state),
     originalCard: getOriginalCard(state),
     databases: getDatabasesList(state),
-    tables: getTables(state),
 
     metadata: getMetadata(state),
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -178,70 +178,6 @@ export const getFirstQueryResult = createSelector([getQueryResults], results =>
   Array.isArray(results) ? results[0] : null,
 );
 
-export const getTableId = createSelector([getCard], card =>
-  getIn(card, ["dataset_query", "query", "source-table"]),
-);
-
-export const getPKColumnIndex = createSelector(
-  [getFirstQueryResult, getTableId],
-  (result, tableId) => {
-    if (!result) {
-      return;
-    }
-    const { cols } = result.data;
-
-    const hasMultiplePks =
-      cols.filter(getIsPKFromTablePredicate(tableId)).length > 1;
-
-    if (hasMultiplePks) {
-      return -1;
-    }
-    return cols.findIndex(getIsPKFromTablePredicate(tableId));
-  },
-);
-
-export const getPKRowIndexMap = createSelector(
-  [getFirstQueryResult, getPKColumnIndex],
-  (result, PKColumnIndex) => {
-    if (!result || !Number.isSafeInteger(PKColumnIndex)) {
-      return {};
-    }
-    const { rows } = result.data;
-    if (PKColumnIndex < 0) {
-      return rows.map((_, index) => index);
-    }
-    const map = {};
-    rows.forEach((row, index) => {
-      const PKValue = row[PKColumnIndex];
-      map[PKValue] = index;
-    });
-    return map;
-  },
-);
-
-// it's very similar to `getPKRowIndexMap` but it is required for covering "view details" click
-// we don't have objectId there, only rowId, mapping from `getPKRowIndexMap` is opposite
-// if rows are showing the same PK, only last one will have the entry in the map
-// and we'll not know which object to show
-export const getRowIndexToPKMap = createSelector(
-  [getFirstQueryResult, getPKColumnIndex],
-  (result, PKColumnIndex) => {
-    if (!result || !Number.isSafeInteger(PKColumnIndex)) {
-      return {};
-    }
-    const { rows } = result.data;
-    if (PKColumnIndex < 0) {
-      return rows.map((_, index) => index);
-    }
-    const map = {};
-    rows.forEach((row, index) => {
-      const PKValue = row[PKColumnIndex];
-      map[index] = PKValue;
-    });
-    return map;
-  },
-);
-
 export const getQueryStartTime = state => state.qb.queryStartTime;
 
 export const getDatabaseId = createSelector(
@@ -273,31 +209,12 @@ export const getTables = createSelector(
   },
 );
 
-export const getTableMetadata = createSelector(
-  [getTableId, getMetadata],
-  (tableId, metadata) => metadata.table(tableId),
-);
-
-export const getTableForeignKeys = createSelector([getTableMetadata], table => {
-  const tableForeignKeys = table?.fks ?? [];
-  const tableForeignKeysWithoutHiddenTables = tableForeignKeys.filter(
-    tableForeignKey => tableForeignKey.origin != null,
-  );
-
-  return tableForeignKeysWithoutHiddenTables;
-});
-
 export const getSampleDatabaseId = createSelector(
   [getDatabasesList],
   databases => {
     const sampleDatabase = _.findWhere(databases, { is_sample: true });
     return sampleDatabase && sampleDatabase.id;
   },
-);
-
-export const getDatabaseFields = createSelector(
-  [getDatabaseId, state => state.qb.databaseFields],
-  (databaseId, databaseFields) => [], // FIXME!
 );
 
 export const getParameters = createSelector(
@@ -399,6 +316,88 @@ export const getQuestion = createSelector(
     return (isModel || isMetric) && isEditable
       ? question.composeQuestion()
       : question;
+  },
+);
+
+export const getTableId = createSelector([getQuestion], question => {
+  if (!question) {
+    return;
+  }
+
+  return Lib.sourceTableOrCardId(question.query());
+});
+
+export const getTableMetadata = createSelector(
+  [getTableId, getMetadata],
+  (tableId, metadata) => metadata.table(tableId),
+);
+
+export const getTableForeignKeys = createSelector([getTableMetadata], table => {
+  const tableForeignKeys = table?.fks ?? [];
+  const tableForeignKeysWithoutHiddenTables = tableForeignKeys.filter(
+    tableForeignKey => tableForeignKey.origin != null,
+  );
+
+  return tableForeignKeysWithoutHiddenTables;
+});
+
+export const getPKColumnIndex = createSelector(
+  [getFirstQueryResult, getTableId],
+  (result, tableId) => {
+    if (!result) {
+      return;
+    }
+    const { cols } = result.data;
+
+    const hasMultiplePks =
+      cols.filter(getIsPKFromTablePredicate(tableId)).length > 1;
+
+    if (hasMultiplePks) {
+      return -1;
+    }
+    return cols.findIndex(getIsPKFromTablePredicate(tableId));
+  },
+);
+
+export const getPKRowIndexMap = createSelector(
+  [getFirstQueryResult, getPKColumnIndex],
+  (result, PKColumnIndex) => {
+    if (!result || !Number.isSafeInteger(PKColumnIndex)) {
+      return {};
+    }
+    const { rows } = result.data;
+    if (PKColumnIndex < 0) {
+      return rows.map((_, index) => index);
+    }
+    const map = {};
+    rows.forEach((row, index) => {
+      const PKValue = row[PKColumnIndex];
+      map[PKValue] = index;
+    });
+    return map;
+  },
+);
+
+// it's very similar to `getPKRowIndexMap` but it is required for covering "view details" click
+// we don't have objectId there, only rowId, mapping from `getPKRowIndexMap` is opposite
+// if rows are showing the same PK, only last one will have the entry in the map
+// and we'll not know which object to show
+export const getRowIndexToPKMap = createSelector(
+  [getFirstQueryResult, getPKColumnIndex],
+  (result, PKColumnIndex) => {
+    if (!result || !Number.isSafeInteger(PKColumnIndex)) {
+      return {};
+    }
+    const { rows } = result.data;
+    if (PKColumnIndex < 0) {
+      return rows.map((_, index) => index);
+    }
+    const map = {};
+    rows.forEach((row, index) => {
+      const PKValue = row[PKColumnIndex];
+      map[index] = PKValue;
+    });
+    return map;
   },
 );
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1,7 +1,7 @@
 /*eslint no-use-before-define: "error"*/
 import { createSelector } from "@reduxjs/toolkit";
 import * as d3 from "d3";
-import { getIn, merge, updateIn } from "icepick";
+import { merge, updateIn } from "icepick";
 import _ from "underscore";
 
 import { getDashboardById } from "metabase/dashboard/selectors";
@@ -193,21 +193,6 @@ export const getDatabasesList = state =>
   Databases.selectors.getList(state, {
     entityQuery: { include: "tables", saved: true },
   }) || getDatabasesListDefaultValue;
-
-const getTablesDefaultValue = [];
-export const getTables = createSelector(
-  [getDatabaseId, getDatabasesList],
-  (databaseId, databases) => {
-    if (databaseId != null && databases && databases.length > 0) {
-      const db = _.findWhere(databases, { id: databaseId });
-      if (db && db.tables) {
-        return db.tables;
-      }
-    }
-
-    return getTablesDefaultValue;
-  },
-);
 
 export const getSampleDatabaseId = createSelector(
   [getDatabasesList],
@@ -1020,10 +1005,6 @@ export const getIsEditingInDashboard = state => {
 export const getDashboard = state => {
   return getDashboardById(state, getDashboardId(state));
 };
-
-export const getTemplateTags = createSelector([getCard], card =>
-  getIn(card, ["dataset_query", "native", "template-tags"]),
-);
 
 export const getEmbeddingParameters = createSelector([getCard], card => {
   if (!card?.enable_embedding) {


### PR DESCRIPTION
Changes:
- Use MBQL lib for `getTableId` selector
- Removes some unused selectors