### PR TITLE
Migrate EditUserModal to RTK

### DIFF
--- a/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
@@ -8,8 +8,6 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import ModalContent from "metabase/components/ModalContent";
-import Users from "metabase/entities/users";
-import { useDispatch } from "metabase/lib/redux";
 import type { User } from "metabase-types/api";
 
 import { UserForm } from "../../forms/UserForm";
@@ -20,7 +18,6 @@ interface EditUserModalProps {
 }
 
 export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
-  const dispatch = useDispatch();
   const userId = params.userId ? parseInt(params.userId) : null;
   const { data: user, isLoading } = useGetUserQuery(userId ?? skipToken);
   const [updateUser] = useUpdateUserMutation();
@@ -32,18 +29,12 @@ export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
     }
 
     // first name and last name keys need to be present, so they can potentially be removed
-    const newUser = await updateUser({
+    await updateUser({
       id: userId,
       first_name: null,
       last_name: null,
       ...newValues,
     }).unwrap();
-
-    // for compatibility with code that relies on the entity framework
-    dispatch({
-      type: Users.actionTypes.UPDATE,
-      payload: { user: newUser },
-    });
 
     onClose();
   };

--- a/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
@@ -32,21 +32,20 @@ export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
     }
 
     // first name and last name keys need to be present, so they can potentially be removed
-    const { data: newUser } = await updateUser({
+    const newUser = await updateUser({
       id: userId,
       first_name: null,
       last_name: null,
       ...newValues,
+    }).unwrap();
+
+    // for compatibility with code that relies on the entity framework
+    dispatch({
+      type: Users.actionTypes.UPDATE,
+      payload: { user: newUser },
     });
 
-    if (newUser != null) {
-      // for compatibility with code that relies on the entity framework
-      dispatch({
-        type: Users.actionTypes.UPDATE,
-        payload: { user: newUser },
-      });
-      onClose();
-    }
+    onClose();
   };
 
   return (

--- a/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/EditUserModal/EditUserModal.tsx
@@ -1,12 +1,16 @@
 import { useMemo } from "react";
 import type { Params } from "react-router/lib/Router";
 
-import { skipToken, useGetUserQuery } from "metabase/api";
+import {
+  skipToken,
+  useGetUserQuery,
+  useUpdateUserMutation,
+} from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import ModalContent from "metabase/components/ModalContent";
 import Users from "metabase/entities/users";
 import { useDispatch } from "metabase/lib/redux";
-import type { User as UserType } from "metabase-types/api";
+import type { User } from "metabase-types/api";
 
 import { UserForm } from "../../forms/UserForm";
 
@@ -19,20 +23,30 @@ export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
   const dispatch = useDispatch();
   const userId = params.userId ? parseInt(params.userId) : null;
   const { data: user, isLoading } = useGetUserQuery(userId ?? skipToken);
-
+  const [updateUser] = useUpdateUserMutation();
   const initialValues = useMemo(() => getInitialValues(user), [user]);
 
-  const handleSubmit = async (newValues: Partial<UserType>) => {
-    // first name and last name keys need to be present so they can
-    // potentially be removed
-    const submitValues = {
+  const handleSubmit = async (newValues: Partial<User>) => {
+    if (userId == null) {
+      return;
+    }
+
+    // first name and last name keys need to be present, so they can potentially be removed
+    const { data: newUser } = await updateUser({
+      id: userId,
       first_name: null,
       last_name: null,
       ...newValues,
-    };
-    // can't use metabase/api hook here until the people list uses it too
-    await dispatch(Users.actions.update({ id: user?.id, ...submitValues }));
-    onClose();
+    });
+
+    if (newUser != null) {
+      // for compatibility with code that relies on the entity framework
+      dispatch({
+        type: Users.actionTypes.UPDATE,
+        payload: { user: newUser },
+      });
+      onClose();
+    }
   };
 
   return (
@@ -52,7 +66,7 @@ export const EditUserModal = ({ onClose, params }: EditUserModalProps) => {
   );
 };
 
-const getInitialValues = (user?: UserType) => {
+const getInitialValues = (user?: User) => {
   return {
     first_name: user?.first_name,
     last_name: user?.last_name,

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -50,6 +50,14 @@ export const userApi = Api.injectEndpoints({
         body,
       }),
       invalidatesTags: (_, error) => invalidateTags(error, [listTag("user")]),
+      onQueryStarted: async (_request, { dispatch, queryFulfilled }) => {
+        const { data: user } = await queryFulfilled;
+        // for compatibility with code that relies on the entity framework
+        dispatch({
+          type: "metabase/entities/users/CREATE",
+          payload: { user },
+        });
+      },
     }),
     updatePassword: builder.mutation<void, UpdatePasswordRequest>({
       query: ({ id, old_password, password }) => ({
@@ -84,6 +92,14 @@ export const userApi = Api.injectEndpoints({
       }),
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [listTag("user"), idTag("user", id)]),
+      onQueryStarted: async (_request, { dispatch, queryFulfilled }) => {
+        const { data: user } = await queryFulfilled;
+        // for compatibility with code that relies on the entity framework
+        dispatch({
+          type: "metabase/entities/users/UPDATE",
+          payload: { user },
+        });
+      },
     }),
   }),
 });

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -52,7 +52,7 @@ export const userApi = Api.injectEndpoints({
       invalidatesTags: (_, error) => invalidateTags(error, [listTag("user")]),
       onQueryStarted: async (_request, { dispatch, queryFulfilled }) => {
         const { data: user } = await queryFulfilled;
-        // for compatibility with code that relies on the entity framework
+        // entity framework compatibility
         dispatch({
           type: "metabase/entities/users/CREATE",
           payload: { user },
@@ -94,7 +94,7 @@ export const userApi = Api.injectEndpoints({
         invalidateTags(error, [listTag("user"), idTag("user", id)]),
       onQueryStarted: async (_request, { dispatch, queryFulfilled }) => {
         const { data: user } = await queryFulfilled;
-        // for compatibility with code that relies on the entity framework
+        // entity framework compatibility
         dispatch({
           type: "metabase/entities/users/UPDATE",
           payload: { user },


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-797/editusermodal

This is a sample PR to illustrate how to migrate an entity mutation to RTK query when there is a dependency on the entity framework in other places.

How to verify:
- Admin -> People -> Open menu for your user -> Change name -> Save
- Exit admin -> Account -> Make sure the name is changed
