### PR TITLE
When randomize sync db schemas, avoid at 0th minute marks

### DIFF
--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -39,8 +39,8 @@
 (defn randomly-once-an-hour
   "Schedule map for once an hour at a random minute of the hour."
   []
-  ;; prevent zeros and 50s which would appear as non-random choices
-  (let [choices (into [] (remove #{0 50}) (range 60))]
+  ;; avoid around zero marks since it's busy time
+  (let [choices (range 5 50)]
     {:schedule_minute (rand-nth choices)
      :schedule_type   "hourly"}))
 

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -40,7 +40,7 @@
   "Schedule map for once an hour at a random minute of the hour."
   []
   ;; avoid around zero marks since it's busy time
-  (let [choices (range 5 50)]
+  (let [choices (range 5 55)]
     {:schedule_minute (rand-nth choices)
      :schedule_type   "hourly"}))
 

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -39,8 +39,8 @@
 (defn randomly-once-an-hour
   "Schedule map for once an hour at a random minute of the hour."
   []
-  ;; avoid around zero marks since it's busy time
-  (let [choices (range 5 55)]
+  ;; avoid around near the hour because it's usually when notifications are scheduled.
+  (let [choices (remove #{50} (range 5 55))]
     {:schedule_minute (rand-nth choices)
      :schedule_type   "hourly"}))
 
@@ -66,10 +66,3 @@
 (def default-metadata-sync-schedule-cron-strings
   "Default `:metadata_sync_schedule`s (two as application and db have different defaults)."
   #{"0 0 * * * ? *" "0 50 * * * ? *"})
-
-(defn scheduling
-  "Adds sync schedule defaults to a map of schedule-maps."
-  [{:keys [cache_field_values metadata_sync] :as _schedules}]
-  {:metadata_sync      (or metadata_sync (randomly-once-an-hour))
-   ;; cache_field_values is nullable
-   :cache_field_values cache_field_values})


### PR DESCRIPTION
This PR updates the cron schedule from running at the 0th minute of every hour to running at the 5th to 55th minute of every hour. This change helps avoid scheduling tasks during the 0th minute, which is typically a busy period.