### PR TITLE
Encode api query urls

### DIFF
--- a/frontend/src/metabase/api/query.ts
+++ b/frontend/src/metabase/api/query.ts
@@ -16,11 +16,20 @@ const isAllowedHTTPMethod = (method: any): method is AllowedHTTPMethods => {
 // custom fetcher that wraps our Api client
 export const apiQuery: BaseQueryFn = async (args, ctx) => {
   const method = typeof args === "string" ? "GET" : (args?.method ?? "GET");
-  const url = typeof args === "string" ? args : args.url;
   const { bodyParamName, noEvent, formData, fetch } = args;
 
   if (!isAllowedHTTPMethod(method)) {
     return { error: "Invalid HTTP method" };
+  }
+
+  let url = typeof args === "string" ? args : args.url;
+
+  // Apply URL encoding to path segments
+  if (url) {
+    const segments = url.split("/") as Array<string>;
+    url = segments
+      .map(segment => (segment ? encodeURIComponent(segment) : segment))
+      .join("/");
   }
 
   try {


### PR DESCRIPTION
We have setting keys like `bcc-enabled?` that get used in the url and need to be encoded. This PR adds to our custom rtk-query fetcher to automatically encodes every path segment. 

I noticed this when using `AdminSettingInput` for `bcc-enabled?`. It wasn't working because it was trying to hit `/api/setting/bcc-enabled?` - note the `?` not being encoded. 

I considered manually adding `encodeURIComponent` into `frontend/src/metabase/api/settings.ts` where the endpoints are defined, but encoding by default seems quite nice. However, I can revert to that option if this is too heavy-handed.

I would also like to add some tests for this, but I can't see where we test `query.ts`

 


