### PR TITLE
integer() for BigQuery

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -670,6 +670,7 @@
                               :percentile-aggregations  true
                               :metadata/key-constraints false
                               :identifiers-with-spaces  true
+                              :cast                     true
                               ;; BigQuery uses timezone operators and arguments on calls like extract() and
                               ;; timezone_trunc() rather than literally using SET TIMEZONE, but we need to flag it as
                               ;; supporting set-timezone anyway so that reporting timezones are returned and used, and

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -190,6 +190,10 @@
 ;;; |                                               SQL Driver Methods                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :integer]
+  [driver [_ value]]
+  (h2x/maybe-cast "BIGINT" (sql.qp/->honeysql driver value)))
+
 ;; TODO -- all this [[temporal-type]] stuff below can be replaced with the more generalized
 ;; [[h2x/with-database-type-info]] stuff we've added. [[h2x/with-database-type-info]] was inspired by this BigQuery code
 ;; but uses a new record type rather than attaching metadata to everything

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1260,7 +1260,7 @@
   (mt/test-driver :bigquery-cloud-sdk
     (mt/dataset test-data
       (let [mp (mt/metadata-provider)]
-        (doseq [[table fields] [[:people [{:field :zip :db-type "TEXT"}]]]
+        (doseq [[table fields] [[:people [{:field :zip :db-type "STRING"}]]]
                 {:keys [field db-type]} fields]
           (testing (str "casting " table "." field "(" db-type ") to integer")
             (let [field-md (lib.metadata/field mp (mt/id table field))
@@ -1283,7 +1283,7 @@
         (doseq [[table expressions] [[:people [{:expression (lib/expression-clause :concat
                                                                                    [(lib.metadata/field mp (mt/id :people :id))
                                                                                     (lib.metadata/field mp (mt/id :people :zip))] nil)
-                                                :db-type "TEXT"}]]]
+                                                :db-type "STRING"}]]]
                 {:keys [expression db-type]} expressions]
           (testing (str "Casting " db-type " to integer")
             (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
@@ -1304,8 +1304,8 @@
   (mt/test-driver :bigquery-cloud-sdk
     (mt/dataset test-data
       (let [mp (mt/metadata-provider)]
-        (doseq [[_table expressions] [[:people [{:expression "'123'" :db-type "TEXT"}
-                                                {:expression "'-123'" :db-type "TEXT"}]]]
+        (doseq [[_table expressions] [[:people [{:expression "'123'" :db-type "STRING"}
+                                                {:expression "'-123'" :db-type "STRING"}]]]
                 {:keys [expression db-type]} expressions]
           (testing (str "Casting " db-type " to integer from native query")
             (let [native-query (mt/native-query {:query (str "SELECT " expression " AS UNCASTED")})]
@@ -1330,7 +1330,7 @@
   (mt/test-driver :bigquery-cloud-sdk
     (mt/dataset test-data
       (let [mp (mt/metadata-provider)]
-        (doseq [[table fields] [[:people [{:field :zip :db-type "TEXT"}]]]
+        (doseq [[table fields] [[:people [{:field :zip :db-type "STRING"}]]]
                 {:keys [field db-type]} fields]
           (let [nested-query (lib/query mp (lib.metadata/table mp (mt/id table)))]
             (testing (str "Casting " db-type " to integer")
@@ -1360,7 +1360,7 @@
         (doseq [[table expressions] [[:people [{:expression (lib/expression-clause :concat
                                                                                    [(lib.metadata/field mp (mt/id :people :id))
                                                                                     (lib.metadata/field mp (mt/id :people :zip))] nil)
-                                                :db-type "TEXT"}]]]
+                                                :db-type "STRING"}]]]
                 {:keys [expression db-type]} expressions]
           (let [nested-query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
                                  (lib/with-fields [])
@@ -1395,7 +1395,7 @@
                                                              (lib/expression-clause :concat
                                                                                     [(lib.metadata/field mp (mt/id :people :id))
                                                                                      (lib.metadata/field mp (mt/id :people :zip))] nil)]
-                                                :db-type "TEXT"}]]]
+                                                :db-type "STRING"}]]]
                 {db-type :db-type [e1 e2] :expression} expressions]
           (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
                           (lib/expression "UNCASTED" e1)
@@ -1413,7 +1413,7 @@
   (mt/test-driver :bigquery-cloud-sdk
     (mt/dataset test-data
       (let [mp (mt/metadata-provider)]
-        (doseq [[table fields] [[:people [{:field :zip :db-type "TEXT"}]]]
+        (doseq [[table fields] [[:people [{:field :zip :db-type "STRING"}]]]
                 {:keys [field db-type]} fields]
           (testing (str "aggregating " table "." field "(" db-type ") and casting to integer")
             (let [field-md (lib.metadata/field mp (mt/id table field))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1317,7 +1317,7 @@
                   :type :question}]
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (as-> q
-                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "uncasted" (:name %))) first)] nil))))
+                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)] nil))))
                       result (-> query (check-integer-query db-type "`uncasted`") qp/process-query)
                       cols (mt/cols result)
                       rows (mt/rows result)]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1237,3 +1237,229 @@
           (is (= "bigquery.example.com"
                  (.getHost (.getOptions client)))
               "BigQuery client should be configured with alternate host"))))))
+
+;; integer()
+
+(defn- check-integer-query
+  ([query db-type uncasted-field]
+   (check-integer-query query db-type uncasted-field "\"subquery\".\"INTCAST\""))
+  ([query db-type uncasted-field casted-field]
+   (mt/native-query {:query (str "SELECT " casted-field ", "
+                                 (case db-type
+                                   ;; need to do regex because some strings have 0 in front
+                                   "TEXT"    (str (name uncasted-field) " ~ '^0*' || " "CAST(" casted-field " AS " db-type ") || '$'")
+                                   "INTEGER" (str "CAST(" casted-field " AS " db-type ") = " (name uncasted-field))
+                                   "FLOAT"   (str "ABS(CAST(" casted-field " AS " db-type ") - " (name uncasted-field) ") < 1"))
+                                 ", "
+                                 (name uncasted-field) " "
+                                 "FROM ( "
+                                 (-> query qp.compile/compile :query)
+                                 " ) AS subquery "
+                                 "LIMIT 100")})))
+
+(deftest ^:parallel integer-cast-table-fields
+  (mt/test-driver :bigquery-cloud-sdk
+    (mt/dataset test-data
+      (let [mp (mt/metadata-provider)]
+        (doseq [[table fields] [[:people [{:field :longitude :db-type "FLOAT"}
+                                          {:field :id :db-type "INTEGER"}
+                                          {:field :zip :db-type "TEXT"}]]
+                                [:orders [{:field :user_id :db-type "INTEGER"}
+                                          {:field :subtotal :db-type "FLOAT"}]]]
+                {:keys [field db-type]} fields]
+          (testing (str "casting " table "." field "(" db-type ") to integer")
+            (let [field-md (lib.metadata/field mp (mt/id table field))
+                  query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
+                            (lib/with-fields [field-md])
+                            (lib/expression "INTCAST" (lib/expression-clause :integer [field-md] nil))
+                            (lib/limit 100))
+                  result (-> query (check-integer-query db-type field) qp/process-query)
+                  cols (mt/cols result)
+                  rows (mt/rows result)]
+              (is (= :type/BigInteger (-> cols first :base_type)))
+              (doseq [[casted-value equals? uncasted-value] rows]
+                (is (int? casted-value))
+                (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))
+
+(deftest ^:parallel integer-cast-custom-expressions
+  (mt/test-driver :bigquery-cloud-sdk
+    (mt/dataset test-data
+      (let [mp (mt/metadata-provider)]
+        (doseq [[table expressions] [[:people [{:expression (lib/expression-clause :concat
+                                                                                   [(lib.metadata/field mp (mt/id :people :id))
+                                                                                    (lib.metadata/field mp (mt/id :people :zip))] nil)
+                                                :db-type "TEXT"}
+                                               {:expression (lib/expression-clause :get-day-of-week
+                                                                                   [(lib.metadata/field mp (mt/id :people :birth_date))] nil)
+                                                :db-type "INTEGER"}]]
+                                     [:orders [{:expression (lib/+ (lib.metadata/field mp (mt/id :orders :total))
+                                                                   (lib.metadata/field mp (mt/id :orders :quantity)))
+                                                :db-type "FLOAT"}]]]
+                {:keys [expression db-type]} expressions]
+          (testing (str "Casting " db-type " to integer")
+            (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
+                            (lib/with-fields [])
+                            (lib/expression "UNCASTED" expression)
+                            (as-> q
+                                  (lib/expression q "INTCAST" (lib/expression-clause :integer [(lib/expression-ref q "UNCASTED")] nil)))
+                            (lib/limit 10))
+                  result (-> query (check-integer-query db-type "\"subquery\".\"UNCASTED\"") qp/process-query)
+                  cols (mt/cols result)
+                  rows (mt/rows result)]
+              (is (= :type/BigInteger (-> cols first :base_type)))
+              (doseq [[casted-value equals? uncasted-value] rows]
+                (is (int? casted-value))
+                (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))
+
+(deftest ^:parallel integer-cast-nested-native-query
+  (mt/test-driver :bigquery-cloud-sdk
+    (mt/dataset test-data
+      (let [mp (mt/metadata-provider)]
+        (doseq [[_table expressions] [[:people [{:expression 1 :db-type "INTEGER"}
+                                                {:expression "'123'" :db-type "TEXT"}
+                                                {:expression "'-123'" :db-type "TEXT"}
+                                                {:expression 4.5 :db-type "FLOAT"}]]]
+                {:keys [expression db-type]} expressions]
+          (testing (str "Casting " db-type " to integer from native query")
+            (let [native-query (mt/native-query {:query (str "SELECT " expression " AS UNCASTED")})]
+              (mt/with-temp
+                [:model/Card
+                 {card-id :id}
+                 {:dataset_query native-query
+                  :result_metadata (-> (qp/process-query native-query) :data :results_metadata :columns)
+                  :type :question}]
+                (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
+                                (as-> q
+                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "uncasted" (:name %))) first)] nil))))
+                      result (-> query (check-integer-query db-type "\"uncasted\"") qp/process-query)
+                      cols (mt/cols result)
+                      rows (mt/rows result)]
+                  (is (= :type/BigInteger (-> cols first :base_type)))
+                  (doseq [[casted-value equals? uncasted-value] rows]
+                    (is (int? casted-value))
+                    (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))))
+
+(deftest ^:parallel integer-cast-nested-query
+  (mt/test-driver :bigquery-cloud-sdk
+    (mt/dataset test-data
+      (let [mp (mt/metadata-provider)]
+        (doseq [[table fields] [[:people [{:field :longitude :db-type "FLOAT"}
+                                          {:field :id :db-type "INTEGER"}
+                                          {:field :zip :db-type "TEXT"}]]
+                                [:orders [{:field :user_id :db-type "INTEGER"}
+                                          {:field :subtotal :db-type "FLOAT"}]]]
+                {:keys [field db-type]} fields]
+          (let [nested-query (lib/query mp (lib.metadata/table mp (mt/id table)))]
+            (testing (str "Casting " db-type " to integer")
+              (mt/with-temp
+                [:model/Card
+                 {card-id :id}
+                 {:dataset_query nested-query
+                  :result_metadata (-> (qp/process-query nested-query) :data :results_metadata :columns)
+                  :type :question}]
+                (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
+                                (lib/with-fields [])
+                                (as-> q
+                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(lib.metadata/field mp (mt/id table field))] nil)))
+                                (lib/limit 10))
+                      result (-> query (check-integer-query db-type field) qp/process-query)
+                      cols (mt/cols result)
+                      rows (mt/rows result)]
+                  (is (= :type/BigInteger (-> cols first :base_type)))
+                  (doseq [[casted-value equals? uncasted-value] rows]
+                    (is (int? casted-value))
+                    (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))))
+
+(deftest ^:parallel integer-cast-nested-query-custom-expressions
+  (mt/test-driver :bigquery-cloud-sdk
+    (mt/dataset test-data
+      (let [mp (mt/metadata-provider)]
+        (doseq [[table expressions] [[:people [{:expression (lib/expression-clause :concat
+                                                                                   [(lib.metadata/field mp (mt/id :people :id))
+                                                                                    (lib.metadata/field mp (mt/id :people :zip))] nil)
+                                                :db-type "TEXT"}
+                                               {:expression (lib/expression-clause :get-day-of-week
+                                                                                   [(lib.metadata/field mp (mt/id :people :birth_date))] nil)
+                                                :db-type "INTEGER"}]]
+                                     [:orders [{:expression (lib/+ (lib.metadata/field mp (mt/id :orders :total))
+                                                                   (lib.metadata/field mp (mt/id :orders :quantity)))
+                                                :db-type "FLOAT"}]]]
+                {:keys [expression db-type]} expressions]
+          (let [nested-query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
+                                 (lib/with-fields [])
+                                 (lib/expression "UNCASTED" expression)
+                                 (lib/limit 10))]
+            (testing (str "Casting " db-type " to integer")
+              (mt/with-temp
+                [:model/Card
+                 {card-id :id}
+                 {:dataset_query nested-query
+                  :result_metadata (-> (qp/process-query nested-query) :data :results_metadata :columns)
+                  :type :question}]
+                (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
+                                (as-> q
+                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)] nil)))
+                                (lib/limit 10))
+                      result (-> query (check-integer-query db-type "\"subquery\".\"UNCASTED\"") qp/process-query)
+                      cols (mt/cols result)
+                      rows (mt/rows result)]
+                  (is (= :type/BigInteger (-> cols first :base_type)))
+                  (doseq [[casted-value equals? uncasted-value] rows]
+                    (is (int? casted-value))
+                    (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))))
+
+(deftest ^:parallel integer-cast-nested-custom-expressions
+  (mt/test-driver :bigquery-cloud-sdk
+    (mt/dataset test-data
+      (let [mp (mt/metadata-provider)]
+        (doseq [[table expressions] [[:people [{:expression [(lib/expression-clause :concat
+                                                                                    [(lib.metadata/field mp (mt/id :people :id))
+                                                                                     (lib.metadata/field mp (mt/id :people :zip))] nil)
+                                                             (lib/expression-clause :concat
+                                                                                    [(lib.metadata/field mp (mt/id :people :id))
+                                                                                     (lib.metadata/field mp (mt/id :people :zip))] nil)]
+                                                :db-type "TEXT"}
+                                               {:expression [(lib/expression-clause :get-day-of-week
+                                                                                    [(lib.metadata/field mp (mt/id :people :birth_date))] nil)
+                                                             (lib/expression-clause :get-day-of-week
+                                                                                    [(lib.metadata/field mp (mt/id :people :birth_date))] nil)]
+                                                :db-type "INTEGER"}]]
+                                     [:orders [{:expression [(lib/+ (lib.metadata/field mp (mt/id :orders :total))
+                                                                    (lib.metadata/field mp (mt/id :orders :quantity)))
+                                                             (lib/+ (lib.metadata/field mp (mt/id :orders :total))
+                                                                    (lib.metadata/field mp (mt/id :orders :quantity)))]
+                                                :db-type "FLOAT"}]]]
+                {db-type :db-type [e1 e2] :expression} expressions]
+          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
+                          (lib/expression "UNCASTED" e1)
+                          (lib/expression "INTCAST" (lib/expression-clause :integer [e2] nil))
+                          (lib/limit 10))
+                result (-> query (check-integer-query db-type "\"subquery\".\"UNCASTED\"") qp/process-query)
+                cols (mt/cols result)
+                rows (mt/rows result)]
+            (is (= :type/BigInteger (-> cols first :base_type)))
+            (doseq [[casted-value equals? uncasted-value] rows]
+              (is (int? casted-value))
+              (is equals? (str "Not equal for: " casted-value " " uncasted-value)))))))))
+
+(deftest ^:parallel integer-cast-aggregations
+  (mt/test-driver :bigquery-cloud-sdk
+    (mt/dataset test-data
+      (let [mp (mt/metadata-provider)]
+        (doseq [[table fields] [[:people [{:field :longitude :db-type "FLOAT"}
+                                          {:field :id :db-type "INTEGER"}
+                                          {:field :zip :db-type "TEXT"}]]
+                                [:orders [{:field :user_id :db-type "INTEGER"}
+                                          {:field :subtotal :db-type "FLOAT"}]]]
+                {:keys [field db-type]} fields]
+          (testing (str "aggregating " table "." field "(" db-type ") and casting to integer")
+            (let [field-md (lib.metadata/field mp (mt/id table field))
+                  query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
+                            (lib/aggregate (lib/max field-md))
+                            (lib/aggregate (lib/max (lib/integer field-md))))
+                  result (-> query (check-integer-query db-type "\"subquery\".\"max\"" "\"subquery\".\"max_2\"") qp/process-query)
+                  cols (mt/cols result)
+                  rows (mt/rows result)]
+              (is (= :type/BigInteger (-> cols first :base_type)))
+              (doseq [[casted-value _equals? _uncasted-value] rows]
+                (is (int? casted-value))))))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1271,7 +1271,7 @@
                   result (-> query (check-integer-query db-type field) qp/process-query)
                   cols (mt/cols result)
                   rows (mt/rows result)]
-              (is (= :type/BigInteger (-> cols first :base_type)))
+              (is (#{:type/Integer :type/BigInteger} (-> cols first :base_type)))
               (doseq [[casted-value equals? uncasted-value] rows]
                 (is (int? casted-value))
                 (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))
@@ -1295,7 +1295,7 @@
                   result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                   cols (mt/cols result)
                   rows (mt/rows result)]
-              (is (= :type/BigInteger (-> cols first :base_type)))
+              (is (#{:type/Integer :type/BigInteger} (-> cols first :base_type)))
               (doseq [[casted-value equals? uncasted-value] rows]
                 (is (int? casted-value))
                 (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))
@@ -1321,7 +1321,7 @@
                       result (-> query (check-integer-query db-type "`uncasted`") qp/process-query)
                       cols (mt/cols result)
                       rows (mt/rows result)]
-                  (is (= :type/BigInteger (-> cols first :base_type)))
+                  (is (#{:type/Integer :type/BigInteger} (-> cols first :base_type)))
                   (doseq [[casted-value equals? uncasted-value] rows]
                     (is (int? casted-value))
                     (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))))
@@ -1348,7 +1348,7 @@
                       result (-> query (check-integer-query db-type field) qp/process-query)
                       cols (mt/cols result)
                       rows (mt/rows result)]
-                  (is (= :type/BigInteger (-> cols first :base_type)))
+                  (is (#{:type/Integer :type/BigInteger} (-> cols first :base_type)))
                   (doseq [[casted-value equals? uncasted-value] rows]
                     (is (int? casted-value))
                     (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))))
@@ -1380,7 +1380,7 @@
                       result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                       cols (mt/cols result)
                       rows (mt/rows result)]
-                  (is (= :type/BigInteger (-> cols first :base_type)))
+                  (is (#{:type/Integer :type/BigInteger} (-> cols first :base_type)))
                   (doseq [[casted-value equals? uncasted-value] rows]
                     (is (int? casted-value))
                     (is equals? (str "Not equal for: " casted-value " " uncasted-value))))))))))))
@@ -1404,7 +1404,7 @@
                 result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                 cols (mt/cols result)
                 rows (mt/rows result)]
-            (is (= :type/BigInteger (-> cols first :base_type)))
+            (is (#{:type/Integer :type/BigInteger} (-> cols first :base_type)))
             (doseq [[casted-value equals? uncasted-value] rows]
               (is (int? casted-value))
               (is equals? (str "Not equal for: " casted-value " " uncasted-value)))))))))
@@ -1423,6 +1423,6 @@
                   result (-> query (check-integer-query db-type "`subquery`.`max`" "`subquery`.`max_2`") qp/process-query)
                   cols (mt/cols result)
                   rows (mt/rows result)]
