### PR TITLE
Control visible entities in Browse sidebar

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -3,6 +3,11 @@ import { c, t } from "ttag";
 import { useUserSetting } from "metabase/common/hooks";
 import CollapseSection from "metabase/components/CollapseSection";
 import CS from "metabase/css/core/index.css";
+import { useSelector } from "metabase/lib/redux";
+import {
+  getEmbedOptions,
+  getIsEmbeddingIframe,
+} from "metabase/selectors/embed";
 
 import { PaddedSidebarLink, SidebarHeading } from "../MainNavbar.styled";
 import type { SelectedItem } from "../types";
@@ -24,6 +29,9 @@ export const BrowseNavSection = ({
     "expand-browse-in-nav",
   );
 
+  const entityTypes = useSelector(state => getEmbedOptions(state).entity_types);
+  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+
   return (
     <CollapseSection
       header={
@@ -36,37 +44,42 @@ export const BrowseNavSection = ({
       headerClass={CS.mb1}
       onToggle={setExpandBrowse}
     >
-      <PaddedSidebarLink
-        icon="model"
-        url={BROWSE_MODELS_URL}
-        isSelected={nonEntityItem?.url?.startsWith(BROWSE_MODELS_URL)}
-        onClick={onItemSelect}
-        aria-label={t`Browse models`}
-      >
-        {t`Models`}
-      </PaddedSidebarLink>
-
-      {hasDataAccess && (
+      {(!isEmbeddingIframe || entityTypes.includes("model")) && (
         <PaddedSidebarLink
-          icon="database"
-          url={BROWSE_DATA_URL}
-          isSelected={nonEntityItem?.url?.startsWith(BROWSE_DATA_URL)}
+          icon="model"
+          url={BROWSE_MODELS_URL}
+          isSelected={nonEntityItem?.url?.startsWith(BROWSE_MODELS_URL)}
           onClick={onItemSelect}
-          aria-label={t`Browse databases`}
+          aria-label={t`Browse models`}
         >
-          {t`Databases`}
+          {t`Models`}
         </PaddedSidebarLink>
       )}
 
-      <PaddedSidebarLink
-        icon="metric"
-        url={BROWSE_METRICS_URL}
-        isSelected={nonEntityItem?.url?.startsWith(BROWSE_METRICS_URL)}
-        onClick={onItemSelect}
-        aria-label={t`Browse metrics`}
-      >
-        {t`Metrics`}
-      </PaddedSidebarLink>
+      {hasDataAccess &&
+        (!isEmbeddingIframe || entityTypes.includes("table")) && (
+          <PaddedSidebarLink
+            icon="database"
+            url={BROWSE_DATA_URL}
+            isSelected={nonEntityItem?.url?.startsWith(BROWSE_DATA_URL)}
+            onClick={onItemSelect}
+            aria-label={t`Browse databases`}
+          >
+            {t`Databases`}
+          </PaddedSidebarLink>
+        )}
+
+      {!isEmbeddingIframe && (
+        <PaddedSidebarLink
+          icon="metric"
+          url={BROWSE_METRICS_URL}
+          isSelected={nonEntityItem?.url?.startsWith(BROWSE_METRICS_URL)}
+          onClick={onItemSelect}
+          aria-label={t`Browse metrics`}
+        >
+          {t`Metrics`}
+        </PaddedSidebarLink>
+      )}
     </CollapseSection>
   );
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
@@ -1,0 +1,119 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import type { EmbeddingEntityType } from "metabase/embedding-sdk/store";
+import * as domUtils from "metabase/lib/dom";
+import {
+  createMockEmbedOptions,
+  createMockEmbedState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { BrowseNavSection } from "./BrowseNavSection";
+
+describe("BrowseNavSection", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should render Models, Databases, and Metrics when not embedding in iframe", () => {
+    setup();
+
+    expect(
+      screen.getByRole("listitem", { name: "Browse models" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("listitem", { name: "Browse databases" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("listitem", { name: "Browse metrics" }),
+    ).toBeInTheDocument();
+  });
+
+  describe("interactive embedding with `entity_types` (EMB-229)", () => {
+    it("should show models and tables when no `entity_types` is provided", () => {
+      setup({ isEmbeddingIframe: true });
+
+      expect(
+        screen.getByRole("listitem", { name: "Browse models" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("listitem", { name: "Browse databases" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("listitem", { name: "Browse metrics" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show models and tables when no `entity_types` is `["model", "table"]`', () => {
+      setup({ isEmbeddingIframe: true, entityTypes: ["model", "table"] });
+
+      expect(
+        screen.getByRole("listitem", { name: "Browse models" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("listitem", { name: "Browse databases" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("listitem", { name: "Browse metrics" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show only models when no `entity_types` is `["model"]`', () => {
+      setup({ isEmbeddingIframe: true, entityTypes: ["model"] });
+
+      expect(
+        screen.getByRole("listitem", { name: "Browse models" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("listitem", { name: "Browse databases" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("listitem", { name: "Browse metrics" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show only tables when no `entity_types` is `["table"]`', () => {
+      setup({ isEmbeddingIframe: true, entityTypes: ["table"] });
+
+      expect(
+        screen.queryByRole("listitem", { name: "Browse models" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("listitem", { name: "Browse databases" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("listitem", { name: "Browse metrics" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+interface SetupOpts {
+  isEmbeddingIframe?: boolean;
+  entityTypes?: EmbeddingEntityType[];
+}
+
+function setup({ isEmbeddingIframe, entityTypes }: SetupOpts = {}) {
+  if (isEmbeddingIframe) {
+    jest.spyOn(domUtils, "isWithinIframe").mockReturnValue(true);
+  }
+
+  renderWithProviders(
+    <BrowseNavSection
+      hasDataAccess
+      nonEntityItem={{ type: "non-entity", url: "/" }}
+      onItemSelect={jest.fn()}
+    />,
+
+    entityTypes
+      ? {
+          storeInitialState: createMockState({
+            embed: createMockEmbedState({
+              options: createMockEmbedOptions({
+                entity_types: entityTypes,
+              }),
+            }),
+          }),
+        }
+      : undefined,
+  );
+}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
@@ -43,7 +43,7 @@ describe("BrowseNavSection", () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should show models and tables when no `entity_types` is `["model", "table"]`', () => {
+    it('should show models and tables when `entity_types` is `["model", "table"]`', () => {
       setup({ isEmbeddingIframe: true, entityTypes: ["model", "table"] });
 
       expect(
@@ -57,7 +57,7 @@ describe("BrowseNavSection", () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should show only models when no `entity_types` is `["model"]`', () => {
+    it('should show only models when `entity_types` is `["model"]`', () => {
       setup({ isEmbeddingIframe: true, entityTypes: ["model"] });
 
       expect(
@@ -71,7 +71,7 @@ describe("BrowseNavSection", () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should show only tables when no `entity_types` is `["table"]`', () => {
+    it('should show only tables when `entity_types` is `["table"]`', () => {
       setup({ isEmbeddingIframe: true, entityTypes: ["table"] });
 
       expect(

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.unit.spec.tsx
@@ -100,6 +100,13 @@ function setup({ isEmbeddingIframe, entityTypes }: SetupOpts = {}) {
   renderWithProviders(
     <BrowseNavSection
       hasDataAccess
+      /**
+       * This prop is required, and this value is grabbed directly from React devtools.
+       * I'm not going to dive into why it has to be this value, or why it's needed.
+       *
+       * From my testing, this doesn't seem to render anything in addition to
+       * the 3 items `BrowseNavSection` already renders as a base.
+       */
       nonEntityItem={{ type: "non-entity", url: "/" }}
       onItemSelect={jest.fn()}
     />,


### PR DESCRIPTION
closes EMB-229

### Description
Hide sidebar browse section item according to [these rules.](https://www.notion.so/metabase/Tech-Let-embedders-hide-tables-1ae69354c9018057bc1ddcf987443164?pvs=4#1ae69354c9018082bb10fb315b1d209b)

Please note that metrics is always excluded (when embedding)


### How to verify
1. Embed interactive embedding.
2. ensure the iframe URL is resolved to your Metabase instance with these search parameters
    - `?entity_types=` we show both models and databases
    - `?entity_types=model,table` same behavior as the one above as this is the default value
    - `?entity_types=model` we show only show models
    - `?entity_types=table` we show only databases

### Demo

#### `entity_types: ["model", "table"]`
![image](https://github.com/user-attachments/assets/6c57a455-714f-418a-a133-9101427625f8)

#### `entity_types: ["model"]`
![image](https://github.com/user-attachments/assets/9b7fd558-77cf-4e64-b8ad-94fee63fcbe8)

#### `entity_types: ["table"]`
![image](https://github.com/user-attachments/assets/01fd3fe0-df91-4ac7-b4e0-74bed3007216)

#### Before
![image](https://github.com/user-attachments/assets/26eeffd0-ac18-4668-9285-df5084c34a4e)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
