### PR TITLE
Closes viz-447 disable text selection when dragging/resizing dashcards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import type { ComponentType, ForwardedRef } from "react";
 import { Component, forwardRef } from "react";
+import type { Responsive as ReactGridLayout } from "react-grid-layout";
 import type { ConnectedProps } from "react-redux";
 import { push } from "react-router-redux";
 import { t } from "ttag";
@@ -78,17 +79,6 @@ import { GridLayout } from "./grid/GridLayout";
 
 type GridBreakpoint = "desktop" | "mobile";
 
-type LayoutItem = {
-  i: string;
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-  minW: number;
-  minH: number;
-  dashcard: BaseDashboardCard;
-};
-
 type ExplicitSizeProps = {
   width: number;
 };
@@ -96,7 +86,10 @@ type ExplicitSizeProps = {
 interface DashboardGridState {
   visibleCardIds: Set<number>;
   initialCardSizes: { [key: string]: { w: number; h: number } };
-  layouts: { desktop: LayoutItem[]; mobile: LayoutItem[] };
+  layouts: {
+    desktop: ReactGridLayout.Layout[];
+    mobile: ReactGridLayout.Layout[];
+  };
   addSeriesModalDashCard: BaseDashboardCard | null;
   replaceCardModalDashCard: BaseDashboardCard | null;
   isDragging: boolean;
@@ -301,7 +294,7 @@ class DashboardGridInner extends Component<
     layout,
     breakpoint,
   }: {
-    layout: LayoutItem[];
+    layout: ReactGridLayout.Layout[];
     breakpoint: GridBreakpoint;
   }) => {
     const { setMultipleDashCardAttributes, isEditing } = this.props;
@@ -355,7 +348,12 @@ class DashboardGridInner extends Component<
     isEditing = this.props.isEditing,
     selectedTabId = this.props.selectedTabId,
   ) => {
-    return getVisibleCards(cards, visibleCardIds, isEditing, selectedTabId);
+    return getVisibleCards(
+      cards,
+      visibleCardIds,
+      isEditing,
+      selectedTabId,
+    ) as DashboardCard[];
   };
 
   getDashcardCountByCardId = (cards: BaseDashboardCard[]) =>
