### PR TITLE
Fixing hover state on time grouping dropdown

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterSettings/TemporalUnitSettings/TemporalUnitSettings.module.css
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/TemporalUnitSettings/TemporalUnitSettings.module.css
@@ -7,7 +7,7 @@
   color: var(--mb-color-text-dark);
 
   &:hover {
-    background-color: var(--mb-color-background-selected);
-    color: var(--mb-color-text-selected);
+    background-color: var(--mb-color-background-hover);
+    color: var(--mb-color-text-hover);
   }
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53818

### Description
Simply updates hover state for items in the Time Groupings options

### Demo
Before:
![image](https://github.com/user-attachments/assets/0af251d1-b90a-440a-b8a5-80cfc8627307)

After:
![image](https://github.com/user-attachments/assets/0f8e05b7-bf65-4eb9-8156-4f9d56794f21)


