### PR TITLE
Add job context for all quartz jobs

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -275,6 +275,7 @@
    compojure.core/context                             {:message "Use metabase.api.util.handlers/route-map-handler instead of compojure.core/context, it is much faster and supports OpenAPI spec generation"}
    compojure.core/defroutes                           {:message "Use metabase.api.util.handlers/defroutes instead of compojure.core/routes, it supports OpenAPI spec generation."}
    compojure.core/routes                              {:message "Use metabase.api.util.handlers/routes instead of compojure.core/routes, it supports OpenAPI spec generation."}
+   clojurewerkz.quartzite.jobs/defjob                 {:message "Use metabase.task/defjob instead of clojurewerkz.quartzite.jobs/defjob"}
    fipp.edn/pprint                                    {:message "Use metabase.util.log instead of fipp.edn/pprint"}
    honeysql.core/call                                 {:message "Use hx/call instead because it is Honey SQL 2 friendly"}
    honeysql.core/raw                                  {:message "Use hx/raw instead because it is Honey SQL 2 friendly"}
@@ -300,7 +301,7 @@
    honeysql.types         {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
    honeysql.util          {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}}
 
-  :discouraged-tag {p {:message "You can use it, but don't commit it." }}
+  :discouraged-tag {p {:message "You can use it, but don't commit it."}}
 
   :unresolved-var
   {:exclude
@@ -570,6 +571,7 @@
   metabase.sso.ldap/with-ldap-connection                                                clojure.core/fn
   metabase.sync.util/sum-for                                                            clojure.core/for
   metabase.sync.util/with-emoji-progress-bar                                            clojure.core/let
+  metabase.task/defjob                                                                  clojure.core/defn
   metabase.test.data.interface/defdataset                                               clojure.core/def
   metabase.test.data.interface/defdataset-edn                                           clojure.core/def
   metabase.test/defdataset                                                              clojure.core/def

--- a/enterprise/backend/src/metabase_enterprise/task/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/cache.clj
@@ -298,7 +298,7 @@
      :schedule-refreshed   schedule-refresh-count
      :duration-refreshed   duration-refresh-count}))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+(task/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc                                   "Refresh 'schedule' caches"}
   Cache [_ctx]
   (refresh-cache-configs!))

--- a/src/metabase/indexed_entities/task/index_values.clj
+++ b/src/metabase/indexed_entities/task/index_values.clj
@@ -49,7 +49,7 @@
           (t2/delete! :model/ModelIndex model-index-id)))
       (model-index/add-values! model-index))))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+(task/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Refresh model indexed columns"}
   ModelIndexRefresh [job-context]
   (let [{:strs [model-index-id]} (qc/from-job-data job-context)]

--- a/src/metabase/lib_be/task/backfill_entity_ids.clj
+++ b/src/metabase/lib_be/task/backfill_entity_ids.clj
@@ -152,7 +152,7 @@
       (when-let [new-model (next-model model)]
         (start-job! new-model)))))
 
-(jobs/defjob  ^{:doc "Adds entity-ids to databases/tables/fields that are missing them."}
+(task/defjob  ^{:doc "Adds entity-ids to databases/tables/fields that are missing them."}
   BackfillEntityIds [ctx]
   (backfill-entity-ids! ctx))
 

--- a/src/metabase/model_persistence/task/persist_refresh.clj
+++ b/src/metabase/model_persistence/task/persist_refresh.clj
@@ -240,12 +240,12 @@
   [_job-context]
   (prune-all-deletable! dispatching-refresher))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+(task/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Refresh persisted tables job"}
   PersistenceRefresh [job-context]
   (refresh-job-fn! job-context))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+(task/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Remove deletable persisted tables"}
   PersistencePrune [job-context]
   (prune-job-fn! job-context))

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -151,7 +151,7 @@
         (log/infof "Updating timezone of trigger %s to %s. Was: %s" trigger-key new-timezone (:timezone trigger))
         (task/reschedule-trigger! (build-trigger subscription-id (get subscription-id->cron subscription-id)))))))
 
-(jobs/defjob ^{:doc "Triggers that send a notification for a subscription."}
+(task/defjob ^{:doc "Triggers that send a notification for a subscription."}
   SendNotification
   [context]
   (let [{:strs [subscription-id]} (qc/from-job-data context)]
@@ -175,7 +175,7 @@
     (doseq [subscription-id to-create]
       (create-new-trigger! (get subscription-id->subscription subscription-id)))))
 
-(jobs/defjob
+(task/defjob
   ^{:doc
     "Find all notification subscriptions with cron schedules and create a trigger for each.
     Run once on startup."

--- a/src/metabase/pulse/task/email_remove_legacy_pulse.clj
+++ b/src/metabase/pulse/task/email_remove_legacy_pulse.clj
@@ -31,7 +31,7 @@
                                                                 :pulses      legacy-pulse
                                                                 :instanceURL (urls/site-url)})})))))
 
