### PR TITLE
Improve log context for exceptions

### DIFF
--- a/src/metabase/server/middleware/exceptions.clj
+++ b/src/metabase/server/middleware/exceptions.clj
@@ -22,7 +22,7 @@
 (defmethod api-exception-response Throwable
   [^Throwable e]
   (let [{:keys [status-code], :as info} (ex-data e)
-        other-info                      (dissoc info :status-code :schema :type :toucan2/context-trace)
+        other-info                      (dissoc info :status-code :schema :type :toucan2/context-trace ::log/context)
         body                            (cond
                                           (and status-code (not= status-code 500) (empty? other-info))
                                           ;; If status code was specified (but not a 500 -- an unexpected error, and

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -30,7 +30,7 @@
                                                  ;; reversed to make inner context override outer context
                                                  (reverse (.getSuppressed t))))
                                        (keep #(when (= suppressed-exception-context-message (ex-message %))
-                                                (ex-data %))))]
+                                                (::context (ex-data %)))))]
     (into {} suppressed-exception-data)))
 
 ;;; --------------------------------------------- CLJ-side macro helpers ---------------------------------------------
@@ -278,11 +278,11 @@
 
 (defn- suppressed-exception
   [context-map]
-  (ex-info suppressed-exception-context-message context-map))
+  (ex-info suppressed-exception-context-message {::context context-map}))
 
 (defn- annotate-ex-info [e context-map]
   (let [new-e (copy-ex-info e
-                            (merge {} context-map (ex-data e))
+                            (assoc (ex-data e) ::context (merge {} context-map (::context (ex-data e))))
                             (ex-cause e))]
     (.addSuppressed new-e (suppressed-exception context-map))
     new-e))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -666,30 +666,30 @@
             (sync/sync-database! database)
             (mt/with-actions-enabled
               (testing "when creating"
-                (is (= {:type        :metabase.actions.error/violate-unique-constraint
-                        :message     "Column1 and Column2 already exist."
-                        :errors      {"column1" "This Column1 value already exists." "column2" "This Column2 value already exists."}
-                        :status-code 400}
-                       (sql-jdbc.actions-test/perform-action-ex-data
-                        :model.row/create (mt/$ids {:create-row {"id"      3
-                                                                 "column1" "A"
-                                                                 "column2" "A"}
-                                                    :database   (:id database)
-                                                    :query      {:source-table $$mytable}
-                                                    :type       :query})))))
+                (is (=? {:type        :metabase.actions.error/violate-unique-constraint
+                         :message     "Column1 and Column2 already exist."
+                         :errors      {"column1" "This Column1 value already exists." "column2" "This Column2 value already exists."}
+                         :status-code 400}
+                        (sql-jdbc.actions-test/perform-action-ex-data
+                         :model.row/create (mt/$ids {:create-row {"id"      3
+                                                                  "column1" "A"
+                                                                  "column2" "A"}
+                                                     :database   (:id database)
+                                                     :query      {:source-table $$mytable}
+                                                     :type       :query})))))
               (testing "when updating"
-                (is (= {:errors      {"column1" "This Column1 value already exists."
-                                      "column2" "This Column2 value already exists."}
-                        :message     "Column1 and Column2 already exist."
-                        :status-code 400
-                        :type        actions.error/violate-unique-constraint}
-                       (sql-jdbc.actions-test/perform-action-ex-data
-                        :model.row/update (mt/$ids {:update-row {"column1" "A"
-                                                                 "column2" "A"}
-                                                    :database   (:id database)
-                                                    :query      {:source-table $$mytable
-                                                                 :filter       [:= $mytable.id 2]}
-                                                    :type       :query}))))))))))))
+                (is (=? {:errors      {"column1" "This Column1 value already exists."
+                                       "column2" "This Column2 value already exists."}
+                         :message     "Column1 and Column2 already exist."
+                         :status-code 400
+                         :type        actions.error/violate-unique-constraint}
+                        (sql-jdbc.actions-test/perform-action-ex-data
+                         :model.row/update (mt/$ids {:update-row {"column1" "A"
+                                                                  "column2" "A"}
+                                                     :database   (:id database)
+                                                     :query      {:source-table $$mytable
+                                                                  :filter       [:= $mytable.id 2]}
+                                                     :type       :query}))))))))))))
 
 (deftest ^:parallel parse-grant-test
   (testing "`parse-grant` should work correctly"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1139,31 +1139,31 @@
             (sync/sync-database! database)
             (mt/with-actions-enabled
               (testing "when creating"
-                (is (= {:errors      {"column1" "This Column1 value already exists."
-                                      "column2" "This Column2 value already exists."}
-                        :message     "Column1 and Column2 already exist."
-                        :status-code 400
-                        :type        actions.error/violate-unique-constraint}
-                       (sql-jdbc.actions-test/perform-action-ex-data
-                        :model.row/create (mt/$ids {:create-row {"id"      3
-                                                                 "column1" "A"
-                                                                 "column2" "A"}
-                                                    :database   (:id database)
-                                                    :query      {:source-table $$mytable}
-                                                    :type       :query})))))
+                (is (=? {:errors      {"column1" "This Column1 value already exists."
+                                       "column2" "This Column2 value already exists."}
+                         :message     "Column1 and Column2 already exist."
+                         :status-code 400
+                         :type        actions.error/violate-unique-constraint}
+                        (sql-jdbc.actions-test/perform-action-ex-data
+                         :model.row/create (mt/$ids {:create-row {"id"      3
+                                                                  "column1" "A"
+                                                                  "column2" "A"}
+                                                     :database   (:id database)
+                                                     :query      {:source-table $$mytable}
+                                                     :type       :query})))))
               (testing "when updating"
-                (is (= {:errors      {"column1" "This Column1 value already exists."
-                                      "column2" "This Column2 value already exists."}
-                        :message     "Column1 and Column2 already exist."
-                        :status-code 400
-                        :type        actions.error/violate-unique-constraint}
-                       (sql-jdbc.actions-test/perform-action-ex-data
-                        :model.row/update (mt/$ids {:update-row {"column1" "A"
-                                                                 "column2" "A"}
-                                                    :database   (:id database)
-                                                    :query      {:source-table $$mytable
-                                                                 :filter       [:= $mytable.id 2]}
-                                                    :type       :query}))))))))))))
+                (is (=? {:errors      {"column1" "This Column1 value already exists."
+                                       "column2" "This Column2 value already exists."}
+                         :message     "Column1 and Column2 already exist."
+                         :status-code 400
+                         :type        actions.error/violate-unique-constraint}
+                        (sql-jdbc.actions-test/perform-action-ex-data
+                         :model.row/update (mt/$ids {:update-row {"column1" "A"
+                                                                  "column2" "A"}
+                                                     :database   (:id database)
+                                                     :query      {:source-table $$mytable
+                                                                  :filter       [:= $mytable.id 2]}
+                                                     :type       :query}))))))))))))
 
 ;;; ------------------------------------------------ Timezone-related ------------------------------------------------
 

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -108,73 +108,73 @@
   (test-action-error-handling!
    (fn [{:keys [db-id group-name]}]
      (testing "violate not-null constraint"
-       (is (= {:message     "Ranking must have values."
-               :errors      {"ranking" "You must provide a value."}
-               :type        actions.error/violate-not-null-constraint
-               :status-code 400}
-              (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name "admin"}
-                                                                  :database   db-id
-                                                                  :query      {:source-table $$group}
-                                                                  :type       :query}))))))))
+       (is (=? {:message     "Ranking must have values."
+                :errors      {"ranking" "You must provide a value."}
+                :type        actions.error/violate-not-null-constraint
+                :status-code 400}
+               (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name "admin"}
+                                                                   :database   db-id
+                                                                   :query      {:source-table $$group}
+                                                                   :type       :query}))))))))
 
 (deftest action-error-handling-not-null-constraint-creating-test-2
   (test-action-error-handling!
    (fn [{:keys [db-id group-name]}]
      (testing "violate not-null constraint"
        (testing "when creating"
-         (is (= {:message     "Ranking must have values."
-                 :errors      {"ranking" "You must provide a value."}
-                 :type        actions.error/violate-not-null-constraint
-                 :status-code 400}
-                (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name "admin"}
-                                                                    :database   db-id
-                                                                    :query      {:source-table $$group}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Ranking must have values."
+                  :errors      {"ranking" "You must provide a value."}
+                  :type        actions.error/violate-not-null-constraint
+                  :status-code 400}
+                 (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name "admin"}
+                                                                     :database   db-id
+                                                                     :query      {:source-table $$group}
+                                                                     :type       :query})))))))))
 
 (deftest action-error-handling-not-null-constraint-updating-test
   (test-action-error-handling!
    (fn [{:keys [db-id group-ranking]}]
      (testing "violate not-null constraint"
        (testing "when updating"
-         (is (= {:message     "Ranking must have values."
-                 :errors      {"ranking" "You must provide a value."}
-                 :type        actions.error/violate-not-null-constraint
-                 :status-code 400}
-                (perform-action-ex-data :model.row/update (mt/$ids {:update-row {group-ranking nil}
-                                                                    :database   db-id
-                                                                    :query      {:filter       [:= $group.id 1]
-                                                                                 :source-table $$group}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Ranking must have values."
+                  :errors      {"ranking" "You must provide a value."}
+                  :type        actions.error/violate-not-null-constraint
+                  :status-code 400}
+                 (perform-action-ex-data :model.row/update (mt/$ids {:update-row {group-ranking nil}
+                                                                     :database   db-id
+                                                                     :query      {:filter       [:= $group.id 1]
+                                                                                  :source-table $$group}
+                                                                     :type       :query})))))))))
 
 (deftest action-error-handling-unique-constraint-creating-test
   (test-action-error-handling!
    (fn [{:keys [db-id group-name group-ranking]}]
      (testing "violate unique constraint"
        (testing "when creating"
-         (is (= {:message     "Ranking already exists."
-                 :errors      {"ranking" "This Ranking value already exists."}
-                 :type        actions.error/violate-unique-constraint
-                 :status-code 400}
-                (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name    "new"
-                                                                                 group-ranking 1}
-                                                                    :database   db-id
-                                                                    :query      {:source-table $$group}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Ranking already exists."
+                  :errors      {"ranking" "This Ranking value already exists."}
+                  :type        actions.error/violate-unique-constraint
+                  :status-code 400}
+                 (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name    "new"
+                                                                                  group-ranking 1}
+                                                                     :database   db-id
+                                                                     :query      {:source-table $$group}
+                                                                     :type       :query})))))))))
 
 (deftest action-error-handling-unique-constraint-updating-test
   (test-action-error-handling!
    (fn [{:keys [db-id group-ranking]}]
      (testing "violate unique constraint"
        (testing "when updating"
-         (is (= {:message     "Ranking already exists."
-                 :errors      {"ranking" "This Ranking value already exists."}
-                 :type        actions.error/violate-unique-constraint
-                 :status-code 400}
-                (perform-action-ex-data :model.row/update (mt/$ids {:update-row {group-ranking 2}
-                                                                    :database   db-id
-                                                                    :query      {:filter [:= $group.id 1]
-                                                                                 :source-table $$group}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Ranking already exists."
+                  :errors      {"ranking" "This Ranking value already exists."}
+                  :type        actions.error/violate-unique-constraint
+                  :status-code 400}
+                 (perform-action-ex-data :model.row/update (mt/$ids {:update-row {group-ranking 2}
+                                                                     :database   db-id
+                                                                     :query      {:filter [:= $group.id 1]
+                                                                                  :source-table $$group}
+                                                                     :type       :query})))))))))
 
 (defmethod driver/database-supports? [::driver/driver ::action-error-handling-incorrect-type-error-message]
   [_driver _feature _database]
@@ -190,84 +190,84 @@
    (fn [{:keys [db-id group-name group-ranking]}]
      (testing "incorrect type"
        (testing "when creating"
-         (is (= {:message     "Some of your values aren’t of the correct type for the database."
-                 :type        actions.error/incorrect-value-type
-                 :status-code 400
-                 :errors      (if (driver/database-supports?
-                                   driver/*driver*
-                                   ::action-error-handling-incorrect-type-error-message
-                                   (mt/db))
-                                {"ranking" "This value should be of type Integer."}
-                                {})}
-                (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name    "new"
-                                                                                 group-ranking "S"}
-                                                                    :database   db-id
-                                                                    :query      {:source-table $$group}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Some of your values aren’t of the correct type for the database."
+                  :type        actions.error/incorrect-value-type
+                  :status-code 400
+                  :errors      (if (driver/database-supports?
+                                    driver/*driver*
+                                    ::action-error-handling-incorrect-type-error-message
+                                    (mt/db))
+                                 {"ranking" "This value should be of type Integer."}
+                                 {})}
+                 (perform-action-ex-data :model.row/create (mt/$ids {:create-row {group-name    "new"
+                                                                                  group-ranking "S"}
+                                                                     :database   db-id
+                                                                     :query      {:source-table $$group}
+                                                                     :type       :query})))))))))
 
 (deftest action-error-handling-incorrect-type-updating-test
   (test-action-error-handling!
    (fn [{:keys [db-id group-ranking]}]
      (testing "incorrect type"
        (testing "when updating"
-         (is (= {:message     "Some of your values aren’t of the correct type for the database."
-                 :type        actions.error/incorrect-value-type
-                 :status-code 400
-                 :errors      (if (driver/database-supports?
-                                   driver/*driver*
-                                   ::action-error-handling-incorrect-type-error-message
-                                   (mt/db))
-                                {"ranking" "This value should be of type Integer."}
-                                {})}
-                (perform-action-ex-data :model.row/update (mt/$ids {:update-row {group-ranking "S"}
-                                                                    :database   db-id
-                                                                    :query      {:filter [:= $group.id 1]
-                                                                                 :source-table $$group}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Some of your values aren’t of the correct type for the database."
+                  :type        actions.error/incorrect-value-type
+                  :status-code 400
+                  :errors      (if (driver/database-supports?
+                                    driver/*driver*
+                                    ::action-error-handling-incorrect-type-error-message
+                                    (mt/db))
+                                 {"ranking" "This value should be of type Integer."}
+                                 {})}
+                 (perform-action-ex-data :model.row/update (mt/$ids {:update-row {group-ranking "S"}
+                                                                     :database   db-id
+                                                                     :query      {:filter [:= $group.id 1]
+                                                                                  :source-table $$group}
+                                                                     :type       :query})))))))))
 
 (deftest action-error-handling-fk-constraint-creating-test
   (test-action-error-handling!
    (fn [{:keys [db-id user-name user-group-id]}]
      (testing "violate fk constraint"
        (testing "when creating"
-         (is (= {:message     "Unable to create a new record."
-                 :errors      {"group_id" "This Group-id does not exist."}
-                 :type        actions.error/violate-foreign-key-constraint
-                 :status-code 400}
-                (perform-action-ex-data :model.row/create (mt/$ids {:create-row {user-name    "new"
-                                                                                 user-group-id 999}
-                                                                    :database   db-id
-                                                                    :query      {:source-table $$user}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Unable to create a new record."
+                  :errors      {"group_id" "This Group-id does not exist."}
+                  :type        actions.error/violate-foreign-key-constraint
+                  :status-code 400}
+                 (perform-action-ex-data :model.row/create (mt/$ids {:create-row {user-name    "new"
+                                                                                  user-group-id 999}
+                                                                     :database   db-id
+                                                                     :query      {:source-table $$user}
+                                                                     :type       :query})))))))))
 
 (deftest action-error-handling-fk-constraint-updating-test
   (test-action-error-handling!
    (fn [{:keys [db-id user-group-id]}]
      (testing "violate fk constraint"
        (testing "when updating"
-         (is (= {:message     "Unable to update the record."
-                 :errors      {"group_id" "This Group-id does not exist."}
-                 :type        actions.error/violate-foreign-key-constraint
-                 :status-code 400}
-                (perform-action-ex-data :model.row/update (mt/$ids {:update-row {user-group-id 999}
-                                                                    :database   db-id
-                                                                    :query      {:filter [:= $user.id 1]
-                                                                                 :source-table $$user}
-                                                                    :type       :query})))))))))
+         (is (=? {:message     "Unable to update the record."
+                  :errors      {"group_id" "This Group-id does not exist."}
+                  :type        actions.error/violate-foreign-key-constraint
+                  :status-code 400}
+                 (perform-action-ex-data :model.row/update (mt/$ids {:update-row {user-group-id 999}
+                                                                     :database   db-id
+                                                                     :query      {:filter [:= $user.id 1]
+                                                                                  :source-table $$user}
+                                                                     :type       :query})))))))))
 
 (deftest action-error-handling-fk-constraint-deleting-test
   (test-action-error-handling!
    (fn [{:keys [db-id]}]
      (testing "violate fk constraint"
        (testing "when deleting"
-         (is (= {:message "Other tables rely on this row so it cannot be deleted."
-                 :errors {}
-                 :type        actions.error/violate-foreign-key-constraint
-                 :status-code 400}
-                (perform-action-ex-data :model.row/delete (mt/$ids {:database db-id
-                                                                    :query    {:filter [:= $group.id 1]
-                                                                               :source-table $$group}
-                                                                    :type     :query})))))))))
+         (is (=? {:message "Other tables rely on this row so it cannot be deleted."
+                  :errors {}
+                  :type        actions.error/violate-foreign-key-constraint
+                  :status-code 400}
+                 (perform-action-ex-data :model.row/delete (mt/$ids {:database db-id
+                                                                     :query    {:filter [:= $group.id 1]
+                                                                                :source-table $$group}
+                                                                     :type     :query})))))))))
 
 (deftest actions-return-rows-with-correct-names-test
   (testing "rows returned by perform action should match the name in metabase_field.name"


### PR DESCRIPTION
This adds a feature to our log context that I've used and loved in the past.

For illustration, let's say I do this:

```
(defn my-fn []
  (log/with-context {:user 123 :database 5}
    (/ 1 0)))

(try (my-fn)
     (catch Exception e (log/error e)))
```

With the current code, we'll run `my-fn`, throw an exception, then *exit* the `log/with-context` block. When we eventually log the exception, the context will be empty.

This is annoying, because when the exception was thrown, we had context that a developer thought would be useful. But just when it would be *most* useful to have that information - an uncaught exception we didn't think about bubbles up to the HTTP request logging middleware or whatever - it's thrown away.

This change essentially wraps `with-context` calls with a `try/catch` that catches any exceptions and re-throws them, annotated with the original context.

This way, when we actually log the exception, we can swap back the original context. In the above example, `{:user 123 :database 5}` would be logged with the exception.
