### PR TITLE
Control visible entities in simple data picker

### DIFF
--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -909,6 +909,24 @@ describe("scenarios > embedding > full app", () => {
       cy.intercept("GET", "/api/table/*/query_metadata").as("getTableMetadata");
     });
 
+    it('should respect "entity_types" search parameter (EMB-228)', () => {
+      cy.log('test `entity_types=["table"]`');
+      startNewEmbeddingQuestion({
+        isMultiStageDataPicker: true,
+        searchParameters: { entity_types: "table" },
+      });
+      H.popover().within(() => {
+        /**
+         * When we're in table step, it means we don't show models, otherwise, we would have shown
+         * the bucket step which has "Raw Data" and "Models" options instead.
+         */
+        cy.findByText("Sample Database").should("be.visible");
+        cy.findByRole("heading", { name: "Orders" }).should("be.visible");
+      });
+
+      // We don't have to test every permutations here because we already cover those cases in `EmbeddingDataPicker.unit.spec.tsx`
+    });
+
     describe("table", () => {
       it("should select a table in the only database", () => {
         startNewEmbeddingQuestion({ isMultiStageDataPicker: true });

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -395,7 +395,7 @@ describe("scenarios > embedding > full app", () => {
       cy.log("test default `entity_types`");
       startNewEmbeddingQuestion();
       H.popover().within(() => {
-        cy.findByRole("link", { name: "Orders" }).should("be.visible");
+        cy.findByRole("link", { name: "Reviews" }).should("be.visible");
         cy.findByRole("link", { name: "Orders Model" }).should("be.visible");
       });
 
@@ -404,7 +404,7 @@ describe("scenarios > embedding > full app", () => {
         searchParameters: { entity_types: "table" },
       });
       H.popover().within(() => {
-        cy.findByRole("link", { name: "Orders" }).should("be.visible");
+        cy.findByRole("link", { name: "Reviews" }).should("be.visible");
         cy.findByRole("link", { name: "Orders Model" }).should("not.exist");
       });
 
@@ -413,7 +413,7 @@ describe("scenarios > embedding > full app", () => {
         searchParameters: { entity_types: "model" },
       });
       H.popover().within(() => {
-        cy.findByRole("link", { name: "Orders" }).should("not.exist");
+        cy.findByRole("link", { name: "Reviews" }).should("not.exist");
         cy.findByRole("link", { name: "Orders Model" }).should("be.visible");
       });
     });

--- a/enterprise/frontend/src/embedding-sdk/components/private/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SimpleDataPicker/SimpleDataPicker.tsx
@@ -105,7 +105,7 @@ function translateEntityTypesToSearchModels(
   }
 
   if (entityTypes.includes("table")) {
-    searchModels.push("card");
+    searchModels.push("table");
   }
 
   return searchModels;

--- a/enterprise/frontend/src/embedding-sdk/components/private/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SimpleDataPicker/SimpleDataPicker.tsx
@@ -1,22 +1,16 @@
 import { useDisclosure } from "@mantine/hooks";
-import { type ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useSearchQuery } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
+import type { EmbeddingEntityType } from "metabase/embedding-sdk/store";
+import type { SimpleDataPickerProps } from "metabase/plugins";
 import { Box, Popover } from "metabase/ui";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type { SearchResult, TableId } from "metabase-types/api";
+import type { SearchModel, SearchResult, TableId } from "metabase-types/api";
 import { SortDirection } from "metabase-types/api/sorting";
 
 import { SimpleDataPickerView } from "./SimpleDataPickerView";
-
-interface SimpleDataPickerProps {
-  filterByDatabaseId: number | null;
-  selectedEntity?: TableId;
-  isInitiallyOpen: boolean;
-  triggerElement: ReactNode;
-  setSourceTableFn: (tableId: TableId) => void;
-}
 
 export function SimpleDataPicker({
   filterByDatabaseId,
@@ -24,12 +18,13 @@ export function SimpleDataPicker({
   isInitiallyOpen,
   setSourceTableFn,
   triggerElement,
+  entityTypes,
 }: SimpleDataPickerProps) {
   const [isDataPickerOpened, { toggle, close }] =
     useDisclosure(isInitiallyOpen);
   const { data, isLoading, error } = useSearchQuery({
     table_db_id: filterByDatabaseId ? filterByDatabaseId : undefined,
-    models: ["dataset", "table"],
+    models: translateEntityTypesToSearchModels(entityTypes),
   });
 
   const options = useMemo(() => {
@@ -99,3 +94,19 @@ function sortEntities(
 }
 
 const compareString = (a: string, b: string) => a.localeCompare(b);
+
+function translateEntityTypesToSearchModels(
+  entityTypes: EmbeddingEntityType[],
+): SearchModel[] {
+  const searchModels: SearchModel[] = [];
+
+  if (entityTypes.includes("model")) {
+    searchModels.push("dataset");
+  }
+
+  if (entityTypes.includes("table")) {
+    searchModels.push("card");
+  }
+
+  return searchModels;
+}

--- a/enterprise/frontend/src/embedding-sdk/components/private/SimpleDataPicker/SimpleDataPicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SimpleDataPicker/SimpleDataPicker.unit.spec.tsx
@@ -31,6 +31,7 @@ function setup(opts?: SetupOpts) {
   const onClick = jest.fn();
   renderWithProviders(
     <SimpleDataPicker
+      entityTypes={["model", "table"]}
       isInitiallyOpen={true}
       setSourceTableFn={onClick}
       filterByDatabaseId={null}

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -34,6 +34,7 @@ import type {
   ModelFilterSettings,
 } from "metabase/browse/models";
 import type { LinkProps } from "metabase/core/components/Link";
+import type { EmbeddingEntityType } from "metabase/embedding-sdk/store";
 import { getIconBase } from "metabase/lib/icon";
 import PluginPlaceholder from "metabase/plugins/components/PluginPlaceholder";
 import type { SearchFilterComponent } from "metabase/search/types";
@@ -60,6 +61,7 @@ import type {
   ModelCacheRefreshStatus,
   Pulse,
   Revision,
+  TableId,
   User,
 } from "metabase-types/api";
 import type { AdminPathKey, State } from "metabase-types/store";
@@ -528,9 +530,18 @@ export const PLUGIN_EMBEDDING = {
   isInteractiveEmbeddingEnabled: (_state: State) => false,
 };
 
+export interface SimpleDataPickerProps {
+  filterByDatabaseId: number | null;
+  selectedEntity?: TableId;
+  isInitiallyOpen: boolean;
+  triggerElement: ReactNode;
+  setSourceTableFn: (tableId: TableId) => void;
+  entityTypes: EmbeddingEntityType[];
+}
+
 export const PLUGIN_EMBEDDING_SDK = {
   isEnabled: () => false,
-  SimpleDataPicker: (_props: any) => null,
+  SimpleDataPicker: (_props: SimpleDataPickerProps) => null,
 };
 
 export const PLUGIN_CONTENT_VERIFICATION = {

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -89,6 +89,7 @@ export function EmbeddingDataPicker({
           />
         }
         setSourceTableFn={onChange}
+        entityTypes={entityTypes}
       />
     );
   }


### PR DESCRIPTION
Closes EMB-272

### Description

Control the visibility of Tables/models in the simple data picker (when no. of combined tables + models is less than 100)

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Ensure you don't have the number of combined models and tables more than 99. That's very likely anyway 😆 
1. Embed this in interactive embedding.
1. You can now try different versions of the `entity_types` parameter. You can see the expectations from [the tests](https://github.com/metabase/metabase/blob/cad3316cd19cf3b554470823893a8a4776a7d154/frontend/src/metabase/redux/embed/embed.unit.spec.ts#L44-L159).
    - `entity_types=table`
    - `entity_types=table&entity_types=model`
    - `entity_types=table,model` / `entity_types= table , model `
    - `entity_types=invalid`
    - `entity_types=`
    - or not passing the entity types at all.
1. Other data selectors should behave the same e.g. database selector in SQL query editor
1. The SDK still works as expected. We won't be able to set the desired `entityTypes` yet, it will be completed in EMB-231

### Demo
#### Tables and Models
![image](https://github.com/user-attachments/assets/d7a842b0-10db-46b0-9d75-c0627308864e)

#### Only tables
![image](https://github.com/user-attachments/assets/70feee7a-1dba-4df8-927d-4cadf972e0e2)

#### Only models
![image](https://github.com/user-attachments/assets/4590ebe8-bc07-4ddf-b632-80654cb16a37)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
