### PR TITLE
Remove @smoke tag from whitelabel test

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -22,7 +22,7 @@ describe("formatting > whitelabel", { tags: "@EE" }, () => {
     H.setTokenFeatures("all");
   });
 
-  it("smoke UI test", { tags: "@smoke" }, () => {
+  it("smoke UI test", () => {
     cy.log("Should show all whitelabel options with the feature enabled");
     cy.visit("/admin/settings/whitelabel");
 


### PR DESCRIPTION
This test is failing our prerelease check because those tests (for some reason that isn't entirely clear to me) aren't configured properly to be able to remove an enterprise token as part of a test. Also, this test probably shouldnt ever have been a `@smoke` test in the first place. That tag is badly named.

Two follow up action items
- [DEV-389: Rename @smoke tests to @prerelease](https://linear.app/metabase/issue/DEV-389/rename-smoke-tests-to-prerelease)
- [DEV-390: Use the e2e-test workflow in prerelease tests](https://linear.app/metabase/issue/DEV-390/use-the-e2e-test-workflow-in-prerelease-tests)