### PR TITLE
Translate comparison text for smart scalars on the BE

### DIFF
--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -519,6 +519,7 @@
                           comparison-statement]]
            :render/text (str value "\n"
                              delta-statement
+                             " "
                              comparison-statement)})
         ;; In other words, defaults to plain scalar if we don't have actual changes
         {:attachments nil

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -495,18 +495,19 @@
           {:keys [last-value previous-value unit last-change] :as _insight}
           (where (comp #{(:name metric-col)} :col) insights)]
       (if (and last-value previous-value unit last-change)
-        (let [value           (format-cell timezone-id last-value metric-col viz-settings)
-              previous        (format-cell timezone-id previous-value metric-col viz-settings)
-              delta-statement (cond
-                                (= last-value previous-value)
-                                (tru "No change")
+        (let [value                (format-cell timezone-id last-value metric-col viz-settings)
+              previous             (format-cell timezone-id previous-value metric-col viz-settings)
+              delta-statement      (cond
+                                     (= last-value previous-value)
+                                     (tru "No change")
 
-                                (pos? last-change)
-                                (tru "Up {0}" (percentage last-change))
+                                     (pos? last-change)
+                                     (tru "Up {0}" (percentage last-change))
 
-                                (neg? last-change)
-                                (tru "Down {0}" (percentage last-change)))
-              comparison-statement (smart-scalar-comparison-statement unit previous)]
+                                     (neg? last-change)
+                                     (tru "Down {0}" (percentage last-change)))
+              comparison-statement (smart-scalar-comparison-statement unit previous)
+              statement            (str delta-statement " " comparison-statement)]
           {:attachments nil
            :content     [:div
                          [:div {:style (style/style (style/scalar-style))}
@@ -515,12 +516,9 @@
                                                    :font-size     :16px
                                                    :font-weight   700
                                                    :padding-right :16px})}
-                          delta-statement
-                          comparison-statement]]
-           :render/text (str value "\n"
-                             delta-statement
-                             " "
-                             comparison-statement)})
+                          statement]]
+
+           :render/text (str value "\n" statement)})
         ;; In other words, defaults to plain scalar if we don't have actual changes
         {:attachments nil
          :content     [:div

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -9,7 +9,6 @@
    [metabase.channel.render.style :as style]
    [metabase.channel.render.table :as table]
    [metabase.formatter :as formatter]
-   [metabase.lib.core :as lib]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.streaming :as qp.streaming]


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/33901

I've switched the `vs. previous ...` string to enumerate all the possible units instead of using string concatenation, per advice on slack: https://metaboat.slack.com/archives/C6UBFU9GW/p1742920184533189

I considered building out a helper macro for this similar to `describe-temporal-interval` but since this is a single specific use case (just for smart scalars) it didn't seem worth it. I'm also thinking about a more generalizable solution to this problem — perhaps a macro that takes a base string and a set of options and generates all the strings that need to be translated separately? But that's not needed to close out this specific bug.