### PR TITLE
Fix loki job — specify renderHook renderer explicitly

### DIFF
--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -7,7 +7,7 @@ import {
   render as testingLibraryRender,
   waitFor,
 } from "@testing-library/react";
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react-hooks/dom";
 import type { History } from "history";
 import { createMemoryHistory } from "history";
 import { KBarProvider } from "kbar";


### PR DESCRIPTION
### Description

[Slack thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1742574208153319)
Ability to run loki tests is broken starting from https://github.com/metabase/metabase/pull/55449. It fails with the following error:
`FAIL chrome.docker/FETCH_STORIES: Could not auto-detect a React renderer. Are you sure you've installed one of the following`
This is because `renderHook` is now included to the bundle without explicitly specifying renderer https://react-hooks-testing-library.com/installation#renderer

### How to verify

- run `yarn test-visual:loki` locally and ensure it runs tests 
- check loki CI jobs actually runs specs (there can be failures due to flakiness) 
