### PR TITLE
Add Expressionable type

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -95,6 +95,11 @@ export type ClauseType =
   | "order-by"
   | "limit";
 
+export type Expressionable =
+  | ExpressionClause
+  | FilterClause
+  | AggregationClause;
+
 export type Limit = number | null;
 
 declare const ColumnMetadata: unique symbol;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -247,7 +247,7 @@ export function AggregationPicker({
         query={query}
         stageIndex={stageIndex}
         name={displayInfo?.displayName}
-        clause={clause as unknown as Lib.ExpressionClause}
+        clause={clause}
         withName
         startRule="aggregation"
         header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -40,7 +40,7 @@ import { useExtensions } from "./extensions";
 
 type EditorProps = {
   id?: string;
-  clause?: Lib.ExpressionClause | null;
+  clause?: Lib.Expressionable | null;
   query: Lib.Query;
   stageIndex: number;
   startRule: StartRule;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -26,7 +26,7 @@ export type ExpressionWidgetProps = {
 
   query: Lib.Query;
   stageIndex: number;
-  clause?: Lib.ExpressionClause | undefined;
+  clause?: Lib.Expressionable | undefined;
   name?: string;
   withName?: boolean;
   reportTimezone?: string;
@@ -54,7 +54,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
 
   const [name, setName] = useState(initialName || "");
   const [clause, setClause] = useState<Lib.ExpressionClause | null>(
-    initialClause ?? null,
+    (initialClause ?? null) as Lib.ExpressionClause | null,
   );
   const [error, setError] = useState<ExpressionError | null>(null);
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
@@ -98,7 +98,7 @@ export function FilterPicker({
       <ExpressionWidget
         query={query}
         stageIndex={stageIndex}
-        clause={filter as unknown as Lib.ExpressionClause}
+        clause={filter}
         startRule="boolean"
         header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
         onChangeClause={handleClauseChange}


### PR DESCRIPTION
Adds a new type `Lib.Expressionable` to avoid type casts in code that uses the expression editor.