### PR TITLE
Add :expression-literals driver feature

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,6 +4,10 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
+## Metabase 0.55.0
+
+- Added a feature `:expression-literals` for drivers that support expressions consisting of a single string, number, or boolean literal value.
+
 ## Metabase 0.54.0
 
 - Added the multi-method `allowed-promotions` that allows driver control over which column type promotions are supported for uploads.

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -1,6 +1,6 @@
 const { H } = cy;
 
-// TODO: QUE-774 restore test
+// TODO: QUE-726 restore test
 describe.skip("scenarios > custom column > literals", () => {
   beforeEach(() => {
     H.restore();

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -530,7 +530,7 @@ describe("issue 41381", () => {
     H.addCustomColumn();
     H.enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
     H.popover().within(() => {
-      // TODO: QUE-774 restore test
+      // TODO: QUE-726 restore test
       // cy.findByText("Invalid expression").should("not.exist");
       // cy.button("Done").should("be.enabled");
       cy.findByText("Standalone constants are not supported.").should(

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -22,6 +22,7 @@ export type DatabaseFeature =
   | "datetime-diff"
   | "dynamic-schema"
   | "expression-aggregations"
+  | "expression-literals"
   | "expressions"
   | "native-parameters"
   | "nested-queries"

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -674,7 +674,8 @@
                               ;; timezone_trunc() rather than literally using SET TIMEZONE, but we need to flag it as
                               ;; supporting set-timezone anyway so that reporting timezones are returned and used, and
                               ;; tests expect the converted values.
-                              :set-timezone             true}]
+                              :set-timezone             true
+                              :expression-literals      true}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))
 
 ;; BigQuery is always in UTC

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -42,6 +42,7 @@
 (doseq [[feature supported?] {:connection-impersonation  true
                               :describe-fields           true
                               :describe-fks              true
+                              :expression-literals       false
                               :identifiers-with-spaces   false
                               :uuid-type                 false
                               :nested-field-columns      false

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -55,8 +55,9 @@
                               :connection-impersonation-requires-role true
                               :convert-timezone                       true
                               :datetime-diff                          true
-                              :identifiers-with-spaces                true
                               :describe-fields                        true
+                              :expression-literals                    true
+                              :identifiers-with-spaces                true
                               :now                                    true}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -578,6 +578,9 @@
     ;; \"avg(x + y)\"
     :expression-aggregations
 
+    ;; Does the driver support expressions consisting of a single literal value like `1`, `\"hello\"`, and `false`.
+    :expression-literals
+
     ;; Does the driver support using a query as the `:source-query` of another MBQL query? Examples are CTEs or
     ;; subselects in SQL queries.
     :nested-queries

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -73,7 +73,8 @@
                               ;; MySQL doesn't let you have lag/lead in the same part of a query as a `GROUP BY`; to
                               ;; fully support `offset` we need to do some kooky query transformations just for MySQL
                               ;; and make this work.
-                              :window-functions/offset                false}]
+                              :window-functions/offset                false
+                              :expression-literals                    true}]
   (defmethod driver/database-supports? [:mysql feature] [_driver _feature _db] supported?))
 
 ;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -79,7 +79,8 @@
                               :uuid-type                true
                               :split-part               true
                               :uploads                  true
-                              :cast                     true}]
+                              :cast                     true
+                              :expression-literals      true}]
   (defmethod driver/database-supports? [:postgres feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:postgres :nested-field-columns]

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
    [metabase.lib.hierarchy :as lib.hierarchy]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
@@ -534,6 +535,7 @@
                    (lib.util.match/match-one expr :offset))
           {:message  (i18n/tru "OFFSET is not supported in custom filters")
            :friendly true})
-        (when (= (first expr) :value)
+        (when (and (= (first expr) :value)
+                   (not (lib.metadata/database-supports? query :expression-literals)))
           {:message  (i18n/tru "Standalone constants are not supported.")
            :friendly true}))))

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -168,6 +168,15 @@
     (mu/disable-enforcement
       (editable-stages? query stages))))
 
+(mu/defn database-supports? :- :boolean
+  "Does `query`s [[database]] support the given `feature`?"
+  [query   :- ::lib.schema/query
+   feature :- :keyword]
+  (-> query
+      database
+      :features
+      (contains? feature)))
+
 ;;; TODO -- I'm wondering if we need both this AND [[bulk-metadata-or-throw]]... most of the rest of the stuff here
 ;;; throws if we can't fetch the metadata, not sure what situations we wouldn't want to do that in places that use
 ;;; this (like QP middleware). Maybe we should only have a throwing version.

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -34,11 +34,6 @@
           [nil, -1]))
       [query, i])))
 
