### PR TITLE
Do not convert tool names

### DIFF
--- a/e2e/test/scenarios/metabot/metabot.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot.cy.spec.ts
@@ -102,7 +102,7 @@ const whoIsYourFavoriteResponse = {
       "tool-calls": [
         {
           id: "call_PVmnR8mcnYFF2AmqupSKzJDh",
-          name: "metabot.tool/who-is-your-favorite",
+          name: "who-is-your-favorite",
           arguments: {},
         },
       ],

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
@@ -34,21 +34,8 @@
 
 (mr/def ::metadata.name
   [:and
-   {:encode/api-request   (fn [x]
-                            (u/->snake_case_en (name x)))
-    :decode/metadata-file (fn [x]
-                            (let [kw (keyword x)]
-                              (if (namespace kw)
-                                kw
-                                (keyword "metabot.tool" (name kw)))))
-    :decode/api-request   (fn [x]
-                            (let [kw (keyword x)]
-                              (if (namespace kw)
-                                kw
-                                (keyword "metabot.tool" (name kw)))))
-    :decode/api-response  (fn [x]
-                            (keyword "metabot.tool" (name (u/->kebab-case-en x))))}
-   :keyword
-   [:fn
-    {:error/message "Tool names should be kebab-case (both parsed and in YAML files)"}
-    #(= (u/->kebab-case-en %) %)]])
+   {:encode/api-request   (fn [x] (u/->snake_case_en (name x)))
+    :decode/metadata-file keyword
+    :decode/api-request   keyword
+    :decode/api-response  keyword}
+   :keyword])

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -415,7 +415,7 @@ const whoIsYourFavoriteResponse = {
       "tool-calls": [
         {
           id: "call_PVmnR8mcnYFF2AmqupSKzJDh",
-          name: "metabot.tool/who-is-your-favorite",
+          name: "who-is-your-favorite",
           arguments: {},
         },
       ],


### PR DESCRIPTION
## Context

Closes: https://linear.app/metabase/issue/BOT-76/use-proper-tool-name-when-sending-message-history-back-to-ai-service 

We are still converting tool names to some internal representation. When sending it back to the LLM this conversion is not reverted which breaks the API call to open AI. 

## What changed

Removed the tool name conversion since it should not be necessary anymore.