### PR TITLE
Fix coercion for model

### DIFF
--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -74,7 +74,13 @@
          (or (and not-multiply-bracketed?
                   (some-> (lib.util.match/match-one field-ref :field)
                           (mbql.u/update-field-options dissoc :binning :temporal-unit)
-                          (cond-> coercion-strategy (mbql.u/assoc-field-options :qp/ignore-coercion true))))
+                          (cond->
+                           (or coercion-strategy
+                               (and (pos-int? field-id)
+                                    (some-> (qp.store/metadata-provider)
+                                            (lib.metadata/field field-id)
+                                            :coercion-strategy)))
+                            (mbql.u/assoc-field-options :qp/ignore-coercion true))))
              ;; otherwise construct a field reference that can be used to refer to this Field.
              ;; Force string id field if expression contains just field. See issue #28451.
              (if (and (not= ref-type :expression)

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -2,12 +2,15 @@
   (:require
    [clojure.test :refer :all]
    [metabase.legacy-mbql.util :as mbql.u]
+   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.add-implicit-clauses :as qp.add-implicit-clauses]
    [metabase.query-processor.middleware.add-source-metadata :as add-source-metadata]
    [metabase.query-processor.preprocess :as qp.preprocess]
@@ -319,3 +322,22 @@
                          :limit        5})
                       mt/rows
                       (mapv (comp int second))))))))))
+
+(deftest changed-coercion-of-models-unerlying-data-test
+  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+        query (lib/query mp (lib.metadata/table mp (mt/id :venues)))]
+    (mt/with-temp
+      [:model/Card
+       card
+       {:type :model
+        :dataset_query (lib.convert/->legacy-MBQL query)}]
+      (qp.store/with-metadata-provider
+        (lib.tu/merged-mock-metadata-provider
+         mp
+         {:fields [{:id (mt/id :venues :price)
+                    :coercion-strategy :Coercion/UNIXSeconds->DateTime
+                    :effective-type :type/Instant}]})
+        ;; It is irrelevant which provider is used to get card and create query. Important is that one used in qp,
+        ;; by means of `with-metdata-provider`, contains the coercion.
+        (is (=? {:status :completed}
+                (qp/process-query (lib/query mp (lib.metadata/card mp (:id card))))))))))

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -217,7 +217,8 @@
           (is (=? (lib.tu.macros/$ids [$venues.id
                                        (mbql.u/update-field-options field-ref dissoc :temporal-unit)
                                        $venues.category-id->categories.name])
-                  (get-in (qp.add-implicit-clauses/add-implicit-clauses query)
+                  (get-in (qp.store/with-metadata-provider meta/metadata-provider
+                            (qp.add-implicit-clauses/add-implicit-clauses query))
                           [:query :fields]))))))))
 
 (deftest ^:parallel add-correct-implicit-fields-for-deeply-nested-source-queries-test


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #53202
Closes https://linear.app/metabase/issue/SEM-15/error-using-cast-to-unix-seconds-on-a-field

### Description

Update to coercion strategy of field from csv upload makes the model that is generated on upload unusable.

The results_metadata are missing the coercion strategy.

In general, we should consider finding a way of updating all dependent cards results_metadata when coercion changes.

Until then, this change fixes the problem for numeric id fields, which I encountered during reproduction attempt.

The issue can be reproduced without csv upload, just using model.

### How to verify

See the new test.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
