### PR TITLE
test: add renderHookWithProviders helper

### DIFF
--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -82,7 +82,6 @@ export function renderWithProviders(
     withUndos,
     customReducers,
     theme,
-    ...options,
   });
 
   const utils = testingLibraryRender(ui, {
@@ -99,26 +98,50 @@ export function renderWithProviders(
 
 export function renderHookWithProviders<TProps, TResult>(
   hook: (props: TProps) => TResult,
-  options?: Omit<RenderHookOptions<TProps>, "wrapper"> &
-    RenderWithProvidersOptions,
+  {
+    mode = "default",
+    initialRoute = "/",
+    storeInitialState = {},
+    withRouter = false,
+    withKBar = false,
+    withDND = false,
+    withUndos = false,
+    customReducers,
+    theme,
+    ...renderHookOptions
+  }: Omit<RenderHookOptions<TProps>, "wrapper"> & RenderWithProvidersOptions,
 ) {
-  const { wrapper, store } = getTestStoreAndWrapper(options);
-  const renderHookReturn = renderHook(hook, { wrapper, ...options });
+  const { wrapper, store } = getTestStoreAndWrapper({
+    mode,
+    initialRoute,
+    storeInitialState,
+    withRouter,
+    withKBar,
+    withDND,
+    withUndos,
+    customReducers,
+    theme,
+  });
+
+  const renderHookReturn = renderHook(hook, { wrapper, ...renderHookOptions });
 
   return { ...renderHookReturn, store };
 }
 
+type GetTestStoreAndWrapperOptions = RenderWithProvidersOptions &
+  Pick<Required<RenderWithProvidersOptions>, "initialRoute">;
+
 export function getTestStoreAndWrapper({
-  mode = "default",
-  initialRoute = "/",
-  storeInitialState = {},
-  withRouter = false,
-  withKBar = false,
-  withDND = false,
-  withUndos = false,
+  mode,
+  initialRoute,
+  storeInitialState,
+  withRouter,
+  withKBar,
+  withDND,
+  withUndos,
   customReducers,
   theme,
-}: RenderWithProvidersOptions = {}) {
+}: GetTestStoreAndWrapperOptions) {
   let { routing, ...initialState }: Partial<State> =
     createMockState(storeInitialState);
 


### PR DESCRIPTION
# Description

In embedding we needed to write some tests for a hook, and using `renderWithProviders` with a test component, while working, was a bit annoying as we need to serialized and deserialized booleans which can be error prone.

This PR extracts most of the setup logic from `renderWithProviders` so we can share it with a newly created `renderHookWithProviders`


# How to verify

CI is green on this PR -> I didn't broke `renderWithProviders`
In [this PR](https://github.com/metabase/metabase/pull/55416/files#diff-ea2d7dbdb0526ca04671b44ac72f3d74c1abb5c80dc4b62275bf0e5348a053b2R7) I'm also using `renderHookWithProviders` and unit tests are green there