### PR TITLE
visualizer start screen: replace map with line option

### DIFF
--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/StartFromViz/StartFromViz.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/StartFromViz/StartFromViz.tsx
@@ -16,9 +16,9 @@ const options = _.shuffle([
     icon: "bar",
   },
   {
-    label: t`Region map`,
-    value: "map",
-    icon: "pinmap",
+    label: t`Line`,
+    value: "line",
+    icon: "line",
   },
   {
     label: t`Scatterplot`,


### PR DESCRIPTION
## Description

No map option anymore:

<img width="2319" alt="Screenshot 2025-03-17 at 6 21 47 PM" src="https://github.com/user-attachments/assets/30791581-e5f7-4884-b250-b0da6a4a1c72" />
