### PR TITLE
[Notification] Conditional expression

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10834,6 +10834,22 @@ databaseChangeLog:
                   name: key_hashed
             indexName: idx_core_session_key_hashed
 
+  - changeSet:
+      id: v54.2025-03-19T16:00:00
+      author: qnkhuat
+      comment: Add `notification.condition` column
+      preConditions:
+      changes:
+        - addColumn:
+            tableName: notification
+            columns:
+              - column:
+                  name: condition
+                  type: ${text.type}
+                  remarks: Condition for the notification
+                  constraints:
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10834,6 +10834,27 @@ databaseChangeLog:
                   name: key_hashed
             indexName: idx_core_session_key_hashed
 
+  - changeSet:
+      id: v54.2025-03-18T16:00:00
+      author: qnkhuat
+      comment: Add notification.condition
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: notification
+                columnName: condition
+      changes:
+        - addColumn:
+            tableName: notification
+            columns:
+              - column:
+                  name: condition
+                  type: ${text.type}
+                  remarks: The condition of the notification
+                  constraints:
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10834,27 +10834,6 @@ databaseChangeLog:
                   name: key_hashed
             indexName: idx_core_session_key_hashed
 
-  - changeSet:
-      id: v54.2025-03-18T16:00:00
-      author: qnkhuat
-      comment: Add notification.condition
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: notification
-                columnName: condition
-      changes:
-        - addColumn:
-            tableName: notification
-            columns:
-              - column:
-                  name: condition
-                  type: ${text.type}
-                  remarks: The condition of the notification
-                  constraints:
-                    nullable: true
-
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/notification/condition.clj
+++ b/src/metabase/notification/condition.clj
@@ -3,30 +3,30 @@
 (defn evaluate-expression
   "Evaluates an array-based expression against a context payload"
   [expr context]
-  (if (vector? expr)
+  (if (sequential? expr)
     (let [operator (first expr)
           operands (rest expr)]
-      (case operator
+      (case (keyword operator)
         ;; Logical operators
-        "and" (boolean (every? #(evaluate-expression % context) operands))
-        "or"  (boolean (some #(evaluate-expression % context) operands))
-        "not" (not (evaluate-expression (first operands) context))
+        :and (boolean (every? #(evaluate-expression % context) operands))
+        :or  (boolean (some #(evaluate-expression % context) operands))
+        :not (not (evaluate-expression (first operands) context))
 
         ;; Comparison operators
-        "="  (apply = (map #(evaluate-expression % context) operands))
-        "!=" (apply not= (map #(evaluate-expression % context) operands))
-        ">"  (apply > (map #(evaluate-expression % context) operands))
-        "<"  (apply < (map #(evaluate-expression % context) operands))
-        ">=" (apply >= (map #(evaluate-expression % context) operands))
-        "<=" (apply <= (map #(evaluate-expression % context) operands))
+        :=  (apply = (map #(evaluate-expression % context) operands))
+        :!= (apply not= (map #(evaluate-expression % context) operands))
+        :>  (apply > (map #(evaluate-expression % context) operands))
+        :<  (apply < (map #(evaluate-expression % context) operands))
+        :>= (apply >= (map #(evaluate-expression % context) operands))
+        :<= (apply <= (map #(evaluate-expression % context) operands))
 
         ;; Data access
-        "context" (get-in context (map keyword operands))
+        :context (get-in context (map keyword operands))
 
         ;; Functions
-        "count" (count (evaluate-expression (first operands) context))
-        "min"   (apply min (map #(evaluate-expression % context) operands))
-        "max"   (apply max (map #(evaluate-expression % context) operands))))
+        :count (count (evaluate-expression (first operands) context))
+        :min   (apply min (map #(evaluate-expression % context) operands))
+        :max   (apply max (map #(evaluate-expression % context) operands))))
     ;; literal value
     expr))
 

--- a/src/metabase/notification/condition.clj
+++ b/src/metabase/notification/condition.clj
@@ -1,0 +1,38 @@
+(ns metabase.notification.condition)
+
+(defn evaluate-expression
+  "Evaluates an array-based expression against a context payload"
+  [expr context]
+  (if (vector? expr)
+    (let [operator (first expr)
+          operands (rest expr)]
+      (case operator
+        ;; Logical operators
+        "and" (boolean (every? #(evaluate-expression % context) operands))
+        "or"  (boolean (some #(evaluate-expression % context) operands))
+        "not" (not (evaluate-expression (first operands) context))
+
+        ;; Comparison operators
+        "="  (apply = (map #(evaluate-expression % context) operands))
+        "!=" (apply not= (map #(evaluate-expression % context) operands))
+        ">"  (apply > (map #(evaluate-expression % context) operands))
+        "<"  (apply < (map #(evaluate-expression % context) operands))
+        ">=" (apply >= (map #(evaluate-expression % context) operands))
+        "<=" (apply <= (map #(evaluate-expression % context) operands))
+
+        ;; Data access
+        "context" (get-in context (map keyword operands))
+
+        ;; Functions
+        "count" (count (evaluate-expression (first operands) context))
+        "min"   (apply min (map #(evaluate-expression % context) operands))
+        "max"   (apply max (map #(evaluate-expression % context) operands))))
+    ;; literal value
+    expr))
+
+(comment
+  (evaluate-expression ["and",
+                        [">", ["count", ["context", "rows"]], 0],
+                        ["=", ["context", "user_id"], 1]]
+                       {:user_id 1
+                        :rows [1 2 3 4]}))

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -51,7 +51,8 @@
     :notification/testing})
 
 (t2/deftransforms :model/Notification
-  {:payload_type (mi/transform-validator mi/transform-keyword (partial mi/assert-enum notification-types))})
+  {:payload_type (mi/transform-validator mi/transform-keyword (partial mi/assert-enum notification-types))
+   :condition    mi/transform-json})
 
 (t2/define-after-select :model/Notification
   [notification]

--- a/test/metabase/notification/condition_test.clj
+++ b/test/metabase/notification/condition_test.clj
@@ -1,0 +1,135 @@
+(ns metabase.notification.condition-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.notification.condition :refer [evaluate-expression]]))
+
+(deftest evaluate-literal-values-test
+  (testing "literal values"
+    (are [expected expression context] (= expected (evaluate-expression expression context))
+      42 42 {}
+      "hello" "hello" {}
+      true true {}
+      false false {})))
+
+(deftest evaluate-logical-operators-test
+  (testing "logical operators"
+    (are [expected expression context] (= expected (evaluate-expression expression context))
+      ;; and
+      true ["and" true true] {}
+      false ["and" true false] {}
+      false ["and" false false] {}
+      true ["and" true true true] {}
+      false ["and" true true false] {}
+
+      ;; or
+      true ["or" true false] {}
+      true ["or" false true] {}
+      false ["or" false false] {}
+      true ["or" false false true] {}
+
+      ;; not
+      false ["not" true] {}
+      true ["not" false] {}
+      false ["not" ["not" false]] {})))
+
+(deftest evaluate-comparison-operators-test
+  (testing "comparison operators"
+    (are [expected expression context] (= expected (evaluate-expression expression context))
+      ;; =
+      true ["=" 1 1] {}
+      false ["=" 1 2] {}
+      true ["=" "a" "a"] {}
+      false ["=" "a" "b"] {}
+      true ["=" 1 1 1] {}
+      false ["=" 1 1 2] {}
+
+      ;; !=
+      false ["!=" 1 1] {}
+      true ["!=" 1 2] {}
+      false ["!=" "a" "a"] {}
+      true ["!=" "a" "b"] {}
+
+      ;; >
+      true [">" 2 1] {}
+      false [">" 1 2] {}
+      false [">" 2 2] {}
+      true [">" 3 2 1] {}
+      false [">" 3 2 2] {}
+
+      ;; <
+      false ["<" 2 1] {}
+      true ["<" 1 2] {}
+      false ["<" 2 2] {}
+      true ["<" 1 2 3] {}
+      false ["<" 1 2 2] {}
+
+      ;; >=
+      true [">=" 2 1] {}
+      false [">=" 1 2] {}
+      true [">=" 2 2] {}
+      true [">=" 3 2 1] {}
+      true [">=" 3 2 2] {}
+      false [">=" 3 3 4] {}
+
+      ;; <=
+      false ["<=" 2 1] {}
+      true ["<=" 1 2] {}
+      true ["<=" 2 2] {}
+      true ["<=" 1 2 3] {}
+      true ["<=" 1 2 2] {}
+      false ["<=" 2 1 1] {})))
+
+(deftest evaluate-context-access-test
+  (testing "context access"
+    (are [expected expression context] (= expected (evaluate-expression expression context))
+      1 ["context" "user_id"] {:user_id 1}
+      "bob" ["context" "name"] {:name "bob"}
+      42 ["context" "user" "id"] {:user {:id 42}}
+      [1 2 3] ["context" "rows"] {:rows [1 2 3]}
+      nil ["context" "missing"] {})))
+
+(deftest evaluate-functions-test
+  (testing "functions"
+    (are [expected expression context] (= expected (evaluate-expression expression context))
+      ;; count
+      3 ["count" ["context" "rows"]] {:rows [1 2 3]}
+      0 ["count" ["context" "empty"]] {:empty []}
+      0 ["count" ["context" "missing"]] {}
+
+      ;; min
+      1 ["min" 1 2 3] {}
+      1 ["min" 3 2 1] {}
+      4 ["min" ["context" "a"] ["context" "b"]] {:a 4, :b 6}
+
+      ;; max
+      3 ["max" 1 2 3] {}
+      3 ["max" 3 2 1] {}
+      6 ["max" ["context" "a"] ["context" "b"]] {:a 4, :b 6})))
+
+(deftest evaluate-nested-expressions-test
+  (testing "nested expressions"
+    (are [expected expression context] (= expected (evaluate-expression expression context))
+      true ["and"
+            [">" ["count" ["context" "rows"]] 0]
+            ["=" ["context" "user_id"] 1]]
+      {:user_id 1, :rows [1 2 3 4]}
+
+      false ["and"
+             [">" ["count" ["context" "rows"]] 0]
+             ["=" ["context" "user_id"] 2]]
+      {:user_id 1, :rows [1 2 3 4]}
+
+      false ["and"
+             [">" ["count" ["context" "rows"]] 5]
+             ["=" ["context" "user_id"] 1]]
+      {:user_id 1, :rows [1 2 3 4]}
+
+      true ["or"
+            ["=" ["context" "status"] "active"]
+            [">" ["context" "score"] 90]]
+      {:status "inactive", :score 95}
+
+      false ["or"
+             ["=" ["context" "status"] "active"]
+             [">" ["context" "score"] 90]]
+      {:status "inactive", :score 85})))

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -455,3 +455,19 @@
                                    vals)]
           (is (> (count consumer-counts) 1))
           (is (every? pos? consumer-counts)))))))
+
+(deftest send-notification-condition-properly-skip-test
+  (doseq [[condition-passed? condition-creator-id] [[true (mt/user->id :crowberto)]
+                                                    [false (mt/user->id :rasta)]]]
+    (notification.tu/with-temp-notification
+      [notification {:notification {:payload_type :notification/testing
+                                    :creator_id   (mt/user->id :crowberto)
+                                    :condition    ["=" ["context" "creator" "id"] condition-creator-id]}
+                     :handlers     [notification.tu/default-testing-handler]}]
+      (let [channel-messages (notification.tu/with-captured-channel-send!
+                               (#'notification.send/send-notification-sync! notification))]
+        (if condition-passed?
+          (testing "received message when condition returns true"
+            (is (= {:channel/metabase-test 1} (update-vals channel-messages count))))
+          (testing "no messages received when condition returns false"
+            (is (empty? channel-messages))))))))

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -288,6 +288,9 @@
           :recipients   [{:type    :notification-recipient/user
                           :user_id (mt/user->id :rasta)}]}))
 
+(def default-testing-handler
+  {:channel_type :channel/metabase-test})
+
 (def default-slack-handler
   {:channel_type :channel/slack
    :recipients   [{:type    :notification-recipient/raw-value


### PR DESCRIPTION
Introduce an expression syntax that'll be used for conditional notification. 

Design goals:
- Simplicity: you should be able to easily understand what an expression do
- Support basic boolean operands and functions
- Composable
- Serializable
- Language agnostic: as FE will need to be able to construct this expression

Grammar:
```
<expr> ::= <literal> | <func_eval>

<literal> ::= <number> | <string> | <boolean>
<number> ::= integer or decimal
<string> ::= quoted text
<boolean> ::= true | false

<func_eval> ::= [<func>, <expr>*]

<func> ::= "and" | "or" | "=" | ">" | "<" | ">=" | "<=" | "max" | "min" | "count" | "context"
<expr>* ::= zero or more expressions or paths
```

Examples:
```clojure
;; Simple comparison - "Is the user_id equal to 1?"
["=", ["context", "user_id"], 1]

;; Logical combination - "Are there any rows AND is the user_id equal to 1?"
["and",
 [">", ["context", "rows", "count"], 0],
 ["=", ["context", "user_id"], 1]]

;; More complex example - "Is the maximum value in rows greater than threshold OR count less than limit?"
["or",
 [">", ["max", ["context", "rows"]], ["context", "threshold"]],
 ["<", ["count", ["context", "items"]], ["context", "limit"]]]
```


An alternative is to use a json based structure that looks like this

```json
{
  "type": "operation",
  "operator": "or",
  "operands": [
    {
      "type": "operation",
      "operator": "gt",
      "operands": [
        {
          "type": "function",
          "name": "max",
          "arguments": [
            { "type": "path", "path": ["rows"] }
          ]
        },
        { "type": "path", "path": ["threshold"] }
      ]
    },
    {
      "type": "operation",
      "operator": "lt",
      "operands": [
        {
          "type": "function",
          "name": "count",
          "arguments": [
            { "type": "path", "path": ["items"] }
          ]
        },
        { "type": "path", "path": ["limit"] }
      ]
    }
  ]
}
```
I'm open to discussion but I'm not sure this adds more value than the array-based version.
FWIW: query builder is using an array-based syntax for custom expressions, so we have some precedence there.

Future works:
- Expression schema
- Macro to `register-operator` that supports inputs and outputs schema
- Operator description (UI should be able to use it to display helper text)
- Convert to cljc (so FE can shared?)