### PR TITLE
WRK-190 input type coercion

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/coerce.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/coerce.clj
@@ -1,0 +1,50 @@
+(ns metabase-enterprise.data-editing.coerce
+  (:import
+   (clojure.lang BigInt)
+   (java.time ZonedDateTime)
+   (java.time.format DateTimeFormatter)))
+
+(set! *warn-on-reflection* true)
+
+(defn- json-zdt->unix-millis ^long [s]
+  (-> s ZonedDateTime/parse .toInstant .toEpochMilli))
+
+(defn- json-zdt->unix-seconds [s]
+  (-> s json-zdt->unix-millis (quot 1000)))
+
+(defn- json-zdt->unix-micros [s]
+  (-> s json-zdt->unix-millis ^BigInt (* 1000N) .toBigInteger))
+
+(defn- json-zdt->unix-nanos [s]
+  (-> s json-zdt->unix-millis ^BigInt (* 1000000N) .toBigInteger))
+
+(let [formatter (DateTimeFormatter/ofPattern "yyyyMMddHHmmSS")]
+  (defn- json-zdt->yyyymmddhhmmss [s]
+    (-> s ZonedDateTime/parse (.format formatter))))
+
+;; the date/time coercions are highly ambigious
+;; in one direction one can make a decision (take the local date, or clock time)
+;; but how do you reverse it?
+;; Often the original SQL string might have been a full date, a zoned or unzoned ISO string,
+;; Needs to be considered properly at some later time.
+;; Idea: make the coercion dependent on previous database string, so if lossy - modify *just* the time, or the date component
+;; * still somewhat ambiguous, e.g did the user *intend* to discard the previous date/time components?
+
+(defn- json-zdt->date [s]
+  (-> s ZonedDateTime/parse .toLocalDate str))
+
+(defn- json-zdt->time [s]
+  (-> s ZonedDateTime/parse .toLocalTime str))
+
+(def input-coercion-fn
+  "Maps a coercion strategy to a function from input JSON object to the action representation (to be supplied to JDBC).
+
+  Assumes the input JSON object is valid for the coercion strategy, and can fit within the bounds of the target column."
+  {:Coercion/UNIXSeconds->DateTime          #'json-zdt->unix-seconds
+   :Coercion/UNIXMilliSeconds->DateTime     #'json-zdt->unix-millis
+   :Coercion/UNIXMicroSeconds->DateTime     #'json-zdt->unix-micros
+   :Coercion/UNIXNanoSeconds->DateTime      #'json-zdt->unix-nanos
+   :Coercion/YYYYMMDDHHMMSSString->Temporal #'json-zdt->yyyymmddhhmmss
+   :Coercion/ISO8601->DateTime              identity
+   :Coercion/ISO8601->Date                  #'json-zdt->date
+   :Coercion/ISO8601->Time                  #'json-zdt->time})

--- a/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
@@ -1,11 +1,12 @@
 (ns metabase-enterprise.data-editing.test-util
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
+   [clojure.walk :as walk]
    [metabase.actions.test-util :as actions.tu]
    [metabase.driver :as driver]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
-   [metabase.util :as u]
    [toucan2.core :as t2])
   (:import
    (clojure.lang IDeref)
@@ -13,14 +14,12 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- create-test-table! [driver db table-name]
+(defn- create-test-table! [driver db table-name column-map create-table-opts]
   (let [_     (driver/create-table! driver
                                     (mt/id)
                                     table-name
-                                    {:id   (driver/upload-type->database-type driver :metabase.upload/auto-incrementing-int-pk)
-                                     :name [:text]
-                                     :song  [:text]}
-                                    :primary-key [:id])
+                                    column-map
+                                    create-table-opts)
         table (sync/create-table! db
                                   {:name         table-name
                                    :schema       nil
@@ -36,22 +35,34 @@
 (defn open-test-table!
   "Sets up an anonymous table in the appdb. Return a box that can be deref'd for the table-id.
 
+  Optionally accepts the column map and opts inputs to driver/create-table!.
+  The symbol auto-inc-type can be used to denote the driver-specific auto-incrementing type for primary keys.
+  e.g (open-test-table {:id 'auto-inc-type, :name [:text]} {:primary-key [:id]})
+
   Returned box is java.io.Closeable so you can clean up with `with-open`.
   Otherwise .close the box to drop the table when finished."
-  ^Closeable []
-  (let [driver     :h2
-        db         (t2/select-one :model/Database (mt/id))
-        table-name (str "temp_table_" (u/lower-case-en (random-uuid)))
-        cleanup    #(try (driver/drop-table! driver (mt/id) table-name) (catch Exception _))]
-    (try
-      (let [table-id (create-test-table! driver db table-name)]
-        (reify Closeable
-          IDeref
-          (deref [_] table-id)
-          (close [_] (cleanup))))
-      (catch Exception e
-        (cleanup)
-        (throw e)))))
+  (^Closeable []
+   (open-test-table!
+    {:id    'auto-inc-type
+     :name  [:text]
+     :song  [:text]}
+    {:primary-key [:id]}))
+  (^Closeable [column-map create-table-opts]
+   (let [driver        :h2
+         auto-inc-type (driver/upload-type->database-type driver :metabase.upload/auto-incrementing-int-pk)
+         column-map    (walk/postwalk-replace {'auto-inc-type auto-inc-type} column-map)
+         db            (t2/select-one :model/Database (mt/id))
+         table-name    (str "temp_table_" (str/replace (random-uuid) "-" "_"))
+         cleanup       #(try (driver/drop-table! driver (mt/id) table-name) (catch Exception _))]
+     (try
+       (let [table-id (create-test-table! driver db table-name column-map create-table-opts)]
+         (reify Closeable
+           IDeref
+           (deref [_] table-id)
+           (close [_] (cleanup))))
+       (catch Exception e
+         (cleanup)
+         (throw e))))))
 
 (defmacro with-temp-test-db!
   "Sets up a temporary database in the appdb to do destrcutive tests.


### PR DESCRIPTION
This PR implements a set of coercions back to database types, when the frontend provides zoned date time strings (ISO8601).

If an integer field representing UNIX seconds is presented to the frontend as a ISO8601 datetime via `coercion_strategy`

The frontend will not currently know that database representation of the value (a int representing seconds in this instance). Therefore data editing needs to accept ISO8601 datetime strings as inputs, as the frontend will present a date picker based on the information it has.

For lossy translations (such as ISO8601->Date or ISO8601->Time) much is left undefined, and in some situations users may lose data or find surprises on edit. A working audit log should protect against somewhat $consequences, given how easy it is to make a mistake anyway.

One definition that might work is that time/date changes keep the corresponding exclusive part of the previous row, so if you say vary the time on 2025-03-27T13:42:03Z to 14:00:00, then we take keep the date as 2025-03-27 for that row. In other words, coercion behaviour might become additionally dependent on the existing record state. A followup PR might be in order to acheive this.

Closes WRK-190