### PR TITLE
Don't run flaky test job on release branches

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -141,7 +141,7 @@ jobs:
     uses: ./.github/workflows/e2e-test.yml
     needs: build
     if: |
-      !cancelled() && needs.build.result == 'success'
+      !cancelled() && needs.build.result == 'success' && !contains(github.ref, 'release-x')
     secrets: inherit
     with:
       name: Flaky


### PR DESCRIPTION

### Description

The flaky tests job is expected to be flaky, so it fails a lot, and this often breaks our automatic patch releases on release branches. Let's keep this information-only job only running on master and pull requests.