### PR TITLE
ci(sdk): Reduce noise in SDK Slack channel

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -78,7 +78,7 @@ jobs:
             );
             const body = `${runLink} - run by ${mentionUserByGithubLogin("${{ github.event.sender.login }}")}`
             const sendSlackMessageResponse = await sendSlackMessage({
-              channelName: 'proj-embedding-sdk',
+              channelName: 'team-embedding-releases',
               message: `${title}\n${body}`,
             });
 
@@ -125,7 +125,7 @@ jobs:
               context.repo.repo,
             );
             sendSlackReply({
-              channelName: 'proj-embedding-sdk',
+              channelName: 'team-embedding-releases',
               message: runLink,
               messageId: ${{ env.slackMessageId}},
               broadcast: true
@@ -162,7 +162,7 @@ jobs:
               context.repo.repo,
             );
             sendSlackReply({
-              channelName: 'proj-embedding-sdk',
+              channelName: 'team-embedding-releases',
               message: runLink,
               messageId: ${{ env.slackMessageId}},
               broadcast: true


### PR DESCRIPTION
[See this thread](https://metaboat.slack.com/archives/C06FCQT0KMZ/p1742516384146919)

The current SDK release deployment status notification seems to be too much for our current channel which is more for updating news/progress of the SDK.

We're moving the release notification to a different channel for this.


### How to verify
- See the test [run here](https://github.com/metabase/metabase/actions/runs/13988410864). I already cancel the run after the first slack message has been posted.
- [Slack notification](https://metaboat.slack.com/archives/C08KC4G8800/p1742548590944109)