### PR TITLE
fix(sdk): Entity ID support for CreateDashboardModal

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "embedding-sdk/store/collections";
 import { CreateDashboardModal as CreateDashboardModalCore } from "metabase/dashboard/containers/CreateDashboardModal";
 import Collections from "metabase/entities/collections";
+import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { useSelector } from "metabase/lib/redux";
 import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
@@ -25,13 +26,23 @@ const CreateDashboardModalInner = ({
   onCreate,
   onClose,
 }: CreateDashboardModalProps) => {
+  const { id, isLoading } = useValidatedEntityId<
+    "collection",
+    SDKCollectionReference
+  >({
+    type: "collection",
+    id: initialCollectionId,
+  });
+
+  const initId = !isLoading && (id ?? initialCollectionId);
+
   const translatedCollectionId = useSelector((state: State) =>
-    getCollectionIdSlugFromReference(state, initialCollectionId),
+    initId ? getCollectionIdSlugFromReference(state, initId) : undefined,
   );
 
   return (
     <CreateDashboardModalCoreWithLoading
-      opened={isOpen}
+      opened={!isLoading && isOpen}
       onCreate={onCreate}
       onClose={onClose}
       collectionId={translatedCollectionId}

--- a/enterprise/frontend/src/metabase-enterprise/collections/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/constants.ts
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import type {
+  BaseEntityId,
   CollectionAuthorityLevelConfig,
   CollectionInstanceAnaltyicsConfig,
 } from "metabase-types/api";
@@ -45,4 +46,4 @@ export const COLLECTION_TYPES: Record<
 };
 
 export const CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID =
-  "okNLSZKdSxaoG58JSQY54";
+  "okNLSZKdSxaoG58JSQY54" as BaseEntityId;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -59,7 +59,8 @@ export interface Collection {
   id: CollectionId;
   name: string;
   slug?: string;
-  entity_id?: BaseEntityId;
+  // "" for the default for EE's CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID
+  entity_id?: BaseEntityId | "";
   description: string | null;
   can_write: boolean;
   can_restore: boolean;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -1,6 +1,7 @@
 import type { ColorName } from "metabase/lib/colors/types";
 import type { IconName, IconProps } from "metabase/ui";
 import type {
+  BaseEntityId,
   CollectionEssentials,
   Dashboard,
   DashboardId,
@@ -58,7 +59,7 @@ export interface Collection {
   id: CollectionId;
   name: string;
   slug?: string;
-  entity_id?: string;
+  entity_id?: BaseEntityId;
   description: string | null;
   can_write: boolean;
   can_restore: boolean;

--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -4,6 +4,8 @@ import type {
   CollectionItem,
 } from "metabase-types/api";
 
+import { createMockEntityId } from "./entity-id";
+
 export const createMockCollection = (
   opts?: Partial<Collection>,
 ): Collection => ({
@@ -17,7 +19,7 @@ export const createMockCollection = (
   archived: false,
   is_personal: false,
   authority_level: null,
-  entity_id: "an_entity_id",
+  entity_id: createMockEntityId(),
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/mocks/entity-id.ts
+++ b/frontend/src/metabase-types/api/mocks/entity-id.ts
@@ -2,5 +2,5 @@ import { nanoid } from "@reduxjs/toolkit";
 
 import { type BaseEntityId, NANOID_LENGTH } from "../entity-id";
 
-export const createMockEntityId = (): BaseEntityId =>
-  nanoid(NANOID_LENGTH) as BaseEntityId;
+export const createMockEntityId = (value?: string): BaseEntityId =>
+  (value ?? nanoid(NANOID_LENGTH)) as BaseEntityId;

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { getIcon, queryIcon, screen } from "__support__/ui";
 import type { CollectionType } from "metabase-types/api";
+import { createMockEntityId } from "metabase-types/api/mocks/entity-id";
 
 import { setup } from "./setup";
 
@@ -65,7 +66,7 @@ describe("instance analytics custom reports collection", () => {
     collection: {
       name: "Custom Reports",
       can_write: true,
-      entity_id: "okNLSZKdSxaoG58JSQY54",
+      entity_id: createMockEntityId("okNLSZKdSxaoG58JSQY54"),
     },
     hasEnterprisePlugins: true,
     // 😬 this test needs the official_collections feature flag so that it

--- a/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/setup.tsx
@@ -6,6 +6,7 @@ import {
   createMockCollection,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
+import { createMockEntityId } from "metabase-types/api/mocks/entity-id";
 import { createMockState } from "metabase-types/store/mocks";
 
 import { CollectionInfoSidebar } from "../CollectionInfoSidebar";
@@ -50,13 +51,13 @@ export const setup = ({
 export const regularCollection = createMockCollection({
   name: "Normal collection",
   description: "Description of a normal collection",
-  entity_id: "entity_id_of_normal_collection",
+  entity_id: createMockEntityId("entity_id_of_normal_collection"),
   authority_level: null,
 });
 
 export const officialCollection = createMockCollection({
   name: "Trusted collection",
   description: "Description of a trusted collection",
-  entity_id: "entity_id_of_trusted_collection",
+  entity_id: createMockEntityId("entity_id_of_trusted_collection"),
   authority_level: "official",
 });

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -42,6 +42,7 @@ import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
+  BaseEntityId,
   BaseUser,
   Bookmark,
   CacheableDashboard,
@@ -313,7 +314,7 @@ export const PLUGIN_COLLECTIONS = {
   ): CollectionAuthorityLevelConfig | CollectionInstanceAnaltyicsConfig =>
     AUTHORITY_LEVEL_REGULAR,
   useGetDefaultCollectionId: null as GetCollectionIdType | null,
-  CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID: "",
+  CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID: "" as BaseEntityId | "",
   INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE: UNABLE_TO_CHANGE_ADMIN_PERMISSIONS,
   getAuthorityLevelMenuItems: (
     _collection: Collection,


### PR DESCRIPTION
We missed a spot with the Entity IDs - this should be the last part where we didn't have entity IDs before.