### PR TITLE
use-escape-to-close-modal, fix closing entity picker on esc

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -50,9 +50,7 @@ describe("scenarios > dashboard", () => {
       );
       H.modal().findByTestId("collection-picker-button").click();
       H.entityPickerModal().findByText("Select a collection");
-      // cy.realPress("Escape");
-      // TODO: Fix this:
-      H.entityPickerModal().button("Cancel").click();
+      cy.realPress("Escape");
       H.modal().findByText("New dashboard").should("be.visible");
 
       cy.log("Create a new dashboard");

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -1102,6 +1102,16 @@ describe("scenarios > organization > entity picker", () => {
 
       closeAndAssertModal(H.dashboardOnTheGoModal);
       closeAndAssertModal(H.entityPickerModal);
+
+      H.openQuestionActions("Duplicate");
+      H.modal()
+        .findByLabelText(/Where do you/)
+        .click();
+      H.entityPickerModalTab("Browse").click();
+      closeAndAssertModal(H.entityPickerModal);
+      closeAndAssertModal(() =>
+        cy.findByRole("heading", { name: /Duplicate/ }),
+      );
     });
   });
 });

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -1021,7 +1021,96 @@ describe("scenarios > organization > entity picker", () => {
       });
     });
   });
+
+  describe("keyboard navigation", () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+    });
+
+    it("should handle esc properly", () => {
+      cy.visit("/");
+
+      // New Collection Flow
+      H.newButton("Collection").click();
+      H.modal()
+        .findByLabelText(/Collection it's saved in/)
+        .click();
+
+      H.entityPickerModalTab("Collections").click();
+      H.entityPickerModal()
+        .button(/New collection/)
+        .click();
+
+      closeAndAssertModal(H.collectionOnTheGoModal);
+      closeAndAssertModal(H.entityPickerModal);
+      closeAndAssertModal(() =>
+        cy.findByRole("dialog", { name: "New collection" }),
+      );
+
+      // New Dashboard
+      H.newButton("Dashboard").click();
+      H.modal()
+        .findByLabelText(/Which collection/)
+        .click();
+
+      H.entityPickerModalTab("Collections").click();
+      H.entityPickerModal()
+        .button(/New collection/)
+        .click();
+
+      closeAndAssertModal(H.collectionOnTheGoModal);
+      closeAndAssertModal(H.entityPickerModal);
+
+      closeAndAssertModal(() =>
+        cy.findByRole("dialog", { name: "New dashboard" }),
+      );
+
+      H.newButton("Question").click();
+      H.entityPickerModalLevel(2).findByText("People").click();
+      H.queryBuilderHeader().findByRole("button", { name: "Save" }).click();
+
+      H.modal()
+        .findByLabelText(/Where do you/)
+        .click();
+      H.entityPickerModalTab("Browse").click();
+
+      H.entityPickerModal()
+        .button(/New dashboard/)
+        .click();
+
+      closeAndAssertModal(H.dashboardOnTheGoModal);
+      H.entityPickerModal()
+        .button(/New collection/)
+        .click();
+
+      closeAndAssertModal(H.collectionOnTheGoModal);
+
+      closeAndAssertModal(H.entityPickerModal);
+
+      closeAndAssertModal(() =>
+        cy.findByRole("dialog", { name: "Save new question" }),
+      );
+
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions("Add to dashboard");
+      H.entityPickerModalTab("Dashboards").click();
+
+      H.entityPickerModal()
+        .button(/New dashboard/)
+        .click();
+
+      closeAndAssertModal(H.dashboardOnTheGoModal);
+      closeAndAssertModal(H.entityPickerModal);
+    });
+  });
 });
+
+function closeAndAssertModal(modalGetterFn: () => Cypress.Chainable) {
+  modalGetterFn().should("exist");
+  cy.realPress("Escape");
+  modalGetterFn().should("not.exist");
+}
 
 function createTestCards() {
   const types = ["question", "model", "metric"] as const;

--- a/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import { useEscapeToCloseModal } from "metabase/common/hooks/use-escape-to-close-modal";
 import { connect } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Modal } from "metabase/ui";
