### PR TITLE
[Notification] Improve memory usage for alerts

### DIFF
--- a/src/metabase/channel/email/result_attachment.clj
+++ b/src/metabase/channel/email/result_attachment.clj
@@ -88,8 +88,8 @@
     result :result
     :as part}]
   (when (pos-int? (:row_count result))
-    (let [realize-data-rows (requiring-resolve 'metabase.channel.shared/realize-data-rows)
-          result            (:result (realize-data-rows part))]
+    (let [maybe-realize-data-rows (requiring-resolve 'metabase.channel.shared/maybe-realize-data-rows)
+          result            (:result (maybe-realize-data-rows part))]
       (->>
        [(when-let [temp-file (and (:include_csv card)
                                   (create-temp-file-or-throw "csv"))]

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -72,7 +72,7 @@
   [timezone part options]
   (case (:type part)
     :card
-    (channel.render/render-pulse-section timezone (channel.shared/realize-data-rows part) options)
+    (channel.render/render-pulse-section timezone (channel.shared/maybe-realize-data-rows part) options)
 
     :text
     {:content (markdown/process-markdown (:text part) :html)}

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -88,7 +88,7 @@
 (mu/defmethod channel/render-notification [:channel/http :notification/card]
   [_channel-type {:keys [payload creator]} _template _recipients]
   (let [{:keys [card notification_card card_part]} payload
-        card_part                        (channel.shared/realize-data-rows card_part)
+        card_part                        (channel.shared/maybe-realize-data-rows card_part)
         request-body {:type               "alert"
                       ;; TODO: can we rename this???
                       :alert_id           (:id notification_card)

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -175,7 +175,7 @@
   "Returns a seq of slack attachment data structures, used in `create-and-upload-slack-attachments!`"
   [parts]
   (for [part  parts
-        :let  [attachment (part->attachment-data (channel.shared/realize-data-rows part))]
+        :let  [attachment (part->attachment-data (channel.shared/maybe-realize-data-rows part))]
         :when attachment]
     attachment))
 

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -50,22 +50,23 @@
 
 (defn- part->attachment-data
   [part]
-  (case (:type part)
-    :card
-    (let [{:keys [card dashcard result]}         part
-          {card-id :id card-name :name :as card} card]
-      {:title           (or (-> dashcard :visualization_settings :card.title)
-                            card-name)
-       :rendered-info   (channel.render/render-pulse-card :inline (channel.render/defaulted-timezone card) card dashcard result)
-       :title_link      (urls/card-url card-id)
-       :attachment-name "image.png"
-       :fallback        card-name})
+  (let [part (channel.shared/maybe-realize-data-rows part)]
+    (case (:type part)
+      :card
+      (let [{:keys [card dashcard result]}         part
+            {card-id :id card-name :name :as card} card]
+        {:title           (or (-> dashcard :visualization_settings :card.title)
+                              card-name)
+         :rendered-info   (channel.render/render-pulse-card :inline (channel.render/defaulted-timezone card) card dashcard result)
+         :title_link      (urls/card-url card-id)
+         :attachment-name "image.png"
+         :fallback        card-name})
 
-    :text
-    (text->markdown-block (:text part))
+      :text
+      (text->markdown-block (:text part))
 
-    :tab-title
-    (text->markdown-block (format "# %s" (:text part)))))
+      :tab-title
+      (text->markdown-block (format "# %s" (:text part))))))
 
 (def ^:private slack-width
   "Maximum width of the rendered PNG of HTML to be sent to Slack. Content that exceeds this width (e.g. a table with
@@ -175,7 +176,7 @@
   "Returns a seq of slack attachment data structures, used in `create-and-upload-slack-attachments!`"
   [parts]
   (for [part  parts
-        :let  [attachment (part->attachment-data (channel.shared/maybe-realize-data-rows part))]
+        :let  [attachment (part->attachment-data part)]
         :when attachment]
     attachment))
 

--- a/src/metabase/channel/shared.clj
+++ b/src/metabase/channel/shared.clj
@@ -28,7 +28,7 @@
     @x
     x))
 
-(defn realize-data-rows
+(defn maybe-realize-data-rows
   "Realize the data rows in a [[metabase.notification.payload.execute/Part]]"
   [part]
   (when part

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase.notification.models :as models.notification]
    [metabase.notification.payload.execute :as notification.payload.execute]
+   [metabase.notification.payload.temp-storage :as notification.payload.temp-storage]
    [metabase.public-settings :as public-settings]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -12,7 +13,10 @@
 (p/import-vars
  [notification.payload.execute
   execute-dashboard
-  process-virtual-dashcard])
+  process-virtual-dashcard]
+ [notification.payload.temp-storage
+  cleanup!
+  is-cleanable?])
 
 (mr/def ::Notification
   "Schema for the notification."

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -134,11 +134,16 @@
                                    tag-names)]
     (update-in dashcard [:visualization_settings :text] shared.params/substitute-tags tag->param (public-settings/site-locale) (escape-markdown-chars? dashcard))))
 
+(def ^{:private true
+       :doc     "If a query has more than the number of rows specified here, we store the data to disk instead of in memory."}
+  rows-to-disk-threadhold
+  1000)
+
 (defn- data-rows-to-disk!
   [qp-result]
-  (if (<= (:row_count qp-result) 1000)
+  (if (<= (:row_count qp-result) rows-to-disk-threadhold)
     (do
-      (log/debugf "Less than 1000 rows, skip storing %d rows to disk" (:row_count qp-result))
+      (log/debugf "Less than %d rows, skip storing %d rows to disk" rows-to-disk-threadhold (:row_count qp-result))
       qp-result)
     (do
       (log/debugf "Storing %d rows to disk" (:row_count qp-result))

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -136,8 +136,13 @@
 
 (defn- data-rows-to-disk!
   [qp-result]
-  (log/debugf "Storing %d rows to disk" (:row_count qp-result))
-  (update-in qp-result [:data :rows] notification.temp-storage/to-temp-file!))
+  (if (<= (:row_count qp-result) 1000)
+    (do
+      (log/debugf "Less than 1000 rows, skip storing %d rows to disk" (:row_count qp-result))
+      qp-result)
+    (do
+      (log/debugf "Storing %d rows to disk" (:row_count qp-result))
+      (update-in qp-result [:data :rows] notification.temp-storage/to-temp-file!))))
 
 (defn execute-dashboard-subscription-card
   "Returns subscription result for a card.
@@ -282,5 +287,5 @@
 
     (log/debugf "Result has %d rows" (:row_count result))
     {:card   (t2/select-one :model/Card card-id)
-     :result result
+     :result (data-rows-to-disk! result)
      :type   :card}))

--- a/src/metabase/notification/payload/impl/card.clj
+++ b/src/metabase/notification/payload/impl/card.clj
@@ -65,11 +65,11 @@
         (throw (IllegalArgumentException. error-text))))))
 
 (defmethod notification.send/do-after-notification-sent :notification/card
-  [{:keys [id creator_id handlers payload] :as notification-info} _notification-payload]
+  [{:keys [id creator_id handlers] :as notification-info} notification-payload]
   (when (-> notification-info :payload :send_once)
     (t2/update! :model/Notification (:id notification-info) {:active false}))
   (try
-    (let [rows (-> payload :result :data_rows)]
+    (let [rows (-> notification-payload :payload :card_part :result :data :rows)]
       (when (and rows (notification.payload/is-cleanable? rows))
         (notification.payload/cleanup! rows)))
     (catch Exception e

--- a/src/metabase/notification/payload/impl/card.clj
+++ b/src/metabase/notification/payload/impl/card.clj
@@ -69,9 +69,8 @@
   (when (-> notification-info :payload :send_once)
     (t2/update! :model/Notification (:id notification-info) {:active false}))
   (try
-    (let [rows (-> notification-payload :payload :card_part :result :data :rows)]
-      (when (and rows (notification.payload/is-cleanable? rows))
-        (notification.payload/cleanup! rows)))
+    (when-let [rows (-> notification-payload :payload :card_part :result :data :rows)]
+      (notification.payload/cleanup! rows))
     (catch Exception e
       (log/warn e "Error cleaning up temp files for notification" id)))
   (events/publish-event! :event/alert-send

--- a/src/metabase/notification/payload/impl/card.clj
+++ b/src/metabase/notification/payload/impl/card.clj
@@ -65,9 +65,15 @@
         (throw (IllegalArgumentException. error-text))))))
 
 (defmethod notification.send/do-after-notification-sent :notification/card
-  [{:keys [id creator_id handlers] :as notification-info} _notification-payload]
+  [{:keys [id creator_id handlers payload] :as notification-info} _notification-payload]
   (when (-> notification-info :payload :send_once)
     (t2/update! :model/Notification (:id notification-info) {:active false}))
+  (try
+    (let [rows (-> payload :result :data_rows)]
+      (when (and rows (notification.payload/is-cleanable? rows))
+        (notification.payload/cleanup! rows)))
+    (catch Exception e
+      (log/warn e "Error cleaning up temp files for notification" id)))
   (events/publish-event! :event/alert-send
                          {:id      id
                           :user-id creator_id

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -55,9 +55,7 @@
   [{:keys [id creator_id handlers] :as notification-info} notification-payload]
   ;; clean up all the temp files that we created for this notification
   (try
-    (run! #(let [rows (get-in % [:result :data :rows])]
-             (when (and rows (notification.payload/is-cleanable? rows))
-               (notification.payload/cleanup! rows)))
+    (run! #(when-let [rows (get-in % [:result :data :rows])] (notification.payload/cleanup! rows))
           (->> notification-payload :payload :dashboard_parts))
     (catch Exception e
       (log/warn e "Error cleaning up temp files for notification" id)))

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -5,7 +5,6 @@
    [metabase.models.params.shared :as shared.params]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.payload.execute :as notification.execute]
-   [metabase.notification.payload.temp-storage :as notification.temp-storage]
    [metabase.notification.send :as notification.send]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.log :as log]
@@ -56,8 +55,9 @@
   [{:keys [id creator_id handlers] :as notification-info} notification-payload]
   ;; clean up all the temp files that we created for this notification
   (try
-    (run! #(when-let [rows (get-in % [:result :data :rows])]
-             (notification.temp-storage/cleanup! rows))
+    (run! #(let [rows (get-in % [:result :data :rows])]
+             (when (and rows (notification.payload/is-cleanable? rows))
+               (notification.payload/cleanup! rows)))
           (->> notification-payload :payload :dashboard_parts))
     (catch Exception e
       (log/warn e "Error cleaning up temp files for notification" id)))

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -55,8 +55,7 @@
   [{:keys [id creator_id handlers] :as notification-info} notification-payload]
   ;; clean up all the temp files that we created for this notification
   (try
-    (run! #(when-let [rows (get-in % [:result :data :rows])] (notification.payload/cleanup! rows))
-          (->> notification-payload :payload :dashboard_parts))
+    (run! #(some-> % :result :data :rows notification.payload/cleanup!) (->> notification-payload :payload :dashboard_parts))
     (catch Exception e
       (log/warn e "Error cleaning up temp files for notification" id)))
   (events/publish-event! :event/subscription-send

--- a/src/metabase/notification/payload/temp_storage.clj
+++ b/src/metabase/notification/payload/temp_storage.clj
@@ -27,17 +27,31 @@
 
 (defn- temp-file
   []
-  (doto (File/createTempFile "notification-" ".npy" @temp-dir)
+  (doto (File/createTempFile "notification-" ".edn" @temp-dir)
     (.deleteOnExit)))
 
 (defn- write-to-file
   [^File file data]
-  (nippy/freeze-to-file file data))
+  (spit file data))
 
 (defn- read-from-file
   [^File file]
   (when (.exists file)
-    (nippy/thaw-from-file file)))
+    (slurp file)))
+
+#_(defn- temp-file
+    []
+    (doto (File/createTempFile "notification-" ".npy" @temp-dir)
+      (.deleteOnExit)))
+
+#_(defn- write-to-file
+    [^File file data]
+    (nippy/freeze-to-file file data))
+
+#_(defn- read-from-file
+    [^File file]
+    (when (.exists file)
+      (nippy/thaw-from-file file)))
 
 (.addShutdownHook
  (Runtime/getRuntime)
@@ -75,6 +89,11 @@
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                           Public APIs                                           ;;
 ;; ------------------------------------------------------------------------------------------------;;
+
+(defn is-cleanable?
+  "Returns true if x implements the Cleanable protocol"
+  [x]
+  (instance? Cleanable x))
 
 (defn to-temp-file!
   "Write data to a temporary file. Returns a TempFileStorage type that:

--- a/src/metabase/notification/payload/temp_storage.clj
+++ b/src/metabase/notification/payload/temp_storage.clj
@@ -4,6 +4,7 @@
   Currently used to store card's rows data when sending notification since it can be large and we don't want to keep it in memory."
   (:require
    [clojure.java.io :as io]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.random :as random]
    [taoensso.nippy :as nippy])
@@ -27,31 +28,17 @@
 
 (defn- temp-file
   []
-  (doto (File/createTempFile "notification-" ".edn" @temp-dir)
+  (doto (File/createTempFile "notification-" ".npy" @temp-dir)
     (.deleteOnExit)))
 
 (defn- write-to-file
   [^File file data]
-  (spit file data))
+  (nippy/freeze-to-file file data))
 
 (defn- read-from-file
   [^File file]
   (when (.exists file)
-    (slurp file)))
-
-#_(defn- temp-file
-    []
-    (doto (File/createTempFile "notification-" ".npy" @temp-dir)
-      (.deleteOnExit)))
-
-#_(defn- write-to-file
-    [^File file data]
-    (nippy/freeze-to-file file data))
-
-#_(defn- read-from-file
-    [^File file]
-    (when (.exists file)
-      (nippy/thaw-from-file file)))
+    (nippy/thaw-from-file file)))
 
 (.addShutdownHook
  (Runtime/getRuntime)

--- a/src/metabase/notification/payload/temp_storage.clj
+++ b/src/metabase/notification/payload/temp_storage.clj
@@ -4,7 +4,6 @@
   Currently used to store card's rows data when sending notification since it can be large and we don't want to keep it in memory."
   (:require
    [clojure.java.io :as io]
-   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.random :as random]
    [taoensso.nippy :as nippy])
