### PR TITLE
Don't load gsheets sync status component for non-admins

### DIFF
--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
@@ -30,7 +30,7 @@ const StatusListing = () => {
       {isAdmin && <DatabaseStatus />}
       <FileUploadStatus />
       <DownloadsStatus />
-      <PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus />
+      {isAdmin && <PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus />}
     </StatusListingRoot>
   );
 };


### PR DESCRIPTION
closes adm-568
closes #55793

## Description

This component was loading for non-logged-in users. There was logic in the component that caused calls to the settings apis if the gsheets folder api errored. For non-logged-in users, we have other code that redirects them if any api request fails, and the settings api requests were always failing 🙃 