### PR TITLE
Encode settings key in url

### DIFF
--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -19,7 +19,7 @@ export const settingsApi = Api.injectEndpoints({
     getSetting: builder.query<SettingValue, SettingKey>({
       query: name => ({
         method: "GET",
-        url: `/api/setting/${name}`,
+        url: `/api/setting/${encodeURIComponent(name)}`,
       }),
       providesTags: ["session-properties"],
     }),
@@ -32,7 +32,7 @@ export const settingsApi = Api.injectEndpoints({
     >({
       query: ({ key, value }) => ({
         method: "PUT",
-        url: `/api/setting/${key}`,
+        url: `/api/setting/${encodeURIComponent(key)}`,
         body: { value },
       }),
       invalidatesTags: (_, error) =>


### PR DESCRIPTION
We have setting keys like bcc-enabled? that get used in the url and need to be encoded. This PR adds encoding to the new `api/settings` endpoints.

This PR replaces #55611 which was a more comprehensive encoding approach. This just targets the new endpoints.