### PR TITLE
Speculative OOM fix: partition index updates, update logging for index sync

### DIFF
--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -80,10 +80,12 @@
                                                         :parent_id nil
                                                         :database_indexed true)
           [removing adding]          (data/diff existing-indexed-field-ids indexed-field-ids)]
-      (doseq [field-id removing]
-        (log/infof "Unmarking Field %d as indexed" field-id))
-      (doseq [field-id adding]
-        (log/infof "Marking Field %d as indexed" field-id))
+      (log/infof "Unmarking %d fields from indexed" (count removing))
+      (doseq [field-ids (partition 10 removing)]
+        (log/tracef "Unmarking Field %s as indexed" (pr-str field-ids)))
+      (log/infof "Marking %d fields as indexed" (count adding))
+      (doseq [field-ids (partition 10 adding)]
+        (log/tracef "Marking Field %s as indexed" (pr-str field-ids)))
       (if (or (seq adding) (seq removing))
         (do
           (t2/update! :model/Field

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -65,6 +65,10 @@
    ;; parameter limit of 65,535. See #52746 for details.
    (partition-all 5000 indexes)))
 
+(def ^:dynamic *update-partition-size*
+  "Size of the partition of indexes to update using one `t2/update!` call. Dynamic for testing purposes."
+  1000)
+
 (defn- sync-all-indexes!
   [database]
   (sync-util/with-error-handling "Error syncing Indexes"
@@ -79,28 +83,27 @@
                                                                         :where [:= :t.db_id database-id]}]
                                                         :parent_id nil
                                                         :database_indexed true)
-          [removing adding]          (data/diff existing-indexed-field-ids indexed-field-ids)]
-      (log/infof "Unmarking %d fields from indexed" (count removing))
-      (doseq [field-ids (partition 10 removing)]
-        (log/tracef "Unmarking Field %s as indexed" (pr-str field-ids)))
-      (log/infof "Marking %d fields as indexed" (count adding))
-      (doseq [field-ids (partition 10 adding)]
-        (log/tracef "Marking Field %s as indexed" (pr-str field-ids)))
+          [removing adding]           (data/diff existing-indexed-field-ids indexed-field-ids)
+          removing-count              (count removing)
+          adding-count                (count adding)]
+      ;; Null database_indexed of fields having NO index.
+      (log/infof "Unmarking %d fields from indexed" removing-count)
+      (doseq [field-ids (partition-all 100 removing)]
+        (log/tracef "Unmarking Fields as indexed: %s" (pr-str field-ids)))
+      (doseq [field-ids (partition-all *update-partition-size* removing)]
+        (log/infof "Executing batch update of at most %d fields" *update-partition-size*)
+        (t2/update! :model/Field :parent_id nil :id [:in field-ids] {:database_indexed false}))
+      ;; Set database_indexed of fields having index.
+      (log/infof "Marking %d fields as indexed" adding-count)
+      (doseq [field-ids (partition-all 100 adding)]
+        (log/tracef "Marking Fields as indexed: %s" (pr-str field-ids)))
+      (doseq [field-ids (partition-all *update-partition-size* adding)]
+        (log/infof "Executing batch update of at most %d fields" *update-partition-size*)
+        (t2/update! :model/Field :parent_id nil :id [:in field-ids] {:database_indexed true}))
       (if (or (seq adding) (seq removing))
-        (do
-          (doseq [indexed-field-ids-part (partition 1000 indexed-field-ids)]
-            (log/info "Executing batch update of at most 1000 fields")
-            (t2/update! :model/Field
-                        :table_id [:in {:select [[:t.id]]
-                                        :from [[(t2/table-name :model/Table) :t]]
-                                        :where [:= :t.db_id database-id]}]
-                        :parent_id nil
-                        {:database_indexed (if (seq indexed-field-ids-part)
-                                             [:case [:in :id indexed-field-ids-part] true :else false]
-                                             false)}))
-          {:total-indexes   (count indexed-field-ids)
-           :added-indexes   (count adding)
-           :removed-indexes (count removing)})
+        {:total-indexes   (count indexed-field-ids)
+         :added-indexes   adding-count
+         :removed-indexes removing-count}
         empty-stats))))
 
 (defn maybe-sync-indexes!

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -67,7 +67,7 @@
 
 (def ^:dynamic *update-partition-size*
   "Size of the partition of indexes to update using one `t2/update!` call. Dynamic for testing purposes."
-  1000)
+  5000)
 
 (defn- sync-all-indexes!
   [database]

--- a/test/metabase/sync/sync_metadata/indexes_test.clj
+++ b/test/metabase/sync/sync_metadata/indexes_test.clj
@@ -1,13 +1,16 @@
 (ns ^:mb/driver-tests metabase.sync.sync-metadata.indexes-test
   (:require
    [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.sync.core :as sync]
    [metabase.sync.sync-metadata.indexes :as sync.indexes]
    [metabase.test :as mt]
+   [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (deftest sync-single-indexed-columns-test
@@ -55,3 +58,58 @@
                                                        :field-name "id"}))
             field-ids (#'sync.indexes/all-indexes->field-ids (:id (mt/db)) many-indexes)]
         (is (seq field-ids))))))
