### PR TITLE
support keys in env vars

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -53,28 +53,28 @@
 
 (defn- init-from-config-file!
   [api-key-config]
-  (let [{:keys [name key group creator]} api-key-config
-        group-id (case group
-                   "admin" (u/the-id (perms/admin-group))
-                   "all-users" (u/the-id (perms/all-users-group)))
-        unhashed-key (u.secret/secret key)
-        _ (when-not (and (<= 11 (count key) 254)
-                         (re-matches #"mb_[A-Za-z0-9+/=]+" key))
-            (throw (ex-info (format "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'.")
-                            {:name name})))
-        prefix (api-key/prefix (u.secret/expose unhashed-key))
-        creator (get-admin-user-by-email creator)]
-
-    ;; Check if there's an existing API key with the same prefix
-    (when (t2/exists? :model/ApiKey :key_prefix prefix)
-      (throw (ex-info (format "API key with prefix '%s' already exists. Keys must have unique prefixes." prefix)
-                      {:name name :prefix prefix})))
-
+  (let [{:keys [name key group creator]} api-key-config]
+    ;; Check if there's an existing API key with the same name first
     (if-let [existing-api-key (select-api-key name)]
       (do
         (log/info (u/format-color :blue "API key with name %s already exists, skipping" (pr-str name)))
         existing-api-key)
-      (do
+      (let [group-id (case group
+                       "admin" (u/the-id (perms/admin-group))
+                       "all-users" (u/the-id (perms/all-users-group)))
+            unhashed-key (u.secret/secret key)
+            _ (when-not (and (<= 11 (count key) 254)
+                             (re-matches #"mb_[A-Za-z0-9+/=]+" key))
+                (throw (ex-info (format "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'.")
+                                {:name name})))
+            prefix (api-key/prefix (u.secret/expose unhashed-key))
+            creator (get-admin-user-by-email creator)]
+
+        ;; Check if there's an existing API key with the same prefix
+        (when (t2/exists? :model/ApiKey :key_prefix prefix)
+          (throw (ex-info (format "API key with prefix '%s' already exists. Keys must have unique prefixes." prefix)
+                          {:name name :prefix prefix})))
+
         (log/info (u/format-color :green "Creating new API key %s" (pr-str name)))
         ;; Create a user for the API key
         (let [email (format "api-key-user-%s@api-key.invalid" (random-uuid))

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -17,9 +17,7 @@
   string?)
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/key
-  (s/and string?
-         #(<= 11 (count %) 254)
-         #(re-matches #"mb_[A-Za-z0-9+/=]+" %)))
+  string?)
 
 (s/def :metabase-enterprise.advanced-config.file.api-keys.config-file-spec/creator
   string?)
@@ -60,6 +58,10 @@
                    "admin" (u/the-id (perms/admin-group))
                    "all-users" (u/the-id (perms/all-users-group)))
         unhashed-key (u.secret/secret key)
+        _ (when-not (and (<= 11 (count key) 254)
+                         (re-matches #"mb_[A-Za-z0-9+/=]+" key))
+            (throw (ex-info (format "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'.")
+                            {:name name})))
         prefix (api-key/prefix (u.secret/expose unhashed-key))
         creator (get-admin-user-by-email creator)]
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -159,10 +159,10 @@
           (mt/with-temp-env-var-value! ["MB_API_KEY_FROM_ENV" "mb_envvariablekey123"]
             (binding [config.file/*config* {:version 1
                                             :config {:api-keys [{:name "ENV API Key"
-                                                                 :key "{{env MB_API_KEY_FROM_ENV}}"
+                                                                 :key "{{env API_KEY_FROM_ENV}}"
                                                                  :creator "admin@test.com"
                                                                  :group "admin"}]}}
-                      config.file/*env*    (assoc @#'config.file/*env* :MB_API_KEY_FROM_ENV "mb_envvariablekey123")]
+                      config.file/*env*    (assoc @#'config.file/*env* :api-key-from-env "mb_envvariablekey123")]
               (is (= :ok (config.file/initialize!)))
               (testing "API key should be created from env var"
                 (is (api-key-exists? "ENV API Key")))))
@@ -174,10 +174,10 @@
           ;; (mt/with-temp-env-var-value! ["MB_INVALID_API_KEY" "invalid_key_format"]
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Invalid ENV API Key"
-                                                               :key "{{env MB_INVALID_API_KEY}}"
+                                                               :key "{{env INVALID_API_KEY}}"
                                                                :creator "admin@test.com"
                                                                :group "admin"}]}}
-                    config.file/*env*    (assoc @#'config.file/*env* :MB_INVALID_API_KEY "invalid_key_format")]
+                    config.file/*env*    (assoc @#'config.file/*env* :invalid-api-key "invalid_key_format")]
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
                  #"Invalid API key format"

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -234,18 +234,11 @@
                                               :config {:api-keys [{:name "Duplicate Name Key"
                                                                    :key "mb_different456" ;; different key with different prefix
                                                                    :creator "admin@test.com"
-                                                                   :group "admin"}
-                                                                  {:name "Another Key"
-                                                                   :key "mb_original789" ;; same prefix as original key
-                                                                   :creator "admin@test.com"
                                                                    :group "admin"}]}}]
                 (config.file/initialize!)
                 (testing "Second key with same name is skipped (no error about duplicate prefix)"
                   (let [key-after-attempt (t2/select-one :model/ApiKey :name "Duplicate Name Key")]
                     (is (= (:id original-key) (:id key-after-attempt)))
-                    (is (= original-key-prefix (:key_prefix key-after-attempt)))))
-
-                (testing "New key with same prefix as original is created without error"
-                  (is (api-key-exists? "Another Key")))))))
+                    (is (= original-key-prefix (:key_prefix key-after-attempt)))))))))
         (finally
           (cleanup-config!))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -213,9 +213,9 @@
 
 (deftest skip-existing-api-keys-with-same-prefix-test
   (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User admin {:email "admin@test.com"
-                                      :first_name "Admin"
-                                      :is_superuser true}]
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
       (try
         ;; First, create an API key with a specific name
         (binding [config.file/*config* {:version 1

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -3,8 +3,6 @@
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-config.file :as config.file]
    [metabase.test :as mt]
-   [metabase.util :as u]
-   [metabase.util.yaml :as yaml]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -12,15 +12,9 @@
 (use-fixtures :each (fn [thunk]
                       (binding [config.file/*supported-versions* {:min 1, :max 1}]
                         (mt/with-premium-features #{:config-text-file}
-                          (thunk)))))
-
-(defn- cleanup-config! []
-  (u/ignore-exceptions
-    (doseq [api-key (t2/select :model/ApiKey)]
-      (t2/delete! :model/ApiKey :id (:id api-key)))
-    (doseq [user (t2/select :model/User :type :api-key)]
-      (t2/delete! :model/User :id (:id user)))
-    (.delete (java.io.File. "config.yml"))))
+                          (mt/with-model-cleanup [:model/User]
+                            (mt/with-model-cleanup [:model/ApiKey]
+                              (thunk)))))))
 
 (defn- api-key-exists? [name]
   (t2/exists? :model/ApiKey :name name))
@@ -29,197 +23,134 @@
   (t2/exists? :model/User :first_name name :type :api-key))
 
 (deftest create-api-keys-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (binding [config.file/*config* {:version 1
-                                        :config {:api-keys [{:name "Test API Key"
-                                                             :key "mb_testapikey123"
-                                                             :creator "admin@test.com"
-                                                             :group "admin"}
-                                                            {:name "All Users API Key"
-                                                             :key "mb_differentapikey456"
-                                                             :creator "admin@test.com"
-                                                             :group "all-users"}]}}]
-          (is (= :ok (config.file/initialize!)))
-          (testing "API keys should be created"
-            (is (api-key-exists? "Test API Key"))
-            (is (api-key-exists? "All Users API Key")))
-          (testing "API key users should be created"
-            (is (api-key-user-exists? "Test API Key"))
-            (is (api-key-user-exists? "All Users API Key"))))
-        (finally
-          (cleanup-config!))))))
+  (binding [config.file/*config* {:version 1
+                                  :config {:api-keys [{:name "Test API Key"
+                                                       :key "mb_testapikey123"
+                                                       :creator (:email (mt/fetch-user :crowberto))
+                                                       :group "admin"}
+                                                      {:name "All Users API Key"
+                                                       :key "mb_differentapikey456"
+                                                       :creator (:email (mt/fetch-user :crowberto))
+                                                       :group "all-users"}]}}]
+    (is (= :ok (config.file/initialize!)))
+    (testing "API keys should be created"
+      (is (api-key-exists? "Test API Key"))
+      (is (api-key-exists? "All Users API Key")))
+    (testing "API key users should be created"
+      (is (api-key-user-exists? "Test API Key"))
+      (is (api-key-user-exists? "All Users API Key")))))
 
 (deftest duplicate-api-key-prefix-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (binding [config.file/*config* {:version 1
-                                        :config {:api-keys [{:name "First API Key"
-                                                             :key "mb_sameprefix123"
-                                                             :creator "admin@test.com"
-                                                             :group "admin"}
-                                                            {:name "Second API Key"
-                                                             :key "mb_sameprefix456"
-                                                             :creator "admin@test.com"
-                                                             :group "admin"}]}}]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"API key with prefix 'mb_same' already exists\. Keys must have unique prefixes\."
-               (config.file/initialize!))))
-        (finally
-          (cleanup-config!))))))
+  (binding [config.file/*config* {:version 1
+                                  :config {:api-keys [{:name "First API Key"
+                                                       :key "mb_sameprefix123"
+                                                       :creator (:email (mt/fetch-user :crowberto))
+                                                       :group "admin"}
+                                                      {:name "Second API Key"
+                                                       :key "mb_sameprefix456"
+                                                       :creator (:email (mt/fetch-user :crowberto))
+                                                       :group "admin"}]}}]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"API key with prefix 'mb_same' already exists\. Keys must have unique prefixes\."
+         (config.file/initialize!)))))
 
 (deftest non-admin-creator-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (mt/with-temp [:model/User _ {:email "regular@test.com"
-                                      :first_name "Regular"
-                                      :is_superuser false}]
-          (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_1testapikey123"
-                                                               :creator "regular@test.com"
-                                                               :group "admin"}]}}]
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"User with email regular@test.com is not an admin"
-                 (config.file/initialize!)))))
-        (finally
-          (cleanup-config!))))))
+  (binding [config.file/*config* {:version 1
+                                  :config {:api-keys [{:name "Test API Key"
+                                                       :key "mb_1testapikey123"
+                                                       :creator (:email (mt/fetch-user :rasta))
+                                                       :group "admin"}]}}]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"User with email rasta@metabase.com is not an admin"
+         (config.file/initialize!)))))
 
 (deftest nonexistent-creator-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (binding [config.file/*config* {:version 1
-                                        :config {:api-keys [{:name "Test API Key"
-                                                             :key "mb_2testapikey123"
-                                                             :creator "nonexistent@test.com"
-                                                             :group "admin"}]}}]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"User with email nonexistent@test.com not found"
-               (config.file/initialize!))))
-        (finally
-          (cleanup-config!))))))
+  (binding [config.file/*config* {:version 1
+                                  :config {:api-keys [{:name "Test API Key"
+                                                       :key "mb_2testapikey123"
+                                                       :creator "nonexistent@test.com"
+                                                       :group "admin"}]}}]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"User with email nonexistent@test.com not found"
+         (config.file/initialize!)))))
 
 (deftest skip-existing-api-keys-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (binding [config.file/*config* {:version 1
-                                        :config {:api-keys [{:name "Test API Key"
-                                                             :key "mb_3testapikey123"
-                                                             :creator "admin@test.com"
-                                                             :group "admin"}]}}]
-          (config.file/initialize!)
-          (let [first-key (t2/select-one :model/ApiKey :name "Test API Key")
-                _ (binding [config.file/*config* {:version 1
-                                                  :config {:api-keys [{:name "Test API Key"
-                                                                       :key "mb_4testapikey123"
-                                                                       :creator "admin@test.com"
-                                                                       :group "admin"}]}}]
-                    (config.file/initialize!))
-                second-key (t2/select-one :model/ApiKey :name "Test API Key")]
-            (is (= (:id first-key) (:id second-key)))))
-        (finally
-          (cleanup-config!))))))
+  (binding [config.file/*config* {:version 1
+                                  :config {:api-keys [{:name "Test API Key"
+                                                       :key "mb_3testapikey123"
+                                                       :creator (:email (mt/fetch-user :crowberto))
+                                                       :group "admin"}]}}]
+    (config.file/initialize!)
+    (let [first-key (t2/select-one :model/ApiKey :name "Test API Key")
+          _ (binding [config.file/*config* {:version 1
+                                            :config {:api-keys [{:name "Test API Key"
+                                                                 :key "mb_4testapikey123"
+                                                                 :creator "admin@test.com"
+                                                                 :group "admin"}]}}]
+              (config.file/initialize!))
+          second-key (t2/select-one :model/ApiKey :name "Test API Key")]
+      (is (= (:id first-key) (:id second-key))))))
 
 (deftest validate-group-values-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (binding [config.file/*config* {:version 1
-                                        :config {:api-keys [{:name "Test API Key"
-                                                             :key "mb_5testapikey123"
-                                                             :creator "admin@test.com"
-                                                             :group "invalid-group"}]}}]
-          (is (thrown? clojure.lang.ExceptionInfo
-                       (config.file/initialize!))))
-        (finally
-          (cleanup-config!))))))
+  (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                :first_name "Admin"
+                                :is_superuser true}]
+    (binding [config.file/*config* {:version 1
+                                    :config {:api-keys [{:name "Test API Key"
+                                                         :key "mb_5testapikey123"
+                                                         :creator "admin@test.com"
+                                                         :group "invalid-group"}]}}]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (config.file/initialize!))))))
 
 (deftest env-var-api-key-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (mt/with-temp-env-var-value! ["MB_API_KEY_FROM_ENV" "mb_envvariablekey123"]
-          (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "ENV API Key"
-                                                               :key "{{env API_KEY_FROM_ENV}}"
-                                                               :creator "admin@test.com"
-                                                               :group "admin"}]}}
-                    config.file/*env*    (assoc @#'config.file/*env* :api-key-from-env "mb_envvariablekey123")]
-            (is (= :ok (config.file/initialize!)))
-            (testing "API key should be created from env var"
-              (is (api-key-exists? "ENV API Key")))))
-        (finally
-          (cleanup-config!))))))
+  (mt/with-temp-env-var-value! ["MB_API_KEY_FROM_ENV" "mb_envvariablekey123"]
+    (binding [config.file/*config* {:version 1
+                                    :config {:api-keys [{:name "ENV API Key"
+                                                         :key "{{env API_KEY_FROM_ENV}}"
+                                                         :creator (:email (mt/fetch-user :crowberto))
+                                                         :group "admin"}]}}
+              config.file/*env*    (assoc @#'config.file/*env* :api-key-from-env "mb_envvariablekey123")]
+      (is (= :ok (config.file/initialize!)))
+      (testing "API key should be created from env var"
+        (is (api-key-exists? "ENV API Key"))))))
 
 (deftest validate-env-var-api-key-format-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        (binding [config.file/*config* {:version 1
-                                        :config {:api-keys [{:name "Invalid ENV API Key"
-                                                             :key "{{env INVALID_API_KEY}}"
-                                                             :creator "admin@test.com"
-                                                             :group "admin"}]}}
-                  config.file/*env*    (assoc @#'config.file/*env* :invalid-api-key "invalid_key_format")]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"Invalid API key format"
-               (config.file/initialize!))))
-        (finally
-          (cleanup-config!))))))
+  (binding [config.file/*config* {:version 1
+                                  :config {:api-keys [{:name "Invalid ENV API Key"
+                                                       :key "{{env INVALID_API_KEY}}"
+                                                       :creator (:email (mt/fetch-user :crowberto))
+                                                       :group "admin"}]}}
+            config.file/*env*    (assoc @#'config.file/*env* :invalid-api-key "invalid_key_format")]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid API key format"
+         (config.file/initialize!)))))
 
 (deftest skip-existing-api-keys-with-same-prefix-test
-  (mt/with-premium-features #{:config-text-file}
-    (mt/with-temp [:model/User _ {:email "admin@test.com"
-                                  :first_name "Admin"
-                                  :is_superuser true}]
-      (try
-        ;; First, create an API key with a specific name
+  ;; First, create an API key with a specific name
+  (binding [config.file/*config* {:version 1
+                                  :config {:api-keys [{:name "Duplicate Name Key"
+                                                       :key "mb_original123"
+                                                       :creator (:email (mt/fetch-user :crowberto))
+                                                       :group "admin"}]}}]
+    (config.file/initialize!)
+    (testing "Original API key is created"
+      (is (api-key-exists? "Duplicate Name Key"))
+      (let [original-key (t2/select-one :model/ApiKey :name "Duplicate Name Key")
+            original-key-prefix (:key_prefix original-key)]
+
+        ;; Now attempt to create another key with the same name but different prefix
         (binding [config.file/*config* {:version 1
                                         :config {:api-keys [{:name "Duplicate Name Key"
-                                                             :key "mb_original123"
+                                                             :key "mb_different456" ;; different key with different prefix
                                                              :creator "admin@test.com"
                                                              :group "admin"}]}}]
           (config.file/initialize!)
-          (testing "Original API key is created"
-            (is (api-key-exists? "Duplicate Name Key"))
-            (let [original-key (t2/select-one :model/ApiKey :name "Duplicate Name Key")
-                  original-key-prefix (:key_prefix original-key)]
-
-              ;; Now attempt to create another key with the same name but different prefix
-              (binding [config.file/*config* {:version 1
-                                              :config {:api-keys [{:name "Duplicate Name Key"
-                                                                   :key "mb_different456" ;; different key with different prefix
-                                                                   :creator "admin@test.com"
-                                                                   :group "admin"}]}}]
-                (config.file/initialize!)
-                (testing "Second key with same name is skipped (no error about duplicate prefix)"
-                  (let [key-after-attempt (t2/select-one :model/ApiKey :name "Duplicate Name Key")]
-                    (is (= (:id original-key) (:id key-after-attempt)))
-                    (is (= original-key-prefix (:key_prefix key-after-attempt)))))))))
-        (finally
-          (cleanup-config!))))))
+          (testing "Second key with same name is skipped (no error about duplicate prefix)"
+            (let [key-after-attempt (t2/select-one :model/ApiKey :name "Duplicate Name Key")]
+              (is (= (:id original-key) (:id key-after-attempt)))
+              (is (= original-key-prefix (:key_prefix key-after-attempt))))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -161,7 +161,8 @@
                                             :config {:api-keys [{:name "ENV API Key"
                                                                  :key "{{env MB_API_KEY_FROM_ENV}}"
                                                                  :creator "admin@test.com"
-                                                                 :group "admin"}]}}]
+                                                                 :group "admin"}]}}
+                      advanced-config.file/*env*    (assoc @#'advanced-config.file/*env* :MB_API_KEY_FROM_ENV "mb_envvariablekey123")]
               (is (= :ok (config.file/initialize!)))
               (testing "API key should be created from env var"
                 (is (api-key-exists? "ENV API Key")))))
@@ -170,15 +171,16 @@
 
       (testing "should validate format of API key from environment variable"
         (try
-          (mt/with-temp-env-var-value! ["MB_INVALID_API_KEY" "invalid_key_format"]
-            (binding [config.file/*config* {:version 1
-                                            :config {:api-keys [{:name "Invalid ENV API Key"
-                                                                 :key "{{env MB_INVALID_API_KEY}}"
-                                                                 :creator "admin@test.com"
-                                                                 :group "admin"}]}}]
-              (is (thrown-with-msg?
-                   clojure.lang.ExceptionInfo
-                   #"Invalid API key format"
-                   (config.file/initialize!)))))
-          (finally
-            (cleanup-config!)))))))
+          ;; (mt/with-temp-env-var-value! ["MB_INVALID_API_KEY" "invalid_key_format"]
+          (binding [config.file/*config* {:version 1
+                                          :config {:api-keys [{:name "Invalid ENV API Key"
+                                                               :key "{{env MB_INVALID_API_KEY}}"
+                                                               :creator "admin@test.com"
+                                                               :group "admin"}]}}
+                    advanced-config.file/*env*    (assoc @#'advanced-config.file/*env* :MB_INVALID_API_KEY "invalid_key_format")]
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Invalid API key format"
+                 (config.file/initialize!)))))
+        (finally
+          (cleanup-config!))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -31,156 +31,182 @@
 (defn- api-key-user-exists? [name]
   (t2/exists? :model/User :first_name name :type :api-key))
 
-(deftest api-keys-config-test
+(deftest create-api-keys-test
   (mt/with-premium-features #{:config-text-file}
     (mt/with-temp [:model/User _ {:email "admin@test.com"
                                   :first_name "Admin"
                                   :is_superuser true}]
-      (testing "should create API keys from config"
-        (try
-          (write-config!
-           {:version 1
-            :config {:api-keys [{:name "Test API Key"
-                                 :key "mb_testapikey123"
-                                 :creator "admin@test.com"
-                                 :group "admin"}
-                                {:name "All Users API Key"
-                                 :key "mb_differentapikey456"
-                                 :creator "admin@test.com"
-                                 :group "all-users"}]}})
+      (try
+        (write-config!
+         {:version 1
+          :config {:api-keys [{:name "Test API Key"
+                               :key "mb_testapikey123"
+                               :creator "admin@test.com"
+                               :group "admin"}
+                              {:name "All Users API Key"
+                               :key "mb_differentapikey456"
+                               :creator "admin@test.com"
+                               :group "all-users"}]}})
+        (binding [config.file/*config* {:version 1
+                                        :config {:api-keys [{:name "Test API Key"
+                                                             :key "mb_testapikey123"
+                                                             :creator "admin@test.com"
+                                                             :group "admin"}
+                                                            {:name "All Users API Key"
+                                                             :key "mb_differentapikey456"
+                                                             :creator "admin@test.com"
+                                                             :group "all-users"}]}}]
+          (is (= :ok (config.file/initialize!)))
+          (testing "API keys should be created"
+            (is (api-key-exists? "Test API Key"))
+            (is (api-key-exists? "All Users API Key")))
+          (testing "API key users should be created"
+            (is (api-key-user-exists? "Test API Key"))
+            (is (api-key-user-exists? "All Users API Key"))))
+        (finally
+          (cleanup-config!))))))
+
+(deftest duplicate-api-key-prefix-test
+  (mt/with-premium-features #{:config-text-file}
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
+      (try
+        (write-config!
+         {:version 1
+          :config {:api-keys [{:name "First API Key"
+                               :key "mb_sameprefix_123"
+                               :creator "admin@test.com"
+                               :group "admin"}]}})
+        (binding [config.file/*config* {:version 1
+                                        :config {:api-keys [{:name "First API Key"
+                                                             :key "mb_sameprefix123"
+                                                             :creator "admin@test.com"
+                                                             :group "admin"}
+                                                            {:name "Second API Key"
+                                                             :key "mb_sameprefix456"
+                                                             :creator "admin@test.com"
+                                                             :group "admin"}]}}]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"API key with prefix 'mb_same' already exists\. Keys must have unique prefixes\."
+               (config.file/initialize!))))
+        (finally
+          (cleanup-config!))))))
+
+(deftest non-admin-creator-test
+  (mt/with-premium-features #{:config-text-file}
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
+      (try
+        (mt/with-temp [:model/User _ {:email "regular@test.com"
+                                      :first_name "Regular"
+                                      :is_superuser false}]
           (binding [config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_testapikey123"
-                                                               :creator "admin@test.com"
-                                                               :group "admin"}
-                                                              {:name "All Users API Key"
-                                                               :key "mb_differentapikey456"
-                                                               :creator "admin@test.com"
-                                                               :group "all-users"}]}}]
-            (is (= :ok (config.file/initialize!)))
-            (testing "API keys should be created"
-              (is (api-key-exists? "Test API Key"))
-              (is (api-key-exists? "All Users API Key")))
-            (testing "API key users should be created"
-              (is (api-key-user-exists? "Test API Key"))
-              (is (api-key-user-exists? "All Users API Key"))))
-          (finally
-            (cleanup-config!))))
-
-      (testing "should fail if API keys have the same prefix"
-        (try
-          (write-config!
-           {:version 1
-            :config {:api-keys [{:name "First API Key"
-                                 :key "mb_sameprefix_123"
-                                 :creator "admin@test.com"
-                                 :group "admin"}]}})
-          (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "First API Key"
-                                                               :key "mb_sameprefix123"
-                                                               :creator "admin@test.com"
-                                                               :group "admin"}
-                                                              {:name "Second API Key"
-                                                               :key "mb_sameprefix456"
-                                                               :creator "admin@test.com"
+                                                               :key "mb_1testapikey123"
+                                                               :creator "regular@test.com"
                                                                :group "admin"}]}}]
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
-                 #"API key with prefix 'mb_same' already exists\. Keys must have unique prefixes\."
-                 (config.file/initialize!))))
-          (finally
-            (cleanup-config!))))
+                 #"User with email regular@test.com is not an admin"
+                 (config.file/initialize!)))))
+        (finally
+          (cleanup-config!))))))
 
-      (testing "should fail if creator is not an admin"
-        (try
-          (mt/with-temp [:model/User _ {:email "regular@test.com"
-                                        :first_name "Regular"
-                                        :is_superuser false}]
-            (binding [config.file/*config* {:version 1
-                                            :config {:api-keys [{:name "Test API Key"
-                                                                 :key "mb_1testapikey123"
-                                                                 :creator "regular@test.com"
-                                                                 :group "admin"}]}}]
-              (is (thrown-with-msg?
-                   clojure.lang.ExceptionInfo
-                   #"User with email regular@test.com is not an admin"
-                   (config.file/initialize!)))))
-          (finally
-            (cleanup-config!))))
+(deftest nonexistent-creator-test
+  (mt/with-premium-features #{:config-text-file}
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
+      (try
+        (binding [config.file/*config* {:version 1
+                                        :config {:api-keys [{:name "Test API Key"
+                                                             :key "mb_2testapikey123"
+                                                             :creator "nonexistent@test.com"
+                                                             :group "admin"}]}}]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"User with email nonexistent@test.com not found"
+               (config.file/initialize!))))
+        (finally
+          (cleanup-config!))))))
 
-      (testing "should fail if creator doesn't exist"
-        (try
+(deftest skip-existing-api-keys-test
+  (mt/with-premium-features #{:config-text-file}
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
+      (try
+        (binding [config.file/*config* {:version 1
+                                        :config {:api-keys [{:name "Test API Key"
+                                                             :key "mb_3testapikey123"
+                                                             :creator "admin@test.com"
+                                                             :group "admin"}]}}]
+          (config.file/initialize!)
+          (let [first-key (t2/select-one :model/ApiKey :name "Test API Key")
+                _ (binding [config.file/*config* {:version 1
+                                                  :config {:api-keys [{:name "Test API Key"
+                                                                       :key "mb_4testapikey123"
+                                                                       :creator "admin@test.com"
+                                                                       :group "admin"}]}}]
+                    (config.file/initialize!))
+                second-key (t2/select-one :model/ApiKey :name "Test API Key")]
+            (is (= (:id first-key) (:id second-key)))))
+        (finally
+          (cleanup-config!))))))
+
+(deftest validate-group-values-test
+  (mt/with-premium-features #{:config-text-file}
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
+      (try
+        (binding [config.file/*config* {:version 1
+                                        :config {:api-keys [{:name "Test API Key"
+                                                             :key "mb_5testapikey123"
+                                                             :creator "admin@test.com"
+                                                             :group "invalid-group"}]}}]
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (config.file/initialize!))))
+        (finally
+          (cleanup-config!))))))
+
+(deftest env-var-api-key-test
+  (mt/with-premium-features #{:config-text-file}
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
+      (try
+        (mt/with-temp-env-var-value! ["MB_API_KEY_FROM_ENV" "mb_envvariablekey123"]
           (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_2testapikey123"
-                                                               :creator "nonexistent@test.com"
-                                                               :group "admin"}]}}]
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"User with email nonexistent@test.com not found"
-                 (config.file/initialize!))))
-          (finally
-            (cleanup-config!))))
-
-      (testing "should skip existing API keys"
-        (try
-          (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_3testapikey123"
-                                                               :creator "admin@test.com"
-                                                               :group "admin"}]}}]
-            (config.file/initialize!)
-            (let [first-key (t2/select-one :model/ApiKey :name "Test API Key")
-                  _ (binding [config.file/*config* {:version 1
-                                                    :config {:api-keys [{:name "Test API Key"
-                                                                         :key "mb_4testapikey123"
-                                                                         :creator "admin@test.com"
-                                                                         :group "admin"}]}}]
-                      (config.file/initialize!))
-                  second-key (t2/select-one :model/ApiKey :name "Test API Key")]
-              (is (= (:id first-key) (:id second-key)))))
-          (finally
-            (cleanup-config!))))
-
-      (testing "should validate group values"
-        (try
-          (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "Test API Key"
-                                                               :key "mb_5testapikey123"
-                                                               :creator "admin@test.com"
-                                                               :group "invalid-group"}]}}]
-            (is (thrown? clojure.lang.ExceptionInfo
-                         (config.file/initialize!))))
-          (finally
-            (cleanup-config!))))
-
-      (testing "should accept API key from environment variable"
-        (try
-          (mt/with-temp-env-var-value! ["MB_API_KEY_FROM_ENV" "mb_envvariablekey123"]
-            (binding [config.file/*config* {:version 1
-                                            :config {:api-keys [{:name "ENV API Key"
-                                                                 :key "{{env API_KEY_FROM_ENV}}"
-                                                                 :creator "admin@test.com"
-                                                                 :group "admin"}]}}
-                      config.file/*env*    (assoc @#'config.file/*env* :api-key-from-env "mb_envvariablekey123")]
-              (is (= :ok (config.file/initialize!)))
-              (testing "API key should be created from env var"
-                (is (api-key-exists? "ENV API Key")))))
-          (finally
-            (cleanup-config!))))
-
-      (testing "should validate format of API key from environment variable"
-        (try
-          ;; (mt/with-temp-env-var-value! ["MB_INVALID_API_KEY" "invalid_key_format"]
-          (binding [config.file/*config* {:version 1
-                                          :config {:api-keys [{:name "Invalid ENV API Key"
-                                                               :key "{{env INVALID_API_KEY}}"
+                                          :config {:api-keys [{:name "ENV API Key"
+                                                               :key "{{env API_KEY_FROM_ENV}}"
                                                                :creator "admin@test.com"
                                                                :group "admin"}]}}
-                    config.file/*env*    (assoc @#'config.file/*env* :invalid-api-key "invalid_key_format")]
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"Invalid API key format"
-                 (config.file/initialize!))))
-          (finally
-            (cleanup-config!)))))))
+                    config.file/*env*    (assoc @#'config.file/*env* :api-key-from-env "mb_envvariablekey123")]
+            (is (= :ok (config.file/initialize!)))
+            (testing "API key should be created from env var"
+              (is (api-key-exists? "ENV API Key")))))
+        (finally
+          (cleanup-config!))))))
+
+(deftest validate-env-var-api-key-format-test
+  (mt/with-premium-features #{:config-text-file}
+    (mt/with-temp [:model/User _ {:email "admin@test.com"
+                                  :first_name "Admin"
+                                  :is_superuser true}]
+      (try
+        (binding [config.file/*config* {:version 1
+                                        :config {:api-keys [{:name "Invalid ENV API Key"
+                                                             :key "{{env INVALID_API_KEY}}"
+                                                             :creator "admin@test.com"
+                                                             :group "admin"}]}}
+                  config.file/*env*    (assoc @#'config.file/*env* :invalid-api-key "invalid_key_format")]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Invalid API key format"
+               (config.file/initialize!))))
+        (finally
+          (cleanup-config!))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -181,6 +181,6 @@
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
                  #"Invalid API key format"
-                 (config.file/initialize!)))))
-        (finally
-          (cleanup-config!))))))
+                 (config.file/initialize!))))
+          (finally
+            (cleanup-config!)))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -14,9 +14,6 @@
                         (mt/with-premium-features #{:config-text-file}
                           (thunk)))))
 
-(defn- write-config! [config]
-  (spit "config.yml" (yaml/generate-string config)))
-
 (defn- cleanup-config! []
   (u/ignore-exceptions
     (doseq [api-key (t2/select :model/ApiKey)]
@@ -37,16 +34,6 @@
                                   :first_name "Admin"
                                   :is_superuser true}]
       (try
-        (write-config!
-         {:version 1
-          :config {:api-keys [{:name "Test API Key"
-                               :key "mb_testapikey123"
-                               :creator "admin@test.com"
-                               :group "admin"}
-                              {:name "All Users API Key"
-                               :key "mb_differentapikey456"
-                               :creator "admin@test.com"
-                               :group "all-users"}]}})
         (binding [config.file/*config* {:version 1
                                         :config {:api-keys [{:name "Test API Key"
                                                              :key "mb_testapikey123"
@@ -72,12 +59,6 @@
                                   :first_name "Admin"
                                   :is_superuser true}]
       (try
-        (write-config!
-         {:version 1
-          :config {:api-keys [{:name "First API Key"
-                               :key "mb_sameprefix_123"
-                               :creator "admin@test.com"
-                               :group "admin"}]}})
         (binding [config.file/*config* {:version 1
                                         :config {:api-keys [{:name "First API Key"
                                                              :key "mb_sameprefix123"

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -162,7 +162,7 @@
                                                                  :key "{{env MB_API_KEY_FROM_ENV}}"
                                                                  :creator "admin@test.com"
                                                                  :group "admin"}]}}
-                      advanced-config.file/*env*    (assoc @#'advanced-config.file/*env* :MB_API_KEY_FROM_ENV "mb_envvariablekey123")]
+                      config.file/*env*    (assoc @#'config.file/*env* :MB_API_KEY_FROM_ENV "mb_envvariablekey123")]
               (is (= :ok (config.file/initialize!)))
               (testing "API key should be created from env var"
                 (is (api-key-exists? "ENV API Key")))))
@@ -177,7 +177,7 @@
                                                                :key "{{env MB_INVALID_API_KEY}}"
                                                                :creator "admin@test.com"
                                                                :group "admin"}]}}
-                    advanced-config.file/*env*    (assoc @#'advanced-config.file/*env* :MB_INVALID_API_KEY "invalid_key_format")]
+                    config.file/*env*    (assoc @#'config.file/*env* :MB_INVALID_API_KEY "invalid_key_format")]
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
                  #"Invalid API key format"


### PR DESCRIPTION
# Support Environment Variables for API Keys
### Overview
This PR adds support for using environment variables to define API keys in the configuration file, enhancing security and flexibility for deployment environments.
### Changes
- Modified API key validation to support environment variable substitution in the key field
- Added runtime validation for API keys from environment variables to ensure proper formatting
- Refactored tests to properly validate environment variable integration
- All API keys (including those from environment variables) still must follow the required format:
  - Must be between 11-254 characters
  - Must start with mb_
  - Must match the pattern mb_[A-Za-z0-9+/=]+
### Usage
```
api-keys:
  - name: "ENV API Key"
    key: "{{env API_KEY_FROM_ENV}}"
    creator: "admin@example.com"
    group: "admin"
```

### Testing
- Creation of API keys from environment variables
- Validation of API key format from environment variables
- Error handling for improperly formatted environment variable values

# Skip keys if they exist
To guarantee that it is possible to keep the same yaml file on each instance initialization, if there is a key in the instance and the config file has a key with the same name, the creation is skipped.