### PR TITLE
Use SDK-specific ID types and reconcile the changes

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/SdkSaveQuestionForm.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/SdkSaveQuestionForm.tsx
@@ -1,11 +1,10 @@
+import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import {
   SaveQuestionForm,
   SaveQuestionTitle,
 } from "metabase/components/SaveQuestionForm";
 import { SaveQuestionProvider } from "metabase/components/SaveQuestionForm/context";
-import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { Stack, Title } from "metabase/ui";
-import type { CollectionId } from "metabase-types/api";
 
 import { useInteractiveQuestionContext } from "../context";
 
@@ -17,16 +16,13 @@ export const SdkSaveQuestionForm = ({ onCancel }: SdkSaveQuestionFormProps) => {
   const { question, originalQuestion, onSave, onCreate, targetCollection } =
     useInteractiveQuestionContext();
 
-  const { id, isLoading } = useValidatedEntityId({
-    type: "collection",
+  const { id, isLoading } = useTranslatedCollectionId({
     id: targetCollection,
   });
 
   if (!question || isLoading) {
     return null;
   }
-
-  const finalId = id ?? targetCollection;
 
   return (
     <SaveQuestionProvider
@@ -35,7 +31,7 @@ export const SdkSaveQuestionForm = ({ onCancel }: SdkSaveQuestionFormProps) => {
       onCreate={onCreate}
       onSave={onSave}
       multiStep={false}
-      targetCollection={isValidId(finalId) ? finalId : undefined}
+      targetCollection={id}
     >
       <Stack p="md">
         <Title>
@@ -44,14 +40,5 @@ export const SdkSaveQuestionForm = ({ onCancel }: SdkSaveQuestionFormProps) => {
         <SaveQuestionForm onCancel={() => onCancel?.()} />
       </Stack>
     </SaveQuestionProvider>
-  );
-};
-
-const isValidId = (collectionId: unknown): collectionId is CollectionId => {
-  return (
-    !!collectionId &&
-    (typeof collectionId === "number" ||
-      collectionId === "personal" ||
-      collectionId === "root")
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/SdkSaveQuestionForm.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/SdkSaveQuestionForm.tsx
@@ -3,7 +3,9 @@ import {
   SaveQuestionTitle,
 } from "metabase/components/SaveQuestionForm";
 import { SaveQuestionProvider } from "metabase/components/SaveQuestionForm/context";
+import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { Stack, Title } from "metabase/ui";
+import type { CollectionId } from "metabase-types/api";
 
 import { useInteractiveQuestionContext } from "../context";
 
@@ -15,9 +17,16 @@ export const SdkSaveQuestionForm = ({ onCancel }: SdkSaveQuestionFormProps) => {
   const { question, originalQuestion, onSave, onCreate, targetCollection } =
     useInteractiveQuestionContext();
 
-  if (!question) {
+  const { id, isLoading } = useValidatedEntityId({
+    type: "collection",
+    id: targetCollection,
+  });
+
+  if (!question || isLoading) {
     return null;
   }
+
+  const finalId = id ?? targetCollection;
 
   return (
     <SaveQuestionProvider
@@ -26,7 +35,7 @@ export const SdkSaveQuestionForm = ({ onCancel }: SdkSaveQuestionFormProps) => {
       onCreate={onCreate}
       onSave={onSave}
       multiStep={false}
-      targetCollection={targetCollection}
+      targetCollection={isValidId(finalId) ? finalId : undefined}
     >
       <Stack p="md">
         <Title>
@@ -35,5 +44,14 @@ export const SdkSaveQuestionForm = ({ onCancel }: SdkSaveQuestionFormProps) => {
         <SaveQuestionForm onCancel={() => onCancel?.()} />
       </Stack>
     </SaveQuestionProvider>
+  );
+};
+
+const isValidId = (collectionId: unknown): collectionId is CollectionId => {
+  return (
+    !!collectionId &&
+    (typeof collectionId === "number" ||
+      collectionId === "personal" ||
+      collectionId === "root")
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -2,10 +2,10 @@ import type { PropsWithChildren } from "react";
 
 import type { MetabasePluginsConfig } from "embedding-sdk";
 import type { LoadQuestionHookResult } from "embedding-sdk/hooks/private/use-load-question";
-import type { SDKCollectionId } from "embedding-sdk/types/collection";
+import type { SdkCollectionId } from "embedding-sdk/types/collection";
 import type {
-  InteractiveQuestionId,
   LoadSdkQuestionParams,
+  SdkQuestionId,
 } from "embedding-sdk/types/question";
 import type { MetabaseQuestion } from "metabase/embedding-sdk/types/question";
 import type { NotebookProps as QBNotebookProps } from "metabase/querying/notebook/components/Notebook";
@@ -37,7 +37,7 @@ type InteractiveQuestionConfig = {
   initialSqlParameters?: ParameterValues;
   withDownloads?: boolean;
 
-  targetCollection?: SDKCollectionId;
+  targetCollection?: SdkCollectionId;
 };
 
 export type QuestionMockLocationParameters = {
@@ -48,7 +48,7 @@ export type QuestionMockLocationParameters = {
 export type InteractiveQuestionProviderProps = PropsWithChildren<
   InteractiveQuestionConfig &
     Omit<LoadSdkQuestionParams, "questionId"> & {
-      questionId: InteractiveQuestionId | null;
+      questionId: SdkQuestionId | null;
       variant?: "static" | "interactive";
     }
 >;
@@ -71,5 +71,5 @@ export type InteractiveQuestionContextType = Omit<
     onSave: (question: Question) => Promise<void>;
   } & {
     isCardIdError: boolean;
-    originalId: InteractiveQuestionId | null;
+    originalId: SdkQuestionId | null;
   };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -2,14 +2,16 @@ import type { PropsWithChildren } from "react";
 
 import type { MetabasePluginsConfig } from "embedding-sdk";
 import type { LoadQuestionHookResult } from "embedding-sdk/hooks/private/use-load-question";
-import type { SDKCollectionReference } from "embedding-sdk/store/collections";
-import type { LoadSdkQuestionParams } from "embedding-sdk/types/question";
-import type { SaveQuestionProps } from "metabase/components/SaveQuestionForm/types";
+import type { SDKCollectionId } from "embedding-sdk/types/collection";
+import type {
+  InteractiveQuestionId,
+  LoadSdkQuestionParams,
+} from "embedding-sdk/types/question";
 import type { MetabaseQuestion } from "metabase/embedding-sdk/types/question";
 import type { NotebookProps as QBNotebookProps } from "metabase/querying/notebook/components/Notebook";
 import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import type Question from "metabase-lib/v1/Question";
-import type { CardId, ParameterId } from "metabase-types/api";
+import type { ParameterId } from "metabase-types/api";
 
 export type EntityTypeFilterKeys = "table" | "question" | "model" | "metric";
 
@@ -34,15 +36,14 @@ type InteractiveQuestionConfig = {
   /** Initial values for the SQL parameters */
   initialSqlParameters?: ParameterValues;
   withDownloads?: boolean;
-} & Pick<SaveQuestionProps<SDKCollectionReference>, "targetCollection">;
+
+  targetCollection?: SDKCollectionId;
+};
 
 export type QuestionMockLocationParameters = {
   location: { search: string; hash: string; pathname: string };
   params: { slug?: string };
 };
-
-// eslint-disable-next-line @typescript-eslint/ban-types -- this is needed to allow any Entity ID string but keep autocomplete for "new", for creating new questions.
-export type InteractiveQuestionId = CardId | "new" | (string & {});
 
 export type InteractiveQuestionProviderProps = PropsWithChildren<
   InteractiveQuestionConfig &

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -11,7 +11,6 @@ import {
 import { shouldRunCardQuery } from "embedding-sdk/lib/interactive-question";
 import type { SdkQuestionTitleProps } from "embedding-sdk/types/question";
 import { SaveQuestionModal } from "metabase/containers/SaveQuestionModal";
-import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import {
   Box,
   Button,
@@ -20,7 +19,6 @@ import {
   PopoverBackButton,
   Stack,
 } from "metabase/ui";
-import type { CollectionId } from "metabase-types/api";
 
 import { InteractiveQuestion } from "../../public/InteractiveQuestion";
 import {
@@ -196,40 +194,27 @@ const DefaultViewSaveModal = ({
     targetCollection,
   } = useInteractiveQuestionContext();
 
-  const { id, isLoading } = useValidatedEntityId({
-    type: "collection",
+  const { id, isLoading } = useTranslatedCollectionId({
     id: targetCollection,
   });
 
-  const finalId = id ?? targetCollection;
+  if (!isSaveEnabled || !isOpen || !question || isLoading) {
+    return null;
+  }
 
   return (
-    isSaveEnabled &&
-    isOpen &&
-    question &&
-    !isLoading && (
-      <SaveQuestionModal
-        question={question}
-        originalQuestion={originalQuestion ?? null}
-        opened
-        closeOnSuccess
-        onClose={close}
-        onCreate={onCreate}
-        onSave={async question => {
-          await onSave(question);
-          close();
-        }}
-        targetCollection={isValidId(finalId) ? finalId : undefined}
-      />
-    )
-  );
-};
-
-const isValidId = (collectionId: unknown): collectionId is CollectionId => {
-  return (
-    !!collectionId &&
-    (typeof collectionId === "number" ||
-      collectionId === "personal" ||
-      collectionId === "root")
+    <SaveQuestionModal
+      question={question}
+      originalQuestion={originalQuestion ?? null}
+      opened
+      closeOnSuccess
+      onClose={close}
+      onCreate={onCreate}
+      onSave={async question => {
+        await onSave(question);
+        close();
+      }}
+      targetCollection={id}
+    />
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -8,6 +8,7 @@ import {
   SdkError,
   SdkLoader,
 } from "embedding-sdk/components/private/PublicComponentWrapper";
+import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import { shouldRunCardQuery } from "embedding-sdk/lib/interactive-question";
 import type { SdkQuestionTitleProps } from "embedding-sdk/types/question";
 import { SaveQuestionModal } from "metabase/containers/SaveQuestionModal";

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -10,12 +10,12 @@ import {
   SdkLoader,
   withPublicComponentWrapper,
 } from "embedding-sdk/components/private/PublicComponentWrapper";
+import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
 import { useSdkSelector } from "embedding-sdk/store/use-sdk-selector";
 import type { SdkCollectionId } from "embedding-sdk/types/collection";
 import { COLLECTION_PAGE_SIZE } from "metabase/collections/components/CollectionContent";
 import { CollectionItemsTable } from "metabase/collections/components/CollectionContent/CollectionItemsTable";
-import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { isNotNull } from "metabase/lib/types";
 import CollectionBreadcrumbs from "metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs";
 import { Stack } from "metabase/ui";
@@ -128,21 +128,11 @@ export const CollectionBrowserInner = ({
   );
 };
 
-const isValidId = (collectionId: unknown): collectionId is CollectionId => {
-  return (
-    !!collectionId &&
-    (typeof collectionId === "number" ||
-      collectionId === "personal" ||
-      collectionId === "root")
-  );
-};
-
 const CollectionBrowserWrapper = ({
   collectionId = "personal",
   ...restProps
 }: CollectionBrowserProps) => {
-  const { id, isLoading } = useValidatedEntityId({
-    type: "collection",
+  const { id, isLoading } = useTranslatedCollectionId({
     id: collectionId,
   });
 
@@ -150,13 +140,11 @@ const CollectionBrowserWrapper = ({
     return <SdkLoader />;
   }
 
-  const finalId = id ?? collectionId;
-
-  if (!isValidId(finalId)) {
+  if (!id) {
     return <CollectionNotFoundError id={collectionId} />;
   }
 
-  return <CollectionBrowserInner collectionId={finalId} {...restProps} />;
+  return <CollectionBrowserInner collectionId={id} {...restProps} />;
 };
 
 export const CollectionBrowser = withPublicComponentWrapper(

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -12,7 +12,7 @@ import {
 } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
 import { useSdkSelector } from "embedding-sdk/store/use-sdk-selector";
-import type { SDKCollectionId } from "embedding-sdk/types/collection";
+import type { SdkCollectionId } from "embedding-sdk/types/collection";
 import { COLLECTION_PAGE_SIZE } from "metabase/collections/components/CollectionContent";
 import { CollectionItemsTable } from "metabase/collections/components/CollectionContent/CollectionItemsTable";
 import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
@@ -58,7 +58,7 @@ const ENTITY_NAME_MAP: Partial<
 };
 
 export type CollectionBrowserProps = {
-  collectionId?: SDKCollectionId;
+  collectionId?: SdkCollectionId;
   onClick?: (item: CollectionItem) => void;
   pageSize?: number;
   visibleEntityTypes?: UserFacingEntityName[];

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
-import type { SDKCollectionId } from "embedding-sdk/types/collection";
+import type { SdkCollectionId } from "embedding-sdk/types/collection";
 import { CreateDashboardModal as CreateDashboardModalCore } from "metabase/dashboard/containers/CreateDashboardModal";
 import Collections from "metabase/entities/collections";
 import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
@@ -12,7 +12,7 @@ import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 export interface CreateDashboardModalProps {
-  initialCollectionId?: SDKCollectionId;
+  initialCollectionId?: SdkCollectionId;
   isOpen?: boolean;
   onCreate: (dashboard: Dashboard) => void;
   onClose?: () => void;

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -1,13 +1,13 @@
-import type React from "react";
 import _ from "underscore";
 
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
-import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
+import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import type { SdkCollectionId } from "embedding-sdk/types/collection";
-import { CreateDashboardModal as CreateDashboardModalCore } from "metabase/dashboard/containers/CreateDashboardModal";
+import {
+  CreateDashboardModal as CreateDashboardModalCore,
+  type CreateDashboardModalProps as CreateDashboardModalCoreProps,
+} from "metabase/dashboard/containers/CreateDashboardModal";
 import Collections from "metabase/entities/collections";
-import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
-import { useSelector } from "metabase/lib/redux";
 import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
@@ -24,33 +24,28 @@ const CreateDashboardModalInner = ({
   onCreate,
   onClose,
 }: CreateDashboardModalProps) => {
-  const { id, isLoading } = useValidatedEntityId({
-    type: "collection",
+  const { id, isLoading } = useTranslatedCollectionId({
     id: initialCollectionId,
   });
 
-  const initId = !isLoading && (id ?? initialCollectionId);
-
-  const translatedCollectionId = useSelector((state: State) =>
-    initId ? getCollectionIdSlugFromReference(state, initId) : undefined,
-  );
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <CreateDashboardModalCoreWithLoading
       opened={!isLoading && isOpen}
       onCreate={onCreate}
       onClose={onClose}
-      collectionId={translatedCollectionId}
+      collectionId={id}
     />
   );
 };
 
 const CreateDashboardModalCoreWithLoading = _.compose(
   Collections.load({
-    id: (
-      _state: State,
-      props: React.ComponentProps<typeof CreateDashboardModalCore>,
-    ) => props.collectionId,
+    id: (_state: State, props: CreateDashboardModalCoreProps) =>
+      props.collectionId,
     loadingAndErrorWrapper: false,
   }),
 )(CreateDashboardModalCore);

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -2,10 +2,8 @@ import type React from "react";
 import _ from "underscore";
 
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
-import {
-  type SDKCollectionReference,
-  getCollectionIdSlugFromReference,
-} from "embedding-sdk/store/collections";
+import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
+import type { SDKCollectionId } from "embedding-sdk/types/collection";
 import { CreateDashboardModal as CreateDashboardModalCore } from "metabase/dashboard/containers/CreateDashboardModal";
 import Collections from "metabase/entities/collections";
 import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
@@ -14,7 +12,7 @@ import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 export interface CreateDashboardModalProps {
-  initialCollectionId?: SDKCollectionReference;
+  initialCollectionId?: SDKCollectionId;
   isOpen?: boolean;
   onCreate: (dashboard: Dashboard) => void;
   onClose?: () => void;
@@ -26,10 +24,7 @@ const CreateDashboardModalInner = ({
   onCreate,
   onClose,
 }: CreateDashboardModalProps) => {
-  const { id, isLoading } = useValidatedEntityId<
-    "collection",
-    SDKCollectionReference
-  >({
+  const { id, isLoading } = useValidatedEntityId({
     type: "collection",
     id: initialCollectionId,
   });

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.ts
@@ -1,16 +1,14 @@
 import { useCallback } from "react";
 
 import { useSdkStore } from "embedding-sdk/store";
-import {
-  type SDKCollectionReference,
-  getCollectionNumericIdFromReference,
-} from "embedding-sdk/store/collections";
+import { getCollectionNumericIdFromReference } from "embedding-sdk/store/collections";
+import type { SDKCollectionId } from "embedding-sdk/types/collection";
 import { useCreateDashboardMutation } from "metabase/api";
 import type { CreateDashboardProperties } from "metabase/dashboard/containers/CreateDashboardForm";
 
 export interface CreateDashboardValues
   extends Omit<CreateDashboardProperties, "collection_id"> {
-  collectionId: SDKCollectionReference;
+  collectionId: SDKCollectionId;
 }
 
 export const useCreateDashboardApi = () => {

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.ts
@@ -2,13 +2,13 @@ import { useCallback } from "react";
 
 import { useSdkStore } from "embedding-sdk/store";
 import { getCollectionNumericIdFromReference } from "embedding-sdk/store/collections";
-import type { SDKCollectionId } from "embedding-sdk/types/collection";
+import type { SdkCollectionId } from "embedding-sdk/types/collection";
 import { useCreateDashboardMutation } from "metabase/api";
 import type { CreateDashboardProperties } from "metabase/dashboard/containers/CreateDashboardForm";
 
 export interface CreateDashboardValues
   extends Omit<CreateDashboardProperties, "collection_id"> {
-  collectionId: SDKCollectionId;
+  collectionId: SdkCollectionId;
 }
 
 export const useCreateDashboardApi = () => {

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -24,7 +24,6 @@ import {
   Title,
 } from "embedding-sdk/components/private/InteractiveQuestion/components";
 import {
-  type InteractiveQuestionId,
   InteractiveQuestionProvider,
   type InteractiveQuestionProviderProps,
 } from "embedding-sdk/components/private/InteractiveQuestion/context";
@@ -33,14 +32,12 @@ import {
   type InteractiveQuestionDefaultViewProps,
 } from "embedding-sdk/components/private/InteractiveQuestionDefaultView";
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
-import type { SDKCollectionReference } from "embedding-sdk/store/collections";
-import type { SaveQuestionProps } from "metabase/components/SaveQuestionForm/types";
+import type { InteractiveQuestionId } from "embedding-sdk/types/question";
 
 export type InteractiveQuestionProps = PropsWithChildren<{
   questionId: InteractiveQuestionId;
   plugins?: InteractiveQuestionProviderProps["componentPlugins"];
 }> &
-  Pick<SaveQuestionProps<SDKCollectionReference>, "targetCollection"> &
   Pick<
     InteractiveQuestionProviderProps,
     | "questionId"
@@ -50,6 +47,7 @@ export type InteractiveQuestionProps = PropsWithChildren<{
     | "isSaveEnabled"
     | "initialSqlParameters"
     | "withDownloads"
+    | "targetCollection"
   >;
 
 export const _InteractiveQuestion = ({

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -32,10 +32,10 @@ import {
   type InteractiveQuestionDefaultViewProps,
 } from "embedding-sdk/components/private/InteractiveQuestionDefaultView";
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
-import type { InteractiveQuestionId } from "embedding-sdk/types/question";
+import type { SdkQuestionId } from "embedding-sdk/types/question";
 
 export type InteractiveQuestionProps = PropsWithChildren<{
-  questionId: InteractiveQuestionId;
+  questionId: SdkQuestionId;
   plugins?: InteractiveQuestionProviderProps["componentPlugins"];
 }> &
   Pick<

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
@@ -2,6 +2,7 @@ import type { Query } from "history";
 import type { CSSProperties } from "react";
 import { pick } from "underscore";
 
+import type { SdkDashboardId } from "embedding-sdk/types/dashboard";
 import { DEFAULT_DASHBOARD_DISPLAY_OPTIONS } from "metabase/dashboard/constants";
 import {
   useDashboardFullscreen,
@@ -11,10 +12,9 @@ import {
 import type { EmbedDisplayParams } from "metabase/dashboard/types";
 import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { isNotNull } from "metabase/lib/types";
-import type { DashboardId } from "metabase-types/api";
 
 export type SdkDashboardDisplayProps = {
-  dashboardId: DashboardId;
+  dashboardId: SdkDashboardId;
   initialParameters?: Query;
   withTitle?: boolean;
   withCardTitle?: boolean;

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-translated-collection-id.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-translated-collection-id.ts
@@ -1,0 +1,29 @@
+import { isValidId } from "embedding-sdk/lib/is-valid-collection-id";
+import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
+import type { SdkCollectionId } from "embedding-sdk/types/collection";
+import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
+import { useSelector } from "metabase/lib/redux";
+import type { State } from "metabase-types/store";
+
+export const useTranslatedCollectionId = ({
+  id: initialCollectionId,
+}: {
+  id?: SdkCollectionId;
+}) => {
+  const { id, isLoading, isError } = useValidatedEntityId({
+    type: "collection",
+    id: initialCollectionId,
+  });
+
+  const initId = !isLoading && (id ?? initialCollectionId);
+
+  const translatedCollectionId = useSelector((state: State) =>
+    initId ? getCollectionIdSlugFromReference(state, initId) : undefined,
+  );
+
+  return {
+    id: isValidId(translatedCollectionId) ? translatedCollectionId : undefined,
+    isLoading,
+    isError,
+  };
+};

--- a/enterprise/frontend/src/embedding-sdk/lib/is-valid-collection-id.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/is-valid-collection-id.ts
@@ -1,0 +1,12 @@
+import type { CollectionId } from "metabase-types/api";
+
+export const isValidId = (
+  collectionId: unknown,
+): collectionId is CollectionId => {
+  return (
+    !!collectionId &&
+    (typeof collectionId === "number" ||
+      collectionId === "personal" ||
+      collectionId === "root")
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk/store/collections.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/collections.ts
@@ -4,7 +4,7 @@ import { P, match } from "ts-pattern";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
 import type { CollectionId, RegularCollectionId } from "metabase-types/api";
 
-import type { SDKCollectionId } from "../types/collection";
+import type { SdkCollectionId } from "../types/collection";
 
 /**
  * Converts "personal" and "root" to the _numeric_ ids accepted by the api
@@ -13,7 +13,7 @@ import type { SDKCollectionId } from "../types/collection";
 export const getCollectionNumericIdFromReference = createSelector(
   [
     getUserPersonalCollectionId,
-    (_, collectionReference: SDKCollectionId) => collectionReference,
+    (_, collectionReference: SdkCollectionId) => collectionReference,
   ],
   (personalCollectionId, collectionReference): CollectionId | null => {
     return match(collectionReference)
@@ -37,7 +37,7 @@ export const getCollectionNumericIdFromReference = createSelector(
 export const getCollectionIdSlugFromReference = createSelector(
   [
     getUserPersonalCollectionId,
-    (_, collectionReference: SDKCollectionId) => collectionReference,
+    (_, collectionReference: SdkCollectionId) => collectionReference,
   ],
   (personalCollectionId, collectionReference): CollectionId => {
     return match(collectionReference)

--- a/enterprise/frontend/src/embedding-sdk/store/collections.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/collections.ts
@@ -2,12 +2,9 @@ import { createSelector } from "@reduxjs/toolkit";
 import { P, match } from "ts-pattern";
 
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
-import type { RegularCollectionId } from "metabase-types/api";
+import type { CollectionId, RegularCollectionId } from "metabase-types/api";
 
-// "CollectionId" from core app also includes "root" | "users" and "trash", we don't want to include those
-// in public apis of the sdk, as we don't support them
-
-export type SDKCollectionReference = RegularCollectionId | "personal" | "root";
+import type { SDKCollectionId } from "../types/collection";
 
 /**
  * Converts "personal" and "root" to the _numeric_ ids accepted by the api
@@ -16,13 +13,13 @@ export type SDKCollectionReference = RegularCollectionId | "personal" | "root";
 export const getCollectionNumericIdFromReference = createSelector(
   [
     getUserPersonalCollectionId,
-    (_, collectionReference: SDKCollectionReference) => collectionReference,
+    (_, collectionReference: SDKCollectionId) => collectionReference,
   ],
-  (personalCollectionId, collectionReference) => {
+  (personalCollectionId, collectionReference): CollectionId | null => {
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
       .with("root", () => null)
-      .with(P.number, () => collectionReference)
+      .with(P.number, () => collectionReference as CollectionId)
       .otherwise(() => {
         throw new Error(
           "Invalid collection id, expected `number | 'root' | 'personal'`",
@@ -40,13 +37,13 @@ export const getCollectionNumericIdFromReference = createSelector(
 export const getCollectionIdSlugFromReference = createSelector(
   [
     getUserPersonalCollectionId,
-    (_, collectionReference: SDKCollectionReference) => collectionReference,
+    (_, collectionReference: SDKCollectionId) => collectionReference,
   ],
-  (personalCollectionId, collectionReference) => {
+  (personalCollectionId, collectionReference): CollectionId => {
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
       .with("root", () => "root" as const)
-      .with(P.number, () => collectionReference)
+      .with(P.number, () => collectionReference as CollectionId)
       .otherwise(() => {
         throw new Error(
           "Invalid collection id, expected `number | 'root' | 'personal'`",

--- a/enterprise/frontend/src/embedding-sdk/store/collections.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/collections.ts
@@ -19,7 +19,7 @@ export const getCollectionNumericIdFromReference = createSelector(
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
       .with("root", () => null)
-      .with(P.number, () => collectionReference as CollectionId)
+      .with(P.number, () => collectionReference as RegularCollectionId)
       .otherwise(() => {
         throw new Error(
           "Invalid collection id, expected `number | 'root' | 'personal'`",
@@ -43,7 +43,7 @@ export const getCollectionIdSlugFromReference = createSelector(
     return match(collectionReference)
       .with("personal", () => personalCollectionId as RegularCollectionId)
       .with("root", () => "root" as const)
-      .with(P.number, () => collectionReference as CollectionId)
+      .with(P.number, () => collectionReference as RegularCollectionId)
       .otherwise(() => {
         throw new Error(
           "Invalid collection id, expected `number | 'root' | 'personal'`",

--- a/enterprise/frontend/src/embedding-sdk/types/collection.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/collection.ts
@@ -1,0 +1,12 @@
+import type { RegularCollectionId } from "metabase-types/api";
+
+import type { SdkEntityId } from "./entity-id";
+
+// "CollectionId" from core app also includes "root" | "users" and "trash", we don't want to include those
+// in public apis of the sdk, as we don't support them
+
+export type SDKCollectionId =
+  | RegularCollectionId
+  | "personal"
+  | "root"
+  | SdkEntityId;

--- a/enterprise/frontend/src/embedding-sdk/types/collection.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/collection.ts
@@ -1,12 +1,6 @@
-import type { RegularCollectionId } from "metabase-types/api";
-
 import type { SdkEntityId } from "./entity-id";
 
 // "CollectionId" from core app also includes "root" | "users" and "trash", we don't want to include those
 // in public apis of the sdk, as we don't support them
 
-export type SDKCollectionId =
-  | RegularCollectionId
-  | "personal"
-  | "root"
-  | SdkEntityId;
+export type SdkCollectionId = number | "personal" | "root" | SdkEntityId;

--- a/enterprise/frontend/src/embedding-sdk/types/dashboard.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/dashboard.ts
@@ -2,4 +2,4 @@ import type { DashboardId } from "metabase-types/api";
 
 import type { SdkEntityId } from "./entity-id";
 
-export type SdkDashboardId = DashboardId & SdkEntityId;
+export type SdkDashboardId = DashboardId | SdkEntityId;

--- a/enterprise/frontend/src/embedding-sdk/types/dashboard.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/dashboard.ts
@@ -1,0 +1,5 @@
+import type { DashboardId } from "metabase-types/api";
+
+import type { SdkEntityId } from "./entity-id";
+
+export type SdkDashboardId = DashboardId & SdkEntityId;

--- a/enterprise/frontend/src/embedding-sdk/types/entity-id.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/entity-id.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/ban-types -- allows for other string literal types in other ID types
+export type SdkEntityId = string & {};

--- a/enterprise/frontend/src/embedding-sdk/types/question.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/question.ts
@@ -9,7 +9,7 @@ import type { Card, CardId } from "metabase-types/api";
 
 import type { SdkEntityId } from "./entity-id";
 
-export type InteractiveQuestionId = CardId | "new" | SdkEntityId;
+export type SdkQuestionId = number | "new" | SdkEntityId;
 
 export interface SdkQuestionState {
   question?: Question;

--- a/enterprise/frontend/src/embedding-sdk/types/question.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/question.ts
@@ -7,6 +7,10 @@ import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/t
 import type Question from "metabase-lib/v1/Question";
 import type { Card, CardId } from "metabase-types/api";
 
+import type { SdkEntityId } from "./entity-id";
+
+export type InteractiveQuestionId = CardId | "new" | SdkEntityId;
+
 export interface SdkQuestionState {
   question?: Question;
   originalQuestion?: Question;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -102,6 +102,7 @@ export type CollectionItemId = number;
 
 export interface CollectionItem {
   id: CollectionItemId;
+  entity_id?: BaseEntityId;
   model: CollectionItemModel;
   name: string;
   description: string | null;

--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -1,4 +1,5 @@
 import type {
+  BaseEntityId,
   Collection,
   CollectionEssentials,
   CollectionItem,
@@ -27,6 +28,7 @@ export const createMockCollectionItem = (
   opts?: Partial<CollectionItem>,
 ): CollectionItem => ({
   id: 1,
+  entity_id: createMockEntityId(),
   model: "card",
   name: "Question",
   description: null,
@@ -47,6 +49,7 @@ export const createMockCollectionItemFromCollection = (
   createMockCollectionItem({
     ...opts,
     id: opts?.id as number,
+    entity_id: opts?.entity_id as BaseEntityId,
     model: "collection",
     type: undefined,
     location: opts?.location || "/",

--- a/frontend/src/metabase-types/api/mocks/entity-id.ts
+++ b/frontend/src/metabase-types/api/mocks/entity-id.ts
@@ -3,4 +3,4 @@ import { nanoid } from "@reduxjs/toolkit";
 import { type BaseEntityId, NANOID_LENGTH } from "../entity-id";
 
 export const createMockEntityId = (value?: string): BaseEntityId =>
-  (value ?? nanoid(NANOID_LENGTH)) as BaseEntityId;
+  (value || nanoid(NANOID_LENGTH)) as BaseEntityId;

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -248,6 +248,7 @@ const setup = async ({
             createMockCollectionItem({
               ...c,
               id: c.id as number,
+              entity_id: c.entity_id as BaseEntityId,
               effective_location: c.location || "/",
               location: c.location || "/",
               type: undefined,

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -21,6 +21,7 @@ import { getNextId } from "__support__/utils";
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
 import { checkNotNull, isNotNull } from "metabase/lib/types";
 import type {
+  BaseEntityId,
   Card,
   Collection,
   Dashboard,

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -25,7 +25,11 @@ import * as qbSelectors from "metabase/query_builder/selectors";
 import { QUESTION_NAME_MAX_LENGTH } from "metabase/questions/constants";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import type { CollectionId, DashboardId } from "metabase-types/api";
+import type {
+  BaseEntityId,
+  CollectionId,
+  DashboardId,
+} from "metabase-types/api";
 import {
   createMockCollection,
   createMockCollectionItem,
@@ -893,6 +897,7 @@ describe("SaveQuestionModal", () => {
           createMockCollectionItem({
             ...COLLECTION.PARENT,
             id: COLLECTION.PARENT.id as number,
+            entity_id: COLLECTION.PARENT.entity_id as BaseEntityId,
             location: COLLECTION.PARENT.location || "/",
             type: undefined,
             model: "collection",
@@ -905,6 +910,7 @@ describe("SaveQuestionModal", () => {
           createMockCollectionItem({
             ...COLLECTION.CHILD,
             id: COLLECTION.CHILD.id as number,
+            entity_id: COLLECTION.CHILD.entity_id as BaseEntityId,
             location: COLLECTION.CHILD.location || "/",
             type: undefined,
             model: "collection",

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -10,7 +10,7 @@ import type { Dashboard } from "metabase-types/api";
 import type { CreateDashboardFormOwnProps } from "./CreateDashboardForm";
 import { CreateDashboardForm } from "./CreateDashboardForm";
 
-interface CreateDashboardModalProps
+export interface CreateDashboardModalProps
   extends Omit<CreateDashboardFormOwnProps, "onCancel"> {
   onClose?: () => void;
 }


### PR DESCRIPTION
Attempts to standardize SDK ID types to ensure that we don't get type errors. 

Three IDs exist for the entities:
- `SdkDashboardId`
- `InteractiveQuestionId` (maybe we rename this)
- `SdkCollectionId`

I've tried to replace all instances of `CollectionId`, `CardId`, and `CollectionId` on **user-facing** props, then coerce them into the internal types once we get into the meat of the components. 

Let me know what you think and how we can improve this, or if I've missed something.