### PR TITLE
feat: add embedding stats to token request

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -50,6 +50,7 @@
            driver
            eid-translation
            integrations
+           internal-stats
            models
            premium-features
            public-settings
@@ -216,6 +217,10 @@
   integrations
   {:api  #{metabase.integrations.slack}
    :uses #{events models util}}
+
+  internal-stats
+  {:api #{metabase.internal-stats}
+   :uses #{db models}}
 
   legacy-mbql
   {:api #{metabase.legacy-mbql.normalize
@@ -408,7 +413,7 @@
   premium-features
   {:api  #{metabase.premium-features.core
            metabase.premium-features.token-check}
-   :uses #{config db models plugins util}}
+   :uses #{config db internal-stats models plugins util}}
 
   public-settings
   {:api  #{metabase.public-settings}

--- a/src/metabase/internal_stats.clj
+++ b/src/metabase/internal_stats.clj
@@ -1,0 +1,20 @@
+(ns metabase.internal-stats
+  (:require
+   [metabase.internal-stats.query-executions :as query-execution-stats]
+   [metabase.internal-stats.questions :as question-stats]
+   [metabase.internal-stats.users :as user-stats]
+   [potemkin :as p]))
+
+(p/import-vars
+ [user-stats
+  email-domain-count
+  external-users-count])
+
+(p/import-vars
+ [query-execution-stats
+  query-executions-all-time-and-last-24h
+  query-execution-last-utc-day])
+
+(p/import-vars
+ [question-stats
+  question-statistics-all-time])

--- a/src/metabase/internal_stats/query_executions.clj
+++ b/src/metabase/internal_stats/query_executions.clj
@@ -1,0 +1,47 @@
+(ns metabase.internal-stats.query-executions
+  (:require
+   [java-time.api :as t]
+   [metabase.internal-stats.util :as u]
+   [toucan2.core :as t2]))
+
+(def ^:private query-execution-statistics
+  [:model/QueryExecution
+   [(u/count-case [:= :embedding_client "embedding-sdk-react"]) :sdk_embed]
+   [(u/count-case [:and [:= :embedding_client "embedding-iframe"]
+                   [:!= :executor_id nil]])
+    :interactive_embed]
+   [(u/count-case [:and [:= :embedding_client "embedding-iframe"]
+                   [:= :executor_id nil]])
+    :static_embed]
+   [(u/count-case [:and
+                   [:or [:= :embedding_client nil]
+                    [:!= :embedding_client "embedding-sdk-react"]]
+                   [:or [:= :embedding_client nil]
+                    [:!= :embedding_client "embedding-iframe"]]
+                   [:like :context "public-%"]])
+    :public_link]
+   [(u/count-case [:and
+                   [:or [:= :embedding_client nil]
+                    [:!= :embedding_client "embedding-sdk-react"]]
+                   [:or [:= :embedding_client nil]
+                    [:!= :embedding_client "embedding-iframe"]]
+                   [:not [:like :context "public-%"]]])
+    :internal]])
+
+(defn query-executions-all-time-and-last-24h
+  "Calculate query executions for the entire available history and over the last 24 hours from now."
+  []
+  (let [qe          (t2/select-one query-execution-statistics)
+        one-day-ago (t/minus (t/offset-date-time) (t/days 1))
+        qe-24h      (t2/select-one query-execution-statistics {:where [:> :started_at one-day-ago]})]
+    {:query-executions     qe
+     :query-executions-24h qe-24h}))
+
+(defn query-execution-last-utc-day
+  "Calculate query executions over a window of the the previous UTC day 00:00-23:59"
+  []
+  (let [yesterday-utc (t/minus (t/offset-date-time (t/zone-offset "+00")) (t/days 1))]
+    (update-keys
+     (t2/select-one query-execution-statistics
+                    {:where [:= [:cast :started_at :date] [:cast yesterday-utc :date]]})
+     #(keyword (str "query_executions_" (name %))))))

--- a/src/metabase/internal_stats/questions.clj
+++ b/src/metabase/internal_stats/questions.clj
@@ -1,0 +1,75 @@
+(ns metabase.internal-stats.questions
+  (:require
+   [metabase.db :as db]
+   [metabase.internal-stats.util :as u]
+   [metabase.models.interface :as mi]
+   [toucan2.core :as t2]))
+
+(defn- and-not-nil
+  ([not-nil-field]
+   (and-not-nil nil not-nil-field))
+  ([case-boolean not-nil-field]
+   (cond->> [:!= not-nil-field nil]
+     case-boolean (conj [:and case-boolean]))))
+
+(defn- card-has-params
+  []
+  (condp = (db/db-type)
+    :mysql [:json_contains_path
+            :dataset_query
+            [:inline "one"]
+            [:inline "$.native.\"template-tags\".*"]]
+    :postgres [:jsonb_path_exists
+               [:cast :dataset_query :jsonb]
+               [:inline "$.native.\"template-tags\" ? (exists(@.*))"]]))
+
+(defn- contains-embedding-param
+  [param]
+  (condp = (db/db-type)
+    :mysql [:!= [:json_search
+                 :embedding_params
+                 [:inline "one"]
+                 [:inline param]]
+            nil]
+    :postgres [:jsonb_path_exists
+               [:cast :embedding_params :jsonb]
+               [:inline (str "$.* ? (@ == \"" param "\")")]]))
+
+(def ^:private embedding-on [:= :enable_embedding [:inline true]])
+
+(defn question-statistics-all-time
+  "Get metrics based on questions "
+  []
+  (let [json-supported? (contains? #{:mysql :mariadb :postgres} (db/db-type))]
+    (t2/select-one (cond-> [:model/Card
+                            [:%count.* :total]
+                            [(u/count-case [:= [:inline "native"] :query_type])
+                             :native]
+                            [(u/count-case [:!= [:inline "native"] :query_type])
+                             :gui]
+                            [(u/count-case [:!= :dashboard_id nil])
+                             :is_dashboard_question]
+                            [(u/count-case [:= :enable_embedding [:inline true]])
+                             :total_embedded]
+                            [(u/count-case (and-not-nil :public_uuid))
+                             :total_public]]
+                                ;; json_exists/contains which we use to query json encoded data stored in text
+                                ;; columns is not supported on h2 databases, so we exclude these stats when
+                                ;; the app db is h2.
+                     json-supported? (conj
+                                      [(u/count-case (card-has-params))
+                                       :with_params]
+                                      [(u/count-case (and-not-nil (card-has-params) :public_uuid))
+                                       :with_params_public]
+                                      [(u/count-case [:and embedding-on (card-has-params)])
+                                       :with_params_embedded]
+                                      [(u/count-case [:and (contains-embedding-param "enabled")
+                                                      embedding-on])
+                                       :with_enabled_params]
+                                      [(u/count-case [:and (contains-embedding-param "locked")
+                                                      embedding-on])
+                                       :with_locked_params]
+                                      [(u/count-case [:and (contains-embedding-param "disabled")
+                                                      embedding-on])
+                                       :with_disabled_params]))
+                   {:where (mi/exclude-internal-content-hsql :model/Card)})))

--- a/src/metabase/internal_stats/users.clj
+++ b/src/metabase/internal_stats/users.clj
@@ -6,17 +6,16 @@
 (defn email-domain-count
   "Count all unique normalized domains found in active user emails"
   []
-  #p (t2/query {:select-distinct (condp contains? (db/db-type)
-                                   #{:postgres}  [[[:split_part :email [:inline "@"] [:inline 2]]]]
-                                   #{:h2 :mysql} [[[:substring :email [:locate "@" :email]]]])
-                :from [:core_user]
-                :where [:= :is_active true]})
   (:count (t2/query-one {:select [[:%count.* :count]]
                          :from [[{:select-distinct (condp contains? (db/db-type)
                                                      #{:postgres}  [[[:split_part :email [:inline "@"] [:inline 2]]]]
                                                      #{:h2 :mysql} [[[:substring :email [:locate "@" :email]]]])
                                   :from [:core_user]
-                                  :where [:= :is_active true]} :distinct_emails]]})))
+                                  :where [:and
+                                          [:= :is_active true]
+                                          ;; Exclude @api-key because we probably don't want to count if it exists
+                                          ;; and it causes test flakes
+                                          [:not [:like :email [:inline "%@api-key.invalid"]]]]} :distinct_emails]]})))
 
 (defn external-users-count
   "Number of users with sso-source: JWT as a proxy for external users of embedded views"

--- a/src/metabase/internal_stats/users.clj
+++ b/src/metabase/internal_stats/users.clj
@@ -1,0 +1,19 @@
+(ns metabase.internal-stats.users
+  (:require
+   [metabase.db :as db]
+   [toucan2.core :as t2]))
+
+(defn email-domain-count
+  "Count all unique normalized domains found in active user emails"
+  []
+  (:count (t2/query-one {:select [[:%count.* :count]]
+                         :from [[{:select-distinct (condp contains? (db/db-type)
+                                                     #{:postgres}  [[[:split_part :email [:inline "@"] [:inline 2]]]]
+                                                     #{:h2 :mysql} [[[:substring :email [:locate "@" :email]]]])
+                                  :from [:core_user]
+                                  :where [:= :is_active true]} :distinct_emails]]})))
+
+(defn external-users-count
+  "Number of users with sso-source: JWT as a proxy for external users of embedded views"
+  []
+  (t2/count :model/User :is_active true :sso_source :jwt))

--- a/src/metabase/internal_stats/users.clj
+++ b/src/metabase/internal_stats/users.clj
@@ -13,11 +13,9 @@
                                   :from [:core_user]
                                   :where [:and
                                           [:= :is_active true]
-                                          ;; Exclude @api-key because we probably don't want to count if it exists
-                                          ;; and it causes test flakes
-                                          [:not [:like :email [:inline "%@api-key.invalid"]]]]} :distinct_emails]]})))
+                                          [:= :type [:inline "personal"]]]} :distinct_emails]]})))
 
 (defn external-users-count
   "Number of users with sso-source: JWT as a proxy for external users of embedded views"
   []
-  (t2/count :model/User :is_active true :sso_source :jwt))
+  (t2/count :model/User :is_active true :sso_source :jwt :type :personal))

