### PR TITLE
Only Show Sync Status to Admin Who Started Gdrive Sync

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_drive/Gdrive.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/Gdrive.module.css
@@ -1,0 +1,6 @@
+.plainLink {
+  width: 100%;
+  display: block;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
@@ -3,6 +3,7 @@ import { usePrevious } from "react-use";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
+import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { reloadSettings } from "metabase/admin/settings/settings";
 import { skipToken } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
@@ -21,13 +22,18 @@ export const GdriveSyncStatus = () => {
   const previousSettingStatus = usePrevious(settingStatus);
   const dispatch = useDispatch();
   const isAdmin = useSelector(getUserIsAdmin);
+  const currentUser = useSelector(getCurrentUser);
+  const isCurrentAdmin =
+    isAdmin &&
+    gsheetsSetting?.["created-by-id"] &&
+    currentUser.id === gsheetsSetting?.["created-by-id"];
   const [forceHide, setForceHide] = useState(
-    !isAdmin || settingStatus !== "loading",
+    !isCurrentAdmin || settingStatus !== "loading",
   );
   const [syncError, setSyncError] = useState({ error: false, message: "" });
   const [dbId, setDbId] = useState<DatabaseId | undefined>();
 
-  const shouldPoll = isAdmin && settingStatus === "loading";
+  const shouldPoll = isCurrentAdmin && settingStatus === "loading";
 
   const { currentData: folderSync, error: apiError } = useGetGsheetsFolderQuery(
     shouldPoll ? undefined : skipToken,
@@ -75,7 +81,7 @@ export const GdriveSyncStatus = () => {
     }
   }, [settingStatus, previousSettingStatus, syncError]);
 
-  if (forceHide || !isAdmin) {
+  if (forceHide || !isCurrentAdmin) {
     return null;
   }
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { InputSettingType } from "./actions";
+import type { UserId } from "./user";
 
 export interface FormattingSettings {
   "type/Temporal"?: DateFormattingSettings;
@@ -374,6 +375,7 @@ interface PublicSettings {
     status: "not-connected" | "loading" | "complete" | "error";
     folder_url: string | null;
     error?: string;
+    "created-by-id"?: UserId;
   };
   "has-user-setup": boolean;
   "help-link": HelpLinkSetting;

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -11,6 +11,7 @@ export * from "./collection";
 export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
+s;
 export * from "./dataset";
 export * from "./email";
 export * from "./field";

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -11,7 +11,6 @@ export * from "./collection";
 export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
-s;
 export * from "./dataset";
 export * from "./email";
 export * from "./field";


### PR DESCRIPTION
## Description
- use the backend `created-by-id` to only show sync status popup to the admin who connected the google drive folder

Demo:
https://www.loom.com/share/39fa8fa421e54b9fa9474f4065b72c76