### PR TITLE
Add placeholder to custom expression editor

### DIFF
--- a/e2e/support/helpers/e2e-custom-column-helpers.ts
+++ b/e2e/support/helpers/e2e-custom-column-helpers.ts
@@ -231,7 +231,12 @@ export const CustomExpressionEditor = {
         lines.each((_, line) => {
           text.push(line.textContent ?? "");
         });
-        return text.join("\n");
+        const value = text.join("\n");
+        const placeholder = "Type your expression, press '[' for columns…";
+        if (value === placeholder) {
+          return "";
+        }
+        return value;
       });
   },
   completions() {

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -158,6 +158,7 @@ export function Editor<S extends StartRule = "expression">(
           id={id}
           ref={ref}
           data-testid="custom-expression-query-editor"
+          placeholder={t`Type your expression, press '[' for columns…`}
           className={S.editor}
           extensions={extensions}
           readOnly={readOnly || isFormatting}


### PR DESCRIPTION
Adds a descriptive placeholder to the expression editor to give users an idea on how to start.

<img width="737" alt="Screenshot 2025-03-21 at 15 47 36" src="https://github.com/user-attachments/assets/c011db26-b728-46c5-bc42-5f6a5e7df418" />
