### PR TITLE
Forbid top-level constants until the BE is fixed

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -1,6 +1,6 @@
 const { H } = cy;
 
-describe("scenarios > custom column > literals", () => {
+describe.skip("scenarios > custom column > literals", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
@@ -13,14 +13,13 @@ describe("scenarios > custom column > literals", () => {
       { name: "Zero", expression: "0", value: "0" },
       { name: "Number", expression: "10", value: "10" },
       { name: "String", expression: '"abc"', value: "abc" },
-      // TODO uncomment when fixed
-      // { name: "DateString", expression: '"2024-01-01"', value: "2024-01-01" },
-      // {
-      //   name: "DateTimeString",
-      //   expression: '"2024-01-01T10:20:00"',
-      //   value: "2024-01-01T10:20:00",
-      // },
-      // { name: "TimeString", expression: '"10:20"', value: "10:20" },
+      { name: "DateString", expression: '"2024-01-01"', value: "2024-01-01" },
+      {
+        name: "DateTimeString",
+        expression: '"2024-01-01T10:20:00"',
+        value: "2024-01-01T10:20:00",
+      },
+      { name: "TimeString", expression: '"10:20"', value: "10:20" },
       { name: "Column", expression: "[Number]", value: "10" },
       { name: "Expression", expression: "[Number] + [Number]", value: "20" },
     ];

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -530,9 +530,9 @@ describe("issue 41381", () => {
     H.addCustomColumn();
     H.enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
     H.popover().within(() => {
-      cy.findByText(
-        "Standalone constants are not supported. expression",
-      ).should("be.visible");
+      cy.findByText("Standalone constants are not supported.").should(
+        "be.visible",
+      );
       cy.button("Done").should("be.disabled");
     });
   });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -525,13 +525,15 @@ describe("issue 41381", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should not show an error message when adding a constant-only custom expression (metabase#41381)", () => {
+  it("should show an error message when adding a constant-only custom expression (metabase#41381)", () => {
     H.openOrdersTable({ mode: "notebook" });
     H.addCustomColumn();
     H.enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
     H.popover().within(() => {
-      cy.findByText("Invalid expression").should("not.exist");
-      cy.button("Done").should("be.enabled");
+      cy.findByText(
+        "Standalone constants are not supported. expression",
+      ).should("be.visible");
+      cy.button("Done").should("be.disabled");
     });
   });
 });

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -528,4 +528,7 @@
         (when (and (= expression-mode :filter)
                    (lib.util.match/match-one expr :offset))
           {:message  (i18n/tru "OFFSET is not supported in custom filters")
+           :friendly true})
+        (when (= (first expr) :value)
+          {:message  (i18n/tru "Standalone constants are not supported.")
            :friendly true}))))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -541,6 +541,15 @@
                                                          100)
                                                   nil))))))
 
+(deftest ^:parallel diagnose-expression-literals-test
+  (testing "top-level literals are not allowed"
+    (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          expr  [:value {:lib/uuid (str (random-uuid)) :effective-type :type/Integer} 1]]
+      (doseq [mode [:expression :filter]]
+        (is (=? {:message  "Standalone constants are not supported."
+                 :friendly true}
+                (lib.expression/diagnose-expression query 0 mode expr nil)))))))
+
 (deftest ^:parallel date-and-time-string-literals-test-1-dates
   (are [types input] (= types (lib.schema.expression/type-of input))
     #{:type/Date :type/Text} "2024-07-02"))


### PR DESCRIPTION
Forbid top-level constants to be able to:
1) merge changes to `master` until everything is fixed
2) fix drivers one-by-one instead of fixing them all at once. When the driver is fixed, the error will not be shown

<img width="766" alt="Screenshot 2025-03-20 at 09 15 13" src="https://github.com/user-attachments/assets/46488186-595a-4765-9a12-52259c498eee" />