-              (is (= :type/BigInteger (-> cols first :base_type)))
+              (is (#{:type/Integer :type/BigInteger} (-> cols first :base_type)))
               (doseq [[casted-value _equals? _uncasted-value] rows]
                 (is (int? casted-value))))))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1244,7 +1244,7 @@
 
 (defn- check-integer-query
   ([query db-type uncasted-field]
-   (check-integer-query query db-type uncasted-field "\"subquery\".\"INTCAST\""))
+   (check-integer-query query db-type uncasted-field "`subquery`.`INTCAST`"))
   ([query db-type uncasted-field casted-field]
    (mt/native-query {:query (str "SELECT " casted-field ", "
                                  ;; need to do regex because some strings have 0 in front
@@ -1292,7 +1292,7 @@
                             (as-> q
                                   (lib/expression q "INTCAST" (lib/expression-clause :integer [(lib/expression-ref q "UNCASTED")] nil)))
                             (lib/limit 10))
-                  result (-> query (check-integer-query db-type "\"subquery\".\"UNCASTED\"") qp/process-query)
+                  result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                   cols (mt/cols result)
                   rows (mt/rows result)]
               (is (= :type/BigInteger (-> cols first :base_type)))
@@ -1318,7 +1318,7 @@
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (as-> q
                                       (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "uncasted" (:name %))) first)] nil))))
