### PR TITLE
Fix date/string literals effective type

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -294,11 +294,11 @@
                                              ;; cases, e.g. #{:type/Text :type/Date} for date literals. Since
                                              ;; `:effective-type` can be just one value, prefer string, numeric, and
                                              ;; boolean types over others.
-                                             (let [type (lib.schema.expression/type-of value)]
-                                               (if (set? type)
-                                                 (or (m/find-first (fn [t] (some #(isa? t %) [:type/Text :type/Number :type/Boolean])) type)
-                                                     (first type))
-                                                 type))))]
+                                             (let [types (lib.schema.expression/type-of value)]
+                                               (if (set? types)
+                                                 (or (m/find-first (fn [t] (some #(isa? t %) [:type/Text :type/Number :type/Boolean])) types)
+                                                     (first types))
+                                                 types))))]
     (lib.options/ensure-uuid [:value opts value])))
 
 (doseq [tag [:case :if]]

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -296,7 +296,8 @@
                                              ;; boolean types over others.
                                              (let [type (lib.schema.expression/type-of value)]
                                                (if (set? type)
-                                                 (m/find-first (fn [t] (some #(isa? t %) [:type/Text :type/Number :type/Boolean :type/*])) type)
+                                                 (or (m/find-first (fn [t] (some #(isa? t %) [:type/Text :type/Number :type/Boolean])) type)
+                                                     (first type))
                                                  type))))]
     (lib.options/ensure-uuid [:value opts value])))
 

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -1060,3 +1060,21 @@
         (testing "round trip to pMBQL and back with small changes"
           (is (= query
                  (lib.convert/->legacy-MBQL (lib.convert/->pMBQL query)))))))))
+
+(deftest ^:parallel round-trip-expression-literal-test
+  (are [literal] (test-round-trip {:database 1
+                                   :type     :query
+                                   :query    {:source-table 224
+                                              :expressions {"a" [:value literal nil]}
+                                              :expression-idents {"a" (u/generate-nano-id)}}})
+    true
+    false
+    0
+    10
+    -10
+    10.15
+    "abc"
+    "2020-10-20"
+    "2020-10-20T10:20:00"
+    "2020-10-20T10:20:00Z"
+    "10:20:00"))

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -233,7 +233,7 @@
       (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
   (testing "simple values can be converted properly (#36459)"
     (let [query (lib.tu/venues-query)
-          legacy-expr ["value" 0 nil]
+          legacy-expr #js ["value" 0 nil]
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
           legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
           query-with-expr (lib/expression query 0 "expr" expr)

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -240,7 +240,7 @@
           expr-from-query (first (lib/expressions query-with-expr 0))
           legacy-expr-from-query (lib.js/legacy-expression-for-expression-clause query-with-expr 0 expr-from-query)
           named-expr (lib/with-expression-name expr "named")]
-      (is (= legacy-expr expr legacy-expr' legacy-expr-from-query))
+      (is (= legacy-expr legacy-expr' legacy-expr-from-query))
       (is (= "named" (lib/display-name query named-expr)))))
   (testing "simple expressions can be converted properly (#37173)"
     (let [query (lib.tu/venues-query)

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -233,7 +233,7 @@
       (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
   (testing "simple values can be converted properly (#36459)"
     (let [query (lib.tu/venues-query)
-          legacy-expr [:value 0 nil]
+          legacy-expr ["value" 0 nil]
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
           legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
           query-with-expr (lib/expression query 0 "expr" expr)

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -240,7 +240,7 @@
           expr-from-query (first (lib/expressions query-with-expr 0))
           legacy-expr-from-query (lib.js/legacy-expression-for-expression-clause query-with-expr 0 expr-from-query)
           named-expr (lib/with-expression-name expr "named")]
-      (is (= legacy-expr legacy-expr' legacy-expr-from-query))
+      (is (= (js->clj legacy-expr) (js->clj legacy-expr') (js->clj legacy-expr-from-query)))
       (is (= "named" (lib/display-name query named-expr)))))
   (testing "simple expressions can be converted properly (#37173)"
     (let [query (lib.tu/venues-query)

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -233,7 +233,7 @@
       (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
   (testing "simple values can be converted properly (#36459)"
     (let [query (lib.tu/venues-query)
-          legacy-expr 0
+          legacy-expr [:value 0 nil]
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
           legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
           query-with-expr (lib/expression query 0 "expr" expr)


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-724/custom-column-with-a-literal-date-string-fails-with-error-in

Fixes `:value` conversion when there is no `:base-type` or `:effective-type`. Following the logic found in other places, handle a `set` of types in a special way. Here, we prefer `:type/Text`, `:type/Number`, `:type/Boolean` descendants over others, namely over `:type/Temporal`.