### PR TITLE
[api/setting] Parallelize settings retrieval

### DIFF
--- a/test/metabase/util/performance_test.clj
+++ b/test/metabase/util/performance_test.clj
@@ -85,3 +85,11 @@
         (when (instance? clojure.lang.Sorted c)
           (is (= (.comparator ^clojure.lang.Sorted c)
                  (.comparator ^clojure.lang.Sorted walked))))))))
+
+(deftest pmap-test
+  (are [f input result] (= result (mapv f input) (perf/mapv f input) (perf/pmap f input))
+    inc (range 10) [1 2 3 4 5 6 7 8 9 10]
+    identity (range 10) [0 1 2 3 4 5 6 7 8 9]
+    inc [] []
+    inc [1] [2]
+    (fn [_] (do (Thread/sleep 10) 0)) (range 5) [0 0 0 0 0]))


### PR DESCRIPTION
The call to `user-readable-values-map` can fetch up to 300 setting values. This translates to 12-13 db calls (one call is responsible for multiple retrievable values, it seems).

When cached, this call finished in 10-20 milliseconds. However, on the first load (and then once per minute) the call may last from 150 ms to up to 500 ms (happened to me). Given that everything starts loading after `api/session/properties`, it delays the whole app by this amount.

In order to improve the worst-case stale-cache scenario, I propose to parallelize retrieving the settings. A simple `pmap` could do; however, a regular `pmap` brings a lot of inefficiencies for tasks where the task grain is low. So, instead, I also propose an implementation of `pmap` that uses Java's parallel streams (and a FJP under the hood). My benchmarks show that this implementation has much smaller overhead over regular `map` compared to `clojure.core/pmap`.

With the pmap, the uncached call to settings returns in ~60 ms on my machine.