### PR TITLE
In e2e sandboxing tests, compare two users with different attributes

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
@@ -539,10 +539,11 @@ export const getParameterValuesForProductCategories = () =>
     field_ids: [SAMPLE_DATABASE.PRODUCTS.CATEGORY],
   });
 
-export const allDataIsUnsandboxed = (
-  dashboard: Dashboard,
+export const assertNoResultsOrValuesAreSandboxed = (
+  dashboard: Dashboard | null,
   questions: CollectionItem[],
 ) => {
+  checkNotNull(dashboard);
   getDashcardResponses(dashboard, questions).then(
     rowsShouldContainGizmosAndWidgets,
   );
@@ -565,7 +566,7 @@ export const allDataIsUnsandboxed = (
   );
 };
 
-export const allDataIsSandboxed = (
+export const assertAllResultsAndValuesAreSandboxed = (
   dashboard: Dashboard | null,
   questions: CollectionItem[],
 ) => {

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -172,7 +172,10 @@ describe(
       ).forEach(([customViewType, customColumnType, customColumnValue]) => {
         it(`...to a table filtered by a custom ${customColumnType} column in a ${customViewType}`, () => {
           cy.signInAsAdmin();
-          assignAttributeToUser({ attributeValue: customColumnValue });
+          assignAttributeToUser({
+            user: gizmoViewer,
+            attributeValue: customColumnValue,
+          });
           configureSandboxPolicy({
             filterTableBy: "custom_view",
             customViewType: customViewType,

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -4,7 +4,8 @@ import { checkNotNull } from "metabase/lib/types";
 import type { CollectionItem, Dashboard } from "metabase-types/api";
 
 import {
-  allDataIsSandboxed,
+  assertALLResultsAndValuesAreSandboxed as assertAllResultsAndValuesAreSandboxed,
+  assertNoResultsOrValuesAreSandboxed,
   assignAttributeToUser,
   configureSandboxPolicy,
   createSandboxingDashboardAndQuestions,
@@ -14,7 +15,6 @@ import {
   questionCustomView,
   sandboxedUser,
   signInAs,
-  signInAsSandboxedUser,
   unsandboxedUser,
   sandboxedUser as user,
 } from "./helpers/e2e-sandboxing-helpers";
@@ -80,9 +80,9 @@ describe(
 
     it("shows all data before sandboxing policy is applied", () => {
       signInAs(sandboxedUser);
-      allDataIsSandboxed(dashboard, sandboxableQuestions);
+      assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
       signInAs(unsandboxedUser);
-      allDataIsSandboxed(dashboard, sandboxableQuestions);
+      assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
     });
 
     describe("we can apply a sandbox policy", () => {
@@ -97,9 +97,9 @@ describe(
           customViewName: questionCustomView.name,
         });
         signInAs(sandboxedUser);
-        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        assertAllResultsAndValuesAreSandboxed(dashboard, sandboxableQuestions);
         signInAs(unsandboxedUser);
-        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
       });
 
       it("to a table filtered using a model as a custom view", () => {
@@ -109,9 +109,9 @@ describe(
           customViewName: modelCustomView.name,
         });
         signInAs(sandboxedUser);
-        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        assertAllResultsAndValuesAreSandboxed(dashboard, sandboxableQuestions);
         signInAs(unsandboxedUser);
-        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
       });
 
       it("to a table filtered by a regular column", () => {
@@ -121,9 +121,9 @@ describe(
           filterColumn: "Category",
         });
         signInAs(sandboxedUser);
-        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        assertAllResultsAndValuesAreSandboxed(dashboard, sandboxableQuestions);
         signInAs(unsandboxedUser);
-        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
       });
     });
 
@@ -148,7 +148,7 @@ describe(
             customViewName: `${customViewType} with custom columns`,
             filterColumn: `my_${customColumnType}`,
           });
-          signInAsSandboxedUser();
+          signInAs(sandboxedUser);
           H.visitDashboard(checkNotNull(dashboard).id);
 
           cy.log("Should not return any data, and return an error");
@@ -241,7 +241,10 @@ describe(
           },
         };
 
-        Object.values(users).forEach(user => cy.createUserFromRawData(user));
+        Object.values(users).forEach(user =>
+          // @ts-expect-error - this isn't typed yet
+          cy.createUserFromRawData(user),
+        );
 
         cy.log("Show the permissions configuration for the Sample Database");
         cy.visit("/admin/permissions/data/database/1");

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -4,22 +4,19 @@ import { checkNotNull } from "metabase/lib/types";
 import type { CollectionItem, Dashboard } from "metabase-types/api";
 
 import {
-  adhocQuestionData,
+  allDataIsSandboxed,
   assignAttributeToUser,
   configureSandboxPolicy,
   createSandboxingDashboardAndQuestions,
-  getCardResponses,
-  getDashcardResponses,
   getFieldValuesForProductCategories,
   getParameterValuesForProductCategories,
   modelCustomView,
   questionCustomView,
-  rowsShouldContainGizmosAndWidgets,
-  rowsShouldContainOnlyGizmos,
-  signInAsNormalUser,
-  sandboxingUser as user,
-  valuesShouldContainGizmosAndWidgets,
-  valuesShouldContainOnlyGizmos,
+  sandboxedUser,
+  signInAs,
+  signInAsSandboxedUser,
+  unsandboxedUser,
+  sandboxedUser as user,
 } from "./helpers/e2e-sandboxing-helpers";
 
 const { H } = cy;
@@ -82,30 +79,10 @@ describe(
     });
 
     it("shows all data before sandboxing policy is applied", () => {
-      signInAsNormalUser();
-
-      getDashcardResponses(dashboard, sandboxableQuestions).then(
-        rowsShouldContainGizmosAndWidgets,
-      );
-
-      getCardResponses(sandboxableQuestions).then(
-        rowsShouldContainGizmosAndWidgets,
-      );
-
-      H.visitQuestionAdhoc(adhocQuestionData).then(({ response }) =>
-        rowsShouldContainGizmosAndWidgets({
-          responses: [response],
-          questions: [adhocQuestionData as unknown as CollectionItem],
-        }),
-      );
-
-      getFieldValuesForProductCategories().then(response =>
-        valuesShouldContainGizmosAndWidgets(response.body.values),
-      );
-
-      getParameterValuesForProductCategories().then(response =>
-        valuesShouldContainGizmosAndWidgets(response.body.values),
-      );
+      signInAs(sandboxedUser);
+      allDataIsSandboxed(dashboard, sandboxableQuestions);
+      signInAs(unsandboxedUser);
+      allDataIsSandboxed(dashboard, sandboxableQuestions);
     });
 
     describe("we can apply a sandbox policy", () => {
@@ -119,24 +96,10 @@ describe(
           customViewType: "Question" as const,
           customViewName: questionCustomView.name,
         });
-        getDashcardResponses(dashboard, sandboxableQuestions).then(
-          rowsShouldContainOnlyGizmos,
-        );
-        getCardResponses(sandboxableQuestions).then(
-          rowsShouldContainOnlyGizmos,
-        );
-        H.visitQuestionAdhoc(adhocQuestionData).then(({ response }) =>
-          rowsShouldContainOnlyGizmos({
-            responses: [response],
-            questions: [adhocQuestionData as unknown as CollectionItem],
-          }),
-        );
-        getFieldValuesForProductCategories().then(response =>
-          valuesShouldContainOnlyGizmos(response.body.values),
-        );
-        getParameterValuesForProductCategories().then(response =>
-          valuesShouldContainOnlyGizmos(response.body.values),
-        );
+        signInAs(sandboxedUser);
+        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        signInAs(unsandboxedUser);
+        allDataIsSandboxed(dashboard, sandboxableQuestions);
       });
 
       it("to a table filtered using a model as a custom view", () => {
@@ -145,24 +108,10 @@ describe(
           customViewType: "Model" as const,
           customViewName: modelCustomView.name,
         });
-        getDashcardResponses(dashboard, sandboxableQuestions).then(
-          rowsShouldContainOnlyGizmos,
-        );
-        getCardResponses(sandboxableQuestions).then(
-          rowsShouldContainOnlyGizmos,
-        );
-        H.visitQuestionAdhoc(adhocQuestionData).then(({ response }) =>
-          rowsShouldContainOnlyGizmos({
-            responses: [response],
-            questions: [adhocQuestionData as unknown as CollectionItem],
-          }),
-        );
-        getFieldValuesForProductCategories().then(response =>
-          valuesShouldContainOnlyGizmos(response.body.values),
-        );
-        getParameterValuesForProductCategories().then(response =>
-          valuesShouldContainOnlyGizmos(response.body.values),
-        );
+        signInAs(sandboxedUser);
+        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        signInAs(unsandboxedUser);
+        allDataIsSandboxed(dashboard, sandboxableQuestions);
       });
 
       it("to a table filtered by a regular column", () => {
@@ -171,24 +120,10 @@ describe(
           filterTableBy: "column",
           filterColumn: "Category",
         });
-        getDashcardResponses(dashboard, sandboxableQuestions).then(
-          rowsShouldContainOnlyGizmos,
-        );
-        getCardResponses(sandboxableQuestions).then(
-          rowsShouldContainOnlyGizmos,
-        );
-        H.visitQuestionAdhoc(adhocQuestionData).then(({ response }) =>
-          rowsShouldContainOnlyGizmos({
-            responses: [response],
-            questions: [adhocQuestionData as unknown as CollectionItem],
-          }),
-        );
-        getFieldValuesForProductCategories().then(response =>
-          valuesShouldContainOnlyGizmos(response.body.values),
-        );
-        getParameterValuesForProductCategories().then(response =>
-          valuesShouldContainOnlyGizmos(response.body.values),
-        );
+        signInAs(sandboxedUser);
+        allDataIsSandboxed(dashboard, sandboxableQuestions);
+        signInAs(unsandboxedUser);
+        allDataIsSandboxed(dashboard, sandboxableQuestions);
       });
     });
 
@@ -213,7 +148,7 @@ describe(
             customViewName: `${customViewType} with custom columns`,
             filterColumn: `my_${customColumnType}`,
           });
-          signInAsNormalUser();
+          signInAsSandboxedUser();
           H.visitDashboard(checkNotNull(dashboard).id);
 
           cy.log("Should not return any data, and return an error");

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -12,7 +12,6 @@ import {
   getFieldValuesForProductCategories,
   getParameterValuesForProductCategories,
   gizmoViewer,
-  gizmoViewer,
   modelCustomView,
   questionCustomView,
   signInAs,


### PR DESCRIPTION
To rigorously ensure that our sandboxing policies respect a user's attributes, let's change the tests so that they compare two users who are exactly the same except for their attributes.