-                      result (-> query (check-integer-query db-type "\"uncasted\"") qp/process-query)
+                      result (-> query (check-integer-query db-type "`uncasted`") qp/process-query)
                       cols (mt/cols result)
                       rows (mt/rows result)]
                   (is (= :type/BigInteger (-> cols first :base_type)))
@@ -1377,7 +1377,7 @@
                                 (as-> q
                                       (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)] nil)))
                                 (lib/limit 10))
-                      result (-> query (check-integer-query db-type "\"subquery\".\"UNCASTED\"") qp/process-query)
+                      result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                       cols (mt/cols result)
                       rows (mt/rows result)]
                   (is (= :type/BigInteger (-> cols first :base_type)))
@@ -1401,7 +1401,7 @@
                           (lib/expression "UNCASTED" e1)
                           (lib/expression "INTCAST" (lib/expression-clause :integer [e2] nil))
                           (lib/limit 10))
-                result (-> query (check-integer-query db-type "\"subquery\".\"UNCASTED\"") qp/process-query)
+                result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                 cols (mt/cols result)
                 rows (mt/rows result)]
             (is (= :type/BigInteger (-> cols first :base_type)))
@@ -1420,7 +1420,7 @@
                   query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
                             (lib/aggregate (lib/max field-md))
                             (lib/aggregate (lib/max (lib/integer field-md))))
