### PR TITLE
[Notification] Efficient filter notifications for a specific table

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -6,6 +6,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.events :as events]
+   [metabase.events.notification :as events.notification]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor :as qp]
@@ -20,6 +21,14 @@
                             :table-id table-id
                             :arg      rows}
                            :policy   :data-editing))
+
+(doseq [topic [:event/data-editing-row-create
+               :event/data-editing-row-update
+               :event/data-editing-row-delete]]
+  (defmethod events.notification/notification-filter-for-topic topic
+    [_topic event-info]
+    (assert (:table_id event-info) "Event info must contain :table_id")
+    [:= :table_id (:table_id event-info)]))
 
 (defn- qp-result->row-map
   [{:keys [rows cols]}]

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10970,6 +10970,19 @@ databaseChangeLog:
                     deleteCascade: true
                     nullable: true
 
+  - changeSet:
+      id: v54.2025-03-19T16:02:00
+      author: qnkhuat
+      comment: Index notification_subscription.table_id
+      preConditions:
+      changes:
+        - createIndex:
+            tableName: notification_subscription
+            columns:
+              - column:
+                  name: table_id
+            indexName: idx_notification_subscription_table_id
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10950,6 +10950,26 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v54.2025-03-19T16:01:00
+      author: qnkhuat
+      comment: Add `notification_subscription.table_id` column
+      preConditions:
+      changes:
+        - addColumn:
+            tableName: notification_subscription
+            columns:
+              - column:
+                  name: table_id
+                  type: int
+                  remarks: The table id of the subscription, used for filtering system events
+                  constraints:
+                    referencedTableName: metabase_table
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_subscription_table_id
+                    deleteCascade: true
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -517,15 +517,18 @@
 
 (defn notifications-for-event
   "Find all active notifications for a given event."
-  [event-name]
+  [event-name additional-filters]
   (t2/select :model/Notification
              {:select    [:n.*]
               :from      [[:notification :n]]
               :left-join [[:notification_subscription :ns] [:= :n.id :ns.notification_id]]
-              :where     [:and
-                          [:= :n.active true]
-                          [:= :ns.event_name (u/qualified-name event-name)]
-                          [:= :ns.type (u/qualified-name :notification-subscription/system-event)]]}))
+              :where     (->> (conj
+                               [[:= :n.active true]
+                                [:= :ns.event_name (u/qualified-name event-name)]
+                                [:= :ns.type (u/qualified-name :notification-subscription/system-event)]]
+                               additional-filters)
+                              (filter some?)
+                              (into [:and]))}))
 
 (defn create-notification!
   "Create a new notification with `subsciptions`.

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -316,7 +316,8 @@
                                                         :type "notification-subscription/cron"
                                                         :event_name nil
                                                         :cron_schedule "0 0 0 * * ?"
-                                                        :ui_display_type nil}]
+                                                        :ui_display_type nil
+                                                        :table_id nil}]
                                        :active false}}}
                  (mt/latest-audit-log-entry))))))))
 


### PR DESCRIPTION
Add a `notification_subscription.table_id` column to help fetching notifications related to a table faster. This field will be restricted to system events subscription only.