### PR TITLE
Add String->Float coercion strategy

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -244,6 +244,9 @@
                       {:type              qp.error-type/unsupported-feature
                        :coercion-strategy coercion}))
 
+      (isa? coercion :Coercion/String->Float)
+      {"$toDouble" field-name}
+
       :else field-name)))
 
 ;; Don't think this needs to implement `->lvalue` because you can't assign something to an aggregation e.g.

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -647,8 +647,7 @@
                (cast-temporal-byte driver coercion-strategy honeysql-form)
 
                [:type/Text (:isa? :Coercion/String->Decimal)]
-               ;; TODO: DECIMAL seems to be universal aka defined by standard. Verify!
-               (h2x/cast :decimal honeysql-form)
+               (h2x/cast :float8  honeysql-form)
 
                :else honeysql-form)
       (when-not (= <> honeysql-form)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -646,6 +646,10 @@
                [(:isa? :type/*) (:isa? :Coercion/Bytes->Temporal)]
                (cast-temporal-byte driver coercion-strategy honeysql-form)
 
+               [:type/Text (:isa? :Coercion/String->Decimal)]
+               ;; TODO: DECIMAL seems to be universal aka defined by standard. Verify!
+               (h2x/cast :decimal honeysql-form)
+
                :else honeysql-form)
       (when-not (= <> honeysql-form)
         (log/tracef "Applied casting\n=>\n%s" (u/pprint-to-str <>))))))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -647,7 +647,7 @@
                (cast-temporal-byte driver coercion-strategy honeysql-form)
 
                [:type/Text (:isa? :Coercion/String->Float)]
-               (h2x/cast :float8  honeysql-form)
+               (->float driver honeysql-form)
 
                :else honeysql-form)
       (when-not (= <> honeysql-form)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -646,7 +646,7 @@
                [(:isa? :type/*) (:isa? :Coercion/Bytes->Temporal)]
                (cast-temporal-byte driver coercion-strategy honeysql-form)
 
-               [:type/Text (:isa? :Coercion/String->Decimal)]
+               [:type/Text (:isa? :Coercion/String->Float)]
                (h2x/cast :float8  honeysql-form)
 
                :else honeysql-form)

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -350,6 +350,9 @@
 (derive :Coercion/UNIXMicroSeconds->DateTime :Coercion/UNIXTime->Temporal)
 (derive :Coercion/UNIXNanoSeconds->DateTime :Coercion/UNIXTime->Temporal)
 
+(derive :Coercion/String->Number :Coercion/*)
+(derive :Coercion/String->Decimal :Coercion/String->Number)
+
 ;;; ---------------------------------------------------- Util Fns ----------------------------------------------------
 
 (def ^:private SnakeCasedField
@@ -455,6 +458,8 @@
 (coercion-hierarchies/define-types! :Coercion/YYYYMMDDHHMMSSString->Temporal :type/Text                 :type/DateTime)
 
 (coercion-hierarchies/define-non-inheritable-type! :Coercion/YYYYMMDDHHMMSSBytes->Temporal :type/* :type/DateTime)
+
+(coercion-hierarchies/define-non-inheritable-type! :Coercion/String->Decimal :type/Text :type/Decimal)
 
 (defn is-coercible-from?
   "Whether `coercion-strategy` is allowed for `base-type`."

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -351,7 +351,7 @@
 (derive :Coercion/UNIXNanoSeconds->DateTime :Coercion/UNIXTime->Temporal)
 
 (derive :Coercion/String->Number :Coercion/*)
-(derive :Coercion/String->Decimal :Coercion/String->Number)
+(derive :Coercion/String->Float :Coercion/String->Number)
 
 ;;; ---------------------------------------------------- Util Fns ----------------------------------------------------
 
@@ -459,7 +459,7 @@
 
 (coercion-hierarchies/define-non-inheritable-type! :Coercion/YYYYMMDDHHMMSSBytes->Temporal :type/* :type/DateTime)
 
-(coercion-hierarchies/define-non-inheritable-type! :Coercion/String->Decimal :type/Text :type/Decimal)
+(coercion-hierarchies/define-non-inheritable-type! :Coercion/String->Float :type/Text :type/Float)
 
 (defn is-coercible-from?
   "Whether `coercion-strategy` is allowed for `base-type`."

--- a/test/metabase/query_processor_test/coercion_test.clj
+++ b/test/metabase/query_processor_test/coercion_test.clj
@@ -13,7 +13,7 @@
   (mt/test-drivers
     (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)
     (mt/dataset
-      string-nums
+      string-nums-db
       (doseq [[human-col col res] [["integer" :int_col   10.0]
                                    ["float"   :float_col 12.5]
                                    ["mixed"   :mix_col   7.259]]]

--- a/test/metabase/query_processor_test/coercion_test.clj
+++ b/test/metabase/query_processor_test/coercion_test.clj
@@ -9,7 +9,6 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]))
 
-;; ATM will fail with mongo
 (deftest string-to-number-coercion-test
   (mt/test-drivers
     (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)

--- a/test/metabase/query_processor_test/coercion_test.clj
+++ b/test/metabase/query_processor_test/coercion_test.clj
@@ -15,17 +15,17 @@
     (mt/normal-drivers)
     (mt/dataset
       string-nums
-      (doseq [[human-col col res] [["integer" :int_col 10.0]
-                                   ["decimal" :dec_col 12.5]
-                                   ["mixed"   :mix_col 7.259]]]
+      (doseq [[human-col col res] [["integer" :int_col   10.0]
+                                   ["float"   :float_col 12.5]
+                                   ["mixed"   :mix_col   7.259]]]
         (let [mp (lib.tu/merged-mock-metadata-provider
                   (lib.metadata.jvm/application-database-metadata-provider (mt/id))
                   {:fields [{:id                (mt/id :string_nums col)
-                             :coercion-strategy :Coercion/String->Decimal
-                             :effective-type    :type/Decimal}]})
+                             :coercion-strategy :Coercion/String->Float
+                             :effective-type    :type/Float}]})
               query (-> (lib/query mp (lib.metadata/table mp (mt/id :string_nums)))
                         (lib/aggregate (lib/sum (lib.metadata/field mp (mt/id :string_nums col)))))]
-          (testing (format "String->Decimal coercion works with %s" human-col)
+          (testing (format "String->Float coercion works with %s" human-col)
             (is (= res
                    (->> (qp.store/with-metadata-provider mp
                           (qp/process-query query))

--- a/test/metabase/query_processor_test/coercion_test.clj
+++ b/test/metabase/query_processor_test/coercion_test.clj
@@ -12,7 +12,7 @@
 ;; ATM will fail with mongo
 (deftest string-to-number-coercion-test
   (mt/test-drivers
-    (mt/normal-drivers)
+    (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)
     (mt/dataset
       string-nums
       (doseq [[human-col col res] [["integer" :int_col   10.0]

--- a/test/metabase/query_processor_test/coercion_test.clj
+++ b/test/metabase/query_processor_test/coercion_test.clj
@@ -11,7 +11,7 @@
 
 (deftest string-to-number-coercion-test
   (mt/test-drivers
-    (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)
+    (mt/normal-drivers)
     (mt/dataset
       string-nums-db
       (doseq [[human-col col res] [["integer" :int_col   10.0]

--- a/test/metabase/query_processor_test/coercion_test.clj
+++ b/test/metabase/query_processor_test/coercion_test.clj
@@ -1,0 +1,33 @@
+(ns ^:mb/driver-tests metabase.query-processor-test.coercion-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.test-util :as lib.tu]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.test :as mt]))
+
+;; ATM will fail with mongo
+(deftest string-to-number-coercion-test
+  (mt/test-drivers
+    (mt/normal-drivers)
+    (mt/dataset
+      string-nums
+      (doseq [[human-col col res] [["integer" :int_col 10.0]
+                                   ["decimal" :dec_col 12.5]
+                                   ["mixed"   :mix_col 7.259]]]
+        (let [mp (lib.tu/merged-mock-metadata-provider
+                  (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                  {:fields [{:id                (mt/id :string_nums col)
+                             :coercion-strategy :Coercion/String->Decimal
+                             :effective-type    :type/Decimal}]})
+              query (-> (lib/query mp (lib.metadata/table mp (mt/id :string_nums)))
+                        (lib/aggregate (lib/sum (lib.metadata/field mp (mt/id :string_nums col)))))]
+          (testing (format "String->Decimal coercion works with %s" human-col)
+            (is (= res
+                   (->> (qp.store/with-metadata-provider mp
+                          (qp/process-query query))
+                        (mt/formatted-rows [3.0])
+                        ffirst)))))))))

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -221,7 +221,7 @@
      ["four_loko"]
      ["ouija_board"]]]])
 
-(tx/defdataset string-nums
+(tx/defdataset string-nums-db
   [["string_nums"
     [{:field-name "int_col"   :base-type :type/Text}
      {:field-name "float_col" :base-type :type/Text}

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -223,9 +223,9 @@
 
 (tx/defdataset string-nums
   [["string_nums"
-    [{:field-name "int_col" :base-type :type/Text}
-     {:field-name "dec_col" :base-type :type/Text}
-     {:field-name "mix_col" :base-type :type/Text}]
+    [{:field-name "int_col"   :base-type :type/Text}
+     {:field-name "float_col" :base-type :type/Text}
+     {:field-name "mix_col"   :base-type :type/Text}]
     [["0" "0.5" "0"]
      ["1" "1.5" "0.5"]
      ["2" "2.5" "1"]

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -220,3 +220,14 @@
     [["toucan_cage"]
      ["four_loko"]
      ["ouija_board"]]]])
+
+(tx/defdataset string-nums
+  [["string_nums"
+    [{:field-name "int_col" :base-type :type/Text}
+     {:field-name "dec_col" :base-type :type/Text}
+     {:field-name "mix_col" :base-type :type/Text}]
+    [["0" "0.5" "0"]
+     ["1" "1.5" "0.5"]
+     ["2" "2.5" "1"]
+     ["3" "3.5" "2.7587"]
+     ["4" "4.5" "3"]]]])


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #55023
Closes https://linear.app/metabase/issue/SEM-107/add-support-for-explicit-string-double-coercion-strategy

### Description

This PR adds `String->Float` coercion strategy.

### How to verify

Run newly added test and/or change the coercion manually.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