-(jobs/defjob ^{:doc "Send email to admins and warn about removal of Pulse in 49, This job will only run once."}
+(task/defjob ^{:doc "Send email to admins and warn about removal of Pulse in 49, This job will only run once."}
   EmailRemoveLegacyPulse [_ctx]
   (email-remove-legacy-pulse))
 

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -145,7 +145,7 @@
         (log/infof "Updating timezone of trigger %s to %s. Was: %s" trigger-key new-timezone (:timezone trigger))
         (task/reschedule-trigger! (send-pulse-trigger pulse-id schedule-map channel-ids new-timezone (:priority trigger)))))))
 
-(jobs/defjob ^{:doc "Triggers that send a pulse to a list of channels at a specific time"}
+(task/defjob ^{:doc "Triggers that send a pulse to a list of channels at a specific time"}
   SendPulse
   [context]
   (let [{:strs [pulse-id channel-ids]} (qc/from-job-data context)]
@@ -226,7 +226,7 @@
         (task/delete-trigger! trigger-key)
         (task/add-trigger! (send-pulse-trigger pulse-id schedule-map new-pc-ids (send-trigger-timezone)))))))
 
-(jobs/defjob
+(task/defjob
   ^{:doc
     "Find all active Dashboard Subscriptino channels, group them by pulse-id and schedule time and create a trigger for each.
     Do this every startup to make sure all active pulse channels are triggered correctly."

--- a/src/metabase/query_analysis/task/analyze_queries.clj
+++ b/src/metabase/query_analysis/task/analyze_queries.clj
@@ -76,7 +76,7 @@
   ([stop-after queue timeout]
    (analyzer-loop* stop-after (partial query-analysis/next-card-or-id! queue timeout))))
 
-(jobs/defjob ^{DisallowConcurrentExecution true
+(task/defjob ^{DisallowConcurrentExecution true
                :doc                        "Analyze "}
   QueryAnalyzer [_ctx]
   (analyzer-loop!))

--- a/src/metabase/query_analysis/task/sweep_query_analysis.clj
+++ b/src/metabase/query_analysis/task/sweep_query_analysis.clj
@@ -89,7 +89,7 @@
    (log/info "Deleting analysis for archived cards")
    (log/infof "Deleted analysis for %s cards" (delete-orphan-analysis!))))
 
-(jobs/defjob ^{DisallowConcurrentExecution true
+(task/defjob ^{DisallowConcurrentExecution true
                :doc                        "Backfill QueryField for cards created earlier. Runs once per instance."}
   SweepQueryAnalysis [_ctx]
   (when (public-settings/query-analysis-enabled)

--- a/src/metabase/search/task/search_index.clj
+++ b/src/metabase/search/task/search_index.clj
@@ -89,16 +89,16 @@
             (analytics/inc! :metabase-search/index-error)
             (throw e)))))))
 
