### PR TITLE
Return 5000 unique user attribute keys

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/user.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/user.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.sandbox.api.user
   "Endpoint(s)for setting user attributes."
   (:require
-   [clojure.set :as set]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.util.i18n :refer [deferred-tru]]
@@ -28,17 +27,21 @@
   (api/check-404 (t2/select-one :model/User :id id))
   (pos? (t2/update! :model/User id {:login_attributes login_attributes})))
 
+(def ^:private max-login-attributes 5000)
+
 (api.macros/defendpoint :get "/attributes"
   "Fetch a list of possible keys for User `login_attributes`. This just looks at keys that have already been set for
   existing Users and returns those. "
   []
-  (->>
-   ;; look at the `login_attributes` for the first 1000 users that have them set. Then make a set of the keys
-   (for [login-attributes (t2/select-fn-set :login_attributes :model/User :login_attributes [:not= nil] {:limit 1000})
-         :when (seq login-attributes)]
-     (set (keys login-attributes)))
-   ;; combine all the sets of attribute keys into a single set
-   (reduce set/union #{})))
+  (into #{}
+        (comp
+         (mapcat keys)
+         (distinct)
+         (take max-login-attributes))
+        (t2/select-fn-reducible :login_attributes [:model/User :login_attributes]
+                                {:where [:and
+                                         [:not= :login_attributes nil]
+                                         [:not= :login_attributes "{}"]]})))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/mt/user` routes."


### PR DESCRIPTION
Previously we looked at 1000 users and got the set of unique user attribute names from them. So if 1000 users each had a `name` and user 1001 had `some-other-attribute`, we would give you back `name` as the complete set of available attributes.

This modifies the magic number (to 5000 from 1000) and the logic. We select the first 5000 unique *attributes*. So if 1000 users each have a `name`, that only counts as 1, and we'll continue looking for other unique attributes before returning to the client.

Fixes https://github.com/metabase/metabase/issues/55647