### PR TITLE
Add UI for integer() function, with e2e tests

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-cast-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-cast-functions.cy.spec.ts
@@ -60,6 +60,44 @@ const TEXT_TEST_CASES: CastTestCase[] = [
   },
 ];
 
+const INTEGER_TEST_CASES: CastTestCase[] = [
+  {
+    name: "Number",
+    expression: "integer(3.14)",
+    filterOperator: "Equals to",
+    filterValue: "3",
+    expectedRowCount: 200,
+  },
+  {
+    name: "String",
+    expression: 'integer("10")',
+    filterOperator: "Equals to",
+    filterValue: "10",
+    expectedRowCount: 200,
+  },
+  {
+    name: "NumberColumn",
+    expression: "integer([Price])",
+    filterOperator: "Equals to",
+    filterValue: "29",
+    expectedRowCount: 4,
+  },
+  {
+    name: "NumberExpression",
+    expression: "integer([Price] + 10)",
+    filterOperator: "Equals to",
+    filterValue: "38",
+    expectedRowCount: 2,
+  },
+  {
+    name: "StringExpression",
+    expression: 'integer(concat([ID], ""))',
+    filterOperator: "Equals to",
+    filterValue: "29",
+    expectedRowCount: 1,
+  },
+];
+
 describe(
   "scenarios > custom column > cast functions",
   { tags: "@external" },
@@ -71,6 +109,10 @@ describe(
 
     it("should support text function", () => {
       testCastFunction(TEXT_TEST_CASES);
+    });
+
+    it("should support integer function", () => {
+      testCastFunction(INTEGER_TEST_CASES);
     });
   },
 );

--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -119,6 +119,7 @@ const expression: TestCase[] = [
     "function with 3 arguments",
   ],
   ["text([User ID])", ["text", userId], "text function"],
+  ['integer("10")', ["integer", "10"], "integer function"],
   [
     'case([Total] > 10, "GOOD", [Total] < 5, "BAD", "OK")',
     [

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -98,7 +98,18 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     requiresFeature: "percentile-aggregations",
   },
   // cast functions
-  text: { displayName: "text", type: "string", args: ["expression"] },
+  text: {
+    displayName: "text",
+    type: "string",
+    args: ["expression"],
+    requiresFeature: "cast",
+  },
+  integer: {
+    displayName: "integer",
+    type: "number",
+    args: ["expression"],
+    requiresFeature: "cast",
+  },
   // string functions
   lower: { displayName: `lower`, type: "string", args: ["string"] },
   upper: { displayName: `upper`, type: "string", args: ["string"] },
@@ -530,6 +541,7 @@ export const AGGREGATION_FUNCTIONS = new Set([
 export const EXPRESSION_FUNCTIONS = new Set([
   // cast
   "text",
+  "integer",
   // string
   "lower",
   "upper",

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -280,6 +280,19 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     ],
   },
   {
+    name: "integer",
+    structure: "integer",
+    description: () =>
+      t`Converts a number or date to text. Useful for applying text filters or joining with other columns based on text comparisons.`,
+    args: [
+      {
+        name: t`value`,
+        description: t`The number or date to convert to text.`,
+        example: ["dimension", "User ID"],
+      },
+    ],
+  },
+  {
     name: "lower",
     structure: "lower",
     description: () => t`Returns the string of text in all lower case.`,

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -283,11 +283,11 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     name: "integer",
     structure: "integer",
     description: () =>
-      t`Converts a number or date to text. Useful for applying text filters or joining with other columns based on text comparisons.`,
+      t`Converts a string or number to an integer. For example, both ${'integer("3")'} and ${"integer(3.14)"}  would return ${3}.`,
     args: [
       {
         name: t`value`,
-        description: t`The number or date to convert to text.`,
+        description: t`The string or number column to convert to integers.`,
         example: ["dimension", "User ID"],
       },
     ],

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.unit.spec.ts
@@ -86,6 +86,7 @@ describe("recursive-parser", () => {
     expect(process("power(log(2.1), 7)")).toEqual(["power", ["log", 2.1], 7]);
     expect(process("trim(ID)")).toEqual(["trim", ["dimension", "ID"]]);
     expect(process("text(ID)")).toEqual(["text", ["dimension", "ID"]]);
+    expect(process("integer(ID)")).toEqual(["integer", ["dimension", "ID"]]);
   });
 
   it("should handle CASE expression", () => {

--- a/frontend/src/metabase-lib/v1/expressions/resolver.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.unit.spec.ts
@@ -141,6 +141,7 @@ describe("resolve", () => {
       expect(expr(["coalesce", P, Q, R]).dimensions).toEqual(["P", "Q", "R"]);
       expect(expr(["in", A, B, C]).dimensions).toEqual(["A", "B", "C"]);
       expect(expr(["text", A]).dimensions).toEqual(["A"]);
+      expect(expr(["integer", A]).dimensions).toEqual(["A"]);
     });
 
     it("should allow any number of arguments in a variadic function", () => {

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -17,6 +17,7 @@ export type DatabaseFeature =
   | "basic-aggregations"
   | "binning"
   | "case-sensitivity-string-filter-options"
+  | "cast"
   | "convert-timezone"
   | "datetime-diff"
   | "dynamic-schema"


### PR DESCRIPTION
Adds support for the new `integer()` MBQL function in the expression editor. The function is not yet implemented by the BE.

<img width="749" alt="Screenshot 2025-03-18 at 14 54 17" src="https://github.com/user-attachments/assets/d7bcd8a1-d5d4-4578-b3ec-f8efc0ae9663" />