-(mu/defn- query-database-supports? :- :boolean
-  [query   :- ::lib.schema/query
-   feature :- :keyword]
-  (contains? (-> query lib.metadata/database :features) feature))
-
 (mu/defn top-level-query :- ::lib.schema/query
   "Returns the \"top-level\" query for the given query.
 
@@ -47,7 +42,7 @@
 
   If the database does not support nested queries, this also returns the original query."
   [query :- ::lib.schema/query]
-  (or (when (query-database-supports? query :nested-queries)
+  (or (when (lib.metadata/database-supports? query :nested-queries)
         (first (pop-until-aggregation-or-breakout query)))
       query))
 
@@ -56,7 +51,7 @@
 
   If there are no such stages, or if the database does not supported nested queries, returns -1."
   [query :- ::lib.schema/query]
-  (or (when (query-database-supports? query :nested-queries)
+  (or (when (lib.metadata/database-supports? query :nested-queries)
         (second (pop-until-aggregation-or-breakout query)))
       -1))
 

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -65,6 +65,19 @@
     (is (lib.metadata/editable? query))
     (is (not (lib.metadata/editable? restritcted-query)))))
 
+(deftest ^:parallel database-supports?-test
+  (let [query          (lib.tu/query-with-join)
+        metadata       ^SimpleGraphMetadataProvider (:lib/metadata query)
+        metadata-graph (.-metadata-graph metadata)
+        metadata-graph-with-feature (update metadata-graph :features conj ::special-feature)
+        metadata-graph-without-feature (update metadata-graph :features disj ::special-feature)
+        provider-with-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-with-feature)
+        provider-without-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-without-feature)
+        query-with-feature (assoc query :lib/metadata provider-with-feature)
+        query-without-feature (assoc query :lib/metadata provider-without-feature)]
+    (is (lib.metadata/database-supports? query-with-feature ::special-feature))
+    (is (not (lib.metadata/database-supports? query-without-feature ::special-feature)))))
+
 (deftest ^:parallel idents-test
   (doseq [table-key (meta/tables)
           field-key (meta/fields table-key)]

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -378,22 +378,10 @@
                     (map second)
                     (map sort))))))))
 
