### PR TITLE
Gdrive Sync Now Button

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -257,7 +257,7 @@
                   json/decode+kw))))
 
 (defn- handle-get-folder []
-  (let [cannot-check-message (tru "Unable to check google drive connection")
+  (let [cannot-check-message (tru "Unable to check Google Drive connection. Reconnect if the issue persists.")
         saved-setting (gsheets-safe)
         conn-id (:gdrive/conn-id saved-setting)
         hm-response (if (empty? saved-setting)

--- a/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
@@ -29,12 +29,14 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/gsheets/folder",
         body: body,
       }),
+      invalidatesTags: ["gsheets-status"],
     }),
     deleteGsheetsFolderLink: builder.mutation<{ success: boolean }, void>({
       query: () => ({
         method: "DELETE",
         url: "/api/ee/gsheets/folder",
       }),
+      invalidatesTags: ["gsheets-status"],
     }),
     syncGsheetsFolder: builder.mutation<{ db_id: DatabaseId }, void>({
       query: () => ({

--- a/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
@@ -18,6 +18,7 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
         method: "GET",
         url: "/api/ee/gsheets/folder",
       }),
+      providesTags: ["gsheets-status"],
     }),
     saveGsheetsFolderLink: builder.mutation<
       { success: boolean },
@@ -35,6 +36,13 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/gsheets/folder",
       }),
     }),
+    syncGsheetsFolder: builder.mutation<{ db_id: DatabaseId }, void>({
+      query: () => ({
+        method: "POST",
+        url: "/api/ee/gsheets/folder/sync",
+      }),
+      invalidatesTags: ["gsheets-status"],
+    }),
   }),
 });
 
@@ -43,4 +51,5 @@ export const {
   useGetGsheetsFolderQuery,
   useDeleteGsheetsFolderLinkMutation,
   useSaveGsheetsFolderLinkMutation,
+  useSyncGsheetsFolderMutation,
 } = gdriveApi;

--- a/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
@@ -1,4 +1,4 @@
-import type { DatabaseId, Settings } from "metabase-types/api";
+import type { DatabaseId, GdrivePayload } from "metabase-types/api";
 
 import { EnterpriseApi } from "./api";
 
@@ -11,7 +11,7 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
       }),
     }),
     getGsheetsFolder: builder.query<