-                  result (-> query (check-integer-query db-type "\"subquery\".\"max\"" "\"subquery\".\"max_2\"") qp/process-query)
+                  result (-> query (check-integer-query db-type "`subquery`.`max`" "`subquery`.`max_2`") qp/process-query)
                   cols (mt/cols result)
                   rows (mt/rows result)]
               (is (= :type/BigInteger (-> cols first :base_type)))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1266,7 +1266,7 @@
             (let [field-md (lib.metadata/field mp (mt/id table field))
                   query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
                             (lib/with-fields [field-md])
-                            (lib/expression "INTCAST" (lib/expression-clause :integer [field-md] nil))
+                            (lib/expression "INTCAST" (lib/integer field-md))
                             (lib/limit 100))
                   result (-> query (check-integer-query db-type field) qp/process-query)
                   cols (mt/cols result)
@@ -1280,9 +1280,9 @@
   (mt/test-driver :bigquery-cloud-sdk
     (mt/dataset test-data
       (let [mp (mt/metadata-provider)]
-        (doseq [[table expressions] [[:people [{:expression (lib/expression-clause :concat
-                                                                                   [(lib.metadata/field mp (mt/id :people :id))
-                                                                                    (lib.metadata/field mp (mt/id :people :zip))] nil)
+        (doseq [[table expressions] [[:people [{:expression (lib/concat
+                                                             (lib.metadata/field mp (mt/id :people :id))
+                                                             (lib.metadata/field mp (mt/id :people :zip)))
                                                 :db-type "STRING"}]]]
                 {:keys [expression db-type]} expressions]
           (testing (str "Casting " db-type " to integer")
@@ -1290,7 +1290,7 @@
                             (lib/with-fields [])
                             (lib/expression "UNCASTED" expression)
                             (as-> q
-                                  (lib/expression q "INTCAST" (lib/expression-clause :integer [(lib/expression-ref q "UNCASTED")] nil)))
+                                  (lib/expression q "INTCAST" (lib/integer (lib/expression-ref q "UNCASTED"))))
                             (lib/limit 10))
                   result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                   cols (mt/cols result)
@@ -1315,7 +1315,7 @@
                  (mt/card-with-source-metadata-for-query native-query)]
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (as-> q
-                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)] nil))))
+                                      (lib/expression q "INTCAST" (lib/integer (->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)))))
                       result (-> query (check-integer-query db-type "`uncasted`") qp/process-query)
                       cols (mt/cols result)
                       rows (mt/rows result)]
@@ -1339,7 +1339,7 @@
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (lib/with-fields [])
                                 (as-> q
-                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(lib.metadata/field mp (mt/id table field))] nil)))
+                                      (lib/expression q "INTCAST" (lib/integer (lib.metadata/field mp (mt/id table field)))))
                                 (lib/limit 10))
                       result (-> query (check-integer-query db-type field) qp/process-query)
                       cols (mt/cols result)
