### PR TITLE
fix: move classloader to init as soon as possible

### DIFF
--- a/src/metabase/core/bootstrap.clj
+++ b/src/metabase/core/bootstrap.clj
@@ -29,4 +29,8 @@
 (defn -main
   "Main entrypoint. Invokes [[metabase.core.core/entrypoint]]"
   [& args]
+  ;; We need to install the classloader here before other namespaces are loaded since they could launch threads on load.
+  ;; If a thread is spun uo and put back into a pool before this happens that pool will have a poisoned thread unable to
+  ;; see classes in our classloader.
+  ((requiring-resolve 'metabase.plugins.classloader/the-classloader))
   (apply (requiring-resolve 'metabase.core.core/entrypoint) args))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #55783
The initial thought was to gatekeep all of the ways to get off thread with a custom module and kondo linters. However this quickly ballooned and I realized that `bootstrap` is setup in a way that makes it possible to initialize the classloader before anything else gets loaded.