+
+(deftest sync-all-indexes!-test
+  (mt/test-drivers
+    (set/intersection (mt/normal-drivers-with-feature :index-info)
+                      (mt/normal-drivers-with-feature :describe-indexes)
+                      (mt/sql-jdbc-drivers))
+    (let [ds-to-index-def (mt/dataset-definition
+                           "ds_to_index"
+                           ["first_table"
+                            [{:field-name "first"
+                              :base-type :type/Integer}
+                             {:field-name "second"
+                              :base-type :type/Integer}
+                             {:field-name "third"
+                              :base-type :type/Integer}]
+                            [[1 2 3]]])]
+      (mt/dataset ds-to-index-def
+        (try
+          (testing "Base: Id is indexed"
+            (is (some? (t2/select-one :model/Field
+                                      {:where [:and
+                                               [:in :table_id (t2/select-fn-vec :id :model/Table :db_id (mt/id))]
+                                               [:= :display_name "ID"]
+                                               [:= :database_indexed true]]}))))
+          (testing "Base: Other columns have no index"
+            (let [other-fields (t2/select :model/Field
+                                          {:where [:and
+                                                   [:in :table_id (t2/select-fn-vec :id :model/Table :db_id (mt/id))]
+                                                   [:!= :display_name "ID"]]})]
+              (is (every? (comp (complement true?) :database_indexed) other-fields))
+              (is (= 3 (count other-fields)))))
+          (testing "All indexed fields picked up by sync (first, second, third)"
+            (doseq [field ["first" "second" "third"]
+                    :let [sql (sql.tx/create-index-sql driver/*driver* "first_table" [field])]]
+              (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db)) sql))
+            (binding [sync.indexes/*update-partition-size* 2]
+              (#'sync.indexes/sync-all-indexes! (mt/db)))
+            (is (every? :database_indexed
+                        (t2/select :model/Field
+                                   {:where [:in :table_id (t2/select-fn-vec :id :model/Table :db_id (mt/id))]}))))
+          (testing "Index removal is picked up correctly"
+            (doseq [field ["first" "second" "third"]
+                    :let [sql (format "DROP INDEX \"idx_first_table_%s\";" field)]]
+              (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db)) sql))
+            (binding [sync.indexes/*update-partition-size* 2]
+              (#'sync.indexes/sync-all-indexes! (mt/db)))
+            (is (every? (complement :database_indexed)
+                        (t2/select :model/Field
+                                   {:where [:and
+                                            [:in :table_id (t2/select-fn-vec :id :model/Table :db_id (mt/id))]
+                                            [:!= :display_name "ID"]]}))))
+          (finally
+            (t2/delete! :model/Database (mt/id))
+            (u/ignore-exceptions
+              (tx/destroy-db! driver/*driver* ds-to-index-def))))))))


### PR DESCRIPTION
This is another PR from series of log enhancements, following the https://github.com/metabase/metabase/pull/55658. It modifies logging of `sync-all-indexes!` to avoid flooding in exceptionally large instances and (2) contains speculative fix for OOM. For details on the OOM and flooding see [my notes](https://www.notion.so/metabase/OOM-Analysis-1c269354c901807c99ace271f4855d7a) on OOM analysis.

---

For the reviewer: This PR changes the index sync behavior a bit. Namely, previously all fields were updated, now only fields for which which index was modified are updated. As a result the fields that never had an index have `:database_index` nil. I was unable to come up with case where this behavior could be harmful.

---

I've attempted to add same logging for non `:describe-indexes` drivers code path. That results in many tests failing. If that turns out necessary it will be done in follow-up.