### PR TITLE
Remove JS from mongo queries

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -390,7 +390,7 @@
                                  name (last path)]
                              (cond-> {:name              name
                                       :database-type     (:type field)
-                                      :base-type         (type-alias->base-type (:type-alias field))
+                                      :base-type         (type-alias->base-type (:type field))
                                       ; index is used by `set-database-position`, and not present in final result
                                       :index             (:index field)
                                       ; path is used to nest fields, and not present in final result

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -163,7 +163,6 @@
     (cond-> {"results"    [{"$match" {"result" true}}]
              "newResults" [{"$match" {"result" false}}
                            {"$group" {"_id"   {"type"       "$type"
-                                               "type-alias" "$type-alias"
                                                "path"       "$path"}
                                       ;; count is zero if type is "null" so we only select "null" as the type if there
                                       ;; is no other type for the path
@@ -174,11 +173,9 @@
                            {"$sort" {"count" -1}}
                            {"$group" {"_id"        "$_id.path"
                                       "type"       {"$first" "$_id.type"}
-                                      "type-alias" {"$first" "$_id.type-alias"}
                                       "index"      {"$min" "$index"}}}
                            {"$project" {"path"      "$_id"
                                         "type"       1
-                                        "type-alias" 1
                                         "result"     {"$literal" true}
                                         "object"     nil
                                         "index"      1}}]}
@@ -192,14 +189,10 @@
                                                                 "object"     {"$cond" {"if"   {"$eq" [{"$type" "$$item.v"} "object"]}
                                                                                        "then" "$$item.v"
                                                                                        "else" nil}}
-                                                                "type"       {"$type" "$$item.v"}
-                                                                "type-alias" {"$function" {"body" "function(val, type) { return (type == 'binData' && val.type == 4) ? 'uuid' : type; }"
-                                                                                           "args" ["$$item.v" {"$type" "$$item.v"}]
-                                                                                           "lang" "js"}}}}}}}
+                                                                "type"       {"$type" "$$item.v"}}}}}}
                           {"$unwind" {"path" "$kvs", "includeArrayIndex" "index"}}
                           {"$project" {"path"       {"$concat" ["$path" "." "$kvs.k"]}
                                        "type"       "$kvs.type"
-                                       "type-alias" "$kvs.type-alias"
                                        "result"     {"$literal" false}
                                        "index"      1
                                        "object"     "$kvs.object"}}]))}
@@ -227,21 +220,17 @@
                                                             "object"     {"$cond" {"if"   {"$eq" [{"$type" "$$item.v"} "object"]}
                                                                                    "then" "$$item.v"
                                                                                    "else" nil}}
-                                                            "type"       {"$type" "$$item.v"}
-                                                            "type-alias" {"$function" {"body" "function(val, type) { return (type == 'binData' && val.type == 4) ? 'uuid' : type; }"
-                                                                                       "args" ["$$item.v" {"$type" "$$item.v"}]
-                                                                                       "lang" "js"}}}}}}}
+                                                            "type"       {"$type" "$$item.v"}}}}}}
                        {"$unwind" {"path" "$kvs", "includeArrayIndex" "index"}}
                        {"$project" {"path"       "$kvs.k"
                                     "result"     {"$literal" false}
                                     "type"       "$kvs.type"
-                                    "type-alias" "$kvs.type-alias"
                                     "index"      1
                                     "object"     "$kvs.object"}}]]
     (concat sample
             initial-items
             (mapcat #(describe-table-query-step max-depth %) (range (inc max-depth)))
-            [{"$project" {"_id" 0, "path" "$path", "type" "$type", "type-alias" "$type-alias", "index" "$index"}}])))
+            [{"$project" {"_id" 0, "path" "$path", "type" "$type", "index" "$index"}}])))
 
 (comment
   ;; `describe-table-clojure` is a reference implementation for [[describe-table-query]] in Clojure.
@@ -309,7 +298,6 @@
                              [:map {:closed true}
                               [:path  ::lib.schema.common/non-blank-string]
                               [:type  ::lib.schema.common/non-blank-string]
-                              [:type-alias  ::lib.schema.common/non-blank-string]
                               [:index :int]]]
   "Queries the database, returning a list of maps with metadata for each field in the table (aka collection).
   Like `driver/describe-table` but the data is directly from the [[describe-table-query]] and needs further processing."
