### PR TITLE
Migrate Chinese site & user locales from zh to zh_CN

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10834,6 +10834,37 @@ databaseChangeLog:
                   name: key_hashed
             indexName: idx_core_session_key_hashed
 
+  - changeSet:
+      id: v54.2025-03-17T18:52:44
+      author: noahmoss
+      comment: Migrating zh site locales to zh_CN
+      preConditions:
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              UPDATE setting SET value = 'zh_CN' where key = 'site-locale' AND value = 'zh';
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE setting SET `value` = 'zh_CN' where `key` = 'site-locale' AND `value` = 'zh';
+        - sql:
+            dbms: h2
+            sql: >-
+              UPDATE setting SET "VALUE" = 'zh_CN' where "KEY" = 'site-locale' AND "VALUE" = 'zh';
+      rollback: # nothing to do; zh_CN is backwards compatible
+
+  - changeSet:
+      id: v54.2025-03-17T18:52:59
+      author: noahmoss
+      comment: Migrating zh user locales to zh_CN
+      preConditions:
+      changes:
+        - sql:
+            sql: >-
+              UPDATE core_user SET locale = 'zh_CN' WHERE locale = 'zh';
+      rollback: # nothing to do; zh_CN is backwards compatible
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -2742,3 +2742,19 @@
 ;;;
 ;;; 53+ tests should go below this line please <3
 ;;;
+
+(deftest chinese-site-locale-migration-test
+  (testing "Site locale is migrated from zh to zh_CN"
+    (impl/test-migrations "v54.2025-03-17T18:52:44" [migrate!]
+      (t2/delete! (t2/table-name :model/Setting) :key "site-locale")
+      (t2/insert! (t2/table-name :model/Setting) {:key "site-locale" :value "zh"})
+      (migrate!)
+      (is (= "zh_CN" (t2/select-one-fn :value (t2/table-name :model/Setting) :key "site-locale"))))))
+
+(deftest chinese-user-locale-migration-test
+  (testing "Site locale is migrated from zh to zh_CN"
+    (impl/test-migrations "v54.2025-03-17T18:52:59" [migrate!]
+      (let [user-id (:id (create-raw-user! (mt/random-email)))]
+        (t2/update! (t2/table-name :model/User) user-id {:locale "zh"})
+        (migrate!)
+        (is (= "zh_CN" (t2/select-one-fn :locale (t2/table-name :model/User) :id user-id)))))))


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C6UBFU9GW/p1741983889165599

Closes DEV-382

We're deprecating the `zh` locale so existing instances need to be migrated to `zh_CN`.

This isn't an encrypted setting so we should be able to do this via a simple SQL migration. Similarly for user locales stored in the `core_user` table.