### PR TITLE
Allow toggling folder/sheet import for gsheets

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
@@ -21,7 +21,7 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
     }),
     saveGsheetsFolderLink: builder.mutation<
       { success: boolean },
-      { url: string }
+      { url: string; link_type?: "folder" | "file" }
     >({
       query: (body) => ({
         method: "POST",

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/Gdrive.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/Gdrive.module.css
@@ -4,3 +4,11 @@
   text-decoration: none;
   cursor: pointer;
 }
+
+.inline {
+  display: inline;
+
+  p {
+    display: inline;
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.strings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.strings.ts
@@ -1,0 +1,19 @@
+import { t } from "ttag";
+
+export const getStrings = (objectType: "file" | "folder") => {
+  if (objectType === "file") {
+    return {
+      clickInstruction: t`In Google Drive, right-click on the file and click Share`,
+      pasteInstruction: t`Paste the sharing link for the file`,
+      copyInstruction: t`In Google Drive, right-click on the file → Share → Copy link`,
+      importText: t`Import file`,
+    };
+  }
+
+  return {
+    clickInstruction: t`In Google Drive, right-click on the folder and click Share`,
+    pasteInstruction: t`Paste the sharing link for the folder`,
+    copyInstruction: t`In Google Drive, right-click on the folder → Share → Copy link`,
+    importText: t`Import folder`,
+  };
+};

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -100,13 +100,10 @@ function GoogleSheetsConnectModal({
     event.preventDefault();
     setErrorMessage("");
 
-    const folderValidationRegex = /^(https|http):\/\/drive\.google\.com\/.+/;
-    const sheetValidationRegex =
-      /^(https|http):\/\/docs\.google\.com\/spreadsheets\/.+/;
+    const validationRegex = /(https|http)\:\/\/(drive|docs)\.google\.com\/.+/;
 
     if (
-      !folderValidationRegex.test(folderLink.trim()) &&
-      !sheetValidationRegex.test(folderLink.trim())
+      !validationRegex.test(folderLink.trim())
     ) {
       setErrorMessage(t`Invalid Google link`);
       return;

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -1,11 +1,12 @@
 import { type FormEvent, useState } from "react";
-import { c, jt, t } from "ttag";
+import { c, t } from "ttag";
 
 import { reloadSettings } from "metabase/admin/settings/settings";
 import { skipToken, useGetUserQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { CopyButton } from "metabase/components/CopyButton";
 import ExternalLink from "metabase/core/components/ExternalLink";
+import Markdown from "metabase/core/components/Markdown";
 import { useDispatch } from "metabase/lib/redux";
 import { getUserName } from "metabase/lib/user";
 import {
@@ -26,6 +27,7 @@ import {
 } from "metabase-enterprise/api";
 
 import Styles from "./Gdrive.module.css";
+import { getStrings } from "./GdriveConnectionModal.strings";
 import { trackSheetImportClick } from "./analytics";
 
 export function GdriveConnectionModal({
@@ -52,7 +54,7 @@ export function GdriveConnectionModal({
     (status === "not-connected" ? (
       <GoogleSheetsConnectModal
         onClose={onClose}
-        serviceAccountEmail={serviceAccountEmail ?? t`email not found`}
+        serviceAccountEmail={serviceAccountEmail ?? t`Email not found`}
         folderUrl={folder_url}
       />
     ) : (
@@ -122,7 +124,8 @@ function GoogleSheetsConnectModal({
       });
   };
 
-  const linkTypeLabel = linkType === "file" ? t`file` : t`folder`;
+  const { clickInstruction, pasteInstruction, importText, copyInstruction } =
+    getStrings(linkType);
 
   return (
     <ModalWrapper onClose={onClose} title={t`Import Google Sheets`}>
@@ -148,29 +151,30 @@ function GoogleSheetsConnectModal({
         gap="md"
       >
         <Box>
-          <Text>
-            1.{" "}
-            {t`In Google Drive, right-click on the ${linkTypeLabel} and click Share`}
-          </Text>
+          <Text>1.{" " + clickInstruction}</Text>
         </Box>
         <Flex align="center" justify="space-between">
           <Text>
             2.{" "}
-            {jt`Enter: ${(<strong key="bold">{serviceAccountEmail ?? t`Error fetching service account email`}</strong>)}`}
+            {c("{0} is an email address")
+              .jt`Enter: ${(<strong key="bold">{serviceAccountEmail ?? t`Error fetching service account email`}</strong>)}`}
           </Text>
           <CopyButton value={serviceAccountEmail}></CopyButton>
         </Flex>
         <Box>
           <Text>
-            3.{" "}
-            {jt`Select ${(<strong key="bold">{t`Viewer`}</strong>)} permissions, and click on ${(<strong key="bold2">{t`Send`}</strong>)}`}
+            <span>{"3. "}</span>
+            <Markdown className={Styles.inline}>
+              {t`Select **Viewer** permissions, and click on **Send**`}
+            </Markdown>
           </Text>
         </Box>
       </Flex>
       <form onSubmit={onSave}>
         <Box>
-          <Text size="lg" fw="bold">{c("{0} is either a file or a folder")
-            .t`Paste the sharing link for the ${linkTypeLabel}`}</Text>
+          <Text size="lg" fw="bold">
+            {pasteInstruction}
+          </Text>
           <TextInput
             my="sm"
             disabled={isSavingFolderLink}
@@ -182,10 +186,9 @@ function GoogleSheetsConnectModal({
                 : "https://docs.google.com/spreadsheets/d/abc123-xyz456"
             }
           />
-          <Text size="sm" color="secondary">{c(
-            "{0} is either a file or a folder",
-          )
-            .t`In Google Drive, right-click on the ${linkTypeLabel} → Share → Copy link`}</Text>
+          <Text size="sm" color="secondary">
+            {copyInstruction}
+          </Text>
         </Box>
         <Flex justify="space-between" align="center" mt="sm" gap="md">
           <Text c="error" lh="1.2rem">
@@ -198,7 +201,7 @@ function GoogleSheetsConnectModal({
             disabled={folderLink.length < 3}
             style={{ flexShrink: 0 }}
           >
-            {c("{0} is either a file or a folder").t`Import ${linkTypeLabel}`}
+            {importText}
           </Button>
         </Flex>
       </form>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -178,7 +178,11 @@ function GoogleSheetsConnectModal({
             disabled={isSavingFolderLink}
             value={folderLink}
             onChange={(e) => setFolderLink(e.target.value)}
-            placeholder="https://drive.google.com/drive/folders/abc123-xyz456"
+            placeholder={
+              linkType === "folder"
+                ? "https://drive.google.com/drive/folders/abc123-xyz456"
+                : "https://docs.google.com/spreadsheets/d/abc123-xyz456"
+            }
           />
           <Text size="sm" color="secondary">{c(
             "{0} is either a file or a folder",

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -5,7 +5,9 @@ import { reloadSettings } from "metabase/admin/settings/settings";
 import { skipToken, useGetUserQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { CopyButton } from "metabase/components/CopyButton";
+import ExternalLink from "metabase/core/components/ExternalLink";
 import { useDispatch } from "metabase/lib/redux";
+import { getUserName } from "metabase/lib/user";
 import {
   Box,
   Button,
@@ -63,12 +65,10 @@ const ModalWrapper = ({
   title,
   children,
   onClose,
-  title,
 }: {
   title?: string;
   children: React.ReactNode;
   onClose: () => void;
-  title?: string;
 }) => (
   <Modal opened onClose={onClose} padding="xl" title={title}>
     <Flex gap="md" pt="lg" direction="column">
@@ -102,9 +102,7 @@ function GoogleSheetsConnectModal({
 
     const validationRegex = /(https|http)\:\/\/(drive|docs)\.google\.com\/.+/;
 
-    if (
-      !validationRegex.test(folderLink.trim())
-    ) {
+    if (!validationRegex.test(folderLink.trim())) {
       setErrorMessage(t`Invalid Google link`);
       return;
     }

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.unit.spec.tsx
@@ -1,0 +1,166 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupGdrivePostFolderEndpoint,
+  setupGdriveServiceAccountEndpoint,
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type { Settings } from "metabase-types/api";
+import { createMockSettings, createMockUser } from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
+import { GdriveConnectionModal } from "./GdriveConnectionModal";
+type GsheetsStatus = Settings["gsheets"]["status"];
+
+const setup = ({ settingStatus }: { settingStatus: GsheetsStatus }) => {
+  const updatedSettings = createMockSettings({
+    "show-google-sheets-integration": true,
+    gsheets: {
+      status: settingStatus,
+      folder_url: null,
+    },
+  });
+
+  setupPropertiesEndpoints(updatedSettings);
+  setupSettingsEndpoints([]);
+  setupGdrivePostFolderEndpoint();
+  setupGdriveServiceAccountEndpoint(
+    "super-service-account@testing.metabase.com",
+  );
+
+  return renderWithProviders(
+    <GdriveConnectionModal onClose={() => {}} isModalOpen reconnect={false} />,
+    {
+      storeInitialState: {
+        settings: createMockSettingsState({
+          gsheets: {
+            status: settingStatus,
+            folder_url: null,
+          },
+        }),
+        currentUser: createMockUser({ is_superuser: true }),
+      },
+    },
+  );
+};
+
+describe("Google Drive > Connect / Disconnect modal", () => {
+  it("should show disconnect modal if connected", async () => {
+    setup({
+      settingStatus: "complete",
+    });
+    expect(await screen.findByText("Disconnect")).toBeInTheDocument();
+  });
+
+  it("should show connection modal if not connected", async () => {
+    setup({
+      settingStatus: "not-connected",
+    });
+    expect(await screen.findByText("Import Google Sheets")).toBeInTheDocument();
+  });
+
+  it("should show service acocunt email", async () => {
+    setup({
+      settingStatus: "not-connected",
+    });
+    expect(await screen.findByText("Import Google Sheets")).toBeInTheDocument();
+
+    expect(
+      await screen.findByText("super-service-account@testing.metabase.com"),
+    ).toBeInTheDocument();
+  });
+
+  it("should show 'import folder' button when folder is selected", async () => {
+    setup({
+      settingStatus: "not-connected",
+    });
+    expect(await screen.findByText("Import Google Sheets")).toBeInTheDocument();
+
+    const folderOption = await screen.findByText("Entire folder");
+    await userEvent.click(folderOption);
+
+    expect(await screen.findByText("Import folder")).toBeInTheDocument();
+  });
+
+  it("should show 'import file' button when file is selected", async () => {
+    setup({
+      settingStatus: "not-connected",
+    });
+    expect(await screen.findByText("Import Google Sheets")).toBeInTheDocument();
+
+    const fileOption = await screen.findByText("Single Sheet");
+    await userEvent.click(fileOption);
+
+    expect(await screen.findByText("Import file")).toBeInTheDocument();
+  });
+
+  it("should POST folder data to /api/ee/gsheets/folder", async () => {
+    setup({
+      settingStatus: "not-connected",
+    });
+    expect(await screen.findByText("Import Google Sheets")).toBeInTheDocument();
+
+    const input = await screen.findByPlaceholderText(/https/i);
+    await userEvent.type(
+      input,
+      "https://drive.google.com/drive/folders/1234567890",
+    );
+
+    const importButton = await screen.findByRole("button", {
+      name: /import folder/i,
+    });
+    await userEvent.click(importButton);
+
+    await waitFor(async () => {
+      const post = fetchMock.calls("path:/api/ee/gsheets/folder");
+      expect(post.length).toBe(1);
+    });
+
+    const post = fetchMock.calls("path:/api/ee/gsheets/folder");
+    const postBody = await post?.[0]?.[1]?.body;
+    expect(postBody).toEqual(
+      JSON.stringify({
+        url: "https://drive.google.com/drive/folders/1234567890",
+        link_type: "folder",
+      }),
+    );
+  });
+
+  it("should POST file data to /api/ee/gsheets/folder", async () => {
+    setup({
+      settingStatus: "not-connected",
+    });
+    expect(await screen.findByText("Import Google Sheets")).toBeInTheDocument();
+
+    const fileOption = await screen.findByText("Single Sheet");
+    await userEvent.click(fileOption);
+
+    const input = await screen.findByPlaceholderText(/https/i);
+    await userEvent.type(
+      input,
+      "https://drive.google.com/drive/folders/1234567890",
+    );
+
+    const importButton = await screen.findByRole("button", {
+      name: /import file/i,
+    });
+    await userEvent.click(importButton);
+
+    await waitFor(async () => {
+      const post = fetchMock.calls("path:/api/ee/gsheets/folder");
+      expect(post.length).toBe(1);
+    });
+
+    const post = fetchMock.calls("path:/api/ee/gsheets/folder");
+    const postBody = await post?.[0]?.[1]?.body;
+    expect(postBody).toEqual(
+      JSON.stringify({
+        url: "https://drive.google.com/drive/folders/1234567890",
+        link_type: "file",
+      }),
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
@@ -102,7 +102,6 @@ export const GdriveSyncStatus = () => {
     <GsheetsSyncStatusView
       status={displayStatus}
       db_id={dbId}
-      error={syncError.message ?? ""}
       onClose={() => setForceHide(true)}
     />
   );
@@ -111,12 +110,10 @@ export const GdriveSyncStatus = () => {
 function GsheetsSyncStatusView({
   status,
   db_id,
-  error,
   onClose,
 }: {
   status: GsheetsStatus;
   db_id?: DatabaseId;
-  error?: string;
   onClose: () => void;
 }) {
   const title = match(status)
@@ -127,10 +124,6 @@ function GsheetsSyncStatusView({
   const itemTitle = match(status)
     .with("complete", () => t`Start exploring`)
     .otherwise(() => t`Google Sheets`);
-
-  if (error) {
-    console.error(error);
-  }
 
   const description = match(status)
     .with("complete", () => t`Files sync every 15 minutes`)

--- a/frontend/test/__support__/server-mocks/gdrive.ts
+++ b/frontend/test/__support__/server-mocks/gdrive.ts
@@ -34,3 +34,7 @@ export function setupGdriveServiceAccountEndpoint(
     return { email };
   });
 }
+
+export function setupGdrivePostFolderEndpoint() {
+  fetchMock.post("path:/api/ee/gsheets/folder", { status: 202 });
+}

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -11,6 +11,7 @@ export * from "./collection";
 export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
+s;
 export * from "./dataset";
 export * from "./email";
 export * from "./field";

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -11,7 +11,6 @@ export * from "./collection";
 export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
-s;
 export * from "./dataset";
 export * from "./email";
 export * from "./field";


### PR DESCRIPTION
Depends on 
- https://github.com/metabase/metabase/pull/55582
- https://github.com/metabase/metabase/pull/55564
- https://github.com/metabase/metabase/pull/54938

### Description

Adds toggle UI for selecting whether to import a single sheet or a folder.

The toggle only changes the UI, the backend is smart and can detect if a link is for a folder or single sheet and does the right thing accordingly

![file-folder-import](https://github.com/user-attachments/assets/6f73d725-f3ef-465a-9457-74bc34856fb0)
