### PR TITLE
SEM-149 Hide unused semantic types (FE only)

### DIFF
--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
@@ -338,9 +338,9 @@ describe("MetadataEditor", () => {
       );
 
       await userEvent.clear(typeInput);
-      await userEvent.type(typeInput, "Pri");
-      expect(popover.getByText("Price")).toBeInTheDocument();
-      expect(popover.queryByText("Score")).not.toBeInTheDocument();
+      await userEvent.type(typeInput, "Ci");
+      expect(popover.getByText("City")).toBeInTheDocument();
+      expect(popover.queryByText("Category")).not.toBeInTheDocument();
     });
 
     it("should show the foreign key target for foreign keys", async () => {

--- a/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
@@ -1,0 +1,61 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { TYPE } from "metabase-lib/v1/types/constants";
+
+import { SemanticTypePicker } from "./SemanticTypePicker";
+
+interface SetupOpts {
+  initialValue?: string | null;
+}
+
+function TestComponent({ initialValue = null }: SetupOpts) {
+  const [value, setValue] = useState<string | null>(initialValue);
+
+  return <SemanticTypePicker value={value} onChange={setValue} />;
+}
+
+const setup = ({ initialValue }: SetupOpts = {}) => {
+  renderWithProviders(<TestComponent initialValue={initialValue} />);
+};
+
+describe("SemanticTypePicker", () => {
+  it("does not show deprecated semantic types", async () => {
+    setup();
+
+    const picker = screen.getByPlaceholderText("Select a semantic type");
+    await userEvent.click(picker);
+
+    const dropdown = within(screen.getByRole("listbox"));
+    expect(dropdown.getByText("Creation date")).toBeInTheDocument();
+    expect(dropdown.queryByText("Cancelation date")).not.toBeInTheDocument();
+  });
+
+  it("shows deprecated semantic type if it is already selected", async () => {
+    setup({ initialValue: TYPE.CancelationDate });
+
+    expect(screen.getByText("Cancelation date")).toBeInTheDocument();
+
+    const picker = screen.getByPlaceholderText("Select a semantic type");
+    await userEvent.click(picker);
+
+    const dropdown = within(screen.getByRole("listbox"));
+    expect(dropdown.getByText("Creation date")).toBeInTheDocument();
+    expect(dropdown.getByText("Cancelation date")).toBeInTheDocument();
+  });
+
+  it("hides deprecated semantic type after it is deselected", async () => {
+    setup({ initialValue: TYPE.CancelationDate });
+
+    expect(screen.getByText("Cancelation date")).toBeInTheDocument();
+
+    const picker = screen.getByPlaceholderText("Select a semantic type");
+    await userEvent.click(picker);
+    const dropdown = within(screen.getByRole("listbox"));
+    await userEvent.click(dropdown.getByText("Creation date"));
+    await userEvent.click(picker);
+
+    expect(dropdown.queryByText("Cancelation date")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/lib/core.ts
+++ b/frontend/src/metabase/lib/core.ts
@@ -342,6 +342,28 @@ export const FIELD_SEMANTIC_TYPES: FieldSemanticType[] = [
   },
 ];
 
+export const DEPRECATED_FIELD_SEMANTIC_TYPES: FieldSemanticType["id"][] = [
+  TYPE.CancelationDate,
+  TYPE.CancelationTime,
+  TYPE.CancelationTimestamp,
+  TYPE.Comment,
+  TYPE.Company,
+  TYPE.Cost,
+  TYPE.DeletionDate,
+  TYPE.DeletionTime,
+  TYPE.DeletionTimestamp,
+  TYPE.Description,
+  TYPE.Enum,
+  TYPE.GrossMargin,
+  TYPE.Owner,
+  TYPE.Price,
+  TYPE.Share,
+  TYPE.Subscription,
+  TYPE.UpdatedDate,
+  TYPE.UpdatedTime,
+  TYPE.UpdatedTimestamp,
+];
+
 export const FIELD_SEMANTIC_TYPES_MAP = FIELD_SEMANTIC_TYPES.reduce(
   (map, type) => Object.assign({}, map, { [type.id]: type }),
   {},


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-149/hide-unused-semantic-types-fe-only

### Description

Hides unused semantic types from the Semantic Type picker.
If user already has a given semantic type selected, keep it in the dropdown.

This change is done only in 1 component. We [plan](https://linear.app/metabase/issue/SEM-176/use-new-semantic-type-picker-everywhere) to bring this component everywhere else (this week) - that's how this change is going to propagate.

### How to verify

1. Be on `master`
2. Go to Admin > Table Metadata > Orders
3. Change any field's semantic type to e.g. "Cancelation Date"
4. Check out this branch
5. Go to Admin > Table Metadata > Orders
6. Notice that "Cancelation Date" is still displayed for your field semantic type
7. Edit it and change it to "Creation Date"
8. Wait for notification to appear in bottom left corner of the screen
9. Click to edit it
10. Verify "Cancelation Date" is not on the list of options anymore
11. Verify that all other unused types are not on that list (see issue description)

### Demo

https://github.com/user-attachments/assets/5b91f5f1-9e14-4721-ae72-4dde535a7763
