### PR TITLE
Allow add series modal cards to be open in visualizer

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -30,7 +30,7 @@ import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import { VisualizerModal } from "metabase/visualizer/components/VisualizerModal";
 import {
   dashboardCardSupportsVisualizer,
-  getInitialStateForCardDataSource,
+  getInitialVisualizerStateForMultipleSeries,
   isVisualizerDashboardCard,
 } from "metabase/visualizer/utils";
 import type {
@@ -362,10 +362,7 @@ function DashCardInner({
       };
     } else {
       return {
-        state: getInitialStateForCardDataSource(
-          series[0].card,
-          series[0].data?.cols ?? [],
-        ),
+        state: getInitialVisualizerStateForMultipleSeries(series),
       };
     }
   }, [dashcard, series, isVisualizerModalOpen]);

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -11,7 +11,10 @@ import type {
 } from "metabase-types/api";
 
 import type { RemappingHydratedDatasetColumn } from "./types";
-import type { Visualization } from "./types/visualization";
+import type {
+  Visualization,
+  VisualizationSettingDefinition,
+} from "./types/visualization";
 
 const visualizations = new Map<VisualizationDisplay, Visualization>();
 const aliases = new Map<string, Visualization>();
@@ -156,14 +159,19 @@ export function isCartesianChart(display: VisualizationDisplay) {
   );
 }
 
+const isDataSetting = ({
+  widget,
+}: VisualizationSettingDefinition<unknown, unknown>) => {
+  // TODO Come up with a better condition
+  return widget === "field" || widget === "fields";
+};
+
 export function getColumnVizSettings(display: VisualizationDisplay) {
   const visualization = visualizations.get(display);
   const settings = visualization?.settings ?? {};
 
-  // TODO Come up with a better condition
   return Object.keys(settings).filter(key => {
-    const { widget } = settings[key] ?? {};
-    return widget === "field" || widget === "fields";
+    return isDataSetting(settings[key] ?? {});
   });
 }
 

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -1,7 +1,11 @@
 import { isNotNull } from "metabase/lib/types";
 import { getColumnVizSettings } from "metabase/visualizations";
