### PR TITLE
ci(sdk): temporarily skip cross version tests on 54

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -1,13 +1,15 @@
 name: E2E Cross-version Component Tests for Embedding SDK
 
 on:
-  push:
-    branches:
-      - "release-**"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - "release-**"
+  # push:
+  #   branches:
+  #     - "release-**"
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
+  #   branches:
+  #     - "release-**"
+  #--- remove this line and uncomment the lines above to re-enable the workflow
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}


### PR DESCRIPTION
Skips the cross-version component tests on 54 branch until we can figure out what went wrong.