### PR TITLE
Operator prefix suggestions

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1509,7 +1509,7 @@ describe("issue #55686", () => {
     H.addCustomColumn();
     H.CustomExpressionEditor.type("not");
 
-    H.CustomExpressionEditor.completion("notin").should("be.visible");
+    H.CustomExpressionEditor.completion("notnull").should("be.visible");
     H.CustomExpressionEditor.completion("notempty").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1497,3 +1497,19 @@ describe("issue #31964", () => {
     );
   });
 });
+
+describe("issue #55686", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.openOrdersTable({ mode: "notebook" });
+  });
+
+  it("should show suggestions for functions even when the current token is an operator (metabase#55686)", () => {
+    H.addCustomColumn();
+    H.CustomExpressionEditor.type("not");
+
+    H.CustomExpressionEditor.completion("notin").should("be.visible");
+    H.CustomExpressionEditor.completion("notempty").should("be.visible");
+  });
+});

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
@@ -13,6 +13,7 @@ import {
   fuzzyMatcher,
   isFieldReference,
   isIdentifier,
+  isOperator,
   tokenAtPos,
 } from "./util";
 
@@ -57,7 +58,11 @@ export function suggestFunctions({
     const source = context.state.doc.toString();
     const token = tokenAtPos(source, context.pos);
 
-    if (!token || !isIdentifier(token) || isFieldReference(token)) {
+    if (
+      !token ||
+      !(isIdentifier(token) || isOperator(token)) ||
+      isFieldReference(token)
+    ) {
       return null;
     }
 

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
@@ -265,4 +265,23 @@ describe("suggestFunctions", () => {
       expect(results).toEqual(RESULTS_NO_TEMPLATE);
     });
   });
+
+  it("should complete functions whose name starts with the an operator name as a prefix (metabase#55686)", async () => {
+    const completer = setup({ startRule: "expression" });
+    const results = await completer("not|");
+    expect(results?.options.map(result => result.displayLabel)).toEqual([
+      "notIn",
+      "notnull",
+      "notempty",
+      "doesNotContain",
+      "now",
+      "interval",
+      "intervalStartingFrom",
+      "length",
+      "monthName",
+      "month",
+      "minute",
+      "contains",
+    ]);
+  });
 });

--- a/frontend/src/metabase-lib/v1/expressions/complete/util.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/util.ts
@@ -120,6 +120,10 @@ export function isIdentifier(token: Token | null) {
   return token != null && token.type === TOKEN.Identifier;
 }
 
+export function isOperator(token: Token | null) {
+  return token != null && token.type === TOKEN.Operator;
+}
+
 export function isFieldReference(token: Token | null) {
   return token != null && token.type === TOKEN.Identifier && token.isReference;
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55686

Fixes a bug where suggestions for functions were not shown when their name started with the name of an operator (ie. `not`).

### To verify 

1. New > Question > Accounts
2. Add filter > Custom expression
3. Type "not"


https://github.com/user-attachments/assets/52469fc4-c6f9-4b6f-90d9-54b75572521d

