### PR TITLE
fix charts glitches in safari

### DIFF
--- a/frontend/src/metabase/lib/browser.ts
+++ b/frontend/src/metabase/lib/browser.ts
@@ -19,9 +19,16 @@ function parseQueryStringOptions(s: string) {
   return options;
 }
 
-export function isDesktopSafari() {
-  // from: https://stackoverflow.com/a/42189492/142317
-  return "safari" in window;
+export function isWebkit() {
+  const ua = navigator.userAgent || "";
+
+  const isiOS = /iPad|iPhone|iPod/.test(ua);
+  if (isiOS) {
+    return true;
+  }
+  return (
+    ua.includes("AppleWebKit") && navigator.vendor === "Apple Computer, Inc."
+  );
 }
 
 export function parseHashOptions(hash: string) {

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.styled.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { isDesktopSafari } from "metabase/lib/browser";
+import { isWebkit } from "metabase/lib/browser";
 
 interface SharedProps {
   isNarrow: boolean;
@@ -97,7 +97,7 @@ export const FunnelNormalRoot = styled.div<FunnelNormalRootProps>`
   padding: ${props => (props.isSmall ? "0.5rem" : "1rem")};
   color: var(--mb-color-text-secondary);
 
-  ${isDesktopSafari()
+  ${isWebkit()
     ? css`
         will-change: transform;
       `

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { useSet } from "react-use";
 
-import { isDesktopSafari } from "metabase/lib/browser";
+import { isWebkit } from "metabase/lib/browser";
 import { ChartRenderingErrorBoundary } from "metabase/visualizations/components/ChartRenderingErrorBoundary";
 import { ResponsiveEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
 import { LegendCaption } from "metabase/visualizations/components/legend/LegendCaption";
@@ -94,7 +94,7 @@ function _CartesianChart(props: VisualizationProps) {
     chartRef.current = chart;
 
     // HACK: clip paths cause glitches in Safari on multiseries line charts on dashboards (metabase#51383)
-    if (isDesktopSafari()) {
+    if (isWebkit()) {
       chartRef.current.on("finished", () => {
         const svg = containerRef.current?.querySelector("svg");
         if (svg) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53713
Closes [VIZ-441](https://linear.app/metabase/issue/VIZ-441/area-charts-in-static-embed-and-embed-preview-dont-load-properly) 

### Description

Partially this was fixed by https://github.com/metabase/metabase/issues/51383 however the Safari detection was not ideal — it did not work in iframes which is the reason static embedding was still broken.

### How to verify

- Open Safari browser
- Verify https://github.com/metabase/metabase/pull/31494 is still cannot be reproduced
- Create multiseries area chart, add it on a dashboard
- On the dashboard click share -> embed -> static -> look and feel to preview the dashboard
- Hover series on the chart, ensure there are no glitches

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