-(defmethod driver/database-supports? [::driver/driver ::expression-aggregation-literals]
-  [driver _feature database]
-  (and (driver/database-supports? driver :expressions database)
-       (driver/database-supports? driver :expression-aggregations database)))
-
-;; literal expressions in aggregations not yet supported for these drivers
-(doseq [driver [:mongo :oracle :redshift :sqlite :sqlserver :vertica]]
-  (defmethod driver/database-supports? [driver ::expression-aggregation-literals]
-    [_driver _feature _database]
-    false))
-
 (deftest ^:parallel literal-expressions-inside-nested-and-filtered-aggregations-test
   (testing "nested aggregated and filtered literal expression"
     ;; TODO Fix this test for H2 (QUE-726)
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature ::expression-aggregation-literals :nested-queries)
-                           :h2)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations :expression-literals :nested-queries)
       (is (= [[2 true "Red Medicine" 1 8 16]
               [3 true "Red Medicine" 1 2 4]
               [4 true "Red Medicine" 1 2 4]]
@@ -430,7 +418,8 @@
 (deftest ^:parallel literal-expressions-inside-joined-aggregations-test
   (testing "joined and aggregated literal expression"
     (mt/test-drivers (mt/normal-drivers-with-feature
-                      ::expression-aggregation-literals
+                      :expression-aggregations
+                      :expression-literals
                       :left-join
                       :nested-queries)
       (is (= [[1 "Red Medicine" 3 0.33 1]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -489,19 +489,9 @@
 (def ^:private standard-literal-expression-values
   (map second (vals standard-literal-expression-defs)))
 
-(defmethod driver/database-supports? [::driver/driver ::expression-literals]
-  [driver _feature database]
-  (driver/database-supports? driver :expressions database))
-
-;; top-level literal expressions not yet supported for these drivers
-(doseq [driver [:mongo :oracle :redshift :sqlite :sqlserver :vertica]]
-  (defmethod driver/database-supports? [driver ::expression-literals]
-    [_driver _feature _database]
-    false))
-
 (deftest ^:parallel basic-literal-expression-test
   (testing "basic literal expressions"
-    (mt/test-drivers (mt/normal-drivers-with-feature ::expression-literals)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
       (is (= [[1 "" "foo" 0 12345 1.234 true false]
               [2 "" "foo" 0 12345 1.234 true false]]
              (mt/formatted-rows
@@ -516,7 +506,7 @@
   (doseq [[and-or eq-ne expected] [[:and :=  [standard-literal-expression-values]]
                                    [:or  :!= []]]]
     (testing (str "filter literal expressions with " and-or " " eq-ne)
-      (mt/test-drivers (mt/normal-drivers-with-feature ::expression-literals)
+      (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
         (is (= expected
                (mt/formatted-rows
                 standard-literal-expression-row-formats
@@ -529,8 +519,7 @@
 (deftest ^:parallel nested-literal-expression-test
   (testing "nested literal expression"
     ;; TODO Fix this test for H2 (QUE-726)
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature ::expression-literals :nested-queries)
-                           :h2)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [(into [1] standard-literal-expression-values)]
              (mt/formatted-rows
               standard-literal-expression-row-formats-with-id
@@ -546,7 +535,7 @@
   (testing "order-by integer literal expression"
     ;; Verify that :order-by of [:expression "One"] does NOT mean ORDER BY 1, which would result in ordering by the
     ;; first column in the select list $id. We want this to mean "order by the expression with value 1".
-    (mt/test-drivers (mt/normal-drivers-with-feature ::expression-literals)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [[29 "20th Century Cafe" 1]
               [8  "25°"               1]]
              (mt/rows
@@ -560,8 +549,7 @@
 (deftest ^:parallel order-by-literal-expression-test
   ;; TODO Fix this test for H2 (QUE-726)
   (testing "order-by all literal expression types"
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature ::expression-literals)
-                           :h2)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [[1 "" "foo" 0 12345 1.234 true false]
               [2 "" "foo" 0 12345 1.234 true false]]
              (mt/formatted-rows
@@ -577,7 +565,7 @@
   (doseq [[op expected] [[:and []]
                          [:or  [[true false]]]]]
     (testing (str "filter literal expressions with " op)
-      (mt/test-drivers (mt/normal-drivers-with-feature ::expression-literals)
+      (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
         (is (= expected
                (mt/formatted-rows
                 [mt/boolish->bool mt/boolish->bool]
@@ -596,7 +584,7 @@
                                  [[:expression "True"]  [standard-literal-expression-values]]
                                  [[:expression "False"] []]]]
     (testing (str "filter literal expressions with " expression)
-      (mt/test-drivers (mt/normal-drivers-with-feature ::expression-literals)
+      (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
         (is (= expected
                (mt/formatted-rows
                 standard-literal-expression-row-formats
@@ -609,8 +597,7 @@
 (deftest ^:parallel nested-and-filtered-literal-expression-test
   (testing "nested and filtered literal expression"
     ;; TODO Fix this test for H2 (QUE-726)
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature ::expression-literals :nested-queries)
-                           :h2)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [[2 "Stout Burgers & Beers" true "Red Medicine" 1 2 "Bob's Burgers"]
               [3 "The Apple Pan" true "Red Medicine" 1 2 "Bob's Burgers"]
               [4 "Wurstküche" true "Red Medicine" 1 2 "Bob's Burgers"]]
@@ -649,8 +636,7 @@
 (deftest ^:parallel joined-literal-expression-test
   (testing "joined literal expression"
     ;; TODO Fix this test for H2 (QUE-726)
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature ::expression-literals :left-join :nested-queries)
-                           :h2)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :left-join :nested-queries)
       (is (= [[2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "25°"]
               [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "In-N-Out Burger"]
               [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "The Apple Pan"]]


### PR DESCRIPTION
### Description

Closes QUE-774

Note this is stacked on top of the changes in #55206. It's split out into a separate PR for easier review.

* add a new `:expression-literals` driver feature and enable it for postgres, mysql, bigquery, and snowflake.
* add `lib.metadata/database-supports?` helper function to check if the database associated with a query supports a given feature. A similar (private) function was already defined in `lib.underlying`, so move it into `lib.metadata` to make it more widely available.
* update existing BE tests to check the "real" feature instead of a test-local one
* update `lib.expression/diagnose-expression` to check the `:expression-literals` feature for conditionally enabling/disabling literal expressions.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset
2. Add custom column with value "Hudson Borer"
    * For unsupported DBs (e.g. H2) you should see an error message and be unable to save the custom column.
    * For supported DBs (e.g. postgres, mysql), you should be able to give the custom column a name and save it.

### Demo

*Supported DB (Postgres)*
![Screenshot 2025-03-24 at 6 47 10 PM](https://github.com/user-attachments/assets/00b88757-fba1-4ea4-8e17-08c5615d56df)

*Unsupported DB (H2)*
![Screenshot 2025-03-24 at 6 48 18 PM](https://github.com/user-attachments/assets/be657c85-0fdf-4f49-a60e-fbef9bcd1d24)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
