### PR TITLE
Use field refs instead of field ids/names for tiles queries

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
@@ -43,10 +43,12 @@ export default class LeafletTilePinMap extends LeafletMap {
       return;
     }
 
-    const latFieldParam =
-      latitudeField.id || encodeURIComponent(latitudeField.name);
-    const lonFieldParam =
-      longitudeField.id || encodeURIComponent(longitudeField.name);
+    const latFieldParam = encodeURIComponent(
+      JSON.stringify(latitudeField.field_ref),
+    );
+    const lonFieldParam = encodeURIComponent(
+      JSON.stringify(longitudeField.field_ref),
+    );
 
     const { dashboard, dashcard, uuid, token } = this.props;
 

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -387,7 +387,9 @@
        [:parameters {:optional true} ms/JSONString]]]
   (let [unsigned   (unsign-and-translate-ids token)
         card-id    (embed/get-in-unsigned-token-or-throw unsigned [:resource :question])
-        parameters (json/decode+kw parameters)]
+        parameters (json/decode+kw parameters)
+        lat-field    (json/decode+kw lat-field)
+        lon-field    (json/decode+kw lon-field)]
     (api.embed.common/check-embedding-enabled-for-card card-id)
     (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field)))
 
@@ -405,5 +407,7 @@
        [:parameters {:optional true} ms/JSONString]]]
   (let [unsigned     (unsign-and-translate-ids token)
         dashboard-id (embed/get-in-unsigned-token-or-throw unsigned [:resource :dashboard])
-        parameters   (json/decode+kw parameters)]
+        parameters   (json/decode+kw parameters)
+        lat-field    (json/decode+kw lat-field)
+        lon-field    (json/decode+kw lon-field)]
     (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field)))

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -737,7 +737,9 @@
        [:parameters {:optional true} ms/JSONString]]]
   (validation/check-public-sharing-enabled)
   (let [card-id    (api/check-404 (t2/select-one-pk :model/Card :public_uuid uuid, :archived false))
-        parameters (json/decode+kw parameters)]
+        parameters (json/decode+kw parameters)
+        lat-field  (json/decode+kw lat-field)
+        lon-field  (json/decode+kw lon-field)]
     (request/as-admin
       (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))))
 
@@ -756,7 +758,9 @@
        [:parameters {:optional true} ms/JSONString]]]
   (validation/check-public-sharing-enabled)
   (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))
-        parameters   (json/decode+kw parameters)]
+        parameters   (json/decode+kw parameters)
+        lat-field    (json/decode+kw lat-field)
+        lon-field    (json/decode+kw lon-field)]
     (request/as-admin
       (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))
 

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -135,21 +135,6 @@
 
 ;;; ---------------------------------------------------- ENDPOINTS ----------------------------------------------------
 
