### PR TITLE
fix: add index to field_usage query_execution_id

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10885,6 +10885,26 @@ databaseChangeLog:
               UPDATE core_user SET locale = 'zh_CN' WHERE locale = 'zh';
       rollback: # nothing to do; zh_CN is backwards compatible
 
+  - changeSet:
+      id: v54.2025-03-25T16:34:12
+      author: edpaget
+      comment: Add index to field_usage query_execution_id column to support faster deletes
+      preConditions:
+      rollback: # cannot rollback an index on a fk in mysql
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: field_usage
+                indexName: idx_field_usage_query_execution_id
+      changes:
+        - createIndex:
+            tableName: field_usage
+            columns:
+              - column:
+                  name: query_execution_id
+            indexName: idx_field_usage_query_execution_id
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10889,7 +10889,6 @@ databaseChangeLog:
       id: v54.2025-03-25T16:34:12
       author: edpaget
       comment: Add index to field_usage query_execution_id column to support faster deletes
-      preConditions:
       rollback: # cannot rollback an index on a fk in mysql
       preConditions:
         - onFail: MARK_RAN


### PR DESCRIPTION
### Description

Large metabase instance have issues with truncate operations on the query execution table timing out. A contributing factor to this is the lack of an index on the field_usage query_execution_id column which has a foreign key constraint with an ON DELETE CASCADE trigger from the query_execution table. Without this index each row we delete from query_executions need to do a table scan on the field_usage table to handle triggers. 

### How to verify

Try to truncate the query execution table
See that it doesn't timeout

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
