### PR TITLE
Fix bugs in api-keys handling in config.yml

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/api_keys_test.clj
@@ -1,16 +1,19 @@
 (ns metabase-enterprise.advanced-config.file.api-keys-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.advanced-config.file :as config.file]
+   [metabase-enterprise.advanced-config.file :as advanced-config.file]
+   [metabase-enterprise.advanced-config.file.api-keys :as api-keys]
+   [metabase.models.api-key :as api-key]
+   [metabase.models.user :as user]
+   [metabase.premium-features-test :as premium-features-test]
    [metabase.test :as mt]
-   [metabase.util :as u]
-   [metabase.util.yaml :as yaml]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
 (use-fixtures :each (fn [thunk]
-                      (binding [config.file/*supported-versions* {:min 1, :max 1}]
+                      (binding [advanced-config.file/*supported-versions* {:min 1, :max 1}]
                         (mt/with-premium-features #{:config-text-file}
                           (thunk)))))
 
@@ -48,7 +51,7 @@
                                  :key "mb_differentapikey456"
                                  :creator "admin@test.com"
                                  :group "all-users"}]}})
-          (binding [config.file/*config* {:version 1
+          (binding [advanced-config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
                                                                :key "mb_testapikey123"
                                                                :creator "admin@test.com"
@@ -57,7 +60,7 @@
                                                                :key "mb_differentapikey456"
                                                                :creator "admin@test.com"
                                                                :group "all-users"}]}}]
-            (is (= :ok (config.file/initialize!)))
+            (is (= :ok (advanced-config.file/initialize!)))
             (testing "API keys should be created"
               (is (api-key-exists? "Test API Key"))
               (is (api-key-exists? "All Users API Key")))
@@ -75,7 +78,7 @@
                                  :key "mb_sameprefix_123"
                                  :creator "admin@test.com"
                                  :group "admin"}]}})
-          (binding [config.file/*config* {:version 1
+          (binding [advanced-config.file/*config* {:version 1
                                           :config {:api-keys [{:name "First API Key"
                                                                :key "mb_sameprefix123"
                                                                :creator "admin@test.com"
@@ -87,7 +90,7 @@
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
                  #"API key with prefix 'mb_same' already exists\. Keys must have unique prefixes\."
-                 (config.file/initialize!))))
+                 (advanced-config.file/initialize!))))
           (finally
             (cleanup-config!))))
 
@@ -96,7 +99,7 @@
           (mt/with-temp [:model/User _ {:email "regular@test.com"
                                         :first_name "Regular"
                                         :is_superuser false}]
-            (binding [config.file/*config* {:version 1
+            (binding [advanced-config.file/*config* {:version 1
                                             :config {:api-keys [{:name "Test API Key"
                                                                  :key "mb_1testapikey123"
                                                                  :creator "regular@test.com"
@@ -104,13 +107,13 @@
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
                    #"User with email regular@test.com is not an admin"
-                   (config.file/initialize!)))))
+                   (advanced-config.file/initialize!)))))
           (finally
             (cleanup-config!))))
 
       (testing "should fail if creator doesn't exist"
         (try
-          (binding [config.file/*config* {:version 1
+          (binding [advanced-config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
                                                                :key "mb_2testapikey123"
                                                                :creator "nonexistent@test.com"
@@ -118,25 +121,25 @@
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
                  #"User with email nonexistent@test.com not found"
-                 (config.file/initialize!))))
+                 (advanced-config.file/initialize!))))
           (finally
             (cleanup-config!))))
 
       (testing "should skip existing API keys"
         (try
-          (binding [config.file/*config* {:version 1
+          (binding [advanced-config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
                                                                :key "mb_3testapikey123"
                                                                :creator "admin@test.com"
                                                                :group "admin"}]}}]
-            (config.file/initialize!)
+            (advanced-config.file/initialize!)
             (let [first-key (t2/select-one :model/ApiKey :name "Test API Key")
-                  _ (binding [config.file/*config* {:version 1
+                  _ (binding [advanced-config.file/*config* {:version 1
                                                     :config {:api-keys [{:name "Test API Key"
                                                                          :key "mb_4testapikey123"
                                                                          :creator "admin@test.com"
                                                                          :group "admin"}]}}]
-                      (config.file/initialize!))
+                      (advanced-config.file/initialize!))
                   second-key (t2/select-one :model/ApiKey :name "Test API Key")]
               (is (= (:id first-key) (:id second-key)))))
           (finally
@@ -144,12 +147,75 @@
 
       (testing "should validate group values"
         (try
-          (binding [config.file/*config* {:version 1
+          (binding [advanced-config.file/*config* {:version 1
                                           :config {:api-keys [{:name "Test API Key"
                                                                :key "mb_5testapikey123"
                                                                :creator "admin@test.com"
                                                                :group "invalid-group"}]}}]
             (is (thrown? clojure.lang.ExceptionInfo
-                         (config.file/initialize!))))
+                         (advanced-config.file/initialize!))))
           (finally
             (cleanup-config!)))))))
+
+(defn- api-key-fixture
+  "A test fixture that removes all API keys from the database after the test has run."
+  [f]
+  (try
+    (f)
+    (finally
+      (t2/delete! :model/ApiKey :name [:like "Test API Key %"])
+      (t2/delete! :model/User :email [:like "%api-key-user-%"]))))
+
+(deftest ^:parallel api-key-validation-test
+  (testing "Validate API key format"
+    (let [validate-api-key #'api-keys/validate-api-key]
+      (testing "Valid API keys don't throw exceptions"
+        (is (nil? (validate-api-key "mb_12345678901234567890"))))
+        
+      (testing "Invalid API keys should throw detailed exceptions"
+        (is (thrown-with-msg? Exception #"API key must start with 'mb_'"
+                             (validate-api-key "invalid_key")))
+        (is (thrown-with-msg? Exception #"API key must start with 'mb_'"
+                             (validate-api-key "123456789012345")))))))
+
+(deftest ^:parallel api-key-name-check-first-test
+  (mt/with-log-level :info
+    (testing "Check existing key by name first"
+      (premium-features-test/with-premium-features #{:config-text-file}
+        (with-redefs [advanced-config.file/config (constantly
+                                                  {:version 1
+                                                   :config
+                                                   {:api-keys
+                                                    [{:name "Test API Key 1"
+                                                      :key "mb_12345678901234567890"
+                                                      :creator (:email (mt/fetch-user :crowberto))
+                                                      :group "admin"}]}})]
+          (mt/with-log-messages [log-messages]
+            ;; Initialize the API key
+            (advanced-config.file/initialize!)
+            ;; Try to initialize it again
+            (advanced-config.file/initialize!)
+            (is (= 1 (t2/count :model/ApiKey :name "Test API Key 1")))
+            (is (some #(re-matches #".*API key with name \"Test API Key 1\" already exists, skipping.*" %)
+                     (map str log-messages)))))))))
+
+(deftest ^:parallel api-key-env-var-test
+  (mt/with-log-level :info
+    (testing "Environment variable substitution before validation"
+      (premium-features-test/with-premium-features #{:config-text-file}
+        (mt/with-temp-env-var-value {:api_key_for_test "mb_12345678901234567890"}
+          (with-redefs [advanced-config.file/config (constantly
+                                                    {:version 1
+                                                     :config
+                                                     {:api-keys
+                                                      [{:name "Test API Key 2"
+                                                        :key "{{ env api_key_for_test }}"
+                                                        :creator (:email (mt/fetch-user :crowberto))
+                                                        :group "admin"}]}})]
+            (mt/with-log-messages [log-messages]
+              ;; This would fail before our fix because it would try to validate "{{ env api_key_for_test }}"
+              ;; directly instead of the resolved value
+              (advanced-config.file/initialize!)
+              (is (= 1 (t2/count :model/ApiKey :name "Test API Key 2")))
+              (is (some #(re-matches #".*Creating new API key \"Test API Key 2\".*" %)
+                       (map str log-messages))))))))))


### PR DESCRIPTION
Fix two bugs in API keys config.yml handling:
1. Environment variable substitution now happens before key validation
3. API key prefix validation is happening before checking to see if the whole key already exists. That causes metabase to crash on subsequent runs (after the API key has been created from config.yml)

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description
The code for `api-keys` in v1.53.8 seems to have two bugs.
1. It's trying to validate the key before the env var substitution happens. So, if I set `key` to `{{ env API_KEY }}`, it fails with the following stacks trace: 
```
```

2. If I use a hardcoded key, it successfully creates the api key on the first time metabase starts up and reads the config.yml file, but fails on subsequent restarts (still reading the config.yml file) with the following stack trace:
``` 
2025-03-27 03:41:24,892 ERROR core.core :: Metabase Initialization FAILED
clojure.lang.ExceptionInfo: API key with prefix 'mb_7MG0' already exists. Keys must have unique prefixes. {:name "Users API Key", :prefix "mb_7MG0"}
        at metabase_enterprise.advanced_config.file.api_keys$init_from_config_file_BANG_.invokeStatic(api_keys.clj:68)
        at metabase_enterprise.advanced_config.file.api_keys$init_from_config_file_BANG_.invoke(api_keys.clj:56)
        at metabase_enterprise.advanced_config.file.api_keys$fn__125737.invokeStatic(api_keys.clj:99)
        at metabase_enterprise.advanced_config.file.api_keys$fn__125737.invoke(api_keys.clj:96)
        at clojure.lang.MultiFn.invoke(MultiFn.java:234)
        at metabase_enterprise.advanced_config.file$initialize_BANG_.invokeStatic(file.clj:268)
        at metabase_enterprise.advanced_config.file$initialize_BANG_.invoke(file.clj:253)
        at clojure.lang.Var.invoke(Var.java:382)
        at metabase.core.config_from_file$init_from_file_if_code_available_BANG_.invokeStatic(config_from_file.clj:17)
        at metabase.core.config_from_file$init_from_file_if_code_available_BANG_.invoke(config_from_file.clj:6)
        at metabase.core.core$init_BANG__STAR_.invokeStatic(core.clj:153)
        at metabase.core.core$init_BANG__STAR_.invoke(core.clj:112)
        at metabase.core.core$init_BANG_.invokeStatic(core.clj:191)
        at metabase.core.core$init_BANG_.invoke(core.clj:186)
        at metabase.core.core$start_normally.invokeStatic(core.clj:203)
        at metabase.core.core$start_normally.invoke(core.clj:197)
        at metabase.core.core$entrypoint.invokeStatic(core.clj:239)
        at metabase.core.core$entrypoint.doInvoke(core.clj:230)
        at clojure.lang.RestFn.invoke(RestFn.java:400)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.RestFn.applyTo(RestFn.java:135)
        at clojure.lang.Var.applyTo(Var.java:707)
        at clojure.core$apply.invokeStatic(core.clj:667)
        at clojure.core$apply.invoke(core.clj:662)
        at metabase.core.bootstrap$_main.invokeStatic(bootstrap.clj:32)
        at metabase.core.bootstrap$_main.doInvoke(bootstrap.clj:29)
        at clojure.lang.RestFn.invoke(RestFn.java:400)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.RestFn.applyTo(RestFn.java:135)
        at metabase.core.bootstrap.main(Unknown Source)
2025-03-27 03:41:24,895 INFO core.core :: Metabase Shutting Down ...
```

The logic should just skip the api key since it's being created from a static config.yml file.


It first checks if any key exists with the same prefix
If so, it throws an exception immediately
Only if the prefix check passes does it check for keys with the same name
This is the wrong order! It should:
First check if a key with the same name exists
Skip creating it if it does
Only check for prefix conflicts if it's going to create a new key
To fix these bugs, you'd need to:
For the environment variable issue - move the template substitution to happen before validation
For the duplicate key issue - rearrange the checks to first check by name, then only check by prefix if creating a new key


