### PR TITLE
[refs] Populate the card `entity_id` in `new Question()`

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -94,6 +94,8 @@ export interface UnsavedCard<Q extends DatasetQuery = DatasetQuery> {
 
   // Not part of the card API contract, a field used by query builder for showing lineage
   original_card_id?: number;
+  // FE randomly generates this NanoID and passes it to the BE when saving the card.
+  entity_id: BaseEntityId;
 }
 
 export type LineSize = "S" | "M" | "L";

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -13,14 +13,13 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
-import { createMockEntityId } from "./entity-id";
+import { MOCK_CARD_ENTITY_ID } from "./entity-id";
 import {
   createMockNativeDatasetQuery,
   createMockStructuredDatasetQuery,
 } from "./query";
 import { createMockUser } from "./user";
 
-const MOCK_CARD_ENTITY_ID = createMockEntityId();
 export const createMockCard = (opts?: Partial<Card>): Card => ({
   id: 1,
   entity_id: MOCK_CARD_ENTITY_ID,
@@ -87,6 +86,7 @@ export const createMockUnsavedCard = (
   display: "table",
   dataset_query: createMockStructuredDatasetQuery(),
   visualization_settings: createMockVisualizationSettings(),
+  entity_id: MOCK_CARD_ENTITY_ID,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/mocks/entity-id.ts
+++ b/frontend/src/metabase-types/api/mocks/entity-id.ts
@@ -4,3 +4,5 @@ import { type BaseEntityId, NANOID_LENGTH } from "../entity-id";
 
 export const createMockEntityId = (value?: string): BaseEntityId =>
   (value || nanoid(NANOID_LENGTH)) as BaseEntityId;
+
+export const MOCK_CARD_ENTITY_ID = createMockEntityId();

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -8,6 +8,7 @@ export * from "./collection";
 export * from "./dashboard";
 export * from "./database";
 export * from "./dataset";
+export * from "./entity-id";
 export * from "./field";
 export * from "./group";
 export * from "./models";

--- a/frontend/src/metabase-types/api/mocks/presets/sample_cards.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_cards.ts
@@ -5,6 +5,7 @@ import type {
   UnsavedCard,
 } from "metabase-types/api";
 import {
+  MOCK_CARD_ENTITY_ID,
   createMockNativeCard,
   createMockStructuredCard,
 } from "metabase-types/api/mocks";
@@ -20,10 +21,12 @@ export const createAdHocCard = (
   opts?: Partial<StructuredUnsavedCard>,
 ): StructuredUnsavedCard => ({
   display: "table",
+  entity_id: MOCK_CARD_ENTITY_ID,
   visualization_settings: {},
   dataset_query: {
     type: "query",
     database: SAMPLE_DB_ID,
+    info: { "card-entity-id": MOCK_CARD_ENTITY_ID },
     query: {
       "source-table": ORDERS_ID,
     },
@@ -35,10 +38,12 @@ export const createAdHocNativeCard = (
   opts?: Partial<NativeUnsavedCard>,
 ): NativeUnsavedCard => ({
   display: "table",
+  entity_id: MOCK_CARD_ENTITY_ID,
   visualization_settings: {},
   dataset_query: {
     type: "native",
     database: SAMPLE_DB_ID,
+    info: { "card-entity-id": MOCK_CARD_ENTITY_ID },
     native: {
       query: "select * from orders",
       "template-tags": {},
@@ -51,10 +56,12 @@ export const createEmptyAdHocNativeCard = (
   opts?: Partial<NativeUnsavedCard>,
 ): NativeUnsavedCard => ({
   display: "table",
+  entity_id: MOCK_CARD_ENTITY_ID,
   visualization_settings: {},
   dataset_query: {
     type: "native",
     database: SAMPLE_DB_ID,
+    info: { "card-entity-id": MOCK_CARD_ENTITY_ID },
     native: {
       query: "",
       "template-tags": {},

--- a/frontend/src/metabase-types/api/mocks/query.ts
+++ b/frontend/src/metabase-types/api/mocks/query.ts
@@ -5,6 +5,8 @@ import type {
   StructuredQuery,
 } from "metabase-types/api";
 
+import { MOCK_CARD_ENTITY_ID } from "./entity-id";
+
 export const createMockStructuredQuery = (
   opts?: Partial<StructuredQuery>,
 ): StructuredQuery => ({
@@ -24,6 +26,7 @@ export const createMockStructuredDatasetQuery = (
 ): StructuredDatasetQuery => ({
   type: "query",
   database: 1,
+  info: { "card-entity-id": MOCK_CARD_ENTITY_ID },
   query: createMockStructuredQuery(),
   ...opts,
 });
@@ -33,6 +36,7 @@ export const createMockNativeDatasetQuery = (
 ): NativeDatasetQuery => ({
   type: "native",
   database: 1,
+  info: { "card-entity-id": MOCK_CARD_ENTITY_ID },
   native: createMockNativeQuery(),
   ...opts,
 });

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -1,5 +1,6 @@
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
+  BaseEntityId,
   CardId,
   DatabaseId,
   FieldId,
@@ -7,6 +8,10 @@ import type {
   TableId,
   TemplateTags,
 } from "metabase-types/api";
+
+export interface QueryInfo {
+  "card-entity-id"?: BaseEntityId;
+}
 
 export interface NativeQuery {
   query: string;
@@ -21,6 +26,7 @@ export interface StructuredDatasetQuery {
   // Database is null when missing data permissions to the database
   database: DatabaseId | null;
   parameters?: UiParameter[];
+  info?: QueryInfo;
 }
 
 export interface NativeDatasetQuery {
@@ -30,6 +36,7 @@ export interface NativeDatasetQuery {
   // Database is null when missing data permissions to the database
   database: DatabaseId | null;
   parameters?: UiParameter[];
+  info?: QueryInfo;
 }
 
 export type DatasetQuery = StructuredDatasetQuery | NativeDatasetQuery;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -1,5 +1,6 @@
 import fetchMock from "fetch-mock";
 import type { LocationDescriptorObject } from "history";
+import { dissoc } from "icepick";
 
 import { createMockEntitiesState } from "__support__/store";
 import Databases from "metabase/entities/databases";
@@ -252,7 +253,7 @@ describe("QB Actions > initializeQB", () => {
 
           expect(loadMetadataForCardSpy).toHaveBeenCalledTimes(1);
           expect(loadMetadataForCardSpy).toHaveBeenCalledWith(
-            expect.objectContaining(card),
+            expect.objectContaining(dissoc(card, "entity_id")),
           );
         });
 

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
@@ -17,6 +17,7 @@ import type {
 import {
   createMockColumn,
   createMockDataset,
+  createMockEntityId,
   createMockNativeDatasetQuery,
   createMockNativeQuery,
   createMockSavedQuestionsDatabase,
@@ -212,11 +213,15 @@ const PIVOT_TABLE_PRODUCT_CATEGORY_FIELD: ConcreteFieldReference = [
   { "source-field": ORDERS.PRODUCT_ID },
 ];
 
+const PIVOT_CARD_ENTITY_ID = createMockEntityId();
+
 const PIVOT_TABLE_QUESTION: UnsavedCard<StructuredDatasetQuery> = {
   display: "pivot",
+  entity_id: PIVOT_CARD_ENTITY_ID,
   dataset_query: {
     type: "query",
     database: SAMPLE_DB_ID,
+    info: { "card-entity-id": PIVOT_CARD_ENTITY_ID },
     query: {
       "source-table": ORDERS_ID,
       aggregation: [["count"]],

--- a/frontend/src/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/src/metabase/query_builder/selectors.unit.spec.js
@@ -16,6 +16,7 @@ import {
   createMockColumn,
   createMockDataset,
   createMockDatasetData,
+  createMockEntityId,
   createMockTable,
   createMockTableColumnOrderSetting,
   createMockVisualizationSettings,
@@ -69,11 +70,14 @@ describe("getQuestion", () => {
   });
 
   it("should return question instance correctly", () => {
+    const eid = createMockEntityId();
     const card = {
       id: 5,
+      entity_id: eid,
       dataset_query: {
         database: 1,
         type: "query",
+        info: { "card-entity-id": eid },
         query: {
           "source-table": 1,
         },
@@ -87,12 +91,15 @@ describe("getQuestion", () => {
   });
 
   it("should return composed dataset when dataset is open", () => {
+    const eid = createMockEntityId();
     const card = {
       id: 1,
+      entity_id: eid,
       type: "model",
       dataset_query: {
         database: SAMPLE_DB_ID,
         type: "query",
+        info: { "card-entity-id": eid },
         query: {
           "source-table": ORDERS_ID,
         },
@@ -107,12 +114,15 @@ describe("getQuestion", () => {
   });
 
   it("should return real dataset when dataset is open in 'dataset' QB mode", () => {
+    const eid = createMockEntityId();
     const card = {
       id: 5,
+      entity_id: eid,
       type: "model",
       dataset_query: {
         database: 1,
         type: "query",
+        info: { "card-entity-id": eid },
         query: {
           "source-table": 1,
         },

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -77,6 +77,7 @@ const base_question = new Question(card, metadata);
 
 const orders_raw_card = {
   id: 1,
+  entity_id: "XVpLtkhhE58O-8EyvMQd7",
   name: "Raw orders data",
   display: "table",
   visualization_settings: {},
@@ -588,7 +589,7 @@ describe("Question", () => {
 
   describe("URLs", () => {
     const adhocUrl =
-      "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjJ9LCJ0eXBlIjoicXVlcnkifSwiZGlzcGxheSI6InRhYmxlIiwibmFtZSI6IlJhdyBvcmRlcnMgZGF0YSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==";
+      "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJpbmZvIjp7ImNhcmQtZW50aXR5LWlkIjoiWFZwTHRraGhFNThPLThFeXZNUWQ3In0sInF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6Mn0sInR5cGUiOiJxdWVyeSJ9LCJkaXNwbGF5IjoidGFibGUiLCJlbnRpdHlfaWQiOiJYVnBMdGtoaEU1OE8tOEV5dk1RZDciLCJuYW1lIjoiUmF3IG9yZGVycyBkYXRhIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319";
 
     // Covered a lot in query_builder/actions.spec.js, just very basic cases here
     // (currently getUrl has logic that is strongly tied to the logic query builder Redux actions)
@@ -866,8 +867,12 @@ describe("Question", () => {
 
     const card = {
       id: 1,
+      entity_id: "vcEFoKc3LfnRgNrdvHAx-",
       dataset_query: {
         type: "query",
+        info: {
+          "card-entity-id": "vcEFoKc3LfnRgNrdvHAx-",
+        },
         query: {
           "source-table": PRODUCTS_ID,
         },

--- a/resources/serialization-order.edn
+++ b/resources/serialization-order.edn
@@ -25,7 +25,8 @@
                                   :result_metadata
                                   :visualization_settings
                                   :serdes/meta]
- [:Card :dataset_query]          []
+ [:Card :dataset_query]          [:info]
+ [:Card :dataset_query :info]    [:card-entity-id]
  [:Card :visualization_settings] []
  :Collection                     [:name
                                   :description

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -719,6 +719,14 @@
                                                   (lib/query (:dataset_query card))
                                                   lib/suggested-name))))
 
+(defn- generate-card-entity-id
+  [card]
+  (let [eid (or (:entity_id card)
+                (-> card :dataset_query :info :card-entity-id)
+                (u/generate-nano-id))]
+    (cond-> card
+      (not= (:entity_id card) eid) (assoc :entity_id eid))))
+
 (defn- add-card-entity-id-to-query
   "Queries now carry the card's entity ID in the `:info` block; make sure that's populated on reading the card."
   [card]
@@ -846,6 +854,8 @@
   (-> card
       (assoc :metabase_version config/mb-version-string)
       maybe-normalize-query
+      generate-card-entity-id
+      add-card-entity-id-to-query
       card.metadata/populate-result-metadata
       pre-insert
       populate-query-fields
@@ -877,6 +887,7 @@
       (apply-dashboard-question-updates)
 
       maybe-normalize-query
+      add-card-entity-id-to-query
       ;; If we have fresh result_metadata, we don't have to populate it anew. When result_metadata doesn't
       ;; change for a native query, populate-result-metadata removes it (set to nil) unless prevented by the
       ;; verified-result-metadata? flag (see #37009).

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -719,6 +719,13 @@
                                                   (lib/query (:dataset_query card))
                                                   lib/suggested-name))))
 
+(defn- add-card-entity-id-to-query
+  "Queries now carry the card's entity ID in the `:info` block; make sure that's populated on reading the card."
+  [card]
+  (if-let [eid (and (:dataset_query card) (:entity_id card))]
+    (assoc-in card [:dataset_query :info :card-entity-id] eid)
+    card))
+
 (defn- derive-ident [prefix entity_id stage-number tail]
   (let [entity_id (cond-> entity_id
                     (instance? clojure.lang.IDeref entity_id) deref)]
@@ -830,6 +837,7 @@
       public-sharing/remove-public-uuid-if-public-sharing-is-disabled
       add-query-description-to-metric-card
       ensure-clause-idents
+      add-card-entity-id-to-query
       ;; At this point, the card should be at schema version 20.
       upgrade-card-schema-to-latest))
 

--- a/test/metabase/query_processor/middleware/parameters_test.clj
+++ b/test/metabase/query_processor/middleware/parameters_test.clj
@@ -341,8 +341,10 @@
                                                        "Filter: expensive venues" (:id where-snippet)})})}]
     (qp.store/with-metadata-provider (mt/id)
       (testing "multiple snippets are correctly expanded in parent query"
-        (is (= (mt/native-query
-                 {:query "SELECT name, price FROM venues WHERE price > 2", :params nil})
+        (is (= (assoc-in (mt/native-query
+                           {:query  "SELECT name, price FROM venues WHERE price > 2"
+                            :params nil})
+                         [:info :card-entity-id] (:entity_id card))
                (substitute-params (:dataset_query card)))))
       (testing "multiple snippets are expanded from saved sub-query"
         (is (=? (mt/native-query

--- a/test/metabase/query_processor/middleware/parameters_test.clj
+++ b/test/metabase/query_processor/middleware/parameters_test.clj
@@ -341,10 +341,9 @@
                                                        "Filter: expensive venues" (:id where-snippet)})})}]
     (qp.store/with-metadata-provider (mt/id)
       (testing "multiple snippets are correctly expanded in parent query"
-        (is (= (assoc-in (mt/native-query
-                           {:query  "SELECT name, price FROM venues WHERE price > 2"
-                            :params nil})
-                         [:info :card-entity-id] (:entity_id card))
+        (is (= (mt/native-query
+                 {:query  "SELECT name, price FROM venues WHERE price > 2"
+                  :params nil})
                (substitute-params (:dataset_query card)))))
       (testing "multiple snippets are expanded from saved sub-query"
         (is (=? (mt/native-query


### PR DESCRIPTION
### Description

Not all callers use `Question.create`, so it was missing in some cases
(eg. new native queries).


### How to verify

FE unit tests passing.

All ad-hoc queries include the generated `entity_id` in their requests, so that
they are available to the library and get saved with the card (should it be saved).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