@@ -45,6 +46,8 @@ function CreateCollectionModal({
     [onCreate, onChangeLocation, onClose],
   );
 
+  useEscapeToCloseModal(onClose);
+
   return (
     <Modal
       opened
@@ -53,6 +56,7 @@ function CreateCollectionModal({
       data-testid="new-collection-modal"
       padding="40px"
       title={t`New collection`}
+      closeOnEscape={false}
     >
       <CreateCollectionForm
         {...props}

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -220,6 +220,9 @@ export const CollectionPickerModal = ({
         recentFilter={recentFilter}
         actionButtons={modalActions}
         trapFocus={!isCreateCollectionDialogOpen}
+        disableCloseOnEscape={
+          isCreateCollectionDialogOpen || isCreateDashboardDialogOpen
+        }
       />
       <NewCollectionDialog
         isOpen={isCreateCollectionDialogOpen}

--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { useCreateCollectionMutation } from "metabase/api";
+import { useEscapeToCloseModal } from "metabase/common/hooks/use-escape-to-close-modal";
 import { FormFooter } from "metabase/core/components/FormFooter";
 import {
   Form,
@@ -42,6 +43,8 @@ export const NewCollectionDialog = ({
     onClose();
   };
 
+  useEscapeToCloseModal(onClose, { capture: true });
+
   return (
     <Modal
       title={t`Create a new collection`}
@@ -50,6 +53,7 @@ export const NewCollectionDialog = ({
       data-testid="create-collection-on-the-go"
       trapFocus={true}
       withCloseButton={false}
+      closeOnEscape={false}
     >
       <FormProvider
         initialValues={{ name: "" }}

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -214,6 +214,7 @@ export const DashboardPickerModal = ({
               : undefined
         }
         trapFocus={!isCreateDialogOpen}
+        disableCloseOnEscape={isCreateDialogOpen}
       />
       <NewDashboardDialog
         isOpen={isCreateDialogOpen}

--- a/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { useCreateDashboardMutation } from "metabase/api";
+import { useEscapeToCloseModal } from "metabase/common/hooks/use-escape-to-close-modal";
 import { FormFooter } from "metabase/core/components/FormFooter";
 import {
   Form,
@@ -43,6 +44,8 @@ export const NewDashboardDialog = ({
     onClose();
   };
 
+  useEscapeToCloseModal(onClose, { capture: true });
+
   return (
     <Modal
       title={t`Create a new dashboard`}
@@ -51,12 +54,12 @@ export const NewDashboardDialog = ({
       data-testid="create-dashboard-on-the-go"
       trapFocus={true}
       withCloseButton={false}
+      closeOnEscape={false}
       styles={{
         content: {
           padding: "1rem",
         },
       }}
-      zIndex={400} // needs to be above the EntityPickerModal at 400
     >
       <FormProvider
         initialValues={{ name: "" }}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -98,6 +98,7 @@ export interface EntityPickerModalProps<
   isLoadingTabs?: boolean;
   searchExtraButtons?: ReactNode[];
   children?: ReactNode;
+  disableCloseOnEscape?: boolean;
 }
 
 export function EntityPickerModal<
@@ -122,6 +123,7 @@ export function EntityPickerModal<
   onConfirm,
   onItemSelect,
   isLoadingTabs = false,
+  disableCloseOnEscape = false,
   children,
 }: EntityPickerModalProps<Id, Model, Item>) {
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -335,10 +337,10 @@ export function EntityPickerModal<
     event => {
       if (event.key === "Escape") {
         event.stopPropagation();
-        onClose();
+        !disableCloseOnEscape && onClose();
       }
     },
-    { capture: true, once: true },
+    { capture: true },
   );
 
   const titleId = useUniqueId("entity-picker-modal-title-");

--- a/frontend/src/metabase/common/hooks/use-escape-to-close-modal/index.js
+++ b/frontend/src/metabase/common/hooks/use-escape-to-close-modal/index.js
@@ -1,0 +1,1 @@
+export * from "./use-escape-to-close-modal";

--- a/frontend/src/metabase/common/hooks/use-escape-to-close-modal/use-escape-to-close-modal.tsx
+++ b/frontend/src/metabase/common/hooks/use-escape-to-close-modal/use-escape-to-close-modal.tsx
@@ -2,6 +2,15 @@ import { useKey } from "react-use";
 
 type Handler = (event?: KeyboardEvent) => void;
 
+/*
+  This hook is designed to be used in place of the `closeOnEscape` prop on some mantine modals.
+  By default, the mantine modal prop will always capture the event, making it hard to override
+  with other event handlers. This is especially tricky with the EntityPickerModal where it is
+  generally the child of another modal (create collection / dashboard). By using this hook and
+  applying the capture option where needed, we can control the order in which modals are
+  dismissed when the user presses Escape.
+*/
+
 export const useEscapeToCloseModal = (
   handler: Handler,
   opts: AddEventListenerOptions = {},

--- a/frontend/src/metabase/common/hooks/use-escape-to-close-modal/use-escape-to-close-modal.tsx
+++ b/frontend/src/metabase/common/hooks/use-escape-to-close-modal/use-escape-to-close-modal.tsx
@@ -1,0 +1,17 @@
+import { useKey } from "react-use";
+
+type Handler = (event?: KeyboardEvent) => void;
+
+export const useEscapeToCloseModal = (
+  handler: Handler,
+  opts: AddEventListenerOptions = {},
+) => {
+  useKey(
+    "Escape",
+    e => {
+      e.stopPropagation();
+      handler(e);
+    },
+    { options: opts },
+  );
+};

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -1,3 +1,4 @@
+import { useEscapeToCloseModal } from "metabase/common/hooks/use-escape-to-close-modal";
 import {
   LLMSuggestionQuestionInfo,
   SaveQuestionForm,
@@ -21,6 +22,7 @@ export const SaveQuestionModal = ({
   targetCollection,
   ...modalProps
 }: SaveQuestionModalProps) => {
+  useEscapeToCloseModal(modalProps.onClose);
   return (
     <SaveQuestionProvider
       question={question}
@@ -39,7 +41,7 @@ export const SaveQuestionModal = ({
       initialCollectionId={initialCollectionId}
       targetCollection={targetCollection}
     >
-      <Modal.Root padding="2.5rem" {...modalProps}>
+      <Modal.Root padding="2.5rem" {...modalProps} closeOnEscape={false}>
         <Modal.Overlay />
         <Modal.Content data-testid="save-question-modal">
           <Modal.Header>

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import { useEscapeToCloseModal } from "metabase/common/hooks/use-escape-to-close-modal";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Modal, type ModalProps } from "metabase/ui";
@@ -12,7 +13,7 @@ import { CreateDashboardForm } from "./CreateDashboardForm";
 
 export interface CreateDashboardModalProps
   extends Omit<CreateDashboardFormOwnProps, "onCancel"> {
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 export const CreateDashboardModal = ({
@@ -36,12 +37,15 @@ export const CreateDashboardModal = ({
     [onCreate, onClose, dispatch],
   );
 
+  useEscapeToCloseModal(onClose);
+
   return (
     <Modal
       title={t`New dashboard`}
       onClose={() => onClose?.()}
       data-testid="new-dashboard-modal"
       size="lg"
+      closeOnEscape={false}
       {...modalProps}
     >
       <CreateDashboardForm


### PR DESCRIPTION
Closes ADM-460

### Description
Takes a fairly straightforward (if naive) approach to allowing users to close the entity picker (and child pickers) using `Escape`. I added tests for the flows I could think of... any other modals that produce entity pickers will need similar treatment, but thankfully it's not too wide spread

Note: Copy modals use the old modal implementation, so they did not require any adjusting for the time being. However, I included it in the test incase we migrate this to a Mantine Modal so that we don't forget to override the `Escape` handler

### How to verify

1. New Collection -> Which collection should this go in 
2. Click the "Collections" tab
3. Click "New Collection" at the bottom of the picker
4. Press escape. The new collection dialog should be gone, but the entity picker is still up
5. Press escape again, the entity picker should dismiss, but the Create Collection modal should still be up
6. Pressing escape for a third time should dismiss the final modal

### Demo
https://github.com/user-attachments/assets/d78d0afc-aefb-41e7-8b61-1a983d85b2f2

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
