### PR TITLE
Auto-categorize truncation units as datetime columns in insights code

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -87,10 +87,10 @@ function buildComparisonObject({
 
   const changeColor = !isEmpty(changeArrowIconName)
     ? getArrowColor(
-      changeArrowIconName,
-      settings["scalar.switch_positive_negative"],
-      { getColor },
-    )
+        changeArrowIconName,
+        settings["scalar.switch_positive_negative"],
+        { getColor },
+      )
     : undefined;
 
   return {
@@ -402,10 +402,10 @@ function computeComparisonPeriodsAgo({
     dateUnitsAgo === 1
       ? t`vs. previous ${dateUnitDisplay}`
       : computeComparisonStrPreviousValue({
-        dateUnitSettings,
-        nextDate,
-        prevDate,
-      });
+          dateUnitSettings,
+          nextDate,
+          prevDate,
+        });
 
   // if no row exists with date "X periods ago"
   if (isEmpty(rowPeriodsAgo)) {
@@ -594,13 +594,13 @@ function getArrowColor(
 ) {
   const arrowIconColorNames = shouldSwitchPositiveNegative
     ? {
-      [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("success"),
-      [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("error"),
-    }
+        [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("success"),
+        [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("error"),
+      }
     : {
-      [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("error"),
-      [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("success"),
-    };
+        [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("error"),
+        [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("success"),
+      };
 
   return arrowIconColorNames[changeArrowIconName];
 }

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -10,6 +10,7 @@ import { COMPARISON_TYPES } from "metabase/visualizations/visualizations/SmartSc
 import { formatChange } from "metabase/visualizations/visualizations/SmartScalar/utils";
 import * as Lib from "metabase-lib";
 import { isDate } from "metabase-lib/v1/types/utils/isa";
+import { isAbsoluteDateTimeUnit } from "metabase-types/guards/date-time";
 
 export function computeTrend(series, insights, settings, { getColor }) {
   try {
@@ -86,10 +87,10 @@ function buildComparisonObject({
 
   const changeColor = !isEmpty(changeArrowIconName)
     ? getArrowColor(
-        changeArrowIconName,
-        settings["scalar.switch_positive_negative"],
-        { getColor },
-      )
+      changeArrowIconName,
+      settings["scalar.switch_positive_negative"],
+      { getColor },
+    )
     : undefined;
 
   return {
@@ -153,7 +154,9 @@ function getCurrentMetricData({ series, insights, settings }) {
   ] = series;
 
   // column locations for date and metric
-  const dimensionColIndex = cols.findIndex((col) => isDate(col));
+  const dimensionColIndex = cols.findIndex((col) => {
+    return isDate(col) || isAbsoluteDateTimeUnit(col.unit);
+  });
   const metricColIndex = cols.findIndex(
     (col) => col.name === settings["scalar.field"],
   );
@@ -399,10 +402,10 @@ function computeComparisonPeriodsAgo({
     dateUnitsAgo === 1
       ? t`vs. previous ${dateUnitDisplay}`
       : computeComparisonStrPreviousValue({
-          dateUnitSettings,
-          nextDate,
-          prevDate,
-        });
+        dateUnitSettings,
+        nextDate,
+        prevDate,
+      });
 
   // if no row exists with date "X periods ago"
   if (isEmpty(rowPeriodsAgo)) {
@@ -591,13 +594,13 @@ function getArrowColor(
 ) {
   const arrowIconColorNames = shouldSwitchPositiveNegative
     ? {
-        [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("success"),
-        [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("error"),
-      }
+      [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("success"),
+      [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("error"),
+    }
     : {
-        [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("error"),
-        [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("success"),
-      };
+      [CHANGE_ARROW_ICONS.ARROW_DOWN]: getColor("error"),
+      [CHANGE_ARROW_ICONS.ARROW_UP]: getColor("success"),
+    };
 
   return arrowIconColorNames[changeArrowIconName];
 }

--- a/src/metabase/analyze/fingerprint/insights.clj
+++ b/src/metabase/analyze/fingerprint/insights.clj
@@ -289,7 +289,7 @@
                                           unit           :unit}]
                                       (cond
                                         (isa? semantic-type :Relation/*)                    :others
-                                        (= unit :year)                                      :datetimes
+                                        (u.date/truncate-units unit)                        :datetimes
                                         (u.date/extract-units unit)                         :numbers
                                         (isa? (or effective-type base-type) :type/Temporal) :datetimes
                                         (isa? base-type :type/Number)                       :numbers

--- a/test/metabase/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/analyze/fingerprint/insights_test.clj
@@ -201,7 +201,7 @@
                     (insights/insights [{:base_type :type/DateTime}
                                         {:base_type :type/Number}
                                         ;; Any column with a base type that is not number or temporal previously
-                                        ;; prevented timeseries insights from being callulated
+                                        ;; prevented timeseries insights from being calculated
                                         {:base_type :type/Text}])
                     [["2024-08-09" 10.0 "weekday"]
                      ["2024-08-10" 20.0 "weekend"]])))))

--- a/test/metabase/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/analyze/fingerprint/insights_test.clj
@@ -215,9 +215,9 @@
                                               [["2024-08-09" 10.0]
                                                ["2024-08-10" 20.0]]))
       nil?  {:base_type :type/Text}
-         ;; Extraction unit (day-of-week) is classified as a numeric column and doesn't produce insights here
+      ;; Extraction unit (day-of-week) is classified as a numeric column and doesn't produce insights here
       nil?  {:base_type :type/Text :unit :day-of-week}
-         ;; Spot check truncation units — should all generate insights
+      ;; Spot check truncation units — should all generate insights
       some? {:base_type :type/Text :unit :day}
       some? {:base_type :type/Text :unit :month}
       some? {:base_type :type/Text :unit :year})))


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/12388

The SQLite JDBC driver seems to report temporal columns as having a base type of `:type/Text`. This causes our insights code to not generate temporal insights, resulting in trend charts being disabled.

Instead, we can go off of the unit selected for the column's breakout—if it's a "truncation" unit (i.e. `:day`, as opposed to `:day-of-week`) then we can assume it's a temporal column for the sake of generating insights. We already have this as a hard-coded workaround for `:year` but I've expanded it to the other units in this PR.

We also have to adjust the FE to not just look at `isDate(col)` when locating the column to use for the trend visualization dimension, since this is only based on the column's type, but instead also check `isAbsoluteDateTimeUnit(col.unit)`.