### PR TITLE
docs(sdk): indicate support for react 19

### DIFF
--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -18,7 +18,7 @@ Here's the [Shoppy source code](https://github.com/metabase/shoppy).
 
 ## Embedded analytics SDK prerequisites
 
-- React application using React 17 or React 18.
+- React application using React 18 or React 19.
 - Nodejs 20.x or higher.
 - Metabase version 1.52 or higher.
 
@@ -94,12 +94,11 @@ The SDK doesn't support:
 
 ## Issues, feature requests and support
 
-[Bugs](https://github.com/metabase/metabase/issues/?q=is%3Aissue%20state%3Aopen%20label%3AType%3ABug%20label%3AEmbedding%2FSDK) and [feature requests](https://github.com/metabase/metabase/issues/?q=is%3Aissue%20state%3Aopen%20label%3AEmbedding%2FSDK%20label%3A%22Type%3ANew%20Feature%22) are tracked on GitHub. 
+[Bugs](https://github.com/metabase/metabase/issues/?q=is%3Aissue%20state%3Aopen%20label%3AType%3ABug%20label%3AEmbedding%2FSDK) and [feature requests](https://github.com/metabase/metabase/issues/?q=is%3Aissue%20state%3Aopen%20label%3AEmbedding%2FSDK%20label%3A%22Type%3ANew%20Feature%22) are tracked on GitHub.
 
 You can upvote an existing feature request by leaving a thumbs up emoji reaction on the issue. Feel free to leave comments with context that could be useful. [Read more](https://www.metabase.com/docs/latest/troubleshooting-guide/requesting-new-features).
 
 Before creating new issues, please make sure an issue for your problem or feature request doesn't already exist.
- 
 To seek help:
 
 - Paid customers can contact our success team through the usual channels.

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -23,7 +23,7 @@ export const PACKAGE_JSON_NOT_FOUND_MESSAGE = `
 
 export const MISSING_REACT_DEPENDENCY = `
   Your package.json file does not contain a dependency for React.
-  Please make sure your package.json file contains a dependency for React 18 - 19.
+  Please make sure your package.json file contains a dependency for React 18 or React 19.
 `;
 
 export const UNSUPPORTED_REACT_VERSION = `

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -23,7 +23,7 @@ export const PACKAGE_JSON_NOT_FOUND_MESSAGE = `
 
 export const MISSING_REACT_DEPENDENCY = `
   Your package.json file does not contain a dependency for React.
-  Please make sure your package.json file contains a dependency for React 18.
+  Please make sure your package.json file contains a dependency for React 18 - 19.
 `;
 
 export const UNSUPPORTED_REACT_VERSION = `
@@ -105,8 +105,8 @@ export const SETUP_PRO_LICENSE_MESSAGE_WITH_SAMPLE_DATABASE = `
 
   If you want to use this tool to set up permissions for multi-tenancy with JWT SSO,
   you'll need to select your own database.
-  
-  With the sample database selected, this tool will simply create a mock back-end server 
+
+  With the sample database selected, this tool will simply create a mock back-end server
   that signs people into Metabase, without setting up JWT SSO.
 `;
 

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
@@ -14,7 +14,7 @@ import {
 } from "../utils/get-package-version";
 
 const isReactVersionSupported = (version: string) =>
-  semver.satisfies(semver.coerce(version)!, "18.x");
+  semver.satisfies(semver.coerce(version)!, "18.x || 19.x");
 
 export const checkIfReactProject: CliStepMethod = async state => {
   const spinner = ora("Checking if this is a React project…").start();


### PR DESCRIPTION
Closes EMB-254

Update the docs and cli to indicate support for React 19. We've previously released React 19 support to the last SDK release for 52 and 53, but we just haven't announced it yet.

### How to test

- We've merged and backported the https://github.com/metabase/metabase/pull/55405 PR which runs the component tests against React 19. Tests are passing so far.
- We have a PR that adds React 19 support to Shoppy in https://github.com/metabase/shoppy/pull/107. You can try out the deploy preview on that branch. Feel free to try out and see if you spot any bugs.

### Known Issues for React 19

- [react 19 console error on deprecated element.ref access](https://linear.app/metabase/issue/EMB-263/%5Bsdk%5D-react-19-console-error-on-deprecated-elementref-access) - console error when running the SDK in development
- [font weight CSS workaround is not applying in React 19 branch in Shoppy](https://linear.app/metabase/issue/EMB-278/[shoppy]-font-weight-css-workaround-is-not-applying-in-react-19-branch) - causes font weight for trend charts to differ on Shoppy, but it's a Shoppy issue and not a SDK issue