### PR TITLE
Fix filter schema and false = false filter

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1457,7 +1457,7 @@
 
 (defmethod ->honeysql [:sql :=]
   [driver [_ field value]]
-  (assert field)
+  (assert (some? field))
   (let [field-honeysql (->honeysql driver (maybe-cast-uuid-for-equality driver field value))]
     (binding [*parent-honeysql-col-type-info* (merge (when-let [database-type (h2x/database-type field-honeysql)]
                                                        {:database-type database-type})

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -912,12 +912,16 @@
                        (is-clause? numeric-functions x)  :numeric
                        (is-clause? string-functions x)   :string
                        (is-clause? boolean-functions x)  :boolean
+                       (is-clause? :value x)             :value
+                       (is-clause? :segment x)           :segment
                        :else                             :else))}
    [:datetime DatetimeExpression]
    [:numeric  NumericExpression]
    [:string   StringExpression]
    [:boolean  BooleanExpression]
-   [:else     (one-of segment)]])
+   [:value    value]
+   [:segment  segment]
+   [:else     Field]])
 
 (def ^:private CaseClause
   [:tuple {:error/message ":case subclause"} Filter ExpressionArg])

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -84,6 +84,16 @@
              mbql->native
              sql.qp-test-util/sql->sql-map))))
 
+(deftest ^:parallel false-equals-false-test
+  (is (= '{:select [COUNT (*) AS count]
+           :from   [CHECKINS]
+           :where  [FALSE = FALSE]}
+         (-> (lib.tu.macros/mbql-query checkins
+               {:aggregation [[:count]]
+                :filter      [:= false false]})
+             mbql->native
+             sql.qp-test-util/sql->sql-map))))
+
 (deftest ^:parallel case-test
   (testing "Test that boolean case defaults are kept (#24100)"
     (is (= [[1 1 true]

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -189,3 +189,10 @@
     ::mbql.s/Addable [:relative-datetime -1 :month]
     ::mbql.s/Addable [:interval -2 :month]
     ::mbql.s/+       [:+ [:relative-datetime -1 :month] [:interval -2 :month]]))
+
+(deftest ^:parallel filter-test
+  (are [x] (not (me/humanize (mr/explain ::mbql.s/Filter x)))
+    [:value true nil]
+    [:value false nil]
+    [:field 1 nil]
+    [:segment 1]))

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -394,7 +394,7 @@
     {:database 1
      :type     :query
      :query    {:source-table 224
-                :expressions {"a" 1}
+                :expressions {"a" [:value 1 nil]}
                 :expression-idents {"a" (u/generate-nano-id)}}}
 
     ;; card__<id> source table syntax.


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-773/filters-reject-boolean-literals-in-dev-mode
Closes https://linear.app/metabase/issue/QUE-722/false-not-supported-as-leftmost-arg-of-=-operator-in-custom-filter

Allow `value`, `field`, and `expression` in filters.