### PR TITLE
ci(sdk): Make 54 the latest in release workflow

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -14,6 +14,7 @@ on:
           - release-x.51.x
           - release-x.52.x
           - release-x.53.x
+          - release-x.54.x
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -390,10 +391,10 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-        if: ${{ inputs.branch == 'release-x.53.x' }}
+      - name: Add `latest` tag to the latest release branch (`release-x.54.x`) deployment
+        if: ${{ inputs.branch == 'release-x.54.x' }}
         working-directory: sdk
         run: |
           npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest


### PR DESCRIPTION
This is supposed to look almost exactly like #52789

Every time we cut a new release we need to add the release branch to the workflow.

A better alternative might be to somehow get this release branch information from GitHub.

But let's do that manually again for now.
