### PR TITLE
Enable shoppy compatibility testing on CI

### DIFF
--- a/.github/workflows/e2e-sample-apps-tests.yml
+++ b/.github/workflows/e2e-sample-apps-tests.yml
@@ -17,7 +17,8 @@ env:
   TEST_SUITES: |
     [
       "metabase-nodejs-react-sdk-embedding-sample-e2e",
-      "metabase-nextjs-sdk-embedding-sample-e2e"
+      "metabase-nextjs-sdk-embedding-sample-e2e",
+      "shoppy-e2e"
     ]
   TEST_SUITES_TO_RUN_IN_MASTER_ONLY: |
     [


### PR DESCRIPTION
Enable shoppy compatibility testing on CI

Closes https://linear.app/metabase/issue/EMB-219/add-support-of-docker-e2e-testing-for-shoppy