### PR TITLE
Closes VIZ-557: picks the proper display when getting the initial state

### DIFF
--- a/frontend/src/metabase/dashboard/components/QuestionPicker/convert-question-to-initial-state.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/convert-question-to-initial-state.ts
@@ -1,10 +1,9 @@
-import visualizations from "metabase/visualizations";
-import { getInitialStateForCardDataSource } from "metabase/visualizer/utils";
-import type {
-  Card,
-  DatasetColumn,
-  VisualizationDisplay,
-} from "metabase-types/api";
+import {
+  DEFAULT_VISUALIZER_DISPLAY,
+  getInitialStateForCardDataSource,
+  isVisualizerSupportedVisualization,
+} from "metabase/visualizer/utils";
+import type { Card, DatasetColumn } from "metabase-types/api";
 import type {
   VisualizerDataSourceId,
   VisualizerHistoryItem,
@@ -21,11 +20,11 @@ export function convertCardToInitialState(card: Card): {
   );
 
   // if the visualization doesn't support the visualizer, default to bar chart
-  if (!visualizations.get(initialState.display!)?.supportsVisualizer) {
+  if (!isVisualizerSupportedVisualization(initialState.display)) {
     return {
       state: {
         ...initialState,
-        display: "bar" as VisualizationDisplay,
+        display: DEFAULT_VISUALIZER_DISPLAY,
       },
       extraDataSources: [`card:${card.id}` as const],
     };

--- a/frontend/src/metabase/visualizer/utils/dashboard-card-supports-visualizer.ts
+++ b/frontend/src/metabase/visualizer/utils/dashboard-card-supports-visualizer.ts
@@ -1,7 +1,9 @@
 import visualizations from "metabase/visualizations";
-import type { DashboardCard } from "metabase-types/api";
+import type { DashboardCard, VisualizationDisplay } from "metabase-types/api";
 
 import { isVisualizerDashboardCard } from "./is-visualizer-dashboard-card";
+
+export const DEFAULT_VISUALIZER_DISPLAY = "bar";
 
 export function dashboardCardSupportsVisualizer(dashcard: DashboardCard) {
   if (isVisualizerDashboardCard(dashcard)) {
@@ -10,10 +12,15 @@ export function dashboardCardSupportsVisualizer(dashcard: DashboardCard) {
     )?.supportsVisualizer;
   }
 
-  const display = dashcard.card.display;
-  if (display) {
-    return visualizations.get(display)!.supportsVisualizer;
+  return isVisualizerSupportedVisualization(dashcard.card.display);
+}
+
+export function isVisualizerSupportedVisualization(
+  display: VisualizationDisplay | null | undefined,
+) {
+  if (!display) {
+    return false;
   }
 
-  return false;
+  return visualizations.get(display)?.supportsVisualizer;
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -8,6 +8,10 @@ import {
   createVisualizerColumnReference,
   extractReferencedColumns,
 } from "./column";
+import {
+  DEFAULT_VISUALIZER_DISPLAY,
+  isVisualizerSupportedVisualization,
+} from "./dashboard-card-supports-visualizer";
 import { createDataSource } from "./data-source";
 
 export function getInitialStateForCardDataSource(
@@ -15,11 +19,14 @@ export function getInitialStateForCardDataSource(
   columns: DatasetColumn[],
 ): VisualizerHistoryItem {
   const state: VisualizerHistoryItem = {
-    display: card.display,
+    display: isVisualizerSupportedVisualization(card.display)
+      ? card.display
+      : DEFAULT_VISUALIZER_DISPLAY,
     columns: [],
     columnValuesMapping: {},
     settings: {},
   };
+
   const dataSource = createDataSource("card", card.id, card.name);
 
   columns.forEach(column => {

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -56,4 +56,13 @@ describe("getInitialStateForCardDataSource", () => {
       "card.title": "TablyMcTableface",
     });
   });
+
+  it("should pick the proper display if it is not supported by the visualizer", () => {
+    const initialState = getInitialStateForCardDataSource(dashCard.card, [
+      createMockColumn({ name: "Foo" }),
+      createMockColumn({ name: "Bar" }),
+    ]);
+
+    expect(initialState.display).toEqual("bar");
+  });
 });


### PR DESCRIPTION
Closes [VIZ-557: Unify behavior for default viz type so you don't get unsupported types](https://linear.app/metabase/issue/VIZ-557/unify-behavior-for-default-viz-type-so-you-dont-get-unsupported-types)

### Description

Avoids showing an unsupported visualization in the modal when adding a first dataset:
https://www.loom.com/share/5b9834658e9448f98774948a2de03aa0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
