### PR TITLE
Fix temporal string definitions

### DIFF
--- a/frontend/src/metabase/querying/filters/components/RelativeDateShortcutPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/RelativeDateShortcutPicker/utils.ts
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { msgid, ngettext, t } from "ttag";
 
 import type { ShortcutGroup } from "./types";
 
@@ -30,15 +30,15 @@ export function getShortcutGroups(): ShortcutGroup[] {
       columns: 3,
       shortcuts: [
         {
-          label: t`Week`,
+          label: ngettext(msgid`Week`, `Weeks`, 1),
           value: { type: "relative", value: -1, unit: "week" },
         },
         {
-          label: t`Month`,
+          label: ngettext(msgid`Month`, `Months`, 1),
           value: { type: "relative", value: -1, unit: "month" },
         },
         {
-          label: t`Year`,
+          label: ngettext(msgid`Year`, `Years`, 1),
           value: { type: "relative", value: -1, unit: "year" },
         },
       ],
@@ -48,15 +48,15 @@ export function getShortcutGroups(): ShortcutGroup[] {
       columns: 3,
       shortcuts: [
         {
-          label: t`Week`,
+          label: ngettext(msgid`Week`, `Weeks`, 1),
           value: { type: "relative", value: 0, unit: "week" },
         },
         {
-          label: t`Month`,
+          label: ngettext(msgid`Month`, `Months`, 1),
           value: { type: "relative", value: 0, unit: "month" },
         },
         {
-          label: t`Year`,
+          label: ngettext(msgid`Year`, `Years`, 1),
           value: { type: "relative", value: 0, unit: "year" },
         },
       ],


### PR DESCRIPTION
Fix string definitions for Day, Month, and Year to be compatible with backend strings.

This will fix this error in the i18n job.

![Screenshot 2025-03-17 at 7 25 44 AM](https://github.com/user-attachments/assets/d19b1d02-2c31-4955-a508-d24c384f4b51)

The developer ergonomics here aren't great, but we can't just define a singular where a plural exists on the backend, we have to define the localization string to say "use the singular form of this singular/plural group"
