### PR TITLE
Remove stack traces from `SQLException`s

### DIFF
--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.catch-exceptions
   "Middleware for catching exceptions thrown by the query processor and returning them in a friendlier format."
   (:require
+   [clojure.string :as str]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.permissions :as qp.perms]
@@ -64,7 +65,9 @@
   [maps :- [:sequential {:min 1} :map]]
   (some (fn [m]
           (when (isa? (:class m) SQLException)
-            (select-keys m [:error])))
+            ;; Some JDBC drivers (e.g. Databricks) return a stacktrace in the
+            ;; error message that we don't want to show the user
+            {:error (first (str/split (get m :error "") #"\n\tat"))}))
         maps))
 
 (mu/defn exception-response :- [:map [:status :keyword]]

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -67,7 +67,7 @@
           (when (isa? (:class m) SQLException)
             ;; Some JDBC drivers (e.g. Databricks) return a stacktrace in the
             ;; error message that we don't want to show the user
-            {:error (first (str/split (get m :error "") #"\n\tat "))}))
+            {:error (first (str/split (get m :error "") #"\n\tat " 2))}))
         maps))
 
 (mu/defn exception-response :- [:map [:status :keyword]]

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -67,7 +67,7 @@
           (when (isa? (:class m) SQLException)
             ;; Some JDBC drivers (e.g. Databricks) return a stacktrace in the
             ;; error message that we don't want to show the user
-            {:error (first (str/split (get m :error "") #"\n\tat"))}))
+            {:error (first (str/split (get m :error "") #"\n\tat "))}))
         maps))
 
 (mu/defn exception-response :- [:map [:status :keyword]]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -476,6 +476,18 @@
                      :data
                      (select-keys [:requested_timezone :results_timezone])))))))))
 
+(deftest databricks-stack-trace-test
+  (testing "exceptions with stacktraces should have the stacktrace removed"
+    (mt/test-driver :databricks
+      (let [res (mt/user-http-request :rasta :post 202 "dataset"
+                                      (lib/native-query (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                                                        "asdf;"))]
+        (is (= {:error_type "invalid-query"
+                :status "failed"
+                :class "class com.databricks.client.support.exceptions.ErrorException"}
+               (select-keys res [:error_type :status :class])))
+        (is (not (str/includes? (:error res) "\n\tat ")))))))
+
 (deftest ^:parallel pivot-dataset-test
   (mt/test-drivers (api.pivots/applicable-drivers)
     (mt/dataset test-data

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -14,7 +14,9 @@
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.test :as mt]
-   [metabase.test.data.users :as test.users]))
+   [metabase.test.data.users :as test.users])
+  (:import
+   (java.sql SQLException)))
 
 (deftest ^:parallel exception-chain-test
   (testing "Should be able to get a sequence of exceptions by following causes, with the top-level Exception first"
@@ -52,7 +54,31 @@
                    (update :stacktrace sequential?)
                    (update :via (fn [causes]
                                   (for [cause causes]
-                                    (update cause :stacktrace sequential?)))))))))))
+                                    (update cause :stacktrace sequential?))))))))))
+  (testing "SQLExceptions that include stack traces should have them removed"
+    (let [e1 (ex-info "mock databricks jdbc driver exception" {:level 1})
+          e2 (SQLException. "mock sql exception\n\tat stacktrace" e1)
+          e3 (ex-info "mock exception" {:level 3} e2)]
+      (is (= {:status     :failed
+              :class      clojure.lang.ExceptionInfo
+              :error      "mock sql exception"
+              :stacktrace true
+              :ex-data    {:level 1}
+              :via        [{:status        :failed
+                            :class         java.sql.SQLException,
+                            :error         "mock sql exception\n\tat stacktrace",
+                            :stacktrace    true
+                            :state nil}
+                           {:status     :failed
+                            :class      clojure.lang.ExceptionInfo
+                            :error      "mock exception"
+                            :stacktrace true
+                            :ex-data    {:level 3}}]}
+             (-> (#'catch-exceptions/exception-response e3)
+                 (update :stacktrace sequential?)
+                 (update :via (fn [causes]
+                                (for [cause causes]
+                                  (update cause :stacktrace sequential?))))))))))
 
 (defn catch-exceptions
   ([run]

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -57,7 +57,7 @@
                                     (update cause :stacktrace sequential?))))))))))
   (testing "SQLExceptions that include stack traces should have them removed"
     (let [e1 (ex-info "mock databricks jdbc driver exception" {:level 1})
-          e2 (SQLException. "mock sql exception\n\tat stacktrace" e1)
+          e2 (SQLException. "mock sql exception\n\tat line1\n\tat line2\n\tat line3" e1)
           e3 (ex-info "mock exception" {:level 3} e2)]
       (is (= {:status     :failed
               :class      clojure.lang.ExceptionInfo
@@ -66,7 +66,7 @@
               :ex-data    {:level 1}
               :via        [{:status        :failed
                             :class         java.sql.SQLException,
-                            :error         "mock sql exception\n\tat stacktrace",
+                            :error         "mock sql exception\n\tat line1\n\tat line2\n\tat line3",
                             :stacktrace    true
                             :state nil}
                            {:status     :failed


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53539

### Description

Some JDBC drivers (e.g. Databricks) return stack traces in their `SQLException`s, which are not very readable when displayed on the FE. This PR removes those stacktraces if they are in the error message.

### How to verify

1. Run an invalid query like `select bad;` on a Databricks DB.
2. An error message with no stack trace should be displayed

### Demo

https://github.com/user-attachments/assets/3295e830-30a6-4632-9a2b-1123dafbaf9b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
