### PR TITLE
Control visible entities on new item menu dropdown

### DIFF
--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -97,6 +97,7 @@ class EntityMenu extends Component {
                 }
 
                 const key = item.key ?? item.title;
+                const itemId = `entity-menu-item-${encodeURIComponent(key)}`;
 
                 if (item.separator) {
                   return (
@@ -108,8 +109,13 @@ class EntityMenu extends Component {
 
                 if (item.content) {
                   return (
-                    <li key={key} data-testid={item.testId}>
+                    <li
+                      key={key}
+                      data-testid={item.testId}
+                      aria-labelledby={itemId}
+                    >
                       <EntityMenuItem
+                        htmlId={itemId}
                         icon={item.icon}
                         title={item.title}
                         action={() =>
@@ -135,8 +141,13 @@ class EntityMenu extends Component {
                 }
 
                 return (
-                  <li key={key} data-testid={item.testId}>
+                  <li
+                    key={key}
+                    data-testid={item.testId}
+                    aria-labelledby={itemId}
+                  >
                     <EntityMenuItem
+                      htmlId={itemId}
                       icon={item.icon}
                       title={item.title}
                       externalLink={item.externalLink}

--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
@@ -24,6 +24,7 @@ export interface EntityMenuItemProps {
   hoverBgColor?: ColorName;
   disabled?: boolean;
   onClose?: () => void;
+  htmlId?: string;
 }
 
 const EntityMenuItem = ({
@@ -38,6 +39,7 @@ const EntityMenuItem = ({
   hoverColor,
   hoverBgColor,
   onClose,
+  htmlId,
 }: EntityMenuItemProps): JSX.Element | null => {
   if (link && action) {
     // You cannot specify both action and link props!
@@ -51,8 +53,8 @@ const EntityMenuItem = ({
       hoverColor={hoverColor}
       hoverBgColor={hoverBgColor}
     >
-      {icon && <MenuItemIcon name={icon} size={16} />}
-      <MenuItemTitle>{title}</MenuItemTitle>
+      {icon && <MenuItemIcon name={icon} size={16} aria-hidden />}
+      <MenuItemTitle id={htmlId}>{title}</MenuItemTitle>
     </MenuItemContent>
   );
 

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -120,7 +120,12 @@ const NewItemMenu = ({
       });
     }
 
-    if (hasModels && hasDatabaseWithActionsEnabled && hasNativeWrite) {
+    if (
+      hasModels &&
+      hasDatabaseWithActionsEnabled &&
+      hasNativeWrite &&
+      !isEmbeddingIframe
+    ) {
       items.push({
         title: t`Action`,
         icon: "bolt",

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -7,6 +7,10 @@ import EntityMenu from "metabase/components/EntityMenu";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { setOpenModal } from "metabase/redux/ui";
+import {
+  getEmbedOptions,
+  getIsEmbeddingIframe,
+} from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
 import type { CollectionId } from "metabase-types/api";
 
@@ -48,6 +52,8 @@ const NewItemMenu = ({
   onCloseNavbar,
 }: NewItemMenuProps) => {
   const dispatch = useDispatch();
+  const entityTypes = useSelector(state => getEmbedOptions(state).entity_types);
+  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
 
   const lastUsedDatabaseId = useSelector(state =>
     getSetting(state, "last-used-native-database-id"),
@@ -98,7 +104,10 @@ const NewItemMenu = ({
       },
     );
 
-    if (hasNativeWrite) {
+    if (
+      hasNativeWrite &&
+      (!isEmbeddingIframe || entityTypes.includes("model"))
+    ) {
       const collectionQuery = collectionId
         ? `?collectionId=${collectionId}`
         : "";
@@ -119,7 +128,7 @@ const NewItemMenu = ({
       });
     }
 
-    if (hasDataAccess) {
+    if (hasDataAccess && !isEmbeddingIframe) {
       items.push({
         title: t`Metric`,
         icon: "metric",
@@ -136,13 +145,15 @@ const NewItemMenu = ({
   }, [
     hasDataAccess,
     hasNativeWrite,
+    isEmbeddingIframe,
+    entityTypes,
     hasModels,
     hasDatabaseWithActionsEnabled,
     collectionId,
     onCloseNavbar,
     hasDatabaseWithJsonEngine,
-    dispatch,
     lastUsedDatabaseId,
+    dispatch,
   ]);
 
   return (


### PR DESCRIPTION
Closes EMB-230

### Description
Hide new item menu dropdown item according to [these rules.](https://www.notion.so/metabase/Tech-Let-embedders-hide-tables-1ae69354c9018057bc1ddcf987443164?pvs=4#1bb69354c90180a3be06ea96c70ecdab)

### How to verify
1. Embed interactive embedding.
2. ensure the iframe URL is resolved to your Metabase instance with these search parameters
    - `?new_button=true`
    - `?new_button=true&entity_types=model,table` same behavior as the one above as this is the default value
    - `?new_button=true&entity_types=model` same behavior as the one above since it's still containing `model`
    - `?new_button=true&entity_types=table` this is the only different case, we'll hide Model here.

### Demo
#### `entity_types: ["model", "table"]`
<img width="249" alt="image" src="https://github.com/user-attachments/assets/607bcda9-ebe9-44dc-be48-32dbd644fece" />

#### `entity_types: ["model"]`
<img width="249" alt="image" src="https://github.com/user-attachments/assets/fcbaadd8-9fa9-4247-9af4-2ba3c26a982f" />

#### `entity_types: ["table"]`
<img width="239" alt="image" src="https://github.com/user-attachments/assets/870b4266-6d92-4702-b8a6-60aa4a853378" />

#### Before
<img width="240" alt="image" src="https://github.com/user-attachments/assets/9f94bb84-3cae-48da-b6ea-8de18b517749" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
