### PR TITLE
test: make scrollable echarts tooltip stable

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -218,42 +218,41 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     cy.signInAsAdmin();
   });
 
-  it(
-    "should be enterable and scollable to view all rows in long tooltips (metabase#53586) (metabase#48347)",
-    { tags: "@flaky" },
-    () => {
-      const testQuestion = {
-        dataset_query: {
-          database: SAMPLE_DB_ID,
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
-              [
-                "field",
-                ORDERS.TOTAL,
-                { binning: { strategy: "num-bins", "num-bins": 50 } },
-              ],
+  it("should be enterable and scrollable to view all rows in long tooltips (metabase#53586) (metabase#48347)", () => {
+    const testQuestion = {
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            [
+              "field",
+              ORDERS.TOTAL,
+              { binning: { strategy: "num-bins", "num-bins": 50 } },
             ],
-          },
-          type: "query",
+          ],
         },
-        display: "bar",
-        visualization_settings: {
-          "graph.dimensions": ["CREATED_AT", "TOTAL"],
-          "graph.metrics": ["count"],
-        },
-      };
-      H.visitQuestionAdhoc(testQuestion);
+        type: "query",
+      },
+      display: "bar",
+      visualization_settings: {
+        "graph.dimensions": ["CREATED_AT", "TOTAL"],
+        "graph.metrics": ["count"],
+      },
+    };
+    H.visitQuestionAdhoc(testQuestion);
 
-      H.chartPathWithFillColor("#A989C5").eq(3).realHover();
-      H.echartsTooltip()
-        .findByText("155 – 160") // bottom row
-        .scrollIntoView()
-        .should("be.visible");
-    },
-  );
+    // realHover is not stable, most of the times tooltip
+    // was shown and hidden instantly using realHover
+    // so we have to use right click instead to invoke tooltip
+    H.chartPathWithFillColor("#A989C5").eq(3).rightclick();
+    H.echartsTooltip()
+      .findByText("155 – 160") // bottom row
+      .scrollIntoView()
+      .should("be.visible");
+  });
 
   describe("> additional columns setting", () => {
     const COUNT = "Count";

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -244,10 +244,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     };
     H.visitQuestionAdhoc(testQuestion);
 
-    // realHover is not stable, most of the times tooltip
-    // was shown and hidden instantly using realHover
-    // so we have to use right click instead to invoke tooltip
-    H.chartPathWithFillColor("#A989C5").eq(3).rightclick();
+    showTooltipForBarInSeries("#A989C5", 3);
     H.echartsTooltip()
       .findByText("155 – 160") // bottom row
       .scrollIntoView()


### PR DESCRIPTION
### Description

This test is broken

<img width="1575" alt="image" src="https://github.com/user-attachments/assets/2e6d1803-9ea9-4e91-8a9e-69ef5f04a702" />

~unfortunately `realHover` isn't able to keep the tooltip opened in cypress, I found `rightclick` a "stable alternative".~

I found a helper which was used in other places and reused it

✅  [stress test](https://github.com/metabase/metabase/actions/runs/14063450297/job/39379836125)
✅ [updated assertion stress test](https://github.com/metabase/metabase/actions/runs/14064841226/job/39384575112)