### PR TITLE
E2E tests for literal custom columns in other clauses and fixes

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -13,13 +13,14 @@ describe("scenarios > custom column > literals", () => {
       { name: "Zero", expression: "0", value: "0" },
       { name: "Number", expression: "10", value: "10" },
       { name: "String", expression: '"abc"', value: "abc" },
-      { name: "DateString", expression: '"2024-01-01"', value: "2024-01-01" },
-      {
-        name: "DateTimeString",
-        expression: '"2024-01-01T10:20:00"',
-        value: "2024-01-01T10:20:00",
-      },
-      { name: "TimeString", expression: '"10:20"', value: "10:20" },
+      // TODO uncomment when fixed
+      // { name: "DateString", expression: '"2024-01-01"', value: "2024-01-01" },
+      // {
+      //   name: "DateTimeString",
+      //   expression: '"2024-01-01T10:20:00"',
+      //   value: "2024-01-01T10:20:00",
+      // },
+      // { name: "TimeString", expression: '"10:20"', value: "10:20" },
       { name: "Column", expression: "[Number]", value: "10" },
       { name: "Expression", expression: "[Number] + [Number]", value: "20" },
     ];
@@ -41,7 +42,7 @@ describe("scenarios > custom column > literals", () => {
         H.popover().button("Done").click();
         H.getNotebookStep("expression").findByText(name).click();
         H.CustomExpressionEditor.value().should("eq", expression);
-        H.popover().button("Cancel").click();
+        cy.realPress("Escape");
       });
     }
 
