### PR TITLE
test: another attempt to fix dashboard flaky test

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1264,6 +1264,12 @@ describe("scenarios > dashboard", () => {
         assertPreventLeave();
         H.saveDashboard();
 
+        cy.findByRole("tab", { name: "Copy of Tab 1" }).should(
+          "have.attr",
+          "aria-selected",
+          "true",
+        );
+
         // remove tab
         H.editDashboard();
         H.deleteTab("Copy of Tab 1");
@@ -1271,7 +1277,7 @@ describe("scenarios > dashboard", () => {
         // can be a side effect
         cy.url().should("include", "tab-1");
         assertPreventLeave();
-        H.saveDashboard();
+        H.saveDashboard({ waitMs: 100 });
 
         // rename tab
         H.editDashboard();


### PR DESCRIPTION
we had another failure https://github.com/metabase/metabase/actions/runs/14115454596/job/39547424242

it failed on a new line, almost in the end, so let's add a small timeout after a save

✅ [stress test](https://github.com/metabase/metabase/actions/runs/14116952481/job/39549333433)