### PR TITLE
[models] Add `card_schema` column, for future use in `after-select`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -16,7 +16,7 @@
   Returns nil if no question was found."
   [table-or-table-id user-or-user-id]
   (t2/select-one :model/Card
-                 {:select [:c.id :c.dataset_query :c.result_metadata]
+                 {:select [:c.id :c.dataset_query :c.result_metadata :c.card_schema]
                   :from   [[:sandboxes]]
                   :join   [[:permissions_group_membership :pgm] [:= :sandboxes.group_id :pgm.group_id]
                            [:report_card :c] [:= :c.id :sandboxes.card_id]]

--- a/enterprise/backend/src/metabase_enterprise/stale/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/api.clj
@@ -67,6 +67,7 @@
                                :database_id
                                [nil :location]
                                :dataset_query
+                               :card_schema
                                :last_used_at
                                [{:select   [:status]
                                  :from     [:moderation_review]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -43,7 +43,7 @@
                       :attributes {:cat 50}}
       ;; Fetch the card and manually compute & save the metadata
       (let [card (t2/select-one :model/Card
-                                {:select [:c.id :c.dataset_query]
+                                {:select [:c.id :c.dataset_query :c.card_schema]
                                  :from   [[:sandboxes :s]]
                                  :join   [[:permissions_group :pg] [:= :s.group_id :pg.id]
                                           [:report_card :c] [:= :c.id :s.card_id]]

--- a/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
@@ -33,7 +33,7 @@
                                              :models "dashboard" :models "card")
                        (dissoc :models)
                        (update :data (fn [results] (map (fn [result] (dissoc result :moderated_status)) results))))
-                   (update result :data (fn [results] (map (fn [result] (dissoc result :collection :moderated_status)) results))))))
+                   (update result :data (fn [results] (map (fn [result] (dissoc result :collection :moderated_status :card_schema)) results))))))
           (testing "The card and dashboard are in there"
             (is (= #{["card" (u/the-id card)] ["dashboard" (u/the-id dashboard)]}
                    (->> result

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10904,6 +10904,40 @@ databaseChangeLog:
                   name: query_execution_id
             indexName: idx_field_usage_query_execution_id
 
+  - changeSet:
+      id: v55.2025-03-24T16:28:41
+      author: bshepherdson
+      comment: Add report_card.card_schema
+      preConditions:
+        - not:
+          - columnExists:
+              tableName: report_card
+              columnName: card_schema
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: card_schema
+                  type: int
+                  remarks: Arbitrary revision number for how we store queries in report_card
+                  defaultValue: 20
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v55.2025-03-24T16:36:19
+      author: bshepherdson
+      comment: Creating index on the card_schema
+      preConditions:
+      changes:
+        - createIndex:
+            tableName: report_card
+            columns:
+              - column:
+                  name: card_schema
+            indexName: idx_report_card_card_schema
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -76,7 +76,7 @@
 
 (defn- check-model-is-not-a-saved-question
   [model-id]
-  (when-not (= (t2/select-one-fn :type [:model/Card :type] :id model-id) :model)
+  (when-not (= (t2/select-one-fn :type [:model/Card :type :card_schema] :id model-id) :model)
     (throw (ex-info (tru "Actions must be made with models, not cards.")
                     {:status-code 400}))))
 

--- a/src/metabase/activity_feed/api.clj
+++ b/src/metabase/activity_feed/api.clj
@@ -18,7 +18,7 @@
    (case model
      "card"      [:model/Card
                   :id :name :collection_id :description :display
-                  :dataset_query :type :archived
+                  :dataset_query :type :archived :card_schema
                   :collection.authority_level [:collection.name :collection_name]
                   [:dashboard.name :dashboard_name] :dashboard_id]
      "dashboard" [:model/Dashboard

--- a/src/metabase/activity_feed/models/recent_views.clj
+++ b/src/metabase/activity_feed/models/recent_views.clj
@@ -249,6 +249,7 @@
                          :card.id
                          :card.database_id
                          :card.display
+                         :card.card_schema
                          [:dashboard.id :dashboard_id]
                          [:dashboard.name :dashboard_name]
                          [:card.collection_id :entity-coll-id]

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -293,7 +293,7 @@
   "Get metrics on Collection usage."
   []
   (let [collections (t2/select :model/Collection {:where (mi/exclude-internal-content-hsql :model/Collection)})
-        cards       (t2/select [:model/Card :collection_id] {:where (mi/exclude-internal-content-hsql :model/Card)})]
+        cards       (t2/select [:model/Card :collection_id :card_schema] {:where (mi/exclude-internal-content-hsql :model/Card)})]
     {:collections              (count collections)
      :cards_in_collections     (count (filter :collection_id cards))
      :cards_not_in_collections (count (remove :collection_id cards))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -711,7 +711,7 @@
     (api/write-check :model/Collection new-collection-id-or-nil))
   ;; for each affected card...
   (when (seq card-ids)
-    (let [cards (t2/select [:model/Card :id :collection_id :collection_position :dataset_query]
+    (let [cards (t2/select [:model/Card :id :collection_id :collection_position :dataset_query :card_schema]
                            {:where [:and [:in :id (set card-ids)]
                                     [:or [:not= :collection_id new-collection-id-or-nil]
                                      (when new-collection-id-or-nil
@@ -829,7 +829,7 @@
   (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check :model/Card card-id))
-  (let [{existing-public-uuid :public_uuid} (t2/select-one [:model/Card :public_uuid] :id card-id)]
+  (let [{existing-public-uuid :public_uuid} (t2/select-one [:model/Card :public_uuid :card_schema] :id card-id)]
     {:uuid (or existing-public-uuid
                (u/prog1 (str (random-uuid))
                  (t2/update! :model/Card card-id
@@ -853,7 +853,7 @@
   []
   (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
-  (t2/select [:model/Card :name :id :public_uuid], :public_uuid [:not= nil], :archived false))
+  (t2/select [:model/Card :name :id :public_uuid :card_schema], :public_uuid [:not= nil], :archived false))
 
 (api.macros/defendpoint :get "/embeddable"
   "Fetch a list of Cards where `enable_embedding` is `true`. The cards can be embedded using the embedding endpoints
@@ -861,7 +861,7 @@
   []
   (validation/check-has-application-permission :setting)
   (validation/check-embedding-enabled)
-  (t2/select [:model/Card :name :id], :enable_embedding true, :archived false))
+  (t2/select [:model/Card :name :id :card_schema], :enable_embedding true, :archived false))
 
 (api.macros/defendpoint :post "/pivot/:card-id/query"
   "Run the query associated with a Card."

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -153,7 +153,7 @@
      (completing conj #(t2/hydrate % :collection :metrics))
      []
      (t2/reducible-query {:select   [:name :description :database_id :dataset_query :id :collection_id
-                                     :result_metadata :type :source_card_id
+                                     :result_metadata :type :source_card_id :card_schema
                                      [{:select   [:status]
                                        :from     [:moderation_review]
                                        :where    [:and
@@ -535,7 +535,8 @@
                         second
                         (str/replace #"-" " ")
                         u/lower-case-en)]
-    (t2/select [:model/Card :id :type :database_id :name :collection_id [:collection.name :collection_name]]
+    (t2/select [:model/Card :id :type :database_id :name :collection_id
+                [:collection.name :collection_name] :card_schema]
                {:where    [:and
                            [:= :report_card.database_id database-id]
                            [:= :report_card.archived false]

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -66,7 +66,7 @@
     ;; add sensible constraints for results limits on our query
     (let [source-card-id (query->source-card-id query)
           source-card    (when source-card-id
-                           (t2/select-one [:model/Card :result_metadata :type] :id source-card-id))
+                           (t2/select-one [:model/Card :result_metadata :type :card_schema] :id source-card-id))
           info           (cond-> {:executed-by api/*current-user-id*
                                   :context     context
                                   :card-id     source-card-id}

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -106,7 +106,7 @@
 (defn- resolve-card-parameters
   "Returns parameters for a card (HUH?)" ; TODO - better docstring
   [card-or-id]
-  (-> (t2/select-one [:model/Card :dataset_query :parameters], :id (u/the-id card-or-id))
+  (-> (t2/select-one [:model/Card :dataset_query :parameters :card_schema], :id (u/the-id card-or-id))
       api.public/combine-parameters-and-template-tags
       :parameters))
 

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -534,7 +534,7 @@
     (let [cards (t2/select :model/Card
                            {:select    [:c.id :c.dataset_query :c.result_metadata :c.name
                                         :c.description :c.collection_id :c.database_id :c.type
-                                        :c.source_card_id :c.created_at :c.entity_id
+                                        :c.source_card_id :c.created_at :c.entity_id :c.card_schema
                                         [:r.status :moderated_status]]
                             :from      [[:report_card :c]]
                             :left-join [[{:select   [:moderated_item_id :status]

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -230,6 +230,7 @@
    (next-method query-type model parsed-args honeysql)
    {:select    [:card/collection_id
                 :card/created_at   ; Needed for backfilling :entity_id on demand; see [[metabase.models.card]].
+                :card/card_schema  ; Needed for after-select logic to work.
                 :card/database_id
                 :card/dataset_query
                 :card/id

--- a/src/metabase/model_persistence/task/persist_refresh.clj
+++ b/src/metabase/model_persistence/task/persist_refresh.clj
@@ -129,7 +129,7 @@
                          (reduce (fn [stats persisted-info]
                                    ;; Since this could be long running, double check state just before deleting
                                    (let [current-state (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info))
-                                         card-info     (t2/select-one [:model/Card :archived :type]
+                                         card-info     (t2/select-one [:model/Card :archived :type :card_schema]
                                                                       :id (:card_id persisted-info))]
                                      (if (or (contains? (persisted-info/prunable-states) current-state)
                                              (:archived card-info)

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -150,7 +150,7 @@ saved later when it is ready."
             (log/infof "Not updating metadata asynchronously for card %s because no metadata" (u/the-id card))
 
             :else
-            (let [current-query (t2/select-one-fn :dataset_query [:model/Card :dataset_query] :id id)]
+            (let [current-query (t2/select-one-fn :dataset_query [:model/Card :dataset_query :card_schema] :id id)]
               (if (= (:dataset_query card) current-query)
                 (do
                   (t2/update! :model/Card id {:result_metadata metadata})

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -474,7 +474,7 @@
     (-> (select-keys dashboard [:description :name :parameters :dashcards])
         (update :dashcards (fn [dashcards]
                              (for [{:keys [id card_id]} dashcards]
-                               (-> (t2/select-one [:model/Card :name :description], :id card_id)
+                               (-> (t2/select-one [:model/Card :name :description :card_schema], :id card_id)
                                    (assoc :id id)
                                    (assoc :card_id card_id))))))
 

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -41,7 +41,7 @@
 (defmethod mi/perms-objects-set :model/DashboardCard
   [dashcard read-or-write]
   (let [card   (or (:card dashcard)
-                   (t2/select-one [:model/Card :dataset_query] :id (u/the-id (:card_id dashcard))))
+                   (t2/select-one [:model/Card :dataset_query :card_schema] :id (u/the-id (:card_id dashcard))))
         series (or (:series dashcard)
                    (series dashcard))]
     (apply set/union (mi/perms-objects-set card read-or-write) (for [series-card series]
@@ -89,7 +89,7 @@
           dashcard-id->series (when (seq dashcard-ids)
                                 (as-> (t2/select
                                        [:model/Card :id :name :description :display :dataset_query :type :database_id
-                                        :visualization_settings :collection_id :series.dashboardcard_id]
+                                        :visualization_settings :collection_id :card_schema :series.dashboardcard_id]
                                        {:left-join [[:dashboardcard_series :series] [:= :report_card.id :series.card_id]]
                                         :where     [:in :series.dashboardcard_id dashcard-ids]
                                         :order-by  [[:series.position :asc]]}) series

--- a/src/metabase/models/query.clj
+++ b/src/metabase/models/query.clj
@@ -112,7 +112,7 @@
     (= :native query-type)  {:database-id database-id, :table-id nil}
     (integer? source-table) {:database-id database-id, :table-id source-table}
     (string? source-table)  (let [[_ card-id] (re-find #"^card__(\d+)$" source-table)]
-                              (t2/select-one [:model/Card [:table_id :table-id] [:database_id :database-id]]
+                              (t2/select-one [:model/Card :card_schema [:table_id :table-id] [:database_id :database-id]]
                                              :id (Integer/parseInt card-id)))
     (map? source-query)     (legacy-query->database-and-table-ids {:database database-id
                                                                    :type     query-type

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -122,7 +122,7 @@
       (if (qp.store/initialized?)
         (when-let [{:keys [collection-id]} (lib.metadata/card (qp.store/metadata-provider) card-id)]
           (t2/instance :model/Card {:collection_id collection-id}))
-        (t2/select-one [:model/Card :collection_id] :id card-id))
+        (t2/select-one [:model/Card :collection_id :card_schema] :id card-id))
       (throw (Exception. (tru "Card {0} does not exist." card-id)))))
 
 (mu/defn- source-card-read-perms :- [:set perms/PathSchema]

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -84,7 +84,8 @@
   public. Throws a 404 if the Card doesn't exist."
   [& conditions]
   (binding [params/*ignore-current-user-perms-and-return-all-field-values* true]
-    (-> (api/check-404 (apply t2/select-one [:model/Card :id :dataset_query :description :display :name :parameters :visualization_settings]
+    (-> (api/check-404 (apply t2/select-one [:model/Card :id :dataset_query :description :display :name :parameters
+                                             :visualization_settings :card_schema]
                               :archived false, conditions))
         remove-card-non-public-columns
         combine-parameters-and-template-tags
@@ -440,7 +441,7 @@
   "Check to make sure the query for Card with `card-id` references Field with `field-id`. Otherwise, or if the Card
   cannot be found, throw an Exception."
   [field-id card-id]
-  (let [card                 (api/check-404 (t2/select-one [:model/Card :dataset_query] :id card-id))
+  (let [card                 (api/check-404 (t2/select-one [:model/Card :dataset_query :card_schema] :id card-id))
         referenced-field-ids (card->referenced-field-ids card)]
     (api/check-404 (contains? referenced-field-ids field-id))))
 

--- a/src/metabase/query_analysis/core.clj
+++ b/src/metabase/query_analysis/core.clj
@@ -231,7 +231,7 @@
   (if (every? #(some? (% card-or-id)) [:id :dataset_query])
     card-or-id
     ;; If we need to query the database though, find out for sure.
-    (t2/select-one [:model/Card :id :archived :dataset_query] (u/the-id card-or-id))))
+    (t2/select-one [:model/Card :id :archived :dataset_query :card_schema] (u/the-id card-or-id))))
 
 (defn analyze!*
   "Update the analysis for a given card if it is active. Should only be called

--- a/src/metabase/query_analysis/task/sweep_query_analysis.clj
+++ b/src/metabase/query_analysis/task/sweep_query_analysis.clj
@@ -30,7 +30,8 @@
   ([]
    (analyze-cards-without-complete-analysis! query-analysis/queue-analysis!))
   ([analyze-fn]
-   (let [cards (t2/reducible-select [:model/Card :id :dataset_query :entity_id :collection_id :name :created_at]
+   (let [cards (t2/reducible-select [:model/Card :id :dataset_query :entity_id :collection_id :name :created_at
+                                     :card_schema]
                                     {:left-join [[:query_analysis :qa]
                                                  [:and
                                                   [:= :qa.card_id :report_card.id]
@@ -45,7 +46,8 @@
    (analyze-cards-without-complete-analysis! query-analysis/queue-analysis!))
   ([analyze-fn]
    ;; TODO once we are storing the hash of the query used for analysis, we'll be able to filter this properly.
-   (let [cards (t2/reducible-select [:model/Card :id :dataset_query :entity_id :collection_id :name :created_at])]
+   (let [cards (t2/reducible-select [:model/Card :id :dataset_query :entity_id :collection_id :name :created_at
+                                     :card_schema])]
      (run-realized!  analyze-fn cards))))
 
 (defn- delete-orphan-analysis! []

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -267,7 +267,7 @@
   {:pre [(int? card-id) (u/maybe? sequential? parameters)]}
   (let [card       (api/read-check (t2/select-one [:model/Card :id :name :dataset_query :database_id :collection_id
                                                    :type :result_metadata :visualization_settings :display
-                                                   :cache_invalidated_at :entity_id :created_at]
+                                                   :cache_invalidated_at :entity_id :created_at :card_schema]
                                                   :id card-id))
         dash-viz   (when (and (not= context :question)
                               dashcard-id)

--- a/src/metabase/query_processor/setup.clj
+++ b/src/metabase/query_processor/setup.clj
@@ -50,7 +50,7 @@
         :id          (:id card)
         :name        (format "Card #%d" (:id card))
         :database-id (:database_id card)})
-     [:model/Card :id :database_id]
+     [:model/Card :id :database_id :card_schema]
      :id [:in (set ids)])))
 
 (deftype ^:private BootstrapMetadataProvider []

--- a/src/metabase/revisions/impl/card.clj
+++ b/src/metabase/revisions/impl/card.clj
@@ -4,6 +4,7 @@
 
 (def ^:private excluded-columns-for-card-revision
   #{:cache_invalidated_at
+    :card_schema
     :created_at
     :creator_id
     :entity_id

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -754,7 +754,7 @@
   "Invalidate the model cache and result metadata for all models where `:based_on_upload` resolves to the given table."
   [table]
   ;; NOTE: It is important that this logic is kept in sync with `model-hydrate-based-on-upload`
-  (when-let [model-ids (->> (t2/select [:model/Card :id :dataset_query]
+  (when-let [model-ids (->> (t2/select [:model/Card :id :dataset_query :card_schema]
                                        :table_id (:id table)
                                        :type     :model
                                        :archived false)
@@ -765,7 +765,7 @@
     (model-persistence/invalidate! {:card_id [:in model-ids]})
     ;; Also refresh the metadata, so that newly added columns are visible, and types are updated.
     (doseq [id model-ids]
-      (let [card     (t2/select-one [:model/Card :dataset_query :result_metadata] id)
+      (let [card     (t2/select-one [:model/Card :dataset_query :result_metadata :card_schema] id)
             ;; Unclear why this is required, would expect it to get this from the field's display name, as it does for
             ;; the initial upload.
             fix-name #(update % :display_name humanization/name->human-readable-name)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -60,7 +60,7 @@
   (cond
     (map? x)
     (into {} (for [[k v] x]
-               (when-not (or (= :id k)
+               (when-not (or (#{:id :card_schema} k)
                              (str/ends-with? k "_id"))
                  (if (#{:created_at :updated_at} k)
                    [k (boolean v)]

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -25,7 +25,8 @@
                (when-not (or (= :id k)
                              (.endsWith (name k) "_id")
                              (= :created_at k)
-                             (= :updated_at k))
+                             (= :updated_at k)
+                             (= :card_schema k))
                  [k (f v)])))))
 
 (deftest ^:parallel retrieve-dashboard-card-test

--- a/test/metabase/models/query_test.clj
+++ b/test/metabase/models/query_test.clj
@@ -38,8 +38,8 @@
                          :type     :query
                          :query    {:source-query {:source-table 6}}}}}]
       (testing message
-        (is (= expected
-               (into {} (query/query->database-and-table-ids query))))))))
+        (is (=? expected
+                (into {} (query/query->database-and-table-ids query))))))))
 
 (deftest ^:parallel query->database-and-table-ids-pMBQL-test
   (testing "Should work for pMBQL queries"

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -20,7 +20,7 @@
    [toucan2.core :as t2]))
 
 (defn- card-metadata [card]
-  (t2/select-one-fn :result_metadata :model/Card :id (u/the-id card)))
+  (:result_metadata (t2/select-one :model/Card :id (u/the-id card))))
 
 (defn- round-to-2-decimals
   "Defaults [[mt/round-all-decimals]] to 2 digits"

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test.check.generators :as gen]
    [java-time.api :as t]
+   [medley.core :as m]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.util.log :as log]
    [reifyhealth.specmonstah.core :as rs]
@@ -345,6 +346,9 @@
     ;; Table names need to be unique within their database. This enforces it, and appends junk to names if needed.
     (= ent-type :table)
     (update :name unique-name)
+    ;; Table schemas also need to be unique.
+    (= ent-type :table)
+    (m/update-existing :schema unique-name)
 
     ;; Field names need to be unique within their table. This enforces it, and appends junk to names if needed.
     (= ent-type :field)

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: series_question_a
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: series_question_b
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: some_question
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null

--- a/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
+++ b/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
@@ -30,6 +30,7 @@ serdes/meta:
   label: source_question
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null

--- a/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
+++ b/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: root_card
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: grandparent_card
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: parent_card
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: child_card
   model: Card
 archived_directly: false
+card_schema: 20
 dashboard_id: null
 metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null


### PR DESCRIPTION
Closes [QUE-794](https://linear.app/metabase/issue/QUE-794) and [QUE-705](https://linear.app/metabase/issue/QUE-795)

### Description

This will enable us to *know*, rather than *infer*, what version of
`report_card` we're looking at.

One example: in the near future, I'm going to add some values to
`result_metadata` on cards. If we later discovered a bug in that logic
and could no longer trust those fields written to AppDB in
`result_metadata`, the `card_schema` will tell us with certainty
whether the card was saved with the broken logic (`:card_schema N`)
or the new logic (`:card_schema (+ N k)`).

The upgrade steps could drop the invalid fields and, if desired, infer
the correct ones.

Note that there's nothing here about writing back! This is about
cleaning up old cards during `after-select`.

There are no upgrades yet; the current version is still the default.

### How to verify

- No user-visible changes.
- New column `report_card.card_schema` with a default value of 20, not `NULL`able.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
