### PR TITLE
[Notification] Fix task history report when channel failed to send and we skip it

### DIFF
--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -38,12 +38,13 @@
    :initial-interval-millis 500
    :multiplier              2.0
    :randomization-factor    0.1
-   :max-interval-millis     30000})
+   :max-interval-millis     30000
+   :retry-on-exception-pred #(-> % ex-data ::skip-retry? not)})
 
-(defn- should-retry-sending?
+(defn- should-skip-retry?
   [exception channel-type]
-  (not (and (= :channel/slack channel-type)
-            (contains? (:errors (ex-data exception)) :slack-token))))
+  (and (= :channel/slack channel-type)
+       (contains? (:errors (ex-data exception)) :slack-token)))
 
 (defn- channel-send-retrying!
   [notification-id payload-type handler message]
@@ -62,12 +63,17 @@
                               (try
                                 (channel/send! channel message)
                                 (catch Exception e
-                                  (when (should-retry-sending? e (:type channel))
+                                  (let [skip-retry? (should-skip-retry? e (:type channel))
+                                        new-e       (ex-info (ex-message e)
+                                                             (assoc (ex-data e) ::skip-retry? skip-retry?))]
                                     (vswap! retry-errors conj {:message   (u/strip-error e)
                                                                :timestamp (t/offset-date-time)})
-                                    (log/warnf e "[Notification %d] Failed to send to channel %s , retrying..."
-                                               notification-id (handler->channel-name handler))
-                                    (throw e)))))
+                                    (if skip-retry?
+                                      (log/warnf e "[Notification %d] Failed to send to channel %s, retrying..."
+                                                 notification-id (handler->channel-name handler))
+                                      (log/warnf e "[Notification %d] Failed to send to channel %s, not retrying"
+                                                 notification-id (handler->channel-name handler)))
+                                    (throw new-e)))))
             retrier         (retry/make retry-config)]
         (log/debugf "[Notification %d] Sending a message to channel %s" notification-id (handler->channel-name handler))
         (task-history/with-task-history {:task            "channel-send"
@@ -84,7 +90,6 @@
                                                            :notification_id   notification-id
                                                            :notification_type payload-type
                                                            :recipient_ids     (map :id (:recipients handler))}}
-
           (retrier send!)
           (log/debugf "[Notification %d] Sent to channel %s with %d retries"
                       notification-id (handler->channel-name handler) (count @retry-errors))))
@@ -94,6 +99,16 @@
         (prometheus/inc! :metabase-notification/channel-send-error {:payload-type payload-type
                                                                     :channel-type channel-type})
         (log/errorf e "[Notification %d] Error sending notification!" notification-id)))))
+
+(do
+  (defn f
+    []
+    (log/info "sending")
+    (throw (ex-info "error" {::skip-retry? true})))
+
+  (let [retrier (retry/make (assoc default-retry-config :retry-on-exception-pred (fn [e]
+                                                                                   (false? (::skip-retry? (ex-data e))))))]
+    (retrier f)))
 
 (defn- hydrate-notification
   [notification-info]

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -100,16 +100,6 @@
                                                                     :channel-type channel-type})
         (log/errorf e "[Notification %d] Error sending notification!" notification-id)))))
 
