### PR TITLE
ci(sdk): adds embedding-sdk-tests-result

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -3,12 +3,6 @@ name: E2E Component Tests for Embedding SDK
 on:
   workflow_call:
 
-
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   files-changed:
     name: Check which files changed

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -1,12 +1,9 @@
 name: E2E Component Tests for Embedding SDK
 
 on:
-  push:
-    branches:
-      - "master"
-      - "release-**"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call:
+
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -201,16 +198,3 @@ jobs:
              const summary = formatSummary(results);
 
              await core.summary.addRaw(summary).write();
-
-# This doesn't do anything at the moment, this was used as stub when the task was required but the job is currently not required (but it should)
-# e2e-tests-skipped-stub:
-#   needs: [e2e-tests]
-#   if: |
-#     !cancelled() &&
-#     needs.e2e-tests.result == 'skipped'
-#   runs-on: ubuntu-22.04
-#   timeout-minutes: 5
-#   name: e2e-tests-embedding-sdk
-#   steps:
-#     - run: |
-#         echo "Didn't run due to conditional filtering"

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -48,3 +48,43 @@ jobs:
         run: yarn build-embedding-sdk
       - name: Run frontend embedding SDK snippets type check
         run: yarn run embedding-sdk:cli-snippets:type-check
+
+
+
+
+  embedding-sdk-tests-result:
+    needs:
+      - embedding-sdk-cli-snippets-type-check
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      needs: ${{ toJson(needs) }}
+    steps:
+      - name: Check frontend job status
+        uses: actions/github-script@v7
+        env:
+          needs: ${{ toJson(needs) }}
+        with:
+          script: | # js
+            const needs = JSON.parse(process.env.needs);
+            const jobs = Object.entries(needs).map(
+              ([jobName, jobValues]) => ({
+                name: jobName,
+                result: jobValues.result
+              }));
+
+            // are all jobs skipped or successful?
+            if (jobs.every(job => (job.result === 'skipped' || job.result === 'success'))) {
+              console.log('All jobs are skipped or successful');
+              process.exit(0);
+            }
+
+            // otherwise, something failed
+            console.log('Some frontend jobs failed');
+            jobs.forEach((job) => {
+              if (job.result !== 'success') {
+                console.log(`${job.name} - ${job.result}`);
+              }
+            });
+            process.exit(1);

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -63,7 +63,7 @@ jobs:
     env:
       needs: ${{ toJson(needs) }}
     steps:
-      - name: Check frontend job status
+      - name: Check embedding SDK job status
         uses: actions/github-script@v7
         env:
           needs: ${{ toJson(needs) }}
@@ -83,7 +83,7 @@ jobs:
             }
 
             // otherwise, something failed
-            console.log('Some frontend jobs failed');
+            console.log('Some embedding SDK jobs failed');
             jobs.forEach((job) => {
               if (job.result !== 'success') {
                 console.log(`${job.name} - ${job.result}`);

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -49,12 +49,14 @@ jobs:
       - name: Run frontend embedding SDK snippets type check
         run: yarn run embedding-sdk:cli-snippets:type-check
 
-
-
+  sdk-e2e-tests:
+    uses: ./.github/workflows/e2e-component-tests-embedding-sdk.yml
+    secrets: inherit
 
   embedding-sdk-tests-result:
     needs:
       - embedding-sdk-cli-snippets-type-check
+      - sdk-e2e-tests
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
closes EMB-268

also closes EMB-141

This adds an umbrella job that will be marked as required, similar to the `*-result` ones we already have for the fe tests, e2es and backend

I _think_ we should double backport this for consistency but mine isn't a super strong opinion