-import type { Card, DatasetColumn } from "metabase-types/api";
-import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
+import type { Card, DatasetColumn, RawSeries } from "metabase-types/api";
+import type {
+  VisualizerColumnReference,
+  VisualizerDataSource,
+  VisualizerHistoryItem,
+} from "metabase-types/store/visualizer";
 
 import {
   copyColumn,
@@ -9,6 +13,81 @@ import {
   extractReferencedColumns,
 } from "./column";
 import { createDataSource } from "./data-source";
+
+type ColumnInfo = {
+  columnRef: VisualizerColumnReference;
+  column: DatasetColumn;
+};
+
+function mapColumnVizSettings(
+  card: Card,
+  columnInfos: ColumnInfo[],
+): Record<string, string | string[]> {
+  const entries = getColumnVizSettings(card.display)
+    .map(setting => {
+      const originalValue = card.visualization_settings[setting];
+
+      if (!originalValue) {
+        return null;
+      }
+
+      if (Array.isArray(originalValue)) {
+        const mappedColumns = originalValue
+          .map(originalColumnName => {
+            const columnInfo = columnInfos.find(
+              info => info.columnRef.originalName === originalColumnName,
+            );
+            return columnInfo?.columnRef.name;
+          })
+          .filter(isNotNull);
+
+        return mappedColumns.length > 0 ? [setting, mappedColumns] : null;
+      } else {
+        const columnInfo = columnInfos.find(
+          info => info.columnRef.originalName === originalValue,
+        );
+        return columnInfo?.columnRef.name
+          ? [setting, columnInfo.columnRef.name]
+          : null;
+      }
+    })
+    .filter(isNotNull);
+
+  return Object.fromEntries(entries);
+}
+
+function processColumnsForDataSource(
+  dataSource: VisualizerDataSource,
+  columns: DatasetColumn[],
+  state: VisualizerHistoryItem,
+): ColumnInfo[] {
+  const columnInfos: ColumnInfo[] = [];
+
+  columns.forEach(column => {
+    const columnRef = createVisualizerColumnReference(
+      dataSource,
+      column,
+      extractReferencedColumns(state.columnValuesMapping),
+    );
+
+    const processedColumn = copyColumn(
+      columnRef.name,
+      column,
+      dataSource.name,
+      state.columns,
+    );
+
+    state.columns.push(processedColumn);
+    state.columnValuesMapping[columnRef.name] = [columnRef];
+
+    columnInfos.push({
+      columnRef,
+      column: processedColumn,
+    });
+  });
+
+  return columnInfos;
+}
 
 export function getInitialStateForCardDataSource(
   card: Card,
@@ -20,53 +99,67 @@ export function getInitialStateForCardDataSource(
     columnValuesMapping: {},
     settings: {},
   };
+
   const dataSource = createDataSource("card", card.id, card.name);
-
-  columns.forEach(column => {
-    const columnRef = createVisualizerColumnReference(
-      dataSource,
-      column,
-      extractReferencedColumns(state.columnValuesMapping),
-    );
-    state.columns.push(
-      copyColumn(columnRef.name, column, dataSource.name, state.columns),
-    );
-    state.columnValuesMapping[columnRef.name] = [columnRef];
-  });
-
-  const entries = getColumnVizSettings(card.display)
-    .map(setting => {
-      const originalValue = card.visualization_settings[setting];
-
-      if (!originalValue) {
-        return null;
-      }
-
-      if (Array.isArray(originalValue)) {
-        return [
-          setting,
-          originalValue.map(originalColumnName => {
-            const index = columns.findIndex(
-              col => col.name === originalColumnName,
-            );
-            return state.columns[index].name;
-          }),
-        ];
-      } else {
-        const index = columns.findIndex(col => col.name === originalValue);
-        if (!state.columns[index]) {
-          return;
-        }
-
-        return [setting, state.columns[index]?.name];
-      }
-    })
-    .filter(isNotNull);
+  const columnInfos = processColumnsForDataSource(dataSource, columns, state);
+  const mappedSettings = mapColumnVizSettings(card, columnInfos);
 
   state.settings = {
     ...card.visualization_settings,
-    ...Object.fromEntries(entries),
+    ...mappedSettings,
     "card.title": card.name,
+  };
+
+  return state;
+}
+
+export function getInitialVisualizerStateForMultipleSeries(
+  rawSeries: RawSeries,
+): VisualizerHistoryItem {
+  const mainCard = rawSeries[0].card;
+
+  const state: VisualizerHistoryItem = {
+    display: mainCard.display,
+    columns: [],
+    columnValuesMapping: {},
+    settings: {},
+  };
+
+  const dataSources = rawSeries.map(({ card }) =>
+    createDataSource("card", card.id, card.name),
+  );
+
+  const allColumnInfos: ColumnInfo[][] = rawSeries.map(
+    (series, seriesIndex) => {
+      return processColumnsForDataSource(
+        dataSources[seriesIndex],
+        series.data.cols,
+        state,
+      );
+    },
+  );
+
+  const settingsFromAllCards = rawSeries.map((series, seriesIndex) =>
+    mapColumnVizSettings(series.card, allColumnInfos[seriesIndex]),
+  );
+
+  const mergedSettings = settingsFromAllCards.reduce<
+    Record<string, string | string[]>
+  >((acc, settings) => {
+    Object.entries(settings).forEach(([key, value]) => {
+      if (acc[key] == null) {
+        acc[key] = value;
+      } else if (Array.isArray(acc[key]) && Array.isArray(value)) {
+        acc[key].push(...value);
+      }
+    });
+    return acc;
+  }, {});
+
+  state.settings = {
+    ...mainCard.visualization_settings,
+    ...mergedSettings,
+    "card.title": mainCard.name,
   };
 
   return state;

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -1,16 +1,24 @@
 import { registerVisualization } from "metabase/visualizations";
+import { LineChart } from "metabase/visualizations/visualizations/LineChart";
 import Table from "metabase/visualizations/visualizations/Table/Table";
 import {
   createMockCard,
   createMockColumn,
   createMockDashboardCard,
+  createMockDatasetData,
+  createMockSingleSeries,
 } from "metabase-types/api/mocks";
 
-import { getInitialStateForCardDataSource } from "./get-initial-state-for-card-data-source";
+import {
+  getInitialStateForCardDataSource,
+  getInitialVisualizerStateForMultipleSeries,
+} from "./get-initial-state-for-card-data-source";
 
 // Not registering all visualizations here for perf reasons
 // @ts-expect-error -- TODO fix this error?
 registerVisualization(Table);
+// @ts-expect-error: incompatible prop types with registerVisualization
+registerVisualization(LineChart);
 
 describe("getInitialStateForCardDataSource", () => {
   const dashCard = createMockDashboardCard({
@@ -54,6 +62,91 @@ describe("getInitialStateForCardDataSource", () => {
       "table.pivot_column": "CATEGORY",
       "table.column_formatting": [],
       "card.title": "TablyMcTableface",
+    });
+  });
+});
+
+describe("getInitialVisualizerStateForMultipleSeries", () => {
+  it("should handle multiple series cartesian charts", () => {
+    const firstCard = createMockCard({
+      id: 1,
+      name: "First Series",
+      display: "line",
+      visualization_settings: {
+        "graph.metrics": ["Revenue"],
+        "graph.dimensions": ["Date"],
+      },
+    });
+
+    const secondCard = createMockCard({
+      id: 2,
+      name: "Second Series",
+      display: "line",
+      visualization_settings: {
+        "graph.metrics": ["Profit"],
+        "graph.dimensions": ["Date"],
+      },
+    });
+
+    const rawSeries = [
+      createMockSingleSeries(firstCard, {
+        data: createMockDatasetData({
+          cols: [
+            createMockColumn({ name: "Date" }),
+            createMockColumn({ name: "Revenue" }),
+          ],
+        }),
+      }),
+      createMockSingleSeries(secondCard, {
+        data: createMockDatasetData({
+          cols: [
+            createMockColumn({ name: "Date" }),
+            createMockColumn({ name: "Profit" }),
+          ],
+        }),
+      }),
+    ];
+
+    const initialState = getInitialVisualizerStateForMultipleSeries(rawSeries);
+
+    expect(initialState.columns).toHaveLength(4);
+    expect(initialState.display).toBe("line");
+
+    expect(initialState.columnValuesMapping).toEqual({
+      COLUMN_1: [
+        {
+          name: "COLUMN_1",
+          originalName: "Date",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "Revenue",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_3: [
+        {
+          name: "COLUMN_3",
+          originalName: "Date",
+          sourceId: "card:2",
+        },
+      ],
+      COLUMN_4: [
+        {
+          name: "COLUMN_4",
+          originalName: "Profit",
+          sourceId: "card:2",
+        },
+      ],
+    });
+
+    expect(initialState.settings).toMatchObject({
+      "graph.metrics": ["COLUMN_2", "COLUMN_4"],
+      "graph.dimensions": ["COLUMN_1", "COLUMN_3"],
+      "card.title": "First Series",
     });
   });
 });


### PR DESCRIPTION
Closes [VIZ-481](https://linear.app/metabase/issue/VIZ-481/make-sure-existing-add-series-cards-are-editable-using-the-visualizer)

### Description

Allow opening "Add series" cards in the visualizer.

### Demo

<video src="https://github.com/user-attachments/assets/1eba118c-e945-4920-9d78-06b3a675b0de" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
