### PR TITLE
WRK-116: Add custom cron scheduling option to Schedule

### DIFF
--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -1,8 +1,10 @@
 import { match } from "ts-pattern";
 
 import { modal, popover } from "e2e/support/helpers";
-import type { ScheduleComponentType } from "metabase/components/Schedule/constants";
-import { getScheduleComponentLabel } from "metabase/components/Schedule/strings";
+import {
+  type ScheduleComponentType,
+  getScheduleComponentLabel,
+} from "metabase/components/Schedule/strings";
 import type {
   CacheStrategyType,
   CacheableModel,

--- a/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
@@ -37,46 +37,46 @@ describe("scenarios > admin > performance > schedule strategy", () => {
 
   // prettier-ignore
   const schedules: ScheduleTestOptions[] = [
-    [{}, "0 0 * * * ?"], // The default schedule is 'every hour, on the hour'
+    [ {}, "0 0 * * * ? *" ], // The default schedule is 'every hour, on the hour'
 
-    [{ frequency: "daily" }, "0 0 8 * * ?"], // 8 am is the default time for a daily schedule
+    [ { frequency: "daily" }, "0 0 8 * * ? *" ], // 8 am is the default time for a daily schedule
 
-    [{ frequency: "hourly" }, "0 0 * * * ?"], // Check that switching back to hourly works
+    [ { frequency: "hourly" }, "0 0 * * * ? *" ], // Check that switching back to hourly works
 
-    [{ frequency: "daily", time: "9:00" }, "0 0 9 * * ?"], // AM is the default choice between AM and PM
-    [{ frequency: "daily", time: "9:00", amPm: "PM" }, "0 0 21 * * ?"],
-    [{ frequency: "daily", time: "12:00", amPm: "AM" }, "0 0 0 * * ?"],
+    [ { frequency: "daily", time: "9:00" }, "0 0 9 * * ? *" ], // AM is the default choice between AM and PM
+    [ { frequency: "daily", time: "9:00", amPm: "PM" }, "0 0 21 * * ? *" ],
+    [ { frequency: "daily", time: "12:00", amPm: "AM" }, "0 0 0 * * ? *" ],
 
-    [ { frequency: "weekly", weekday: "Monday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 2" ],
-    [ { frequency: "weekly", weekday: "Monday", time: "1:00", amPm: "AM" }, "0 0 1 ? * 2" ],
+    [ { frequency: "weekly", weekday: "Monday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 2 *" ],
+    [ { frequency: "weekly", weekday: "Monday", time: "1:00", amPm: "AM" }, "0 0 1 ? * 2 *" ],
 
-    [ { frequency: "weekly", weekday: "Tuesday", time: "2:00", amPm: "AM" }, "0 0 2 ? * 3" ],
-    [ { frequency: "weekly", weekday: "Tuesday", time: "3:00", amPm: "AM" }, "0 0 3 ? * 3" ],
+    [ { frequency: "weekly", weekday: "Tuesday", time: "2:00", amPm: "AM" }, "0 0 2 ? * 3 *" ],
+    [ { frequency: "weekly", weekday: "Tuesday", time: "3:00", amPm: "AM" }, "0 0 3 ? * 3 *" ],
 
-    [ { frequency: "weekly", weekday: "Wednesday", time: "4:00", amPm: "AM" }, "0 0 4 ? * 4" ],
-    [ { frequency: "weekly", weekday: "Wednesday", time: "5:00", amPm: "AM" }, "0 0 5 ? * 4" ],
+    [ { frequency: "weekly", weekday: "Wednesday", time: "4:00", amPm: "AM" }, "0 0 4 ? * 4 *" ],
+    [ { frequency: "weekly", weekday: "Wednesday", time: "5:00", amPm: "AM" }, "0 0 5 ? * 4 *" ],
 
-    [ { frequency: "weekly", weekday: "Thursday", time: "6:00", amPm: "AM" }, "0 0 6 ? * 5" ],
-    [ { frequency: "weekly", weekday: "Thursday", time: "7:00", amPm: "AM" }, "0 0 7 ? * 5" ],
+    [ { frequency: "weekly", weekday: "Thursday", time: "6:00", amPm: "AM" }, "0 0 6 ? * 5 *" ],
+    [ { frequency: "weekly", weekday: "Thursday", time: "7:00", amPm: "AM" }, "0 0 7 ? * 5 *" ],
 
-    [ { frequency: "weekly", weekday: "Friday", time: "8:00", amPm: "AM" }, "0 0 8 ? * 6" ],
-    [ { frequency: "weekly", weekday: "Friday", time: "9:00", amPm: "AM" }, "0 0 9 ? * 6" ],
+    [ { frequency: "weekly", weekday: "Friday", time: "8:00", amPm: "AM" }, "0 0 8 ? * 6 *" ],
+    [ { frequency: "weekly", weekday: "Friday", time: "9:00", amPm: "AM" }, "0 0 9 ? * 6 *" ],
 
-    [ { frequency: "weekly", weekday: "Saturday", time: "10:00", amPm: "AM" }, "0 0 10 ? * 7" ],
-    [ { frequency: "weekly", weekday: "Saturday", time: "11:00", amPm: "AM" }, "0 0 11 ? * 7" ],
+    [ { frequency: "weekly", weekday: "Saturday", time: "10:00", amPm: "AM" }, "0 0 10 ? * 7 *" ],
+    [ { frequency: "weekly", weekday: "Saturday", time: "11:00", amPm: "AM" }, "0 0 11 ? * 7 *" ],
 
-    [ { frequency: "weekly", weekday: "Sunday", time: "12:00", amPm: "PM" }, "0 0 12 ? * 1" ],
-    [ { frequency: "weekly", weekday: "Sunday", time: "1:00", amPm: "PM" }, "0 0 13 ? * 1" ],
+    [ { frequency: "weekly", weekday: "Sunday", time: "12:00", amPm: "PM" }, "0 0 12 ? * 1 *" ],
+    [ { frequency: "weekly", weekday: "Sunday", time: "1:00", amPm: "PM" }, "0 0 13 ? * 1 *" ],
 
-    [ { frequency: "monthly", frame: "first", weekdayOfMonth: "Sunday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 1#1" ],
-    [ { frequency: "monthly", frame: "first", weekdayOfMonth: "Monday", time: "2:00", amPm: "AM" }, "0 0 2 ? * 2#1" ],
+    [ { frequency: "monthly", frame: "first", weekdayOfMonth: "Sunday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 1#1 *" ],
+    [ { frequency: "monthly", frame: "first", weekdayOfMonth: "Monday", time: "2:00", amPm: "AM" }, "0 0 2 ? * 2#1 *" ],
 
-    [ { frequency: "monthly", frame: "last", weekdayOfMonth: "Tuesday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 3L" ],
-    [ { frequency: "monthly", frame: "last", weekdayOfMonth: "Wednesday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 4L" ],
+    [ { frequency: "monthly", frame: "last", weekdayOfMonth: "Tuesday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 3L *" ],
+    [ { frequency: "monthly", frame: "last", weekdayOfMonth: "Wednesday", time: "12:00", amPm: "AM" }, "0 0 0 ? * 4L *" ],
 
-    [ { frequency: "monthly", frame: "15th", time: "12:00", amPm: "AM" }, "0 0 0 15 * ?" ],
-    [ { frequency: "monthly", frame: "15th", time: "11:00", amPm: "PM" }, "0 0 23 15 * ?" ],
-    [ { frequency: "monthly", frame: "first", weekdayOfMonth: "calendar day", time: "3:00", amPm: "PM" }, "0 0 15 1 * ?" ],
+    [ { frequency: "monthly", frame: "15th", time: "12:00", amPm: "AM" }, "0 0 0 15 * ? *" ],
+    [ { frequency: "monthly", frame: "15th", time: "11:00", amPm: "PM" }, "0 0 23 15 * ? *" ],
+    [ { frequency: "monthly", frame: "first", weekdayOfMonth: "calendar day", time: "3:00", amPm: "PM" }, "0 0 15 1 * ? *" ],
 
   ];
 

--- a/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
@@ -1,4 +1,4 @@
-import type { ScheduleComponentType } from "metabase/components/Schedule/constants";
+import type { ScheduleComponentType } from "metabase/components/Schedule/strings";
 import { checkNotNull } from "metabase/lib/types";
 import type { CacheableModel } from "metabase-types/api";
 

--- a/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
 
       // Check that changes stuck
       cy.wait("@updatedAlert").then(({ response: { body } }) => {
-        expect(body.subscriptions[0].cron_schedule).to.equal("0 0 8 ? * 2");
+        expect(body.subscriptions[0].cron_schedule).to.equal("0 0 8 ? * 2 *");
       });
     });
   });
@@ -135,7 +135,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
 
       // Check that changes stuck
       cy.wait("@updatedAlert").then(({ response: { body } }) => {
-        expect(body.subscriptions[0].cron_schedule).to.equal("0 0 8 ? * 2");
+        expect(body.subscriptions[0].cron_schedule).to.equal("0 0 8 ? * 2 *");
       });
 
       H.modal().findByText("Check on Monday at 8:00 AM");

--- a/frontend/src/metabase-types/api/mocks/notification.ts
+++ b/frontend/src/metabase-types/api/mocks/notification.ts
@@ -101,5 +101,6 @@ export const createMockNotificationCronSubscription = (
   event_name: null,
   created_at: "2025-01-07T18:40:47.245205+03:00",
   cron_schedule: "0 0 9 * * ?",
+  ui_display_type: "cron/builder",
   ...opts,
 });

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -102,10 +102,12 @@ export type NotificationHandler =
 //#endregion
 
 //#region Subscription type
+export type ScheduleDisplayType = "cron/builder" | "cron/raw" | null;
 export type NotificationCronSubscription = {
   type: "notification-subscription/cron";
   event_name: null;
   cron_schedule: string;
+  ui_display_type: ScheduleDisplayType;
 
   // only for existing notifications
   id?: number;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -87,7 +87,8 @@ export type ScheduleType =
   | "hourly"
   | "daily"
   | "weekly"
-  | "monthly";
+  | "monthly"
+  | "cron";
 
 export type ScheduleDayType =
   | "sun"

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -88,6 +88,8 @@ export type ScheduleType =
   | "daily"
   | "weekly"
   | "monthly"
+  // 'cron' type implies usage of more complex expressions represented
+  // by raw cron string.
   | "cron";
 
 export type ScheduleDayType =

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -35,7 +35,6 @@ import type {
   CacheStrategyType,
   CacheableModel,
   DurationStrategy,
-  ScheduleSettings,
   ScheduleStrategy,
 } from "metabase-types/api";
 import { CacheDurationUnit } from "metabase-types/api";
@@ -48,7 +47,6 @@ import {
   cronToScheduleSettings,
   getDefaultValueForField,
   getLabelString,
-  scheduleSettingsToCron,
 } from "../utils";
 
 import Styles from "./PerformanceApp.module.css";
@@ -58,6 +56,7 @@ import {
   StyledForm,
   StyledFormButtonsGroup,
 } from "./StrategyForm.styled";
+import { DEFAULT_ALERT_CRON_SCHEDULE } from "metabase/notifications/utils";
 
 interface ButtonLabels {
   save: string;
@@ -391,19 +390,14 @@ const ScheduleStrategyFormFields = () => {
   const { values, setFieldValue } = useFormikContext<ScheduleStrategy>();
   const { schedule: scheduleInCronFormat } = values;
   const initialSchedule = cronToScheduleSettings(scheduleInCronFormat);
-  const [schedule, setSchedule] = useState<ScheduleSettings>(
-    initialSchedule || {},
-  );
   const timezone = useSelector(state =>
     getSetting(state, "report-timezone-short"),
   );
   const onScheduleChange = useCallback(
-    (nextSchedule: ScheduleSettings) => {
-      setSchedule(nextSchedule);
-      const cron = scheduleSettingsToCron(nextSchedule);
-      setFieldValue("schedule", cron);
+    (newCronSchedule: string) => {
+      setFieldValue("schedule", newCronSchedule);
     },
-    [setFieldValue, setSchedule],
+    [setFieldValue],
   );
   if (!initialSchedule) {
     return (
@@ -412,10 +406,11 @@ const ScheduleStrategyFormFields = () => {
       />
     );
   }
+
   return (
     <>
       <Schedule
-        schedule={schedule}
+        cronString={scheduleInCronFormat || DEFAULT_ALERT_CRON_SCHEDULE}
         scheduleOptions={["hourly", "daily", "weekly", "monthly"]}
         onScheduleChange={onScheduleChange}
         verb={c("A verb in the imperative mood").t`Invalidate`}

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -40,7 +40,7 @@ import type {
 import { CacheDurationUnit } from "metabase-types/api";
 
 import { strategyValidationSchema } from "../constants/complex";
-import { rootId } from "../constants/simple";
+import { defaultCronSchedule, rootId } from "../constants/simple";
 import { useIsFormPending } from "../hooks/useIsFormPending";
 import { isModelWithClearableCache } from "../types";
 import {
@@ -56,7 +56,6 @@ import {
   StyledForm,
   StyledFormButtonsGroup,
 } from "./StrategyForm.styled";
-import { DEFAULT_ALERT_CRON_SCHEDULE } from "metabase/notifications/utils";
 
 interface ButtonLabels {
   save: string;
@@ -410,7 +409,7 @@ const ScheduleStrategyFormFields = () => {
   return (
     <>
       <Schedule
-        cronString={scheduleInCronFormat || DEFAULT_ALERT_CRON_SCHEDULE}
+        cronString={scheduleInCronFormat || defaultCronSchedule}
         scheduleOptions={["hourly", "daily", "weekly", "monthly"]}
         onScheduleChange={onScheduleChange}
         verb={c("A verb in the imperative mood").t`Invalidate`}

--- a/frontend/src/metabase/admin/performance/constants/simple.ts
+++ b/frontend/src/metabase/admin/performance/constants/simple.ts
@@ -1,2 +1,3 @@
 export const rootId = 0;
 export const defaultMinDurationMs = 1000;
+export const defaultCronSchedule = "0 0 8 * * ? *";

--- a/frontend/src/metabase/admin/performance/constants/simple.ts
+++ b/frontend/src/metabase/admin/performance/constants/simple.ts
@@ -1,3 +1,3 @@
 export const rootId = 0;
 export const defaultMinDurationMs = 1000;
-export const defaultCronSchedule = "0 0 8 * * ? *";
+export const defaultCronSchedule = "0 0 * * * ? *";

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -53,6 +53,7 @@ const frameFromCron = (frameInCronFormat: string) =>
 
 export const scheduleSettingsToCron = (settings: ScheduleSettings): string => {
   const second = "0";
+  const year = "*";
   let minute = settings.schedule_minute?.toString() ?? Cron.AllValues;
   const hour = settings.schedule_hour?.toString() ?? Cron.AllValues;
   let weekday = settings.schedule_day
@@ -88,6 +89,7 @@ export const scheduleSettingsToCron = (settings: ScheduleSettings): string => {
     dayOfMonth,
     month,
     weekday,
+    year,
   ].join(" ");
   return cronExpression;
 };
@@ -112,7 +114,7 @@ export const cronToScheduleSettings_unmemoized = (
 
   const [_second, minute, hour, dayOfMonth, month, weekday] = cron.split(" ");
 
-  if (month !== Cron.AllValues) {
+  if (month !== Cron.AllValues && !isCustomSchedule) {
     return null;
   }
   let schedule_type: ScheduleType | undefined;

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -26,8 +26,9 @@ const PM = 1;
 
 const everyToCronSyntax = (every: number | string) =>
   `${Cron.EveryPrefix}${every}`;
-const isRepeatingEvery = (every: string) => every.startsWith(Cron.EveryPrefix);
-const cronUnitToNumber = (unit: string) =>
+export const isRepeatingEvery = (every: string) =>
+  every.startsWith(Cron.EveryPrefix);
+export const cronUnitToNumber = (unit: string) =>
   parseInt(unit.replace(Cron.EveryPrefix, ""));
 
 const dayToCron = (day: ScheduleSettings["schedule_day"]) => {
@@ -94,6 +95,7 @@ export const scheduleSettingsToCron = (settings: ScheduleSettings): string => {
 /** Returns null if we can't convert the cron expression to a ScheduleSettings object */
 export const cronToScheduleSettings_unmemoized = (
   cron: string | null | undefined,
+  isCustomSchedule: boolean = false,
 ): ScheduleSettings | null => {
   if (!cron) {
     return defaultSchedule;
@@ -114,7 +116,9 @@ export const cronToScheduleSettings_unmemoized = (
     return null;
   }
   let schedule_type: ScheduleType | undefined;
-  if (dayOfMonth === Cron.AllValues) {
+  if (isCustomSchedule) {
+    schedule_type = "cron";
+  } else if (dayOfMonth === Cron.AllValues) {
     if (weekday === Cron.AllValues) {
       if (hour === Cron.AllValues) {
         schedule_type = isRepeatingEvery(minute) ? "every_n_minutes" : "hourly";
@@ -178,6 +182,7 @@ export const cronToScheduleSettings_unmemoized = (
 };
 export const cronToScheduleSettings = memoize(
   cronToScheduleSettings_unmemoized,
+  (cron, isCustomSchedule) => `${cron}_${isCustomSchedule}`,
 );
 
 const defaultSchedule: ScheduleSettings = {

--- a/frontend/src/metabase/admin/performance/utils.unit.spec.ts
+++ b/frontend/src/metabase/admin/performance/utils.unit.spec.ts
@@ -20,7 +20,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_hour: null,
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 0/10 * * * ?");
+    expect(cron).toEqual("0 0/10 * * * ? *");
   });
 
   it("converts hourly schedule to cron", () => {
@@ -30,7 +30,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_hour: 1,
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 1 1 * * ?");
+    expect(cron).toEqual("0 1 1 * * ? *");
   });
 
   it("converts daily schedule to cron", () => {
@@ -40,7 +40,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_hour: 14,
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 30 14 * * ?");
+    expect(cron).toEqual("0 30 14 * * ? *");
   });
 
   it("converts weekly schedule to cron", () => {
@@ -51,7 +51,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_hour: 12,
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 0 12 ? * 2");
+    expect(cron).toEqual("0 0 12 ? * 2 *");
   });
 
   it("converts 'first Wednesday of the month at 9:15am' to cron", () => {
@@ -63,7 +63,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_hour: 9,
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 15 9 ? * 4#1");
+    expect(cron).toEqual("0 15 9 ? * 4#1 *");
   });
 
   it("converts 'last calendar day of the month' to cron", () => {
@@ -74,7 +74,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_hour: 16,
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 45 16 L * ?");
+    expect(cron).toEqual("0 45 16 L * ? *");
   });
 
   it("converts 'monthly on the 15th' to cron", () => {
@@ -85,7 +85,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_hour: 23,
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 5 23 15 * ?");
+    expect(cron).toEqual("0 5 23 15 * ? *");
   });
 
   it("missing minute and hour should default to wildcard", () => {
@@ -93,7 +93,7 @@ describe("scheduleSettingsToCron", () => {
       schedule_type: "daily",
     };
     const cron = scheduleSettingsToCron(settings);
-    expect(cron).toEqual("0 * * * * ?");
+    expect(cron).toEqual("0 * * * * ? *");
   });
 });
 
@@ -138,6 +138,11 @@ describe("cronToScheduleSettings", () => {
     it('sets schedule type to "monthly" when dayOfMonth is specific', () => {
       const cron = "0 30 8 15 * ?";
       expect(cronToScheduleSettings(cron)?.schedule_type).toBe("monthly");
+    });
+
+    it('sets schedule type to "cron" when isCustomSchedule is true', () => {
+      const cron = "0 30 8 15 * ?";
+      expect(cronToScheduleSettings(cron, true)?.schedule_type).toBe("cron");
     });
   });
 

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CronExpressionInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CronExpressionInput.tsx
@@ -3,12 +3,19 @@ import { jt, msgid, ngettext, t } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { validateCronExpression } from "metabase/lib/cron";
-import { Flex, Icon, Text, TextInput, Tooltip } from "metabase/ui";
+import {
+  Flex,
+  type FlexProps,
+  Icon,
+  Text,
+  TextInput,
+  Tooltip,
+} from "metabase/ui";
 
 import S from "./CronExpressionInput.module.css";
 import { CustomScheduleExplainer } from "./CustomScheduleExplainer";
 
-type CronExpressionInputProps = {
+type CronExpressionInputProps = Omit<FlexProps, "onChange"> & {
   value: string;
   onChange: (value: string) => void;
   onBlurChange: (value: string) => void;
@@ -20,6 +27,7 @@ export function CronExpressionInput({
   onBlurChange,
   value,
   showExplainer = true,
+  ...flexProps
 }: CronExpressionInputProps) {
   const [error, setError] = useState<string | null>(null);
   const handleChange = (cronExpression: string) => {
@@ -46,7 +54,7 @@ export function CronExpressionInput({
   };
 
   return (
-    <Flex direction="column">
+    <Flex direction="column" {...flexProps}>
       <CustomScheduleInputHint />
       <TextInput
         placeholder="For example 5   0   *   Aug   ?"

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CronExpressionInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CronExpressionInput.tsx
@@ -3,7 +3,7 @@ import { jt, msgid, ngettext, t } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { validateCronExpression } from "metabase/lib/cron";
-import { Icon, Text, TextInput, Tooltip } from "metabase/ui";
+import { Flex, Icon, Text, TextInput, Tooltip } from "metabase/ui";
 
 import S from "./CronExpressionInput.module.css";
 import { CustomScheduleExplainer } from "./CustomScheduleExplainer";
@@ -12,12 +12,14 @@ type CronExpressionInputProps = {
   value: string;
   onChange: (value: string) => void;
   onBlurChange: (value: string) => void;
+  showExplainer?: boolean;
 };
 
 export function CronExpressionInput({
   onChange,
   onBlurChange,
   value,
+  showExplainer = true,
 }: CronExpressionInputProps) {
   const [error, setError] = useState<string | null>(null);
   const handleChange = (cronExpression: string) => {
@@ -44,11 +46,11 @@ export function CronExpressionInput({
   };
 
   return (
-    <>
+    <Flex direction="column">
       <CustomScheduleInputHint />
       <TextInput
         placeholder="For example 5   0   *   Aug   ?"
-        size="lg"
+        size="md"
         fw={600}
         error={error}
         errorProps={{ fz: ".875rem", lh: "1.3rem" }}
@@ -60,8 +62,10 @@ export function CronExpressionInput({
         rightSection={<CronFormatTooltip />}
       />
 
-      {value && !error && <CustomScheduleExplainer cronExpression={value} />}
-    </>
+      {showExplainer && value && !error && (
+        <CustomScheduleExplainer cronExpression={value} />
+      )}
+    </Flex>
   );
 }
 

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CustomScheduleExplainer.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CustomScheduleExplainer.tsx
@@ -1,24 +1,12 @@
 import { useMemo } from "react";
-import { memoize } from "underscore";
-
-import { explainCronExpressionLowercase } from "metabase/lib/cron";
-import { Text, type TextProps } from "metabase/ui";
 import { t } from "ttag";
+
+import { getScheduleExplanation } from "metabase/lib/cron";
+import { Text, type TextProps } from "metabase/ui";
 
 interface ScheduleExplanationProps {
   cronExpression: string;
 }
-
-export const getScheduleExplanation = memoize(
-  (cronExpression: string): string | null => {
-    try {
-      const readableSchedule = explainCronExpressionLowercase(cronExpression);
-      return readableSchedule;
-    } catch {
-      return null;
-    }
-  },
-);
 
 export function CustomScheduleExplainer({
   cronExpression,

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CustomScheduleExplainer.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CustomScheduleExplainer.tsx
@@ -1,36 +1,38 @@
 import { useMemo } from "react";
+import { memoize } from "underscore";
+
+import { explainCronExpressionLowercase } from "metabase/lib/cron";
+import { Text, type TextProps } from "metabase/ui";
 import { t } from "ttag";
 
-import { explainCronExpression as _explainCronExpression } from "metabase/lib/cron";
-import { Text } from "metabase/ui";
-
-function lowerCaseFirstLetter(str: string) {
-  return str.charAt(0).toLowerCase() + str.slice(1);
-}
-
-function explainCronExpression(cronExpression: string) {
-  return lowerCaseFirstLetter(_explainCronExpression(cronExpression));
-}
-
-export function CustomScheduleExplainer({
-  cronExpression,
-}: {
+interface ScheduleExplanationProps {
   cronExpression: string;
-}) {
-  const explanation = useMemo(() => {
+}
+
+export const getScheduleExplanation = memoize(
+  (cronExpression: string): string | null => {
     try {
-      const readableSchedule = explainCronExpression(cronExpression);
-      return t`We will refresh your models ${lowerCaseFirstLetter(
-        readableSchedule,
-      )}`;
+      const readableSchedule = explainCronExpressionLowercase(cronExpression);
+      return readableSchedule;
     } catch {
       return null;
     }
-  }, [cronExpression]);
+  },
+);
+
+export function CustomScheduleExplainer({
+  cronExpression,
+  ...props
+}: ScheduleExplanationProps & TextProps) {
+  const explanation = useMemo(
+    () =>
+      t`We will refresh your models ${getScheduleExplanation(cronExpression)}`,
+    [cronExpression],
+  );
 
   if (!explanation) {
     return null;
   }
 
-  return <Text>{explanation}</Text>;
+  return <Text {...props}>{explanation}</Text>;
 }

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import { Group, Select, Stack, Text } from "metabase/ui";
 
@@ -13,7 +13,7 @@ interface ModelCachingScheduleWidgetProps {
 
 const DEFAULT_CUSTOM_SCHEDULE = "0 * * * ?";
 
-function formatCronExpression(cronExpression: string): string {
+export function formatCronExpression(cronExpression: string): string {
   const [, ...partsWithoutSeconds] = cronExpression.split(" ");
   const partsWithoutSecondsAndYear = partsWithoutSeconds.slice(0, -1);
   return partsWithoutSecondsAndYear.join(" ");
@@ -68,13 +68,12 @@ export const ModelCachingScheduleWidget = ({
           />
         </Stack>
         {isCustom && customCronSchedule !== undefined && (
-          <Stack gap={0}>
-            <CronExpressionInput
-              value={customCronSchedule}
-              onChange={setCustomCronSchedule}
-              onBlurChange={onChange}
-            />
-          </Stack>
+          <CronExpressionInput
+            value={customCronSchedule}
+            onChange={setCustomCronSchedule}
+            onBlurChange={onChange}
+            showExplainer
+          />
         )}
       </Group>
     </Stack>

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
-import { c, t } from "ttag";
+import { t } from "ttag";
 
+import { formatCronExpressionForUI } from "metabase/lib/cron";
 import { Group, Select, Stack, Text } from "metabase/ui";
 
 import { CronExpressionInput } from "./CronExpressionInput";
@@ -12,12 +13,6 @@ interface ModelCachingScheduleWidgetProps {
 }
 
 const DEFAULT_CUSTOM_SCHEDULE = "0 * * * ?";
-
-export function formatCronExpression(cronExpression: string): string {
-  const [, ...partsWithoutSeconds] = cronExpression.split(" ");
-  const partsWithoutSecondsAndYear = partsWithoutSeconds.slice(0, -1);
-  return partsWithoutSecondsAndYear.join(" ");
-}
 
 function isCustomSchedule(
   value: string,
@@ -36,7 +31,7 @@ export const ModelCachingScheduleWidget = ({
   const [customCronSchedule, setCustomCronSchedule] = useState<string>(
     // We don't allow to specify the "year" component, but it's present in the value
     // So we need to cut it visually to avoid confusion
-    isCustom ? formatCronExpression(value) : "",
+    isCustom ? formatCronExpressionForUI(value) : "",
   );
 
   const handleScheduleChange = useCallback(

--- a/frontend/src/metabase/components/Schedule/GroupControlsTogether.tsx
+++ b/frontend/src/metabase/components/Schedule/GroupControlsTogether.tsx
@@ -31,6 +31,14 @@ import { combineConsecutiveStrings } from "./utils";
  *
  * (For ease of explanation, I've omitted classnames from the HTML, and I'm
  * pretending that a Mantine Select is rendered as <select />.)
+ *
+ * Customization:
+ *
+ * If you need to break the default layout flow, the following
+ * hatches are available:
+ * - [data-group="separate"] – providing this attribute will cause the component
+ *   to be placed in its own group (when otherwise it would've been grouped with
+ *   the previous component).
  * */
 export const GroupControlsTogether = ({
   children,
@@ -49,11 +57,11 @@ export const GroupControlsTogether = ({
       currentGroup.push(child);
 
       const nextIndex = index + 1;
-      if (!isValidElement(compactChildren[nextIndex])) {
+      const nextChild = compactChildren[nextIndex];
+      if (!isValidElement(nextChild)) {
         // If next child is the last string, add it to the current group
         // to prevent it from being left hanging on the last line.
         if (nextIndex === compactChildren.length - 1) {
-          const nextChild = compactChildren[nextIndex];
           if (typeof nextChild === "string" && !!nextChild.trim()) {
             currentGroup.push(
               <Text key={`node-${nextIndex}`} ml="0.5rem">
@@ -69,6 +77,17 @@ export const GroupControlsTogether = ({
           break;
         }
         // Flush current group
+        groupedNodes.push(
+          <div className={S.ControlGroup} key={`node-${index}`}>
+            {currentGroup}
+          </div>,
+        );
+        currentGroup = [];
+      } else if (
+        nextChild.props?.["data-group"] === GROUP_ATTRIBUTES.separate
+      ) {
+        // If the next child has a "separate" attribute, break the current group cycle
+        // and start a new one
         groupedNodes.push(
           <div className={S.ControlGroup} key={`node-${index}`}>
             {currentGroup}
@@ -101,4 +120,8 @@ export const GroupControlsTogether = ({
   }
 
   return <>{groupedNodes}</>;
+};
+
+export const GROUP_ATTRIBUTES = {
+  separate: "separate",
 };

--- a/frontend/src/metabase/components/Schedule/Schedule.module.css
+++ b/frontend/src/metabase/components/Schedule/Schedule.module.css
@@ -1,9 +1,10 @@
 .Schedule {
   line-height: 2.5rem;
   display: grid;
-  grid-template-columns: fit-content(100%) auto;
+  grid-template-columns: min-content auto;
   gap: var(--schedule-grid-gap, 0.5rem);
   row-gap: var(--schedule-row-gap, 0.35rem);
+  align-items: start;
   font-weight: var(--schedule-font-weight, normal);
 }
 
@@ -19,6 +20,7 @@
 .TextInFirstColumn {
   display: flex;
   flex-flow: row wrap;
+  white-space: nowrap;
   align-items: flex-start;
   font-weight: var(--schedule-first-column-font-weight, normal);
 }
@@ -26,7 +28,7 @@
 .TextInSecondColumn {
   line-height: 1.5rem;
   grid-column: 2;
-  font-weight: var(--schedule-second-column-font-weight, normal);
+  font-weight: normal;
 }
 
 .CompactLabels .TextInFirstColumn {

--- a/frontend/src/metabase/components/Schedule/Schedule.stories.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.stories.tsx
@@ -11,6 +11,7 @@ import { Api } from "metabase/api";
 import { MetabaseReduxProvider } from "metabase/lib/redux";
 import { LocaleProvider } from "metabase/public/LocaleProvider";
 import { publicReducers } from "metabase/reducers-public";
+import type { ScheduleSettings } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 import { createMockState } from "metabase-types/store/mocks";
 
@@ -49,7 +50,7 @@ export default {
 const Template: StoryFn<typeof Schedule> = args => {
   const [
     {
-      schedule,
+      cronString,
       scheduleOptions = [
         "every_n_minutes",
         "hourly",
@@ -60,38 +61,37 @@ const Template: StoryFn<typeof Schedule> = args => {
       timezone = "UTC",
       locale = "en",
       longVerb = false,
+      isCustomSchedule = false,
     },
     updateArgs,
   ] = useArgs();
 
   const verb = longVerb ? t`Clear cache for this dashboard` : t`Send`;
-  const handleChange = (schedule: unknown) => updateArgs({ schedule });
+  const handleChange = (cronString: string, schedule: ScheduleSettings) =>
+    updateArgs({
+      cronString,
+      isCustomSchedule: schedule.schedule_type === "cron",
+    });
   return (
     <LocaleProvider locale={locale}>
       <Schedule
         {...args}
         verb={verb}
-        schedule={schedule}
+        cronString={cronString}
         scheduleOptions={scheduleOptions}
         timezone={timezone}
         onScheduleChange={handleChange}
+        isCustomSchedule={isCustomSchedule}
       />
     </LocaleProvider>
   );
-};
-
-const defaultSchedule = {
-  schedule_day: "mon",
-  schedule_frame: null,
-  schedule_hour: 0,
-  schedule_type: "daily",
 };
 
 export const Default = {
   render: Template,
 
   args: {
-    schedule: defaultSchedule,
+    cronString: "0 0 9 * * ? *",
     longVerb: false,
     locale: "en",
   },
@@ -100,7 +100,7 @@ export const Default = {
 export const LongVerb = {
   render: Template,
   args: {
-    schedule: defaultSchedule,
+    cronString: "0 0 9 * * ? *",
     longVerb: true,
     locale: "en",
   },
@@ -109,11 +109,7 @@ export const LongVerb = {
 export const EveryNMinutes = {
   render: Template,
   args: {
-    schedule: {
-      schedule_type: "every_n_minutes",
-      shedule_hour: null,
-      schedule_minute: 15,
-    },
+    cronString: "0 0/10 * * * ? *",
     longVerb: false,
     locale: "en",
   },
@@ -122,13 +118,41 @@ export const EveryNMinutes = {
 export const HourlyOnSpecificMinute = {
   render: Template,
   args: {
-    schedule: {
-      schedule_type: "hourly",
-      schedule_hour: null,
-      schedule_minute: 10,
-    },
+    cronString: "0 10 * * * ? *",
     longVerb: false,
     locale: "en",
     minutesOnHourPicker: true,
+  },
+};
+
+export const CustomSchedule = {
+  render: Template,
+  args: {
+    cronString: "0 10 10 * * ? *",
+    scheduleOptions: [
+      "every_n_minutes",
+      "hourly",
+      "daily",
+      "weekly",
+      "monthly",
+      "cron",
+    ],
+    isCustomSchedule: true,
+    renderScheduleDescription: (
+      schedule: ScheduleSettings,
+      cronString: string,
+    ) => {
+      return (
+        <ul style={{ marginTop: "1rem" }}>
+          <li>
+            Demo of <code>renderScheduleDescription</code>:
+          </li>
+          <li>Cron String: {cronString}</li>
+          <li>Schedule updated on blur: {JSON.stringify(schedule)}</li>
+        </ul>
+      );
+    },
+    locale: "en",
+    labelAlignment: "left",
   },
 };

--- a/frontend/src/metabase/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.tsx
@@ -258,8 +258,10 @@ export const Schedule = ({
       .with(
         "cron",
         () =>
-          c("{0} is a verb like 'Send', {1} is an adverb like 'hourly'")
-            .jt`${verb} ${selectFrequency} every ${selectCron}`,
+          c(
+            "{0} is a verb like 'Send', {1} is an adverb like 'hourly', {2} is a cron string like '0 0 * * *'",
+          ).jt`${verb} ${selectFrequency} every ${selectCron}`,
+        // ‏‏‎ ‎
       )
       .with(null, () => null)
       .with(undefined, () => null)

--- a/frontend/src/metabase/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useCallback, useMemo, useState } from "react";
+import { type HTMLAttributes, useCallback, useMemo, useState } from "react";
 import { match } from "ts-pattern";
 import { c, msgid, ngettext } from "ttag";
 import _ from "underscore";
@@ -11,7 +11,7 @@ import {
 import { CronExpressionInput } from "metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CronExpressionInput";
 import { formatCronExpressionForUI } from "metabase/lib/cron";
 import { removeNullAndUndefinedValues } from "metabase/lib/types";
-import { Box, Flex } from "metabase/ui";
+import { Box, Flex, type FlexProps } from "metabase/ui";
 import type { ScheduleSettings, ScheduleType } from "metabase-types/api";
 
 import {
@@ -61,7 +61,8 @@ export const Schedule = ({
   labelAlignment = "compact",
   isCustomSchedule,
   renderScheduleDescription,
-}: ScheduleProps) => {
+  ...flexProps
+}: ScheduleProps & FlexProps & HTMLAttributes<HTMLDivElement>) => {
   const [internalCronString, setInternalCronString] = useState(() =>
     formatCronExpressionForUI(initialCronString),
   );
@@ -279,7 +280,7 @@ export const Schedule = ({
   }, [renderScheduleDescription, schedule, internalCronString]);
 
   return (
-    <Flex direction="column" gap="1rem">
+    <Flex direction="column" gap="1rem" {...flexProps}>
       <Box
         className={cx(
           S.Schedule,

--- a/frontend/src/metabase/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.tsx
@@ -14,7 +14,10 @@ import { removeNullAndUndefinedValues } from "metabase/lib/types";
 import { Box, Flex } from "metabase/ui";
 import type { ScheduleSettings, ScheduleType } from "metabase-types/api";
 
-import { GroupControlsTogether } from "./GroupControlsTogether";
+import {
+  GROUP_ATTRIBUTES,
+  GroupControlsTogether,
+} from "./GroupControlsTogether";
 import S from "./Schedule.module.css";
 import {
   SelectFrame,
@@ -185,6 +188,7 @@ export const Schedule = ({
 
     const selectCron = (
       <CronExpressionInput
+        data-group={GROUP_ATTRIBUTES.separate}
         key="cron"
         value={internalCronString}
         onChange={(value: string) => {
@@ -255,14 +259,7 @@ export const Schedule = ({
               selectWeekdayOfMonth
             } at ${selectTime}`,
       )
-      .with(
-        "cron",
-        () =>
-          c(
-            "{0} is a verb like 'Send', {1} is an adverb like 'hourly', {2} is a cron string like '0 0 * * *'",
-          ).jt`${verb} ${selectFrequency} every ${selectCron}`,
-        // ‏‏‎ ‎
-      )
+      .with("cron", () => [verb, selectFrequency, selectCron])
       .with(null, () => null)
       .with(undefined, () => null)
       .exhaustive();

--- a/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
@@ -83,4 +83,12 @@ describe("Schedule", () => {
     expect(optionValues).not.toContain("0");
     expect(Math.min(...optionValues.map(Number))).toBe(1);
   });
+
+  it("shows custom cron input", () => {
+    setup({
+      cronString: "0 0/5 * * * ? *",
+      isCustomSchedule: true,
+    });
+    expect(getInputValues()).toEqual(["custom", "0/5 * * * ?"]);
+  });
 });

--- a/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
@@ -16,37 +16,33 @@ describe("Schedule", () => {
   });
 
   it("shows time when schedule is daily", () => {
-    setup();
-    expect(getInputValues()).toEqual(["daily", "12:00"]);
+    setup({ cronString: "0 0 8 * * ? *" });
+    expect(getInputValues()).toEqual(["daily", "8:00"]);
   });
 
   it("shows minutes schedule is hourly and minutesOnHourPicker is true", () => {
-    setup({ schedule: { schedule_type: "hourly" }, minutesOnHourPicker: true });
+    setup({ cronString: "0 0 * * * ? *", minutesOnHourPicker: true });
     expect(getInputValues()).toEqual(["hourly", "0"]);
     expect(screen.getByText("minutes past the hour")).toBeInTheDocument();
   });
 
   it("shows day and time when schedule is weekly", () => {
     setup({
-      schedule: { schedule_type: "weekly", schedule_day: "mon" },
+      cronString: "0 0 8 ? * 2 *",
     });
     expect(getInputValues()).toEqual(["weekly", "Monday", "8:00"]);
   });
 
   it("shows first/last/mid value, day, and time when schedule is monthly", async () => {
     setup({
-      schedule: {
-        schedule_type: "monthly",
-        schedule_frame: "first",
-        schedule_day: "mon",
-      },
+      cronString: "0 0 8 ? * 2#1 *",
     });
     expect(getInputValues()).toEqual(["monthly", "first", "Monday", "8:00"]);
   });
 
   it("shows 10 minutes by default for every_n_minutes schedule", () => {
     setup({
-      schedule: { schedule_type: "every_n_minutes" },
+      cronString: "0 0/10 * * * ? *",
     });
     expect(getInputValues()).toEqual(["by the minute", "10"]);
     expect(screen.getByText("minutes")).toBeInTheDocument();
@@ -54,7 +50,7 @@ describe("Schedule", () => {
 
   it("shows proper single noun for every_n_minutes schedule", () => {
     setup({
-      schedule: { schedule_type: "every_n_minutes", schedule_minute: 1 },
+      cronString: "0 0/1 * * * ? *",
     });
     expect(getInputValues()).toEqual(["by the minute", "1"]);
     expect(screen.getByText("minute")).toBeInTheDocument();
@@ -62,7 +58,7 @@ describe("Schedule", () => {
 
   it("shows proper plural noun for every_n_minutes schedule", () => {
     setup({
-      schedule: { schedule_type: "every_n_minutes", schedule_minute: 5 },
+      cronString: "0 0/5 * * * ? *",
     });
     expect(getInputValues()).toEqual(["by the minute", "5"]);
     expect(screen.getByText("minutes")).toBeInTheDocument();
@@ -70,7 +66,7 @@ describe("Schedule", () => {
 
   it("does not allow 0 minutes option for every_n_minutes schedule", async () => {
     setup({
-      schedule: { schedule_type: "every_n_minutes" },
+      cronString: "0 0/10 * * * ? *",
     });
 
     const minuteInput = screen.getByTestId("select-minute");

--- a/frontend/src/metabase/components/Schedule/strings.ts
+++ b/frontend/src/metabase/components/Schedule/strings.ts
@@ -64,6 +64,7 @@ export const getScheduleStrings = () => {
     daily: c("adverb").t`daily`,
     weekly: c("adverb").t`weekly`,
     monthly: c("adverb").t`monthly`,
+    cron: c("adverb").t`custom`,
   };
 
   const weekdays: Weekday[] = [

--- a/frontend/src/metabase/components/Schedule/strings.ts
+++ b/frontend/src/metabase/components/Schedule/strings.ts
@@ -59,12 +59,12 @@ export const getScheduleStrings = () => {
     // The context is needed because 'hourly' can be an adjective ('hourly
     // rate') or adverb ('update hourly'). Same with 'daily', 'weekly', and
     // 'monthly'.
-    every_n_minutes: c("adverbial phrase").t`by the minute`,
+    every_n_minutes: t`by the minute`,
     hourly: c("adverb").t`hourly`,
     daily: c("adverb").t`daily`,
     weekly: c("adverb").t`weekly`,
     monthly: c("adverb").t`monthly`,
-    cron: c("adverb").t`custom`,
+    cron: t`custom`,
   };
 
   const weekdays: Weekday[] = [

--- a/frontend/src/metabase/components/Schedule/test-utils.tsx
+++ b/frontend/src/metabase/components/Schedule/test-utils.tsx
@@ -2,11 +2,7 @@ import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders } from "__support__/ui";
-import type {
-  ScheduleSettings,
-  ScheduleType,
-  TokenFeatures,
-} from "metabase-types/api";
+import type { ScheduleType, TokenFeatures } from "metabase-types/api";
 import {
   createMockSettings,
   createMockTokenFeatures,
@@ -20,13 +16,6 @@ export interface SetupOpts {
   tokenFeatures?: Partial<TokenFeatures>;
 }
 
-const mockSchedule: ScheduleSettings = {
-  schedule_type: "daily",
-  schedule_day: null,
-  schedule_frame: null,
-  schedule_hour: 12,
-  schedule_minute: 0,
-};
 const mockScheduleOptions: ScheduleType[] = [
   "every_n_minutes",
   "hourly",
@@ -57,7 +46,7 @@ export const setup = ({
   }
 
   const propsWithDefaults = {
-    schedule: { ...mockSchedule, ...props.schedule },
+    cronString: props.cronString ?? "0 0 8 * * ? *",
     scheduleOptions: mockScheduleOptions,
     onScheduleChange: mockOnScheduleChange,
     timezone: mockTimezone,

--- a/frontend/src/metabase/components/Schedule/test-utils.tsx
+++ b/frontend/src/metabase/components/Schedule/test-utils.tsx
@@ -22,6 +22,7 @@ const mockScheduleOptions: ScheduleType[] = [
   "daily",
   "weekly",
   "monthly",
+  "cron",
 ];
 const mockVerb = "Send";
 const mockTimezone = "America/New_York";

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -106,5 +106,11 @@ export const getScheduleDefaults = (
       schedule_hour: defaultHour,
       schedule_minute: 0,
     }))
+    .with({ schedule_type: "cron" }, () => ({
+      schedule_day: null,
+      schedule_frame: null,
+      schedule_hour: defaultHour,
+      schedule_minute: 0,
+    }))
     .otherwise(() => ({}));
 };

--- a/frontend/src/metabase/lib/cron.ts
+++ b/frontend/src/metabase/lib/cron.ts
@@ -73,16 +73,8 @@ function lowerCaseFirstLetter(str: string) {
 }
 
 export const getScheduleExplanation = memoize(
-  (cronExpression: string): string | null => {
-    try {
-      const readableSchedule = lowerCaseFirstLetter(
-        explainCronExpression(cronExpression),
-      );
-      return readableSchedule;
-    } catch {
-      return null;
-    }
-  },
+  (cronExpression: string): string | null =>
+    lowerCaseFirstLetter(explainCronExpression(cronExpression)),
 );
 
 export function formatCronExpressionForUI(cronExpression: string): string {

--- a/frontend/src/metabase/lib/cron.ts
+++ b/frontend/src/metabase/lib/cron.ts
@@ -1,6 +1,7 @@
 import { isValidCronExpression } from "cron-expression-validator";
 import cronstrue from "cronstrue";
 import { t } from "ttag";
+import { memoize } from "underscore";
 
 import MetabaseSettings from "metabase/lib/settings";
 import { has24HourModeSetting } from "metabase/lib/time";
@@ -21,7 +22,9 @@ function translateErrorMessage(message: string) {
     "? can only be specified for Day-of-Month -OR- Day-of-Week": t`You must use ? in the day-of-week or day-of-month field`,
     "Unexpected end of expression": t`Invalid cron expression`,
   };
-  return errorMessageMap[message];
+  // Some messages are dynamic and do not have translation mapping,
+  // so we've decided to return them as is.
+  return errorMessageMap[message] || message;
 }
 
 export function validateCronExpression(
@@ -69,6 +72,21 @@ function lowerCaseFirstLetter(str: string) {
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
 
-export function explainCronExpressionLowercase(cronExpression: string) {
-  return lowerCaseFirstLetter(explainCronExpression(cronExpression));
+export const getScheduleExplanation = memoize(
+  (cronExpression: string): string | null => {
+    try {
+      const readableSchedule = lowerCaseFirstLetter(
+        explainCronExpression(cronExpression),
+      );
+      return readableSchedule;
+    } catch {
+      return null;
+    }
+  },
+);
+
+export function formatCronExpressionForUI(cronExpression: string): string {
+  const [, ...partsWithoutSeconds] = cronExpression.split(" ");
+  const partsWithoutSecondsAndYear = partsWithoutSeconds.slice(0, -1);
+  return partsWithoutSecondsAndYear.join(" ");
 }

--- a/frontend/src/metabase/lib/cron.ts
+++ b/frontend/src/metabase/lib/cron.ts
@@ -73,8 +73,16 @@ function lowerCaseFirstLetter(str: string) {
 }
 
 export const getScheduleExplanation = memoize(
-  (cronExpression: string): string | null =>
-    lowerCaseFirstLetter(explainCronExpression(cronExpression)),
+  (cronExpression: string): string | null => {
+    try {
+      const readableSchedule = lowerCaseFirstLetter(
+        explainCronExpression(cronExpression),
+      );
+      return readableSchedule;
+    } catch {
+      return null;
+    }
+  },
 );
 
 export function formatCronExpressionForUI(cronExpression: string): string {

--- a/frontend/src/metabase/lib/cron.ts
+++ b/frontend/src/metabase/lib/cron.ts
@@ -64,3 +64,11 @@ export function explainCronExpression(cronExpression: string) {
     use24HourTimeFormat: has24HourModeSetting(),
   });
 }
+
+function lowerCaseFirstLetter(str: string) {
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}
+
+export function explainCronExpressionLowercase(cronExpression: string) {
+  return lowerCaseFirstLetter(explainCronExpression(cronExpression));
+}

--- a/frontend/src/metabase/lib/notifications.ts
+++ b/frontend/src/metabase/lib/notifications.ts
@@ -33,7 +33,7 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
-import { explainCronExpressionLowercase } from "./cron";
+import { getScheduleExplanation } from "./cron";
 
 export const formatTitle = ({ item, type }: NotificationListItem) => {
   switch (type) {
@@ -294,11 +294,13 @@ export const formatNotificationCheckSchedule = (
     }
     case "cron":
       try {
-        return t`Check ${explainCronExpressionLowercase(cronSchedule)}`;
+        return t`Check ${getScheduleExplanation(cronSchedule)}`;
       } catch {
         return null;
       }
   }
+
+  return null;
 };
 
 export const formatNotificationScheduleDescription = ({

--- a/frontend/src/metabase/lib/notifications.ts
+++ b/frontend/src/metabase/lib/notifications.ts
@@ -33,6 +33,8 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
+import { explainCronExpressionLowercase } from "./cron";
+
 export const formatTitle = ({ item, type }: NotificationListItem) => {
   switch (type) {
     case "pulse":
@@ -229,18 +231,28 @@ export const getNotificationHandlersGroupedByTypes = (
 export const formatNotificationSchedule = (
   subscription: NotificationCronSubscription,
 ): string | null => {
-  const schedule = cronToScheduleSettings(subscription.cron_schedule);
+  const schedule = cronToScheduleSettings(
+    subscription.cron_schedule,
+    subscription.ui_display_type === "cron/raw",
+  );
 
-  return (schedule && formatNotificationCheckSchedule(schedule)) || null;
+  return (
+    (schedule &&
+      formatNotificationCheckSchedule(schedule, subscription.cron_schedule)) ||
+    null
+  );
 };
 
-export const formatNotificationCheckSchedule = ({
-  schedule_type,
-  schedule_minute,
-  schedule_hour,
-  schedule_day,
-  schedule_frame,
-}: ScheduleSettings) => {
+export const formatNotificationCheckSchedule = (
+  {
+    schedule_type,
+    schedule_minute,
+    schedule_hour,
+    schedule_day,
+    schedule_frame,
+  }: ScheduleSettings,
+  cronSchedule: string,
+) => {
   const options = MetabaseSettings.formattingOptions();
 
   switch (schedule_type) {
@@ -280,6 +292,12 @@ export const formatNotificationCheckSchedule = ({
       }
       break;
     }
+    case "cron":
+      try {
+        return t`Check ${explainCronExpressionLowercase(cronSchedule)}`;
+      } catch {
+        return null;
+      }
   }
 };
 

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -81,6 +81,7 @@ const ALERT_SCHEDULE_OPTIONS: ScheduleType[] = [
   "daily",
   "weekly",
   "monthly",
+  "cron",
 ];
 
 type CreateOrEditQuestionAlertModalProps = {

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -346,6 +346,11 @@ export const CreateOrEditQuestionAlertModal = ({
         <AlertModalSettingsBlock title={t`More options`}>
           <Switch
             label={t`Only send this alert once`}
+            styles={{
+              label: {
+                lineHeight: "1.5rem",
+              },
+            }}
             labelPosition="right"
             size="sm"
             checked={notification.payload.send_once}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
@@ -137,7 +137,7 @@ describe("CreateOrEditQuestionAlertModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("should show daily and 9am as default schedule settings", async () => {
+  it("should show daily and 8am as default schedule settings", async () => {
     setup({
       isAdmin: true,
       isEmailSetup: true,
@@ -151,9 +151,9 @@ describe("CreateOrEditQuestionAlertModal", () => {
     const scheduleTypeSelect = screen.getByTestId("select-frequency");
     expect(scheduleTypeSelect).toHaveValue("daily");
 
-    // Find the time selector (showing "9:00")
+    // Find the time selector (showing "8:00")
     const timeSelector = screen.getByTestId("select-time");
-    expect(timeSelector).toHaveValue("9:00");
+    expect(timeSelector).toHaveValue("8:00");
   });
 
   it("should show the editing alert data when in edit mode", async () => {
@@ -281,6 +281,51 @@ describe("CreateOrEditQuestionAlertModal", () => {
 
       // Verify the cron schedule is for 8am daily
       expect(subscription.cron_schedule).toBe("0 0 8 * * ? *");
+    });
+
+    expect(onAlertCreatedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should create a new notification with custom schedule", async () => {
+    // Setup fetchMock for API call - note we use '*' matcher to capture any request to this endpoint
+    fetchMock.postOnce("path:/api/notification", { body: { id: 123 } });
+    const onAlertCreatedMock = jest.fn();
+
+    setup({
+      isAdmin: true,
+      isEmailSetup: true,
+      onAlertCreatedMock,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("New alert")).toBeInTheDocument();
+    });
+
+    // Verify default daily schedule is selected initially
+    const scheduleTypeSelect = screen.getByTestId("select-frequency");
+
+    await userEvent.click(scheduleTypeSelect);
+    const optionCustom = screen.getByRole("option", { name: /custom/i });
+    await userEvent.click(optionCustom);
+
+    const cronInput = screen.getByDisplayValue("0 8 * * ?");
+
+    await userEvent.clear(cronInput);
+    await userEvent.type(cronInput, "0/10 8 * * ?");
+
+    const saveButton = screen.getByRole("button", { name: /done/i });
+    await userEvent.click(saveButton);
+
+    // Verify the API was called with the correct cron schedule for 8am
+    const calls = fetchMock.calls("path:/api/notification");
+    expect(calls.length).toBe(1);
+
+    await waitFor(async () => {
+      const requestBody = await calls[0][1]?.body;
+      const subscription = JSON.parse(requestBody as string).subscriptions[0];
+
+      // Verify the cron schedule is for 8am daily
+      expect(subscription.cron_schedule).toBe("0 0/10 8 * * ? *");
     });
 
     expect(onAlertCreatedMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
@@ -161,7 +161,7 @@ describe("CreateOrEditQuestionAlertModal", () => {
     const mockNotification = createMockNotification({
       subscriptions: [
         createMockNotificationCronSubscription({
-          cron_schedule: "0 0 14 ? * 2",
+          cron_schedule: "0 0 14 ? * 2 *",
         }),
       ],
       payload: {
@@ -210,7 +210,7 @@ describe("CreateOrEditQuestionAlertModal", () => {
       subscriptions: [
         createMockNotificationCronSubscription({
           // Hourly at 5 minutes past the hour
-          cron_schedule: "0 5 * * * ?",
+          cron_schedule: "0 5 * * * ? *",
         }),
       ],
       payload: {
@@ -280,7 +280,7 @@ describe("CreateOrEditQuestionAlertModal", () => {
       const subscription = JSON.parse(requestBody as string).subscriptions[0];
 
       // Verify the cron schedule is for 8am daily
-      expect(subscription.cron_schedule).toBe("0 0 8 * * ?");
+      expect(subscription.cron_schedule).toBe("0 0 8 * * ? *");
     });
 
     expect(onAlertCreatedMock).toHaveBeenCalledTimes(1);
@@ -300,7 +300,7 @@ describe("CreateOrEditQuestionAlertModal", () => {
       id: notificationId,
       subscriptions: [
         createMockNotificationCronSubscription({
-          cron_schedule: "0 0 14 ? * 2", // Monday at 2pm
+          cron_schedule: "0 0 14 ? * 2 *", // Monday at 2pm
         }),
       ],
       payload: {
@@ -340,7 +340,7 @@ describe("CreateOrEditQuestionAlertModal", () => {
       const subscription = JSON.parse(requestBody as string).subscriptions[0];
 
       // Verify the cron schedule is for Tuesday at 2pm (day 3)
-      expect(subscription.cron_schedule).toBe("0 0 14 ? * 3");
+      expect(subscription.cron_schedule).toBe("0 0 14 ? * 3 *");
     });
 
     expect(onAlertUpdatedMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.module.css
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.module.css
@@ -4,6 +4,12 @@
     --notification-schedule-padding,
     var(--mantine-spacing-lg) var(--mantine-spacing-xl)
   );
+
+  &:has([data-error="true"]) {
+    .customScheduleExplainer {
+      display: none;
+    }
+  }
 }
 
 .schedule {

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
@@ -3,12 +3,17 @@ import { c, t } from "ttag";
 
 import {
   cronToScheduleSettings,
-  scheduleSettingsToCron,
+  cronUnitToNumber,
+  isRepeatingEvery,
 } from "metabase/admin/performance/utils";
+import { getScheduleExplanation } from "metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CustomScheduleExplainer";
 import { Schedule } from "metabase/components/Schedule/Schedule";
 import { formatNotificationScheduleDescription } from "metabase/lib/notifications";
 import { useSelector } from "metabase/lib/redux";
-import { DEFAULT_ALERT_SCHEDULE } from "metabase/notifications/utils";
+import {
+  DEFAULT_ALERT_CRON_SCHEDULE,
+  DEFAULT_ALERT_SCHEDULE,
+} from "metabase/notifications/utils";
 import { getSetting } from "metabase/selectors/settings";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Box, type BoxProps, Flex, Text } from "metabase/ui";
@@ -39,87 +44,109 @@ export const NotificationSchedule = ({
 
   const scheduleSettings = useMemo(() => {
     return (
-      cronToScheduleSettings(subscription?.cron_schedule) ||
-      DEFAULT_ALERT_SCHEDULE
+      cronToScheduleSettings(
+        subscription?.cron_schedule,
+        subscription?.ui_display_type === "cron/raw",
+      ) || DEFAULT_ALERT_SCHEDULE
     );
-  }, [subscription?.cron_schedule]);
+  }, [subscription?.cron_schedule, subscription?.ui_display_type]);
+
+  const cronString = subscription?.cron_schedule || DEFAULT_ALERT_CRON_SCHEDULE;
+
+  const actionText = t`Alerts will be sent`;
+  const applicationName = useSelector(getApplicationName);
+  const renderScheduleDescription = useMemo(() => {
+    // No description is necessary for schedule types, which recur periodically.
+    const PERIODIC_SCHEDULE_TYPES = ["every_n_minutes", "hourly"];
+    return function ScheduleDescription(
+      schedule: ScheduleSettings,
+      cronExpression: string,
+    ) {
+      if (PERIODIC_SCHEDULE_TYPES.includes(schedule.schedule_type as string)) {
+        return null;
+      }
+
+      if (schedule.schedule_type === "cron") {
+        return (
+          <Text className={styles.customScheduleExplainer}>
+            {`${actionText} ${getScheduleExplanation(cronExpression)}${t`, according to your ${applicationName} timezone (${timezone}).`}`}
+          </Text>
+        );
+      }
+
+      const scheduleDescription =
+        formatNotificationScheduleDescription(schedule);
+      if (!scheduleDescription) {
+        return null;
+      }
+
+      const timezoneLabel = t`${timezone}, your ${applicationName} timezone.`;
+
+      return (
+        <Text c="var(--mb-color-text-secondary)">
+          {`${actionText} ${scheduleDescription} ${timezoneLabel}`}
+        </Text>
+      );
+    };
+  }, [actionText, applicationName, timezone]);
 
   const handleScheduleChange = useCallback(
-    (nextSchedule: ScheduleSettings) => {
-      if (nextSchedule.schedule_type && subscription) {
-        const newCronSchedule = scheduleSettingsToCron(nextSchedule);
+    (newCronString: string, newSchedule: ScheduleSettings) => {
+      if (subscription) {
         onScheduleChange({
           ...subscription,
-          cron_schedule: newCronSchedule,
+          cron_schedule: newCronString,
+          ui_display_type:
+            newSchedule.schedule_type === "cron" ? "cron/raw" : "cron/builder",
         });
       }
     },
-    [onScheduleChange, subscription],
-  );
-
-  const actionText = t`Alerts will be sent at`;
-  const scheduleDescription = useScheduleDescription(
-    scheduleSettings,
-    timezone,
-    actionText,
+    [subscription, onScheduleChange],
   );
 
   return (
     <Box {...boxProps}>
       <Flex className={styles.scheduleContainer} direction="column" gap="md">
         <Schedule
-          className={styles.schedule}
-          schedule={scheduleSettings}
-          scheduleOptions={scheduleOptions}
-          labelAlignment="left"
-          minutesOnHourPicker
-          onScheduleChange={handleScheduleChange}
           verb={c("A verb in the imperative mood").t`Check`}
+          cronString={cronString}
+          scheduleOptions={scheduleOptions}
+          minutesOnHourPicker
+          isCustomSchedule={subscription?.ui_display_type === "cron/raw"}
+          renderScheduleDescription={renderScheduleDescription}
+          onScheduleChange={handleScheduleChange}
           aria-label={t`Describe how often the alert notification should be sent`}
+          labelAlignment="left"
+          className={styles.schedule}
+          timezone={timezone}
         />
-        {scheduleDescription && (
-          <Text c="var(--mb-color-text-secondary)">{scheduleDescription}</Text>
-        )}
       </Flex>
-      {showWarning(scheduleSettings) && <NotificationScheduleWarning />}
+      {showWarning(scheduleSettings, cronString) && (
+        <NotificationScheduleWarning />
+      )}
     </Box>
   );
 };
 
 const UNSAFE_SCHEDULE_TYPES = ["every_n_minutes", "cron"];
 const WARNING_THRESHOLD_MINS = 10;
-function showWarning(schedule: ScheduleSettings) {
+function showWarning(schedule: ScheduleSettings, cronString?: string) {
   if (
     !schedule.schedule_type ||
-    !UNSAFE_SCHEDULE_TYPES.includes(schedule.schedule_type)
+    !UNSAFE_SCHEDULE_TYPES.includes(schedule.schedule_type) ||
+    !schedule.schedule_minute
   ) {
     return false;
   }
-  return (
-    typeof schedule.schedule_minute === "number" &&
-    schedule.schedule_minute < WARNING_THRESHOLD_MINS
-  );
-}
-
-// No description is necessary for schedule types, which recur periodically.
-const PERIODIC_SCHEDULE_TYPES = ["every_n_minutes", "hourly"];
-function useScheduleDescription(
-  schedule: ScheduleSettings,
-  timezone: string,
-  actionText: string,
-) {
-  const applicationName = useSelector(getApplicationName);
-
-  if (PERIODIC_SCHEDULE_TYPES.includes(schedule.schedule_type as string)) {
-    return null;
+  if (schedule.schedule_type === "every_n_minutes") {
+    return schedule.schedule_minute < WARNING_THRESHOLD_MINS;
   }
-
-  const scheduleDescription = formatNotificationScheduleDescription(schedule);
-  if (!scheduleDescription) {
-    return null;
+  if (schedule.schedule_type === "cron") {
+    const [, minute] = cronString?.split(" ") || [];
+    return (
+      isRepeatingEvery(minute) &&
+      cronUnitToNumber(minute) < WARNING_THRESHOLD_MINS
+    );
   }
-
-  const timezoneLabel = t`${timezone}, your ${applicationName} timezone.`;
-
-  return `${actionText} ${scheduleDescription} ${timezoneLabel}`;
+  return false;
 }

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
@@ -69,7 +69,7 @@ export const NotificationSchedule = ({
       if (schedule.schedule_type === "cron") {
         return (
           <Text className={styles.customScheduleExplainer}>
-            {`${actionText} ${getScheduleExplanation(cronExpression)}${t`, according to your ${applicationName} timezone (${timezone}).`}`}
+            {`${actionText} ${getScheduleExplanation(cronExpression)}${c("An additional clarification for a human-readable schedule description").t`, according to your ${applicationName} timezone (${timezone}).`}`}
           </Text>
         );
       }
@@ -80,7 +80,9 @@ export const NotificationSchedule = ({
         return null;
       }
 
-      const timezoneLabel = t`${timezone}, your ${applicationName} timezone.`;
+      const timezoneLabel = c(
+        "An additional clarification for a human-readable schedule description",
+      ).t`${timezone}, your ${applicationName} timezone.`;
 
       return (
         <Text c="var(--mb-color-text-secondary)">

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.tsx
@@ -6,8 +6,8 @@ import {
   cronUnitToNumber,
   isRepeatingEvery,
 } from "metabase/admin/performance/utils";
-import { getScheduleExplanation } from "metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CustomScheduleExplainer";
 import { Schedule } from "metabase/components/Schedule/Schedule";
+import { getScheduleExplanation } from "metabase/lib/cron";
 import { formatNotificationScheduleDescription } from "metabase/lib/notifications";
 import { useSelector } from "metabase/lib/redux";
 import {
@@ -118,7 +118,6 @@ export const NotificationSchedule = ({
           aria-label={t`Describe how often the alert notification should be sent`}
           labelAlignment="left"
           className={styles.schedule}
-          timezone={timezone}
         />
       </Flex>
       {showWarning(scheduleSettings, cronString) && (

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
@@ -12,6 +12,7 @@ describe("NotificationSchedule", () => {
         event_name: null,
         cron_schedule: "0 0/5 * * * ?", // every 5 minutes
         created_at: "2025-03-14T16:11:12Z",
+        ui_display_type: "cron/builder",
       },
     });
 
@@ -31,6 +32,7 @@ describe("NotificationSchedule", () => {
         event_name: null,
         cron_schedule: "0 0/10 * * * ?", // every 10 minutes
         created_at: "2025-03-14T16:11:12Z",
+        ui_display_type: "cron/builder",
       },
     });
 

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/components/NotificationSchedule/NotificationSchedule.unit.spec.tsx
@@ -1,45 +1,48 @@
 import { screen } from "__support__/ui";
+import type { ScheduleDisplayType } from "metabase-types/api";
 
 import { setup } from "./setup";
 
 describe("NotificationSchedule", () => {
-  it("should show warning when notification schedule is set to less than 10 minutes", () => {
-    setup({
-      subscription: {
-        id: 1,
-        notification_id: 1,
-        type: "notification-subscription/cron",
-        event_name: null,
-        cron_schedule: "0 0/5 * * * ?", // every 5 minutes
-        created_at: "2025-03-14T16:11:12Z",
-        ui_display_type: "cron/builder",
-      },
+  ["builder", "raw"].forEach(uiDisplayType => {
+    it(`${uiDisplayType} - should show warning when notification schedule is set to less than 10 minutes`, () => {
+      setup({
+        subscription: {
+          id: 1,
+          notification_id: 1,
+          type: "notification-subscription/cron",
+          event_name: null,
+          cron_schedule: "0 0/5 * * * ? *", // every 5 minutes
+          created_at: "2025-03-14T16:11:12Z",
+          ui_display_type: `cron/${uiDisplayType}` as ScheduleDisplayType,
+        },
+      });
+
+      expect(
+        screen.getByText(
+          /If an alert is still in progress when the next one is scheduled, the next alert will be skipped/,
+        ),
+      ).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(
-        /If an alert is still in progress when the next one is scheduled, the next alert will be skipped/,
-      ),
-    ).toBeInTheDocument();
-  });
+    it(`${uiDisplayType} - should not show warning when notification schedule is set to 10 or more minutes`, () => {
+      setup({
+        subscription: {
+          id: 1,
+          notification_id: 1,
+          type: "notification-subscription/cron",
+          event_name: null,
+          cron_schedule: "0 0/10 * * * ? *", // every 10 minutes
+          created_at: "2025-03-14T16:11:12Z",
+          ui_display_type: `cron/${uiDisplayType}` as ScheduleDisplayType,
+        },
+      });
 
-  it("should not show warning when notification schedule is set to 10 or more minutes", () => {
-    setup({
-      subscription: {
-        id: 1,
-        notification_id: 1,
-        type: "notification-subscription/cron",
-        event_name: null,
-        cron_schedule: "0 0/10 * * * ?", // every 10 minutes
-        created_at: "2025-03-14T16:11:12Z",
-        ui_display_type: "cron/builder",
-      },
+      expect(
+        screen.queryByText(
+          /If an alert is still in progress when the next one is scheduled, the next alert will be skipped/,
+        ),
+      ).not.toBeInTheDocument();
     });
-
-    expect(
-      screen.queryByText(
-        /If an alert is still in progress when the next one is scheduled, the next alert will be skipped/,
-      ),
-    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/notifications/utils.ts
+++ b/frontend/src/metabase/notifications/utils.ts
@@ -10,12 +10,12 @@ import type {
 
 import type { NotificationTriggerOption } from "./modals/CreateOrEditQuestionAlertModal/types";
 
-export const DEFAULT_ALERT_CRON_SCHEDULE = "0 0 9 * * ?";
+export const DEFAULT_ALERT_CRON_SCHEDULE = "0 0 8 * * ? *";
 export const DEFAULT_ALERT_SCHEDULE: ScheduleSettings = {
   schedule_type: "daily",
   schedule_day: null,
   schedule_frame: null,
-  schedule_hour: 10,
+  schedule_hour: 8,
   schedule_minute: 0,
 };
 
@@ -113,6 +113,7 @@ export const getDefaultQuestionAlertRequest = ({
         type: "notification-subscription/cron",
         event_name: null,
         cron_schedule: DEFAULT_ALERT_CRON_SCHEDULE,
+        ui_display_type: "cron/builder",
       },
     ],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,14 +1108,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.6", "@babel/runtime@^7.20.13", "@babel/runtime@^7.21.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
-  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.26.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.6", "@babel/runtime@^7.20.13", "@babel/runtime@^7.21.0", "@babel/runtime@^7.26.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
   integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==


### PR DESCRIPTION
Closes [WRK-116](https://linear.app/metabase/issue/WRK-116/cron-scheduling-for-alerts)
Closes https://github.com/metabase/metabase/issues/3846

### Description
In this PR we introduce a new option enabling to use custom cron expressions (using Quartz syntax) for alerts scheduling. It provides the user with a human-readable explanation of resulting schedule, including timezone information.

<img width="574" alt="image" src="https://github.com/user-attachments/assets/793d2516-d733-452b-9c99-ae48267e60b6" />

The input provides a reasonable level of validation for custom expressions using https://www.npmjs.com/package/cron-expression-validator library. Invalid expressions will not be saved.

<img width="554" alt="image" src="https://github.com/user-attachments/assets/5f33a8ae-d63a-42d8-9b1b-b11ba6c93a15" />

If the expression has a valid syntax, but doesn't make sense in real world, e.g. as having `0/0` minute interval (every 0 minutes) – it will be ignored by the backend.

If the specified interval is more frequent than "every 10 minutes" user is presented with a warning:
<img width="553" alt="image" src="https://github.com/user-attachments/assets/25a0fb58-85b7-46e0-aca7-1c8c6ed4ed46" />

Alert list items were updated to properly display human-readable custom schedules:
<img width="635" alt="image" src="https://github.com/user-attachments/assets/9248357d-1a9f-47bc-8f23-2851159c1f38" />

And, of course, some refactoring was made along the way to customize `CronExpressionInput` and related functionality. `Schedule` component was updated to accept `cronString` instead of `scheduleSettings` and parse the string internally. 

Also, found an issue with existing validation functionality and adjusted error-generating function to return untranslated error in English (if applicable) before resolving to fallback message.

### How to verify

1. Create a new alert
2. Select "custom" option.
3. Input valid cron expression.
4. Save alert, check that email on set notification has been received. Wait to receive the notification.

### Demo
[Loom](https://www.loom.com/share/be864458acb64ea9b6b60ec26e377049?sid=04263055-5c94-4aa8-93b0-4637a310c90b)