-(do
-  (defn f
-    []
-    (log/info "sending")
-    (throw (ex-info "error" {::skip-retry? true})))
-
-  (let [retrier (retry/make (assoc default-retry-config :retry-on-exception-pred (fn [e]
-                                                                                   (false? (::skip-retry? (ex-data e))))))]
-    (retrier f)))
-
 (defn- hydrate-notification
   [notification-info]
   (case (:payload_type notification-info)

--- a/src/metabase/util/retry.clj
+++ b/src/metabase/util/retry.clj
@@ -57,7 +57,8 @@
           {:keys [^long max-attempts ^long initial-interval-millis
                   ^double multiplier ^double randomization-factor
                   ^long max-interval-millis
-                  retry-on-result-pred retry-on-exception-pred]}]
+                  ^Callable retry-on-result-pred
+                  ^Callable retry-on-exception-pred]}]
   (let [interval-fn (IntervalFunction/ofExponentialRandomBackoff
                      initial-interval-millis multiplier
                      randomization-factor max-interval-millis)

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -4,6 +4,8 @@
    [java-time.api :as t]
    [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.channel.core :as channel]
+   [metabase.channel.email :as email]
+   [metabase.integrations.slack :as slack]
    [metabase.notification.core :as notification]
    [metabase.notification.models :as models.notification]
    [metabase.notification.payload.core :as notification.payload]
@@ -11,8 +13,10 @@
    [metabase.notification.test-util :as notification.tu]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.test.util :as tu]
    [metabase.util :as u]
    [metabase.util.log :as log]
+   [metabase.util.retry :as retry]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -120,12 +124,217 @@
                 (#'notification.send/send-notification-sync! n))
               (is (some? @send-args))
               (is (=? {:task "channel-send"
+                       :status       :success
                        :task_details {:attempted_retries 1
                                       :retry_config      (mt/malli=? :map)
                                       :retry_errors      (mt/malli=? [:sequential [:map {:closed true}
                                                                                    [:timestamp :string]
                                                                                    [:message :string]]])}}
                       (t2/select-one :model/TaskHistory :task "channel-send"))))))))))
