### PR TITLE
Don't show dashcard's info tooltip in edit mode

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -1,5 +1,8 @@
+import userEvent from "@testing-library/user-event";
+
 import {
   act,
+  getIcon,
   mockGetBoundingClientRect,
   queryIcon,
   renderWithProviders,
@@ -29,6 +32,7 @@ const testDashboard = createMockDashboard();
 const tableDashcard = createMockDashboardCard({
   card: createMockCard({
     name: "My Card",
+    description: "This is a table card",
     display: "table",
   }),
 });
@@ -132,6 +136,22 @@ describe("DashCard", () => {
     expect(screen.getByText("My Card")).toBeVisible();
   });
 
+  it("should show card's description in a tooltip", async () => {
+    setup();
+    expect(screen.queryByText("This is a table card")).not.toBeInTheDocument();
+    userEvent.hover(getIcon("info"));
+    expect(await screen.findByText("This is a table card")).toBeVisible();
+  });
+
+  it("should not show the info icon if a card doesn't have description", () => {
+    setup({
+      dashcard: createMockDashboardCard({
+        card: createMockCard({ description: null }),
+      }),
+    });
+    expect(queryIcon("info")).not.toBeInTheDocument();
+  });
+
   it("should show a table card", () => {
     setup();
     act(() => {
@@ -210,6 +230,11 @@ describe("DashCard", () => {
   });
 
   describe("edit mode", () => {
+    it("should not show the info icon", () => {
+      setup({ isEditing: true });
+      expect(queryIcon("info")).not.toBeInTheDocument();
+    });
+
     it("should show a 'replace card' action", async () => {
       setup({ isEditing: true });
       expect(screen.getByLabelText("Replace")).toBeInTheDocument();

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -16,6 +16,7 @@ interface ChartCaptionProps {
   settings: VisualizationSettings;
   icon?: IconProps | null;
   actionButtons?: ReactNode;
+  hasInfoTooltip?: boolean;
   width?: number;
   getHref?: () => string | undefined;
   onChangeCardAndRun?: OnChangeCardAndRun | null;
@@ -26,6 +27,7 @@ const ChartCaption = ({
   settings,
   icon,
   actionButtons,
+  hasInfoTooltip,
   onChangeCardAndRun,
   getHref,
   width,
@@ -50,6 +52,7 @@ const ChartCaption = ({
       getHref={getHref}
       icon={icon}
       actionButtons={actionButtons}
+      hasInfoTooltip={hasInfoTooltip}
       onSelectTitle={canSelectTitle ? handleSelectTitle : undefined}
       width={width}
     />

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -715,6 +715,7 @@ class Visualization extends PureComponent<
                 settings={settings}
                 icon={headerIcon}
                 actionButtons={extra}
+                hasInfoTooltip={!isDashboard || !isEditing}
                 width={width}
                 getHref={getHref}
                 onChangeCardAndRun={

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
@@ -37,6 +37,7 @@ interface LegendCaptionProps {
   getHref?: () => string | undefined;
   icon?: IconProps | null;
   actionButtons?: React.ReactNode;
+  hasInfoTooltip?: boolean;
   onSelectTitle?: () => void;
   width?: number;
 }
@@ -48,6 +49,7 @@ export const LegendCaption = ({
   getHref,
   icon,
   actionButtons,
+  hasInfoTooltip = true,
   onSelectTitle,
   width,
 }: LegendCaptionProps) => {
@@ -90,7 +92,7 @@ export const LegendCaption = ({
         <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>
       </LegendLabel>
       <LegendRightContent>
-        {description && !shouldHideDescription(width) && (
+        {hasInfoTooltip && description && !shouldHideDescription(width) && (
           <Tooltip
             label={
               <Markdown dark disallowHeading unstyleLinks lineClamp={8}>

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -49,6 +49,8 @@ function _CartesianChart(props: VisualizationProps) {
     showTitle,
     headerIcon,
     actionButtons,
+    isDashboard,
+    isEditing,
     isQueryBuilder,
     isFullscreen,
     hovered,
@@ -146,6 +148,7 @@ function _CartesianChart(props: VisualizationProps) {
           description={description}
           icon={headerIcon}
           actionButtons={actionButtons}
+          hasInfoTooltip={!isDashboard || !isEditing}
           getHref={canSelectTitle ? getHref : undefined}
           onSelectTitle={
             canSelectTitle ? () => onOpenQuestion(card.id) : undefined

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -212,6 +212,8 @@ export function Funnel(props: VisualizationProps) {
     rawSeries,
     fontFamily,
     getHref,
+    isDashboard,
+    isEditing,
   } = props;
   const hasTitle = showTitle && settings["card.title"];
 
@@ -242,6 +244,7 @@ export function Funnel(props: VisualizationProps) {
           icon={headerIcon}
           getHref={getHref}
           actionButtons={actionButtons}
+          hasInfoTooltip={!isDashboard || !isEditing}
           onChangeCardAndRun={onChangeCardAndRun}
         />
       )}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #46085
### Demo

**Before**

<img src="https://github.com/user-attachments/assets/e051750b-9919-4485-b148-e9a09a0d783a" width="520px" />


**After**

<img src="https://github.com/user-attachments/assets/52733ef5-ca0f-44b2-9f79-1a081e48abad" width="520px" />
