### PR TITLE
fix(sdk): Clean up "Unrecognized Prop" errors on CreateDashboardModal

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -1,15 +1,8 @@
-import _ from "underscore";
-
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import type { SdkCollectionId } from "embedding-sdk/types/collection";
-import {
-  CreateDashboardModal as CreateDashboardModalCore,
-  type CreateDashboardModalProps as CreateDashboardModalCoreProps,
-} from "metabase/dashboard/containers/CreateDashboardModal";
-import Collections from "metabase/entities/collections";
+import { CreateDashboardModal as CreateDashboardModalCore } from "metabase/dashboard/containers/CreateDashboardModal";
 import type { Dashboard } from "metabase-types/api";
-import type { State } from "metabase-types/store";
 
 export interface CreateDashboardModalProps {
   initialCollectionId?: SdkCollectionId;
@@ -33,22 +26,14 @@ const CreateDashboardModalInner = ({
   }
 
   return (
-    <CreateDashboardModalCoreWithLoading
+    <CreateDashboardModalCore
       opened={!isLoading && isOpen}
       onCreate={onCreate}
-      onClose={onClose}
+      onClose={() => onClose?.()}
       collectionId={id}
     />
   );
 };
-
-const CreateDashboardModalCoreWithLoading = _.compose(
-  Collections.load({
-    id: (_state: State, props: CreateDashboardModalCoreProps) =>
-      props.collectionId,
-    loadingAndErrorWrapper: false,
-  }),
-)(CreateDashboardModalCore);
 
 export const CreateDashboardModal = withPublicComponentWrapper(
   CreateDashboardModalInner,


### PR DESCRIPTION
We have this logic for loading collections but we don't seem to actually use it anywhere. It's the culprit of the issues for these errors so I removed it.