### PR TITLE
Less noise and more emojis in release channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -565,7 +565,6 @@ jobs:
               version: '${{ inputs.version }}',
               runId: '${{ github.run_id }}',
               channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
-              generalChannelName: !isAutoRelease ? '${{ vars.SLACK_GENERAL_CHANNEL }}' : '',
             }).catch(console.error);
 
   manage-milestones:


### PR DESCRIPTION
## Description
The release channel has gotten noisier lately as we've gotten on a more frequent release cadence of multiple major releases. This attempts to reduce the noise by
- Not broadcasting release complete messages to the channel, and keeping them in the thread
- adding a ⚠️  to the build thread when there's a problem with a release
- adding a ✅  to the build thread (and removing any ⚠️ s) when a release is completed
- removing some outdated text from the release-complete message

problem | complete
--- | ---
![Screenshot 2025-03-25 at 9 16 38 AM](https://github.com/user-attachments/assets/50f84b79-d9c4-4cdb-bbfb-20c76b80f252) | ![Screenshot 2025-03-25 at 9 16 54 AM](https://github.com/user-attachments/assets/22c18011-6f71-4199-b87c-8629281ae184)

