### PR TITLE
[Notification] Fix query limit for alerts

### DIFF
--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -255,16 +255,17 @@
   (let [result (request/with-current-user creator-id
                  (qp.card/process-query-for-card card-id :api
                                                  ;; TODO rename to :notification?
-                                                 :context    :pulse
-                                                 :middleware {:skip-results-metadata?            false
-                                                              :process-viz-settings?             true
-                                                              :js-int-to-string?                 false
-                                                              :add-default-userland-constraints? false}
-                                                 :make-run      (fn make-run [qp _export-format]
-                                                                  (^:once fn* [query info]
-                                                                    (qp
-                                                                     (qp/userland-query query info)
-                                                                     nil)))))]
+                                                 :context     :pulse
+                                                 :constraints {}
+                                                 :middleware  {:skip-results-metadata?            false
+                                                               :process-viz-settings?             true
+                                                               :js-int-to-string?                 false
+                                                               :add-default-userland-constraints? false}
+                                                 :make-run    (fn make-run [qp _export-format]
+                                                                (^:once fn* [query info]
+                                                                  (qp
+                                                                   (qp/userland-query query info)
+                                                                   nil)))))]
 
     {:card   (t2/select-one :model/Card card-id)
      :result result

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -68,7 +68,7 @@
   (when-not (disable-max-results? query)
     (let [context (-> query :info :context)
           download-context? #{:csv-download :json-download :xlsx-download}
-          attachment-context? #{:dashboard-subscription :pulse}
+          attachment-context? #{:dashboard-subscription :pulse :notification}
           download-limit (when (download-context? context) (download-row-limit))
           attachment-limit (when (attachment-context? context) (attachment-row-limit))
           res (u/safe-min (mbql.u/query->max-rows-limit query)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/55522


Make sure we don't override the limit with the default value of 2k.