### PR TITLE
Editable table components in dashboards

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -879,7 +879,7 @@
     (-> dashcard
         ;; This is a downside to creating a new card. If we find more pockets like this we should pivot to reusing
         ;; the existing card.
-        (update :parameter_mappings #(walk/postwalk (fn [x] (if (:card_id x) (assoc x :card_id card-id) x)) %))
+        (u/update-if-exists :parameter_mappings #(walk/postwalk (fn [x] (if (:card_id x) (assoc x :card_id card-id) x)) %))
         (assoc :dashboard_id dashboard-id
                :card_id card-id))))
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1327,7 +1327,12 @@
    :bookmark     [:model/CardBookmark [:and
                                        [:= :bookmark.card_id :this.id]
                                        [:= :bookmark.user_id :current_user/id]]]
-   :where        [:= :collection.namespace nil]
+   :where        [:and
+                  [:= :collection.namespace nil]
+                  [:or
+                   ;; Leaving the door open to editable models (e.g., joining read-only and editable columns)
+                   [:not= :this.display "table-editable"]
+                   [:= :this.dashboard_id nil]]]
    :joins        {:collection [:model/Collection [:= :collection.id :this.collection_id]]
                   :r          [:model/Revision [:and
                                                 [:= :r.model_id :this.id]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1849,8 +1849,8 @@
                                                        :size_y           2
                                                        :col              2
                                                        :row              2}
-                                                     ;; remove the dashcard3 and create a new card using negative numbers
-                                                     ;; and assign into the newly created dashcard
+                                                      ;; remove the dashcard3 and create a new card using negative numbers
+                                                      ;; and assign into the newly created dashcard
                                                       {:id               -1
                                                        :size_x           1
                                                        :size_y           1

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1805,15 +1805,14 @@
                                                        :dashboard_tab_id -1
                                                        :visualization_settings {:table_id table-id}}]})]
           (testing "the dashcard gets turned into something richer, that supports filtering."
-            (let []
-              (is (=? [{:id               (mt/malli=? [:fn pos-int?])
-                        :size_x           1
-                        :size_y           1
-                        :col              3
-                        :row              3
-                        :card_id          int?
-                        :visualization_settings {:table_id table-id}}]
-                      (:dashcards resp))))))))))
+            (is (=? [{:id                     (mt/malli=? [:fn pos-int?])
+                      :size_x                 1
+                      :size_y                 1
+                      :col                    3
+                      :row                    3
+                      :card_id                int?
+                      :visualization_settings {:table_id table-id}}]
+                    (:dashcards resp)))))))))
 
 (deftest e2e-update-dashboard-cards-and-tabs-test
   (testing "PUT /api/dashboard/:id with updating dashboard and create/update/delete of dashcards and tabs in a single req"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1788,6 +1788,33 @@
                                                              {:dashcards [new-dashcard-info]
                                                               :tabs      []}))}))))))
 
+(deftest e2e-create-editable-table-card
+  (testing "PUT /api/dashboard/:id with a placeholder for an editable table.\n"
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp
+        [:model/Dashboard               {dashboard-id :id}  {}]
+        (let [table-id (mt/id :venues)
+              resp (mt/user-http-request :rasta :put 200 (format "dashboard/%d" dashboard-id)
+                                         {:tabs      [{:id   -1
+                                                       :name "New tab"}]
+                                          :dashcards [{:id               -1
+                                                       :size_x           1
+                                                       :size_y           1
+                                                       :col              3
+                                                       :row              3
+                                                       :dashboard_tab_id -1
+                                                       :visualization_settings {:table_id table-id}}]})]
+          (testing "the dashcard gets turned into something richer, that supports filtering."
+            (let []
+              (is (=? [{:id               (mt/malli=? [:fn pos-int?])
+                        :size_x           1
+                        :size_y           1
+                        :col              3
+                        :row              3
+                        :card_id          int?
+                        :visualization_settings {:table_id table-id}}]
+                      (:dashcards resp))))))))))
+
 (deftest e2e-update-dashboard-cards-and-tabs-test
   (testing "PUT /api/dashboard/:id with updating dashboard and create/update/delete of dashcards and tabs in a single req"
     (mt/test-helpers-set-global-values!
@@ -1823,8 +1850,8 @@
                                                        :size_y           2
                                                        :col              2
                                                        :row              2}
-                                                      ;; remove the dashcard3 and create a new card using negative numbers
-                                                      ;; and assign into the newly created dashcard
+                                                     ;; remove the dashcard3 and create a new card using negative numbers
+                                                     ;; and assign into the newly created dashcard
                                                       {:id               -1
                                                        :size_x           1
                                                        :size_y           1


### PR DESCRIPTION
Add support for editable table components within dashboards, with dashboard filter support.

The idea here is that the frontend can build a simple template, a bit like a text card, knowing nothing about our implementation details, and doesn't require touching MLib or requesting any additional metadata. The backend will then lazily construct something more complex, whose shape "just works" for executing queries, attaching filters, applying filters, and updating things when the filters change.

Basically saving us a ton of time and a ton of extra surface area. The returned card is just that... a `:model/Card`. I will still retains the "template" data though, and has a distinct "display" type so we know to render the new component. The template can be updated, and the underlying card will get rebuilt.

The major downside with this approach is that it adds more overloading to an already heavily overloaded primitive. I still believe this is the right approach versus duplicating a huge amount of APIs and functionality, or making all that code polymorphic. If we continue down this road though we'll need to improve the encapsulation of a "card" and add more validation and consistency checks. 

Given how directly we're able to deliver advanced new functionality in the short term, and how naturally many longer term features will fall out of things, I strongly believe in taking this route for now. For now it's hiding the "cards" as best it can, using them as an internal detail, but we might want to consider first class things like "editable models" for the join / aggregation cases. Joins provide a really nice way to segregate column permissions in many basic use cases.

An awkward thing with this "just in time" creation is that the frontend won't know how to attach dashboard filters until after first saving any new table dashcards. Not huge to handle, but not very obvious. We could look at adding a new API for returning this metadata immediately when the template card is created, or perhaps this can even use what's returned by from `/table/:id/data`.