### PR TITLE
fix(enterprise): delete row query

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
@@ -39,6 +39,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
         method: "DELETE",
         url: `/api/ee/data-editing/table/${tableId}`,
         body: { rows },
+        hasBody: true,
       }),
     }),
   }),

--- a/frontend/src/metabase/api/query.ts
+++ b/frontend/src/metabase/api/query.ts
@@ -17,7 +17,7 @@ const isAllowedHTTPMethod = (method: any): method is AllowedHTTPMethods => {
 export const apiQuery: BaseQueryFn = async (args, ctx) => {
   const method = typeof args === "string" ? "GET" : (args?.method ?? "GET");
   const url = typeof args === "string" ? args : args.url;
-  const { bodyParamName, noEvent, formData, fetch } = args;
+  const { bodyParamName, noEvent, formData, fetch, hasBody } = args;
 
   if (!isAllowedHTTPMethod(method)) {
     return { error: "Invalid HTTP method" };
@@ -32,6 +32,7 @@ export const apiQuery: BaseQueryFn = async (args, ctx) => {
         noEvent,
         formData,
         fetch,
+        hasBody,
       },
     );
     return { data: response };


### PR DESCRIPTION
The API expects DELETE request with body, however the current toolkit does not allow it. The PR adds an ability to pass additional option to attach a body to a DELETE request
