### PR TITLE
Add hover effect for dirty query state - with button transform

### DIFF
--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -263,6 +263,7 @@
   transition:
     transform 0.25s,
     opacity 0.25s;
+  transform-origin: center;
 }
 
 .RunButton.RunButtonCircular {

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -343,6 +343,10 @@
         var(--mb-color-brand) 3%,
         color-mix(in srgb, var(--mb-color-bg-white) 75%, transparent)
       );
+
+      .RunButton {
+        transform: scale(1.2);
+      }
     }
   }
 


### PR DESCRIPTION
Same as https://github.com/metabase/metabase/pull/55627, but with the run button changing its size on hover. This seems problematic since the overlay is immediately under the cursor after clicking `Add filter` button. 