### PR TITLE
Closes VIZ-523: don't save a card when the chart cannot render

### DIFF
--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -73,6 +73,10 @@ export function registerVisualization(visualization: Visualization) {
 
 type SeriesLike = Array<{ card: { display: VisualizationDisplay } }>;
 
+export function getVisualization(display: VisualizationDisplay | null) {
+  return display ? visualizations.get(display) : defaultVisualization;
+}
+
 export function getVisualizationRaw(series: SeriesLike) {
   return visualizations.get(series[0].card.display);
 }

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import { useVisualizerHistory } from "metabase/visualizer/hooks/use-visualizer-h
 import {
   getCurrentVisualizerState,
   getIsDirty,
+  getIsRenderable,
   getVisualizationTitle,
 } from "metabase/visualizer/selectors";
 import {
@@ -33,14 +34,16 @@ export function Header({
 }: HeaderProps) {
   const { canUndo, canRedo, undo, redo } = useVisualizerHistory();
 
-  const visualization = useSelector(getCurrentVisualizerState);
+  const visualizerState = useSelector(getCurrentVisualizerState);
+
   const isDirty = useSelector(getIsDirty);
+  const isRenderable = useSelector(getIsRenderable);
   const title = useSelector(getVisualizationTitle);
 
   const dispatch = useDispatch();
 
   const handleSave = () => {
-    onSave?.(visualization);
+    onSave?.(visualizerState);
   };
 
   const handleChangeTitle = useCallback(
@@ -49,6 +52,8 @@ export function Header({
     },
     [dispatch],
   );
+
+  const saveButtonEnabled = isRenderable && (isDirty || allowSaveWhenPristine);
 
   return (
     <Flex p="md" pb="sm" align="center" className={className}>
@@ -74,7 +79,7 @@ export function Header({
         </Tooltip>
         <Button
           variant="filled"
-          disabled={!isDirty && !allowSaveWhenPristine}
+          disabled={!saveButtonEnabled}
           onClick={handleSave}
         >
           {saveLabel ?? t`Add to dashboard`}

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -4,6 +4,7 @@ import _ from "underscore";
 import { utf8_to_b64 } from "metabase/lib/encoding";
 import {
   extractRemappings,
+  getVisualization,
   getVisualizationTransformed,
   isCartesianChart,
 } from "metabase/visualizations";
@@ -245,3 +246,25 @@ function checkIfStateDirty(state: VisualizerHistoryItem) {
     Object.keys(state.columnValuesMapping).length > 0
   );
 }
+
+export const getIsRenderable = createSelector(
+  [getVisualizationType, getVisualizerRawSeries, getVisualizerComputedSettings],
+  (display, rawSeries, settings) => {
+    if (!display) {
+      return false;
+    }
+
+    const visualization = getVisualization(display);
+
+    if (!visualization) {
+      return false;
+    }
+
+    try {
+      visualization.checkRenderable(rawSeries, settings);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+);


### PR DESCRIPTION
Closes [VIZ-523: Removing all columns still lets you "Add to dashboard" then nothing happens](https://linear.app/metabase/issue/VIZ-523/removing-all-columns-still-lets-you-add-to-dashboard-then-nothing)

### Description

Disables the Save button when the chart can't render:

<img width="1486" alt="image" src="https://github.com/user-attachments/assets/965def99-e82b-4e5b-ba16-0743f069f205" />