@@ -1353,9 +1353,9 @@
   (mt/test-driver :bigquery-cloud-sdk
     (mt/dataset test-data
       (let [mp (mt/metadata-provider)]
-        (doseq [[table expressions] [[:people [{:expression (lib/expression-clause :concat
-                                                                                   [(lib.metadata/field mp (mt/id :people :id))
-                                                                                    (lib.metadata/field mp (mt/id :people :zip))] nil)
+        (doseq [[table expressions] [[:people [{:expression (lib/concat
+                                                             (lib.metadata/field mp (mt/id :people :id))
+                                                             (lib.metadata/field mp (mt/id :people :zip)))
                                                 :db-type "STRING"}]]]
                 {:keys [expression db-type]} expressions]
           (let [nested-query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
@@ -1369,7 +1369,7 @@
                  (mt/card-with-source-metadata-for-query nested-query)]
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (as-> q
-                                      (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)] nil)))
+                                      (lib/expression q "INTCAST" (lib/integer (->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first))))
                                 (lib/limit 10))
                       result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                       cols (mt/cols result)
@@ -1383,17 +1383,17 @@
   (mt/test-driver :bigquery-cloud-sdk
     (mt/dataset test-data
       (let [mp (mt/metadata-provider)]
-        (doseq [[table expressions] [[:people [{:expression [(lib/expression-clause :concat
-                                                                                    [(lib.metadata/field mp (mt/id :people :id))
-                                                                                     (lib.metadata/field mp (mt/id :people :zip))] nil)
-                                                             (lib/expression-clause :concat
-                                                                                    [(lib.metadata/field mp (mt/id :people :id))
-                                                                                     (lib.metadata/field mp (mt/id :people :zip))] nil)]
+        (doseq [[table expressions] [[:people [{:expression [(lib/concat
+                                                              (lib.metadata/field mp (mt/id :people :id))
+                                                              (lib.metadata/field mp (mt/id :people :zip)))
+                                                             (lib/concat
+                                                              (lib.metadata/field mp (mt/id :people :id))
+                                                              (lib.metadata/field mp (mt/id :people :zip)))]
                                                 :db-type "STRING"}]]]
                 {db-type :db-type [e1 e2] :expression} expressions]
           (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
                           (lib/expression "UNCASTED" e1)
-                          (lib/expression "INTCAST" (lib/expression-clause :integer [e2] nil))
+                          (lib/expression "INTCAST" (lib/integer e2))
                           (lib/limit 10))
                 result (-> query (check-integer-query db-type "`subquery`.`UNCASTED`") qp/process-query)
                 cols (mt/cols result)

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1248,7 +1248,7 @@
   ([query db-type uncasted-field casted-field]
    (mt/native-query {:query (str "SELECT " casted-field ", "
                                  ;; need to do regex because some strings have 0 in front
-                                 (name uncasted-field) " ~ '^0*' || " "CAST(" casted-field " AS " db-type ") || '$'"
+                                 "REGEXP_CONTAINS(" (name uncasted-field) ", CONCAT('^0*', " "CAST(" casted-field " AS " db-type "), '$'))"
                                  ", "
                                  (name uncasted-field) " "
                                  "FROM ( "

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1312,9 +1312,7 @@
               (mt/with-temp
                 [:model/Card
                  {card-id :id}
-                 {:dataset_query native-query
-                  :result_metadata (-> (qp/process-query native-query) :data :results_metadata :columns)
-                  :type :question}]
+                 (mt/card-with-source-metadata-for-query native-query)]
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (as-> q
                                       (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)] nil))))
@@ -1337,9 +1335,7 @@
               (mt/with-temp
                 [:model/Card
                  {card-id :id}
-                 {:dataset_query nested-query
-                  :result_metadata (-> (qp/process-query nested-query) :data :results_metadata :columns)
-                  :type :question}]
+                 (mt/card-with-source-metadata-for-query nested-query)]
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (lib/with-fields [])
                                 (as-> q
@@ -1370,9 +1366,7 @@
               (mt/with-temp
                 [:model/Card
                  {card-id :id}
-                 {:dataset_query nested-query
-                  :result_metadata (-> (qp/process-query nested-query) :data :results_metadata :columns)
-                  :type :question}]
+                 (mt/card-with-source-metadata-for-query nested-query)]
                 (let [query (-> (lib/query mp (lib.metadata/card mp card-id))
                                 (as-> q
                                       (lib/expression q "INTCAST" (lib/expression-clause :integer [(->> q lib/visible-columns (filter #(= "UNCASTED" (:name %))) first)] nil)))


### PR DESCRIPTION
Closes QUE-786

This adds support for the `integer()` custom expression for BigQuery, one of the Tier 2 databases.

