### PR TITLE
Closes #55829: Upgrade @octokit/rest to address ReDos vulnerabilities

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -19,7 +19,7 @@
   "author": "Metabase",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@octokit/rest": "^20.0.2",
+    "@octokit/rest": "^20.1.2",
     "@slack/web-api": "^6.12.1",
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",

--- a/release/yarn.lock
+++ b/release/yarn.lock
@@ -1835,7 +1835,7 @@
     "@octokit/types" "^13.1.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^20.0.2":
+"@octokit/rest@^20.1.2":
   version "20.1.2"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-20.1.2.tgz#1d74d0c72ade0d64f7c5416448d5c885f5e3ccc4"
   integrity sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==


### PR DESCRIPTION
Addresses https://github.com/metabase/metabase/security/code-scanning/351