@@ -48,6 +47,11 @@
 
 (defprotocol Cleanable
   (cleanup! [this] "Cleanup any resources associated with this object"))
+
+;; Add a default implementation that does nothing
+(extend-protocol Cleanable
+  Object
+  (cleanup! [_] nil))
 
 (deftype TempFileStorage [^File file]
   Cleanable

--- a/src/metabase/notification/payload/temp_storage.clj
+++ b/src/metabase/notification/payload/temp_storage.clj
@@ -80,7 +80,7 @@
 (defn is-cleanable?
   "Returns true if x implements the Cleanable protocol"
   [x]
-  (instance? Cleanable x))
+  (satisfies? Cleanable x))
 
 (defn to-temp-file!
   "Write data to a temporary file. Returns a TempFileStorage type that:

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -228,7 +228,7 @@
 (defn execute-dashboard
   [& args]
   (let [dashboard-result (apply notification.payload.execute/execute-dashboard args)]
-    (map channel.shared/realize-data-rows dashboard-result)))
+    (map channel.shared/maybe-realize-data-rows dashboard-result)))
 
 (deftest ^:parallel execute-dashboard-test
   (testing "it runs for each non-virtual card"
@@ -977,7 +977,7 @@
 
 (defn- result-attachment
   [part]
-  (let [{{{:keys [rows]} :data, :as result} :result} (channel.shared/realize-data-rows part)]
+  (let [{{{:keys [rows]} :data, :as result} :result} (channel.shared/maybe-realize-data-rows part)]
     (when (seq rows)
       [(let [^java.io.ByteArrayOutputStream baos (java.io.ByteArrayOutputStream.)]
          (with-open [os baos]

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -549,9 +549,8 @@
                     :fields
                     [{:type "mrkdwn", :text "*State*\nCA, NY, and NJ"}
                      {:type "mrkdwn", :text "*Quarter and Year*\nQ1, 2021"}]}
-                   {:type "section", :fields [{:type "mrkdwn",
-                                               :text
-                                               #"<https://testmb\.com/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\|\*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
+                   {:type "section", :fields [{:type "mrkdwn"
+                                               :text #"<https://testmb\.com/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\|\*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
 
                  {:title "Test card",
                   :rendered-info {:attachments false, :content true, :render/text true},
@@ -1183,6 +1182,54 @@
                                     {:card         card-id
                                      :creator_id   (mt/user->id :rasta)
                                      :dashboard    dashboard-id
-                                     :cahnnel-type :email}]
+                                     :channel-type :email}]
         (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id))
         (is (empty? (.listFiles ^java.io.File @@#'notification.temp-storage/temp-dir)))))))
+
+(deftest dashboard-with-rows-saved-to-disk-test
+  (testing "whether the rows of a dashboard saved to disk or in memory, all channels should work"
+    (doseq [limit [1 #_10]]
+      (with-redefs [notification.payload.execute/rows-to-disk-threadhold 5]
+        (testing (if (> limit @#'notification.payload.execute/rows-to-disk-threadhold)
+                   "dashboard has rows saved to disk"
+                   "dashboard has rows saved in memory")
+          (mt/with-temp [:model/Card          {card-id :id} {:name          pulse.test-util/card-name
+                                                             :dataset_query (mt/mbql-query orders {:limit limit})}
+                         :model/Dashboard     {dashboard-id :id} {:name "Aviary KPIs"}
+                         :model/DashboardCard _ {:dashboard_id dashboard-id
+                                                 :card_id      card-id}
+                         :model/Pulse         {pulse-id :id} {:name         "Pulse Name"
+                                                              :dashboard_id dashboard-id}
+                         :model/PulseCard     _ {:pulse_id          pulse-id
+                                                 :card_id           card-id
+                                                 :position          0}
+                         :model/PulseChannel  {pc-id :id} {:pulse_id     pulse-id
+                                                           :channel_type "email"}
+                         :model/PulseChannel  _           {:pulse_id     pulse-id
+                                                           :channel_type "slack"
+                                                           :details      {:channel "#general"}}
+                         :model/PulseChannelRecipient _ {:user_id          (pulse.test-util/rasta-id)
+                                                         :pulse_channel_id pc-id}]
+            (let [pulse-results (pulse.test-util/with-captured-channel-send-messages!
+                                  (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id)))]
+              ;; Test email channel
+              (is (= (rasta-dashsub-message
+                      {:message [{pulse.test-util/card-name true}
+                                 pulse.test-util/png-attachment]})
+                     (mt/summarize-multipart-single-email
+                      (first (:channel/email pulse-results))
+                      #"Test card")))
+
+              ;; Test slack channel
+              (is (=? {:channel-id "#general",
+                       :attachments
+                       [{:blocks
+                         [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
+                          {:type "section",
+                           :fields
+                           [{:type "mrkdwn"}]}]}
+                        {:title "Test card",
+                         :rendered-info {:attachments false, :content true},
+                         :attachment-name "image.png",
+                         :fallback "Test card"}]}
+                      (pulse.test-util/thunk->boolean (first (:channel/slack pulse-results))))))))))))

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -1170,11 +1170,12 @@
   (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:name "Aviary KPIs"
                                                           :description "How are the birds doing today?"}
                  :model/Card          {card-id :id} {:name pulse.test-util/card-name
-                                                     :dataset_query (mt/mbql-query orders {:limit 1})}]
+                                                     :dataset_query (mt/mbql-query orders {:limit 2})}]
     (with-redefs [notification.temp-storage/temp-dir (delay (let [dir (io/file (System/getProperty "java.io.tmpdir")
                                                                                (str "metabase-test" (random/random-name)))]
                                                               (.mkdirs dir)
                                                               dir))
+                  notification.payload.execute/rows-to-disk-threadhold 1
                   channel/send!                      (fn [& _args]
                                                        (testing "sanity check that there are files there to cleanup"
                                                          (is (not-empty (.listFiles ^java.io.File @@#'notification.temp-storage/temp-dir)))))]


### PR DESCRIPTION
Follow up of https://github.com/metabase/metabase/pull/51708.
Previously we save query result to memory for all cards of dashboard notification. In this PR we:
- do the same for alerts
- introduce a threshold (default: 1000) at which, if a query has less than this number of rows, we keep it memory, else we save the data to disk


## Benchmark

I used the same script from #51708 where we setup a dashboard subscription with lots of cards. All cards are just a query of a raw table from the sample datasets, each table has different rows size:
- Accounts: 2.5k
- Analytics events: 37k
- Feedback: 642
- Invoices: 13.8k 
- Orders: 18.7k
- Products: 200
- People: 2500
- Reviews: 1112


### Speed

For a dashboard with 100 cards:
- master: 8.7 seconds
- this branch: 8.4 seconds

I'd expect it to be a bit faster because lots more cards are saved in memory.


### Memory

OOM at:
- master 340 cards
- this branch: 350 cards

A bit counter intuitive because this branch changes it so that we keeps more stuff in memory.
But I think the improvement comes from the fact that when loading things back from disk, nippy actually increase the size.

![Screenshot 2025-03-28 at 19 25 46](https://github.com/user-attachments/assets/0a404024-0210-452d-8bc1-fa573bd519ba)