@@ -324,7 +312,7 @@
         cols  (map (comp keyword :name) (:cols data))]
     (map #(zipmap cols %) (:rows data))))
 
-(defn- type-alias->base-type [type-alias]
+(defn- db-type->base-type [db-type]
   ;; Mongo types from $type aggregation operation
   ;; https://www.mongodb.com/docs/manual/reference/operator/aggregation/type/#available-types
   (get {"double"     :type/Float
@@ -349,7 +337,7 @@
         "timestamp"  :type/Instant
         "long"       :type/Integer
         "decimal"    :type/Decimal}
-       type-alias :type/*))
+       db-type :type/*))
 
 (defn- add-database-position
   "Adds :database-position to all fields. It starts at 0 and is ordered by a depth-first traversal of nested fields."
@@ -390,7 +378,7 @@
                                  name (last path)]
                              (cond-> {:name              name
                                       :database-type     (:type field)
-                                      :base-type         (type-alias->base-type (:type field))
+                                      :base-type         (db-type->base-type (:type field))
                                       ; index is used by `set-database-position`, and not present in final result
                                       :index             (:index field)
                                       ; path is used to nest fields, and not present in final result

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -417,7 +417,7 @@
     (isa? base-type :type/MongoBSONID)
     (ObjectId. (str value))
 
-    (= base-type :type/UUID)
+    (isa? base-type :type/UUID)
     (try
       (-> (str value)
           java.util.UUID/fromString

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -741,16 +741,18 @@
 (defn- str-match-pattern [field options prefix value suffix]
   (if (mbql.u/is-clause? ::not value)
     {$not (str-match-pattern field options prefix (second value) suffix)}
-    (let [base-type (get-in field [2 :base-type])]
+    (let [base-type (get-in field [2 :base-type])
+          supports-toString? (-> (get-mongo-version) :semantic-version (driver.u/semantic-version-gte [8]))]
       (assert (and (contains? #{nil "^"} prefix) (contains? #{nil "$"} suffix))
               "Wrong prefix or suffix value.")
-      {$regexMatch {"input" (if (= :type/UUID base-type)
-                              ;; TODO: Update this to use $toString once all supported
-                              ;; Mongo versions have $toString available (>= 8.0)
-                              {"$function" {"body" "function(uuid) { return uuid.toString().substring(6, 42) }",
-                                            "args" [(->rvalue field)],
-                                            "lang" "js"}}
-                              (->rvalue field))
+      {$regexMatch {"input" (cond (and (= :type/UUID base-type) supports-toString?)
+                                  {"$toString" (->rvalue field)}
+
+                                  (= :type/UUID base-type)
+                                  (throw (Exception. "String searching on UUIDs is only supported in Mongo v8.0+"))
+
+                                  :else
+                                  (->rvalue field))
                     "regex" (if (= (first value) :value)
                               (str prefix (->rvalue value) suffix)
                               {$concat (into [] (remove nil?) [(when (some? prefix) {$literal prefix})

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -745,10 +745,10 @@
           supports-toString? (-> (get-mongo-version) :semantic-version (driver.u/semantic-version-gte [8]))]
       (assert (and (contains? #{nil "^"} prefix) (contains? #{nil "$"} suffix))
               "Wrong prefix or suffix value.")
-      {$regexMatch {"input" (cond (and (= :type/UUID base-type) supports-toString?)
+      {$regexMatch {"input" (cond (and (= :type/* base-type) supports-toString?)
                                   {"$toString" (->rvalue field)}
 
-                                  (= :type/UUID base-type)
+                                  (= :type/* base-type)
                                   (throw (Exception. "String searching on UUIDs is only supported in Mongo v8.0+"))
 
                                   :else

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -417,7 +417,7 @@
     (isa? base-type :type/MongoBSONID)
     (ObjectId. (str value))
 
-    (isa? base-type :type/*)
+    (= base-type :type/*)
     (try
       (-> (str value)
           java.util.UUID/fromString

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -417,7 +417,7 @@
     (isa? base-type :type/MongoBSONID)
     (ObjectId. (str value))
 
-    (isa? base-type :type/UUID)
+    (isa? base-type :type/*)
     (try
       (-> (str value)
           java.util.UUID/fromString

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -417,7 +417,7 @@
     (isa? base-type :type/MongoBSONID)
     (ObjectId. (str value))
 
-    (isa? base-type :type/UUID)
+    (= base-type :type/*)
     (try
       (-> (str value)
           java.util.UUID/fromString

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -7,7 +7,6 @@
    [metabase.driver.common.parameters :as params]
    [metabase.driver.mongo.parameters :as mongo.params]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.util.json :as json]))
 
@@ -188,39 +187,37 @@
            (substitute {:date (params/->FieldFilter {:name "date"} params/no-value)} ["[{$match: " (param :date) "}]"])))))
 
 (deftest ^:parallel field-filter-test-5
-  (mt/test-driver :mongo
-    (qp.store/with-metadata-provider (mt/id)
-      (testing "operators"
-        (testing "string"
-          (doseq [[operator form input options]
-                  [[:string/starts-with
-                    {"$expr" {"$regexMatch" {"input" "$description" "regex" "^foo" "options" ""}}}
-                    ["foo"]]
-                   [:string/ends-with
-                    {"$expr" {"$regexMatch" {"input" "$description" "regex" "foo$" "options" ""}}}
-                    ["foo"]]
-                   [:string/ends-with
-                    {"$expr" {"$regexMatch" {"input" "$description" "regex" "foo$" "options" "i"}}}
-                    ["foo"]
-                    {:case-sensitive false}]
-                   [:string/contains
-                    {"$expr" {"$regexMatch" {"input" "$description" "regex" "foo" "options" ""}}}
-                    ["foo"]]
-                   [:string/does-not-contain
-                    {"$expr"
-                     {"$not" {"$regexMatch" {"input" "$description" "regex" "foo" "options" ""}}}}
-                    ["foo"]]
-                   [:string/does-not-contain
-                    {"$expr"
-                     {"$not" {"$regexMatch" {"input" "$description" "regex" "foo" "options" "i"}}}}
-                    ["foo"]
-                    {:case-sensitive false}]
-                   [:string/= {"description" "foo"} ["foo"]]]]
-            (testing operator
-              (is (= (strip (to-bson [{:$match form}]))
-                     (strip
-                      (substitute {:desc (field-filter "description" :type/Text operator input options)}
-                                  ["[{$match: " (param :desc) "}]"])))))))))))
+  (testing "operators"
+    (testing "string"
+      (doseq [[operator form input options]
+              [[:string/starts-with
+                {"$expr" {"$regexMatch" {"input" "$description" "regex" "^foo" "options" ""}}}
+                ["foo"]]
+               [:string/ends-with
+                {"$expr" {"$regexMatch" {"input" "$description" "regex" "foo$" "options" ""}}}
+                ["foo"]]
+               [:string/ends-with
+                {"$expr" {"$regexMatch" {"input" "$description" "regex" "foo$" "options" "i"}}}
+                ["foo"]
+                {:case-sensitive false}]
+               [:string/contains
+                {"$expr" {"$regexMatch" {"input" "$description" "regex" "foo" "options" ""}}}
+                ["foo"]]
+               [:string/does-not-contain
+                {"$expr"
+                 {"$not" {"$regexMatch" {"input" "$description" "regex" "foo" "options" ""}}}}
+                ["foo"]]
+               [:string/does-not-contain
+                {"$expr"
+                 {"$not" {"$regexMatch" {"input" "$description" "regex" "foo" "options" "i"}}}}
+                ["foo"]
+                {:case-sensitive false}]
+               [:string/= {"description" "foo"} ["foo"]]]]
+        (testing operator
+          (is (= (strip (to-bson [{:$match form}]))
+                 (strip
+                  (substitute {:desc (field-filter "description" :type/Text operator input options)}
+                              ["[{$match: " (param :desc) "}]"])))))))))
 
 (deftest ^:parallel field-filter-test-6
   (testing "operators"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -6,6 +6,7 @@
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.mongo.query-processor :as mongo.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
@@ -637,19 +638,26 @@
       (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
             dogs (lib.metadata/table mp (mt/id :dogs))
             person-id (lib.metadata/field mp (mt/id :dogs :person_id))]
-        (is (= [[1 #uuid "27e164bc-54f8-47a0-a85a-9f0e90dd7667" "Ivan" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]
-                [2 #uuid "3a0c0508-6b00-40ff-97f6-549666b2d16b" "Zach" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]]
-               (-> (lib/query mp dogs)
-                   (lib/filter (lib/starts-with person-id "d6"))
-                   qp/process-query
-                   mt/rows)))
-        (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
-               (-> (lib/query mp dogs)
-                   (lib/filter (lib/ends-with person-id "9b"))
-                   qp/process-query
-                   mt/rows)))
-        (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
-               (-> (lib/query mp dogs)
-                   (lib/filter (lib/contains person-id "e"))
-                   qp/process-query
-                   mt/rows)))))))
+        (if (-> (driver/dbms-version :mongo (mt/db)) :semantic-version (driver.u/semantic-version-gte [8]))
+          (do
+            (is (= [[1 #uuid "27e164bc-54f8-47a0-a85a-9f0e90dd7667" "Ivan" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]
+                    [2 #uuid "3a0c0508-6b00-40ff-97f6-549666b2d16b" "Zach" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]]
+                   (-> (lib/query mp dogs)
+                       (lib/filter (lib/starts-with person-id "d6"))
+                       qp/process-query
+                       mt/rows)))
+            (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
+                   (-> (lib/query mp dogs)
+                       (lib/filter (lib/ends-with person-id "9b"))
+                       qp/process-query
+                       mt/rows)))
+            (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
+                   (-> (lib/query mp dogs)
+                       (lib/filter (lib/contains person-id "e"))
+                       qp/process-query
+                       mt/rows))))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"String searching on UUIDs is only supported in Mongo v8.0+"
+                                (-> (lib/query mp dogs)
+                                    (lib/filter (lib/contains person-id "e"))
+                                    qp/process-query))))))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -6,10 +6,6 @@
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.mongo.query-processor :as mongo.qp]
-   [metabase.driver.util :as driver.u]
-   [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.query-processor :as qp]
    [metabase.query-processor-test.alternative-date-test :as qp.alternative-date-test]
    [metabase.query-processor-test.date-time-zone-functions-test :as qp.datetime-test]
@@ -632,32 +628,33 @@
            (qp/process-query
             (mt/mbql-query times {:fields [$t]})))))))
 
-(deftest ^:parallel filter-uuids-with-string-patterns-test
-  (mt/test-driver :mongo
-    (mt/dataset uuid-dogs
-      (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-            dogs (lib.metadata/table mp (mt/id :dogs))
-            person-id (lib.metadata/field mp (mt/id :dogs :person_id))]
-        (if (-> (driver/dbms-version :mongo (mt/db)) :semantic-version (driver.u/semantic-version-gte [8]))
-          (do
-            (is (= [[1 #uuid "27e164bc-54f8-47a0-a85a-9f0e90dd7667" "Ivan" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]
-                    [2 #uuid "3a0c0508-6b00-40ff-97f6-549666b2d16b" "Zach" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]]
-                   (-> (lib/query mp dogs)
-                       (lib/filter (lib/starts-with person-id "d6"))
-                       qp/process-query
-                       mt/rows)))
-            (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
-                   (-> (lib/query mp dogs)
-                       (lib/filter (lib/ends-with person-id "9b"))
-                       qp/process-query
-                       mt/rows)))
-            (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
-                   (-> (lib/query mp dogs)
-                       (lib/filter (lib/contains person-id "e"))
-                       qp/process-query
-                       mt/rows))))
-          (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                                #"String searching on UUIDs is only supported in Mongo v8.0+"
-                                (-> (lib/query mp dogs)
-                                    (lib/filter (lib/contains person-id "e"))
-                                    qp/process-query))))))))
+;; TODO: Re-enable this test if it becomes possible to determine type/UUID without using JavaScript
+#_(deftest ^:parallel filter-uuids-with-string-patterns-test
+    (mt/test-driver :mongo
+      (mt/dataset uuid-dogs
+        (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+              dogs (lib.metadata/table mp (mt/id :dogs))
+              person-id (lib.metadata/field mp (mt/id :dogs :person_id))]
+          (if (-> (driver/dbms-version :mongo (mt/db)) :semantic-version (driver.u/semantic-version-gte [8]))
+            (do
+              (is (= [[1 #uuid "27e164bc-54f8-47a0-a85a-9f0e90dd7667" "Ivan" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]
+                      [2 #uuid "3a0c0508-6b00-40ff-97f6-549666b2d16b" "Zach" #uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]]
+                     (-> (lib/query mp dogs)
+                         (lib/filter (lib/starts-with person-id "d6"))
+                         qp/process-query
+                         mt/rows)))
+              (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
+                     (-> (lib/query mp dogs)
+                         (lib/filter (lib/ends-with person-id "9b"))
+                         qp/process-query
+                         mt/rows)))
+              (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
+                     (-> (lib/query mp dogs)
+                         (lib/filter (lib/contains person-id "e"))
+                         qp/process-query
+                         mt/rows))))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"String searching on UUIDs is only supported in Mongo v8.0+"
+                                  (-> (lib/query mp dogs)
+                                      (lib/filter (lib/contains person-id "e"))
+                                      qp/process-query))))))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -626,7 +626,7 @@
   [["birds"
     [{:field-name "name", :base-type :type/Text}
      {:field-name "bird_id", :base-type :type/MongoBSONID}
-     {:field-name "bird_uuid", :base-type :type/UUID}]
+     {:field-name "bird_uuid", :base-type :type/*}]
     [["Rasta Toucan" (ObjectId. "012345678901234567890123") #uuid "11111111-1111-1111-1111-111111111111"]
      ["Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef") #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]
      ["Unlucky Raven" nil]]]])
@@ -948,7 +948,7 @@
                           "          \"_id\": ObjectId(\"abcdefabcdefabcdefabcdef\")"
                           "        },"
                           "        {"
-                          "          \"mixed_uuid\": \"11111111-1111-1111-1111-111111111111\""
+                          "          \"mixed_uuid\": UUID(\"11111111-1111-1111-1111-111111111111\")"
                           "        },"
                           "        {"
                           "          \"$expr\": {"
@@ -1011,7 +1011,7 @@
                                [:field (mt/id :nested-bindata :_id) {:base-type :type/MongoBSONID}]
                                "abcdefabcdefabcdefabcdef"]
                               [:=
-                               [:field (mt/id :nested-bindata :mixed_uuid) {:base-type :type/UUID}]
+                               [:field (mt/id :nested-bindata :mixed_uuid) {:base-type :type/*}]
                                "11111111-1111-1111-1111-111111111111"]
                               [:=
                                [:field (mt/id :nested-bindata :date) {:base-type :type/Instant}]

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -208,16 +208,12 @@
               {"k" "$$item.k",
                "object"
                {"$cond" {"if" {"$eq" [{"$type" "$$item.v"} "object"]}, "then" "$$item.v", "else" nil}},
-               "type"       {"$type" "$$item.v"},
-               "type-alias" {"$function" {"body" "function(val, type) { return (type == 'binData' && val.type == 4) ? 'uuid' : type; }"
-                                          "args" ["$$item.v" {"$type" "$$item.v"}]
-                                          "lang" "js"}}}}}}}
+               "type"       {"$type" "$$item.v"}}}}}}
           {"$unwind" {"path" "$kvs", "includeArrayIndex" "index"}}
           {"$project"
            {"path" "$kvs.k",
             "result" {"$literal" false},
             "type" "$kvs.type",
-            "type-alias" "$kvs.type-alias"
             "index" 1,
             "object" "$kvs.object"}}
           {"$facet"
@@ -225,12 +221,12 @@
             "newResults"
             [{"$match" {"result" false}}
              {"$group"
-              {"_id" {"type" "$type", "type-alias" "$type-alias", "path" "$path"},
+              {"_id" {"type" "$type", "path" "$path"},
                "count" {"$sum" {"$cond" {"if" {"$eq" ["$type" "null"]}, "then" 0, "else" 1}}},
                "index" {"$min" "$index"}}}
              {"$sort" {"count" -1}}
-             {"$group" {"_id" "$_id.path", "type" {"$first" "$_id.type"}, "type-alias" {"$first" "$_id.type-alias"}, "index" {"$min" "$index"}}}
-             {"$project" {"path" "$_id", "type" 1, "type-alias" 1, "result" {"$literal" true}, "object" nil, "index" 1}}],
+             {"$group" {"_id" "$_id.path", "type" {"$first" "$_id.type"}, "index" {"$min" "$index"}}}
+             {"$project" {"path" "$_id", "type" 1, "result" {"$literal" true}, "object" nil, "index" 1}}],
             "nextItems"
             [{"$match" {"result" false, "object" {"$ne" nil}}}
              {"$project"
@@ -243,15 +239,11 @@
                  {"k" "$$item.k",
                   "object"
                   {"$cond" {"if" {"$eq" [{"$type" "$$item.v"} "object"]}, "then" "$$item.v", "else" nil}},
-                  "type"       {"$type" "$$item.v"},
-                  "type-alias" {"$function" {"body" "function(val, type) { return (type == 'binData' && val.type == 4) ? 'uuid' : type; }"
-                                             "args" ["$$item.v" {"$type" "$$item.v"}]
-                                             "lang" "js"}}}}}}}
+                  "type"       {"$type" "$$item.v"}}}}}}
              {"$unwind" {"path" "$kvs", "includeArrayIndex" "index"}}
              {"$project"
               {"path" {"$concat" ["$path" "." "$kvs.k"]},
                "type" "$kvs.type",
-               "type-alias" "$kvs.type-alias",
                "result" {"$literal" false},
                "index" 1,
                "object" "$kvs.object"}}]}}
@@ -263,16 +255,16 @@
             "newResults"
             [{"$match" {"result" false}}
              {"$group"
-              {"_id" {"type" "$type",  "type-alias" "$type-alias", "path" "$path"},
+              {"_id" {"type" "$type", "path" "$path"},
                "count" {"$sum" {"$cond" {"if" {"$eq" ["$type" "null"]}, "then" 0, "else" 1}}},
                "index" {"$min" "$index"}}}
              {"$sort" {"count" -1}}
-             {"$group" {"_id" "$_id.path", "type" {"$first" "$_id.type"}, "type-alias" {"$first" "$_id.type-alias"}, "index" {"$min" "$index"}}}
-             {"$project" {"path" "$_id", "type" 1, "type-alias" 1, "result" {"$literal" true}, "object" nil, "index" 1}}]}}
+             {"$group" {"_id" "$_id.path", "type" {"$first" "$_id.type"}, "index" {"$min" "$index"}}}
+             {"$project" {"path" "$_id", "type" 1, "result" {"$literal" true}, "object" nil, "index" 1}}]}}
           {"$project" {"acc" {"$concatArrays" ["$results" "$newResults"]}}}
           {"$unwind" "$acc"}
           {"$replaceRoot" {"newRoot" "$acc"}}
-          {"$project" {"_id" 0, "index" "$index", "path" "$path", "type" "$type", "type-alias" "$type-alias"}}]
+          {"$project" {"_id" 0, "index" "$index", "path" "$path", "type" "$type"}}]
          (#'mongo/describe-table-query :collection-name "collection-name" :sample-size 1000 :max-depth 1))))
 
 (tx/defdataset nested-bindata-coll
@@ -326,27 +318,27 @@
                        :database-position 0}}}
            (driver/describe-table :mongo (mt/db) (t2/select-one :model/Table :id (mt/id :venues)))))
     (mt/dataset uuid-dogs
-      (testing "binData uuid fields are identified as type/UUID"
+      (testing "binData uuid fields are identified as type/*"
         (is (= {:schema nil,
                 :name "dogs",
                 :fields
                 #{{:name "_id", :database-type "long", :base-type :type/Integer, :pk? true, :database-position 0}
                   {:name "name", :database-type "string", :base-type :type/Text, :database-position 2}
-                  {:name "person_id", :database-type "binData", :base-type :type/UUID, :database-position 3}
-                  {:name "id", :database-type "binData", :base-type :type/UUID, :database-position 1}}}
+                  {:name "person_id", :database-type "binData", :base-type :type/*, :database-position 3}
+                  {:name "id", :database-type "binData", :base-type :type/*, :database-position 1}}}
                (driver/describe-table :mongo (mt/db) (t2/select-one :model/Table :id (mt/id :dogs)))))))
     (mt/dataset nested-bindata-coll
-      (testing "nested fields with mixed binData subtypes are correctly identified as type/UUID"
+      (testing "nested fields with mixed binData subtypes are identified as type/*"
         (is (= {:schema nil, :name "nested-bindata",
                 :fields #{{:name "_id", :database-type "objectId", :base-type :type/MongoBSONID, :pk? true, :database-position 0}
                           {:name "int", :database-type "long", :base-type :type/Integer, :database-position 2}
                           {:name "float", :database-type "double", :base-type :type/Float, :database-position 3}
                           {:name "text", :database-type "string", :base-type :type/Text, :database-position 10}
                           {:name "date", :database-type "date", :base-type :type/Instant, :database-position 1}
-                          {:name "mixed_uuid", :database-type "binData", :base-type :type/UUID, :database-position 7}
+                          {:name "mixed_uuid", :database-type "binData", :base-type :type/*, :database-position 7}
                           {:name "mixed_not_uuid", :database-type "binData", :base-type :type/*, :database-position 6}
                           {:name "nested_mixed_uuid", :database-type "object", :base-type :type/Dictionary, :database-position 8,
-                           :nested-fields #{{:name "nested_data", :database-type "binData", :base-type :type/UUID, :database-position 9}}}
+                           :nested-fields #{{:name "nested_data", :database-type "binData", :base-type :type/*, :database-position 9}}}
                           {:name "nested_mixed_not_uuid", :database-type "object", :base-type :type/Dictionary, :database-position 4,
                            :nested-fields #{{:name "nested_data_2", :database-type "binData", :base-type :type/*, :database-position 5}}}}}
                (driver/describe-table :mongo (mt/db) (t2/select-one :model/Table :id (mt/id :nested-bindata)))))))))
@@ -937,7 +929,7 @@
       (mt/dataset uuid-dogs
         (is (= [[3 #uuid "d6a82cf5-7dc9-48a3-a15d-61df91a6edeb" "Boss" #uuid "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]]
                (->> {:filter [:=
-                              [:field (mt/id :dogs :person_id) {:base-type "type/UUID"}]
+                              [:field (mt/id :dogs :person_id) {:base-type "type/*"}]
                               "d39bbe77-4e2e-4b7b-8565-cce90c25c99b"]
                      :source-table (mt/id :dogs)}
                     (mt/run-mbql-query dogs)
@@ -956,7 +948,7 @@
                           "          \"_id\": ObjectId(\"abcdefabcdefabcdefabcdef\")"
                           "        },"
                           "        {"
-                          "          \"mixed_uuid\": UUID(\"11111111-1111-1111-1111-111111111111\")"
+                          "          \"mixed_uuid\": \"11111111-1111-1111-1111-111111111111\""
                           "        },"
                           "        {"
                           "          \"$expr\": {"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55214
Closes https://github.com/metabase/metabase/issues/54880

### Description

Some offerings of Mongo don't support JS in the queries with `$function`. This PR removes our usage of such JS when doing UUID string searching and identifying UUID types during sync. UUID fields are now marked as `type/*` during sync, which limits filtering ability to just "Filter by this value". ~~I've left the code for handling UUID string searching there for now in case we are able to identify UUID types in the future.~~

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a Mongo database and populate it with UUIDs
2. You should be able to see the UUIDs correctly and filter them with "Filter by this value"

### Demo

https://github.com/user-attachments/assets/94406dbf-c578-4799-b110-0c318011d170

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
