### PR TITLE
Add hover effect for dirty query state

### DIFF
--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -132,6 +132,7 @@ const BaseButton = forwardRef(function BaseButton(
       <ButtonContent iconVertical={iconVertical}>
         {icon && typeof icon === "string" ? (
           <Icon
+            className={classNames.icon}
             color={iconColor}
             name={icon as unknown as IconName}
             size={iconSize ? iconSize : 16}

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -120,24 +120,6 @@
   transition: background 0.3s linear;
 }
 
-.Loading {
-  background-color: color-mix(
-    in srgb,
-    var(--mb-color-bg-white) 70%,
-    transparent
-  );
-  transition: opacity 0.5s;
-}
-
-.Loading.LoadingHidden {
-  background-color: transparent;
-  pointer-events: none;
-}
-
-.Loading.LoadingHidden * {
-  pointer-events: none;
-}
-
 .QueryError {
   flex-direction: column;
   justify-content: center;
@@ -334,4 +316,32 @@
 /* need to do this ugliness to override the locally scoped font size from Scalar.css */
 .QueryBuilder .ScalarValue {
   font-size: 5em;
+}
+
+.overlay {
+  background-color: color-mix(
+    in srgb,
+    var(--mb-color-bg-white) 75%,
+    transparent
+  );
+  transition:
+    opacity 0.5s,
+    background-color 0.5s;
+
+  &.interactive {
+    cursor: pointer;
+
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--mb-color-brand) 3%,
+        color-mix(in srgb, var(--mb-color-bg-white) 75%, transparent)
+      );
+    }
+  }
+
+  &.hidden {
+    background-color: transparent;
+    pointer-events: none;
+  }
 }

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -263,6 +263,7 @@
   transition:
     transform 0.25s,
     opacity 0.25s;
+  transform-origin: center;
 }
 
 .RunButton.RunButtonCircular {
@@ -319,7 +320,7 @@
   font-size: 5em;
 }
 