-(jobs/defjob ^{:doc "Ensure a Search Index exists"}
+(task/defjob ^{:doc "Ensure a Search Index exists"}
   SearchIndexInit [_ctx]
   (init!))
 
-(jobs/defjob ^{DisallowConcurrentExecution true
+(task/defjob ^{DisallowConcurrentExecution true
                :doc                        "Populate a new Search Index"}
   SearchIndexReindex [_ctx]
   (reindex!))
 
-(jobs/defjob ^{:doc                        "Keep Search Index updated"}
+(task/defjob ^{:doc                        "Keep Search Index updated"}
   SearchIndexUpdate [ctx]
   (update-index! ctx))
 

--- a/src/metabase/session/task/session_cleanup.clj
+++ b/src/metabase/session/task/session_cleanup.clj
@@ -11,7 +11,7 @@
 (def ^:private session-cleanup-job-key (jobs/key "metabase.task.session-cleanup.job"))
 (def ^:private session-cleanup-trigger-key (triggers/key "metabase.task.session-cleanup.trigger"))
 
-(jobs/defjob ^{:doc "Job that cleans up outdated sessions."}
+(task/defjob ^{:doc "Job that cleans up outdated sessions."}
   SessionCleanup
   [_]
   (session/cleanup-sessions!))

--- a/src/metabase/sync/task/sync_databases.clj
+++ b/src/metabase/sync/task/sync_databases.clj
@@ -107,7 +107,7 @@
           ;; if a previous run is already running, this is a noop
           (task/init! :metabase.lib-be.task.backfill-entity-ids/BackfillEntityIds)))))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+(task/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Sync and analyze the database"}
   SyncAndAnalyzeDatabase [job-context]
   (sync-and-analyze-database! job-context))
@@ -125,7 +125,7 @@
         (sync.field-values/update-field-values! database)
         (log/infof "Skipping update, automatic Field value updates are disabled for Database %d." database-id)))))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+(task/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Update field values"}
   UpdateFieldValues [job-context]
   (update-field-values! job-context))

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -18,6 +18,7 @@
   Find the JavaDoc for Quartz here: http://www.quartz-scheduler.org/api/2.3.0/index.html"
   (:require
    [clojure.string :as str]
+   [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.scheduler :as qs]
    [environ.core :as env]
    [metabase.db :as mdb]
@@ -329,11 +330,10 @@
          (log/error e# msg#)
          (throw (JobExecutionException. msg# e# true))))))
 
+#_{:clj-kondo/ignore [:discouraged-var]}
 (defmacro defjob
   "Like `clojurewerkz.quartzite.task/defjob` but with a log context."
   [jtype args & body]
-  `(defrecord ~jtype []
-     org.quartz.Job
-     (execute [this# ~@args]
-       (log/with-context {:quartz-job-type (quote ~jtype)}
-         ~@body))))
+  `(jobs/defjob ~jtype ~args
+     (log/with-context {:quartz-job-type (quote ~jtype)}
+       ~@body)))

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -328,3 +328,12 @@
        (catch Exception e#
          (log/error e# msg#)
          (throw (JobExecutionException. msg# e# true))))))
+
+(defmacro defjob
+  "Like `clojurewerkz.quartzite.task/defjob` but with a log context."
+  [jtype args & body]
+  `(defrecord ~jtype []
+     org.quartz.Job
+     (execute [this# ~@args]
+       (log/with-context {:quartz-job-type (quote ~jtype)}
+         ~@body))))

--- a/src/metabase/task/QUARTZ.md
+++ b/src/metabase/task/QUARTZ.md
@@ -36,7 +36,7 @@ These tasks execute once when Metabase starts up. They're useful for initializat
 (def startup-job-key     (jobs/key "my.startup.task.job"))
 (def startup-trigger-key (triggers/key "my.startup.task.trigger"))
 
-(jobs/defjob StartupTask [_]
+(task/defjob StartupTask [_]
   (println "Running startup initialization task"))
 
 (defmethod task/init! ::StartupTask [_]  
@@ -59,7 +59,7 @@ These tasks run on a recurring schedule defined by a cron expression.
 (def daily-job-key     (jobs/key "my.scheduled.daily.task.job"))
 (def daily-trigger-key (triggers/key "my.scheduled.daily.task.trigger"))
 
-(jobs/defjob DailyTask [_]
+(task/defjob DailyTask [_]
   (println "Running daily scheduled task"))
 
 (defmethod task/init! ::DailyTask [_]
@@ -105,7 +105,7 @@ You can pass data to jobs using the job data map:
 Inside the job, you can access this data:
 
 ```clojure
-(jobs/defjob MyJob [job-context]
+(task/defjob MyJob [job-context]
   (let [data-map (qc/from-job-data job-context)
         db-id (get data-map "db-id")]
     ;; Use the data...
@@ -129,7 +129,7 @@ Choose the appropriate misfire handling based on your task's requirements.
 By default, Quartz allows multiple instances of the same job to run concurrently. To prevent concurrent execution of a job, use the `DisallowConcurrentExecution` annotation:
 
 ```clojure
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true} MyNonConcurrentJob [job-context]
+(task/defjob ^{org.quartz.DisallowConcurrentExecution true} MyNonConcurrentJob [job-context]
   (println "This job will not run concurrently with itself"))
 ```
 
@@ -143,7 +143,7 @@ This is particularly important for long-running tasks that:
 Metabase provides a `rerun-on-error` macro to automatically retry a job if it fails with an exception:
 
 ```clojure
-(jobs/defjob MyJob [job-context]
+(task/defjob MyJob [job-context]
   (task/rerun-on-error job-context
     ;; Your job code here
     (do-something-that-might-fail)))

--- a/src/metabase/task/creator_sentiment_emails.clj
+++ b/src/metabase/task/creator_sentiment_emails.clj
@@ -102,7 +102,7 @@
           (catch Throwable e
             (log/error e "Problem sending creator sentiment email:")))))))
 
-(jobs/defjob ^{:doc "Sends out a monthly survey to a portion of the creators."} CreatorSentimentEmail [_]
+(task/defjob ^{:doc "Sends out a monthly survey to a portion of the creators."} CreatorSentimentEmail [_]
   (let [current-week (.get (t/local-date) (.weekOfWeekBasedYear (WeekFields/of (Locale/getDefault))))]
     (send-creator-sentiment-emails! current-week)))
 

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -51,7 +51,7 @@
   ^java.time.temporal.Temporal []
   (t2/select-one-fn :date_joined :model/User, {:order-by [[:date_joined :asc]]}))
 
-(jobs/defjob ^{:doc "Sends out a general 2 week email follow up email"} FollowUpEmail [_]
+(task/defjob ^{:doc "Sends out a general 2 week email follow up email"} FollowUpEmail [_]
   ;; if we've already sent the follow-up email then we are done
   (when-not (follow-up-email-sent)
     ;; figure out when we consider the instance created

--- a/src/metabase/task/refresh_slack_channel_user_cache.clj
+++ b/src/metabase/task/refresh_slack_channel_user_cache.clj
@@ -25,9 +25,9 @@
 (def ^:private startup-job-key "metabase.task.on-startup-refresh-channel-cache.job")
 (def ^:private startup-trigger-key "metabase.task.on-startup-refresh-channel-cache.trigger")
 
-(jobs/defjob ^{:doc "General slack cache refresh job"} RefreshCache [_] (job))
+(task/defjob ^{:doc "General slack cache refresh job"} RefreshCache [_] (job))
 
-(jobs/defjob ^{:doc "Startup cache refresh, with cleanup on failure."} RefreshCacheOnStartup [_]
+(task/defjob ^{:doc "Startup cache refresh, with cleanup on failure."} RefreshCacheOnStartup [_]
   (try (job)
        (finally
          (task/delete-task! (jobs/key startup-job-key)

--- a/src/metabase/task/send_anonymous_stats.clj
+++ b/src/metabase/task/send_anonymous_stats.clj
@@ -11,7 +11,7 @@
 
 (set! *warn-on-reflection* true)
 
-(jobs/defjob ^{:doc "If we can collect usage data, do so and send it home"} SendAnonymousUsageStats [_]
+(task/defjob ^{:doc "If we can collect usage data, do so and send it home"} SendAnonymousUsageStats [_]
   (when (public-settings/anon-tracking-enabled)
     (log/debug "Sending anonymous usage stats.")
     (try

--- a/src/metabase/task/task_history_cleanup.clj
+++ b/src/metabase/task/task_history_cleanup.clj
@@ -24,7 +24,7 @@
          "Task history cleanup successful, rows were deleted"
          "Task history cleanup successful, no rows were deleted")))))
 
-(jobs/defjob
+(task/defjob
   ^{:doc "Delete older TaskHistory rows -- see docstring of `task-history/cleanup-task-history!` for more details."}
   TaskHistoryCleanup [_]
   (task-history-cleanup!))

--- a/src/metabase/task/truncate_audit_tables.clj
+++ b/src/metabase/task/truncate_audit_tables.clj
@@ -132,7 +132,7 @@ If set to 0, Metabase will keep all rows.")
        (truncate-table! model timestamp-col)))
    (audit-models-to-truncate)))
 
-(jobs/defjob ^{:doc "Triggers the removal of `query_execution` rows older than the configured threshold."} TruncateAuditTables [_]
+(task/defjob ^{:doc "Triggers the removal of `query_execution` rows older than the configured threshold."} TruncateAuditTables [_]
   (truncate-audit-tables!))
 
 (def ^:private truncate-audit-tables-job-key "metabase.task.truncate-audit-tables.job")

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -31,7 +31,7 @@
       (throw (Exception. (format "[%d]: %s" status body))))
     (json/decode+kw body)))
 
-(jobs/defjob ^{:doc "Simple job which looks up all databases and runs a sync on them"} CheckForNewVersions [_]
+(task/defjob ^{:doc "Simple job which looks up all databases and runs a sync on them"} CheckForNewVersions [_]
   (when (public-settings/check-for-updates)
     (log/debug "Checking for new Metabase version info.")
     (try

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -78,7 +78,7 @@
       (is (= (sort versions)
              versions)))))
 
-(jobs/defjob AbandonmentEmail [_] :default)
+(task/defjob AbandonmentEmail [_] :default)
 
 (defn- table-default [table]
   (letfn [(with-timestamped [props]

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -22,7 +22,7 @@
 
 ;; make sure we attempt to reschedule tasks so changes made in source are propogated to JDBC backend
 
-(jobs/defjob TestJob [_])
+(task/defjob TestJob [_])
 
 (defn- job ^JobDetail []
   (jobs/build


### PR DESCRIPTION
Replace `clojurewerkz.quartzite.jobs/defjob` with our custom defjob macro that's wrap the body with a job context log.