--- a/src/metabase/internal_stats/users.clj
+++ b/src/metabase/internal_stats/users.clj
@@ -6,6 +6,11 @@
 (defn email-domain-count
   "Count all unique normalized domains found in active user emails"
   []
+  #p (t2/query {:select-distinct (condp contains? (db/db-type)
+                                   #{:postgres}  [[[:split_part :email [:inline "@"] [:inline 2]]]]
+                                   #{:h2 :mysql} [[[:substring :email [:locate "@" :email]]]])
+                :from [:core_user]
+                :where [:= :is_active true]})
   (:count (t2/query-one {:select [[:%count.* :count]]
                          :from [[{:select-distinct (condp contains? (db/db-type)
                                                      #{:postgres}  [[[:split_part :email [:inline "@"] [:inline 2]]]]

--- a/src/metabase/internal_stats/util.clj
+++ b/src/metabase/internal_stats/util.clj
@@ -1,0 +1,6 @@
+(ns metabase.internal-stats.util)
+
+(defn count-case
+  "Counts number of times a boolean value is try for a SQL query"
+  [case-boolean]
+  [:count [:case case-boolean [:inline 1] :else [:inline nil]]])

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -524,51 +524,6 @@
                     (get query_executions_24h k)))
             "There are never more query executions in the 24h version than all-of-time.")))))
 
