### PR TITLE
fix(sdk): Remove 'Unrecognized Props'  error from InteractiveDashboard

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -124,3 +124,46 @@ body:where(:global(.mb-wrapper)) {
     background-color: transparent;
   }
 }
+
+.ParametersWidgetContainer {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.AllowSticky {
+  position: sticky;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 3;
+  border-bottom: 1px solid transparent;
+}
+
+.IsSticky {
+  border-bottom-color: var(--mb-color-border);
+}
+
+.IsStickyNight {
+  background-color: color-mix(
+    in srgb,
+    var(--mb-color-bg-black),
+    var(--mb-color-bg-dashboard) 15%
+  );
+}
+
+.IsStickyTransparent {
+  background-color: color-mix(
+    in srgb,
+    var(--mb-color-bg-white),
+    transparent 15%
+  );
+  border-bottom-color: transparent;
+}
+
+.IsStickyDefault {
+  background-color: color-mix(
+    in srgb,
+    var(--mb-color-bg-white),
+    var(--mb-color-bg-dashboard) 15%
+  );
+}

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -4,13 +4,11 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import { FixedWidthContainer } from "metabase/dashboard/components/Dashboard/DashboardComponents";
-import type { DisplayTheme } from "metabase/public/lib/types";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 import {
   breakpointMaxSmall,
   breakpointMinLarge,
   breakpointMinSmall,
-  space,
 } from "metabase/styled-components/theme";
 
 export const Root = styled.div<{
@@ -115,53 +113,6 @@ const footerVariantStyles = {
     }
   `,
 };
-
-function getParameterPanelBackgroundColor(theme: DisplayTheme | undefined) {
-  if (theme === "night") {
-    return `color-mix(in srgb, var(--mb-color-bg-black), var(--mb-color-bg-dashboard) 15%)`;
-  }
-
-  if (theme === "transparent") {
-    return `color-mix(in srgb, var(--mb-color-bg-white), transparent 15%)`;
-  }
-
-  return `color-mix(in srgb, var(--mb-color-bg-white), var(--mb-color-bg-dashboard) 15%)`;
-}
-
-function getParameterPanelBorderColor(theme?: DisplayTheme) {
-  if (theme === "transparent") {
-    return "transparent";
-  }
-  return "var(--mb-color-border)";
-}
-
-export const ParametersWidgetContainer = styled(FullWidthContainer)<{
-  embedFrameTheme?: DisplayTheme;
-  allowSticky: boolean;
-  isSticky: boolean;
-}>`
-  padding-top: ${space(1)};
-  padding-bottom: ${space(1)};
-
-  ${({ allowSticky }) =>
-    allowSticky &&
-    css`
-      position: sticky;
-      top: 0;
-      left: 0;
-      width: 100%;
-      z-index: 3;
-      /* this is for proper transitions from the \`transparent\` value to other values if set */
-      border-bottom: 1px solid transparent;
-    `}
-
-  ${({ embedFrameTheme, isSticky }) =>
-    isSticky &&
-    css`
-      background-color: ${getParameterPanelBackgroundColor(embedFrameTheme)};
-      border-bottom-color: ${getParameterPanelBorderColor(embedFrameTheme)};
-    `}
-`;
 
 export const Footer = styled.footer<{ variant: FooterVariant }>`
   display: flex;

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -24,6 +24,7 @@ import type { DisplayTheme } from "metabase/public/lib/types";
 import { SyncedParametersList } from "metabase/query_builder/components/SyncedParametersList";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
+import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 import { Box } from "metabase/ui";
 import { SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS } from "metabase/visualizations/lib/save-chart-image";
 import type Question from "metabase-lib/v1/Question";
@@ -46,7 +47,6 @@ import {
   DashboardTabsContainer,
   Footer,
   Header,
-  ParametersWidgetContainer,
   Root,
   Separator,
   TitleAndButtonsContainer,
@@ -216,14 +216,18 @@ export const EmbedFrame = ({
 
         <span ref={parameterPanelRef} />
         {hasVisibleParameters && (
-          <ParametersWidgetContainer
+          <FullWidthContainer
             className={cx({
               [TransitionS.transitionThemeChange]:
                 shouldApplyParameterPanelThemeChangeTransition,
+              [EmbedFrameS.ParametersWidgetContainer]: true,
+              [EmbedFrameS.AllowSticky]: allowParameterPanelSticky,
+              [EmbedFrameS.IsSticky]: isParameterPanelSticky,
+              [EmbedFrameS.IsStickyTransparent]:
+                isParameterPanelSticky && theme === "transparent",
+              [EmbedFrameS.IsStickyDefault]:
+                isParameterPanelSticky && (!theme || theme === "light"),
             })}
-            embedFrameTheme={theme}
-            allowSticky={allowParameterPanelSticky}
-            isSticky={isParameterPanelSticky}
             data-testid="dashboard-parameters-widget-container"
           >
             <FixedWidthContainer
@@ -250,7 +254,7 @@ export const EmbedFrame = ({
               />
               {dashboard && <FilterApplyButton />}
             </FixedWidthContainer>
-          </ParametersWidgetContainer>
+          </FullWidthContainer>
         )}
         <Body>{children}</Body>
       </ContentContainer>


### PR DESCRIPTION
It actually seems like the error has been solved somewhere else? I guess it must have happened during the offsite because it seemed to be failing before