### PR TITLE
Fix interval example: change string "-1" to -1

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -874,7 +874,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
       {
         name: t`number`,
         description: t`Period of interval, where negative values are back in time.`,
-        example: "-1",
+        example: -1,
       },
       {
         name: t`unit`,


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.


### Description

Minimal change in Interval documentation

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Custom Column > Interval expression

![Screenshot 2025-04-03 at 9 19 08 AM](https://github.com/user-attachments/assets/b49b3c55-78a4-4e50-bf52-cff8fed0c818)
Instead of `interval([Created At], "-1", "month")`, this should show `interval([Created At], -1, "month")`


Having `"-1"` shows "Types are incompatible, but having `-1` works just fine.
![Screenshot 2025-04-03 at 9 21 26 AM](https://github.com/user-attachments/assets/9db3d84d-de5e-4b8a-acab-dde638136e44)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
