### PR TITLE
make rspack error when the port is already in use

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -26,6 +26,7 @@ frontend_sources: &frontend_sources
   - "babel.config.json"
   - ".eslintrc.js"
   - "postcss.config.js"
+  - "rspack.config.js"
   - "webpack.config.js"
   - "webpack.embedding-sdk.config.js"
   - "webpack.static-viz.config.js"

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -307,6 +307,7 @@ if (shouldEnableHotRefresh) {
     "http://localhost:8080/" + config.output.publicPath;
 
   config.devServer = {
+    port: 8080, // make the port explicit so it errors if it's already in use
     hot: true,
     client: {
       progress: false,

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -23,6 +23,7 @@ const TEST_SUPPORT_PATH = __dirname + "/frontend/test/__support__";
 const BUILD_PATH = __dirname + "/resources/frontend_client";
 const E2E_PATH = __dirname + "/e2e";
 
+const PORT = process.env.PORT || 8080;
 const WEBPACK_BUNDLE = process.env.WEBPACK_BUNDLE || "development";
 const devMode = WEBPACK_BUNDLE !== "production";
 const shouldEnableHotRefresh = WEBPACK_BUNDLE === "hot";
@@ -304,10 +305,10 @@ if (shouldEnableHotRefresh) {
 
   // point the publicPath (inlined in index.html by HtmlWebpackPlugin) to the hot-reloading server
   config.output.publicPath =
-    "http://localhost:8080/" + config.output.publicPath;
+    `http://localhost:${PORT}/` + config.output.publicPath;
 
   config.devServer = {
-    port: 8080, // make the port explicit so it errors if it's already in use
+    port: PORT, // make the port explicit so it errors if it's already in use
     hot: true,
     client: {
       progress: false,


### PR DESCRIPTION
https://metaboat.slack.com/archives/C084XNEPH6K/p1743022729785849
This also happened to me multiple times and the fix is simple

Before:
When port 8080 is in use rspack will use 8081 and you will see weird 404 errors when loading metabase. This can be hard to debug if it's the first time you see them ~or if you forget about how you solved it the last time~

After:
It errors out, this should make the issue more visible saving us time
```
Error: listen EADDRINUSE: address already in use 0.0.0.0:8080
```