### PR TITLE
fix: only remove vis_settings from dashboardcard

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -21,8 +21,15 @@
 
   This map works around this: given a model (e.g. `Card`) that triggered a dependency loop, it provides a set of keys
   to remove from the model so that we'll be able to successfully load it."
-  {"Dashboard" #{:dashcards}
-   "Card" #{:dashboard_id}})
+  {"Dashboard" #{[:dashcards :* :visualization_settings]}
+   "Card" #{[:dashboard_id]}})
+
+(defn- remove-by-path
+  [entity [first-key & rest]]
+  (cond
+    (empty? rest) (dissoc entity first-key)
+    (= :* first-key) (mapv #(remove-by-path % rest) entity)
+    :else (update entity first-key remove-by-path rest)))
 
 (defn- without-references
   "Remove references to other entities from a given one. Used to break circular dependencies when loading."
@@ -32,7 +39,7 @@
                                            {:entity entity
                                             :model model
                                             :error ::no-known-references})))]
-    (apply dissoc entity keys-to-remove)))
+    (reduce remove-by-path entity keys-to-remove)))
 
 (defn- load-deps!
   "Given a list of `deps` (hierarchies), [[load-one]] them all.

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -19,8 +19,9 @@
   pointing to the dashboard it's in. But when we try to load that dashboard, we'll create all its dashcards, and one
   of those dashcards will point to the card we started with.
 
-  This map works around this: given a model (e.g. `Card`) that triggered a dependency loop, it provides a set of keys
-  to remove from the model so that we'll be able to successfully load it."
+  This map works around this: given a model (e.g. `Card`) that triggered a dependency loop, it provides a set of paths to
+  keys to remove from the model so that we'll be able to successfully load it. You can remove keys in vectors using :* to
+  indicate that all items in that vector should have a key removed."
   {"Dashboard" #{[:dashcards :* :visualization_settings]}
    "Card" #{[:dashboard_id]}})
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1194,11 +1194,15 @@
           card-2 (ts/create! :model/Card :name "card-2" :dashboard_id (:id dash1))
           ser   (into [] (serdes.extract/extract {:no-settings   true
                                                   :no-data-model true}))]
-      (t2/delete! :model/DashboardCard :id [:in (map :id [dc1 dc2 dc3])])
       (testing "Circular dependencies are loaded correctly"
         (is (serdes.load/load-metabase! (ingestion-in-memory ser)))
         (let [select-target #(-> % :visualization_settings :click_behavior :targetId)]
-
+          (is (= (:id dc1)
+                 (t2/select-one-fn :id :model/DashboardCard :entity_id (:entity_id dc1))))
+          (is (= (:id dc2)
+                 (t2/select-one-fn :id :model/DashboardCard :entity_id (:entity_id dc2))))
+          (is (= (:id dc3)
+                 (t2/select-one-fn :id :model/DashboardCard :entity_id (:entity_id dc3))))
           (is (= (:id dash2)
                  (t2/select-one-fn select-target :model/DashboardCard :entity_id (:entity_id dc1))))
           (is (= (:id dash3)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #55496
### Description

Fixes loading serialized dashboard cards where we would previously delete and recreate them on each load.

In order to handle circular dependencies caused by links to other dashboards in a dashboardcard's visualization_settings we were removing the dashboardcards entirely from the dashboard model to break the cycle. Later when we traversed back through the dependency path we would load the original dashboard a second time with the restored dashboardcards.

However, on the load of the cycle breaking change we could entirely drop dashcards belonging to the dashboard because the serialization code was treating our cycle breaking changes as an edit to the dashboard to drop those cards. This meant when we got back to the the second load of the dashboard we would create the dashcards fresh instead of updating existing instances.

The fix here is that we only remove the values from the dasboard card model that can cause the cycle -- in this case just the visualization_settings column. This seemed the most straightforward fix, but there are other possibilities here.

One is that we could _just_ preserve the entity_id column in dashcards which would eliminate the possibility of any other cycles here.

Another option would be to change how we handle nested models in serialization. There is not really a foreign key dependency here between dashboard A and dashboard B linked by the dashboard card. If we instead just created those dashboards first _then_ went back and created their dashcards we don't have any problems at all. We could move nested models up to the same level of handling in serialization that we do for models, which would let us create the dashboards first then create any dashboard cards in a subsequent step.

### How to verify

On an instance of metabase with an open repl run 
```clojure
(require '[metabase-enterprise.audit-app.audit :as audit])
(require '[metabase.plugins :as plugins])
(require '[metabase-enterprise.serialization.cmd :as serialization.cmd])


(serialization.cmd/v2-load-internal! (str (#'audit/instance-analytics-plugin-dir (plugins/plugins-dir)))
                                                            {:backfill? false}
                                                            :token-check? false
                                                            :require-initialized-db? false)
```

You would previously see the ids of the dashcards for the audit analytics change. now they will not change. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
