### PR TITLE
force <DefaultLogoIcon />  on welcome page

### DIFF
--- a/frontend/src/metabase/components/LogoIcon/LogoIcon.jsx
+++ b/frontend/src/metabase/components/LogoIcon/LogoIcon.jsx
@@ -5,7 +5,7 @@ import { Component } from "react";
 import CS from "metabase/css/core/index.css";
 import { PLUGIN_LOGO_ICON_COMPONENTS } from "metabase/plugins";
 
-class DefaultLogoIcon extends Component {
+export class DefaultLogoIcon extends Component {
   static defaultProps = {
     height: 32,
   };

--- a/frontend/src/metabase/components/LogoIcon/index.jsx
+++ b/frontend/src/metabase/components/LogoIcon/index.jsx
@@ -1,1 +1,2 @@
+export * from "./LogoIcon";
 export { default } from "./LogoIcon";

--- a/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.styled.tsx
+++ b/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.styled.tsx
@@ -23,6 +23,7 @@ export const PageMain = styled.main`
 export const PageTitle = styled.h1`
   color: var(--mb-color-brand);
   font-size: 2.2rem;
+  margin-top: 1.5rem;
 `;
 
 export const PageBody = styled.div`

--- a/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
+++ b/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useTimeout } from "react-use";
 import { t } from "ttag";
 
-import LogoIcon from "metabase/components/LogoIcon";
+import { DefaultLogoIcon } from "metabase/components/LogoIcon";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 
 import { goToNextStep, loadDefaults } from "../../actions";
@@ -38,7 +38,7 @@ export const WelcomePage = (): JSX.Element | null => {
   return (
     <PageRoot data-testid="welcome-page">
       <PageMain>
-        <LogoIcon height={118} />
+        <DefaultLogoIcon height={118} />
         <PageTitle>{t`Welcome to Metabase`}</PageTitle>
         <PageBody>
           {t`Looks like everything is working.`}{" "}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41687

### Description
In a specific scenario, when going through the setup process while a premium token is present, Our logo icon can be swapped with one designed to accommodate whitelabelling. This PR forces the icon on the Welcome page to be the Default Metabase logo, rather than the one found in the enterprise plugins.

Also, this adds a small amout of space between the icon and the welcome text

### How to verify
1. Start a fresh enterprise instance with the premium token specified via MB_PREMIUM_EMBEDDING_TOKEN
2. Verify that the logo is full size on the welcome page

### Demo
![image](https://github.com/user-attachments/assets/0080ae22-355a-4a8a-b2d9-bed918b90d25)

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~

_I'm honestly not sure how to add a test to this. I spent a bit of time seeing if I could setup this scenario in e2e, but didn't have any real luck. Open to ideas though!_
