### PR TITLE
Closes VIZ-507 bubble chart drag-and-drop issues

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -336,49 +336,47 @@ export function DashCardVisualization({
   });
 
   return (
-    <>
-      <Visualization
-        className={cx(CS.flexFull, {
-          [CS.pointerEventsNone]: isEditingDashboardLayout,
-          [CS.overflowAuto]: visualizationOverlay,
-          [CS.overflowHidden]: !visualizationOverlay,
-        })}
-        dashboard={dashboard}
-        dashcard={dashcard}
-        rawSeries={series}
-        visualizerRawSeries={
-          isVisualizerDashboardCard(dashcard) ? rawSeries : undefined
-        }
-        metadata={metadata}
-        mode={getClickActionMode}
-        getHref={getHref}
-        gridSize={gridSize}
-        totalNumGridCols={totalNumGridCols}
-        headerIcon={headerIcon}
-        expectedDuration={expectedDuration}
-        error={error?.message}
-        errorIcon={error?.icon}
-        showTitle={withTitle}
-        canToggleSeriesVisibility={!isEditing}
-        isAction={isAction}
-        isDashboard
-        isSlow={isSlow}
-        isFullscreen={isFullscreen}
-        isNightMode={isNightMode}
-        isEditing={isEditing}
-        isPreviewing={isPreviewing}
-        isEditingParameter={isEditingParameter}
-        isMobile={isMobile}
-        actionButtons={actionButtons}
-        replacementContent={visualizationOverlay}
-        getExtraDataForClick={getExtraDataForClick}
-        onUpdateVisualizationSettings={handleOnUpdateVisualizationSettings}
-        onTogglePreviewing={onTogglePreviewing}
-        onChangeCardAndRun={onChangeCardAndRun}
-        onChangeLocation={onChangeLocation}
-        token={token}
-        uuid={uuid}
-      />
-    </>
+    <Visualization
+      className={cx(CS.flexFull, {
+        [CS.pointerEventsNone]: isEditingDashboardLayout,
+        [CS.overflowAuto]: visualizationOverlay,
+        [CS.overflowHidden]: !visualizationOverlay,
+      })}
+      dashboard={dashboard}
+      dashcard={dashcard}
+      rawSeries={series}
+      visualizerRawSeries={
+        isVisualizerDashboardCard(dashcard) ? rawSeries : undefined
+      }
+      metadata={metadata}
+      mode={getClickActionMode}
+      getHref={getHref}
+      gridSize={gridSize}
+      totalNumGridCols={totalNumGridCols}
+      headerIcon={headerIcon}
+      expectedDuration={expectedDuration}
+      error={error?.message}
+      errorIcon={error?.icon}
+      showTitle={withTitle}
+      canToggleSeriesVisibility={!isEditing}
+      isAction={isAction}
+      isDashboard
+      isSlow={isSlow}
+      isFullscreen={isFullscreen}
+      isNightMode={isNightMode}
+      isEditing={isEditing}
+      isPreviewing={isPreviewing}
+      isEditingParameter={isEditingParameter}
+      isMobile={isMobile}
+      actionButtons={actionButtons}
+      replacementContent={visualizationOverlay}
+      getExtraDataForClick={getExtraDataForClick}
+      onUpdateVisualizationSettings={handleOnUpdateVisualizationSettings}
+      onTogglePreviewing={onTogglePreviewing}
+      onChangeCardAndRun={onChangeCardAndRun}
+      onChangeLocation={onChangeLocation}
+      token={token}
+      uuid={uuid}
+    />
   );
 }

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/ScatterFloatingWell/ScatterFloatingWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/ScatterFloatingWell/ScatterFloatingWell.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useSelector } from "metabase/lib/redux";
-import { Stack, Text } from "metabase/ui";
+import { Box, Text } from "metabase/ui";
 import { DROPPABLE_ID } from "metabase/visualizer/constants";
 import {
   getVisualizerComputedSettings,
@@ -35,7 +35,7 @@ export function ScatterFloatingWell() {
   );
 
   return (
-    <Stack
+    <Box
       p="md"
       bg="bg-medium"
       style={{
@@ -45,14 +45,15 @@ export function ScatterFloatingWell() {
             ? "1px solid var(--mb-color-brand)"
             : "none",
       }}
+      ref={setNodeRef}
     >
-      <WellItem ref={setNodeRef}>
+      <WellItem>
         <Text truncate>
           {bubbleSize
             ? t`Bubble size` + `: ${bubbleSize.display_name}`
             : t`Bubble size`}
         </Text>
       </WellItem>
-    </Stack>
+    </Box>
   );
 }

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1,0 +1,194 @@
+import { createMockColumn } from "metabase-types/api/mocks";
+import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
+
+import { createDataSource, createVisualizerColumnReference } from "../utils";
+
+import {
+  addDimensionColumnToCartesianChart,
+  addMetricColumnToCartesianChart,
+  replaceMetricColumnAsScatterBubbleSize,
+} from "./cartesian";
+
+describe("cartesian", () => {
+  describe("scatter bubble size", () => {
+    const dataSource = createDataSource("card", 1, "Card 1");
+
+    const column1 = createMockColumn({ name: "count" });
+    const column1Ref = createVisualizerColumnReference(dataSource, column1, []);
+
+    const column2 = createMockColumn({ name: "sum" });
+    const column2Ref = createVisualizerColumnReference(dataSource, column2, [
+      column1Ref,
+    ]);
+
+    it("should add a column", () => {
+      const state: VisualizerHistoryItem = {
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+        display: "scatter",
+      };
+
+      replaceMetricColumnAsScatterBubbleSize(
+        state,
+        column1,
+        column1Ref,
+        dataSource,
+      );
+
+      expect(state.columns.map(c => c.name)).toEqual(["COLUMN_1"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          {
+            name: "COLUMN_1",
+            originalName: "count",
+            sourceId: "card:1",
+          },
+        ],
+      });
+      expect(state.settings).toEqual({ "scatter.bubble": "COLUMN_1" });
+    });
+
+    it("should replace a column", () => {
+      const state: VisualizerHistoryItem = {
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+        display: "scatter",
+      };
+      // Add the first column
+      replaceMetricColumnAsScatterBubbleSize(
+        state,
+        column1,
+        column1Ref,
+        dataSource,
+      );
+
+      // Replace the first column with the second column
+      replaceMetricColumnAsScatterBubbleSize(
+        state,
+        column2,
+        column2Ref,
+        dataSource,
+      );
+
+      // Check that we only have the second column
+      expect(state.columns.map(c => c.name)).toEqual(["COLUMN_2"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_2: [
+          {
+            name: "COLUMN_2",
+            originalName: "sum",
+            sourceId: "card:1",
+          },
+        ],
+      });
+      expect(state.settings).toEqual({ "scatter.bubble": "COLUMN_2" });
+    });
+
+    it("should not delete a column that's used as a metric", () => {
+      const state: VisualizerHistoryItem = {
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+        display: "scatter",
+      };
+      // Add the first column as the Y axis
+      addMetricColumnToCartesianChart(state, column1, column1Ref, dataSource);
+
+      // Add it as the bubble size too
+      replaceMetricColumnAsScatterBubbleSize(
+        state,
+        column1,
+        column1Ref,
+        dataSource,
+      );
+
+      // Add the second column
+      replaceMetricColumnAsScatterBubbleSize(
+        state,
+        column2,
+        column2Ref,
+        dataSource,
+      );
+
+      // Check that we have both columns where they should be
+      expect(state.columns.map(c => c.name)).toEqual(["COLUMN_1", "COLUMN_2"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          {
+            name: "COLUMN_1",
+            originalName: "count",
+            sourceId: "card:1",
+          },
+        ],
+        COLUMN_2: [
+          {
+            name: "COLUMN_2",
+            originalName: "sum",
+            sourceId: "card:1",
+          },
+        ],
+      });
+      expect(state.settings).toEqual({
+        "scatter.bubble": "COLUMN_2",
+        "graph.metrics": ["COLUMN_1"],
+      });
+    });
+
+    it("should not delete a column that's used as a dimension", () => {
+      const state: VisualizerHistoryItem = {
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+        display: "scatter",
+      };
+      // Add the first column as the X axis
+      addDimensionColumnToCartesianChart(
+        state,
+        column1,
+        column1Ref,
+        dataSource,
+      );
+
+      // Add it as the bubble size too
+      replaceMetricColumnAsScatterBubbleSize(
+        state,
+        column1,
+        column1Ref,
+        dataSource,
+      );
+
+      // Add the second column
+      replaceMetricColumnAsScatterBubbleSize(
+        state,
+        column2,
+        column2Ref,
+        dataSource,
+      );
+
+      // Check that we have both columns where they should be
+      expect(state.columns.map(c => c.name)).toEqual(["COLUMN_1", "COLUMN_2"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          {
+            name: "COLUMN_1",
+            originalName: "count",
+            sourceId: "card:1",
+          },
+        ],
+        COLUMN_2: [
+          {
+            name: "COLUMN_2",
+            originalName: "sum",
+            sourceId: "card:1",
+          },
+        ],
+      });
+      expect(state.settings).toEqual({
+        "scatter.bubble": "COLUMN_2",
+        "graph.dimensions": ["COLUMN_1"],
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -253,34 +253,28 @@ const visualizerHistoryItemSlice = createSlice({
         column: originalColumn,
         card,
       } = action.payload;
-
       if (!state.display) {
         return;
       }
-
       const columnRef = createVisualizerColumnReference(
         dataSource,
         originalColumn,
         extractReferencedColumns(state.columnValuesMapping),
       );
-
       const column = copyColumn(
         columnRef.name,
         originalColumn,
         dataSource.name,
         state.columns,
       );
-
       if (state.display === "funnel") {
         addColumnToFunnel(state, column, columnRef, dataSource, dataset, card);
         return;
       }
-
       state.columns.push(column);
       state.columnValuesMapping[column.name] = [columnRef];
-
       if (isCartesianChart(state.display)) {
-        addColumnToCartesianChart(state, column, columnRef, card);
+        addColumnToCartesianChart(state, column, columnRef, dataSource, card);
       } else if (state.display === "pie") {
         addColumnToPieChart(state, column);
       }


### PR DESCRIPTION
Closes [VIZ-507: Bubble size setting isn't being set via wells](https://linear.app/metabase/issue/VIZ-507/bubble-size-setting-isnt-being-set-via-wells)

### Description

This closes several issues:

 - drag and drop to set the bubble size in a scatter chart was buggy
 - dragging a column would drag the dash card behind the visualizer modal and mess up with the dnd logic
 - clicking on column in the data importer would not add columns properly to the scatter chart

### How to verify

Dragging and droping columns on the scatter chart wells should work consistently (i.e. no ghost columns, no weird feedback or misaligned hitbox, etc.).
Dropping a column on the bubble size well when there's already a column should replace it.
Removing a column from a well when it's also used in another well (count used as both the metric and the bubble size, for instance) should only remove the column from the aforementioned well, not all of them (i.e. no shotgun removal of columns in columnMaps).
Removing all columns and adding them back by clicking on them should add them in the following order: dimension, metric, bubble size.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
