### PR TITLE
test: add test to a flaky group

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -408,10 +408,14 @@ describe("issue 52806", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)", () => {
-    H.visitQuestionAdhoc(questionDetails);
-    cy.findByTestId("main-logo-link").click();
-    H.modal().button("Discard changes").click();
-    cy.location().should((location) => expect(location.search).to.eq(""));
-  });
+  it(
+    "should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)",
+    { tags: "@flaky" },
+    () => {
+      H.visitQuestionAdhoc(questionDetails);
+      cy.findByTestId("main-logo-link").click();
+      H.modal().button("Discard changes").click();
+      cy.location().should((location) => expect(location.search).to.eq(""));
+    },
+  );
 });


### PR DESCRIPTION
`e2e/test/scenarios/native/native-reproductions.cy.spec.ts`

`should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)`

<img width="1590" alt="image" src="https://github.com/user-attachments/assets/76817467-0c2f-4c75-a428-4fe53a489518" />

Original test was backported, so this one too
