### PR TITLE
feature(enterprise): add creation and editing modals for table editing 

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
@@ -98,18 +98,17 @@ export const EditTableDataContainer = ({
     { open: openCreateRowModal, close: closeCreateRowModal },
   ] = useDisclosure(false);
 
-  const [expandedRowIndex, setExpandedRowIndex] = useState<number | null>(null);
-  const handleRowExpectClick = useCallback(
-    (rowIndex: number) => {
-      setExpandedRowIndex(rowIndex);
-    },
-    [setExpandedRowIndex],
-  );
+  const [expandedRowIndex, setExpandedRowIndex] = useState<
+    number | undefined
+  >();
 
-  const handleCreationOrEditingModalClose = useCallback(() => {
-    closeCreateRowModal();
-    setExpandedRowIndex(null);
-  }, [closeCreateRowModal, setExpandedRowIndex]);
+  const handleModalOpenAndExpandedRow = useCallback(
+    (rowIndex?: number) => {
+      setExpandedRowIndex(rowIndex);
+      openCreateRowModal();
+    },
+    [openCreateRowModal],
+  );
 
   if (!database || isLoading || tableIdLoading) {
     // TODO: show loader
@@ -127,7 +126,7 @@ export const EditTableDataContainer = ({
         {table && (
           <EditTableDataHeader
             table={table}
-            onCreate={openCreateRowModal}
+            onCreate={handleModalOpenAndExpandedRow}
             onDelete={handleRowsDelete}
           />
         )}
@@ -137,7 +136,7 @@ export const EditTableDataContainer = ({
               <EditTableDataGrid
                 data={datasetData}
                 onCellValueUpdate={handleCellValueUpdate}
-                onRowExpandClick={handleRowExpectClick}
+                onRowExpandClick={handleModalOpenAndExpandedRow}
               />
             </Box>
             <Flex
@@ -162,11 +161,11 @@ export const EditTableDataContainer = ({
         )}
       </Stack>
       <EditingBaseRowModal
-        opened={isCreateRowModalOpen || expandedRowIndex !== null}
-        onClose={handleCreationOrEditingModalClose}
+        opened={isCreateRowModalOpen}
+        onClose={closeCreateRowModal}
         datasetColumns={datasetData.data.cols}
         currentRowData={
-          expandedRowIndex !== null
+          expandedRowIndex !== undefined
             ? datasetData.data.rows[expandedRowIndex]
             : undefined
         }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
@@ -16,17 +16,19 @@ import type { Dataset, RowValue, RowValues } from "metabase-types/api";
 import type { UpdatedRowCellsHandlerParams } from "../types";
 
 import S from "./EditTableData.module.css";
-import { EditingBodyCellConditional } from "./EditingBodyCell";
+import { EditingBodyCellWrapper } from "./EditingBodyCell";
 import { useTableEditing } from "./use-table-editing";
 
 type EditTableDataGridProps = {
   data: Dataset;
   onCellValueUpdate: (params: UpdatedRowCellsHandlerParams) => void;
+  onRowExpandClick: (rowIndex: number) => void;
 };
 
 export const EditTableDataGrid = ({
   data,
   onCellValueUpdate,
+  onRowExpandClick,
 }: EditTableDataGridProps) => {
   const { cols, rows } = useMemo(
     () => extractRemappedColumns(data.data),
@@ -56,7 +58,7 @@ export const EditTableDataGrid = ({
           );
         },
         editingCell: cellContext => (
-          <EditingBodyCellConditional
+          <EditingBodyCellWrapper
             cellContext={cellContext}
             column={column}
             onCellValueUpdate={onCellValueUpdate}
@@ -73,8 +75,9 @@ export const EditTableDataGrid = ({
   const rowId: RowIdColumnOptions = useMemo(
     () => ({
       variant: "expandButton",
+      onRowExpandClick,
     }),
-    [],
+    [onRowExpandClick],
   );
 
   const tableProps = useDataGridInstance({

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataHeader.tsx
@@ -14,7 +14,7 @@ interface EditTableDataHeaderProps {
 export const EditTableDataHeader = ({
   table,
   onCreate,
-  onDelete,
+  // onDelete,
 }: EditTableDataHeaderProps) => {
   return (
     <Flex
@@ -34,11 +34,11 @@ export const EditTableDataHeader = ({
           variant="filled"
           onClick={onCreate}
         >{t`New record`}</Button>
-        <Button
+        {/* <Button
           leftSection={<Icon name="trash" />}
           disabled
           onClick={onDelete}
-        >{t`Delete`}</Button>
+        >{t`Delete`}</Button> */}
       </Group>
     </Flex>
   );

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.module.css
@@ -1,4 +1,4 @@
-.input {
+.inlineEditingInput {
   transition: none;
   outline: 2px solid var(--mb-base-color-blue-50);
   outline-offset: -2px;
@@ -6,12 +6,10 @@
   box-sizing: border-box;
   font-weight: 700;
   background-color: var(--mb-base-color-white);
+  border-radius: 0;
 
-  /* needed to avoid outline truncation for a focused cell */
-  z-index: 5;
-  position: relative;
-}
-
-.noBackground {
-  background-color: transparent;
+  /** DateInput behaves a bit differently, therefore we need a style override for focused state */
+  &:focus {
+    outline: 2px solid var(--mb-base-color-blue-50);
+  }
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.tsx
@@ -5,22 +5,18 @@ import type { DatasetColumn, RowValue, RowValues } from "metabase-types/api";
 
 import type { UpdatedRowCellsHandlerParams } from "../types";
 
-import {
-  EditingBodyCellBasicInput,
-  EditingBodyCellCategorySelect,
-  EditingBodyCellDatetime,
-  EditingBodyCellFKSelect,
-} from "./inputs";
+import S from "./EditingBodyCell.module.css";
+import { EditingBodyCellConditional } from "./inputs";
 
-interface EditingBodyCellProps<TRow, TValue> {
+interface EditingBodyCellWrapperProps<TRow, TValue> {
   column: DatasetColumn;
   cellContext: CellContext<TRow, TValue>;
   onCellValueUpdate: (params: UpdatedRowCellsHandlerParams) => void;
   onCellEditCancel: () => void;
 }
 
-export const EditingBodyCellConditional = (
-  props: EditingBodyCellProps<RowValues, RowValue>,
+export const EditingBodyCellWrapper = (
+  props: EditingBodyCellWrapperProps<RowValues, RowValue>,
 ) => {
   const {
     onCellEditCancel,
@@ -50,49 +46,14 @@ export const EditingBodyCellConditional = (
     [columnName, onCellEditCancel, onCellValueUpdate, rowIndex, initialValue],
   );
 
-  if (
-    column.semantic_type === "type/State" ||
-    column.semantic_type === "type/Country" ||
-    column.semantic_type === "type/Category"
-  ) {
-    return (
-      <EditingBodyCellCategorySelect
-        initialValue={initialValue}
-        datasetColumn={column}
-        onSubmit={doCellValueUpdate}
-        onCancel={onCellEditCancel}
-      />
-    );
-  }
-
-  if (column.semantic_type === "type/FK") {
-    return (
-      <EditingBodyCellFKSelect
-        initialValue={initialValue}
-        datasetColumn={column}
-        onSubmit={doCellValueUpdate}
-        onCancel={onCellEditCancel}
-      />
-    );
-  }
-
-  if (
-    column.effective_type === "type/Date" ||
-    column.effective_type === "type/DateTime" ||
-    column.effective_type === "type/DateTimeWithLocalTZ"
-  ) {
-    return (
-      <EditingBodyCellDatetime
-        initialValue={initialValue}
-        datasetColumn={column}
-        onSubmit={doCellValueUpdate}
-        onCancel={onCellEditCancel}
-      />
-    );
-  }
-
   return (
-    <EditingBodyCellBasicInput
+    <EditingBodyCellConditional
+      autoFocus
+      inputProps={{
+        variant: "unstyled",
+        className: S.inlineEditingInput,
+        size: "sm",
+      }}
       initialValue={initialValue}
       datasetColumn={column}
       onSubmit={doCellValueUpdate}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellBasicInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellBasicInput.tsx
@@ -1,9 +1,10 @@
 import { Input } from "metabase/ui";
 
-import S from "./EditingBodyCellInput.module.css";
 import type { EditingBodyPrimitiveProps } from "./types";
 
 export const EditingBodyCellBasicInput = ({
+  autoFocus,
+  inputProps,
   initialValue,
   onSubmit,
   onCancel,
@@ -11,10 +12,7 @@ export const EditingBodyCellBasicInput = ({
   return (
     <Input
       defaultValue={(initialValue ?? "").toString()}
-      className={S.input}
-      variant="unstyled"
-      size="sm"
-      autoFocus
+      autoFocus={autoFocus}
       onKeyUp={event => {
         if (event.key === "Escape") {
           onCancel();
@@ -25,6 +23,7 @@ export const EditingBodyCellBasicInput = ({
       onBlur={event => {
         onSubmit(event.currentTarget.value);
       }}
+      {...inputProps}
     />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.module.css
@@ -1,0 +1,3 @@
+.fakeInput {
+  caret-color: transparent;
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import { noop } from "underscore";
@@ -14,6 +15,7 @@ import {
   useCombobox,
 } from "metabase/ui";
 
+import S from "./EditingBodyCellCategorySelect.module.css";
 import type { EditingBodyPrimitiveProps } from "./types";
 
 type EditingBodyCellCategorySelectProps = EditingBodyPrimitiveProps & {
@@ -75,13 +77,10 @@ export const EditingBodyCellCategorySelect = ({
         <Input
           value={value}
           pointer
-          onClick={() => combobox.toggleDropdown()}
-          // makes input to act like a button, however appear like a regular input field
-          onMouseDown={event => {
-            event.preventDefault();
-          }}
+          onClick={() => combobox.openDropdown()}
           onChange={noop}
           {...inputProps}
+          className={cx(S.fakeInput, inputProps?.className)}
         />
       </Combobox.Target>
 
@@ -100,7 +99,7 @@ export const EditingBodyCellCategorySelect = ({
           {options.length > 0 ? (
             options.map(item => (
               <Combobox.Option
-                selected={initialValue === item.value}
+                selected={value === item.value}
                 value={item.value}
                 key={item.value}
               >

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
@@ -39,7 +39,7 @@ export const EditingBodyCellCategorySelect = ({
     datasetColumn.id ?? skipToken,
   );
 
-  const [value, setValue] = useState(initialValue?.toString());
+  const [value, setValue] = useState(initialValue?.toString() ?? "");
   const [search, setSearch] = useState("");
   const combobox = useCombobox({
     defaultOpened: autoFocus,

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
+import { noop } from "underscore";
 
 import { skipToken, useGetFieldValuesQuery } from "metabase/api";
 import { getFieldOptions } from "metabase/querying/filters/components/FilterValuePicker/utils";
@@ -13,7 +14,6 @@ import {
   useCombobox,
 } from "metabase/ui";
 
-import S from "./EditingBodyCellInput.module.css";
 import type { EditingBodyPrimitiveProps } from "./types";
 
 type EditingBodyCellCategorySelectProps = EditingBodyPrimitiveProps & {
@@ -24,6 +24,8 @@ type EditingBodyCellCategorySelectProps = EditingBodyPrimitiveProps & {
 const DefaultItemLabelTextGetter = (item: SelectOption) => item.label;
 
 export const EditingBodyCellCategorySelect = ({
+  autoFocus,
+  inputProps,
   initialValue,
   datasetColumn,
   withCreateNew = true,
@@ -35,9 +37,10 @@ export const EditingBodyCellCategorySelect = ({
     datasetColumn.id ?? skipToken,
   );
 
+  const [value, setValue] = useState(initialValue?.toString());
   const [search, setSearch] = useState("");
   const combobox = useCombobox({
-    defaultOpened: true,
+    defaultOpened: autoFocus,
     onDropdownClose: onCancel,
   });
 
@@ -53,21 +56,32 @@ export const EditingBodyCellCategorySelect = ({
     [fieldData, getDropdownLabelText, search],
   );
 
+  const handleOptionSubmit = useCallback(
+    (value: string) => {
+      setValue(value);
+      onSubmit(value);
+      combobox.toggleDropdown();
+    },
+    [onSubmit, setValue, combobox],
+  );
+
   return (
     <Combobox
       store={combobox}
       position="bottom-start"
-      onOptionSubmit={onSubmit}
+      onOptionSubmit={handleOptionSubmit}
     >
       <Combobox.Target>
         <Input
-          value={(initialValue ?? "").toString()}
-          variant="unstyled"
+          value={value}
           pointer
           onClick={() => combobox.toggleDropdown()}
-          onMouseDown={onCancel}
-          className={S.input}
-          size="sm"
+          // makes input to act like a button, however appear like a regular input field
+          onMouseDown={event => {
+            event.preventDefault();
+          }}
+          onChange={noop}
+          {...inputProps}
         />
       </Combobox.Target>
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellConditional.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellConditional.tsx
@@ -1,0 +1,33 @@
+import { EditingBodyCellBasicInput } from "./EditingBodyCellBasicInput";
+import { EditingBodyCellCategorySelect } from "./EditingBodyCellCategorySelect";
+import { EditingBodyCellDatetime } from "./EditingBodyCellDatetime";
+import { EditingBodyCellFKSelect } from "./EditingBodyCellFKSelect";
+import type { EditingBodyPrimitiveProps } from "./types";
+
+export const EditingBodyCellConditional = (
+  props: EditingBodyPrimitiveProps,
+) => {
+  const { datasetColumn: column } = props;
+
+  if (
+    column.semantic_type === "type/State" ||
+    column.semantic_type === "type/Country" ||
+    column.semantic_type === "type/Category"
+  ) {
+    return <EditingBodyCellCategorySelect {...props} />;
+  }
+
+  if (column.semantic_type === "type/FK") {
+    return <EditingBodyCellFKSelect {...props} />;
+  }
+
+  if (
+    column.effective_type === "type/Date" ||
+    column.effective_type === "type/DateTime" ||
+    column.effective_type === "type/DateTimeWithLocalTZ"
+  ) {
+    return <EditingBodyCellDatetime {...props} />;
+  }
+
+  return <EditingBodyCellBasicInput {...props} />;
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellDatetime.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellDatetime.tsx
@@ -6,12 +6,13 @@ import {
 } from "metabase/lib/formatting/datetime-utils";
 import { DateInput } from "metabase/ui";
 
-import S from "./EditingBodyCellInput.module.css";
 import type { EditingBodyPrimitiveProps } from "./types";
 
 const DEFAULT_DATETIME_STYLE = `${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`;
 
 export const EditingBodyCellDatetime = ({
+  autoFocus,
+  inputProps,
   initialValue,
   datasetColumn,
   onSubmit,
@@ -28,8 +29,14 @@ export const EditingBodyCellDatetime = ({
   const valueFormat = isDateTime ? DEFAULT_DATETIME_STYLE : DEFAULT_DATE_STYLE;
 
   const [value, setValue] = useState<Date | null>(initialDateValue);
+  const [isFocused, setFocused] = useState(false);
+
+  const handleFocus = useCallback(() => {
+    setFocused(true);
+  }, [setFocused]);
 
   const handleBlur = useCallback(() => {
+    setFocused(false);
     onSubmit(value ? value.toISOString() : null);
   }, [value, onSubmit]);
 
@@ -46,16 +53,18 @@ export const EditingBodyCellDatetime = ({
 
   return (
     <DateInput
-      size="sm"
-      autoFocus
-      variant="unstyled"
+      size={inputProps?.size}
+      autoFocus={autoFocus}
+      variant={inputProps?.variant}
+      placeholder={inputProps?.placeholder}
       value={value}
       valueFormat={valueFormat}
-      className={S.input}
-      classNames={{ input: S.noBackground }}
-      popoverProps={{ opened: true }}
+      classNames={{ input: inputProps?.className }}
+      // Keeps popover mounted when focused to improve time editing UX
+      popoverProps={{ opened: isFocused }}
       onChange={setValue}
       onBlur={handleBlur}
+      onFocus={handleFocus}
       onKeyUp={handleKeyUp}
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellFKSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellFKSelect.tsx
@@ -6,6 +6,7 @@ import { EditingBodyCellCategorySelect } from "./EditingBodyCellCategorySelect";
 import type { EditingBodyPrimitiveProps } from "./types";
 
 export const EditingBodyCellFKSelect = ({
+  autoFocus,
   initialValue,
   datasetColumn,
   onSubmit,
@@ -18,6 +19,7 @@ export const EditingBodyCellFKSelect = ({
 
   return (
     <EditingBodyCellCategorySelect
+      autoFocus={autoFocus}
       initialValue={initialValue}
       datasetColumn={datasetColumn}
       withCreateNew={false}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/index.ts
@@ -2,3 +2,4 @@ export { EditingBodyCellBasicInput } from "./EditingBodyCellBasicInput";
 export { EditingBodyCellCategorySelect } from "./EditingBodyCellCategorySelect";
 export { EditingBodyCellFKSelect } from "./EditingBodyCellFKSelect";
 export { EditingBodyCellDatetime } from "./EditingBodyCellDatetime";
+export { EditingBodyCellConditional } from "./EditingBodyCellConditional";

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/types.ts
@@ -1,8 +1,16 @@
+import type { MantineSize, TextInputProps } from "metabase/ui";
 import type { DatasetColumn, RowValue } from "metabase-types/api";
 
 export interface EditingBodyPrimitiveProps {
+  autoFocus?: boolean;
   datasetColumn: DatasetColumn;
   initialValue: RowValue;
+  inputProps?: {
+    size?: MantineSize;
+    variant: TextInputProps["variant"];
+    className?: string;
+    placeholder?: string;
+  };
   onSubmit: (value: RowValue) => unknown;
   onCancel: () => unknown;
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/types.ts
@@ -7,9 +7,10 @@ export interface EditingBodyPrimitiveProps {
   initialValue: RowValue;
   inputProps?: {
     size?: MantineSize;
-    variant: TextInputProps["variant"];
+    variant?: TextInputProps["variant"];
     className?: string;
     placeholder?: string;
+    disabled?: boolean;
   };
   onSubmit: (value: RowValue) => unknown;
   onCancel: () => unknown;

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.module.css
@@ -1,0 +1,35 @@
+.modalHeader {
+  background-color: var(--mb-color-background);
+  border-bottom: 1px solid var(--mb-color-border);
+  height: rem(80);
+  padding-top: 0;
+  padding-bottom: 0;
+  align-items: center;
+}
+
+.modalBody {
+  background-color: var(--mb-base-color-orion-5);
+  display: grid;
+  grid-template-columns: rem(32) auto auto;
+  row-gap: rem(24);
+  max-height: calc(
+    100vh - (var(--modal-y-offset) * 2) - rem(80) - rem(72)
+      /* header + footer */
+  );
+  overflow-y: scroll;
+}
+
+.modalBodyEditing {
+  max-height: calc(100vh - (var(--modal-y-offset) * 2) - rem(80) /* header */);
+}
+
+.modalBodyColumn {
+  align-self: center;
+}
+
+.modalFooter {
+  background-color: var(--mb-color-background);
+  border-top: 1px solid var(--mb-color-border);
+  height: rem(72);
+  align-items: center;
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
@@ -1,0 +1,85 @@
+import cx from "classnames";
+import { Fragment } from "react";
+
+import {
+  ActionIcon,
+  Button,
+  Flex,
+  Group,
+  Icon,
+  Modal,
+  Text,
+  rem,
+} from "metabase/ui";
+import type { DatasetColumn, RowValues } from "metabase-types/api";
+
+import { EditingBodyCellConditional } from "../inputs";
+
+import S from "./EditingBaseRowModal.module.css";
+
+interface EditingBaseRowModalProps {
+  datasetColumns: DatasetColumn[];
+  onClose: () => void;
+  opened: boolean;
+  currentRowData?: RowValues;
+}
+
+export function EditingBaseRowModal({
+  datasetColumns,
+  onClose,
+  opened,
+  currentRowData,
+}: EditingBaseRowModalProps) {
+  const isEditingMode = !!currentRowData;
+
+  return (
+    <Modal.Root opened={opened} onClose={onClose}>
+      <Modal.Overlay />
+      <Modal.Content>
+        <Modal.Header px="xl" pb="0" className={S.modalHeader}>
+          <Modal.Title>Create a new record</Modal.Title>
+          <Group
+            gap="xs"
+            mr={rem(-5) /* alings cross with modal right padding */}
+          >
+            {isEditingMode && (
+              <ActionIcon variant="subtle">
+                <Icon name="trash" />
+              </ActionIcon>
+            )}
+            <ActionIcon variant="subtle" onClick={onClose}>
+              <Icon name="close" />
+            </ActionIcon>
+          </Group>
+        </Modal.Header>
+        <Modal.Body
+          px="xl"
+          py="lg"
+          className={cx(S.modalBody, { [S.modalBodyEditing]: isEditingMode })}
+        >
+          {datasetColumns.map((column, index) => (
+            <Fragment key={column.id}>
+              <Icon className={S.modalBodyColumn} name="grabber" />
+              <Text className={S.modalBodyColumn}>{column.display_name}</Text>
+              <EditingBodyCellConditional
+                autoFocus={false}
+                datasetColumn={column}
+                initialValue={currentRowData ? currentRowData[index] : null}
+                onCancel={() => {}}
+                onSubmit={() => {}}
+              />
+            </Fragment>
+          ))}
+        </Modal.Body>
+        {!isEditingMode && (
+          <Flex px="xl" className={S.modalFooter} gap="lg" justify="flex-end">
+            <Button variant="subtle" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button variant="filled">Create new record</Button>
+          </Flex>
+        )}
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
@@ -1,17 +1,20 @@
 import cx from "classnames";
 import { Fragment } from "react";
+import { t } from "ttag";
 
+import { FIELD_SEMANTIC_TYPES } from "metabase/lib/core";
 import {
   ActionIcon,
   Button,
   Flex,
   Group,
   Icon,
+  type IconName,
   Modal,
   Text,
   rem,
 } from "metabase/ui";
-import type { DatasetColumn, RowValues } from "metabase-types/api";
+import type { DatasetColumn, RowValues, Table } from "metabase-types/api";
 
 import { EditingBodyCellConditional } from "../inputs";
 
@@ -19,10 +22,16 @@ import S from "./EditingBaseRowModal.module.css";
 
 interface EditingBaseRowModalProps {
   datasetColumns: DatasetColumn[];
+  datasetTable?: Table;
   onClose: () => void;
   opened: boolean;
   currentRowData?: RowValues;
 }
+
+const semanticIconMap: Record<string, IconName> = FIELD_SEMANTIC_TYPES.reduce(
+  (acc, type) => ({ ...acc, [type.id]: type.icon }),
+  {},
+);
 
 export function EditingBaseRowModal({
   datasetColumns,
@@ -37,7 +46,9 @@ export function EditingBaseRowModal({
       <Modal.Overlay />
       <Modal.Content>
         <Modal.Header px="xl" pb="0" className={S.modalHeader}>
-          <Modal.Title>Create a new record</Modal.Title>
+          <Modal.Title>
+            {isEditingMode ? t`Edit record` : t`Create a new record`}
+          </Modal.Title>
           <Group
             gap="xs"
             mr={rem(-5) /* alings cross with modal right padding */}
@@ -59,7 +70,14 @@ export function EditingBaseRowModal({
         >
           {datasetColumns.map((column, index) => (
             <Fragment key={column.id}>
-              <Icon className={S.modalBodyColumn} name="grabber" />
+              <Icon
+                className={S.modalBodyColumn}
+                name={
+                  column.semantic_type
+                    ? semanticIconMap[column.semantic_type]
+                    : "string"
+                }
+              />
               <Text className={S.modalBodyColumn}>{column.display_name}</Text>
               <EditingBodyCellConditional
                 autoFocus={false}
@@ -74,9 +92,9 @@ export function EditingBaseRowModal({
         {!isEditingMode && (
           <Flex px="xl" className={S.modalFooter} gap="lg" justify="flex-end">
             <Button variant="subtle" onClick={onClose}>
-              Cancel
+              {t`Cancel`}
             </Button>
-            <Button variant="filled">Create new record</Button>
+            <Button variant="filled">{t`Create new record`}</Button>
           </Flex>
         )}
       </Modal.Content>

--- a/frontend/src/metabase/data-grid/components/RowIdCell/RowIdCell.tsx
+++ b/frontend/src/metabase/data-grid/components/RowIdCell/RowIdCell.tsx
@@ -12,11 +12,13 @@ import S from "./RowIdCell.module.css";
 export interface RowIdCellProps {
   value?: React.ReactNode;
   backgroundColor?: string;
+  onRowExpandClick?: () => void;
 }
 
 export const RowIdCell = memo(function RowIdCell({
   value,
   backgroundColor,
+  onRowExpandClick,
 }: RowIdCellProps) {
   const hasValue = value != null;
 
@@ -47,6 +49,7 @@ export const RowIdCell = memo(function RowIdCell({
             className={cx(DataGridS.rowHoverVisible, S.expandButton)}
             size="compact-md"
             leftSection={<Icon name="expand" size={14} />}
+            onClick={onRowExpandClick}
           />
         </BaseCell>
       </span>

--- a/frontend/src/metabase/data-grid/types.ts
+++ b/frontend/src/metabase/data-grid/types.ts
@@ -110,6 +110,9 @@ export interface RowIdColumnOptions {
 
   /** Function to determine background color for the ID cells */
   getBackgroundColor?: (rowIndex: number) => string;
+
+  /** Handler for variant="expandButton" */
+  onRowExpandClick?: (rowIndex: number) => void;
 }
 
 export interface DataGridTheme {

--- a/frontend/src/metabase/data-grid/utils/columns/row-id-column.tsx
+++ b/frontend/src/metabase/data-grid/utils/columns/row-id-column.tsx
@@ -14,6 +14,7 @@ export const getRowIdColumnSize = (variant: RowIdVariant) =>
 export const getRowIdColumn = <TRow, TValue>({
   variant,
   getBackgroundColor,
+  onRowExpandClick,
 }: RowIdColumnOptions): ColumnDef<TRow, TValue> => {
   const shouldShowIndex = ["indexOnly", "indexExpand"].includes(variant);
   return {
@@ -29,6 +30,7 @@ export const getRowIdColumn = <TRow, TValue>({
         <RowIdCell
           value={value}
           backgroundColor={getBackgroundColor?.(row.index)}
+          onRowExpandClick={() => onRowExpandClick?.(row.index)}
         />
       );
     },

--- a/frontend/src/metabase/lib/core.ts
+++ b/frontend/src/metabase/lib/core.ts
@@ -366,7 +366,7 @@ export const DEPRECATED_FIELD_SEMANTIC_TYPES: FieldSemanticType["id"][] = [
 
 export const FIELD_SEMANTIC_TYPES_MAP = FIELD_SEMANTIC_TYPES.reduce(
   (map, type) => Object.assign({}, map, { [type.id]: type }),
-  {},
+  {} as Record<FieldSemanticType["id"], FieldSemanticType>,
 );
 
 export const HAS_FIELD_VALUES_OPTIONS = [


### PR DESCRIPTION
The changeset is relatively big, so I decided to split visual logic and actual backend calls. This is the the first part, that only renders the modals.


https://github.com/user-attachments/assets/6141a3e8-efcf-4fe2-91f9-acd37217fa77

