### PR TITLE
Adding labelRightSection to visualizations, adding verified badge to pinned questions

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/EntityModerationIcon/EntityModerationIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/EntityModerationIcon/EntityModerationIcon.tsx
@@ -1,5 +1,5 @@
 import type Question from "metabase-lib/v1/Question";
-import type { Dashboard } from "metabase-types/api";
+import type { Card, Dashboard } from "metabase-types/api";
 
 import ModerationReviewIcon from "../../containers/ModerationReviewIcon";
 import { getLatestModerationReview } from "../../service";
@@ -7,20 +7,26 @@ import { getLatestModerationReview } from "../../service";
 export interface EntityModerationIconProps {
   question?: Question;
   dashboard?: Dashboard;
+  card?: Card;
+  filled?: boolean;
 }
 
 export const EntityModerationIcon = ({
+  card,
   question,
   dashboard,
+  filled,
 }: EntityModerationIconProps): JSX.Element | null => {
   const entityReviews = question
     ? question.getModerationReviews()
-    : dashboard?.moderation_reviews;
+    : card
+      ? card.moderation_reviews
+      : dashboard?.moderation_reviews;
 
   const review = getLatestModerationReview(entityReviews);
 
   if (review) {
-    return <ModerationReviewIcon review={review} />;
+    return <ModerationReviewIcon review={review} filled={filled} />;
   } else {
     return null;
   }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/EntityModerationIcon/EntityModerationIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/EntityModerationIcon/EntityModerationIcon.tsx
@@ -1,5 +1,5 @@
 import type Question from "metabase-lib/v1/Question";
-import type { Card, Dashboard } from "metabase-types/api";
+import type { Dashboard } from "metabase-types/api";
 
 import ModerationReviewIcon from "../../containers/ModerationReviewIcon";
 import { getLatestModerationReview } from "../../service";
@@ -7,21 +7,17 @@ import { getLatestModerationReview } from "../../service";
 export interface EntityModerationIconProps {
   question?: Question;
   dashboard?: Dashboard;
-  card?: Card;
   filled?: boolean;
 }
 
 export const EntityModerationIcon = ({
-  card,
   question,
   dashboard,
   filled,
 }: EntityModerationIconProps): JSX.Element | null => {
   const entityReviews = question
     ? question.getModerationReviews()
-    : card
-      ? card.moderation_reviews
-      : dashboard?.moderation_reviews;
+    : dashboard?.moderation_reviews;
 
   const review = getLatestModerationReview(entityReviews);
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
@@ -10,13 +10,15 @@ import { TooltipTime } from "./ModerationReviewIcon.styled";
 export interface ModerationReviewIconProps {
   review: ModerationReview;
   currentUser: User;
+  filled?: boolean;
 }
 
 const ModerationReviewIcon = ({
   review,
   currentUser,
+  filled,
 }: ModerationReviewIconProps): JSX.Element => {
-  const { name: iconName, color: iconColor } = getIconForReview(review);
+  const { name: iconName, color: iconColor } = getIconForReview(review, filled);
   const { user: moderator } = review;
 
   const tooltip = moderator && (

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -99,6 +99,7 @@ const PinnedQuestionCard = ({
                 errorIcon={errorIcon}
                 showTitle
                 isDashboard
+                isPinnedQuestion
               />
             )
           }

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -12,6 +12,7 @@ import {
 } from "metabase/collections/utils";
 import EventSandbox from "metabase/components/EventSandbox";
 import CS from "metabase/css/core/index.css";
+import { PLUGIN_MODERATION } from "metabase/plugins";
 import type { IconName } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -99,7 +100,12 @@ const PinnedQuestionCard = ({
                 errorIcon={errorIcon}
                 showTitle
                 isDashboard
-                isPinnedQuestion
+                labelRightSection={
+                  <PLUGIN_MODERATION.EntityModerationIcon
+                    question={question}
+                    filled
+                  />
+                }
               />
             )
           }

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -20,6 +20,7 @@ interface ChartCaptionProps {
   width?: number;
   getHref?: () => string | undefined;
   onChangeCardAndRun?: OnChangeCardAndRun | null;
+  isPinnedQuestion?: boolean;
 }
 
 const ChartCaption = ({
@@ -31,6 +32,7 @@ const ChartCaption = ({
   onChangeCardAndRun,
   getHref,
   width,
+  isPinnedQuestion,
 }: ChartCaptionProps) => {
   const title = settings["card.title"] ?? series?.[0].card.name ?? "";
   const description = settings["card.description"];
@@ -47,6 +49,7 @@ const ChartCaption = ({
 
   return (
     <ChartCaptionRoot
+      card={isPinnedQuestion ? card : undefined}
       title={title}
       description={description}
       getHref={getHref}

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -20,7 +20,7 @@ interface ChartCaptionProps {
   width?: number;
   getHref?: () => string | undefined;
   onChangeCardAndRun?: OnChangeCardAndRun | null;
-  isPinnedQuestion?: boolean;
+  labelRightSection?: ReactNode;
 }
 
 const ChartCaption = ({
@@ -32,7 +32,7 @@ const ChartCaption = ({
   onChangeCardAndRun,
   getHref,
   width,
-  isPinnedQuestion,
+  labelRightSection,
 }: ChartCaptionProps) => {
   const title = settings["card.title"] ?? series?.[0].card.name ?? "";
   const description = settings["card.description"];
@@ -49,7 +49,7 @@ const ChartCaption = ({
 
   return (
     <ChartCaptionRoot
-      card={isPinnedQuestion ? card : undefined}
+      labelRightSection={labelRightSection}
       title={title}
       description={description}
       getHref={getHref}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -127,6 +127,7 @@ type VisualizationOwnProps = {
   height?: number | null;
   isAction?: boolean;
   isDashboard?: boolean;
+  isPinnedQuestion?: boolean;
   isMobile?: boolean;
   isShowingSummarySidebar?: boolean;
   isSlow?: CardSlownessStatus;
@@ -542,6 +543,7 @@ class Visualization extends PureComponent<
       isMobile,
       isNightMode,
       isObjectDetail,
+      isPinnedQuestion,
       isPreviewing,
       isRawTable,
       isQueryBuilder,
@@ -714,6 +716,7 @@ class Visualization extends PureComponent<
                     ? this.handleOnChangeCardAndRun
                     : null
                 }
+                isPinnedQuestion={!!isPinnedQuestion}
               />
             </VisualizationHeader>
           )}
@@ -772,6 +775,7 @@ class Visualization extends PureComponent<
                   height={rawHeight}
                   hovered={hovered}
                   isDashboard={!!isDashboard}
+                  isPinnedQuestion={!!isPinnedQuestion}
                   isEditing={!!isEditing}
                   isEmbeddingSdk={isEmbeddingSdk}
                   isFullscreen={!!isFullscreen}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -127,11 +127,11 @@ type VisualizationOwnProps = {
   height?: number | null;
   isAction?: boolean;
   isDashboard?: boolean;
-  isPinnedQuestion?: boolean;
   isMobile?: boolean;
   isShowingSummarySidebar?: boolean;
   isSlow?: CardSlownessStatus;
   isVisible?: boolean;
+  labelRightSection?: React.ReactNode;
   metadata?: Metadata;
   mode?: ClickActionModeGetter | Mode | QueryClickActionsMode;
   onEditSummary?: () => void;
@@ -543,7 +543,6 @@ class Visualization extends PureComponent<
       isMobile,
       isNightMode,
       isObjectDetail,
-      isPinnedQuestion,
       isPreviewing,
       isRawTable,
       isQueryBuilder,
@@ -551,6 +550,7 @@ class Visualization extends PureComponent<
       isShowingDetailsOnlyColumns,
       isShowingSummarySidebar,
       isSlow,
+      labelRightSection,
       metadata,
       mode,
       onEditSummary,
@@ -716,7 +716,7 @@ class Visualization extends PureComponent<
                     ? this.handleOnChangeCardAndRun
                     : null
                 }
-                isPinnedQuestion={!!isPinnedQuestion}
+                labelRightSection={labelRightSection}
               />
             </VisualizationHeader>
           )}
@@ -775,7 +775,7 @@ class Visualization extends PureComponent<
                   height={rawHeight}
                   hovered={hovered}
                   isDashboard={!!isDashboard}
-                  isPinnedQuestion={!!isPinnedQuestion}
+                  labelRightSection={labelRightSection}
                   isEditing={!!isEditing}
                   isEmbeddingSdk={isEmbeddingSdk}
                   isFullscreen={!!isFullscreen}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
@@ -1,9 +1,10 @@
 import PropTypes from "prop-types";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { delay } from "__support__/utils";
 import { NumberColumn, StringColumn } from "__support__/visualizations";
 import { color } from "metabase/lib/colors";
+import { Icon } from "metabase/ui";
 import { registerVisualization } from "metabase/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
 import registerVisualizations from "metabase/visualizations/register";
@@ -96,6 +97,31 @@ describe("Visualization", () => {
 
       expect(screen.getByTestId("scalar-value")).toHaveTextContent("1");
     });
+
+    // Can unskip once we decide what to do with this viz
+    // eslint-disable-next-line
+    it.skip("should support labelRightSection", async () => {
+      await renderViz(
+        [
+          {
+            card: createMockCard({
+              display: "scalar",
+              visualization_settings: createMockVisualizationSettings({
+                "card.title": "Foo Question",
+              }),
+            }),
+            data: { rows: [[1]], cols: [NumberColumn({ name: "Count" })] },
+          },
+        ],
+        {
+          labelRightSection: <Icon name="check" />,
+          isDashboard: true,
+          showTitle: true,
+        },
+      );
+      expect(screen.getByText("Foo Question")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: /check/ })).toBeInTheDocument();
+    });
   });
 
   describe("bar", () => {
@@ -118,6 +144,38 @@ describe("Visualization", () => {
         ]);
 
         expect(chartPathsWithColor(color("brand"))).toHaveLength(2);
+      });
+
+      it("should support leftLabelSection", async () => {
+        await renderViz(
+          [
+            {
+              card: createMockCard({
+                display: "bar",
+                visualization_settings: createMockVisualizationSettings({
+                  "card.title": "Foo Question",
+                }),
+              }),
+              data: {
+                cols: [
+                  StringColumn({ name: "Dimension" }),
+                  NumberColumn({ name: "Count" }),
+                ],
+                rows: [
+                  ["foo", 1],
+                  ["bar", 2],
+                ],
+              },
+            },
+          ],
+          {
+            labelRightSection: <Icon name="check" />,
+            isDashboard: true,
+            showTitle: true,
+          },
+        );
+        expect(screen.getByText("Foo Question")).toBeInTheDocument();
+        expect(screen.getByRole("img", { name: /check/ })).toBeInTheDocument();
       });
     });
 
@@ -205,6 +263,138 @@ describe("Visualization", () => {
         expect(chartPathsWithColor(color("brand"))).toHaveLength(2); // "count"
         expect(chartPathsWithColor(color("accent2"))).toHaveLength(2); // "Card2"
       });
+    });
+  });
+
+  describe("pie", () => {
+    it("should support leftLabelSection", async () => {
+      await renderViz(
+        [
+          {
+            card: createMockCard({
+              display: "pie",
+              visualization_settings: createMockVisualizationSettings({
+                "card.title": "Foo Question",
+              }),
+            }),
+            data: {
+              cols: [
+                StringColumn({ name: "Dimension" }),
+                NumberColumn({ name: "Count" }),
+              ],
+              rows: [
+                ["foo", 1],
+                ["bar", 2],
+              ],
+            },
+          },
+        ],
+        {
+          labelRightSection: <Icon name="check" />,
+          isDashboard: true,
+          showTitle: true,
+        },
+      );
+      expect(screen.getByText("Foo Question")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: /check/ })).toBeInTheDocument();
+    });
+  });
+
+  describe("row", () => {
+    it("should support leftLabelSection", async () => {
+      await renderViz(
+        [
+          {
+            card: createMockCard({
+              display: "row",
+              visualization_settings: createMockVisualizationSettings({
+                "card.title": "Foo Question",
+              }),
+            }),
+            data: {
+              cols: [
+                StringColumn({ name: "Dimension" }),
+                NumberColumn({ name: "Count" }),
+              ],
+              rows: [
+                ["foo", 1],
+                ["bar", 2],
+              ],
+            },
+          },
+        ],
+        {
+          labelRightSection: <Icon name="check" />,
+          isDashboard: true,
+          showTitle: true,
+        },
+      );
+      expect(screen.getByText("Foo Question")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: /check/ })).toBeInTheDocument();
+    });
+  });
+
+  describe("table", () => {
+    it("should support leftLabelSection", async () => {
+      await renderViz(
+        [
+          {
+            card: createMockCard({
+              display: "table",
+              visualization_settings: createMockVisualizationSettings({
+                "card.title": "Foo Question",
+              }),
+            }),
+            data: {
+              cols: [
+                StringColumn({ name: "Dimension" }),
+                NumberColumn({ name: "Count" }),
+              ],
+              rows: [
+                ["foo", 1],
+                ["bar", 2],
+              ],
+            },
+          },
+        ],
+        {
+          labelRightSection: <Icon name="check" />,
+          isDashboard: true,
+          showTitle: true,
+        },
+      );
+      expect(screen.getByText("Foo Question")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: /check/ })).toBeInTheDocument();
+    });
+  });
+
+  describe("progress", () => {
+    it("should support leftLabelSection", async () => {
+      await renderViz(
+        [
+          {
+            card: createMockCard({
+              display: "progress",
+              visualization_settings: createMockVisualizationSettings({
+                "card.title": "Foo Question",
+              }),
+            }),
+            data: { rows: [[1]], cols: [NumberColumn({ name: "Count" })] },
+          },
+        ],
+        {
+          labelRightSection: <Icon name="check" />,
+          isDashboard: true,
+          showTitle: true,
+        },
+      );
+
+      expect(screen.getByText("Foo Question")).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId("legend-caption")).getByRole("img", {
+          name: /check/,
+        }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
@@ -5,9 +5,11 @@ import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Markdown from "metabase/core/components/Markdown";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
+import { PLUGIN_MODERATION } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import type { IconProps } from "metabase/ui";
-import { Tooltip } from "metabase/ui";
+import { Group, Tooltip } from "metabase/ui";
+import type { Card } from "metabase-types/api";
 
 import LegendActions from "./LegendActions";
 import {
@@ -40,9 +42,11 @@ interface LegendCaptionProps {
   hasInfoTooltip?: boolean;
   onSelectTitle?: () => void;
   width?: number;
+  card?: Card;
 }
 
 export const LegendCaption = ({
+  card,
   className,
   title,
   description,
@@ -78,19 +82,22 @@ export const LegendCaption = ({
   return (
     <LegendCaptionRoot className={className} data-testid="legend-caption">
       {icon && <LegendLabelIcon {...icon} />}
-      <LegendLabel
-        className={cx(
-          DashboardS.fullscreenNormalText,
-          DashboardS.fullscreenNightText,
-          EmbedFrameS.fullscreenNightText,
-        )}
-        href={href}
-        onClick={onSelectTitle}
-        onFocus={handleFocus}
-        onMouseEnter={handleMouseEnter}
-      >
-        <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>
-      </LegendLabel>
+      <Group gap="0.25rem" align="center">
+        <LegendLabel
+          className={cx(
+            DashboardS.fullscreenNormalText,
+            DashboardS.fullscreenNightText,
+            EmbedFrameS.fullscreenNightText,
+          )}
+          href={href}
+          onClick={onSelectTitle}
+          onFocus={handleFocus}
+          onMouseEnter={handleMouseEnter}
+        >
+          <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>
+        </LegendLabel>
+        {card && <PLUGIN_MODERATION.EntityModerationIcon card={card} filled />}
+      </Group>
       <LegendRightContent>
         {hasInfoTooltip && description && !shouldHideDescription(width) && (
           <Tooltip

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
@@ -1,11 +1,10 @@
 import cx from "classnames";
-import { useCallback, useState } from "react";
+import { type ReactNode, useCallback, useState } from "react";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Markdown from "metabase/core/components/Markdown";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
-import { PLUGIN_MODERATION } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import type { IconProps } from "metabase/ui";
 import { Group, Tooltip } from "metabase/ui";
@@ -43,10 +42,10 @@ interface LegendCaptionProps {
   onSelectTitle?: () => void;
   width?: number;
   card?: Card;
+  labelRightSection?: ReactNode;
 }
 
 export const LegendCaption = ({
-  card,
   className,
   title,
   description,
@@ -56,6 +55,7 @@ export const LegendCaption = ({
   hasInfoTooltip = true,
   onSelectTitle,
   width,
+  labelRightSection,
 }: LegendCaptionProps) => {
   /*
    * Optimization: lazy computing the href on title focus & mouseenter only.
@@ -96,7 +96,7 @@ export const LegendCaption = ({
         >
           <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>
         </LegendLabel>
-        {card && <PLUGIN_MODERATION.EntityModerationIcon card={card} filled />}
+        {labelRightSection}
       </Group>
       <LegendRightContent>
         {hasInfoTooltip && description && !shouldHideDescription(width) && (

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -173,6 +173,8 @@ export interface VisualizationProps {
   onUpdateWarnings?: any;
 
   dispatch: Dispatch;
+
+  labelRightSection?: React.ReactNode;
 }
 
 export type VisualizationPassThroughProps = {
@@ -180,7 +182,6 @@ export type VisualizationPassThroughProps = {
   canToggleSeriesVisibility?: boolean;
   isObjectDetail?: boolean;
   isQueryBuilder?: boolean;
-  isPinnedQuestion?: boolean;
   queryBuilderMode?: QueryBuilderMode;
   onDeselectTimelineEvents?: () => void;
   onOpenTimelines?: () => void;

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -180,6 +180,7 @@ export type VisualizationPassThroughProps = {
   canToggleSeriesVisibility?: boolean;
   isObjectDetail?: boolean;
   isQueryBuilder?: boolean;
+  isPinnedQuestion?: boolean;
   queryBuilderMode?: QueryBuilderMode;
   onDeselectTimelineEvents?: () => void;
   onOpenTimelines?: () => void;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -52,7 +52,7 @@ function _CartesianChart(props: VisualizationProps) {
     isDashboard,
     isEditing,
     isQueryBuilder,
-    isPinnedQuestion,
+    labelRightSection,
     isFullscreen,
     hovered,
     onChangeCardAndRun,
@@ -145,7 +145,7 @@ function _CartesianChart(props: VisualizationProps) {
     <CartesianChartRoot isQueryBuilder={isQueryBuilder}>
       {showTitle && (
         <LegendCaption
-          card={isPinnedQuestion ? card : undefined}
+          labelRightSection={labelRightSection}
           title={settings["card.title"]}
           description={description}
           icon={headerIcon}

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -52,6 +52,7 @@ function _CartesianChart(props: VisualizationProps) {
     isDashboard,
     isEditing,
     isQueryBuilder,
+    isPinnedQuestion,
     isFullscreen,
     hovered,
     onChangeCardAndRun,
@@ -144,6 +145,7 @@ function _CartesianChart(props: VisualizationProps) {
     <CartesianChartRoot isQueryBuilder={isQueryBuilder}>
       {showTitle && (
         <LegendCaption
+          card={isPinnedQuestion ? card : undefined}
           title={settings["card.title"]}
           description={description}
           icon={headerIcon}

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -101,7 +101,7 @@ const RowChartVisualization = ({
   isFullscreen,
   isQueryBuilder,
   isDashboard,
-  isPinnedQuestion,
+  labelRightSection,
   onRender,
   onHoverChange,
   showTitle,
@@ -282,7 +282,7 @@ const RowChartVisualization = ({
     <RowVisualizationRoot className={className} isQueryBuilder={isQueryBuilder}>
       {hasTitle && (
         <RowLegendCaption
-          card={isPinnedQuestion ? card : undefined}
+          labelRightSection={labelRightSection}
           title={title}
           description={description}
           icon={headerIcon}

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -101,6 +101,7 @@ const RowChartVisualization = ({
   isFullscreen,
   isQueryBuilder,
   isDashboard,
+  isPinnedQuestion,
   onRender,
   onHoverChange,
   showTitle,
@@ -281,6 +282,7 @@ const RowChartVisualization = ({
     <RowVisualizationRoot className={className} isQueryBuilder={isQueryBuilder}>
       {hasTitle && (
         <RowLegendCaption
+          card={isPinnedQuestion ? card : undefined}
           title={title}
           description={description}
           icon={headerIcon}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51570

### Description
Adds the ability to pass a new `labelRightSection` prop to `<Visualization/>`, which accepts a react node and routes it to the viz title / label. This is used by the Pinned Question Card for the collection items view

### How to verify
1. Create a question in a collection and verify it
2. Pin the question inside the collection
3. You should see a rendering of the question, along with the verification icon

### Demo
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/35ce4ec2-d52a-4075-b972-8b8b29925af5" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
