### PR TITLE
paginate pr-env job id retrieval

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -42,14 +42,48 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/run-tests.yml/runs?head_sha=${{ github.event.pull_request.head.sha || github.sha }}
           ID=$(jq -r '.workflow_runs[0].id' e2e-tests.json)
+          echo "Run ID: ${ID}"
+
+          ## Get workflow run id for uberjar build
+          while [ -z "$JOB_ID" ]; do
+            NEXT_URL="https://api.github.com/repos/${{ github.repository }}/actions/runs/${ID}/jobs?filter=latest"
+
+            # Search for build job
+            echo "Searching for build job..."
+            while [ -z "$JOB_ID" ] && [ -n "$NEXT_URL" ]; do
+              # Get one page of jobs
+              RESPONSE=$(curl -s -i \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "$NEXT_URL")
+
+              # Extract headers and body
+              HEADERS=$(echo "$RESPONSE" | sed -n '1,/^\r$/p')
+              BODY=$(echo "$RESPONSE" | sed '1,/^\r$/d')
+              LINK_HEADER=$(echo "$HEADERS" | grep -i '^link:' | sed 's/^link: //')
+
+              # Check for next page in Link header
+              if echo "$LINK_HEADER" | grep -q 'rel="next"'; then
+                NEXT_URL=$(echo "$LINK_HEADER" | sed -E 's/.*<([^>]+)>; rel="next".*/\1/')
+              else
+                NEXT_URL=""
+              fi
+
+              # Check for build job
+              JOB_ID=$(echo "$BODY" | jq -r '.jobs[] | select(.name | contains("build (ee)")) | .id')
+            done
+          done
+          echo "Job ID: ${JOB_ID}"
+
           ## Wait for uberjar build to complete
           while [ true ]; do
             curl -Ls --output uberjar.json \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/actions/runs/${ID}/jobs?filter=latest
-            jq -r '.jobs[] | select(.name == "build (ee)") | .steps[] | select(.name == "Prepare uberjar artifact") | .status' uberjar.json | grep -q "completed" && break
+            https://api.github.com/repos/${{ github.repository }}/actions/jobs/${JOB_ID}
+            jq -r '.steps[] | select(.name == "Prepare uberjar artifact") | .status' uberjar.json | grep -q "completed" && break
             echo "Waiting for uberjar build..."
             sleep 10
           done

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -42,14 +42,48 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/run-tests.yml/runs?head_sha=${{ github.event.pull_request.head.sha || github.sha }}
           ID=$(jq -r '.workflow_runs[0].id' e2e-tests.json)
+          echo "Run ID: ${ID}"
+
+          ## Get workflow run id for uberjar build
+          while [ -z "$JOB_ID" ]; do
+            NEXT_URL="https://api.github.com/repos/${{ github.repository }}/actions/runs/${ID}/jobs?filter=latest"
+
+            # Search for build job
+            echo "Searching for build job..."
+            while [ -z "$JOB_ID" ] && [ -n "$NEXT_URL" ]; do
+              # Get one page of jobs
+              RESPONSE=$(curl -s -i \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "$NEXT_URL")
+
+              # Extract headers and body
+              HEADERS=$(echo "$RESPONSE" | sed -n '1,/^\r$/p')
+              BODY=$(echo "$RESPONSE" | sed '1,/^\r$/d')
+              LINK_HEADER=$(echo "$HEADERS" | grep -i '^link:' | sed 's/^link: //')
+
+              # Check for next page in Link header
+              if echo "$LINK_HEADER" | grep -q 'rel="next"'; then
+                NEXT_URL=$(echo "$LINK_HEADER" | sed -E 's/.*<([^>]+)>; rel="next".*/\1/')
+              else
+                NEXT_URL=""
+              fi
+
+              # Check for build job
+              JOB_ID=$(echo "$BODY" | jq -r '.jobs[] | select(.name | contains("build (ee)")) | .id')
+            done
+          done
+          echo "Job ID: ${JOB_ID}"
+
           ## Wait for uberjar build to complete
           while [ true ]; do
             curl -Ls --output uberjar.json \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/actions/runs/${ID}/jobs?filter=latest
-            jq -r '.jobs[] | select(.name == "build (ee)") | .steps[] | select(.name == "Prepare uberjar artifact") | .status' uberjar.json | grep -q "completed" && break
+            https://api.github.com/repos/${{ github.repository }}/actions/jobs/${JOB_ID}
+            jq -r '.steps[] | select(.name == "Prepare uberjar artifact") | .status' uberjar.json | grep -q "completed" && break
             echo "Waiting for uberjar build..."
             sleep 10
           done


### PR DESCRIPTION
### Description
Fixes a couple of issues with PR envs:
There were more jobs for the workflow now so pagination was causing an issue
The name of the job was prefixed with `e2e-tests / `

I added logic to retrieve all pages if it is paginated until we find our job. And switched it to the job name contains `build (ee)` instead of `==`. 
### How to verify
Add PR-Env label and verify PR env is created