-.overlay {
+.Overlay {
   background-color: color-mix(
     in srgb,
     var(--mb-color-bg-white) 75%,
@@ -329,7 +330,7 @@
     opacity 0.5s,
     background-color 0.5s;
 
-  &.active {
+  &.OverlayActive {
     cursor: pointer;
 
     &:hover {
@@ -338,10 +339,14 @@
         var(--mb-color-brand) 3%,
         color-mix(in srgb, var(--mb-color-bg-white) 75%, transparent)
       );
+
+      .RunButton {
+        transform: scale(1.2);
+      }
     }
   }
 
-  &.hidden {
+  &.OverlayHidden {
     background-color: transparent;
     pointer-events: none;
   }

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -328,7 +328,7 @@
     opacity 0.5s,
     background-color 0.5s;
 
-  &.interactive {
+  &.active {
     cursor: pointer;
 
     &:hover {

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -263,7 +263,6 @@
   transition:
     transform 0.25s,
     opacity 0.25s;
-  transform-origin: center;
 }
 
 .RunButton.RunButtonCircular {

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -269,6 +269,10 @@
 .RunButton.RunButtonCircular {
   padding: 0.25rem 1.5rem;
   border: none;
+
+  .RunButtonIcon {
+    transform: translateX(2px);
+  }
 }
 
 .RunButton.RunButtonHidden {

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -266,7 +266,8 @@
 }
 
 .RunButton.RunButtonCircular {
-  padding: 16px 32px;
+  padding: 0.25rem 1.5rem;
+  border: none;
 }
 
 .RunButton.RunButtonHidden {

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -343,10 +343,6 @@
         var(--mb-color-brand) 3%,
         color-mix(in srgb, var(--mb-color-bg-white) 75%, transparent)
       );
-
-      .RunButton {
-        transform: scale(1.2);
-      }
     }
   }
 

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -265,7 +265,7 @@
     opacity 0.25s;
 }
 
-.RunButton.RunButtonCompact {
+.RunButton.RunButtonCircular {
   padding: 16px 32px;
 }
 
@@ -276,7 +276,7 @@
 
 @media (prefers-reduced-motion) {
   .RunButton,
-  .RunButton.RunButtonCompact,
+  .RunButton.RunButtonCircular,
   .RunButton.RunButtonHidden {
     transition-duration: 10ms;
   }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.tsx
@@ -127,7 +127,6 @@ export const NativeQueryEditorSidebar = (
           isDirty={isResultDirty}
           onRun={runQuery}
           onCancel={cancelQuery}
-          compact
           getTooltip={getTooltip}
         />
       )}

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -139,7 +139,7 @@ export function VisualizationRunningState({ className = "" }) {
 
   return (
     <Flex
-      className={cx(className, QueryBuilderS.overlay)}
+      className={cx(className, QueryBuilderS.Overlay)}
       c="brand"
       direction="column"
       justify="center"
@@ -176,9 +176,9 @@ export const VisualizationDirtyState = ({
 
   return (
     <Flex
-      className={cx(className, QueryBuilderS.overlay, {
-        [QueryBuilderS.active]: !hidden,
-        [QueryBuilderS.hidden]: hidden,
+      className={cx(className, QueryBuilderS.Overlay, {
+        [QueryBuilderS.OverlayActive]: !hidden,
+        [QueryBuilderS.OverlayHidden]: hidden,
       })}
       direction="column"
       justify="center"

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -190,7 +190,6 @@ export const VisualizationDirtyState = ({
       <RunButtonWithTooltip
         className={CS.shadowed}
         circular
-        compact
         result={result}
         hidden={hidden}
         isRunning={isRunning}

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -189,8 +189,8 @@ export const VisualizationDirtyState = ({
     >
       <RunButtonWithTooltip
         className={CS.shadowed}
+        iconSize={32}
         circular
-        result={result}
         hidden={hidden}
         isRunning={isRunning}
         isDirty={isResultDirty}

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -26,6 +26,7 @@ export default function QueryVisualization(props) {
   const {
     className,
     question,
+    isRunnable,
     isRunning,
     isObjectDetail,
     isResultDirty,
@@ -49,6 +50,7 @@ export default function QueryVisualization(props) {
         hidden={
           !canRun ||
           !isResultDirty ||
+          !isRunnable ||
           isRunning ||
           isNativeEditorOpen ||
           result?.error
@@ -154,18 +156,16 @@ export function VisualizationRunningState({ className = "" }) {
 export const VisualizationDirtyState = ({
   className,
   result,
-  isRunnable,
   isRunning,
   isResultDirty,
   runQuestionQuery,
   cancelQuery,
   hidden,
 }) => {
-  const isEnabled = isRunnable && !hidden;
   const keyboardShortcut = getRunQueryShortcut();
 
   const handleClick = () => {
-    if (isEnabled) {
+    if (!hidden) {
       if (isRunning) {
         cancelQuery();
       } else {
@@ -177,7 +177,7 @@ export const VisualizationDirtyState = ({
   return (
     <Flex
       className={cx(className, QueryBuilderS.overlay, {
-        [QueryBuilderS.interactive]: isEnabled,
+        [QueryBuilderS.active]: !hidden,
         [QueryBuilderS.hidden]: hidden,
       })}
       direction="column"
@@ -192,11 +192,11 @@ export const VisualizationDirtyState = ({
         circular
         compact
         result={result}
-        hidden={!isEnabled}
+        hidden={hidden}
         isRunning={isRunning}
         isDirty={isResultDirty}
       />
-      {isEnabled && <Text c="text-medium">{keyboardShortcut}</Text>}
+      {!hidden && <Text c="text-medium">{keyboardShortcut}</Text>}
     </Flex>
   );
 };

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -11,7 +11,7 @@ import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { isMac } from "metabase/lib/browser";
 import { useSelector } from "metabase/lib/redux";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
-import { Box, Flex, Stack, Text } from "metabase/ui";
+import { Box, Flex, Stack, Text, Title } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 
@@ -136,19 +136,18 @@ export function VisualizationRunningState({ className = "" }) {
   const message = getLoadingMessage(isSlow());
 
   return (
-    <div
-      className={cx(
-        className,
-        QueryBuilderS.Loading,
-        CS.flex,
-        CS.flexColumn,
-        CS.layoutCentered,
-        CS.textBrand,
-      )}
+    <Flex
+      className={cx(className, QueryBuilderS.overlay)}
+      c="brand"
+      direction="column"
+      justify="center"
+      align="center"
     >
       <LoadingSpinner />
-      <h2 className={cx(CS.textBrand, CS.textUppercase, CS.my3)}>{message}</h2>
-    </div>
+      <Title className={CS.textUppercase} c="brand" order={2} mt="lg">
+        {message}
+      </Title>
+    </Flex>
   );
 }
 
@@ -176,32 +175,29 @@ export const VisualizationDirtyState = ({
   };
 
   return (
-    <div
-      className={cx(
-        className,
-        QueryBuilderS.Loading,
-        CS.flex,
-        CS.flexColumn,
-        CS.layoutCentered,
-        CS.cursorPointer,
-        { [QueryBuilderS.LoadingHidden]: hidden },
-      )}
+    <Flex
+      className={cx(className, QueryBuilderS.overlay, {
+        [QueryBuilderS.interactive]: isEnabled,
+        [QueryBuilderS.hidden]: hidden,
+      })}
+      direction="column"
+      justify="center"
+      align="center"
+      gap="sm"
       data-testid="run-button-overlay"
       onClick={handleClick}
     >
-      <Stack gap="sm" align="center">
-        <RunButtonWithTooltip
-          className={CS.shadowed}
-          circular
-          compact
-          result={result}
-          hidden={!isEnabled}
-          isRunning={isRunning}
-          isDirty={isResultDirty}
-        />
-        {isEnabled && <Text c="text-medium">{keyboardShortcut}</Text>}
-      </Stack>
-    </div>
+      <RunButtonWithTooltip
+        className={CS.shadowed}
+        circular
+        compact
+        result={result}
+        hidden={!isEnabled}
+        isRunning={isRunning}
+        isDirty={isResultDirty}
+      />
+      {isEnabled && <Text c="text-medium">{keyboardShortcut}</Text>}
+    </Flex>
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -40,7 +40,7 @@ const RunButton = forwardRef(function RunButton(
       primary={isDirty}
       className={cx(className, QueryBuilderS.RunButton, {
         [QueryBuilderS.RunButtonHidden]: hidden,
-        [QueryBuilderS.RunButtonCompact]: circular,
+        [QueryBuilderS.RunButtonCircular]: circular,
         [CS.circular]: circular,
       })}
       data-testid="run-button"

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -13,6 +13,7 @@ interface RunButtonProps {
   isDirty: boolean;
   circular?: boolean;
   hidden?: boolean;
+  iconSize?: number;
   onRun?: () => void;
   onCancel?: () => void;
 }

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -12,7 +12,9 @@ interface RunButtonProps {
   isRunning: boolean;
   isDirty: boolean;
   circular?: boolean;
+  medium?: boolean;
   hidden?: boolean;
+  onlyIcon?: boolean;
   iconSize?: number;
   onRun?: () => void;
   onCancel?: () => void;
@@ -36,6 +38,7 @@ const RunButton = forwardRef(function RunButton(
 
   return (
     <Button
+      {...props}
       ref={ref}
       className={cx(className, QueryBuilderS.RunButton, {
         [QueryBuilderS.RunButtonHidden]: hidden,
@@ -50,7 +53,6 @@ const RunButton = forwardRef(function RunButton(
       data-testid="run-button"
       aria-label={ariaLabel}
       onClick={isRunning ? onCancel : onRun}
-      {...props}
     />
   );
 });

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -11,7 +11,6 @@ interface RunButtonProps {
   className?: string;
   isRunning: boolean;
   isDirty: boolean;
-  compact?: boolean;
   circular?: boolean;
   borderless?: boolean;
   hidden?: boolean;
@@ -26,7 +25,6 @@ const RunButton = forwardRef(function RunButton(
     onRun,
     onCancel,
     className,
-    compact,
     circular,
     hidden,
     ...props
@@ -35,7 +33,6 @@ const RunButton = forwardRef(function RunButton(
 ) {
   const icon = getButtonIcon(isRunning, isDirty);
   const ariaLabel = getButtonLabel(isRunning, isDirty);
-  const buttonLabel = compact || (!isRunning && !isDirty) ? null : ariaLabel;
 
   return (
     <Button
@@ -44,17 +41,14 @@ const RunButton = forwardRef(function RunButton(
       primary={isDirty}
       className={cx(className, QueryBuilderS.RunButton, {
         [QueryBuilderS.RunButtonHidden]: hidden,
-        [QueryBuilderS.RunButtonCompact]:
-          circular && !props.borderless && compact,
+        [QueryBuilderS.RunButtonCompact]: circular && !props.borderless,
         [CS.circular]: circular,
       })}
       data-testid="run-button"
       onClick={isRunning ? onCancel : onRun}
       ref={ref}
       aria-label={ariaLabel}
-    >
-      {buttonLabel}
-    </Button>
+    />
   );
 });
 

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -35,18 +35,18 @@ const RunButton = forwardRef(function RunButton(
 
   return (
     <Button
-      {...props}
-      icon={icon}
-      primary={isDirty}
+      ref={ref}
       className={cx(className, QueryBuilderS.RunButton, {
         [QueryBuilderS.RunButtonHidden]: hidden,
         [QueryBuilderS.RunButtonCircular]: circular,
         [CS.circular]: circular,
       })}
+      icon={icon}
+      primary={isDirty}
       data-testid="run-button"
-      onClick={isRunning ? onCancel : onRun}
-      ref={ref}
       aria-label={ariaLabel}
+      onClick={isRunning ? onCancel : onRun}
+      {...props}
     />
   );
 });

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -12,7 +12,6 @@ interface RunButtonProps {
   isRunning: boolean;
   isDirty: boolean;
   circular?: boolean;
-  borderless?: boolean;
   hidden?: boolean;
   onRun?: () => void;
   onCancel?: () => void;
@@ -41,7 +40,7 @@ const RunButton = forwardRef(function RunButton(
       primary={isDirty}
       className={cx(className, QueryBuilderS.RunButton, {
         [QueryBuilderS.RunButtonHidden]: hidden,
-        [QueryBuilderS.RunButtonCompact]: circular && !props.borderless,
+        [QueryBuilderS.RunButtonCompact]: circular,
         [CS.circular]: circular,
       })}
       data-testid="run-button"

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -42,6 +42,9 @@ const RunButton = forwardRef(function RunButton(
         [QueryBuilderS.RunButtonCircular]: circular,
         [CS.circular]: circular,
       })}
+      classNames={{
+        icon: QueryBuilderS.RunButtonIcon,
+      }}
       icon={icon}
       primary={isDirty}
       data-testid="run-button"

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
@@ -200,7 +200,6 @@ export function ViewTitleHeaderRightSide({
             iconSize={16}
             onlyIcon
             medium
-            result={result}
             isRunning={isRunning}
             isDirty={isResultDirty}
             onRun={() => runQuestionQuery({ ignoreCache: true })}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
@@ -200,7 +200,6 @@ export function ViewTitleHeaderRightSide({
             iconSize={16}
             onlyIcon
             medium
-            compact
             result={result}
             isRunning={isRunning}
             isDirty={isResultDirty}


### PR DESCRIPTION
Changes:
- Updates the run button shown in the overlay
- Adds a background color animation effect for the overlay
- The run button doesn't change its size on hover. This is done in https://github.com/metabase/metabase/pull/55629 so that you can compare.

How to verify:
- New -> Question -> Orders -> Visualize
- Filter -> ID -> Equal to 1 -> Add filter
- You should see the dirty query state with a play button in the middle
- The background color should change on hover

<img width="1728" alt="Screenshot 2025-03-24 at 10 12 47" src="https://github.com/user-attachments/assets/1a2e9dde-ea4c-40e4-bb52-b54607e9af07" />