-(deftest query-execution-24h-filtering-test
-  (let [before (#'stats/->snowplow-grouped-metric-info)
-        one-year-ago-defaults (assoc query-execution-defaults
-                                     :started_at (-> (t/offset-date-time)
-                                                     (t/minus (t/years 1))))]
-    (mt/with-temp [:model/User           u {}
-                   :model/QueryExecution _ one-year-ago-defaults
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-sdk-react")
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc one-year-ago-defaults
-                                                  :embedding_client "embedding-iframe"
-                                                  :executor_id (u/the-id u))
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-question)
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-csv-download)
-                   :model/QueryExecution _ query-execution-defaults
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
-                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
-      (let [after (#'stats/->snowplow-grouped-metric-info)
-            before-internal (-> before :query-executions :internal)
-            after-internal (-> after :query-executions :internal)
-            before-24h-internal (-> before :query-executions-24h :internal)
-            after-24h-internal (-> after :query-executions-24h :internal)]
-        (is (= 2 (- after-internal before-internal)))
-        (is (= 1 (- after-24h-internal before-24h-internal)))
-        (is (= 2 (- (-> after :query-executions :sdk_embed)
-                    (-> before :query-executions :sdk_embed))))
-        (is (= 4 (- (-> after :query-executions :static_embed)
-                    (-> before :query-executions :static_embed))))
-        (is (= 4 (- (-> after :query-executions :public_link)
-                    (-> before :query-executions :public_link))))
-        (is (= 1 (- (-> after :query-executions :interactive_embed)
-                    (-> before :query-executions :interactive_embed))))
-        (is (= 1 (- (-> after :query-executions-24h :sdk_embed)
-                    (-> before :query-executions-24h :sdk_embed))))
-        (is (= 2 (- (-> after :query-executions-24h :static_embed)
-                    (-> before :query-executions-24h :static_embed))))
-        (is (= 2 (- (-> after :query-executions-24h :public_link)
-                    (-> before :query-executions-24h :public_link))))
-        (is (= 0 (- (-> after :query-executions-24h :interactive_embed)
-                    (-> before :query-executions-24h :interactive_embed))))))))
-
 (deftest snowplow-setting-tests
   (testing "snowplow formated settings"
     (let [instance-stats (#'stats/instance-settings)

--- a/test/metabase/internal_stats/query_executions_test.clj
+++ b/test/metabase/internal_stats/query_executions_test.clj
@@ -1,0 +1,92 @@
+(ns metabase.internal-stats.query-executions-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [java-time.api :as t]
+   [metabase.internal-stats.query-executions :as sut]
+   [metabase.query-processor.util :as qp.util]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
+
+(def ^:private query-execution-defaults
+  {:hash         (qp.util/query-hash {})
+   :running_time 1
+   :result_rows  1
+   :native       false
+   :executor_id  nil
+   :card_id      nil
+   :context      :ad-hoc
+   :started_at   (t/offset-date-time)})
+
+(deftest query-execution-24h-filtering-test
+  (let [before (sut/query-executions-all-time-and-last-24h)
+        one-year-ago-defaults (assoc query-execution-defaults
+                                     :started_at (-> (t/offset-date-time)
+                                                     (t/minus (t/years 1))))]
+    (mt/with-temp [:model/User           u {}
+                   :model/QueryExecution _ one-year-ago-defaults
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-sdk-react")
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc one-year-ago-defaults
+                                                  :embedding_client "embedding-iframe"
+                                                  :executor_id (u/the-id u))
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-question)
+                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-csv-download)
+                   :model/QueryExecution _ query-execution-defaults
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
+                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
+      (let [after (sut/query-executions-all-time-and-last-24h)
+            before-internal (-> before :query-executions :internal)
+            after-internal (-> after :query-executions :internal)
+            before-24h-internal (-> before :query-executions-24h :internal)
+            after-24h-internal (-> after :query-executions-24h :internal)]
+        (is (= 2 (- after-internal before-internal)))
+        (is (= 1 (- after-24h-internal before-24h-internal)))
+        (is (= 2 (- (-> after :query-executions :sdk_embed)
+                    (-> before :query-executions :sdk_embed))))
+        (is (= 4 (- (-> after :query-executions :static_embed)
+                    (-> before :query-executions :static_embed))))
+        (is (= 4 (- (-> after :query-executions :public_link)
+                    (-> before :query-executions :public_link))))
+        (is (= 1 (- (-> after :query-executions :interactive_embed)
+                    (-> before :query-executions :interactive_embed))))
+        (is (= 1 (- (-> after :query-executions-24h :sdk_embed)
+                    (-> before :query-executions-24h :sdk_embed))))
+        (is (= 2 (- (-> after :query-executions-24h :static_embed)
+                    (-> before :query-executions-24h :static_embed))))
+        (is (= 2 (- (-> after :query-executions-24h :public_link)
+                    (-> before :query-executions-24h :public_link))))
+        (is (= 0 (- (-> after :query-executions-24h :interactive_embed)
+                    (-> before :query-executions-24h :interactive_embed))))))))
+
+(deftest query-execution-last-utc-day-test
+  (testing "count query exeuections over the previous utc day")
+  (let [yesterday-defaults (assoc query-execution-defaults
+                                  :started_at (-> (t/offset-date-time (t/zone-offset "+00"))
+                                                  (t/minus (t/days 1))))]
+    (mt/with-temp [:model/User           u {}
+                   :model/QueryExecution _ yesterday-defaults
+                   :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-sdk-react")
+                   :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc yesterday-defaults
+                                                  :embedding_client "embedding-iframe"
+                                                  :executor_id (u/the-id u))
+                   :model/QueryExecution _ (assoc yesterday-defaults :context :public-question)
+                   :model/QueryExecution _ (assoc yesterday-defaults :context :public-csv-download)
+                   :model/QueryExecution _ query-execution-defaults
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
+                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
+      (is (= {:query_executions_row_count 0,
+              :query_executions_sdk_embed 1,
+              :query_executions_interactive_embed 1,
+              :query_executions_static_embed 2,
+              :query_executions_public_link 2,
+              :query_executions_internal 1}
+             (sut/query-execution-last-utc-day))))))

--- a/test/metabase/internal_stats/users_test.clj
+++ b/test/metabase/internal_stats/users_test.clj
@@ -1,0 +1,30 @@
+(ns metabase.internal-stats.users-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [metabase.internal-stats.users :as sut]
+   [metabase.test :as mt]))
+
+(deftest email-domain-count-test
+  (testing "counts different email domains"
+    (mt/with-temp [:model/User _ {:email "ed@gmail.com"}
+                   :model/User _ {:email "ted@gmail.com"}
+                   :model/User _ {:email "fred@gmail.com"}
+                   :model/User _ {:email "jed@gmail.com"}
+                   :model/User _ {:email "ed@metabase.com"}
+                   :model/User _ {:email "ed@meta.com"}
+                   :model/User _ {:email "ed@megabase.com" :is_active false}
+                   :model/User _ {:email "ed@metalbase.com"}
+                   :model/User _ {:email "ted@metalbase.com"}]
+      (is (= 4 (sut/email-domain-count))))))
+
+(deftest external-users-count-test
+  (testing "counts users with sso source jwt domains"
+    (mt/with-temp [:model/User _ {:sso_source :jwt}
+                   :model/User _ {:sso_source :jwt}
+                   :model/User _ {:sso_source :jwt :is_active false}
+                   :model/User _ {}
+                   :model/User _ {}
+                   :model/User _ {:sso_source :google_sso}
+                   :model/User _ {:sso_source :saml}
+                   :model/User _ {:sso_source :jwt}]
+      (is (= 3 (sut/external-users-count))))))

--- a/test/metabase/internal_stats/users_test.clj
+++ b/test/metabase/internal_stats/users_test.clj
@@ -13,6 +13,7 @@
                    :model/User _ {:email "ed@metabase.com"}
                    :model/User _ {:email "ed@meta.com"}
                    :model/User _ {:email "ed@megabase.com" :is_active false}
+                   :model/User _ {:email "ed@ubertbase.com" :type :internal}
                    :model/User _ {:email "ed@metalbase.com"}
                    :model/User _ {:email "ted@metalbase.com"}]
       (is (= 4 (sut/email-domain-count))))))
