### PR TITLE
Fix incorrect condition to hide parameters section in SubscriptionSid…

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.tsx
@@ -7,6 +7,7 @@ import CollapseSection from "metabase/components/CollapseSection";
 import CS from "metabase/css/core/index.css";
 import { getPulseParameters } from "metabase/lib/pulse";
 import { ParametersList } from "metabase/parameters/components/ParametersList";
+import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import {
   PULSE_PARAM_USE_DEFAULT,
@@ -59,13 +60,8 @@ export const MutableParametersSection = ({
   };
 
   const connectedParameters = useMemo(() => {
-    return parameters.filter(parameter => {
-      if ("fields" in parameter) {
-        return parameter.fields?.length > 0;
-      }
-      return false;
-    });
-  }, [parameters]);
+    return getVisibleParameters(parameters, hiddenParameters);
+  }, [parameters, hiddenParameters]);
 
   return _.isEmpty(connectedParameters) ? null : (
     <CollapseSection

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/premium.unit.spec.ts
@@ -14,11 +14,22 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
     dashboard_subscription_filters: true,
   };
 
-  describe("Email Subscription sidebar", () => {
-    it("should not show advanced filtering options with no mapped parameters", async () => {
+  [
+    {
+      channel: "email",
+      buttonText: "Email it",
+      headerText: "Email this dashboard",
+    },
+    {
+      channel: "slack",
+      buttonText: "Send it to Slack",
+      headerText: "Send this dashboard to Slack",
+    },
+  ].forEach(({ channel, buttonText, headerText }) => {
+    it(`${channel} channel: should not show advanced filtering options with no mapped parameters`, async () => {
       setup({
         isAdmin: true,
-        email: true,
+        [channel]: true,
         tokenFeatures,
         hasEnterprisePlugins: true,
         dashcards: [
@@ -28,21 +39,21 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
         ],
       });
 
-      await userEvent.click(await screen.findByText("Email it"));
+      await userEvent.click(await screen.findByText(buttonText));
 
-      await screen.findByText("Email this dashboard");
+      screen.getByText(headerText);
 
       expect(hasAdvancedFilterOptionsHidden(screen)).toBe(true);
     });
 
-    it("should show all mapped parameters in advanced filtering options", async () => {
-      const TOTAL_PARAMETER = createMockParameter({
+    it(`${channel} channel: should show all mapped parameters in advanced filtering options`, async () => {
+      const totalParameter = createMockParameter({
         id: "1",
         type: "number/=",
         slug: "total",
         name: "Total",
       });
-      const TITLE_PARAMETER = createMockParameter({
+      const titleParameter = createMockParameter({
         id: "2",
         type: "string/contains",
         slug: "title",
@@ -52,21 +63,21 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
         id: 1,
         name: "Numeric Question",
         display: "table",
-        parameters: [TOTAL_PARAMETER],
+        parameters: [totalParameter],
       });
       const mockCardString = createMockCard({
         id: 2,
         name: "String Question",
         display: "pie",
-        parameters: [TITLE_PARAMETER],
+        parameters: [titleParameter],
       });
 
       setup({
         isAdmin: true,
-        email: true,
+        [channel]: true,
         tokenFeatures,
         hasEnterprisePlugins: true,
-        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
+        parameters: [totalParameter, titleParameter],
         dashcards: [
           createMockDashboardCard({
             id: mockCardNumeric.id,
@@ -75,8 +86,8 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
             parameter_mappings: [
               {
                 card_id: mockCardNumeric.id,
-                parameter_id: TOTAL_PARAMETER.id,
-                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
+                parameter_id: totalParameter.id,
+                target: ["variable", ["template-tag", totalParameter.slug]],
               },
             ],
           }),
@@ -87,10 +98,10 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
             parameter_mappings: [
               {
                 card_id: mockCardString.id,
-                parameter_id: TITLE_PARAMETER.id,
+                parameter_id: titleParameter.id,
                 target: [
                   "dimension",
-                  ["field", TITLE_PARAMETER.slug, { "base-type": "type/Text" }],
+                  ["field", titleParameter.slug, { "base-type": "type/Text" }],
                 ],
               },
             ],
@@ -98,9 +109,9 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
         ],
       });
 
-      await userEvent.click(await screen.findByText("Email it"));
+      await userEvent.click(await screen.findByText(buttonText));
 
-      await screen.findByText("Email this dashboard");
+      screen.getByText(headerText);
 
       const subscriptionParametersSection = screen.getByTestId(
         "subscription-parameters-section",
@@ -116,14 +127,14 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
       ).toBeInTheDocument();
     });
 
-    it("should show only mapped parameters in advanced filtering options", async () => {
-      const TOTAL_PARAMETER = createMockParameter({
+    it(`${channel} channel: should show only mapped parameters in advanced filtering options`, async () => {
+      const totalParameter = createMockParameter({
         id: "1",
         type: "number/=",
         slug: "total",
         name: "Total",
       });
-      const TITLE_PARAMETER = createMockParameter({
+      const titleParameter = createMockParameter({
         id: "2",
         type: "string/contains",
         slug: "title",
@@ -133,21 +144,21 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
         id: 1,
         name: "Numeric Question",
         display: "table",
-        parameters: [TOTAL_PARAMETER],
+        parameters: [totalParameter],
       });
       const mockCardString = createMockCard({
         id: 2,
         name: "String Question",
         display: "pie",
-        parameters: [TITLE_PARAMETER],
+        parameters: [titleParameter],
       });
 
       setup({
         isAdmin: true,
-        email: true,
+        [channel]: true,
         tokenFeatures,
         hasEnterprisePlugins: true,
-        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
+        parameters: [totalParameter, titleParameter],
         dashcards: [
           createMockDashboardCard({
             id: mockCardNumeric.id,
@@ -156,8 +167,8 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
             parameter_mappings: [
               {
                 card_id: mockCardNumeric.id,
-                parameter_id: TOTAL_PARAMETER.id,
-                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
+                parameter_id: totalParameter.id,
+                target: ["variable", ["template-tag", totalParameter.slug]],
               },
             ],
           }),
@@ -170,184 +181,9 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
         ],
       });
 
-      await userEvent.click(await screen.findByText("Email it"));
+      await userEvent.click(await screen.findByText(buttonText));
 
-      await screen.findByText("Email this dashboard");
-
-      const subscriptionParametersSection = screen.getByTestId(
-        "subscription-parameters-section",
-      );
-
-      expect(subscriptionParametersSection).toBeInTheDocument();
-
-      expect(
-        await within(subscriptionParametersSection).findByLabelText("Total"),
-      ).toBeInTheDocument();
-      expect(
-        within(subscriptionParametersSection).queryByLabelText("Title"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Slack Subscription sidebar", () => {
-    it("should not show advanced filtering options with no mapped parameters", async () => {
-      setup({
-        isAdmin: true,
-        slack: true,
-        tokenFeatures,
-        hasEnterprisePlugins: true,
-        dashcards: [
-          createMockDashboardCard({
-            parameter_mappings: [],
-          }),
-        ],
-      });
-
-      await userEvent.click(await screen.findByText("Send it to Slack"));
-
-      await screen.findByText("Send this dashboard to Slack");
-
-      expect(hasAdvancedFilterOptionsHidden(screen)).toBe(true);
-    });
-
-    it("should show all mapped parameters in advanced filtering options", async () => {
-      const TOTAL_PARAMETER = createMockParameter({
-        id: "1",
-        type: "number/=",
-        slug: "total",
-        name: "Total",
-      });
-      const TITLE_PARAMETER = createMockParameter({
-        id: "2",
-        type: "string/contains",
-        slug: "title",
-        name: "Title",
-      });
-      const mockCardNumeric = createMockCard({
-        id: 1,
-        name: "Numeric Question",
-        display: "table",
-        parameters: [TOTAL_PARAMETER],
-      });
-      const mockCardString = createMockCard({
-        id: 2,
-        name: "String Question",
-        display: "pie",
-        parameters: [TITLE_PARAMETER],
-      });
-
-      setup({
-        isAdmin: true,
-        slack: true,
-        tokenFeatures,
-        hasEnterprisePlugins: true,
-        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
-        dashcards: [
-          createMockDashboardCard({
-            id: mockCardNumeric.id,
-            card: mockCardNumeric,
-            card_id: mockCardNumeric.id,
-            parameter_mappings: [
-              {
-                card_id: mockCardNumeric.id,
-                parameter_id: TOTAL_PARAMETER.id,
-                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
-              },
-            ],
-          }),
-          createMockDashboardCard({
-            id: mockCardString.id,
-            card: mockCardString,
-            card_id: mockCardString.id,
-            parameter_mappings: [
-              {
-                card_id: mockCardString.id,
-                parameter_id: TITLE_PARAMETER.id,
-                target: [
-                  "dimension",
-                  ["field", TITLE_PARAMETER.slug, { "base-type": "type/Text" }],
-                ],
-              },
-            ],
-          }),
-        ],
-      });
-
-      await userEvent.click(await screen.findByText("Send it to Slack"));
-
-      await screen.findByText("Send this dashboard to Slack");
-
-      const subscriptionParametersSection = screen.getByTestId(
-        "subscription-parameters-section",
-      );
-
-      expect(subscriptionParametersSection).toBeInTheDocument();
-
-      expect(
-        await within(subscriptionParametersSection).findByLabelText("Total"),
-      ).toBeInTheDocument();
-      expect(
-        await within(subscriptionParametersSection).findByLabelText("Title"),
-      ).toBeInTheDocument();
-    });
-
-    it("should show only mapped parameters in advanced filtering options", async () => {
-      const TOTAL_PARAMETER = createMockParameter({
-        id: "1",
-        type: "number/=",
-        slug: "total",
-        name: "Total",
-      });
-      const TITLE_PARAMETER = createMockParameter({
-        id: "2",
-        type: "string/contains",
-        slug: "title",
-        name: "Title",
-      });
-      const mockCardNumeric = createMockCard({
-        id: 1,
-        name: "Numeric Question",
-        display: "table",
-        parameters: [TOTAL_PARAMETER],
-      });
-      const mockCardString = createMockCard({
-        id: 2,
-        name: "String Question",
-        display: "pie",
-        parameters: [TITLE_PARAMETER],
-      });
-
-      setup({
-        isAdmin: true,
-        slack: true,
-        tokenFeatures,
-        hasEnterprisePlugins: true,
-        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
-        dashcards: [
-          createMockDashboardCard({
-            id: mockCardNumeric.id,
-            card: mockCardNumeric,
-            card_id: mockCardNumeric.id,
-            parameter_mappings: [
-              {
-                card_id: mockCardNumeric.id,
-                parameter_id: TOTAL_PARAMETER.id,
-                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
-              },
-            ],
-          }),
-          createMockDashboardCard({
-            id: mockCardString.id,
-            card: mockCardString,
-            card_id: mockCardString.id,
-            parameter_mappings: [],
-          }),
-        ],
-      });
-
-      await userEvent.click(await screen.findByText("Send it to Slack"));
-
-      await screen.findByText("Send this dashboard to Slack");
+      screen.getByText(headerText);
 
       const subscriptionParametersSection = screen.getByTestId(
         "subscription-parameters-section",

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/premium.unit.spec.ts
@@ -1,6 +1,11 @@
 import userEvent from "@testing-library/user-event";
 
-import { screen } from "__support__/ui";
+import { screen, within } from "__support__/ui";
+import {
+  createMockCard,
+  createMockDashboardCard,
+  createMockParameter,
+} from "metabase-types/api/mocks";
 
 import { hasAdvancedFilterOptionsHidden, setup } from "./setup";
 
@@ -10,12 +15,17 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
   };
 
   describe("Email Subscription sidebar", () => {
-    it("should show advanced filtering options with the correct feature flag", async () => {
+    it("should not show advanced filtering options with no mapped parameters", async () => {
       setup({
         isAdmin: true,
         email: true,
         tokenFeatures,
         hasEnterprisePlugins: true,
+        dashcards: [
+          createMockDashboardCard({
+            parameter_mappings: [],
+          }),
+        ],
       });
 
       await userEvent.click(await screen.findByText("Email it"));
@@ -24,15 +34,173 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
 
       expect(hasAdvancedFilterOptionsHidden(screen)).toBe(true);
     });
+
+    it("should show all mapped parameters in advanced filtering options", async () => {
+      const TOTAL_PARAMETER = createMockParameter({
+        id: "1",
+        type: "number/=",
+        slug: "total",
+        name: "Total",
+      });
+      const TITLE_PARAMETER = createMockParameter({
+        id: "2",
+        type: "string/contains",
+        slug: "title",
+        name: "Title",
+      });
+      const mockCardNumeric = createMockCard({
+        id: 1,
+        name: "Numeric Question",
+        display: "table",
+        parameters: [TOTAL_PARAMETER],
+      });
+      const mockCardString = createMockCard({
+        id: 2,
+        name: "String Question",
+        display: "pie",
+        parameters: [TITLE_PARAMETER],
+      });
+
+      setup({
+        isAdmin: true,
+        email: true,
+        tokenFeatures,
+        hasEnterprisePlugins: true,
+        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
+        dashcards: [
+          createMockDashboardCard({
+            id: mockCardNumeric.id,
+            card: mockCardNumeric,
+            card_id: mockCardNumeric.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardNumeric.id,
+                parameter_id: TOTAL_PARAMETER.id,
+                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
+              },
+            ],
+          }),
+          createMockDashboardCard({
+            id: mockCardString.id,
+            card: mockCardString,
+            card_id: mockCardString.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardString.id,
+                parameter_id: TITLE_PARAMETER.id,
+                target: [
+                  "dimension",
+                  ["field", TITLE_PARAMETER.slug, { "base-type": "type/Text" }],
+                ],
+              },
+            ],
+          }),
+        ],
+      });
+
+      await userEvent.click(await screen.findByText("Email it"));
+
+      await screen.findByText("Email this dashboard");
+
+      const subscriptionParametersSection = screen.getByTestId(
+        "subscription-parameters-section",
+      );
+
+      expect(subscriptionParametersSection).toBeInTheDocument();
+
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Total"),
+      ).toBeInTheDocument();
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Title"),
+      ).toBeInTheDocument();
+    });
+
+    it("should show only mapped parameters in advanced filtering options", async () => {
+      const TOTAL_PARAMETER = createMockParameter({
+        id: "1",
+        type: "number/=",
+        slug: "total",
+        name: "Total",
+      });
+      const TITLE_PARAMETER = createMockParameter({
+        id: "2",
+        type: "string/contains",
+        slug: "title",
+        name: "Title",
+      });
+      const mockCardNumeric = createMockCard({
+        id: 1,
+        name: "Numeric Question",
+        display: "table",
+        parameters: [TOTAL_PARAMETER],
+      });
+      const mockCardString = createMockCard({
+        id: 2,
+        name: "String Question",
+        display: "pie",
+        parameters: [TITLE_PARAMETER],
+      });
+
+      setup({
+        isAdmin: true,
+        email: true,
+        tokenFeatures,
+        hasEnterprisePlugins: true,
+        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
+        dashcards: [
+          createMockDashboardCard({
+            id: mockCardNumeric.id,
+            card: mockCardNumeric,
+            card_id: mockCardNumeric.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardNumeric.id,
+                parameter_id: TOTAL_PARAMETER.id,
+                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
+              },
+            ],
+          }),
+          createMockDashboardCard({
+            id: mockCardString.id,
+            card: mockCardString,
+            card_id: mockCardString.id,
+            parameter_mappings: [],
+          }),
+        ],
+      });
+
+      await userEvent.click(await screen.findByText("Email it"));
+
+      await screen.findByText("Email this dashboard");
+
+      const subscriptionParametersSection = screen.getByTestId(
+        "subscription-parameters-section",
+      );
+
+      expect(subscriptionParametersSection).toBeInTheDocument();
+
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Total"),
+      ).toBeInTheDocument();
+      expect(
+        within(subscriptionParametersSection).queryByLabelText("Title"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("Slack Subscription sidebar", () => {
-    it("should show advanced filtering options with the correct feature flag", async () => {
+    it("should not show advanced filtering options with no mapped parameters", async () => {
       setup({
         isAdmin: true,
         slack: true,
         tokenFeatures,
         hasEnterprisePlugins: true,
+        dashcards: [
+          createMockDashboardCard({
+            parameter_mappings: [],
+          }),
+        ],
       });
 
       await userEvent.click(await screen.findByText("Send it to Slack"));
@@ -40,6 +208,159 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
       await screen.findByText("Send this dashboard to Slack");
 
       expect(hasAdvancedFilterOptionsHidden(screen)).toBe(true);
+    });
+
+    it("should show all mapped parameters in advanced filtering options", async () => {
+      const TOTAL_PARAMETER = createMockParameter({
+        id: "1",
+        type: "number/=",
+        slug: "total",
+        name: "Total",
+      });
+      const TITLE_PARAMETER = createMockParameter({
+        id: "2",
+        type: "string/contains",
+        slug: "title",
+        name: "Title",
+      });
+      const mockCardNumeric = createMockCard({
+        id: 1,
+        name: "Numeric Question",
+        display: "table",
+        parameters: [TOTAL_PARAMETER],
+      });
+      const mockCardString = createMockCard({
+        id: 2,
+        name: "String Question",
+        display: "pie",
+        parameters: [TITLE_PARAMETER],
+      });
+
+      setup({
+        isAdmin: true,
+        slack: true,
+        tokenFeatures,
+        hasEnterprisePlugins: true,
+        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
+        dashcards: [
+          createMockDashboardCard({
+            id: mockCardNumeric.id,
+            card: mockCardNumeric,
+            card_id: mockCardNumeric.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardNumeric.id,
+                parameter_id: TOTAL_PARAMETER.id,
+                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
+              },
+            ],
+          }),
+          createMockDashboardCard({
+            id: mockCardString.id,
+            card: mockCardString,
+            card_id: mockCardString.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardString.id,
+                parameter_id: TITLE_PARAMETER.id,
+                target: [
+                  "dimension",
+                  ["field", TITLE_PARAMETER.slug, { "base-type": "type/Text" }],
+                ],
+              },
+            ],
+          }),
+        ],
+      });
+
+      await userEvent.click(await screen.findByText("Send it to Slack"));
+
+      await screen.findByText("Send this dashboard to Slack");
+
+      const subscriptionParametersSection = screen.getByTestId(
+        "subscription-parameters-section",
+      );
+
+      expect(subscriptionParametersSection).toBeInTheDocument();
+
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Total"),
+      ).toBeInTheDocument();
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Title"),
+      ).toBeInTheDocument();
+    });
+
+    it("should show only mapped parameters in advanced filtering options", async () => {
+      const TOTAL_PARAMETER = createMockParameter({
+        id: "1",
+        type: "number/=",
+        slug: "total",
+        name: "Total",
+      });
+      const TITLE_PARAMETER = createMockParameter({
+        id: "2",
+        type: "string/contains",
+        slug: "title",
+        name: "Title",
+      });
+      const mockCardNumeric = createMockCard({
+        id: 1,
+        name: "Numeric Question",
+        display: "table",
+        parameters: [TOTAL_PARAMETER],
+      });
+      const mockCardString = createMockCard({
+        id: 2,
+        name: "String Question",
+        display: "pie",
+        parameters: [TITLE_PARAMETER],
+      });
+
+      setup({
+        isAdmin: true,
+        slack: true,
+        tokenFeatures,
+        hasEnterprisePlugins: true,
+        parameters: [TOTAL_PARAMETER, TITLE_PARAMETER],
+        dashcards: [
+          createMockDashboardCard({
+            id: mockCardNumeric.id,
+            card: mockCardNumeric,
+            card_id: mockCardNumeric.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardNumeric.id,
+                parameter_id: TOTAL_PARAMETER.id,
+                target: ["variable", ["template-tag", TOTAL_PARAMETER.slug]],
+              },
+            ],
+          }),
+          createMockDashboardCard({
+            id: mockCardString.id,
+            card: mockCardString,
+            card_id: mockCardString.id,
+            parameter_mappings: [],
+          }),
+        ],
+      });
+
+      await userEvent.click(await screen.findByText("Send it to Slack"));
+
+      await screen.findByText("Send this dashboard to Slack");
+
+      const subscriptionParametersSection = screen.getByTestId(
+        "subscription-parameters-section",
+      );
+
+      expect(subscriptionParametersSection).toBeInTheDocument();
+
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Total"),
+      ).toBeInTheDocument();
+      expect(
+        within(subscriptionParametersSection).queryByLabelText("Title"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -21,8 +21,10 @@ import {
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
-import type { DashboardState } from "metabase-types/store";
-import { createMockState } from "metabase-types/store/mocks";
+import {
+  createMockDashboardState,
+  createMockState,
+} from "metabase-types/store/mocks";
 
 import DashboardSubscriptionsSidebar from "../DashboardSubscriptionsSidebar";
 
@@ -53,7 +55,7 @@ function createDashboardState(
   dashboard: Dashboard,
   dashcards: DashboardCard[],
 ) {
-  return {
+  return createMockDashboardState({
     dashboardId: dashboard.id,
     dashcards: dashcards.reduce(
       (acc, card) => {
@@ -68,7 +70,7 @@ function createDashboardState(
         dashcards: dashcards.map(d => d.id),
       },
     },
-  } as DashboardState;
+  });
 }
 
 export function setup(

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -7,7 +7,12 @@ import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pul
 import { mockSettings } from "__support__/settings";
 import type { Screen } from "__support__/ui";
 import { renderWithProviders } from "__support__/ui";
-import type { TokenFeatures } from "metabase-types/api";
+import type { UiParameter } from "metabase-lib/v1/parameters/types";
+import type {
+  Dashboard,
+  DashboardCard,
+  TokenFeatures,
+} from "metabase-types/api";
 import {
   createMockActionDashboardCard,
   createMockCard,
@@ -33,18 +38,38 @@ const linkDashcard = createMockActionDashboardCard({
 
 export const user = createMockUser();
 
-const dashboard = createMockDashboard({
-  dashcards: [dashcard, actionDashcard, linkDashcard],
-  parameters: [
-    {
-      name: "ID",
-      slug: "id",
-      id: "abcd1234",
-      type: "id",
-      sectionId: "id",
+const defaultDashcards = [dashcard, actionDashcard, linkDashcard];
+const defaultParameters = [
+  {
+    name: "ID",
+    slug: "id",
+    id: "abcd1234",
+    type: "id",
+    sectionId: "id",
+  },
+];
+
+function createDashboardState(
+  dashboard: Dashboard,
+  dashcards: DashboardCard[],
+) {
+  return {
+    dashboardId: dashboard.id,
+    dashcards: dashcards.reduce(
+      (acc, card) => {
+        acc[card.id] = card;
+        return acc;
+      },
+      {} as Record<number, DashboardCard>,
+    ),
+    dashboards: {
+      [dashboard.id]: {
+        ...dashboard,
+        dashcards: dashcards.map(d => d.id),
+      },
     },
-  ],
-});
+  } as DashboardState;
+}
 
 export function setup(
   {
@@ -53,12 +78,16 @@ export function setup(
     tokenFeatures = {},
     hasEnterprisePlugins = false,
     isAdmin = false,
+    dashcards = defaultDashcards,
+    parameters = defaultParameters,
   }: {
     email?: boolean;
     slack?: boolean;
     tokenFeatures?: Partial<TokenFeatures>;
     hasEnterprisePlugins?: boolean;
     isAdmin?: boolean;
+    dashcards?: DashboardCard[];
+    parameters?: UiParameter[];
   } = {
     email: true,
     slack: true,
@@ -67,6 +96,11 @@ export function setup(
     isAdmin: false,
   },
 ) {
+  const dashboard = createMockDashboard({
+    dashcards,
+    parameters,
+  });
+
   const channelData: {
     channels: {
       email?: any;
@@ -135,20 +169,7 @@ export function setup(
         currentUser: createMockUser({
           is_superuser: isAdmin,
         }),
-        dashboard: {
-          dashboardId: dashboard.id,
-          dashcards: {
-            [dashcard.id]: dashcard,
-            [actionDashcard.id]: actionDashcard,
-            [linkDashcard.id]: linkDashcard,
-          },
-          dashboards: {
-            [dashboard.id]: {
-              ...dashboard,
-              dashcards: [dashcard.id, actionDashcard.id, linkDashcard.id],
-            },
-          },
-        } as DashboardState,
+        dashboard: createDashboardState(dashboard, dashcards),
       }),
     },
   );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55205

### Description

This PR fixes incorrect condition to hide advanced filtering section in subscription sidebar, introduced in https://github.com/metabase/metabase/pull/54508

### How to verify

1. Create 1 question: select * from orders where id = {{id}} (parameter is a number)
2. Add it to a dahboard and use a number filter
3. Save it and try to send a subscription, verify that the parameter is present

### Demo

https://github.com/user-attachments/assets/c15824fd-e488-429f-a948-b7220be7f0e9

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
