### PR TITLE
test: make dashboard flaky test more robust and stable

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1249,15 +1249,10 @@ describe("scenarios > dashboard", () => {
         H.saveDashboard();
 
         // move tab
-        H.editDashboard();
-
-        dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -500);
-
-        // Verify tab order with more robust assertions
-        cy.findAllByRole("tab").should($tabs => {
-          expect($tabs[0].textContent).to.equal("Tab 2");
-          expect($tabs[1].textContent).to.equal("Tab 1");
-        });
+        dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
+        // assert tab order is now correct and ui has caught up to result of dragging the tab
+        cy.findAllByRole("tab").eq(0).should("have.text", "Tab 2");
+        cy.findAllByRole("tab").eq(1).should("have.text", "Tab 1");
 
         assertPreventLeave();
         H.saveDashboard();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1236,45 +1236,45 @@ describe("scenarios > dashboard", () => {
       assertPreventLeave();
     });
 
-    it(
-      "should warn a user before leaving after adding, removed, moving, or duplicating a tab",
-      { tags: "@flaky" },
-      () => {
-        cy.visit("/");
+    it("should warn a user before leaving after adding, removed, moving, or duplicating a tab", () => {
+      cy.visit("/");
 
-        // add tab
-        createNewDashboard();
-        H.createNewTab();
-        assertPreventLeave();
-        H.saveDashboard();
+      // add tab
+      createNewDashboard();
+      H.createNewTab();
+      assertPreventLeave();
+      H.saveDashboard();
 
-        // move tab
-        H.editDashboard();
-        dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
-        // assert tab order is now correct and ui has caught up to result of dragging the tab
-        cy.findAllByRole("tab").eq(0).should("have.text", "Tab 2");
-        cy.findAllByRole("tab").eq(1).should("have.text", "Tab 1");
-        assertPreventLeave();
-        H.saveDashboard();
+      // move tab
+      H.editDashboard();
+      dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
 
-        // duplicate tab
-        H.editDashboard();
-        H.duplicateTab("Tab 1");
-        assertPreventLeave();
-        H.saveDashboard();
+      // Verify tab order with more robust assertions
+      cy.findAllByRole("tab").should($tabs => {
+        expect($tabs[0].textContent).to.equal("Tab 2");
+        expect($tabs[1].textContent).to.equal("Tab 1");
+      });
 
-        // remove tab
-        H.editDashboard();
-        H.deleteTab("Copy of Tab 1");
-        assertPreventLeave();
-        H.saveDashboard();
+      assertPreventLeave();
+      H.saveDashboard();
 
-        // rename tab
-        H.editDashboard();
-        H.renameTab("Tab 2", "Foo tab");
-        assertPreventLeave();
-      },
-    );
+      // duplicate tab
+      H.editDashboard();
+      H.duplicateTab("Tab 1");
+      assertPreventLeave();
+      H.saveDashboard();
+
+      // remove tab
+      H.editDashboard();
+      H.deleteTab("Copy of Tab 1");
+      assertPreventLeave();
+      H.saveDashboard();
+
+      // rename tab
+      H.editDashboard();
+      H.renameTab("Tab 2", "Foo tab");
+      assertPreventLeave();
+    });
 
     function createNewDashboard() {
       H.newButton("Dashboard").click();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1250,6 +1250,12 @@ describe("scenarios > dashboard", () => {
 
         // move tab
         H.editDashboard();
+
+        cy.findAllByRole("tab").should($tabs => {
+          expect($tabs[0].textContent).to.equal("Tab 1");
+          expect($tabs[1].textContent).to.equal("Tab 2");
+        });
+
         dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
 
         // Verify tab order with more robust assertions

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1249,6 +1249,7 @@ describe("scenarios > dashboard", () => {
         H.saveDashboard();
 
         // move tab
+        H.editDashboard();
         dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
         // assert tab order is now correct and ui has caught up to result of dragging the tab
         cy.findAllByRole("tab").eq(0).should("have.text", "Tab 2");

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1251,12 +1251,7 @@ describe("scenarios > dashboard", () => {
         // move tab
         H.editDashboard();
 
-        cy.findAllByRole("tab").should($tabs => {
-          expect($tabs[0].textContent).to.equal("Tab 1");
-          expect($tabs[1].textContent).to.equal("Tab 2");
-        });
-
-        dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
+        dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -500);
 
         // Verify tab order with more robust assertions
         cy.findAllByRole("tab").should($tabs => {
@@ -1297,6 +1292,8 @@ describe("scenarios > dashboard", () => {
     function dragOnXAxis(el, distance) {
       el.trigger("mousedown", { clientX: 0 })
         .trigger("mousemove", { clientX: distance })
+        // to avoid flakiness
+        .wait(10)
         .trigger("mouseup");
     }
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1236,45 +1236,49 @@ describe("scenarios > dashboard", () => {
       assertPreventLeave();
     });
 
-    it("should warn a user before leaving after adding, removed, moving, or duplicating a tab", () => {
-      cy.visit("/");
+    it(
+      "should warn a user before leaving after adding, removed, moving, or duplicating a tab",
+      { tags: "@flaky" },
+      () => {
+        cy.visit("/");
 
-      // add tab
-      createNewDashboard();
-      H.createNewTab();
-      assertPreventLeave();
-      H.saveDashboard();
+        // add tab
+        createNewDashboard();
+        H.createNewTab();
+        assertPreventLeave();
+        H.saveDashboard();
 
-      // move tab
-      H.editDashboard();
-      dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
+        // move tab
+        H.editDashboard();
+        dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
 
-      // Verify tab order with more robust assertions
-      cy.findAllByRole("tab").should($tabs => {
-        expect($tabs[0].textContent).to.equal("Tab 2");
-        expect($tabs[1].textContent).to.equal("Tab 1");
-      });
+        // Verify tab order with more robust assertions
+        cy.findAllByRole("tab").should($tabs => {
+          expect($tabs[0].textContent).to.equal("Tab 2");
+          expect($tabs[1].textContent).to.equal("Tab 1");
+        });
 
-      assertPreventLeave();
-      H.saveDashboard();
+        assertPreventLeave();
+        H.saveDashboard();
 
-      // duplicate tab
-      H.editDashboard();
-      H.duplicateTab("Tab 1");
-      assertPreventLeave();
-      H.saveDashboard();
+        // duplicate tab
+        H.editDashboard();
+        H.duplicateTab("Tab 1");
+        assertPreventLeave();
+        H.saveDashboard();
 
-      // remove tab
-      H.editDashboard();
-      H.deleteTab("Copy of Tab 1");
-      assertPreventLeave();
-      H.saveDashboard();
+        // remove tab
+        H.editDashboard();
+        H.deleteTab("Copy of Tab 1");
+        assertPreventLeave();
+        H.saveDashboard();
 
-      // rename tab
-      H.editDashboard();
-      H.renameTab("Tab 2", "Foo tab");
-      assertPreventLeave();
-    });
+        // rename tab
+        H.editDashboard();
+        H.renameTab("Tab 2", "Foo tab");
+        assertPreventLeave();
+      },
+    );
 
     function createNewDashboard() {
       H.newButton("Dashboard").click();


### PR DESCRIPTION
https://linear.app/metabase/issue/DEV-358/fix-flaky-test-should-warn-a-user-before-leaving-after-adding-removed

make flaky test stable again

<img width="1598" alt="image" src="https://github.com/user-attachments/assets/df9a4bbf-b316-4d79-81c6-19df7eea11b8" />


✅  [stress test](https://github.com/metabase/metabase/actions/runs/14067691913/job/39394179546)
✅ [updated stress test](https://github.com/metabase/metabase/actions/runs/14082477048/job/39438385856)