### PR TITLE
Fix failed tests for text() function

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-cast-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-cast-functions.cy.spec.ts
@@ -6,7 +6,7 @@ describe(
   () => {
     beforeEach(() => {
       H.restore("postgres-12");
-      cy.signInAsNormalUser();
+      cy.signInAsAdmin();
     });
 
     it("should support text function", () => {

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -57,7 +57,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
 
     H.CustomExpressionEditor.helpTextHeader()
       .should("be.visible")
-      .should("contain", "lower(text)");
+      .should("contain", "lower(column)");
 
     H.CustomExpressionEditor.helpText()
       .should("be.visible")

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -57,7 +57,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
 
     H.CustomExpressionEditor.helpTextHeader()
       .should("be.visible")
-      .should("contain", "lower(column)");
+      .should("contain", "lower(value)");
 
     H.CustomExpressionEditor.helpText()
       .should("be.visible")

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -1193,14 +1193,14 @@ describe("scenarios > question > custom column > help text", () => {
     H.enterCustomColumnDetails({ formula: "lower(", blur: false });
     H.CustomExpressionEditor.helpTextHeader()
       .should("be.visible")
-      .should("contain", "lower(column)");
+      .should("contain", "lower(value)");
   });
 
   it("should appear after a field reference", () => {
     H.enterCustomColumnDetails({ formula: "lower([Category]", blur: false });
     H.CustomExpressionEditor.helpTextHeader()
       .should("be.visible")
-      .should("contain", "lower(column)");
+      .should("contain", "lower(value)");
   });
 
   it("should not appear while outside a function", () => {

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -1193,14 +1193,14 @@ describe("scenarios > question > custom column > help text", () => {
     H.enterCustomColumnDetails({ formula: "lower(", blur: false });
     H.CustomExpressionEditor.helpTextHeader()
       .should("be.visible")
-      .should("contain", "lower(text)");
+      .should("contain", "lower(column)");
   });
 
   it("should appear after a field reference", () => {
     H.enterCustomColumnDetails({ formula: "lower([Category]", blur: false });
     H.CustomExpressionEditor.helpTextHeader()
       .should("be.visible")
-      .should("contain", "lower(text)");
+      .should("contain", "lower(column)");
   });
 
   it("should not appear while outside a function", () => {

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -285,7 +285,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns the string of text in all lower case.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column with values to convert to lower case.`,
         example: ["dimension", t`Status`],
       },
@@ -297,7 +297,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns the text in all upper case.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column with values to convert to upper case.`,
         example: ["dimension", t`Status`],
       },
@@ -309,7 +309,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns a portion of the supplied text.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column or text to return a portion of.`,
         example: ["dimension", t`Title`],
       },
@@ -333,7 +333,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
       t`Extracts matching substrings according to a regular expression.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column or text to search through.`,
         example: ["dimension", t`Address`],
       },
@@ -374,7 +374,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Replaces a part of the input text with new text.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column or text to search through.`,
         example: ["dimension", t`Title`],
       },
@@ -396,7 +396,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns the number of characters in text.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column or text you want to get the length of.`,
         example: ["dimension", t`Comment`],
       },
@@ -409,7 +409,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
       t`Removes leading and trailing whitespace from a string of text.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column or text you want to trim.`,
         example: ["dimension", t`Comment`],
       },
@@ -421,7 +421,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Removes trailing whitespace from a string of text.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column or text you want to trim.`,
         example: ["dimension", t`Comment`],
       },
@@ -433,7 +433,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Removes leading whitespace from a string of text.`,
     args: [
       {
-        name: t`text`,
+        name: t`column`,
         description: t`The column or text you want to trim.`,
         example: ["dimension", t`Comment`],
       },
@@ -790,7 +790,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: 7,
       },
       {
-        name: t`text`,
+        name: t`column`,
         description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: "day",
       },
@@ -813,7 +813,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: "-1",
       },
       {
-        name: t`text`,
+        name: t`column`,
         description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: "month",
       },
@@ -863,7 +863,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: -30,
       },
       {
-        name: t`text`,
+        name: t`column`,
         description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: "day",
       },

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -285,7 +285,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns the string of text in all lower case.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column with values to convert to lower case.`,
         example: ["dimension", t`Status`],
       },
@@ -297,7 +297,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns the text in all upper case.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column with values to convert to upper case.`,
         example: ["dimension", t`Status`],
       },
@@ -309,7 +309,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns a portion of the supplied text.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column or text to return a portion of.`,
         example: ["dimension", t`Title`],
       },
@@ -333,7 +333,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
       t`Extracts matching substrings according to a regular expression.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column or text to search through.`,
         example: ["dimension", t`Address`],
       },
@@ -374,7 +374,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Replaces a part of the input text with new text.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column or text to search through.`,
         example: ["dimension", t`Title`],
       },
@@ -396,7 +396,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Returns the number of characters in text.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column or text you want to get the length of.`,
         example: ["dimension", t`Comment`],
       },
@@ -409,7 +409,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
       t`Removes leading and trailing whitespace from a string of text.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column or text you want to trim.`,
         example: ["dimension", t`Comment`],
       },
@@ -421,7 +421,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Removes trailing whitespace from a string of text.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column or text you want to trim.`,
         example: ["dimension", t`Comment`],
       },
@@ -433,7 +433,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     description: () => t`Removes leading whitespace from a string of text.`,
     args: [
       {
-        name: t`column`,
+        name: t`value`,
         description: t`The column or text you want to trim.`,
         example: ["dimension", t`Comment`],
       },
@@ -790,7 +790,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: 7,
       },
       {
-        name: t`column`,
+        name: t`unit`,
         description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: "day",
       },
@@ -813,7 +813,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: "-1",
       },
       {
-        name: t`column`,
+        name: t`unit`,
         description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: "month",
       },
@@ -863,7 +863,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: -30,
       },
       {
-        name: t`column`,
+        name: t`unit`,
         description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: "day",
       },


### PR DESCRIPTION
We cannot name our function parameters `text` anymore as the expression parser will think it's an unfinished function call when doing autocomplete. This PR changes `text` to `column` as it is used for many other functions.

How to verify:
- `should correctly accept the chosen function suggestion` e2e test should not fail.