-      Settings["gsheets"] & { db_id: DatabaseId },
+      GdrivePayload & { db_id: DatabaseId },
       void
     >({
       query: () => ({

--- a/enterprise/frontend/src/metabase-enterprise/api/tags.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tags.ts
@@ -1,1 +1,1 @@
-export const ENTERPRISE_TAG_TYPES = ["scim"] as const;
+export const ENTERPRISE_TAG_TYPES = ["scim", "gsheets-status"] as const;

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -49,7 +49,7 @@ export function GdriveConnectionModal({
     return null;
   }
 
-  const { status, folder_url } = gSheetData;
+  const { status, url } = gSheetData;
 
   return (
     isModalOpen &&
@@ -57,7 +57,7 @@ export function GdriveConnectionModal({
       <GoogleSheetsConnectModal
         onClose={onClose}
         serviceAccountEmail={serviceAccountEmail ?? "email not found"}
-        folderUrl={folder_url ?? ""}
+        folderUrl={url ?? ""}
       />
     ) : (
       <GoogleSheetsDisconnectModal onClose={onClose} reconnect={reconnect} />
@@ -223,7 +223,7 @@ function GoogleSheetsDisconnectModal({
   const { data: gdriveInfo } = useGetGsheetsFolderQuery();
 
   const connectingUserId = gdriveInfo?.created_by_id;
-  const folderUrl = gdriveInfo?.folder_url;
+  const folderUrl = gdriveInfo?.url;
 
   const { data: connectingUser } = useGetUserQuery(
     connectingUserId ? connectingUserId : skipToken,
@@ -241,13 +241,16 @@ function GoogleSheetsDisconnectModal({
           onClose();
         }
       })
-      .catch((response) => {
+      .catch((response: { data: { message: string } }) => {
         setErrorMessage(response?.data?.message ?? "Something went wrong");
       });
   };
 
   const userName = getUserName(connectingUser);
-  const relativeConnectionTime = dayjs(gdriveInfo?.created_at).fromNow();
+
+  const relativeConnectionTime = gdriveInfo?.created_at
+    ? dayjs.unix(gdriveInfo.created_at).fromNow()
+    : "";
 
   return (
     <ModalWrapper

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -30,7 +30,7 @@ import {
 import Styles from "./Gdrive.module.css";
 import { getStrings } from "./GdriveConnectionModal.strings";
 import { trackSheetImportClick } from "./analytics";
-import { getStatus } from "./utils";
+import { getErrorMessage, getStatus } from "./utils";
 
 export function GdriveConnectionModal({
   isModalOpen,
@@ -238,8 +238,8 @@ function GoogleSheetsDisconnectModal({
           onClose();
         }
       })
-      .catch((response: { data: { message: string } }) => {
-        setErrorMessage(response?.data?.message ?? "Something went wrong");
+      .catch((response: unknown) => {
+        setErrorMessage(getErrorMessage(response));
       });
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -32,11 +32,11 @@ export function GdriveDbMenu() {
     showGdrive ? undefined : skipToken,
   );
 
-  if (!showGdrive || !isDwh || !folderInfo) {
+  if (!showGdrive || !isDwh) {
     return null;
   }
 
-  const { status } = folderInfo;
+  const status = folderInfo?.status || "not-connected";
 
   if (status === "not-connected") {
     return (

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -27,11 +27,13 @@ export function GdriveDbMenu() {
   const isDwh = databaseInfo?.is_attached_dwh;
   const showGdrive = useShowGdrive();
 
+  const showMenu = showGdrive && isDwh;
+
   const { data: folderInfo } = useGetGsheetsFolderQuery(
-    showGdrive ? undefined : skipToken,
+    showMenu ? undefined : skipToken,
   );
 
-  if (!showGdrive || !isDwh) {
+  if (!showMenu) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -96,6 +96,7 @@ export function GdriveDbMenu() {
     </>
   );
 }
+
 function SyncNowButton({ disabled }: { disabled: boolean }) {
   const [doSync, { isLoading }] = useSyncGsheetsFolderMutation();
 
@@ -117,7 +118,9 @@ function SyncNowButton({ disabled }: { disabled: boolean }) {
 }
 
 function MenuSyncStatus() {
-  const { data: folderInfo } = useGetGsheetsFolderQuery();
+  const { data: folderInfo } = useGetGsheetsFolderQuery(undefined, {
+    refetchOnMountOrArgChange: 5,
+  });
 
   const lastSync = folderInfo?.["folder-upload-time"];
   const folderStatus = folderInfo?.status;
@@ -126,9 +129,16 @@ function MenuSyncStatus() {
     ? dayjs.unix(lastSync).fromNow()
     : t`unknown`;
 
-  const nextSyncRelative = lastSync
+  const nextSyncOverDue =
+    !lastSync ||
+    dayjs
+      .unix(lastSync)
+      .add(SYNC_INTERVAL_MINUTES, "minutes")
+      .isBefore(dayjs());
+
+  const nextSyncRelative = !nextSyncOverDue
     ? dayjs.unix(lastSync).add(SYNC_INTERVAL_MINUTES, "minutes").fromNow()
-    : t`a while`;
+    : t`soon` + "™";
 
   return (
     <>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -12,7 +12,7 @@ import {
 
 import { GdriveConnectionModal } from "./GdriveConnectionModal";
 import { trackSheetConnectionClick } from "./analytics";
-import { getStatus, useShowGdrive } from "./utils";
+import { getErrorMessage, getStatus, useShowGdrive } from "./utils";
 
 export function GdriveDbMenu() {
   const [showModal, setShowModal] = useState(false);
@@ -143,10 +143,11 @@ function MenuSyncStatus() {
     : t`soon` + "™";
 
   if (folderStatus === "error") {
-    const errorMessage =
-      folderError?.data?.message ??
+    const errorMessage = getErrorMessage(
+      folderError,
       // eslint-disable-next-line no-literal-metabase-strings -- admin UI
-      t`Please check that the folder is shared with the Metabase Service Account.`;
+      t`Please check that the folder is shared with the Metabase Service Account.`,
+    );
 
     return (
       <Tooltip label={errorMessage} position="bottom" maw="20rem">

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -4,7 +4,7 @@ import { useLocation } from "react-use";
 import { t } from "ttag";
 
 import { skipToken, useGetDatabaseQuery } from "metabase/api";
-import { Button, Flex, Icon, Loader, Menu, Text } from "metabase/ui";
+import { Button, Flex, Icon, Loader, Menu, Text, Tooltip } from "metabase/ui";
 import {
   useGetGsheetsFolderQuery,
   useSyncGsheetsFolderMutation,
@@ -110,7 +110,6 @@ function SyncNowButton({ disabled }: { disabled: boolean }) {
         e.preventDefault();
         e.stopPropagation();
         await doSync();
-        // error handling?
       }}
     >
       {t`Sync now`}
@@ -144,13 +143,20 @@ function MenuSyncStatus() {
     : t`soon` + "™";
 
   if (folderStatus === "error") {
+    const errorMessage =
+      folderError?.data?.message ??
+      // eslint-disable-next-line no-literal-metabase-strings -- admin UI
+      t`Please check that the folder is shared with the Metabase Service Account.`;
+
     return (
-      <Flex align="center" gap="md">
-        <Icon name="warning" c="error" />
-        <Text fz="sm" c="error">
-          {t`Error syncing`}
-        </Text>
-      </Flex>
+      <Tooltip label={errorMessage} position="bottom" maw="20rem">
+        <Flex align="center" gap="md">
+          <Icon name="warning" c="error" />
+          <Text fz="sm" c="error">
+            {t`Error syncing`}
+          </Text>
+        </Flex>
+      </Tooltip>
     );
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -127,9 +127,7 @@ function MenuSyncStatus() {
   const nextSync = folderInfo?.next_sync_at;
   const folderStatus = folderInfo?.status;
 
-  const lastSyncRelative = lastSync
-    ? dayjs.unix(lastSync).fromNow()
-    : t`unknown`;
+  const lastSyncRelative = lastSync ? dayjs.unix(lastSync).fromNow() : null;
 
   const nextSyncOverDue =
     !lastSync || !nextSync || dayjs.unix(nextSync).isBefore(dayjs());
@@ -145,13 +143,15 @@ function MenuSyncStatus() {
       ) : (
         <Text fw="bold">{t`Next sync ${nextSyncRelative}`}</Text>
       )}
-      <Text fz="sm">{t`Last synced ${lastSyncRelative}`}</Text>
+      {lastSyncRelative && (
+        <Text fz="sm">{t`Last synced ${lastSyncRelative}`}</Text>
+      )}
     </>
   );
 }
 
 const SyncingText = () => (
-  <Flex justify="space-between">
+  <Flex justify="space-between" align="center">
     <Text fw="bold">{t`Syncing`}</Text>
     <Loader size="xs" />
   </Flex>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
@@ -1,0 +1,212 @@
+import userEvent from "@testing-library/user-event";
+import dayjs from "dayjs";
+import fetchMock from "fetch-mock";
+
+import {
+  setupDatabaseEndpoints,
+  setupGdriveGetFolderEndpoint,
+  setupGdriveServiceAccountEndpoint,
+  setupGdriveSyncEndpoint,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Settings } from "metabase-types/api";
+import { createMockDatabase, createMockUser } from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
+import { GdriveDbMenu } from "./GdriveDbMenu";
+
+jest.mock("react-use", () => {
+  return {
+    ...jest.requireActual("react-use"),
+    useLocation: jest.fn(() => ({
+      pathname: "/databases/11",
+    })),
+  };
+});
+
+type Status = Settings["gsheets"]["status"];
+
+const openMenu = async () => {
+  const menu = await screen.findByText("Google Sheets");
+  await userEvent.click(menu);
+};
+
+const closeMenu = openMenu;
+
+const setup = ({
+  status,
+  uploadTime,
+}: {
+  status: Status;
+  uploadTime?: number;
+}) => {
+  setupGdriveGetFolderEndpoint({ status, "folder-upload-time": uploadTime });
+  setupGdriveServiceAccountEndpoint();
+  setupDatabaseEndpoints(
+    createMockDatabase({
+      id: 11,
+      name: "Data Warehouse DB",
+      is_attached_dwh: true,
+    }),
+  );
+  setupGdriveSyncEndpoint();
+
+  return renderWithProviders(<GdriveDbMenu />, {
+    // withRouter: true,
+    initialRoute: "/databases/11",
+    storeInitialState: {
+      settings: createMockSettingsState({
+        "show-google-sheets-integration": true,
+        gsheets: {
+          status,
+          folder_url: null,
+        },
+      }),
+      currentUser: createMockUser({ is_superuser: true }),
+    },
+  });
+};
+
+describe("Google Drive > DB Menu", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ advanceTimers: true });
+  });
+
+  it("shows a connect button when not connected", async () => {
+    setup({ status: "not-connected" });
+
+    expect(
+      await screen.findByText("Connect Google Sheets"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a menu when connected", async () => {
+    setup({ status: "complete" });
+
+    expect(await screen.findByText("Google Sheets")).toBeInTheDocument();
+    expect(screen.getByLabelText("chevrondown icon")).toBeInTheDocument();
+  });
+
+  it("shows a menu when loading", async () => {
+    setup({ status: "loading" });
+
+    expect(await screen.findByText("Google Sheets")).toBeInTheDocument();
+    expect(screen.getByLabelText("chevrondown icon")).toBeInTheDocument();
+  });
+
+  it("shows 'Syncing' when loading", async () => {
+    setup({ status: "loading" });
+
+    await openMenu();
+    expect(await screen.findByText("Syncing")).toBeInTheDocument();
+  });
+
+  it("shows a disconnect button when connected", async () => {
+    setup({
+      status: "complete",
+    });
+
+    await openMenu();
+    const disconnectButton = await screen.findByRole("menuitem", {
+      name: /close icon disconnect/i,
+    });
+    expect(disconnectButton).toBeEnabled();
+  });
+
+  it("disables disconnect button when loading", async () => {
+    setup({
+      status: "loading",
+    });
+
+    await openMenu();
+    const disconnectButton = await screen.findByRole("menuitem", {
+      name: /close icon disconnect/i,
+    });
+    expect(disconnectButton).toBeDisabled();
+  });
+
+  it("should show last sync time", async () => {
+    setup({
+      status: "complete",
+      uploadTime: dayjs().subtract(3, "minute").unix(),
+    });
+
+    await openMenu();
+
+    expect(
+      await screen.findByText("Last synced 3 minutes ago"),
+    ).toBeInTheDocument();
+  });
+
+  it("should show next sync time", async () => {
+    setup({
+      status: "complete",
+      uploadTime: dayjs().subtract(13, "minute").unix(),
+    });
+
+    await openMenu();
+
+    expect(
+      await screen.findByText("Next sync in 2 minutes"),
+    ).toBeInTheDocument();
+  });
+
+  it("should show next sync time as soon if the last sync was more than 15 min ago", async () => {
+    setup({
+      status: "complete",
+      uploadTime: dayjs().subtract(20, "minute").unix(),
+    });
+
+    await openMenu();
+    expect(
+      await screen.findByText("Last synced 20 minutes ago"),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Next sync soon™")).toBeInTheDocument();
+  });
+
+  it("should call the sync API when clicking sync now", async () => {
+    setup({ status: "complete" });
+
+    await openMenu();
+
+    const syncButton = await screen.findByRole("menuitem", {
+      name: /sync now/i,
+    });
+    expect(syncButton).toBeEnabled();
+
+    setupGdriveGetFolderEndpoint({
+      status: "loading",
+      "folder-upload-time": dayjs().subtract(3, "minute").unix(),
+    });
+    await userEvent.click(syncButton);
+
+    const syncCalls = fetchMock.calls("path:/api/ee/gsheets/folder/sync");
+    expect(syncCalls).toHaveLength(1);
+
+    // sync should cause a refetch
+    expect(await screen.findByText("Syncing")).toBeInTheDocument();
+
+    closeMenu();
+    jest.advanceTimersByTime(6000);
+    setupGdriveGetFolderEndpoint({
+      status: "complete",
+      "folder-upload-time": dayjs().subtract(2, "second").unix(),
+    });
+    // reopening the menu after 5 seconds should cause refetch
+    openMenu();
+    await screen.findByText("Last synced a few seconds ago");
+  });
+
+  it("should open disconnect modal when clicking disconnect", async () => {
+    setup({ status: "complete" });
+    await openMenu();
+    const disconnectButton = await screen.findByRole("menuitem", {
+      name: /close icon disconnect/i,
+    });
+    expect(disconnectButton).toBeEnabled();
+    await userEvent.click(disconnectButton);
+    expect(
+      screen.getByText(/Disconnect from Google Drive?/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
@@ -100,6 +100,13 @@ describe("Google Drive > DB Menu", () => {
     expect(screen.getByLabelText("chevrondown icon")).toBeInTheDocument();
   });
 
+  it("shows a menu in error state", async () => {
+    setup({ status: "error" });
+
+    await openMenu();
+    expect(await screen.findByText("Error syncing")).toBeInTheDocument();
+  });
+
   it("shows a menu when loading", async () => {
     setup({ status: "syncing" });
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
@@ -34,7 +34,7 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
 
   const helperText = match(status)
     .with("not-connected", () => null)
-    .with("syncing", () => t`Importing files...`)
+    .with("syncing", () => t`Syncing files...`)
     .with("active", () => t`Connected`)
     .otherwise(() => null);
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
@@ -6,11 +6,11 @@ import { Button, Flex, Icon, Menu, Text } from "metabase/ui";
 import { useGetGsheetsFolderQuery } from "metabase-enterprise/api";
 
 import { trackSheetConnectionClick } from "./analytics";
-import { useShowGdrive } from "./utils";
+import { getStatus, useShowGdrive } from "./utils";
 
 export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
   const showGdrive = useShowGdrive();
-  const { data: folder } = useGetGsheetsFolderQuery(
+  const { data: folder, error } = useGetGsheetsFolderQuery(
     !showGdrive ? skipToken : undefined,
     { refetchOnMountOrArgChange: 5 },
   );
@@ -19,7 +19,7 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
     return null;
   }
 
-  const status = folder?.status || "not-connected";
+  const status = getStatus({ status: folder?.status, error });
 
   const handleClick = () => {
     trackSheetConnectionClick({ from: "left-nav" });
@@ -33,6 +33,7 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
     .otherwise(() => t`Google Sheets`);
 
   const helperText = match(status)
+    .with("error", () => t`Connection error`)
     .with("not-connected", () => null)
     .with("syncing", () => t`Syncing files...`)
     .with("active", () => t`Connected`)
@@ -51,7 +52,7 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
               {buttonText}
             </Text>
             {helperText && (
-              <Text size="sm" c="text-medium">
+              <Text size="sm" c={status === "error" ? "error" : "text-medium"}>
                 {helperText}
               </Text>
             )}

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
@@ -2,7 +2,7 @@ import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { skipToken } from "metabase/api";
-import { Button, Flex, Icon, Menu, Text } from "metabase/ui";
+import { Button, Flex, Icon, Menu, Text, Tooltip } from "metabase/ui";
 import { useGetGsheetsFolderQuery } from "metabase-enterprise/api";
 
 import { trackSheetConnectionClick } from "./analytics";
@@ -39,6 +39,17 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
     .with("active", () => t`Connected`)
     .otherwise(() => null);
 
+  const errorMessage = folder?.message ?? error?.data?.message;
+
+  const MaybeTooltip = ({ children }: { children: React.ReactNode }) =>
+    status === "error" ? (
+      <Tooltip label={errorMessage} position="bottom" maw="20rem">
+        {children}
+      </Tooltip>
+    ) : (
+      <>{children}</>
+    );
+
   return (
     <Menu.Item onClick={handleClick} disabled={status === "syncing"}>
       <Flex gap="sm" align="flex-start" justify="space-between" w="100%">
@@ -52,9 +63,14 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
               {buttonText}
             </Text>
             {helperText && (
-              <Text size="sm" c={status === "error" ? "error" : "text-medium"}>
-                {helperText}
-              </Text>
+              <MaybeTooltip>
+                <Text
+                  size="sm"
+                  c={status === "error" ? "error" : "text-medium"}
+                >
+                  {helperText}
+                </Text>
+              </MaybeTooltip>
             )}
           </div>
         </Flex>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
@@ -6,7 +6,7 @@ import { Button, Flex, Icon, Menu, Text, Tooltip } from "metabase/ui";
 import { useGetGsheetsFolderQuery } from "metabase-enterprise/api";
 
 import { trackSheetConnectionClick } from "./analytics";
-import { getStatus, useShowGdrive } from "./utils";
+import { getErrorMessage, getStatus, useShowGdrive } from "./utils";
 
 export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
   const showGdrive = useShowGdrive();
@@ -39,7 +39,7 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
     .with("active", () => t`Connected`)
     .otherwise(() => null);
 
-  const errorMessage = folder?.message ?? error?.data?.message;
+  const errorMessage = getErrorMessage(error);
 
   const MaybeTooltip = ({ children }: { children: React.ReactNode }) =>
     status === "error" ? (

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
@@ -61,7 +61,7 @@ export const GdriveSyncStatus = () => {
     }
 
     if (status === "error" && previousStatus === "syncing") {
-      console.error((apiError as ErrorPayload)?.data?.message);
+      console.error((apiError as ErrorPayload)?.data?.message ?? t`Sync error`);
     }
   }, [status, previousStatus, gdriveFolder, dbId, apiError]);
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
@@ -12,10 +12,9 @@ import { EnterpriseApi } from "metabase-enterprise/api/api";
 import type { DatabaseId, GdrivePayload } from "metabase-types/api";
 
 import { SYNC_POLL_INTERVAL } from "./constants";
-import { getStatus, useShowGdrive } from "./utils";
+import { getErrorMessage, getStatus, useShowGdrive } from "./utils";
 
 type GsheetsStatus = GdrivePayload["status"];
-type ErrorPayload = { data?: { message: string } };
 
 export const GdriveSyncStatus = () => {
   const dispatch = useDispatch();
@@ -61,7 +60,7 @@ export const GdriveSyncStatus = () => {
     }
 
     if (status === "error" && previousStatus === "syncing") {
-      console.error((apiError as ErrorPayload)?.data?.message ?? t`Sync error`);
+      console.error(getErrorMessage(apiError));
     }
   }, [status, previousStatus, gdriveFolder, dbId, apiError]);
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
@@ -12,7 +12,7 @@ import { EnterpriseApi } from "metabase-enterprise/api/api";
 import type { DatabaseId, GdrivePayload } from "metabase-types/api";
 
 import { SYNC_POLL_INTERVAL } from "./constants";
-import { useShowGdrive } from "./utils";
+import { getStatus, useShowGdrive } from "./utils";
 
 type GsheetsStatus = GdrivePayload["status"];
 type ErrorPayload = { data?: { message: string } };
@@ -30,15 +30,7 @@ export const GdriveSyncStatus = () => {
   const currentUser = useSelector(getCurrentUser);
   const isCurrentUser = currentUser?.id === gdriveFolder?.created_by_id;
 
-  const status = match({
-    apiStatus: gdriveFolder?.status,
-    folderSyncError: !!apiError,
-  })
-    .returnType<GsheetsStatus>()
-    .with({ folderSyncError: true }, () => "error")
-    .with({ apiStatus: "active" }, () => "active")
-    .with({ apiStatus: "syncing" }, () => "syncing")
-    .otherwise(() => "not-connected");
+  const status = getStatus({ status: gdriveFolder?.status, error: apiError });
 
   const previousStatus = usePrevious(status);
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
@@ -238,7 +238,18 @@ describe("GsheetsSyncStatus", () => {
     });
 
     // initial loading state
-    expect(screen.getByText("Importing Google Sheets...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
+
+    setupGdriveGetFolderEndpoint({
+      status: "not-connected",
+      created_by_id: USER_ID,
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(3000);
+    });
 
     // not-connected state
     await waitFor(() =>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
@@ -2,81 +2,78 @@ import userEvent from "@testing-library/user-event";
 
 import {
   setupGdriveGetFolderEndpoint,
-  setupPropertiesEndpoints,
-  setupSettingsEndpoints,
+  setupGdriveServiceAccountEndpoint,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { reloadSettings } from "metabase/admin/settings/settings";
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import { useDispatch } from "metabase/lib/redux";
-import type { Settings, UserId } from "metabase-types/api";
-import { createMockSettings, createMockUser } from "metabase-types/api/mocks";
+import { EnterpriseApi } from "metabase-enterprise/api/api";
+import type { GdrivePayload } from "metabase-types/api";
+import {
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { GdriveSyncStatus } from "./GdriveSyncStatus";
 
-type GsheetsStatus = Settings["gsheets"]["status"];
-
 function TestComponent() {
   const dispatch = useDispatch();
+  const refresh = () => {
+    dispatch(EnterpriseApi.util.invalidateTags(["gsheets-status"]));
+  };
+
   return (
     <>
       <GdriveSyncStatus />
-      <button onClick={() => dispatch(reloadSettings())}>
-        Test Settings Update
-      </button>
+      <button onClick={refresh}>Test Settings Update</button>
     </>
   );
 }
 
+const USER_ID = 2;
+
 const setup = ({
-  settingStatus,
-  updatedSettingStatus,
-  createdById = 2,
-  folderStatus,
+  initialFolderPayload,
   isAdmin = true,
   errorCode,
 }: {
-  settingStatus: GsheetsStatus;
-  updatedSettingStatus?: GsheetsStatus;
-  createdById?: UserId;
-  folderStatus: GsheetsStatus;
+  initialFolderPayload?: GdrivePayload;
   isAdmin?: boolean;
   errorCode?: number;
 }) => {
-  const updatedSettings = createMockSettings({
-    gsheets: {
-      status: updatedSettingStatus ?? settingStatus,
-      folder_url: null,
-      "created-by-id": createdById,
-    },
+  const settings = createMockSettings({
+    "show-google-sheets-integration": true,
+    "token-features": createMockTokenFeatures({
+      attached_dwh: true,
+    }),
   });
 
-  setupPropertiesEndpoints(updatedSettings);
-  setupSettingsEndpoints([]);
-
-  errorCode
-    ? setupGdriveGetFolderEndpoint({ errorCode })
-    : setupGdriveGetFolderEndpoint({ status: folderStatus });
+  setupGdriveGetFolderEndpoint({
+    errorCode,
+    created_by_id: USER_ID,
+    ...initialFolderPayload,
+  });
+  setupGdriveServiceAccountEndpoint(
+    "test-service-account@service-account.metabase.com",
+  );
 
   return renderWithProviders(<TestComponent />, {
     storeInitialState: {
-      settings: createMockSettingsState({
-        gsheets: {
-          status: settingStatus,
-          folder_url: null,
-          "created-by-id": createdById,
-        },
-      }),
-      currentUser: createMockUser({ id: 2, is_superuser: isAdmin }),
+      settings: createMockSettingsState(settings),
+      currentUser: createMockUser({ id: USER_ID, is_superuser: isAdmin }),
     },
   });
 };
 
 describe("GsheetsSyncStatus", () => {
+  beforeAll(() => {
+    jest.useFakeTimers({ advanceTimers: true });
+  });
+
   it("should not render anything in not-connected state", () => {
     setup({
-      settingStatus: "not-connected",
-      folderStatus: "not-connected",
+      initialFolderPayload: { status: "not-connected" },
     });
 
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
@@ -84,16 +81,19 @@ describe("GsheetsSyncStatus", () => {
 
   it("should appear when status changes from not-connected to loading", async () => {
     setup({
-      settingStatus: "not-connected",
-      updatedSettingStatus: "loading",
-      folderStatus: "loading",
+      initialFolderPayload: { status: "not-connected" },
     });
 
     // initial state
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
 
+    setupGdriveGetFolderEndpoint({
+      status: "syncing",
+      created_by_id: USER_ID,
+    });
+
     // trigger settings update
-    userEvent.click(await screen.findByText("Test Settings Update"));
+    await userEvent.click(await screen.findByText("Test Settings Update"));
 
     // loading state
     expect(
@@ -103,39 +103,38 @@ describe("GsheetsSyncStatus", () => {
 
   it("should not render anything for non-admins", () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "loading",
-      isAdmin: false,
+      initialFolderPayload: { status: "syncing", created_by_id: USER_ID },
     });
 
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
   });
 
-  it("should not render anything when initial state is complete", () => {
+  it("should not render anything when initial state is active", () => {
     setup({
-      settingStatus: "complete",
-      folderStatus: "complete",
+      initialFolderPayload: { status: "active" },
     });
 
     expect(screen.queryByText(/Google/i)).not.toBeInTheDocument();
   });
 
-  it("should render loading state", () => {
+  it("should render loading state", async () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "loading",
+      initialFolderPayload: { status: "syncing" },
     });
 
-    expect(screen.getByText("Importing Google Sheets...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
   });
 
   it("should close when the X is clicked", async () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "loading",
+      initialFolderPayload: { status: "syncing" },
     });
 
-    expect(screen.getByText("Importing Google Sheets...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
 
     userEvent.click(await screen.findByLabelText("Dismiss"));
     await waitFor(() =>
@@ -145,12 +144,23 @@ describe("GsheetsSyncStatus", () => {
 
   it("should render completed state after initial status is loading", async () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "complete",
+      initialFolderPayload: { status: "syncing" },
     });
 
     // initial loading state
-    expect(screen.getByText("Importing Google Sheets...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
+
+    setupGdriveGetFolderEndpoint({
+      status: "active",
+      db_id: 1,
+      created_by_id: USER_ID,
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(3000);
+    });
 
     // complete state
     expect(
@@ -163,13 +173,21 @@ describe("GsheetsSyncStatus", () => {
 
   it("should show errors", async () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "loading",
-      errorCode: 500,
+      initialFolderPayload: { status: "syncing" },
     });
 
     // initial loading state
-    expect(screen.getByText("Importing Google Sheets...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
+
+    setupGdriveGetFolderEndpoint({
+      errorCode: 500,
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(3000);
+    });
 
     // error state
     expect(
@@ -179,26 +197,44 @@ describe("GsheetsSyncStatus", () => {
 
   it("should clear error if the user tries to connect again", async () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "not-connected",
-      errorCode: 500,
-      updatedSettingStatus: "not-connected",
+      initialFolderPayload: { status: "syncing" },
     });
 
-    // initial loading state
-    expect(screen.getByText("Importing Google Sheets...")).toBeInTheDocument();
+    // initial syncing state
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
 
-    // not-connected state
-    await waitFor(() =>
-      expect(screen.queryByText(/Google/i)).not.toBeInTheDocument(),
-    );
+    setupGdriveGetFolderEndpoint({
+      errorCode: 500,
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // error display
+    expect(
+      await screen.findByText("Error importing Google Sheets"),
+    ).toBeInTheDocument();
+
+    setupGdriveGetFolderEndpoint({
+      status: "syncing",
+      created_by_id: USER_ID,
+    });
+
+    // trigger settings update
+    await userEvent.click(await screen.findByText("Test Settings Update"));
+
+    // syncing state
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
   });
 
-  it("should disappear if state changes from loading to not-connected without an error", async () => {
+  it("should disappear if state changes from syncing to not-connected without an error", async () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "not-connected",
-      updatedSettingStatus: "not-connected",
+      initialFolderPayload: { status: "syncing" },
     });
 
     // initial loading state
@@ -212,9 +248,7 @@ describe("GsheetsSyncStatus", () => {
 
   it("should not show the sync component if the user did not connect the folder", async () => {
     setup({
-      settingStatus: "loading",
-      folderStatus: "loading",
-      createdById: 99,
+      initialFolderPayload: { status: "syncing", created_by_id: 99 },
     });
 
     await screen.findByText("Test Settings Update");

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.unit.spec.tsx
@@ -171,7 +171,7 @@ describe("GsheetsSyncStatus", () => {
     screen.getByText("Files sync every 15 minutes");
   });
 
-  it("should show errors", async () => {
+  it("should show error from error response", async () => {
     setup({
       initialFolderPayload: { status: "syncing" },
     });
@@ -183,6 +183,31 @@ describe("GsheetsSyncStatus", () => {
 
     setupGdriveGetFolderEndpoint({
       errorCode: 500,
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // error state
+    expect(
+      await screen.findByText(/Error importing Google Sheets/),
+    ).toBeInTheDocument();
+  });
+
+  it("should show from error status", async () => {
+    setup({
+      initialFolderPayload: { status: "syncing" },
+    });
+
+    // initial loading state
+    expect(
+      await screen.findByText("Importing Google Sheets..."),
+    ).toBeInTheDocument();
+
+    setupGdriveGetFolderEndpoint({
+      status: "error",
+      created_by_id: USER_ID,
     });
 
     await act(() => {

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/constants.ts
@@ -1,2 +1,1 @@
-export const SYNC_INTERVAL_MINUTES = 15;
 export const SYNC_POLL_INTERVAL = 3 * 1000; // 3 seconds

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/constants.ts
@@ -1,1 +1,2 @@
 export const SYNC_INTERVAL_MINUTES = 15;
+export const SYNC_POLL_INTERVAL = 3 * 1000; // 3 seconds

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/constants.ts
@@ -1,0 +1,1 @@
+export const SYNC_INTERVAL_MINUTES = 15;

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
@@ -1,24 +1,22 @@
 import { skipToken } from "metabase/api";
-import { useSetting } from "metabase/common/hooks";
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { useGetServiceAccountQuery } from "metabase-enterprise/api";
 
 export function useShowGdrive() {
-  const gSheetsSetting = useSetting("gsheets");
   const gSheetsEnabled = useSetting("show-google-sheets-integration");
+  const hasDwh = useHasTokenFeature("attached_dwh");
   const userIsAdmin = useSelector(getUserIsAdmin);
 
-  const shouldGetServiceAccount = gSheetsEnabled && userIsAdmin;
+  const shouldGetServiceAccount = gSheetsEnabled && userIsAdmin && hasDwh;
 
-  const { data: { email: serviceAccountEmail } = {} } =
-    useGetServiceAccountQuery(shouldGetServiceAccount ? undefined : skipToken);
+  const { data: serviceAccount } = useGetServiceAccountQuery(
+    shouldGetServiceAccount ? undefined : skipToken,
+  );
 
   const showGdrive = Boolean(
-    gSheetsEnabled &&
-      gSheetsSetting?.status &&
-      userIsAdmin &&
-      serviceAccountEmail,
+    hasDwh && gSheetsEnabled && userIsAdmin && serviceAccount?.email,
   );
 
   return showGdrive;

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
@@ -1,8 +1,11 @@
+import { P, match } from "ts-pattern";
+
 import { skipToken } from "metabase/api";
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { useGetServiceAccountQuery } from "metabase-enterprise/api";
+import type { GdrivePayload } from "metabase-types/api";
 
 export function useShowGdrive() {
   const gSheetsEnabled = useSetting("show-google-sheets-integration");
@@ -21,3 +24,16 @@ export function useShowGdrive() {
 
   return showGdrive;
 }
+
+export const getStatus = ({
+  status,
+  error,
+}: {
+  status: GdrivePayload["status"] | undefined;
+  error: unknown | undefined;
+}): GdrivePayload["status"] =>
+  match({ error: !!error, status })
+    .returnType<GdrivePayload["status"]>()
+    .with({ error: true }, () => "error")
+    .with({ status: P.string.minLength(1) }, ({ status }) => status)
+    .otherwise(() => "not-connected");

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
@@ -1,4 +1,5 @@
 import { P, match } from "ts-pattern";
+import { t } from "ttag";
 
 import { skipToken } from "metabase/api";
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
@@ -37,3 +38,41 @@ export const getStatus = ({
     .with({ error: true }, () => "error")
     .with({ status: P.string.minLength(1) }, ({ status }) => status)
     .otherwise(() => "not-connected");
+
+export const getErrorMessage = (
+  payload:
+    | unknown
+    | string
+    | { data: { message: string } | string }
+    | { message: string },
+  fallback: string = t`Something went wrong`,
+): string => {
+  if (!payload || typeof payload !== "object") {
+    return fallback;
+  }
+
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  if ("message" in payload && typeof payload.message === "string") {
+    return payload.message;
+  }
+
+  if ("data" in payload) {
+    const data = payload.data;
+    if (typeof data === "string") {
+      return data;
+    }
+    if (
+      typeof data === "object" &&
+      data &&
+      "message" in data &&
+      typeof data.message === "string"
+    ) {
+      return data.message;
+    }
+  }
+
+  return fallback;
+};

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
@@ -43,35 +43,29 @@ export const getErrorMessage = (
   payload:
     | unknown
     | string
-    | { data: { message: string } | string }
-    | { message: string },
+    | { data: { message: string } | { error_message: string } | string }
+    | { message: string }
+    | { error_message: string },
   fallback: string = t`Something went wrong`,
 ): string => {
-  if (!payload || typeof payload !== "object") {
-    return fallback;
-  }
-
   if (typeof payload === "string") {
     return payload;
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return fallback;
   }
 
   if ("message" in payload && typeof payload.message === "string") {
     return payload.message;
   }
 
+  if ("error_message" in payload && typeof payload.error_message === "string") {
+    return payload.error_message;
+  }
+
   if ("data" in payload) {
-    const data = payload.data;
-    if (typeof data === "string") {
-      return data;
-    }
-    if (
-      typeof data === "object" &&
-      data &&
-      "message" in data &&
-      typeof data.message === "string"
-    ) {
-      return data.message;
-    }
+    return getErrorMessage(payload.data, fallback);
   }
 
   return fallback;

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
@@ -29,8 +29,8 @@ export const getStatus = ({
   status,
   error,
 }: {
-  status: GdrivePayload["status"] | undefined;
-  error: unknown | undefined;
+  status: GdrivePayload["status"] | undefined | null;
+  error?: unknown | null;
 }): GdrivePayload["status"] =>
   match({ error: !!error, status })
     .returnType<GdrivePayload["status"]>()

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.unit.spec.ts
@@ -1,0 +1,51 @@
+import { getStatus } from "./utils";
+
+describe("google_drive > getStatus", () => {
+  it("should return 'not-connected' if status is undefined", () => {
+    const result = getStatus({ status: undefined, error: undefined });
+    expect(result).toEqual("not-connected");
+  });
+
+  it("should return 'not-connected' if status is an empty string", () => {
+    // @ts-expect-error - testing invalid case
+    const result = getStatus({ status: "", error: undefined });
+    expect(result).toEqual("not-connected");
+  });
+
+  it("should return 'not-connected' if status is null", () => {
+    const result = getStatus({ status: null, error: undefined });
+    expect(result).toEqual("not-connected");
+  });
+
+  it("should return 'error' if error is truthy", () => {
+    // @ts-expect-error - testing invalid case
+    const result = getStatus({ status: "some-status", error: new Error() });
+    expect(result).toEqual("error");
+  });
+
+  it("should return 'error' if status is status is error", () => {
+    const result = getStatus({ status: "error" });
+    expect(result).toEqual("error");
+  });
+
+  it("should return 'syncing' if status is status is syncing", () => {
+    const result = getStatus({ status: "syncing" });
+    expect(result).toEqual("syncing");
+  });
+
+  it("should return 'active' if status is status is active", () => {
+    const result = getStatus({ status: "active" });
+    expect(result).toEqual("active");
+  });
+
+  it("should return 'not-connected' if status is status is not-connected", () => {
+    const result = getStatus({ status: "not-connected" });
+    expect(result).toEqual("not-connected");
+  });
+
+  it("should return the status if status is an invalid non-empty string", () => {
+    // @ts-expect-error - testing invalid case
+    const result = getStatus({ status: "some-status", error: undefined });
+    expect(result).toEqual("some-status");
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getStatus } from "./utils";
+import { getErrorMessage, getStatus } from "./utils";
 
 describe("google_drive > getStatus", () => {
   it("should return 'not-connected' if status is undefined", () => {
@@ -47,5 +47,59 @@ describe("google_drive > getStatus", () => {
     // @ts-expect-error - testing invalid case
     const result = getStatus({ status: "some-status", error: undefined });
     expect(result).toEqual("some-status");
+  });
+
+  describe("getErrorMessage", () => {
+    it("should return a message from a string payload", () => {
+      const result = getErrorMessage("Some error message");
+      expect(result).toEqual("Some error message");
+    });
+
+    it("should return a message from an object payload with a message property", () => {
+      const result = getErrorMessage({ message: "Some error message" });
+      expect(result).toEqual("Some error message");
+    });
+
+    it("should return a message from an object payload with an error_message property", () => {
+      const result = getErrorMessage({ error_message: "Some error message" });
+      expect(result).toEqual("Some error message");
+    });
+
+    it("should return a message from a data.message property", () => {
+      const result = getErrorMessage({
+        data: { message: "Some error message" },
+      });
+      expect(result).toEqual("Some error message");
+    });
+
+    it("should return a message from data.error_message", () => {
+      const result = getErrorMessage({
+        data: { error_message: "Some error message" },
+      });
+      expect(result).toEqual("Some error message");
+    });
+
+    it("should return a message from an object payload with a data property containing a string", () => {
+      const result = getErrorMessage({ data: "Some error message" });
+      expect(result).toEqual("Some error message");
+    });
+
+    it("should return a fallback message if no message is found", () => {
+      const result = getErrorMessage(
+        { data: { not_message: "some message" } },
+        "Fallback message",
+      );
+      expect(result).toEqual("Fallback message");
+    });
+
+    it("should return a fallback message if payload is null", () => {
+      const result = getErrorMessage(null, "Fallback message");
+      expect(result).toEqual("Fallback message");
+    });
+
+    it("should return a default fallback message if payload is null", () => {
+      const result = getErrorMessage(null);
+      expect(result).toEqual("Something went wrong");
+    });
   });
 });

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -202,7 +202,7 @@ export const createMockSettings = (
   "enable-xrays": false,
   engines: createMockEngines(),
   "example-dashboard-id": 1,
-  gsheets: { status: "not-connected", folder_url: null },
+  gsheets: {},
   "humanization-strategy": "simple",
   "has-user-setup": true,
   "hide-embed-branding?": true,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -142,6 +142,18 @@ export type LoadingMessage =
 
 export type TokenStatusStatus = "unpaid" | "past-due" | "invalid" | string;
 
+export type GdrivePayload = {
+  status: "not-connected" | "syncing" | "active" | "error";
+  folder_url?: string;
+  created_at?: number;
+  created_by_id?: UserId;
+  sync_started_at?: number;
+  last_sync_at?: number;
+  next_sync_at?: number;
+  db_id?: number;
+  error?: string;
+};
+
 const tokenStatusFeatures = [
   "advanced-config",
   "advanced-permissions",
@@ -332,13 +344,7 @@ interface AdminSettings {
   "embedding-homepage": EmbeddingHomepageStatus;
   "setup-license-active-at-setup": boolean;
   "store-url": string;
-  gsheets: {
-    status: "not-connected" | "loading" | "complete" | "error";
-    folder_url: string | null;
-    error?: string;
-    db_id?: number | null;
-    "folder-upload-time"?: number | null; // timestamp
-  };
+  gsheets: Partial<GdrivePayload>;
 }
 interface SettingsManagerSettings {
   "bcc-enabled?": boolean;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -332,6 +332,13 @@ interface AdminSettings {
   "embedding-homepage": EmbeddingHomepageStatus;
   "setup-license-active-at-setup": boolean;
   "store-url": string;
+  gsheets: {
+    status: "not-connected" | "loading" | "complete" | "error";
+    folder_url: string | null;
+    error?: string;
+    db_id?: number | null;
+    "folder-upload-time"?: number | null; // timestamp
+  };
 }
 interface SettingsManagerSettings {
   "bcc-enabled?": boolean;
@@ -375,12 +382,6 @@ interface PublicSettings {
   engines: Record<string, Engine>;
   "google-auth-client-id": string | null;
   "google-auth-enabled": boolean;
-  gsheets: {
-    status: "not-connected" | "loading" | "complete" | "error";
-    folder_url: string | null;
-    error?: string;
-    "created-by-id"?: UserId;
-  };
   "has-user-setup": boolean;
   "help-link": HelpLinkSetting;
   "help-link-custom-destination": string;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -151,6 +151,7 @@ export type GdrivePayload = {
   sync_started_at?: number;
   last_sync_at?: number;
   next_sync_at?: number;
+  error_message?: string;
   db_id?: number;
   error?: string;
 };

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -145,6 +145,7 @@ export type TokenStatusStatus = "unpaid" | "past-due" | "invalid" | string;
 export type GdrivePayload = {
   status: "not-connected" | "syncing" | "active" | "error";
   url?: string;
+  message?: string; // only for errors
   created_at?: number;
   created_by_id?: UserId;
   sync_started_at?: number;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -144,7 +144,7 @@ export type TokenStatusStatus = "unpaid" | "past-due" | "invalid" | string;
 
 export type GdrivePayload = {
   status: "not-connected" | "syncing" | "active" | "error";
-  folder_url?: string;
+  url?: string;
   created_at?: number;
   created_by_id?: UserId;
   sync_started_at?: number;

--- a/frontend/src/metabase/nav/containers/MainNavbar/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/tests/premium.unit.spec.tsx
@@ -1,6 +1,9 @@
 import userEvent from "@testing-library/user-event";
 
-import { setupGdriveServiceAccountEndpoint } from "__support__/server-mocks";
+import {
+  setupGdriveGetFolderEndpoint,
+  setupGdriveServiceAccountEndpoint,
+} from "__support__/server-mocks";
 import { screen, within } from "__support__/ui";
 import { createMockUser } from "metabase-types/api/mocks";
 
@@ -8,6 +11,7 @@ import { type SetupOpts, setup } from "./setup";
 
 function setupPremium(opts: SetupOpts) {
   setupGdriveServiceAccountEndpoint();
+  setupGdriveGetFolderEndpoint({ status: "not-connected" });
   return setup({
     hasEnterprisePlugins: true,
     hasDWHAttached: true,

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   setupCollectionItemsEndpoint,
   setupCollectionsEndpoints,
   setupDatabasesEndpoints,
+  setupGdriveGetFolderEndpoint,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
 import {
@@ -58,6 +59,7 @@ async function setup({
     collection: createMockCollection(ROOT_COLLECTION),
     collectionItems: [],
   });
+  setupGdriveGetFolderEndpoint({ status: "active" });
   fetchMock.get("path:/api/bookmark", []);
 
   const storeInitialState = createMockState({

--- a/frontend/test/__support__/server-mocks/gdrive.ts
+++ b/frontend/test/__support__/server-mocks/gdrive.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import fetchMock from "fetch-mock";
 
 import type { Settings } from "metabase-types/api";
@@ -5,21 +6,32 @@ import type { Settings } from "metabase-types/api";
 type Props =
   | {
       status?: never;
+      "folder-upload-time"?: never;
       errorCode: number;
     }
   | {
       status: Settings["gsheets"]["status"];
+      "folder-upload-time"?: number;
       errorCode?: never;
     };
 
-export function setupGdriveGetFolderEndpoint({ status, errorCode }: Props) {
+export function setupGdriveGetFolderEndpoint({
+  status,
+  errorCode,
+  "folder-upload-time": uploadTime,
+}: Props) {
   if (status) {
-    fetchMock.get("path:/api/ee/gsheets/folder", () => {
-      return {
-        status,
-        db_id: 1,
-      };
-    });
+    fetchMock.get(
+      "path:/api/ee/gsheets/folder",
+      () => {
+        return {
+          status,
+          db_id: 1,
+          "folder-upload-time": uploadTime ?? dayjs().unix(),
+        };
+      },
+      { overwriteRoutes: true },
+    );
   }
 
   if (errorCode) {
@@ -35,6 +47,8 @@ export function setupGdriveServiceAccountEndpoint(
   });
 }
 
-export function setupGdrivePostFolderEndpoint() {
-  fetchMock.post("path:/api/ee/gsheets/folder", { status: 202 });
+export function setupGdriveSyncEndpoint() {
+  fetchMock.post("path:/api/ee/gsheets/folder/sync", () => {
+    return { db_id: 1 };
+  });
 }

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -11,6 +11,7 @@ export * from "./collection";
 export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
+s;
 export * from "./dataset";
 export * from "./email";
 export * from "./field";

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -11,7 +11,6 @@ export * from "./collection";
 export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
-s;
 export * from "./dataset";
 export * from "./email";
 export * from "./field";

--- a/frontend/test/__support__/server-mocks/util.ts
+++ b/frontend/test/__support__/server-mocks/util.ts
@@ -3,3 +3,23 @@ import fetchMock from "fetch-mock";
 export function setupPasswordCheckEndpoint() {
   fetchMock.post("path:/api/util/password_check", 204);
 }
+
+type ResponseInfo = {
+  url: string;
+  body: any;
+};
+
+export async function findRequests(
+  method: "PUT" | "POST" | "GET" | "DELETE",
+): Promise<ResponseInfo[]> {
+  const calls = fetchMock.calls();
+  const data = calls.filter((call) => call[1]?.method === method) ?? [];
+
+  const posts = data.map(async ([url, putDetails]) => {
+    const body = ((await putDetails?.body) as string) ?? "{}";
+
+    return { url, body: JSON.parse(body ?? "{}") };
+  });
+
+  return Promise.all(posts);
+}

--- a/frontend/test/__support__/server-mocks/util.ts
+++ b/frontend/test/__support__/server-mocks/util.ts
@@ -15,11 +15,11 @@ export async function findRequests(
   const calls = fetchMock.calls();
   const data = calls.filter((call) => call[1]?.method === method) ?? [];
 
-  const posts = data.map(async ([url, putDetails]) => {
-    const body = ((await putDetails?.body) as string) ?? "{}";
+  const reqs = data.map(async ([url, details]) => {
+    const body = ((await details?.body) as string) ?? "{}";
 
     return { url, body: JSON.parse(body ?? "{}") };
   });
 
-  return Promise.all(posts);
+  return Promise.all(reqs);
 }


### PR DESCRIPTION
> [!Note]
> depends on https://github.com/metabase/metabase/pull/54940

## Description

In some ways, this is substantial rewrite. 
- We changed the backend api payload shape significantly
- We stopped relying on setting state, and instead, rely exclusively on state from `/api/ee/gshhets/folder` - this helped eliminate quite a few bugs

This also enhances existing UI by:
- converting the db gsheets button on the database page to a menu when a folder is connected
- shows sync status in the menu
- allow manual re-syncs in the menu

![Screenshot 2025-03-21 at 9 59 59 AM](https://github.com/user-attachments/assets/6286a3f1-0a62-4137-96e3-329933fd56ad)

![i-love-filipe](https://github.com/user-attachments/assets/21630e4e-9c6a-49f8-9e86-a9d7d0ff0e08)

We even got error states!

![Screenshot 2025-04-15 at 12 18 21 PM](https://github.com/user-attachments/assets/cf9a48a2-95d7-4296-900f-d8d6bd90f149)