@@ -26,5 +27,6 @@
                    :model/User _ {}
                    :model/User _ {:sso_source :google_sso}
                    :model/User _ {:sso_source :saml}
+                   :model/User _ {:sso_source :jwt :type :internal}
                    :model/User _ {:sso_source :jwt}]
       (is (= 3 (sut/external-users-count))))))

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -38,9 +38,9 @@
   [token token-check-response]
   (http-fake/with-fake-routes-in-isolation
     {{:address      (#'token-check/token-status-url token @#'token-check/token-check-url)
-      :query-params {:users      (str (#'token-check/active-users-count))
-                     :site-uuid  (public-settings/site-uuid-for-premium-features-token-checks)
-                     :mb-version (:tag config/mb-version-info)}}
+      :query-params (merge (#'token-check/stats-for-token-request)
+                           {:site-uuid  (public-settings/site-uuid-for-premium-features-token-checks)
+                            :mb-version (:tag config/mb-version-info)})}
      (constantly token-check-response)}
     (#'token-check/fetch-token-status* token)))
 
@@ -154,13 +154,13 @@
   (testing "No DB calls are made for the user count when checking token status if the status is cached"
     (let [token (random-token)]
       (t2/with-call-count [call-count]
-        ;; First fetch, should trigger a DB call to fetch user count
+        ;; First fetch, should trigger a DB call to fetch user count and db calls for other stats
         (#'token-check/fetch-token-status token)
-        (is (= 1 (call-count)))
+        (is (= 4 (call-count)))
 
         ;; Subsequent fetches with the same token should not trigger additional DB calls
         (#'token-check/fetch-token-status token)
-        (is (= 1 (call-count)))))))
+        (is (= 4 (call-count)))))))
 
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response


### PR DESCRIPTION
### Description

Adds the embedding_users, internal_users, domains, and query_execution_* stats to the token check request in order to track embedding usage.

This creates a new internal_stats module to share code between the anonymously reported stats the stats for the token check request to avoid some circular dependencies. This also separates the logic for a stat and how it is reported, so we could move over other stats calculated for the phone home metric.

### How to verify

1. Start a new instance with a token
2. It should call the token check endpoint with these stats as query params

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