-(defn- int-or-string
-  "Parse a string into an integer if it can be otherwise return the string. Intended to determine whether something is a
-  field id or a field name."
-  [x]
-  (if (re-matches #"\d+" x)
-    (Integer/parseInt x)
-    x))
-
-(defn- field-ref
-  "Makes a field reference for `id-or-name`. If id, the type information can be determined, if a string, must be
-  provided. Since we deal exclusively with lat/long fields, assumed to be a float."
-  [id-or-name]
-  (let [id-or-name' (int-or-string id-or-name)]
-    [:field id-or-name' (when (string? id-or-name') {:base-type :type/Float})]))
-
 (defn- tiles-query
   "Transform a card's query into a query finding coordinates in a particular region.
 
@@ -157,10 +142,8 @@
   - add [:inside lat lon bounding-region coordings] filter
   - limit query results to `tile-coordinate-limit` number of results
   - only select lat and lon fields rather than entire query's fields"
-  [query zoom x y lat-field lon-field]
-  (let [query         (mbql.normalize/normalize query)
-        lat-field-ref (field-ref lat-field)
-        lon-field-ref (field-ref lon-field)]
+  [query zoom x y lat-field-ref lon-field-ref]
+  (let [query (mbql.normalize/normalize query)]
     (-> query
         native->source-query
         (update :query query-with-inside-filter
@@ -176,16 +159,16 @@
 
 (mr/def :api.tiles/route-params
   [:map
-   [:zoom        ms/Int]
-   [:x           ms/Int]
-   [:y           ms/Int]
-   [:lat-field   :api.tiles/field-id-or-name]
-   [:lon-field   :api.tiles/field-id-or-name]])
+   [:zoom      ms/Int]
+   [:x         ms/Int]
+   [:y         ms/Int]
+   [:lat-field :string]
+   [:lon-field :string]])
 
 (defn- result->points
-  [{{:keys [rows cols]} :data} lat-field lon-field]
-  (let [lat-key (qp.util/field-ref->key (field-ref lat-field))
-        lon-key (qp.util/field-ref->key (field-ref lon-field))
+  [{{:keys [rows cols]} :data} lat-field-ref lon-field-ref]
+  (let [lat-key (qp.util/field-ref->key lat-field-ref)
+        lon-key (qp.util/field-ref->key lon-field-ref)
         find-fn (fn [lat-or-lon-key]
                   (first (keep-indexed
                           (fn [idx col] (when (= (qp.util/field-ref->key (:field_ref col)) lat-or-lon-key) idx))
@@ -217,6 +200,8 @@
    {:keys [query]} :- [:map
                        [:query ms/JSONString]]]
   (let [query         (json/decode+kw query)
+        lat-field     (mbql.normalize/normalize (json/decode+kw lat-field))
+        lon-field     (mbql.normalize/normalize (json/decode+kw lon-field))
         updated-query (tiles-query query zoom x y lat-field lon-field)
         result        (qp/process-query
                        (qp/userland-query updated-query {:executed-by api/*current-user-id*
@@ -226,7 +211,7 @@
 
 (defn process-tiles-query-for-card
   "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
-  [card-id parameters zoom x y lat-field lon-field]
+  [card-id parameters zoom x y lat-field-ref lon-field-ref]
   (let [result
         (qp.card/process-query-for-card
          card-id
@@ -237,15 +222,15 @@
                        (fn [query info]
                          (-> query
                              (update :info merge info)
-                             (tiles-query zoom x y lat-field lon-field)
+                             (tiles-query zoom x y lat-field-ref lon-field-ref)
                              qp/userland-query
                              qp/process-query)))})
-        points (result->points result lat-field lon-field)]
+        points (result->points result lat-field-ref lon-field-ref)]
     (tiles-response result zoom points)))
 
 (defn process-tiles-query-for-dashcard
   "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
-  [dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field]
+  [dashboard-id dashcard-id card-id parameters zoom x y lat-field-ref lon-field-ref]
   (let [result
         (qp.dashboard/process-query-for-dashcard
          :dashboard-id  dashboard-id
@@ -258,10 +243,10 @@
                          (fn [query info]
                            (-> query
                                (update :info merge info)
-                               (tiles-query zoom x y lat-field lon-field)
+                               (tiles-query zoom x y lat-field-ref lon-field-ref)
                                qp/userland-query
                                qp/process-query))))
-        points (result->points result lat-field lon-field)]
+        points (result->points result lat-field-ref lon-field-ref)]
     (tiles-response result zoom points)))
 
 (api.macros/defendpoint :get "/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
@@ -274,7 +259,9 @@
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
-  (let [parameters (json/decode+kw parameters)]
+  (let [parameters (json/decode+kw parameters)
+        lat-field  (mbql.normalize/normalize (json/decode+kw lat-field))
+        lon-field  (mbql.normalize/normalize (json/decode+kw lon-field))]
     (process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field)))
 
 (api.macros/defendpoint :get "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
@@ -289,5 +276,7 @@
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
-  (let [parameters (json/decode+kw parameters)]
+  (let [parameters (json/decode+kw parameters)
+        lat-field  (mbql.normalize/normalize (json/decode+kw lat-field))
+        lon-field  (mbql.normalize/normalize (json/decode+kw lon-field))]
     (process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field)))

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -212,7 +212,9 @@
 (defn process-tiles-query-for-card
   "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
   [card-id parameters zoom x y lat-field-ref lon-field-ref]
-  (let [result
+  (let [lat-field-ref (mbql.normalize/normalize lat-field-ref)
+        lon-field-ref (mbql.normalize/normalize lon-field-ref)
+        result
         (qp.card/process-query-for-card
          card-id
          :api
@@ -231,7 +233,9 @@
 (defn process-tiles-query-for-dashcard
   "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
   [dashboard-id dashcard-id card-id parameters zoom x y lat-field-ref lon-field-ref]
-  (let [result
+  (let [lat-field-ref (mbql.normalize/normalize lat-field-ref)
+        lon-field-ref (mbql.normalize/normalize lon-field-ref)
+        result
         (qp.dashboard/process-query-for-dashcard
          :dashboard-id  dashboard-id
          :dashcard-id   dashcard-id
@@ -260,8 +264,8 @@
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
   (let [parameters (json/decode+kw parameters)
-        lat-field  (mbql.normalize/normalize (json/decode+kw lat-field))
-        lon-field  (mbql.normalize/normalize (json/decode+kw lon-field))]
+        lat-field  (json/decode+kw lat-field)
+        lon-field  (json/decode+kw lon-field)]
     (process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field)))
 
 (api.macros/defendpoint :get "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
@@ -277,6 +281,6 @@
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
   (let [parameters (json/decode+kw parameters)
-        lat-field  (mbql.normalize/normalize (json/decode+kw lat-field))
-        lon-field  (mbql.normalize/normalize (json/decode+kw lon-field))]
+        lat-field  (json/decode+kw lat-field)
+        lon-field  (json/decode+kw lon-field)]
     (process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field)))

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -24,6 +24,7 @@
    [metabase.query-processor.pivot.test-util :as api.pivots]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
+   [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
    [toucan2.core :as t2])
   (:import
@@ -2090,10 +2091,10 @@
                                                 :enable_embedding true}]
         (let [token (card-token card-id)]
           (is (png? (mt/user-http-request
-                     :crowberto :get 200 (format "embed/tiles/card/%s/1/1/1/%d/%d"
+                     :crowberto :get 200 (format "embed/tiles/card/%s/1/1/1/%s/%s"
                                                  token
-                                                 (mt/id :people :latitude)
-                                                 (mt/id :people :longitude))))))))))
+                                                 (tiles.api-test/encoded-lat-field-ref)
+                                                 (tiles.api-test/encoded-lon-field-ref))))))))))
 
 (deftest dashcard-tile-query-test
   (testing "GET api/embed/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
@@ -2105,9 +2106,9 @@
                                                               :dashboard_id dashboard-id}]
         (let [token (dash-token dashboard-id)]
           (is (png? (mt/user-http-request
-                     :crowberto :get 200 (format "embed/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1/%d/%d"
+                     :crowberto :get 200 (format "embed/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1/%s/%s"
                                                  token
                                                  dashcard-id
                                                  card-id
-                                                 (mt/id :people :latitude)
-                                                 (mt/id :people :longitude))))))))))
+                                                 (tiles.api-test/encoded-lat-field-ref)
+                                                 (tiles.api-test/encoded-lon-field-ref))))))))))

--- a/test/metabase/public_sharing/api_test.clj
+++ b/test/metabase/public_sharing/api_test.clj
@@ -24,6 +24,7 @@
    [metabase.query-processor.pivot.test-util :as api.pivots]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
+   [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [throttle.core :as throttle]
@@ -2034,10 +2035,10 @@
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (mt/with-temp [:model/Card _card {:dataset_query (venues-query)
                                           :public_uuid uuid}]
-          (is (png? (client/client :get 200 (format "public/tiles/card/%s/1/1/1/%d/%d"
+          (is (png? (client/client :get 200 (format "public/tiles/card/%s/1/1/1/%s/%s"
                                                     uuid
-                                                    (mt/id :people :latitude)
-                                                    (mt/id :people :longitude))))))))))
+                                                    (tiles.api-test/encoded-lat-field-ref)
+                                                    (tiles.api-test/encoded-lon-field-ref))))))))))
 
 (deftest dashcard-tile-query-test
   (testing "GET api/public/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
@@ -2047,12 +2048,12 @@
                        :model/Card          {card-id :id}      {:dataset_query (venues-query)}
                        :model/DashboardCard {dashcard-id :id}  {:card_id card-id
                                                                 :dashboard_id dashboard-id}]
-          (is (png? (client/client :get 200 (format "public/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1/%d/%d"
+          (is (png? (client/client :get 200 (format "public/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1/%s/%s"
                                                     uuid
                                                     dashcard-id
                                                     card-id
-                                                    (mt/id :people :latitude)
-                                                    (mt/id :people :longitude))))))))))
+                                                    (tiles.api-test/encoded-lat-field-ref)
+                                                    (tiles.api-test/encoded-lon-field-ref))))))))))
 
 ;;; --------------------------------- POST /oembed ----------------------------------
 

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -6,7 +6,8 @@
    [metabase.test :as mt]
    [metabase.tiles.api :as api.tiles]
    [metabase.util :as u]
-   [metabase.util.json :as json]))
+   [metabase.util.json :as json]
+   [ring.util.codec :as codec]))
 
 ;; TODO: Assert on the contents of the response, not just the format
 (defn png? [s]
@@ -40,18 +41,26 @@
                                        :type         "text"
                                        :required     false}}}})
 
+(defn- encoded-lat-field-ref
+  []
+  (codec/url-encode (json/encode (mt/$ids $people.latitude))))
+
+(defn- encoded-lon-field-ref
+  []
+  (codec/url-encode (json/encode (mt/$ids $people.longitude))))
+
 (deftest ad-hoc-query-test
   (testing "GET /api/tiles/:zoom/:x/:y/:lat-field/:lon-field"
     (is (png? (mt/user-http-request
-               :crowberto :get 200 (format "tiles/4/2/4/%d/%d"
-                                           (mt/id :people :latitude)
-                                           (mt/id :people :longitude))
+               :crowberto :get 200 (format "tiles/4/2/4/%s/%s"
+                                           (encoded-lat-field-ref)
+                                           (encoded-lon-field-ref))
                :query (json/encode (venues-query))))))
   (testing "Works on native queries"
     (is (png? (mt/user-http-request
                :crowberto :get 200 (format "tiles/1/1/1/%s/%s"
-                                           "LATITUDE"
-                                           "LONGITUDE")
+                                           (encoded-lat-field-ref)
+                                           (encoded-lon-field-ref))
                :query (json/encode (native-query)))))))
 
 (deftest saved-card-test
@@ -59,10 +68,10 @@
     (testing "MBQL saved card"
       (mt/with-temp [:model/Card card {:dataset_query (venues-query)}]
         (is (png? (mt/user-http-request
-                   :crowberto :get 200 (format "tiles/%d/1/1/1/%d/%d"
+                   :crowberto :get 200 (format "tiles/%d/1/1/1/%s/%s"
                                                (u/id card)
-                                               (mt/id :people :latitude)
-                                               (mt/id :people :longitude)))))))
+                                               (encoded-lat-field-ref)
+                                               (encoded-lon-field-ref)))))))
 
     (testing "Native saved card"
       (mt/with-temp [:model/Card card {:dataset_query (native-query)}]
@@ -70,7 +79,8 @@
           (is (png? (mt/user-http-request
                      :crowberto :get 200 (format "tiles/%d/1/1/1/%s/%s"
                                                  (u/id card)
-                                                 "LATITUDE" "LONGITUDE")))))))
+                                                 (encoded-lat-field-ref)
+                                                 (encoded-lon-field-ref))))))))
 
     (testing "Parameterized native saved card"
       (mt/with-temp [:model/Card card {:dataset_query (parameterized-native-query)}]
@@ -78,8 +88,8 @@
           (is (png? (mt/user-http-request
                      :crowberto :get 200 (format "tiles/%d/1/1/1/%s/%s"
                                                  (u/id card)
-                                                 "LATITUDE"
-                                                 "LONGITUDE")
+                                                 (encoded-lat-field-ref)
+                                                 (encoded-lon-field-ref))
                      :parameters (json/encode [{:type :text
                                                 :target [:variable [:template-tag :state]]
                                                 :value "CA"}])))))))))
@@ -92,12 +102,12 @@
                      :model/DashboardCard {dashcard-id :id}  {:card_id card-id
                                                               :dashboard_id dashboard-id}]
         (is (png? (mt/user-http-request
-                   :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%d/%d"
+                   :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
                                                dashboard-id
                                                dashcard-id
                                                card-id
-                                               (mt/id :people :latitude)
-                                               (mt/id :people :longitude)))))))
+                                               (encoded-lat-field-ref)
+                                               (encoded-lon-field-ref)))))))
 
     (testing "Native dashcard"
       (mt/with-temp [:model/Dashboard     {dashboard-id :id} {}
@@ -110,8 +120,8 @@
                                                  dashboard-id
                                                  dashcard-id
                                                  card-id
-                                                 "LATITUDE"
-                                                 "LONGITUDE")))))))))
+                                                 (encoded-lat-field-ref)
+                                                 (encoded-lon-field-ref))))))))))
 
 (deftest parameterized-dashcard-test
   (testing "Parameterized mbql dashcard"
@@ -131,8 +141,8 @@
                                                dashboard-id
                                                dashcard-id
                                                card-id
-                                               (mt/id :people :latitude)
-                                               (mt/id :people :longitude))
+                                               (encoded-lat-field-ref)
+                                               (encoded-lon-field-ref))
                    :parameters (json/encode [{:id "_STATE_"
                                               :value ["CA"]}])))))))
 
@@ -153,8 +163,8 @@
                                                dashboard-id
                                                dashcard-id
                                                card-id
-                                               "LATITUDE"
-                                               "LONGITUDE")
+                                               (encoded-lat-field-ref)
+                                               (encoded-lon-field-ref))
                    :parameters (json/encode [{:id "_STATE_"
                                               :value ["CA"]}]))))))))
 
@@ -179,7 +189,7 @@
                           :limit 2000
                           :filter [:inside [:field 574 nil] [:field 576 nil]]}
                   :type :query}
-                 (clean (#'api.tiles/tiles-query query 2 3 1 "574" "576")))))))
+                 (clean (#'api.tiles/tiles-query query 2 3 1 [:field 574 nil] [:field 576 nil])))))))
 
     (testing "native"
       (testing "nests the query, selects fields"
@@ -196,7 +206,9 @@
                                    [:field "longitude" {:base-type :type/Float}]]
                           :limit  2000}
                   :type :query}
-                 (clean (@#'api.tiles/tiles-query query 2 2 1 "latitude" "longitude")))))))))
+                 (clean (@#'api.tiles/tiles-query query 2 2 1
+                                                  [:field "latitude" {:base-type :type/Float}]
+                                                  [:field "longitude" {:base-type :type/Float}])))))))))
 
 (deftest breakout-query-test
   (testing "the appropriate lat/lon fields are selected from the results, if the query contains a :breakout clause (#20182)"
@@ -204,9 +216,9 @@
       (with-redefs [api.tiles/create-tile (fn [_ points] points)
                     api.tiles/tile->byte-array identity]
         (let [result (mt/user-http-request
-                      :crowberto :get 200 (format "tiles/7/30/49/%d/%d"
-                                                  (mt/id :people :latitude)
-                                                  (mt/id :people :longitude))
+                      :crowberto :get 200 (format "tiles/7/30/49/%s/%s"
+                                                  (encoded-lat-field-ref)
+                                                  (encoded-lon-field-ref))
                       :query (json/encode
                               (mt/mbql-query people
                                 {:breakout    [[:field (mt/id :people :latitude)]
@@ -221,14 +233,7 @@
   (testing "if the query fails, don't attempt to generate a map without any points -- the endpoint should return a 400"
     (is (=? {:status "failed"}
             (mt/user-http-request
-             :rasta :get 400 (format "tiles/1/1/1/%d/%d"
-                                     (mt/id :venues :latitude)
-                                     (mt/id :venues :longitude))
+             :rasta :get 400 (format "tiles/1/1/1/%s/%s"
+                                     (encoded-lat-field-ref)
+                                     (encoded-lon-field-ref))
              :query (json/encode (mt/mbql-query venues {:filter [:= $users.id 1]})))))))
-
-(deftest ^:parallel field-ref-test
-  (testing "Field refs can be constructed from strings representing integer field IDs or field names"
-    (is (= [:field 1 nil]
-           (@#'api.tiles/field-ref "1")))
-    (is (= [:field "Latitude" {:base-type :type/Float}]
-           (@#'api.tiles/field-ref "Latitude")))))

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -41,11 +41,13 @@
                                        :type         "text"
                                        :required     false}}}})
 
-(defn- encoded-lat-field-ref
+(defn encoded-lat-field-ref
+  "URL-encoded latitude field ref for the People table"
   []
   (codec/url-encode (json/encode (mt/$ids $people.latitude))))
 
-(defn- encoded-lon-field-ref
+(defn encoded-lon-field-ref
+  "URL-encoded longitude field ref for the People table"
   []
   (codec/url-encode (json/encode (mt/$ids $people.longitude))))
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/9421

Changes tile APIs for pin maps to accept URL-encoded field refs for latitude and longitude fields instead of raw field IDs or names. This replaces the previous implementation which would construct ad-hoc field refs based on IDs/names, which did not work for foreign key references.