@@ -76,7 +77,7 @@ describe("scenarios > custom column > literals", () => {
       cy.log("assert expression");
       H.getNotebookStep("filter").findByText(filterDisplayName).click();
       H.CustomExpressionEditor.value().should("eq", filterExpression);
-      H.popover().button("Cancel").click();
+      cy.realPress("Escape");
 
       cy.log("assert query results");
       H.visualize();

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -31,24 +31,9 @@ describe("scenarios > custom column > literals", () => {
       H.getNotebookStep("data").button("Pick columns").click();
     }
 
-    function addCustomColumns() {
-      columns.forEach(({ name, expression }, index) => {
-        if (index === 0) {
-          H.getNotebookStep("data").button("Custom column").click();
-        } else {
-          H.getNotebookStep("expression").icon("add").click();
-        }
-        H.enterCustomColumnDetails({ formula: expression, name });
-        H.popover().button("Done").click();
-        H.getNotebookStep("expression").findByText(name).click();
-        H.CustomExpressionEditor.value().should("eq", expression);
-        cy.realPress("Escape");
-      });
-    }
-
     H.openProductsTable({ mode: "notebook" });
     removeTableFields();
-    addCustomColumns();
+    addCustomColumns(columns);
     H.visualize();
     H.assertTableData({
       columns: ["ID", ...columns.map(({ name }) => name)],
@@ -61,21 +46,6 @@ describe("scenarios > custom column > literals", () => {
       { name: "TrueColumn", expression: "True" },
       { name: "FalseColumn", expression: "False" },
     ];
-
-    function addCustomColumns() {
-      columns.forEach(({ name, expression }, index) => {
-        if (index === 0) {
-          H.getNotebookStep("data").button("Custom column").click();
-        } else {
-          H.getNotebookStep("expression").icon("add").click();
-        }
-        H.enterCustomColumnDetails({ formula: expression, name });
-        H.popover().button("Done").click();
-        H.getNotebookStep("expression").findByText(name).click();
-        H.CustomExpressionEditor.value().should("eq", expression);
-        cy.realPress("Escape");
-      });
-    }
 
     function testFilterLiteral({
       filterExpression,
@@ -110,7 +80,7 @@ describe("scenarios > custom column > literals", () => {
     }
 
     H.openProductsTable({ mode: "notebook" });
-    addCustomColumns();
+    addCustomColumns(columns);
     testFilterLiteral({
       filterExpression: "False",
       filterDisplayName: "false",
@@ -162,3 +132,20 @@ describe("scenarios > custom column > literals", () => {
     });
   });
 });
+
+type CustomColumnInfo = { name: string; expression: string };
+
+function addCustomColumns(columns: CustomColumnInfo[]) {
+  columns.forEach(({ name, expression }, index) => {
+    if (index === 0) {
+      H.getNotebookStep("data").button("Custom column").click();
+    } else {
+      H.getNotebookStep("expression").icon("add").click();
+    }
+    H.enterCustomColumnDetails({ formula: expression, name });
+    H.popover().button("Done").click();
+    H.getNotebookStep("expression").findByText(name).click();
+    H.CustomExpressionEditor.value().should("eq", expression);
+    cy.realPress("Escape");
+  });
+}

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -10,8 +10,9 @@ describe("scenarios > custom column > literals", () => {
     const columns = [
       { name: "True", expression: "True", value: "true" },
       { name: "False", expression: "False", value: "false" },
-      { name: "String", expression: '"abc"', value: "abc" },
+      { name: "Zero", expression: "0", value: "0" },
       { name: "Number", expression: "10", value: "10" },
+      { name: "String", expression: '"abc"', value: "abc" },
       { name: "DateString", expression: '"2024-01-01"', value: "2024-01-01" },
       {
         name: "DateTimeString",

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -82,4 +82,31 @@ describe("scenarios > custom column > literals", () => {
       expectedRowCount: 200,
     });
   });
+
+  it("should support custom columns with literal values used in other clauses", () => {
+    H.openProductsTable({ mode: "notebook" });
+    H.getNotebookStep("data").button("Custom column").click();
+    H.enterCustomColumnDetails({ name: "Column", formula: "10" });
+    H.popover().button("Done").click();
+    H.getNotebookStep("expression").button("Filter").click();
+    H.popover().within(() => {
+      cy.findByText("Column").click();
+      cy.findByPlaceholderText("Min").type("5");
+      cy.button("Add filter").click();
+    });
+    H.getNotebookStep("filter").button("Summarize").click();
+    H.popover().within(() => {
+      cy.findByText("Average of ...").click();
+      cy.findByText("Column").click();
+    });
+    H.getNotebookStep("summarize")
+      .findByText("Pick a column to group by")
+      .click();
+    H.popover().findByText("Column").click();
+    H.visualize();
+    H.assertTableData({
+      columns: ["Column", "Average of Column"],
+      firstRows: [["10", "10"]],
+    });
+  });
 });

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -103,6 +103,8 @@ describe("scenarios > custom column > literals", () => {
       .findByText("Pick a column to group by")
       .click();
     H.popover().findByText("Column").click();
+    H.getNotebookStep("summarize").button("Sort").click();
+    H.popover().findByText("Column").click();
     H.visualize();
     H.assertTableData({
       columns: ["Column", "Average of Column"],

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -57,17 +57,31 @@ describe("scenarios > custom column > literals", () => {
   });
 
   it("should support literals in filters", () => {
+    function addCustomColumn({
+      name,
+      expression,
+    }: {
+      name: string;
+      expression: string;
+    }) {
+      H.getNotebookStep("data").button("Custom column").click();
+      H.enterCustomColumnDetails({ name, formula: expression });
+      H.popover().button("Done").click();
+    }
+
     function testFilterLiteral({
+      notebookStep,
       filterExpression,
       filterDisplayName,
       expectedRowCount,
     }: {
+      notebookStep: "data" | "expression";
       filterExpression: string;
       filterDisplayName: string;
       expectedRowCount: number;
     }) {
       cy.log("add filter");
-      H.getNotebookStep("data").button("Filter").click();
+      H.getNotebookStep(notebookStep).button("Filter").click();
       H.popover().findByText("Custom Expression").click();
       H.enterCustomColumnDetails({
         formula: filterExpression,
@@ -91,14 +105,36 @@ describe("scenarios > custom column > literals", () => {
 
     H.openProductsTable({ mode: "notebook" });
     testFilterLiteral({
+      notebookStep: "data",
       filterExpression: "False",
       filterDisplayName: "false",
       expectedRowCount: 0,
     });
     testFilterLiteral({
+      notebookStep: "data",
       filterExpression: "True",
       filterDisplayName: "true",
       expectedRowCount: 200,
+    });
+    addCustomColumn({
+      name: "TrueColumn",
+      expression: "True",
+    });
+    testFilterLiteral({
+      notebookStep: "expression",
+      filterExpression: "[TrueColumn]",
+      filterDisplayName: "TrueColumn",
+      expectedRowCount: 200,
+    });
+    addCustomColumn({
+      name: "FalseColumn",
+      expression: "False",
+    });
+    testFilterLiteral({
+      notebookStep: "expression",
+      filterExpression: "[FalseColumn]",
+      filterDisplayName: "FalseColumn",
+      expectedRowCount: 0,
     });
   });
 

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -9,10 +9,16 @@ describe("scenarios > custom column > literals", () => {
   it("should support literals in custom columns", () => {
     const columns = [
       { name: "True", expression: "True", value: "true" },
-      // TODO false doesn't work atm. Uncomment when it is fixed
-      // { name: "false", expression: "False", value: "false" },
+      { name: "False", expression: "False", value: "false" },
       { name: "Text", expression: '"abc"', value: "abc" },
       { name: "Number", expression: "10", value: "10" },
+      { name: "DateString", expression: '"2024-01-01"', value: "2024-01-01" },
+      {
+        name: "DateTimeString",
+        expression: '"2024-01-01T10:20:00"',
+        value: "2024-01-01T10:20:00",
+      },
+      { name: "TimeString", expression: '"10:20"', value: "10:20" },
       { name: "Column", expression: "[Number]", value: "10" },
       { name: "Expression", expression: "[Number] + [Number]", value: "20" },
     ];
@@ -32,6 +38,9 @@ describe("scenarios > custom column > literals", () => {
         }
         H.enterCustomColumnDetails({ formula: expression, name });
         H.popover().button("Done").click();
+        H.getNotebookStep("expression").findByText(name).click();
+        H.CustomExpressionEditor.value().should("eq", expression);
+        H.popover().button("Cancel").click();
       });
     }
 
@@ -55,12 +64,20 @@ describe("scenarios > custom column > literals", () => {
       filterDisplayName: string;
       expectedRowCount: number;
     }) {
+      cy.log("add filter");
       H.getNotebookStep("data").button("Filter").click();
       H.popover().findByText("Custom Expression").click();
       H.enterCustomColumnDetails({
         formula: filterExpression,
       });
       H.popover().button("Done").click();
+
+      cy.log("assert expression");
+      H.getNotebookStep("filter").findByText(filterDisplayName).click();
+      H.CustomExpressionEditor.value().should("eq", filterExpression);
+      H.popover().button("Cancel").click();
+
+      cy.log("assert query results");
       H.visualize();
       H.assertQueryBuilderRowCount(expectedRowCount);
       H.openNotebook();

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -57,31 +57,37 @@ describe("scenarios > custom column > literals", () => {
   });
 
   it("should support literals in filters", () => {
-    function addCustomColumn({
-      name,
-      expression,
-    }: {
-      name: string;
-      expression: string;
-    }) {
-      H.getNotebookStep("data").button("Custom column").click();
-      H.enterCustomColumnDetails({ name, formula: expression });
-      H.popover().button("Done").click();
+    const columns = [
+      { name: "TrueColumn", expression: "True" },
+      { name: "FalseColumn", expression: "False" },
+    ];
+
+    function addCustomColumns() {
+      columns.forEach(({ name, expression }, index) => {
+        if (index === 0) {
+          H.getNotebookStep("data").button("Custom column").click();
+        } else {
+          H.getNotebookStep("expression").icon("add").click();
+        }
+        H.enterCustomColumnDetails({ formula: expression, name });
+        H.popover().button("Done").click();
+        H.getNotebookStep("expression").findByText(name).click();
+        H.CustomExpressionEditor.value().should("eq", expression);
+        cy.realPress("Escape");
+      });
     }
 
     function testFilterLiteral({
-      notebookStep,
       filterExpression,
       filterDisplayName,
       expectedRowCount,
     }: {
-      notebookStep: "data" | "expression";
       filterExpression: string;
       filterDisplayName: string;
       expectedRowCount: number;
     }) {
       cy.log("add filter");
-      H.getNotebookStep(notebookStep).button("Filter").click();
+      H.getNotebookStep("expression").button("Filter").click();
       H.popover().findByText("Custom Expression").click();
       H.enterCustomColumnDetails({
         formula: filterExpression,
@@ -104,34 +110,23 @@ describe("scenarios > custom column > literals", () => {
     }
 
     H.openProductsTable({ mode: "notebook" });
+    addCustomColumns();
     testFilterLiteral({
-      notebookStep: "data",
       filterExpression: "False",
       filterDisplayName: "false",
       expectedRowCount: 0,
     });
     testFilterLiteral({
-      notebookStep: "data",
       filterExpression: "True",
       filterDisplayName: "true",
       expectedRowCount: 200,
     });
-    addCustomColumn({
-      name: "TrueColumn",
-      expression: "True",
-    });
     testFilterLiteral({
-      notebookStep: "expression",
       filterExpression: "[TrueColumn]",
       filterDisplayName: "TrueColumn",
       expectedRowCount: 200,
     });
-    addCustomColumn({
-      name: "FalseColumn",
-      expression: "False",
-    });
     testFilterLiteral({
-      notebookStep: "expression",
       filterExpression: "[FalseColumn]",
       filterDisplayName: "FalseColumn",
       expectedRowCount: 0,

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -10,7 +10,7 @@ describe("scenarios > custom column > literals", () => {
     const columns = [
       { name: "True", expression: "True", value: "true" },
       { name: "False", expression: "False", value: "false" },
-      { name: "Text", expression: '"abc"', value: "abc" },
+      { name: "String", expression: '"abc"', value: "abc" },
       { name: "Number", expression: "10", value: "10" },
       { name: "DateString", expression: '"2024-01-01"', value: "2024-01-01" },
       {

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -560,26 +560,26 @@ describe("scenarios > question > filter", () => {
     cy.findByText("wilma-muller");
   });
 
-  it("should not reject a number literal", () => {
+  it("should reject a number literal", () => {
     H.openProductsTable({ mode: "notebook" });
     H.filter({ mode: "notebook" });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Custom Expression").click();
-
+    H.popover().findByText("Custom Expression").click();
     H.enterCustomColumnDetails({ formula: "3.14159" });
-
-    cy.button("Done").should("be.enabled");
+    H.popover().within(() => {
+      cy.button("Done").should("be.disabled");
+      cy.findByText("Expecting boolean but found 3.14159");
+    });
   });
 
-  it("should not reject a string literal", () => {
+  it("should reject a string literal", () => {
     H.openProductsTable({ mode: "notebook" });
     H.filter({ mode: "notebook" });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Custom Expression").click();
-
+    H.popover().findByText("Custom Expression").click();
     H.enterCustomColumnDetails({ formula: '"TheAnswer"' });
-
-    cy.button("Done").should("be.enabled");
+    H.popover().within(() => {
+      cy.button("Done").should("be.disabled");
+      cy.findByText('Expecting boolean but found "TheAnswer"');
+    });
   });
 
   it.skip("column filters should work for metrics (metabase#15333)", () => {

--- a/frontend/src/metabase-lib/v1/expressions/identifier.ts
+++ b/frontend/src/metabase-lib/v1/expressions/identifier.ts
@@ -49,7 +49,11 @@ export function formatMetricName(
 
 export function parseSegment(
   segmentName: string,
-  { query, stageIndex }: { query: Lib.Query; stageIndex: number },
+  {
+    query,
+    stageIndex,
+    expressionIndex,
+  }: { query: Lib.Query; stageIndex: number; expressionIndex?: number },
 ) {
   const segment = Lib.availableSegments(query, stageIndex).find(segment => {
     const displayInfo = Lib.displayInfo(query, stageIndex, segment);
@@ -61,7 +65,11 @@ export function parseSegment(
     return segment;
   }
 
-  const column = Lib.fieldableColumns(query, stageIndex).find(field => {
+  const column = Lib.expressionableColumns(
+    query,
+    stageIndex,
+    expressionIndex,
+  ).find(field => {
     const displayInfo = Lib.displayInfo(query, stageIndex, field);
     return displayInfo.name.toLowerCase() === segmentName.toLowerCase();
   });

--- a/frontend/src/metabase-lib/v1/expressions/resolver.js
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.js
@@ -90,7 +90,8 @@ export function resolve({
     const [op, ...operands] = expression;
 
     if (op === "value") {
-      return expression;
+      const [value] = operands;
+      return [op, resolve({ expression: value, type, fn, database })];
     } else if (FIELD_MARKERS.includes(op)) {
       const kind = MAP_TYPE[type] || "dimension";
       const [name] = operands;
@@ -230,12 +231,7 @@ export function resolve({
       return resolve({ expression: operand, type: args[i], fn, database });
     });
     return [op, ...resolvedOperands];
-  } else if (
-    !isCompatible(
-      type,
-      typeof expression === "boolean" ? "expression" : typeof expression,
-    )
-  ) {
+  } else if (!isCompatible(type, typeof expression)) {
     throw new ResolverError(
       t`Expecting ${type} but found ${JSON.stringify(expression)}`,
       expression.node,


### PR DESCRIPTION
Changes:
- A test that checks that a column with a literal value can be used in all other clauses - filter, aggregation, breakout, order by. The suite fails right now, and it will work only when the BE is fixed.
- Fixes a previously broken case with rejection of raw strings and numbers for filter expressions.
- Fixes a case where wrong columns we used for the fallback when parsing a segment. The issue made it impossible to use a) custom boolean expressions, b) joined columns.

How to verify:
- No failed E2E tests.