### PR TITLE
Allow Assertion Functions in Jest Tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -255,6 +255,13 @@ module.exports = {
       ],
       rules: {
         "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
+        "jest/expect-expect": [
+          "error",
+          {
+            "assertFunctionNames": ["expect*", "assert*"],
+            "additionalTestBlockFunctions": []
+          }
+        ],
       },
     },
     {

--- a/enterprise/frontend/src/embedding-sdk/test/sdk-config-errors.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/sdk-config-errors.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectErrorMessage"] }] */
-
 import { render, screen, waitFor } from "@testing-library/react";
 import fetchMock from "fetch-mock";
 

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable jest/expect-expect */
-
 import expression from "ts-dedent";
 
 import type { Expression } from "metabase-types/api";
@@ -11,9 +9,11 @@ import type { StartRule } from "../types";
 import { format } from "./formatter";
 
 function setup(printWidth: number, startRule: StartRule = "expression") {
-  async function isFormatted(expressions: string | string[]): Promise<void> {
+  async function assertFormatted(
+    expressions: string | string[],
+  ): Promise<void> {
     if (!Array.isArray(expressions)) {
-      return isFormatted([expressions]);
+      return assertFormatted([expressions]);
     }
     for (const source of expressions) {
       const options = {
@@ -39,15 +39,15 @@ function setup(printWidth: number, startRule: StartRule = "expression") {
       expect(result).toBe(source);
     }
   }
-  return { isFormatted };
+  return { assertFormatted };
 }
 
 describe("format", () => {
   describe("printWidth = 25", () => {
-    const { isFormatted } = setup(25);
+    const { assertFormatted } = setup(25);
 
     it("formats nested arithmetic expressions", async () => {
-      await isFormatted([
+      await assertFormatted([
         expression`
           1 + 2 - 3 + 4 / 5
         `,
@@ -85,7 +85,7 @@ describe("format", () => {
     });
 
     it("formats function calls", async () => {
-      await isFormatted([
+      await assertFormatted([
         expression`
           concat(
             "http://mysite.com/user/",
@@ -121,7 +121,7 @@ describe("format", () => {
     });
 
     it("formats chained function calls", async () => {
-      await isFormatted([
+      await assertFormatted([
         expression`
           concat("a", "b")
           AND concat("c", "d")
@@ -162,8 +162,8 @@ describe("format", () => {
     });
 
     it("formats unary operators", async () => {
-      const { isFormatted } = setup(25, "boolean");
-      await isFormatted([
+      const { assertFormatted } = setup(25, "boolean");
+      await assertFormatted([
         expression`
           NOT [Total] < 10
         `,

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jest/expect-expect */
-
 import userEvent from "@testing-library/user-event";
 import fetchMock, { type MockResponse } from "fetch-mock";
 

--- a/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
+++ b/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 /* eslint-disable react/prop-types */
 
 import userEvent from "@testing-library/user-event";
@@ -93,10 +92,10 @@ describe("TokenField", () => {
   const inputKeydown = keyCode =>
     fireEvent.keyDown(input(), { keyCode: keyCode });
 
-  const findWithinValues = collection =>
+  const assertWithinValues = collection =>
     expect(values()).toHaveTextContent(collection.join(""));
 
-  const findWithinOptions = collection =>
+  const assertWithinOptions = collection =>
     expect(options()).toHaveTextContent(collection.join(""));
 
   it("should render with no options or values", () => {
@@ -123,8 +122,8 @@ describe("TokenField", () => {
         options={["bar"]}
       />,
     );
-    findWithinValues(["foo"]);
-    findWithinOptions(["bar"]);
+    assertWithinValues(["foo"]);
+    assertWithinOptions(["bar"]);
   });
 
   it("shouldn't show previous used option by default", () => {
@@ -143,7 +142,7 @@ describe("TokenField", () => {
         removeSelected={false}
       />,
     );
-    findWithinOptions(["foo"]);
+    assertWithinOptions(["foo"]);
   });
 
   it("should filter correctly", () => {
@@ -156,7 +155,7 @@ describe("TokenField", () => {
     type("nope");
     expect(options()).toBeFalsy();
     type("bar");
-    findWithinOptions(["bar"]);
+    assertWithinOptions(["bar"]);
   });
 
   it("should not allow adding new items when canAddItems is false", () => {
@@ -193,11 +192,11 @@ describe("TokenField", () => {
         options={["bar", "baz"]}
       />,
     );
-    findWithinOptions(["bar", "baz"]);
+    assertWithinOptions(["bar", "baz"]);
 
     clickText("bar");
-    findWithinValues(["bar"]);
-    findWithinOptions(["baz"]);
+    assertWithinValues(["bar"]);
+    assertWithinOptions(["baz"]);
   });
 
   it("should add option when filtered and clicked", () => {
@@ -210,7 +209,7 @@ describe("TokenField", () => {
     );
     type("ba");
     clickText("bar");
-    findWithinValues(["bar"]);
+    assertWithinValues(["bar"]);
   });
 
   describe("when updateOnInputChange is provided", () => {
@@ -229,17 +228,17 @@ describe("TokenField", () => {
     it("should add freeform value immediately if updateOnInputChange is provided", () => {
       setup();
       type("yep");
-      findWithinValues(["yep"]);
+      assertWithinValues(["yep"]);
     });
 
     it("should only add one option when filtered and clicked", () => {
       setup();
 
       type("Do");
-      findWithinValues(["Do"]);
+      assertWithinValues(["Do"]);
 
       clickText("Doohickey");
-      findWithinValues(["Doohickey"]);
+      assertWithinValues(["Doohickey"]);
       expect(input().value).toEqual("");
     });
 
@@ -247,20 +246,20 @@ describe("TokenField", () => {
       setup();
 
       type("Do");
-      findWithinValues(["Do"]);
+      assertWithinValues(["Do"]);
 
       inputKeydown(KEYCODE_ENTER);
-      findWithinValues(["Doohickey"]);
+      assertWithinValues(["Doohickey"]);
       expect(input().value).toEqual("");
-      findWithinOptions(["Gadget", "Gizmo", "Widget"]);
+      assertWithinOptions(["Gadget", "Gizmo", "Widget"]);
     });
 
     it("shouldn't hide option matching input freeform value", () => {
       setup();
 
       type("Doohickey");
-      findWithinValues(["Doohickey"]);
-      findWithinOptions(["Doohickey"]);
+      assertWithinValues(["Doohickey"]);
+      assertWithinOptions(["Doohickey"]);
     });
 
     // This is messy and tricky to test with RTL
@@ -279,50 +278,50 @@ describe("TokenField", () => {
       setup();
 
       type("G");
-      findWithinOptions(["Gadget", "Gizmo"]);
+      assertWithinOptions(["Gadget", "Gizmo"]);
 
       inputKeydown(KEYCODE_ENTER);
-      findWithinOptions(["Gizmo"]);
+      assertWithinOptions(["Gizmo"]);
       expect(input().value).toEqual("");
 
       // Reset search on focus (it was a separate test before)
       act(() => {
         input().focus();
       });
-      findWithinOptions(["Doohickey", "Gizmo", "Widget"]);
+      assertWithinOptions(["Doohickey", "Gizmo", "Widget"]);
     });
 
     it("should reset the search when adding the last option", () => {
       setup();
 
       type("G");
-      findWithinOptions(["Gadget", "Gizmo"]);
+      assertWithinOptions(["Gadget", "Gizmo"]);
 
       inputKeydown(KEYCODE_ENTER);
-      findWithinOptions(["Gizmo"]);
+      assertWithinOptions(["Gizmo"]);
 
       inputKeydown(KEYCODE_ENTER);
-      findWithinOptions(["Doohickey", "Widget"]);
+      assertWithinOptions(["Doohickey", "Widget"]);
     });
 
     it("should hide the option if typed exactly then press enter", () => {
       setup();
 
       type("Gadget");
-      findWithinOptions(["Gadget"]);
+      assertWithinOptions(["Gadget"]);
       inputKeydown(KEYCODE_ENTER);
-      findWithinValues(["Gadget"]);
-      findWithinOptions(["Doohickey", "Gizmo", "Widget"]);
+      assertWithinValues(["Gadget"]);
+      assertWithinOptions(["Doohickey", "Gizmo", "Widget"]);
     });
 
     it("should hide the option if typed partially then press enter", () => {
       setup();
 
       type("Gad");
-      findWithinOptions(["Gadget"]);
+      assertWithinOptions(["Gadget"]);
       inputKeydown(KEYCODE_ENTER);
-      findWithinValues(["Gadget"]);
-      findWithinOptions(["Doohickey", "Gizmo", "Widget"]);
+      assertWithinValues(["Gadget"]);
+      assertWithinOptions(["Doohickey", "Gizmo", "Widget"]);
     });
 
     it("should hide the option if typed exactly then clicked", () => {
@@ -330,8 +329,8 @@ describe("TokenField", () => {
 
       type("Gadget");
       fireEvent.click(within(options()).getByText("Gadget"));
-      findWithinValues(["Gadget"]);
-      findWithinOptions(["Doohickey", "Gizmo", "Widget"]);
+      assertWithinValues(["Gadget"]);
+      assertWithinOptions(["Doohickey", "Gizmo", "Widget"]);
     });
 
     it("should hide the option if typed partially then clicked", () => {
@@ -339,8 +338,8 @@ describe("TokenField", () => {
 
       type("Gad");
       fireEvent.click(within(options()).getByText("Gadget"));
-      findWithinValues(["Gadget"]);
-      findWithinOptions(["Doohickey", "Gizmo", "Widget"]);
+      assertWithinValues(["Gadget"]);
+      assertWithinOptions(["Doohickey", "Gizmo", "Widget"]);
     });
   });
 
@@ -394,7 +393,7 @@ describe("TokenField", () => {
       setup();
       type("yep");
       fireEvent.blur(input());
-      findWithinValues(["yep"]);
+      assertWithinValues(["yep"]);
     });
   });
 
@@ -415,7 +414,7 @@ describe("TokenField", () => {
         },
       });
 
-      findWithinValues(["1", "2", "3"]);
+      assertWithinValues(["1", "2", "3"]);
       // prevent pasting into <input>
       expect(input().value).toBe("");
     });

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import userEvent from "@testing-library/user-event";
 
 import { fireEvent, render, screen } from "__support__/ui";
@@ -48,7 +47,7 @@ describe("AccordionList", () => {
 
   it("should show search field is searchable is set", () => {
     render(<AccordionList sections={SECTIONS} searchable />);
-    screen.getByRole("img", { name: /search/i });
+    expect(screen.getByRole("img", { name: /search/i })).toBeInTheDocument();
   });
 
   it("should close the section when header is clicked", () => {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/DashboardHeaderButtonRow.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/DashboardHeaderButtonRow.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jest/expect-expect */
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectButtonInHeader"] }] */
 import userEvent from "@testing-library/user-event";
 import { Route } from "react-router";
 

--- a/frontend/src/metabase/hooks/use-list-keyboard-navigation/use-list-keyboard-navigation.unit.spec.ts
+++ b/frontend/src/metabase/hooks/use-list-keyboard-navigation/use-list-keyboard-navigation.unit.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import { renderHook } from "@testing-library/react-hooks";
 
 import { fireEvent } from "__support__/ui";

--- a/frontend/src/metabase/lib/formatting/link.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/link.unit.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import { createMockColumn } from "metabase-types/api/mocks";
 
 import type { ValueAndColumnForColumnNameDate } from "./link";
@@ -19,7 +18,7 @@ const createMockLinkData = (
 
 describe("formatting/link", () => {
   describe("renderLinkURLForClick", () => {
-    const testLinkTemplate = (
+    const assertLinkTemplate = (
       template: string,
       data: Partial<ValueAndColumnForColumnNameDate>,
       expectedUrl: string,
@@ -39,7 +38,7 @@ describe("formatting/link", () => {
     ])(
       "should not encode safe urls from dataset columns when a link template starts with it",
       url => {
-        testLinkTemplate(
+        assertLinkTemplate(
           "{{col}}",
           {
             column: {
@@ -58,7 +57,7 @@ describe("formatting/link", () => {
     ])(
       "should encode safe urls from dataset columns when a link template does not start with it",
       (url, expectedUrl) => {
-        testLinkTemplate(
+        assertLinkTemplate(
           "_{{col}}",
           {
             column: {
@@ -82,7 +81,7 @@ describe("formatting/link", () => {
     ])(
       "should encode unsafe urls from dataset columns when a link template starts with it",
       (url, expectedUrl) => {
-        testLinkTemplate(
+        assertLinkTemplate(
           "{{col}}",
           {
             column: {
@@ -101,7 +100,7 @@ describe("formatting/link", () => {
     ])(
       "should encode safe urls not from url parameters when a link template starts with it",
       (url, expectedUrl) => {
-        testLinkTemplate(
+        assertLinkTemplate(
           "{{param}}",
           {
             parameterBySlug: {
@@ -120,7 +119,7 @@ describe("formatting/link", () => {
     ])(
       "should encode safe urls not from parameters when a link template starts with it",
       (url, expectedUrl) => {
-        testLinkTemplate(
+        assertLinkTemplate(
           "{{param}}",
           {
             parameterByName: {
@@ -139,7 +138,7 @@ describe("formatting/link", () => {
     ])(
       "should encode safe urls not from user attributes when a link template starts with it",
       (url, expectedUrl) => {
-        testLinkTemplate(
+        assertLinkTemplate(
           "{{param}}",
           {
             userAttribute: {

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jest/expect-expect */
-
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
@@ -105,7 +103,7 @@ describe("SemanticTypePicker", () => {
     it("does not show deprecated semantic types", async () => {
       setup({ fieldId: TEMPORAL_FIELD.id });
 
-      await verifySemanticTypesVisibility({
+      await assertSemanticTypesVisibility({
         visibleTypes: ["Creation date"],
         hiddenTypes: ["Cancelation date"],
       });
@@ -119,7 +117,7 @@ describe("SemanticTypePicker", () => {
 
       expect(screen.getByText("Cancelation date")).toBeInTheDocument();
 
-      await verifySemanticTypesVisibility({
+      await assertSemanticTypesVisibility({
         visibleTypes: ["Creation date", "Cancelation date"],
       });
     });
@@ -145,7 +143,7 @@ describe("SemanticTypePicker", () => {
   it("shows Category semantic type for boolean field's", async () => {
     setup({ fieldId: BOOLEAN_FIELD.id });
 
-    await verifySemanticTypesVisibility({
+    await assertSemanticTypesVisibility({
       visibleTypes: ["Category"],
     });
   });
@@ -156,7 +154,7 @@ describe("SemanticTypePicker", () => {
       async field => {
         setup({ fieldId: field.id });
 
-        await verifySemanticTypesVisibility({
+        await assertSemanticTypesVisibility({
           visibleTypes: ["Entity Key", "Foreign Key", "No semantic type"],
         });
       },
@@ -167,7 +165,7 @@ describe("SemanticTypePicker", () => {
     it("shows Entity Name when field's effective_type is derived from text/Type", async () => {
       setup({ fieldId: TEXT_FIELD.id });
 
-      await verifySemanticTypesVisibility({
+      await assertSemanticTypesVisibility({
         visibleTypes: ["Entity Name"],
       });
     });
@@ -184,7 +182,7 @@ describe("SemanticTypePicker", () => {
       async field => {
         setup({ fieldId: field.id });
 
-        await verifySemanticTypesVisibility({
+        await assertSemanticTypesVisibility({
           hiddenTypes: ["Entity Name"],
         });
       },
@@ -197,7 +195,7 @@ describe("SemanticTypePicker", () => {
       async field => {
         setup({ fieldId: field.id });
 
-        await verifySemanticTypesVisibility({
+        await assertSemanticTypesVisibility({
           visibleTypes: ["Field containing JSON"],
           hiddenTypes: ["Category", "Title"],
         });
@@ -209,7 +207,7 @@ describe("SemanticTypePicker", () => {
     it("also shows semantic types derived from text/Number when field's effective_type is derived from $display_name", async () => {
       setup({ fieldId: TEXT_FIELD.id });
 
-      await verifySemanticTypesVisibility({
+      await assertSemanticTypesVisibility({
         visibleTypes: [
           "Latitude",
           "Longitude",
@@ -242,7 +240,7 @@ describe("SemanticTypePicker", () => {
     const picker = screen.getByPlaceholderText("Select a semantic type");
     await userEvent.click(picker);
 
-    await verifySemanticTypesVisibility({
+    await assertSemanticTypesVisibility({
       visibleTypes: ["Title"],
       hiddenTypes: ["Birthday", "Creation date"],
     });
@@ -263,14 +261,14 @@ describe("SemanticTypePicker", () => {
       fieldId,
     });
 
-    await verifySemanticTypesVisibility({
+    await assertSemanticTypesVisibility({
       visibleTypes: ["Birthday", "Creation date"],
       hiddenTypes: ["Title"],
     });
   });
 });
 
-async function verifySemanticTypesVisibility({
+async function assertSemanticTypesVisibility({
   visibleTypes = [],
   hiddenTypes = [],
 }: {

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import type { Store } from "@reduxjs/toolkit";
 import fetchMock from "fetch-mock";
 import { Route } from "react-router";

--- a/frontend/src/metabase/public/LocaleProvider.unit.spec.ts
+++ b/frontend/src/metabase/public/LocaleProvider.unit.spec.ts
@@ -1,4 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectLocale"] }] */
 import { getLocaleToUse } from "./LocaleProvider";
 
 const expectLocale = ({

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -309,7 +309,6 @@ describe("Notebook", () => {
         });
       });
 
-      // eslint-disable-next-line jest/expect-expect
       it("should show tabs if more than one type is chosen", async () => {
         const models: DataPickerValue["model"][] = ["dataset", "card"];
 
@@ -357,7 +356,6 @@ describe("Notebook", () => {
     describe.each<DataPickerValue["model"]>(TEST_ENTITY_TYPES)(
       "when filtering with %s",
       entityType => {
-        // eslint-disable-next-line jest/expect-expect
         it(`should show the Collection item picker when modelsFilterList=[${entityType}]`, async () => {
           setup({
             question: createSummarizedQuestion("question"),

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["assertActionButtonsOrder"] }] */
 import type { ComponentProps } from "react";
 
 import { createMockMetadata } from "__support__/metadata";

--- a/frontend/src/metabase/setup/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/common.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
-
 import userEvent from "@testing-library/user-event";
 
 import { screen } from "__support__/ui";

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
-
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 

--- a/frontend/src/metabase/setup/tests/premium-pro-cloud.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-pro-cloud.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
-
 import { screen } from "__support__/ui";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 

--- a/frontend/src/metabase/setup/tests/premium-pro-selfhosted.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-pro-selfhosted.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
-
 import userEvent from "@testing-library/user-event";
 
 import { screen } from "__support__/ui";

--- a/frontend/src/metabase/setup/tests/premium-starter-cloud.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-starter-cloud.unit.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
-
 import { screen } from "__support__/ui";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 


### PR DESCRIPTION
## Description

[Our Jest Linter's expect-expect rule](https://github.com/jest-community/eslint-plugin-jest/blob/v27.2.0/docs/rules/expect-expect.md) is a good one! It keeps us from accidentally writing meaningless tests. However, we end up ignoring it a bunch because we do complex assertions in functions like

```ts
it("should show valid mbql", () => {
    setup();
    expectMBQLToBePretty();
});
```

This PR extends the rule to say that any function name beginning with `assert*` or `expect*` should count as an assertion for this rule.

This config change itself made nearly all of the ignore comments obsolete. In a few tests I renamed some functions to make it clear that they were asserting something.