### PR TITLE
Baseline-align text in NativeQueryClickFallback

### DIFF
--- a/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
@@ -3,7 +3,7 @@ import { jt, t } from "ttag";
 import { isWithinIframe } from "metabase/lib/dom";
 import { setUIControls } from "metabase/query_builder/actions";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
-import { Button, Text } from "metabase/ui";
+import { Button, Flex } from "metabase/ui";
 import type {
   CustomClickActionWithCustomView,
   LegacyDrill,
@@ -25,15 +25,7 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
       section: "info",
       type: "custom",
       view: ({ dispatch }) => (
-        <Text
-          styles={{
-            root: {
-              display: "flex",
-              alignItems: "baseline",
-              gap: "0.25rem",
-            },
-          }}
-        >
+        <Flex display="flex" align="baseline" gap="0.25rem">
           {jt`${(
             <Button
               key=""
@@ -46,7 +38,7 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
               {t`Save`}
             </Button>
           )} this question to drill-thru.`}
-        </Text>
+        </Flex>
       ),
     } as CustomClickActionWithCustomView,
   ];

--- a/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
@@ -37,7 +37,7 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
             >
               {t`Save`}
             </Button>
-          )} this question to drill-thru.`}
+          )} this question to drill-through.`}
         </Flex>
       ),
     } as CustomClickActionWithCustomView,

--- a/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
@@ -25,16 +25,28 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
       section: "info",
       type: "custom",
       view: ({ dispatch }) => (
-        <Text>{jt`${(
-          <Button
-            key="button"
-            variant="subtle"
-            p={0}
-            onClick={() => dispatch(setUIControls({ modal: MODAL_TYPES.SAVE }))}
-          >
-            {t`Save`}
-          </Button>
-        )} this question to drill-thru.`}</Text>
+        <Text
+          styles={{
+            root: {
+              display: "flex",
+              alignItems: "baseline",
+              gap: "0.25rem",
+            },
+          }}
+        >
+          {jt`${(
+            <Button
+              key=""
+              variant="subtle"
+              p={0}
+              onClick={() =>
+                dispatch(setUIControls({ modal: MODAL_TYPES.SAVE }))
+              }
+            >
+              {t`Save`}
+            </Button>
+          )} this question to drill-thru.`}
+        </Text>
       ),
     } as CustomClickActionWithCustomView,
   ];


### PR DESCRIPTION
There's no issue for this (AFAIK) but I noticed this text is misaligned because the first word is a button. I've tried fixing this using flexbox `baseline` alignment. Wasn't sure the best way to apply the styles so I went with Mantine `styles` prop but let me know if there's a better approach I should use.

Before:
<img width="264" alt="image" src="https://github.com/user-attachments/assets/a822cb6f-e056-4ce2-9153-92a0b4c05c3e" />


After:
<img width="253" alt="image" src="https://github.com/user-attachments/assets/4f87ae2b-5807-40f7-8200-dfad6c3b270a" />
