### PR TITLE
prevent text wrapping from being applied to links

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -249,7 +249,7 @@ class Table extends Component<TableProps, TableState> {
     if (isString(column)) {
       const canWrapText = (columnSettings: OptionsType) => {
         return (
-          columnSettings["view_as"] === null ||
+          columnSettings["view_as"] == null ||
           columnSettings["view_as"] === "auto"
         );
       };
@@ -259,6 +259,9 @@ class Table extends Component<TableProps, TableState> {
         default: false,
         widget: "toggle",
         inline: true,
+        isValid: (_column, columnSettings) => {
+          return canWrapText(columnSettings);
+        },
         getHidden: (_column, columnSettings) => {
           return !canWrapText(columnSettings);
         },

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.unit.spec.js
@@ -245,6 +245,17 @@ describe("text_wrapping", () => {
       expect(isHidden).toBe(true);
     });
 
+    it("should be not valid when view_as is not null or auto (metabase#55881)", () => {
+      const stringColumn = createMockStringColumn();
+      const settings = Table.columnSettings(stringColumn);
+
+      const isValid = settings["text_wrapping"].isValid(stringColumn, {
+        view_as: "link",
+      });
+
+      expect(isValid).toBe(false);
+    });
+
     it("should be visible when view_as is null", () => {
       const stringColumn = createMockStringColumn();
       const settings = Table.columnSettings(stringColumn);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55881

### Description

The text wrapping option has been hidden for "link" formatting, but if users enabled wrapping and then switched to link formatting, the table tried to apply it which messed up the layout due to the way links are rendered. When doing the project we decided to apply wrapping to columns with text formatting.

### How to verify

- New Question -> Reviews table
- Enable wrapping on the `Body` column
- Switch its "Display as" to link
- Ensure the table layout is corrent and no text wrapping is applied

### Demo

https://github.com/user-attachments/assets/fb3f82cf-a3f2-49fe-bb89-5a521e381618

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
