### PR TITLE
Update embedding team codeowners files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 
 enterprise/frontend/src/embedding-sdk @metabase/embedding
 frontend/src/metabase/embedding-sdk @metabase/embedding
+frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
+frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 # snowplow/* @metabase/data
 e2e @filiphric


### PR DESCRIPTION
This would help reviewing PRs from other teams easier. Since we'd be able to filter by files we own. For example, when reviewing https://github.com/metabase/metabase/pull/54703, I need to manually filter file by name `embed` otherwise, these 2 new files I added won't be shown if I just filter files by the current codeowner files.
