### PR TITLE
Closes viz-566 switching between visualizations

### DIFF
--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -32,11 +32,7 @@ import type {
   VisualizerState,
 } from "metabase-types/store/visualizer";
 
-import {
-  getCards,
-  getDatasets,
-  getVisualizerComputedSettings,
-} from "./selectors";
+import { getCards, getDatasets } from "./selectors";
 import {
   canCombineCard,
   copyColumn,
@@ -207,12 +203,8 @@ const fetchCardQuery = createAsyncThunk<Dataset, CardId>(
   },
 );
 
-export const setDisplay = createAsyncThunk(
+export const setDisplay = createAction<VisualizationDisplay>(
   "visualizer/setDisplay",
-  (display: VisualizationDisplay | null, { getState }) => {
-    const computedSettings = getVisualizerComputedSettings(getState());
-    return { display, computedSettings };
-  },
 );
 
 const visualizerHistoryItemSlice = createSlice({
@@ -300,12 +292,13 @@ const visualizerHistoryItemSlice = createSlice({
   },
   extraReducers: builder => {
     builder
-      .addCase(setDisplay.fulfilled, (state, action) => {
-        const { display, computedSettings } = action.payload;
+      .addCase(setDisplay, (state, action) => {
+        const display = action.payload;
+
         const updatedSettings = getUpdatedSettingsForDisplay(
           state.columnValuesMapping,
           state.columns,
-          computedSettings,
+          state.settings,
           state.display,
           display,
         );

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -203,14 +203,30 @@ const fetchCardQuery = createAsyncThunk<Dataset, CardId>(
   },
 );
 
-export const setDisplay = createAction<VisualizationDisplay>(
-  "visualizer/setDisplay",
-);
-
 const visualizerHistoryItemSlice = createSlice({
   name: "present",
   initialState: getInitialVisualizerHistoryItem(),
   reducers: {
+    setDisplay: (state, action: PayloadAction<VisualizationDisplay>) => {
+      const display = action.payload;
+
+      const updatedSettings = getUpdatedSettingsForDisplay(
+        state.columnValuesMapping,
+        state.columns,
+        state.settings,
+        state.display,
+        display,
+      );
+
+      if (updatedSettings) {
+        const { columnValuesMapping, columns, settings } = updatedSettings;
+        state.columnValuesMapping = columnValuesMapping;
+        state.columns = columns;
+        state.settings = settings;
+      }
+
+      state.display = display;
+    },
     setTitle: (state, action: PayloadAction<string>) => {
       if (!state.settings) {
         state.settings = {};
@@ -292,26 +308,6 @@ const visualizerHistoryItemSlice = createSlice({
   },
   extraReducers: builder => {
     builder
-      .addCase(setDisplay, (state, action) => {
-        const display = action.payload;
-
-        const updatedSettings = getUpdatedSettingsForDisplay(
-          state.columnValuesMapping,
-          state.columns,
-          state.settings,
-          state.display,
-          display,
-        );
-
-        if (updatedSettings) {
-          const { columnValuesMapping, columns, settings } = updatedSettings;
-          state.columnValuesMapping = columnValuesMapping;
-          state.columns = columns;
-          state.settings = settings;
-        }
-
-        state.display = display;
-      })
       .addCase(initializeVisualizer.fulfilled, (state, action) => {
         const initialState = action.payload;
         if (initialState) {
@@ -694,7 +690,7 @@ function maybeCombineDataset(
 
 const { addColumnInner } = visualizerHistoryItemSlice.actions;
 
-export const { setTitle, updateSettings, removeColumn } =
+export const { setTitle, updateSettings, removeColumn, setDisplay } =
   visualizerHistoryItemSlice.actions;
 
 export const {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #55406
Closes [VIZ-566: Switching between visualizations is broken](https://linear.app/metabase/issue/VIZ-566/switching-between-visualizations-is-broken)

### Description
Instead of using the computed settings, uses the settings to migrate from one viz to another when using the viz selector.