### PR TITLE
disable column reordering on raw query views

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -1,7 +1,10 @@
 const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_BY_YEAR_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > visualizations > table", () => {
   beforeEach(() => {
@@ -22,6 +25,38 @@ describe("scenarios > visualizations > table", () => {
     // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText(option).click(clickOpts);
   }
+
+  it("should not be sortable when displays raw query results (metabase#19817)", () => {
+    H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+    cy.findByLabelText("Switch to data").click();
+    const initialColumnsOrder = ["Created At: Year", "Count"];
+
+    H.assertTableData({
+      columns: initialColumnsOrder,
+    });
+
+    H.tableHeaderColumn("Count").as("countHeaderInPreview");
+    H.moveDnDKitElementByAlias("@countHeaderInPreview", { horizontal: -100 });
+
+    H.assertTableData({
+      columns: initialColumnsOrder,
+    });
+
+    H.notebookButton().click();
+
+    cy.findAllByTestId("step-preview-button").eq(1).click();
+
+    H.assertTableData({
+      columns: initialColumnsOrder,
+    });
+
+    H.tableHeaderColumn("Count").as("countHeaderInNotebook");
+    H.moveDnDKitElementByAlias("@countHeaderInNotebook", { horizontal: -100 });
+
+    H.assertTableData({
+      columns: initialColumnsOrder,
+    });
+  });
 
   it("should allow changing column title when the field ref is the same except for the join-alias", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");

--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
@@ -20,7 +20,7 @@ import {
 } from "metabase/data-grid/constants";
 import { isVirtualRow } from "metabase/data-grid/guards";
 import { DataGridThemeProvider } from "metabase/data-grid/hooks/use-table-theme";
-import type { DataGridInstance } from "metabase/data-grid/types";
+import type { DataGridInstance, DataGridTheme } from "metabase/data-grid/types";
 import { useForceUpdate } from "metabase/hooks/use-force-update";
 import { getScrollBarSize } from "metabase/lib/dom";
 
@@ -50,8 +50,9 @@ export interface DataGridProps<TData>
   extends DataGridInstance<TData>,
     DataGridStylesProps {
   emptyState?: React.ReactNode;
-  isSortingDisabled?: boolean;
   showRowsCount?: boolean;
+  isColumnReorderingDisabled?: boolean;
+  theme?: DataGridTheme;
 }
 
 export const DataGrid = function DataGrid<TData>({
@@ -65,11 +66,11 @@ export const DataGrid = function DataGrid<TData>({
   theme,
   classNames,
   styles,
-  isSortingDisabled,
   enablePagination,
   showRowsCount,
   getTotalHeight,
   getVisibleRows,
+  isColumnReorderingDisabled,
   onBodyCellClick,
   onHeaderCellClick,
   onAddColumnClick,
@@ -222,7 +223,9 @@ export const DataGrid = function DataGrid<TData>({
                             backgroundColor: stickyElementsBackgroundColor,
                             ...styles?.headerCell,
                           }}
-                          isSortingDisabled={isSortingDisabled}
+                          isColumnReorderingDisabled={
+                            isColumnReorderingDisabled
+                          }
                           header={header}
                           onClick={onHeaderCellClick}
                         >

--- a/frontend/src/metabase/data-grid/components/SortableHeader/SortableHeader.tsx
+++ b/frontend/src/metabase/data-grid/components/SortableHeader/SortableHeader.tsx
@@ -15,7 +15,7 @@ type DragPosition = { x: number; y: number };
 export interface SortableHeaderProps<TData, TValue> {
   children: React.ReactNode;
   className?: string;
-  isSortingDisabled?: boolean;
+  isColumnReorderingDisabled?: boolean;
   style?: React.CSSProperties;
   header: Header<TData, TValue>;
   onClick?: (e: React.MouseEvent<HTMLDivElement>, columnId: string) => void;
@@ -25,7 +25,7 @@ export const SortableHeader = memo(function SortableHeader<TData, TValue>({
   header,
   className,
   children,
-  isSortingDisabled,
+  isColumnReorderingDisabled,
   style: styleProp,
   onClick,
 }: SortableHeaderProps<TData, TValue>) {
@@ -38,7 +38,7 @@ export const SortableHeader = memo(function SortableHeader<TData, TValue>({
   const { attributes, isDragging, listeners, setNodeRef, transform } =
     useSortable({
       id,
-      disabled: isSortingDisabled || !!isPinned,
+      disabled: isColumnReorderingDisabled || !!isPinned,
     });
 
   const dragStartPosition = useRef<DragPosition | null>(null);

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -709,6 +709,9 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     return <div ref={ref} className={className} />;
   }
 
+  const isColumnReorderingDisabled =
+    (isDashboard || mode == null || isRawTable) && !isSettings;
+
   return (
     <div
       ref={ref}
@@ -723,8 +726,8 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
       <DataGrid
         {...tableProps}
         styles={dataGridStyles}
-        isSortingDisabled={isDashboard && !isSettings}
         showRowsCount={isDashboard}
+        isColumnReorderingDisabled={isColumnReorderingDisabled}
         emptyState={emptyState}
         onBodyCellClick={handleBodyCellClick}
         onAddColumnClick={handleAddColumnButtonClick}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #19817
Closes [VIZ-370](https://linear.app/metabase/issue/VIZ-370/disable-dragging-columns-in-raw-data-view-of-a-non-table-visualization) 

### Description

This PR disabled column reordering in
- The raw query table view (toggle in the bottom of the QB)
- Notebook step results preview 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
