### PR TITLE
Fix sig-figs-after-decimal 

### DIFF
--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -74,7 +74,7 @@
      - 0.100 -> 1 (counting 1, ignoring trailing zeros)
      - 1.23 -> 2 (counting 23)
      - 1.0 -> 0 (no significant figures after decimal)"
-  [value decimal]
+  [value]
   (if (zero? value)
     0
     (let [;; Convert number to string with appropriate precision
@@ -83,7 +83,7 @@
                        java.lang.Double (format "%.20f" value)
                        java.lang.Float (format "%.20f" value)
                        (str value))
-          decimal-idx (str/index-of val-string decimal)]
+          decimal-idx (str/index-of val-string ".")]
       (if decimal-idx
         (let [;; Get everything after the decimal point
               after-decimal (subs val-string (inc decimal-idx))
@@ -175,7 +175,7 @@
                                   percent?    (min 2 decimals-in-value) ;; 5.5432 -> %554.32
                                   :else       (if (>= (abs scaled-value) 1)
                                                 (min 2 decimals-in-value) ;; values greater than 1 round to 2 decimal places
-                                                (let [n-figs (sig-figs-after-decimal scaled-value decimal)]
+                                                (let [n-figs (sig-figs-after-decimal scaled-value)]
                                                   (if (> n-figs 2)
                                                     (max 2 (- decimals-in-value (- n-figs 2))) ;; values less than 1 round to 2 sig-dig
                                                     decimals-in-value))))

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -106,7 +106,12 @@
       (is (= ["2"    "0.001"]   [(format 2.001 nil)   (format 0.001 nil)]))
       (is (= ["2.01" "0.006"]   [(format 2.006 nil)   (format 0.006 nil)]))
       (is (= ["2"    "0.0049"]  [(format 2.0049 nil)  (format 0.0049 nil)]))
-      (is (= ["2"    "0.005"]   [(format 2.00499 nil) (format 0.00499 nil)])))
+      (is (= ["2"    "0.005"]   [(format 2.00499 nil) (format 0.00499 nil)]))
+      ;; Test small numbers with many decimal places
+      (is (= ["2"    "0.0014"]  [(format 2.0013593702702702702M nil)
+                                 (format 0.0013593702702702702M nil)]))
+      (is (= ["2"    "0.000012"] [(format 2.0000123456789M nil)
+                                  (format 0.0000123456789M nil)])))
     (testing "Column Settings"
       (letfn [(fmt-with-type
                 ([type value] (fmt-with-type type value nil))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #31405
Resolves VIZ-67

- Updates the `sig-figs-after-decimal` helper function for `number-formatter`s to support decimals with multiple zeros
- Removes `decimal` param as incoming value should always be numerical

```clojure
;; Before
(sig-figs-after-decimal 0.001203 ".") -> 1

;; Now
(sig-figs-after-decimal 0.001203) -> 4
```