### PR TITLE
[serdes] introduce (partial) schema coercion for Dashboard

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1390,8 +1390,8 @@
 
 (deftest blank-eid-creates-new-entity-test
   (mt/with-empty-h2-app-db
-    (let [db         (ts/create! :model/Collection :name "mycoll")
-          [coll-ser] (serdes.extract/extract {:targets [["Collection" (:id db)]]})
+    (let [coll       (ts/create! :model/Collection :name "mycoll")
+          [coll-ser] (serdes.extract/extract {:targets [["Collection" (:id coll)]]})
           new-coll   (assoc coll-ser :entity_id nil)
           coll-count (fn [] (t2/count :model/Collection :name "mycoll"))]
       (serdes.load/load-metabase! (ingestion-in-memory [new-coll]))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -410,7 +410,8 @@
                :made_public_by_id      (serdes/fk :model/User)
                :parameters             {:export serdes/export-parameters :import serdes/import-parameters}
                :tabs                   (serdes/nested :model/DashboardTab :dashboard_id opts)
-               :dashcards              (serdes/nested :model/DashboardCard :dashboard_id opts)}})
+               :dashcards              (serdes/nested :model/DashboardCard :dashboard_id opts)}
+   :schema {:parameters [:maybe [:sequential ms/Parameter]]}})
 
 (defn- serdes-deps-dashcard
   [{:keys [action_id card_id parameter_mappings visualization_settings series]}]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -411,7 +411,7 @@
                :parameters             {:export serdes/export-parameters :import serdes/import-parameters}
                :tabs                   (serdes/nested :model/DashboardTab :dashboard_id opts)
                :dashcards              (serdes/nested :model/DashboardCard :dashboard_id opts)}
-   :schema {:parameters [:maybe [:sequential ms/Parameter]]}})
+   :coerce {:parameters [:maybe [:sequential ms/Parameter]]}})
 
 (defn- serdes-deps-dashcard
   [{:keys [action_id card_id parameter_mappings visualization_settings series]}]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -50,7 +50,8 @@
   - Put it in `:skip` if this column shouldn't be synchronized
   - You have to make decisions inside `:transform` column `:export` function (or `:import`)
   - To prevent value being serialized, return `::serdes/skip` instead of `nil` (the reason being that serialization
-    format distinguishes between `nil` and absence)"
+    format distinguishes between `nil` and absence)
+  - If your data is coming in watered down by YAML (like strings instead of keywords), take a look at `:coerce`"
   (:refer-clojure :exclude [descendants])
   (:require
    [clojure.core.match :refer [match]]
@@ -399,19 +400,20 @@
 ;;; *Note:* "descendants" and "dependencies" are quite different things!
 
 (defmulti make-spec
-  "Return specification for serialization. This should be a map of three keys: `:copy`, `:skip`, `:transform`.
+  "Return specification for serialization, should be a map of:
 
-  `:copy` and `:skip` are vectors of field names. `:skip` is only used in tests to check that all fields were
-  mentioned. `:transform` is a map from field name to an `{:import (fn [v] ...) :export (fn [v] ...)}` map.
+  - `:copy`: a vector of field names, to directly copy from db into output and ingest back with no changes.
+  - `:skip`: a vector of field names, used it tests to check if all fields were specified (`:id` and `:updated_at`
+    are always skipped, no need to mention them).
+  - `:transform`: is a map like `{:field-name {:export (fn [v] ...) :import (fn [v] ...)}}`. For behavior see docs
+    on `extract-one` and `xform-one`. There are a number of transfomers, see this field for `fk` and similar.
+  - `:coerce`: a map like `{:field-name Schema}`; incoming data will be coerced to schema after `:import`/`:copy`.
 
-  For behavior, see `extract-one` and `xform-one`. Two fields - `id` and `updated_at` - are always skipped, no need to
-  mention them in `:skip`.
-
-  Example:
+  Example (search codebase for more examples):
 
   (defmethod serdes/make-spec \"ModelName\" [_model-name _opts]
     {:copy [:name :description]
-     :skip [;; it's nice to comment why it's skipped
+     :skip [;; please leave a comment why a field is skipped
             :internal_data]
      :transform {:card_id (serdes/fk :model/Card)}})"
   {:arglists '([model-name opts])}
@@ -751,7 +753,7 @@
   (fn [ingested _]
     (ingested-model ingested)))
 
-(defn- coerce-schema [data schemas]
+(defn- coerce-keys [data schemas]
   (reduce (fn [data [k schema]] (update data k #(mc/coerce schema % mtx/string-transformer)))
           data
           schemas))
@@ -772,7 +774,7 @@
                                (or (some? res)
                                    (contains? ingested import-k)))]
                 [k res]))
-        (coerce-schema (:schema spec)))))
+        (coerce-keys (:coerce spec)))))
 
 (defn- spec-nested! [model-name ingested instance]
   (let [spec (make-spec model-name nil)]


### PR DESCRIPTION
This adds coercion support for serialization and adds a very limited partial schema for a Dashboard, in hopes that this grows to be a full schema for our data models at some point.

fixes #54941
