### PR TITLE
Add create table endpoint

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -752,7 +752,7 @@
 
   enterprise/data-editing
   {:api #{}
-   :uses #{api actions util}}
+   :uses #{api actions driver upload util}}
 
   enterprise/task
   {:api  #{metabase-enterprise.task.truncate-audit-tables}

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -4,6 +4,9 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
+   [metabase.driver :as driver]
+   [metabase.upload :as-alias upload]
+   [metabase.util.i18n :as i18n]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -35,6 +38,56 @@
    {}
    {:keys [rows]}]
   (perform-bulk-action! :bulk/delete table-id rows))
+
+;; might later be changed, or made driver specific, we might later drop the requirement depending on admin trust
+;; model (e.g are admins trusted with writing arbitrary SQL cases anyway, will non admins ever call this?)
+(def ^:private Identifier
+  "A malli schema for strings that can be used as SQL identifiers"
+  [:re #"^[\w\- ]+$"])
+
+;; upload types are used temporarily, I expect this to change
+(def ^:private column-type->upload-type
+  {"auto_incrementing_int_pk" ::upload/auto-incrementing-int-pk
+   "boolean"                  ::upload/boolean
+   "int"                      ::upload/int
+   "float"                    ::upload/float
+   "varchar255"               ::upload/varchar-255
+   "text"                     ::upload/text
+   "date"                     ::upload/date
+   "datetime"                 ::upload/datetime
+   "offset_datetime"          ::upload/timestamp-with-time-zone})
+
+(def ^:private ColumnType
+  (into [:enum] (keys column-type->upload-type)))
+
+(defn- ensure-database-type [driver column-type]
+  (if-some [upload-type (column-type->upload-type column-type)]
+    (driver/upload-type->database-type driver upload-type)
+    (throw (ex-info (i18n/tru "Not a supported column type: {0}" column-type)
+                    {:status 400, :column-type column-type}))))
+
+(api.macros/defendpoint :post "/database/:db-id/table"
+  "Creates a new table in the given database"
+  [{:keys [db-id]} :- [:map [:db-id ms/PositiveInt]]
+   _
+   {table-name :name
+    :keys [primary_key columns]}
+   :-
+   [:map
+    [:name Identifier]
+    [:primary_key [:seqable {:min-count 1} Identifier]]
+    [:columns [:seqable
+               [:map
+                [:name Identifier]
+                [:type ColumnType]]]]]]
+  (api/check-superuser)
+  (let [{driver :engine :as database} (api/check-404 (t2/select-one :model/Database db-id))
+        _ (actions/check-data-editing-enabled-for-database! database)
+        column-map (->> (for [{column-name :name
+                               column-type :type} columns]
+                          [column-name (ensure-database-type driver column-type)])
+                        (into {}))]
+    (driver/create-table! driver db-id table-name column-map :primary-key (map keyword primary_key))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -19,6 +19,7 @@
  [metabase.actions.actions
   cached-value
   check-actions-enabled!
+  check-data-editing-enabled-for-database!
   perform-action!
   perform-action!*]
  [metabase.actions.error


### PR DESCRIPTION
Adds a new endpoint: `POST ee/data-editing/database/{db-id}/table`
- shares policy with data editing (admin only, data editing enabled)
- has a fixed type set (upload types) to limit security exposure for now
- does not permit changing nullable/default/generated yet
- no error handling for things like table already exists, syntax errors and so on - you'll just get a `500`
