### PR TITLE
Support for `text` MBQL function on the FE

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -118,6 +118,7 @@ const expression: TestCase[] = [
     ["concat", "http://mysite.com/user/", userId, "/"],
     "function with 3 arguments",
   ],
+  ["text([User ID])", ["text", userId], "text function"],
   [
     'case([Total] > 10, "GOOD", [Total] < 5, "BAD", "OK")',
     [

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -97,6 +97,8 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     args: ["number", "number"],
     requiresFeature: "percentile-aggregations",
   },
+  // cast functions
+  text: { displayName: "text", type: "string", args: ["expression"] },
   // string functions
   lower: { displayName: `lower`, type: "string", args: ["string"] },
   upper: { displayName: `upper`, type: "string", args: ["string"] },
@@ -526,6 +528,8 @@ export const AGGREGATION_FUNCTIONS = new Set([
 ]);
 
 export const EXPRESSION_FUNCTIONS = new Set([
+  // cast
+  "text",
   // string
   "lower",
   "upper",

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -267,6 +267,19 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     ],
   },
   {
+    name: "text",
+    structure: "text",
+    description: () =>
+      t`Converts a number or date to text. Useful for applying text filters or joining with other columns based on text comparisons.`,
+    args: [
+      {
+        name: t`value`,
+        description: t`The number or date to convert to text.`,
+        example: ["dimension", "User ID"],
+      },
+    ],
+  },
+  {
     name: "lower",
     structure: "lower",
     description: () => t`Returns the string of text in all lower case.`,

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
@@ -85,6 +85,7 @@ describe("recursive-parser", () => {
     expect(process("log(1 + sqrt(9))")).toEqual(["log", ["+", 1, ["sqrt", 9]]]);
     expect(process("power(log(2.1), 7)")).toEqual(["power", ["log", 2.1], 7]);
     expect(process("trim(ID)")).toEqual(["trim", ["dimension", "ID"]]);
+    expect(process("text(ID)")).toEqual(["text", ["dimension", "ID"]]);
   });
 
   it("should handle CASE expression", () => {

--- a/frontend/src/metabase-lib/v1/expressions/resolver.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.unit.spec.ts
@@ -140,6 +140,7 @@ describe("resolve", () => {
       expect(expr(["coalesce", P]).dimensions).toEqual(["P"]);
       expect(expr(["coalesce", P, Q, R]).dimensions).toEqual(["P", "Q", "R"]);
       expect(expr(["in", A, B, C]).dimensions).toEqual(["A", "B", "C"]);
+      expect(expr(["text", A]).dimensions).toEqual(["A"]);
     });
 
     it("should allow any number of arguments in a variadic function", () => {

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -464,7 +464,7 @@
              :get-minute :get-second :get-quarter
              :datetime-add :datetime-subtract
              :concat :substring :replace :regex-match-first
-             :length :trim :ltrim :rtrim :upper :lower]]
+             :length :trim :ltrim :rtrim :upper :lower :text]]
   (lib.hierarchy/derive tag ::expression))
 
 (defmethod ->legacy-MBQL ::aggregation-or-expression

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -37,3 +37,6 @@
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text
   [:args [:repeat {:min 2} [:schema [:ref ::expression/expression]]]])
+
+(mbql-clause/define-tuple-mbql-clause :text :- :type/Text
+  [:schema [:ref ::expression/string]])


### PR DESCRIPTION
How to verify:
- New -> Question -> Orders
- Custom column -> `text([ID])` -> Done
- Click on the expression. It should be properly formatted

**Note - the function is not implemented by the BE yet!**

<img width="804" alt="Screenshot 2025-03-17 at 13 27 21" src="https://github.com/user-attachments/assets/a177612b-066a-454e-b060-b5110de982cf" />
