### PR TITLE
Update metabase.com links so that they are not targeted at redirect pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The easiest way to get started with Metabase is to sign up for a free trial of [
 ## Features
 
 - [Set up in five minutes](https://www.metabase.com/docs/latest/setting-up-metabase.html) (we're not kidding).
-- Let anyone on your team [ask questions](https://www.metabase.com/docs/latest/users-guide/04-asking-questions.html) without knowing SQL.
+- Let anyone on your team [ask questions](https://www.metabase.com/docs/latest/questions/introduction) without knowing SQL.
 - Use the [SQL editor](https://www.metabase.com/docs/latest/questions/native-editor/writing-sql) for more complex queries.
 - Build handsome, interactive [dashboards](https://www.metabase.com/docs/latest/users-guide/07-dashboards.html) with filters, auto-refresh, fullscreen, and custom click behavior.
 - Create [models](https://www.metabase.com/learn/metabase-basics/getting-started/models) that clean up, annotate, and/or combine raw tables.

--- a/docs/configuring-metabase/setting-up-metabase.md
+++ b/docs/configuring-metabase/setting-up-metabase.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Setting up Metabase
 
-This guide will help you set up Metabase once you’ve gotten it installed. If you haven’t installed Metabase yet, you can [get Metabase here](https://metabase.com/start).
+This guide will help you set up Metabase once you’ve gotten it installed. If you haven’t installed Metabase yet, you can [get Metabase here](https://metabase.com/pricing/).
 
 Start Metabase up for the first time and you’ll see this screen:
 ![Welcome Screen](images/WelcomeScreen.png)

--- a/docs/dashboards/introduction.md
+++ b/docs/dashboards/introduction.md
@@ -289,7 +289,7 @@ If your Metabase administrator has enabled [public sharing](../embedding/public-
 
 ![Share icon](./images/share-icon.png)
 
-Public links can be viewed by anyone, even if they don't have access to Metabase. You can also use the public embedding code to embed your question or dashboard in a simple web page or blog post. Check out examples of simple apps with embedded dashboards in our [embedding-reference-apps repository](https://github.com/metabase/embedding-reference-apps). To learn more about [embedding](../embedding/introduction.md), check out our article on [How to use Metabase to deliver analytics to your customers](https://www.metabase.com/blog/external-facing-analytics), as well as an article on how to combine branding, Single Sign-On, full app embedding, and data sandboxing to deliver [multi-tenant, self-service analytics](https://www.metabase.com/blog/embedding).
+Public links can be viewed by anyone, even if they don't have access to Metabase. You can also use the public embedding code to embed your question or dashboard in a simple web page or blog post. Check out examples of simple apps with embedded dashboards in our [embedding-reference-apps repository](https://github.com/metabase/embedding-reference-apps). To learn more about [embedding](../embedding/introduction.md), check out our article on [How to use Metabase to deliver analytics to your customers](/learn/metabase-basics/embedding/overview), as well as an article on how to combine branding, Single Sign-On, full app embedding, and data sandboxing to deliver [multi-tenant, self-service analytics](https://www.metabase.com/learn/developing-applications/advanced-metabase/multi-tenant-self-service-analytics).
 
 ## Exporting results from a dashboard
 

--- a/docs/developers-guide/partner-and-community-drivers.md
+++ b/docs/developers-guide/partner-and-community-drivers.md
@@ -76,7 +76,7 @@ If you don't see a driver for your database, try looking in the comments of the 
 
 If you are having problems installing or using a community driver, your best bet is to contact the author of the driver.
 
-[Metabase Cloud](https://www.metabase.com/start/) doesn't support community drivers, meaning that (for now) you can only use Metabase Cloud with the [officially supported drivers](../databases/connecting.md#connecting-to-supported-databases), and the partner drivers listed above.
+[Metabase Cloud](https://www.metabase.com/cloud/) doesn't support community drivers, meaning that (for now) you can only use Metabase Cloud with the [officially supported drivers](../databases/connecting.md#connecting-to-supported-databases), and the partner drivers listed above.
 
 ## Write your own driver
 

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -26,7 +26,7 @@ Click on the **gear** icon > **Admin settings** > **People**. You'll see a list 
 
 Admins can add people to their Metabase. To add a new person manually, click on the gear icon and select **Admin settings**. Under the **People** tab, click **Invite someone** in the upper right corner. You’ll be prompted to enter their email, and optionally their first and last names–only the email is required.
 
-Click **Create** to activate an account. An account becomes active once you click **Create**, even if the person never signs into the account. The account remains active until you [deactivate the account](#deactivating-an-account). If you're on a Pro or Enterprise Metabase plan, all active accounts will count toward your user account total. If one person has more than one account, each account will count toward the total (see [how billing works](https://www.metabase.com/pricing/how-billing-works)).
+Click **Create** to activate an account. An account becomes active once you click **Create**, even if the person never signs into the account. The account remains active until you [deactivate the account](#deactivating-an-account). If you're on a Pro or Enterprise Metabase plan, all active accounts will count toward your user account total. If one person has more than one account, each account will count toward the total (see [how billing works](https://www.metabase.com/docs/latest/cloud/how-billing-works)).
 
 If you’ve already [configured Metabase to use email](../configuring-metabase/email.md), Metabase will send the person an email inviting them to log into Metabase. If you haven't yet setup email for your Metabase, Metabase will give you a temporary password that you’ll have to manually send to the person.
 

--- a/docs/troubleshooting-guide/index.md
+++ b/docs/troubleshooting-guide/index.md
@@ -83,7 +83,7 @@ Metabase adds new features and squashes bugs with each release. [Upgrading to th
 [appdb]: ./loading-from-h2.md
 [bugs]: ./bugs.md
 [cant-see-tables]: ./cant-see-tables.md
-[cloud]: https://www.metabase.com/start/
+[cloud]: https://www.metabase.com/cloud/
 [db-connection]: ./db-connection.md
 [db-performance]: ./db-performance.md
 [docker]: ./docker.md


### PR DESCRIPTION
Solves docs side of [Remove meta refresh tags](https://www.notion.so/metabase/Remove-meta-refresh-tags-1b469354c90180559d07ed053a826e67)

Essentially this replaces links that are redirected to their final URL.

### How?

Our redirection plugin creates pages for the intermediary URLs.

Those rely on refresh meta tags for the redirection.

This PR will make links go straight to the final page.

The redirectable pages will still exist. Hope is they won't be scraped by search engines and no longer be counted as errors (this may require further work, we'll see).