### PR TITLE
Log context

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%date %level %logger{2} :: %notEmpty{%X }%notEmpty{%x }%message%n%throwable">
+      <PatternLayout pattern="%date %level %logger{2} :: %notEmpty{%X }%message%n%throwable">
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>
     </Console>

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%date %level %logger{2} :: %message%n%throwable">
+      <PatternLayout pattern="%date %level %logger{2} :: %notEmpty{%X }%notEmpty{%x }%message%n%throwable">
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>
     </Console>

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -215,25 +215,19 @@
    The context map's keys and values are added to the ThreadContext individually.
 
    Example usage:
-   (with-context {:stack {:notification_id 1}
-                  :map \"Notification 1\"}
+   (with-context {:notification_id 1}
      (log/infof \"Hello\"))
 
    ThreadContext will contain: {\"notification_id\" \"1\"} and stack \"Notification 1\""
-  [{:keys [map stack]} & body]
+  [context-map & body]
   (macros/case
-    :clj `(let [ctx-map# ~map
-                ctx-stack# ~stack
+    :clj `(let [ctx-map# ~context-map
                 ctx-keys# (keys ctx-map#)]
             (try
-              (when ctx-stack#
-                (ThreadContext/push ctx-stack#))
               (doseq [k# ctx-keys#]
                 (ThreadContext/put (name k#) (str (get ctx-map# k#))))
               ~@body
               (finally
-                (when ctx-stack#
-                  (ThreadContext/pop))
                 (doseq [k# ctx-keys#]
                   (ThreadContext/remove (name k#))))))
     :cljs ~@body))


### PR DESCRIPTION
I need this to debug OOMs on stats


Add a `with-context` macro for log4j.

```clj

(with-context {:database_id 123}
    (info "Starting full database sync")
    (do-the-sync)
    (info "Completed database sync"))

2025-03-26 07:31:41,382 INFO util.log :: {database_id=123} Start 
2025-03-26 07:31:41,382 INFO util.log :: {database_id=123} Completed

```


Can also be netsed

```clj

(with-context {:database_id 123}
    (info "Start ")
    (with-context {:table_id 1234}
      (info "Start ")
      (info "Completed"))
   (info "Completed"))

2025-03-26 07:32:15,492 INFO util.log :: {database_id=123}Start 
2025-03-26 07:32:15,492 INFO util.log :: {database_id=123, table_id=1234} Start 
2025-03-26 07:32:15,492 INFO util.log :: {database_id=123, table_id=1234} Completed
2025-03-26 07:32:15,492 INFO util.log :: {database_id=123} Completed
```