@@ -634,7 +632,7 @@ class DashboardGridInner extends Component<
     const { layouts } = this.state;
     const rowHeight = this.getRowHeight();
     return (
-      <GridLayout
+      <GridLayout<DashboardCard>
         className={cx({
           [DashboardS.DashEditing]: this.isEditingLayout,
           [DashboardS.DashDragging]: this.state.isDragging,

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { Responsive as ReactGridLayout } from "react-grid-layout";
+import {
+  type ItemCallback,
+  Layout,
+  Responsive as ReactGridLayout,
+} from "react-grid-layout";
 
 import { useMantineTheme } from "metabase/ui";
 
@@ -195,14 +199,22 @@ export function GridLayout<T extends { id: number | null }>(
   // https://github.com/react-grid-layout/react-grid-layout#performance
   const children = useMemo(() => items.map(renderItem), [items, renderItem]);
 
-  // prevent user selection when dragging metabase#53842
+  // // prevent user selection when dragging metabase#53842
   const originalUserSelect = useRef(document.body.style.userSelect);
-  const disableTextSelection = useCallback(() => {
-    document.body.style.userSelect = "none";
-  }, []);
-  const enableTextSelection = useCallback(() => {
-    document.body.style.userSelect = originalUserSelect.current;
-  }, []);
+  const disableTextSelection = useCallback<ItemCallback>(
+    (...params) => {
+      document.body.style.userSelect = "none";
+      otherProps.onDragStart?.(...params);
+    },
+    [otherProps],
+  );
+  const enableTextSelection = useCallback<ItemCallback>(
+    (...params) => {
+      document.body.style.userSelect = originalUserSelect.current;
+      otherProps.onDragStop?.(...params);
+    },
+    [otherProps],
+  );
 
   return (
     <ReactGridLayout

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Responsive as ReactGridLayout } from "react-grid-layout";
 

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Responsive as ReactGridLayout } from "react-grid-layout";
 
 import { useMantineTheme } from "metabase/ui";
@@ -9,33 +9,95 @@ import "react-resizable/css/styles.css";
 
 import { generateGridBackground } from "./utils";
 
-export function GridLayout({
-  items,
-  itemRenderer,
-  breakpoints,
-  layouts,
-  cols: columnsMap,
-  width: gridWidth,
-  margin: marginMap,
-  rowHeight,
-  isEditing,
-  onLayoutChange,
-  ...props
-}) {
+// We need to omit onLayoutChange and margin from the props of ReactGridLayout
+// because we're overriding them in OwnProps
+type OmittedPropsFromGridLayout = Omit<
+  ReactGridLayout.ResponsiveProps,
+  "onLayoutChange" | "margin"
+>;
+// We need to make cols, width and margin mandatory from the props of ReactGridLayout
+type RequiredPropsFromGridLayout = Required<
+  Pick<
+    ReactGridLayout.ResponsiveProps,
+    "cols" | "width" | "margin" | "rowHeight"
+  >
+>;
+type OwnProps<T extends { id: number | null }> = {
+  /**
+   * Items to render in the grid
+   */
+  items: T[];
+
+  /**
+   * The function that renders the item
+   * @param props - the props for the item renderer
+   * @param props.item - the item to render
+   * @param props.gridItemWidth - the width of the grid item
+   * @param props.breakpoint - the current breakpoint
+   * @param props.totalNumGridCols - the total number of grid columns
+   * @returns the rendered item
+   */
+  itemRenderer: (props: {
+    item: T;
+    gridItemWidth: number;
+    breakpoint: "desktop" | "mobile";
+    totalNumGridCols: number;
+  }) => React.ReactNode;
+
+  /**
+   * Are we in editing mode?
+   */
+  isEditing: boolean;
+
+  /**
+   * Called when the layout changes
+   * @param layout - the new layout
+   * @param breakpoint - the current breakpoint
+   */
+  onLayoutChange: (layout: {
+    layout: ReactGridLayout.Layout[];
+    breakpoint: "desktop" | "mobile";
+  }) => void;
+
+  /**
+   * The breakpoints for the grid
+   */
+  margin?: Record<string, [number, number]>;
+};
+
+export function GridLayout<T extends { id: number | null }>(
+  props: OwnProps<T> & OmittedPropsFromGridLayout & RequiredPropsFromGridLayout,
+) {
+  const {
+    items,
+    itemRenderer,
+    breakpoints,
+    layouts = {},
+    cols: columnsMap = {},
+    width: gridWidth = 0,
+    margin: marginMap = {},
+    rowHeight,
+    isEditing,
+    onLayoutChange,
+    ...otherProps
+  } = props;
   const theme = useMantineTheme();
 
   const [currentBreakpoint, setCurrentBreakpoint] = useState(
-    ReactGridLayout.utils.getBreakpointFromWidth(breakpoints, gridWidth),
+    (ReactGridLayout as any).utils.getBreakpointFromWidth(
+      breakpoints,
+      gridWidth,
+    ),
   );
 
   const onLayoutChangeWrapped = useCallback(
-    (nextLayout) => {
+    (currentLayout: ReactGridLayout.Layout[]) => {
       onLayoutChange({
-        layout: nextLayout,
+        layout: currentLayout,
         // Calculating the breakpoint right here,
         // so we're definitely passing the most recent one
         // Workaround for https://github.com/react-grid-layout/react-grid-layout/issues/889
-        breakpoint: ReactGridLayout.utils.getBreakpointFromWidth(
+        breakpoint: (ReactGridLayout as any).utils.getBreakpointFromWidth(
           breakpoints,
           gridWidth,
         ),
@@ -44,7 +106,7 @@ export function GridLayout({
     [onLayoutChange, breakpoints, gridWidth],
   );
 
-  const onBreakpointChange = useCallback((newBreakpoint) => {
+  const onBreakpointChange = useCallback((newBreakpoint: string) => {
     setCurrentBreakpoint(newBreakpoint);
   }, []);
 
@@ -68,6 +130,7 @@ export function GridLayout({
     const [horizontalMargin] = margin;
     const totalHorizontalMargin = marginSlotsCount * horizontalMargin;
     const freeSpace = gridWidth - totalHorizontalMargin;
+
     return {
       width: freeSpace / cols,
       height: rowHeight,
@@ -75,9 +138,14 @@ export function GridLayout({
   }, [cols, gridWidth, rowHeight, margin]);
 
   const renderItem = useCallback(
-    (item) => {
+    (item: T) => {
       const itemLayout = layout.find((l) => String(l.i) === String(item.id));
+      if (!itemLayout) {
+        return null;
+      }
+
       const gridItemWidth = cellSize.width * itemLayout.w;
+
       return itemRenderer({
         item,
         gridItemWidth,
@@ -93,8 +161,7 @@ export function GridLayout({
     if (isEditing) {
       lowestLayoutCellPoint += Math.ceil(window.innerHeight / cellSize.height);
     }
-    // eslint-disable-next-line no-unused-vars
-    const [horizontalMargin, verticalMargin] = margin;
+    const verticalMargin = margin[1];
     return (cellSize.height + verticalMargin) * lowestLayoutCellPoint;
   }, [cellSize.height, layout, margin, isEditing]);
 
@@ -129,6 +196,15 @@ export function GridLayout({
   // https://github.com/react-grid-layout/react-grid-layout#performance
   const children = useMemo(() => items.map(renderItem), [items, renderItem]);
 
+  // prevent user selection when dragging metabase#53842
+  const originalUserSelect = useRef(document.body.style.userSelect);
+  const disableTextSelection = useCallback(() => {
+    document.body.style.userSelect = "none";
+  }, []);
+  const enableTextSelection = useCallback(() => {
+    document.body.style.userSelect = originalUserSelect.current;
+  }, []);
+
   return (
     <ReactGridLayout
       breakpoints={breakpoints}
@@ -139,11 +215,15 @@ export function GridLayout({
       rowHeight={rowHeight}
       isDraggable={isEditing && !isMobile}
       isResizable={isEditing && !isMobile}
-      {...props}
+      {...otherProps}
       autoSize={false}
       onLayoutChange={onLayoutChangeWrapped}
       onBreakpointChange={onBreakpointChange}
       style={style}
+      onDragStart={disableTextSelection}
+      onDragStop={enableTextSelection}
+      onResizeStart={disableTextSelection}
+      onResizeStop={enableTextSelection}
     >
       {children}
     </ReactGridLayout>

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.unit.spec.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+
+import { renderWithProviders } from "__support__/ui";
+import { ThemeProvider } from "metabase/ui";
+
+import { GridLayout } from "./GridLayout";
+
+// Sample items for testing
+const testItems = [
+  { id: 1, name: "Item 1" },
+  { id: 2, name: "Item 2" },
+];
+
+// Default props for tests
+const defaultProps = {
+  items: testItems,
+  itemRenderer: ({ item, gridItemWidth, breakpoint, totalNumGridCols }) => (
+    <div
+      key={item.id}
+      data-testid={`item-${item.id}`}
+      data-width={gridItemWidth}
+      data-breakpoint={breakpoint}
+      data-cols={totalNumGridCols}
+    >
+      {item.id}
+    </div>
+  ),
+  isEditing: false,
+  onLayoutChange: jest.fn(),
+  breakpoints: { desktop: 992, mobile: 768 },
+  layouts: {
+    desktop: [
+      { i: "1", x: 0, y: 0, w: 2, h: 2 },
+      { i: "2", x: 2, y: 0, w: 2, h: 2 },
+    ],
+    mobile: [
+      { i: "1", x: 0, y: 0, w: 1, h: 1 },
+      { i: "2", x: 0, y: 1, w: 1, h: 1 },
+    ],
+  },
+  cols: { desktop: 12, mobile: 6 },
+  width: 1200,
+  margin: {
+    desktop: [10, 10] as [number, number],
+    mobile: [5, 5] as [number, number],
+  },
+  rowHeight: 100,
+} as ComponentProps<typeof GridLayout>;
+
+describe("GridLayout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock window.innerHeight
+    Object.defineProperty(window, "innerHeight", {
+      value: 800,
+      writable: true,
+    });
+
+    // ReactGridLayout internally uses offsetParent, which is not supported by jsdom
+    // This is a workaround to make it work
+    Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+      get() {
+        // eslint-disable-next-line testing-library/no-node-access
+        return this.parentNode;
+      },
+    });
+  });
+
+  test("renders all items correctly", () => {
+    renderWithProviders(
+      <ThemeProvider>
+        <GridLayout {...defaultProps} />,
+      </ThemeProvider>,
+    );
+
+    // Check if all items are rendered
+    expect(screen.getByTestId("item-1")).toBeInTheDocument();
+    expect(screen.getByTestId("item-2")).toBeInTheDocument();
+  });
+
+  test("disables and enables text selection during drag", () => {
+    // Capture original user select style
+    const originalUserSelect = document.body.style.userSelect;
+
+    renderWithProviders(
+      <ThemeProvider>
+        <GridLayout {...defaultProps} isEditing={true} />
+      </ThemeProvider>,
+    );
+
+    const grid = screen.getByTestId("item-1");
+
+    // Test drag start disables text selection
+    fireEvent.mouseDown(grid);
+    fireEvent.mouseMove(grid);
+    expect(document.body).toHaveStyle({ userSelect: "none" });
+
+    // Test drag stop re-enables text selection
+    fireEvent.mouseUp(grid);
+    expect(document.body).toHaveStyle({ userSelect: "" });
+
+    // Restore original style
+    document.body.style.userSelect = originalUserSelect;
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #53842
Closes [VIZ-447: Text in the page is selected when dragging cards in dashboard edit mode](https://linear.app/metabase/issue/VIZ-447/text-in-the-page-is-selected-when-dragging-cards-in-dashboard-edit)

### Description

We don't want to select stuff when dragging round a dashcard or resizing it.

### How to verify

In a dashboard, resize/reorder dashcard and check that no test gets selected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
