### PR TITLE
Allow SegmentedControl to have colors

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.config.ts
@@ -15,12 +15,13 @@ export const segmentedControlOverrides: MantineThemeOverride["components"] = {
     classNames: {
       root: S.SegmentedControl,
       label: S.SegmentedControlLabel,
-      indicator: S.SegmentedControlIndicator,
       control: S.SegmentedControl_Control,
       input: S.SegmentedControlInput,
     },
     vars: (theme, props) => ({
       root: {
+        "--sc-active-text-color": props.c ?? "var(--mb-color-text-dark)",
+        "--sc-background-color": props.bg ?? "var(--mb-color-bg-medium)",
         "--sc-padding": props.fullWidth
           ? `${theme.spacing.sm} ${theme.spacing.md}`
           : theme.spacing.sm,

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.mdx
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.mdx
@@ -24,3 +24,9 @@ Our themed wrapper around [Mantine SegmentedControl](https://mantine.dev/core/se
 <Canvas>
   <Story of={SegmentedControlStories.FullWidth} />
 </Canvas>
+
+## Colors
+
+<Canvas>
+  <Story of={SegmentedControlStories.Color} />
+</Canvas>

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.module.css
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.module.css
@@ -1,5 +1,5 @@
 .SegmentedControl {
-  background-color: var(--mb-color-bg-medium);
+  background-color: var(--sc-background-color);
 }
 
 .SegmentedControlLabel {
@@ -20,7 +20,7 @@
   &[data-active] {
     &,
     &:hover {
-      color: var(--mb-color-text-dark);
+      color: var(--sc-active-text-color);
     }
   }
 }
@@ -38,8 +38,4 @@
       color: var(--mb-color-text-light);
     }
   }
-}
-
-.SegmentedControlIndicator {
-  background-color: var(--mb-color-bg-white);
 }

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.stories.tsx
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.stories.tsx
@@ -53,3 +53,24 @@ export const FullWidth = {
     fullWidth: true,
   },
 };
+
+export const Color = {
+  args: {
+    data: [
+      {
+        label: "Light",
+        value: "light",
+      },
+      {
+        label: "Dark",
+        value: "dark",
+      },
+      {
+        label: "Transparent",
+        value: "transparent",
+      },
+    ],
+    color: "brand",
+    c: "var(--mb-color-text-white)",
+  },
+};


### PR DESCRIPTION
## Description

The initial implementation of [SegmentedControl](https://mantine.dev/core/segmented-control/?t=styles-api) had overrides that prevented the `color` prop from having any effect. This adds the ability to customize
- indicator color
- active text color, and
- background color

while maintaining the same defaults

Default | brand
-- | --
![Screenshot 2025-03-21 at 2 21 26 PM](https://github.com/user-attachments/assets/5df55e8e-7b97-4050-8397-09897ca650e4) | ![Screenshot 2025-03-21 at 2 17 44 PM](https://github.com/user-attachments/assets/8b6e8ec7-8a50-49c1-94b6-d4072a75d286)

