### PR TITLE
Change version for alert api change log from 53 to 54

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -4,7 +4,7 @@ title: API changelog
 
 # Breaking changes to the API interface
 
-## Metabase 0.53.0
+## Metabase 0.54.0
 
 - The alert system has been migrated from the legacy pulse infrastructure to the new notification system. This migration includes the following changes:
 


### PR DESCRIPTION
we shipped this in 54, not 53.