### PR TITLE
docs: You can't use Metabase with MongoDB Flex (yet)

### DIFF
--- a/docs/databases/connections/mongodb.md
+++ b/docs/databases/connections/mongodb.md
@@ -58,7 +58,7 @@ If you need to use a certificate, connect via the [default method](#using-metaba
 
 ## Connecting to a MongoDB Atlas cluster
 
-> You can use Metabase with Atlas Dedicated and Shared clusters. Metabase does not currently support Atlas Serverless.
+> You can use Metabase with Atlas Dedicated and Free clusters. Metabase does not currently support Atlas Flex.
 
 ### Whitelist IP addresses
 


### PR DESCRIPTION
So there were a few things wrong: we actually started supporting MongoDB Serverless in ~march 2024, so the docs have been wrong for a while. BUT in Feb 2025 MongoDB Atlas changed their offerings, and Flex is the replacement for serverless, and now we don't work with it again, see https://github.com/metabase/metabase/issues/54880