### PR TITLE
Fix wells and column add/remove for multi-series charts

### DIFF
--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/CartesianVerticalWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/CartesianVerticalWell.tsx
@@ -7,9 +7,11 @@ import { Flex, Text } from "metabase/ui";
 import { getDefaultMetricFilter } from "metabase/visualizations/shared/settings/cartesian-chart";
 import { DRAGGABLE_ID, DROPPABLE_ID } from "metabase/visualizer/constants";
 import {
+  getIsMultiseriesCartesianChart,
   getVisualizationType,
   getVisualizerComputedSettings,
   getVisualizerDatasetColumns,
+  getVisualizerRawSettings,
 } from "metabase/visualizer/selectors";
 import { isDraggedColumnItem } from "metabase/visualizer/utils";
 import { removeColumn } from "metabase/visualizer/visualizer.slice";
@@ -21,8 +23,10 @@ import { SimpleVerticalWell } from "./SimpleVerticalWell";
 
 export function CartesianVerticalWell() {
   const display = useSelector(getVisualizationType);
-  const settings = useSelector(getVisualizerComputedSettings);
+  const rawSettings = useSelector(getVisualizerRawSettings);
+  const computedSettings = useSelector(getVisualizerComputedSettings);
   const columns = useSelector(getVisualizerDatasetColumns);
+  const isMultiseries = useSelector(getIsMultiseriesCartesianChart);
   const dispatch = useDispatch();
 
   const { active, isOver, setNodeRef } = useDroppable({
@@ -30,11 +34,12 @@ export function CartesianVerticalWell() {
   });
 
   const metrics = useMemo(() => {
+    const settings = isMultiseries ? rawSettings : computedSettings;
     const metricNames = settings["graph.metrics"] ?? [];
     return metricNames
       .map(name => columns.find(column => column.name === name))
       .filter(isNotNull);
-  }, [columns, settings]);
+  }, [columns, computedSettings, rawSettings, isMultiseries]);
 
   const canHandleActiveItem = useMemo(() => {
     if (!display || !active || !isDraggedColumnItem(active)) {

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -38,7 +38,8 @@ const getCurrentHistoryItem = (state: State) => state.visualizer.present;
 
 export const getCards = (state: State) => state.visualizer.cards;
 
-const getRawSettings = (state: State) => getCurrentHistoryItem(state).settings;
+export const getVisualizerRawSettings = (state: State) =>
+  getCurrentHistoryItem(state).settings;
 
 const getVisualizationColumns = (state: State) =>
   getCurrentHistoryItem(state).columns;
@@ -49,7 +50,7 @@ const getVisualizerColumnValuesMapping = (state: State) =>
 // Public selectors
 
 export function getVisualizationTitle(state: State) {
-  const settings = getRawSettings(state);
+  const settings = getVisualizerRawSettings(state);
   return settings["card.title"] ?? getDefaultVisualizationName();
 }
 
@@ -136,7 +137,7 @@ export const getVisualizerRawSeries = createSelector(
   [
     getVisualizationType,
     getVisualizerColumnValuesMapping,
-    getRawSettings,
+    getVisualizerRawSettings,
     getVisualizerDatasetData,
   ],
   (display, columnValuesMapping, settings, data): RawSeries => {

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -112,6 +112,18 @@ export const getUsedDataSources = createSelector(
   },
 );
 
+export const getIsMultiseriesCartesianChart = createSelector(
+  [
+    getVisualizationType,
+    getVisualizerColumnValuesMapping,
+    getVisualizerRawSettings,
+  ],
+  (display, columnValuesMapping, settings) =>
+    display &&
+    isCartesianChart(display) &&
+    shouldSplitVisualizerSeries(columnValuesMapping, settings),
+);
+
 const getVisualizerDatasetData = createSelector(
   [
     getUsedDataSources,
@@ -139,8 +151,15 @@ export const getVisualizerRawSeries = createSelector(
     getVisualizerColumnValuesMapping,
     getVisualizerRawSettings,
     getVisualizerDatasetData,
+    getIsMultiseriesCartesianChart,
   ],
-  (display, columnValuesMapping, settings, data): RawSeries => {
+  (
+    display,
+    columnValuesMapping,
+    settings,
+    data,
+    isMultiseriesCartesianChart,
+  ): RawSeries => {
     if (!display) {
       return [];
     }
@@ -159,10 +178,7 @@ export const getVisualizerRawSeries = createSelector(
       } as SingleSeries,
     ];
 
-    if (
-      isCartesianChart(display) &&
-      shouldSplitVisualizerSeries(columnValuesMapping, settings)
-    ) {
+    if (isMultiseriesCartesianChart) {
       return splitVisualizerSeries(series, columnValuesMapping);
     }
 

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -1,4 +1,5 @@
 import type { DragEndEvent } from "@dnd-kit/core";
+import _ from "underscore";
 
 import { isCartesianChart } from "metabase/visualizations";
 import {
@@ -19,12 +20,20 @@ import type { Card, Dataset, DatasetColumn } from "metabase-types/api";
 import type {
   VisualizerColumnReference,
   VisualizerDataSource,
+  VisualizerDataSourceId,
   VisualizerHistoryItem,
 } from "metabase-types/store/visualizer";
 
 export const cartesianDropHandler = (
   state: VisualizerHistoryItem,
   { active, over }: DragEndEvent,
+  {
+    dataSourceMap,
+    datasetMap,
+  }: {
+    dataSourceMap: Record<VisualizerDataSourceId, VisualizerDataSource>;
+    datasetMap: Record<VisualizerDataSourceId, Dataset>;
+  },
 ) => {
   if (!over) {
     return;
@@ -51,6 +60,14 @@ export const cartesianDropHandler = (
 
     if (isSuitableColumn(column)) {
       addDimensionColumnToCartesianChart(state, column, columnRef, dataSource);
+      if (column.id) {
+        maybeImportDimensionsFromOtherDataSources(
+          state,
+          column.id,
+          _.omit(datasetMap, dataSource.id),
+          dataSourceMap,
+        );
+      }
     }
   }
 

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -199,13 +199,17 @@ export function addColumnToCartesianChart(
     }
   }
 
+  if (!card) {
+    return;
+  }
+
+  const ownMetrics = state.settings["graph.metrics"] ?? [];
+  const ownDimensions = state.settings["graph.dimensions"] ?? [];
+
   if (
-    card &&
+    ownDimensions.length === 0 ||
     canCombineCard(state.display, state.columns, state.settings, card)
   ) {
-    const ownMetrics = state.settings["graph.metrics"] ?? [];
-    const ownDimensions = state.settings["graph.dimensions"] ?? [];
-
     const metrics = card.visualization_settings["graph.metrics"] ?? [];
     const dimensions = card.visualization_settings["graph.dimensions"] ?? [];
 

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -1,5 +1,6 @@
 import type { DragEndEvent } from "@dnd-kit/core";
 
+import { isCartesianChart } from "metabase/visualizations";
 import {
   getDefaultDimensionFilter,
   getDefaultMetricFilter,
@@ -11,7 +12,9 @@ import {
   createVisualizerColumnReference,
   extractReferencedColumns,
   isDraggedColumnItem,
+  shouldSplitVisualizerSeries,
 } from "metabase/visualizer/utils";
+import { isCategory, isDate } from "metabase-lib/v1/types/utils/isa";
 import type { Card, DatasetColumn } from "metabase-types/api";
 import type {
   VisualizerColumnReference,
@@ -223,11 +226,24 @@ export function removeColumnFromCartesianChart(
   state: VisualizerHistoryItem,
   columnName: string,
 ) {
+  const isMultiseries =
+    state.display &&
+    isCartesianChart(state.display) &&
+    shouldSplitVisualizerSeries(state.columnValuesMapping, state.settings);
+
   if (state.settings["graph.dimensions"]) {
     const dimensions = state.settings["graph.dimensions"];
-    state.settings["graph.dimensions"] = dimensions.filter(
-      dimension => dimension !== columnName,
-    );
+    const isDimension = dimensions.includes(columnName);
+
+    if (isDimension) {
+      if (isMultiseries) {
+        removeDimensionFromMultiSeriesChart(state, columnName);
+      } else {
+        state.settings["graph.dimensions"] = dimensions.filter(
+          dimension => dimension !== columnName,
+        );
+      }
+    }
   }
 
   if (state.settings["graph.metrics"]) {
@@ -240,4 +256,41 @@ export function removeColumnFromCartesianChart(
   if (state.settings["scatter.bubble"] === columnName) {
     delete state.settings["scatter.bubble"];
   }
+}
+
+function removeDimensionFromMultiSeriesChart(
+  state: VisualizerHistoryItem,
+  columnName: string,
+) {
+  const originalDimensions = [...(state.settings["graph.dimensions"] ?? [])];
+
+  const dimensionColumnMap = Object.fromEntries(
+    originalDimensions.map(dimension => [
+      dimension,
+      state.columns.find(col => col.name === dimension),
+    ]),
+  );
+  const column = dimensionColumnMap[columnName];
+
+  // For multi-series charts, we need a dimension from each data source
+  // to plot the data correctly. When a dimension is removed, we need to remove
+  // all dimensions of the same type to avoid invalid states.
+  if (isDate(column)) {
+    state.settings["graph.dimensions"] = originalDimensions.filter(
+      name => !isDate(dimensionColumnMap[name]),
+    );
+  } else if (isCategory(column)) {
+    state.settings["graph.dimensions"] = originalDimensions.filter(
+      name => !isCategory(dimensionColumnMap[name]),
+    );
+  }
+
+  const removedColumns = originalDimensions.filter(
+    name => !state.settings["graph.dimensions"]?.includes(name),
+  );
+
+  removedColumns.forEach(name => {
+    state.columns = state.columns.filter(col => col.name !== name);
+    delete state.columnValuesMapping[name];
+  });
 }

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -263,6 +263,8 @@ const visualizerHistoryItemSlice = createSlice({
         addColumnToFunnel(state, column, columnRef, dataSource, dataset, card);
         return;
       }
+      state.columns.push(column);
+      state.columnValuesMapping[column.name] = [columnRef];
       if (isCartesianChart(state.display)) {
         addColumnToCartesianChart(state, column, columnRef, dataSource, card);
 


### PR DESCRIPTION
To work correctly (e.g., for drills and plotting time-series data), multi-series charts in the visualizer must "import" a dimension column from each used data source. So it's easy to get a visualization into a bad state if you add only one dimension column. This PR updates the add/remove column behavior for multi-series charts, so:

1. When we're removing a dimension column (from a well or the data manager), the visualizer automatically removes the corresponding dimension from other datasets as well
2. When we're adding a dimension, the visualizer automatically adds the corresponding dimension from each imported data source (if available)

Also, fixes an issue that the Y-axis was showing only the first metric

### Demo

https://github.com/user-attachments/assets/13092170-bc75-4c90-bc08-2f1244e364f1