+
+(deftest notification-send-skip-retry-still-report-failed-task-history-test
+  (notification.tu/with-notification-testing-setup!
+    (mt/with-temp [:model/Channel chn notification.tu/default-can-connect-channel]
+      (let [n (models.notification/create-notification!
+               {:payload_type :notification/testing}
+               nil
+               [{:channel_type notification.tu/test-channel-type
+                 :channel_id   (:id chn)
+                 :recipients   [{:type :notification-recipient/user :user_id (mt/user->id :crowberto)}]}])]
+        (testing (str "if channel/send! throws an exception and should-skip-retry? returns true"
+                      "the task history should still be recorded and status is failed")
+          (t2/delete! :model/TaskHistory :task "channel-send")
+          (testing "and record exception in task history"
+            (let [send!       (fn [& _args]
+                                (throw (ex-info "Failed to send" {:metadata 42})))]
+              (mt/with-dynamic-fn-redefs [notification.send/should-skip-retry? (constantly true)
+                                          channel/send!                        send!]
+                (#'notification.send/send-notification-sync! n))
+              (is (=? {:task "channel-send"
+                       :status       :failed
+                       :task_details {:attempted_retries 1
+                                      :message           "Failed to send"
+                                      :ex-data           {:metadata 42
+                                                          :metabase.notification.send/skip-retry? true}
+
+                                      :retry_errors      (mt/malli=? [:sequential [:map {:closed true}
+                                                                                   [:timestamp :string]
+                                                                                   [:message :string]]])}}
+                      (t2/select-one :model/TaskHistory :task "channel-send"))))))))))
+
+(defn- get-positive-retry-metrics [^io.github.resilience4j.retry.Retry retry]
+  (let [metrics (bean (.getMetrics retry))]
+    (into {}
+          (map (fn [field]
+                 (let [n (metrics field)]
+                   (when (pos? n)
+                     [field n]))))
+          [:numberOfFailedCallsWithRetryAttempt
+           :numberOfFailedCallsWithoutRetryAttempt
+           :numberOfSuccessfulCallsWithRetryAttempt
+           :numberOfSuccessfulCallsWithoutRetryAttempt])))
+
+(def ^:private fake-email-notification
+  {:subject      "test-message"
+   :recipients   ["whoever@example.com"]
+   :message-type :text
+   :message      "test message body"})
+
+(def ^:private test-retry-configuration
+  (assoc @#'notification.send/default-retry-config
+         :initial-interval-millis 1
+         :max-attempts 2))
+
+(deftest email-notification-retry-test
+  (testing "send email succeeds w/o retry"
+    (let [test-retry (retry/random-exponential-backoff-retry "test-retry" test-retry-configuration)]
+      (with-redefs [email/send-email!                      mt/fake-inbox-email-fn
+                    retry/random-exponential-backoff-retry (constantly test-retry)]
+        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
+                                           email-smtp-port 587]
+          (mt/reset-inbox!)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
+          (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry)))
+          (is (= 1 (count @mt/inbox)))))))
+  (testing "send email succeeds hiding SMTP host not set error"
+    (let [test-retry (retry/random-exponential-backoff-retry "test-retry" test-retry-configuration)]
+      (with-redefs [email/send-email!                      (fn [& _] (throw (ex-info "Bumm!" {:cause :smtp-host-not-set})))
+                    retry/random-exponential-backoff-retry (constantly test-retry)]
+        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
+                                           email-smtp-port 587]
+          (mt/reset-inbox!)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
+          (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry)))
+          (is (= 0 (count @mt/inbox)))))))
+  (testing "send email fails b/c retry limit"
+    (let [retry-config (assoc test-retry-configuration :max-attempts 1)
+          test-retry (retry/random-exponential-backoff-retry "test-retry" retry-config)]
+      (with-redefs [email/send-email!                      (tu/works-after 1 mt/fake-inbox-email-fn)
+                    retry/random-exponential-backoff-retry (constantly test-retry)]
+        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
+                                           email-smtp-port 587]
+          (mt/reset-inbox!)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
+          (is (= {:numberOfFailedCallsWithRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry)))
+          (is (= 0 (count @mt/inbox)))))))
+  (testing "send email succeeds w/ retry"
+    (let [retry-config (assoc test-retry-configuration :max-attempts 2)
+          test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
+      (with-redefs [email/send-email!                      (tu/works-after 1 mt/fake-inbox-email-fn)
+                    retry/random-exponential-backoff-retry (constantly test-retry)]
+        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
+                                           email-smtp-port 587]
+          (mt/reset-inbox!)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
+          (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry)))
+          (is (= 1 (count @mt/inbox))))))))
+
+(def ^:private fake-slack-notification
+  {:channel-id  "#test-channel"
+   :attachments [{:blocks [{:type "section", :text {:type "plain_text", :text ""}}]}]})
+
+(deftest slack-notification-retry-test
+  (notification.tu/with-send-notification-sync
+    (testing "post slack message succeeds w/o retry"
+      (let [test-retry (retry/random-exponential-backoff-retry "test-retry" test-retry-configuration)]
+        (with-redefs [retry/random-exponential-backoff-retry (constantly test-retry)
+                      slack/post-chat-message!               (constantly nil)]
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
+          (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry))))))
+    (testing "post slack message succeeds hiding token error"
+      (let [test-retry (retry/random-exponential-backoff-retry "test-retry" test-retry-configuration)]
+        (with-redefs [retry/random-exponential-backoff-retry (constantly test-retry)
+                      slack/post-chat-message!               (fn [& _]
+                                                               (throw (ex-info "Invalid token"
+                                                                               {:errors {:slack-token "Invalid token"}})))]
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
+          (is (= {:numberOfFailedCallsWithoutRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry))))))
+    (testing "post slack message fails b/c retry limit"
+      (let [retry-config (assoc test-retry-configuration :max-attempts 1)
+            test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
+        (with-redefs [slack/post-chat-message!               (tu/works-after 1 (constantly nil))
+                      retry/random-exponential-backoff-retry (constantly test-retry)]
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
+          (is (= {:numberOfFailedCallsWithRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry))))))
+    (testing "post slack message succeeds with retry"
+      (let [retry-config (assoc test-retry-configuration :max-attempts 2)
+            test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
+        (with-redefs [slack/post-chat-message!               (tu/works-after 1 (constantly nil))
+                      retry/random-exponential-backoff-retry (constantly test-retry)]
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
+          (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
+                 (get-positive-retry-metrics test-retry))))))))
+
+(defn- latest-task-history-entry
+  [task-name]
+  (t2/select-one-fn #(dissoc % :id :started_at :ended_at :duration)
+                    :model/TaskHistory
+                    {:order-by [[:started_at :desc]]
+                     :where [:= :task (name task-name)]}))
+
+(deftest send-channel-record-task-history-test
+  (with-redefs [notification.send/default-retry-config {:max-attempts            4
+                                                        :initial-interval-millis 1
+                                                        :multiplier              2.0
+                                                        :randomization-factor    0.1
+                                                        :max-interval-millis     30000}]
+    (mt/with-model-cleanup [:model/TaskHistory]
+      (let [pulse-id             (rand-int 10000)
+            default-task-details {:notification_id pulse-id
+                                  :notification_type "notification/card"
+                                  :channel_type "channel/slack"
+                                  :channel_id   nil
+                                  :retry_config {:max-attempts            4
+                                                 :initial-interval-millis 1
+                                                 :multiplier              2.0
+                                                 :randomization-factor    0.1
+                                                 :max-interval-millis     30000}}
+            send!                #(#'notification.send/channel-send-retrying! pulse-id :notification/card {:channel_type :channel/slack} fake-slack-notification)]
+        (testing "channel send task history task details include retry config"
+          (with-redefs [channel/send! (constantly true)]
+            (send!)
+            (is (=? {:task         "channel-send"
+                     :db_id        nil
+                     :status       :success
+                     :task_details default-task-details}
+                    (latest-task-history-entry :channel-send)))))
+
+        (testing "retry errors are recorded when the task eventually succeeds"
+          (with-redefs [channel/send! (tu/works-after 2 (constantly nil))]
+            (send!)
+            (is (=? {:task         "channel-send"
+                     :db_id        nil
+                     :status       :success
+                     :task_details (merge default-task-details
+                                          {:attempted_retries 2
+                                           :retry_errors      (mt/malli=?
+                                                               [:sequential {:min 2 :max 2}
+                                                                [:map
+                                                                 [:message :string]
+                                                                 [:timestamp :string]]])})}
+                    (latest-task-history-entry :channel-send)))))
+
+        (testing "retry errors are recorded when the task eventually fails"
+          (with-redefs [channel/send! (tu/works-after 5 (constantly nil))]
+            (send!)
+            (is (=? {:task         "channel-send"
+                     :db_id        nil
+                     :status       :failed
+                     :task_details {:original-info     default-task-details
+                                    :attempted_retries 4
+                                    :retry_errors      (mt/malli=?
+                                                        [:sequential {:min 4 :max 4}
+                                                         [:map
+                                                          [:message :string]
+                                                          [:timestamp :string]]])}}
+                    (latest-task-history-entry :channel-send)))))))))
 
 (deftest send-notification-record-prometheus-metrics-test
   (mt/with-prometheus-system! [_ system]

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -152,7 +152,7 @@
                 (#'notification.send/send-notification-sync! n))
               (is (=? {:task "channel-send"
                        :status       :failed
-                       :task_details {:attempted_retries 1
+                       :task_details {:attempted_retries 0
                                       :message           "Failed to send"
                                       :ex-data           {:metadata 42
                                                           :metabase.notification.send/skip-retry? true}

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -6,21 +6,16 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.channel.core :as channel]
-   [metabase.channel.email :as email]
    [metabase.channel.impl.http-test :as channel.http-test]
    [metabase.channel.render.body :as body]
    [metabase.channel.render.core :as channel.render]
-   [metabase.integrations.slack :as slack]
-   [metabase.notification.send :as notification.send]
    [metabase.notification.test-util :as notification.tu]
    [metabase.pulse.models.pulse :as models.pulse]
    [metabase.pulse.send :as pulse.send]
    [metabase.pulse.test-util :as pulse.test-util]
    [metabase.query-processor.middleware.limit :as limit]
    [metabase.test :as mt]
-   [metabase.test.util :as tu]
    [metabase.util :as u]
-   [metabase.util.retry :as retry]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -619,181 +614,6 @@
          (pulse.send/send-pulse! (models.pulse/retrieve-notification pulse-id))
          (is (mt/received-email-body? :rasta #"Manage your subscriptions"))
          (is (mt/received-email-body? "nonuser@metabase.com" #"Unsubscribe")))))))
-
-(defn- get-positive-retry-metrics [^io.github.resilience4j.retry.Retry retry]
-  (let [metrics (bean (.getMetrics retry))]
-    (into {}
-          (map (fn [field]
-                 (let [n (metrics field)]
-                   (when (pos? n)
-                     [field n]))))
-          [:numberOfFailedCallsWithRetryAttempt
-           :numberOfFailedCallsWithoutRetryAttempt
-           :numberOfSuccessfulCallsWithRetryAttempt
-           :numberOfSuccessfulCallsWithoutRetryAttempt])))
-
-(def ^:private fake-email-notification
-  {:subject      "test-message"
-   :recipients   ["whoever@example.com"]
-   :message-type :text
-   :message      "test message body"})
-
-(defn ^:private test-retry-configuration
-  []
-  (assoc (#'retry/retry-configuration)
-         :initial-interval-millis 1
-         :max-attempts 2))
-
-(deftest email-notification-retry-test
-  (testing "send email succeeds w/o retry"
-    (let [test-retry (retry/random-exponential-backoff-retry "test-retry" (test-retry-configuration))]
-      (with-redefs [email/send-email!                      mt/fake-inbox-email-fn
-                    retry/random-exponential-backoff-retry (constantly test-retry)]
-        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
-                                           email-smtp-port 587]
-          (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
-          (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry)))
-          (is (= 1 (count @mt/inbox)))))))
-  (testing "send email succeeds hiding SMTP host not set error"
-    (let [test-retry (retry/random-exponential-backoff-retry "test-retry" (test-retry-configuration))]
-      (with-redefs [email/send-email!                      (fn [& _] (throw (ex-info "Bumm!" {:cause :smtp-host-not-set})))
-                    retry/random-exponential-backoff-retry (constantly test-retry)]
-        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
-                                           email-smtp-port 587]
-          (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
-          (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry)))
-          (is (= 0 (count @mt/inbox)))))))
-  (testing "send email fails b/c retry limit"
-    (let [retry-config (assoc (test-retry-configuration) :max-attempts 1)
-          test-retry (retry/random-exponential-backoff-retry "test-retry" retry-config)]
-      (with-redefs [email/send-email!                      (tu/works-after 1 mt/fake-inbox-email-fn)
-                    retry/random-exponential-backoff-retry (constantly test-retry)]
-        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
-                                           email-smtp-port 587]
-          (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
-          (is (= {:numberOfFailedCallsWithRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry)))
-          (is (= 0 (count @mt/inbox)))))))
-  (testing "send email succeeds w/ retry"
-    (let [retry-config (assoc (test-retry-configuration) :max-attempts 2)
-          test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
-      (with-redefs [email/send-email!                      (tu/works-after 1 mt/fake-inbox-email-fn)
-                    retry/random-exponential-backoff-retry (constantly test-retry)]
-        (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
-                                           email-smtp-port 587]
-          (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
-          (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry)))
-          (is (= 1 (count @mt/inbox))))))))
-
-(def ^:private fake-slack-notification
-  {:channel-id  "#test-channel"
-   :attachments [{:blocks [{:type "section", :text {:type "plain_text", :text ""}}]}]})
-
-(deftest slack-notification-retry-test
-  (notification.tu/with-send-notification-sync
-    (testing "post slack message succeeds w/o retry"
-      (let [test-retry (retry/random-exponential-backoff-retry "test-retry" (test-retry-configuration))]
-        (with-redefs [retry/random-exponential-backoff-retry (constantly test-retry)
-                      slack/post-chat-message!               (constantly nil)]
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
-          (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry))))))
-    (testing "post slack message succeeds hiding token error"
-      (let [test-retry (retry/random-exponential-backoff-retry "test-retry" (test-retry-configuration))]
-        (with-redefs [retry/random-exponential-backoff-retry (constantly test-retry)
-                      slack/post-chat-message!               (fn [& _]
-                                                               (throw (ex-info "Invalid token"
-                                                                               {:errors {:slack-token "Invalid token"}})))]
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
-          (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry))))))
-    (testing "post slack message fails b/c retry limit"
-      (let [retry-config (assoc (test-retry-configuration) :max-attempts 1)
-            test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
-        (with-redefs [slack/post-chat-message!               (tu/works-after 1 (constantly nil))
-                      retry/random-exponential-backoff-retry (constantly test-retry)]
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
-          (is (= {:numberOfFailedCallsWithRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry))))))
-    (testing "post slack message succeeds with retry"
-      (let [retry-config (assoc (test-retry-configuration) :max-attempts 2)
-            test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
-        (with-redefs [slack/post-chat-message!               (tu/works-after 1 (constantly nil))
-                      retry/random-exponential-backoff-retry (constantly test-retry)]
-          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
-          (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
-                 (get-positive-retry-metrics test-retry))))))))
-
-(defn- latest-task-history-entry
-  [task-name]
-  (t2/select-one-fn #(dissoc % :id :started_at :ended_at :duration)
-                    :model/TaskHistory
-                    {:order-by [[:started_at :desc]]
-                     :where [:= :task (name task-name)]}))
-
-(deftest send-channel-record-task-history-test
-  (with-redefs [notification.send/default-retry-config {:max-attempts            4
-                                                        :initial-interval-millis 1
-                                                        :multiplier              2.0
-                                                        :randomization-factor    0.1
-                                                        :max-interval-millis     30000}]
-    (mt/with-model-cleanup [:model/TaskHistory]
-      (let [pulse-id             (rand-int 10000)
-            default-task-details {:notification_id pulse-id
-                                  :notification_type "notification/card"
-                                  :channel_type "channel/slack"
-                                  :channel_id   nil
-                                  :retry_config {:max-attempts            4
-                                                 :initial-interval-millis 1
-                                                 :multiplier              2.0
-                                                 :randomization-factor    0.1
-                                                 :max-interval-millis     30000}}
-            send!                #(#'notification.send/channel-send-retrying! pulse-id :notification/card {:channel_type :channel/slack} fake-slack-notification)]
-        (testing "channel send task history task details include retry config"
-          (with-redefs [channel/send! (constantly true)]
-            (send!)
-            (is (=? {:task         "channel-send"
-                     :db_id        nil
-                     :status       :success
-                     :task_details default-task-details}
-                    (latest-task-history-entry :channel-send)))))
-
-        (testing "retry errors are recorded when the task eventually succeeds"
-          (with-redefs [channel/send! (tu/works-after 2 (constantly nil))]
-            (send!)
-            (is (=? {:task         "channel-send"
-                     :db_id        nil
-                     :status       :success
-                     :task_details (merge default-task-details
-                                          {:attempted_retries 2
-                                           :retry_errors      (mt/malli=?
-                                                               [:sequential {:min 2 :max 2}
-                                                                [:map
-                                                                 [:message :string]
-                                                                 [:timestamp :string]]])})}
-                    (latest-task-history-entry :channel-send)))))
-
-        (testing "retry errors are recorded when the task eventually fails"
-          (with-redefs [channel/send! (tu/works-after 5 (constantly nil))]
-            (send!)
-            (is (=? {:task         "channel-send"
-                     :db_id        nil
-                     :status       :failed
-                     :task_details {:original-info     default-task-details
-                                    :attempted_retries 4
-                                    :retry_errors      (mt/malli=?
-                                                        [:sequential {:min 4 :max 4}
-                                                         [:map
-                                                          [:message :string]
-                                                          [:timestamp :string]]])}}
-                    (latest-task-history-entry :channel-send)))))))))
 
 (deftest partial-channel-failure-will-deliver-all-that-success-test
   (testing "if a pulse is set to send to multiple channels and one of them fail, the other channels should still receive the message"


### PR DESCRIPTION
I was reviewing https://github.com/metabase/metabase/pull/55180 and I found out that when we send notification, if a channel is failed to send and we skip retrying (currently on when we detect slack token is invalid), the `channel-send` task history for that task has status=success. 

This PR fixes it so that the task history correctly reporting a failure.