### PR TITLE
fix: submit SaveQuestion modal by pressing Enter

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2499,3 +2499,28 @@ describe("issue 53036", () => {
     });
   });
 });
+
+describe("issue 54708", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should submit form on enter right after modal appearance (metabase#54708)", () => {
+    H.openOrdersTable();
+    cy.findByTestId("qb-save-button").click();
+
+    cy.findByRole("dialog").within(() => {
+      cy.focused().should("have.attr", "value", "Orders");
+    });
+
+    cy.log("submit form by pressing Enter");
+    cy.realPress("Enter");
+
+    cy.log("verify that form was submitted");
+    cy.findByRole("dialog").should(
+      "contain",
+      "Saved! Add this to a dashboard?",
+    );
+  });
+});

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -103,6 +103,7 @@ export const SaveQuestionForm = ({
       {values.saveType === "create" && (
         <Stack gap="md" mb="md">
           <FormTextInput
+            data-autofocus
             name="name"
             label={t`Name`}
             placeholder={nameInputPlaceholder}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54708

### Description

Set focus to the first input element in the modal, so pressing Enter will submit the form. 
Previously focus was on "X" button after modal appearing, so pressing Enter closed the modal without any notice

### How to verify

follow steps from the issue

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

Example of the failing test

<img width="915" alt="Screenshot 2025-03-19 at 19 12 17" src="https://github.com/user-attachments/assets/512074be-fa55-4614-9fe7-18e8934909ab" />

