### PR TITLE
Require explicit access to router/mirror dbs

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -147,6 +147,10 @@
   {:api  #{metabase.core.initialization-status}
    :uses :any}
 
+  database-routing
+  {:api #{metabase.database-routing.core}
+   :uses #{premium-features}}
+
   db
   {:api  #{metabase.db metabase.db.metadata-queries metabase.db.query metabase.db.setup}
    :uses #{auth-provider config connection-pool driver legacy-mbql lib plugins query-processor task util}}
@@ -179,6 +183,7 @@
            auth-provider
            config
            connection-pool
+           database-routing
            db
            legacy-mbql
            lib
@@ -193,7 +198,8 @@
            sync
            task
            upload
-           util}}
+           util
+           enterprise/database-routing}}
 
   eid-translation
   {:api  #{metabase.eid-translation.core}
@@ -683,7 +689,7 @@
 
   enterprise/database-routing
   {:api #{metabase-enterprise.database-routing.core metabase-enterprise.database-routing.api}
-   :uses #{api events lib models premium-features query-processor util}}
+   :uses #{api config database-routing events lib models premium-features query-processor util}}
 
   enterprise/enhancements
   {:api  #{metabase-enterprise.enhancements.init}

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -1,5 +1,8 @@
 (ns metabase-enterprise.database-routing.common
   (:require
+   [metabase.api.common :as api]
+   [metabase.config :as config]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -9,26 +12,101 @@
   (t2/select-one-fn :user_attribute :model/DatabaseRouter :database_id (u/the-id db-or-id)))
 
 (defn router-db-or-id->mirror-db-id
-  "Given a the current user and a database (or id), returns the ID of the mirror database that the user's query should
-  ultimately be routed to. If the database is not a Router Database, returns `nil`. If the database is a Router
-  Database but no current user exists, an exception will be thrown."
-  [current-user db-or-id]
-  (when-let [attr-name (user-attribute db-or-id)]
-    (let [database-name (get (:login_attributes @current-user) attr-name)]
-      (cond
-        (nil? @current-user)
-        (throw (ex-info "Anonymous access to a Router Database is prohibited." {}))
+  "Given a user and a database (or id), returns the ID of the mirror database that the user's query should ultimately be
+  routed to. If the database is not a Router Database, returns `nil`. If the database is a Router Database but no
+  current user exists, an exception will be thrown."
+  ([db-or-id]
+   (router-db-or-id->mirror-db-id @api/*current-user* db-or-id))
+  ([user db-or-id]
+   (when-let [attr-name (user-attribute db-or-id)]
+     (let [database-name (get (:login_attributes user) attr-name)]
+       (cond
+         (nil? user)
+         (throw (ex-info "Anonymous access to a Router Database is prohibited." {}))
 
-        (= database-name "__METABASE_ROUTER__")
-        (u/the-id db-or-id)
+         (= database-name "__METABASE_ROUTER__")
+         (u/the-id db-or-id)
 
-        (nil? database-name)
-        (throw (ex-info "User attribute missing, cannot lookup Mirror Database" {:database-name database-name
-                                                                                 :router-database-id (u/the-id db-or-id)}))
+         ;; superusers default to the Router Database
+         (and (nil? database-name)
+              api/*is-superuser?*)
+         (u/the-id db-or-id)
 
-        :else
-        (or (t2/select-one-pk :model/Database
-                              :router_database_id (u/the-id db-or-id)
-                              :name database-name)
-            (throw (ex-info "No Mirror Database found for user attribute" {:database-name database-name
-                                                                           :router-database-id (u/the-id db-or-id)})))))))
+         ;; non-superusers get an error
+         (nil? database-name)
+         (throw (ex-info "User attribute missing, cannot lookup Mirror Database" {:database-name database-name
+                                                                                  :router-database-id (u/the-id db-or-id)}))
+
+         :else
+         (or (t2/select-one-pk :model/Database
+                               :router_database_id (u/the-id db-or-id)
+                               :name database-name)
+             (throw (ex-info "No Mirror Database found for user attribute" {:database-name database-name
+                                                                            :router-database-id (u/the-id db-or-id)}))))))))
+
+;; We want, at all times, a guarantee that we are not hitting a router *or* destination database without being
+;; intentional about it. It would be bad to EITHER:
+;;
+;; - (a) accidentally hit a router database because we didn't include the middleware necessary to turn on Database
+;; Routing, OR
+;;
+;; (b) accidentally hit a mirror database when doing so is nonsensical, e.g. for database sync processes that should
+;; only use router databases. In these cases we don't want database routing, we just want to ensure we're not hitting
+;; a Destination Database
+;;
+;; The former looks like:
+;; - I am looking at a Router Database,
+;; - `router-db-or-id->mirror-db-id` returns a *different* database ID, and
+;; - `*database-routing-on?*` is `true` or `nil` (unset)
+;;
+;; The latter looks like:
+;; - I am looking at a Mirror Database,
+;; - `*database-routing-on?*` is `false` or `nil` (unset)
+
+(def ^:dynamic ^:private *database-routing-on?* nil)
+
+(defenterprise with-database-routing-on-fn
+  "Enterprise version. Calls the function with Database Routing allowed."
+  :feature :database-routing
+  [f]
+  (binding [*database-routing-on?* true]
+    (f)))
+
+(defenterprise with-database-routing-off-fn
+  "Enterprise version. Calls the function with Database Routing prohibited."
+  :feature :database-routing
+  [f]
+  (binding [*database-routing-on?* false]
+    (f)))
+
+(defn- is-disallowed-router-db-access?
+  [db-or-id]
+  (and (some-> (router-db-or-id->mirror-db-id db-or-id)
+               (not= db-or-id))
+       (not= *database-routing-on?* false)))
+
+(defn- is-disallowed-mirror-db-access?
+  [db-or-id]
+  (and (t2/exists? :model/Database :id db-or-id :router_database_id [:not= nil])
+       (not= *database-routing-on?* true)))
+
+(defenterprise check-allowed-access!
+  "This is intended as a safety harness. In dev/testing, if any access to a router or destination database is detected
+  outside those circumstances where we've explicitly declared it okay, throw an exception.
+
+  In production, skip this (fairly expensive) check.
+
+  The idea here is that at all times we should be aware of whether:
+
+  - we're explicitly accessing a router database (e.g. sync) and DO NOT want to reroute to a destination database, or
+
+  - we're explicitly using the Database Routing feature (e.g. a query) and DO NOT want to access the router
+  database (unless that was the user's intent, i.e. the user's attribute was `__METABASE_ROUTER__`) "
+  :feature :database-routing
+  [db-or-id-or-spec]
+  (when-let [db-id (and (not config/is-prod?)
+                        (u/id db-or-id-or-spec))]
+    (when (is-disallowed-router-db-access? db-id)
+      (throw (ex-info "Forbidden access to Router Database without `with-database-routing-off`" {})))
+    (when (is-disallowed-mirror-db-access? db-id)
+      (throw (ex-info "Forbidden access to Mirror Database without `with-database-routing-on`" {})))))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -5,6 +5,7 @@
   (:require
    [metabase-enterprise.database-routing.common :refer [router-db-or-id->mirror-db-id]]
    [metabase.api.common :as api]
+   [metabase.database-routing.core :refer [with-database-routing-on]]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.store :as qp.store]
@@ -24,7 +25,8 @@
                        (rff metadata))))]
         (binding [qp.store/*DANGER-allow-replacing-metadata-provider* true]
           (qp.store/with-metadata-provider mirror-db-id
-            (qp query rff*))))
+            (with-database-routing-on
+              (qp query rff*)))))
       (qp query rff))))
 
 (defenterprise attach-mirror-db-middleware
@@ -33,6 +35,6 @@
   :feature :database-routing
   [query]
   (let [database (lib.metadata/database (qp.store/metadata-provider))
-        mirror-db-id (router-db-or-id->mirror-db-id api/*current-user* database)]
+        mirror-db-id (router-db-or-id->mirror-db-id @api/*current-user* database)]
     (cond-> query
       mirror-db-id (assoc :mirror-database/id mirror-db-id))))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
@@ -29,5 +29,5 @@
   "Enterprise version. Returns a hash input that will be used for fields subject to database routing."
   :feature :database-routing
   [field]
-  (when-let [mirror-db-id (some->> field u/the-id field/field-id->database-id (router-db-or-id->mirror-db-id api/*current-user*))]
+  (when-let [mirror-db-id (some->> field u/the-id field/field-id->database-id (router-db-or-id->mirror-db-id @api/*current-user*))]
     {:mirror-db-id mirror-db-id}))

--- a/src/metabase/database_routing/core.clj
+++ b/src/metabase/database_routing/core.clj
@@ -1,0 +1,37 @@
+(ns metabase.database-routing.core
+  "The OSS namespace for database routing."
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]))
+
+(defenterprise with-database-routing-on-fn
+  "OSS Version, does nothing"
+  metabase-enterprise.database-routing.common
+  [f]
+  (f))
+
+(defmacro with-database-routing-on
+  "Turns database routing on. Access to a Router Database in this block will be an error (unless things are configured
+  that way, of course.)"
+  [& body]
+  `(with-database-routing-on-fn
+     (fn []
+       ~@body)))
+
+(defenterprise with-database-routing-off-fn
+  "OSS version, does nothing"
+  metabase-enterprise.database-routing.common
+  [f]
+  (f))
+
+(defmacro with-database-routing-off
+  "Turns database routing off. Access to a mirror database within this block will result in an error."
+  [& body]
+  `(with-database-routing-off-fn
+     (fn []
+       ~@body)))
+
+(defenterprise check-allowed-access!
+  "OSS version, does nothing"
+  metabase-enterprise.database-routing.common
+  [_db-or-id-or-spec]
+  nil)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -5,6 +5,7 @@
    [clojure.java.jdbc :as jdbc]
    [metabase.config :as config]
    [metabase.connection-pool :as connection-pool]
+   [metabase.database-routing.core :as database-routing]
    [metabase.db :as mdb]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
@@ -289,6 +290,8 @@ For setting the maximum, see [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#mb_ap
   "Return a JDBC connection spec that includes a c3p0 `ComboPooledDataSource`. These connection pools are cached so we
   don't create multiple ones for the same DB."
   [db-or-id-or-spec]
+  (when-let [db-id (u/id db-or-id-or-spec)]
+    (database-routing/check-allowed-access! db-id))
   (cond
     ;; db-or-id-or-spec is a Database instance or an integer ID
     (u/id db-or-id-or-spec)

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1713,7 +1713,7 @@
       (doseq [main-string main-strings
               delimiter delimiters
               index indexes]
-        (testing (str "split part")
+        (testing "split part"
           (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
                           (lib/expression "SPLITPART" (lib/expression-clause :split-part [main-string delimiter index] nil))
                           (lib/limit 100))
@@ -2182,7 +2182,7 @@
     (let [mp (mt/metadata-provider)]
       (doseq [[table exprs] [[:people [(fn [] (lib/concat "2010" "-" "10" "-" "02"))]]]
               ef exprs]
-        (testing (str "casting custom expression to date")
+        (testing "casting custom expression to date"
           (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
                           (lib/with-fields [])
                           (lib/expression "CUSTOMEXPR" (ef))


### PR DESCRIPTION
I was considering possible errors here and I think this will work well
as a safety harness.

In dev/testing (non-prod) environments, let's add an assertion to the
JDBC driver that if we're about to connect to a database. Either:

- we're *explicitly* trying to only connect to Router Databases. For
example, sync should *never* connect to mirror databases or go through
Database Routing. OR

- we've enabled Database Routing, and we *don't* want to access the
Router Database (unless of course DB routing has been configured to send
us there)

Another way of putting this is that there are two obvious ways for this
feature to go sideways: we accidentally sync a mirror database or do
something else that shouldn't work for mirror databases, OR we
accidentally skip the Database Routing process and connect to the router
database when we shouldn't.

Of course, we can't guarantee that all drivers will call
`(database-routing/check-allowed-access!)` before connecting! But we can
just call it from the JDBC router and that should be sufficient to catch
any issues in development in the vast vast majority of cases.
