### PR TITLE
Add explicit CAST when compiling string literal expressions in H2 driver

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -153,9 +153,9 @@ describe("scenarios > custom column > literals", () => {
         fields: [
           ["field", PRODUCTS.ID, { "base-type": "type/Integer" }],
           ["field", PRODUCTS.TITLE, { "base-type": "type/Text" }],
-          ["field", PRODUCTS.PRICE, { "base-type": "type/Number" }],
-          ["expression", "Rustic", { "base-type": "type/Text" }],
-          ["expression", "MinPrice", { "base-type": "type/Number" }],
+          ["field", PRODUCTS.PRICE, { "base-type": "type/Float" }],
+          ["expression", "Rustic"],
+          ["expression", "MinPrice"],
         ],
         expressions: {
           Rustic: [
@@ -163,7 +163,7 @@ describe("scenarios > custom column > literals", () => {
             "Rustic Paper Wallet",
             { "base-type": "type/Text" },
           ],
-          MinPrice: ["value", 20, { "base-type": "type/Number" }],
+          MinPrice: ["value", 20.0, { "base-type": "type/Float" }],
         },
       },
     };
@@ -183,8 +183,8 @@ describe("scenarios > custom column > literals", () => {
               ],
               [
                 ">",
-                ["field", "PRICE", { "base-type": "type/Number" }],
-                ["field", "MinPrice", { "base-type": "type/Number" }],
+                ["field", "PRICE", { "base-type": "type/Float" }],
+                ["field", "MinPrice", { "base-type": "type/Float" }],
               ],
             ],
           },

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -158,12 +158,8 @@ describe("scenarios > custom column > literals", () => {
           ["expression", "MinPrice"],
         ],
         expressions: {
-          Rustic: [
-            "value",
-            "Rustic Paper Wallet",
-            { "base-type": "type/Text" },
-          ],
-          MinPrice: ["value", 20.0, { "base-type": "type/Float" }],
+          Rustic: ["value", "Rustic Paper Wallet", { base_type: "type/Text" }],
+          MinPrice: ["value", 20.0, { base_type: "type/Float" }],
         },
       },
     };

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -1,7 +1,6 @@
 const { H } = cy;
 
-// TODO: QUE-726 restore test
-describe.skip("scenarios > custom column > literals", () => {
+describe("scenarios > custom column > literals", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -530,13 +530,8 @@ describe("issue 41381", () => {
     H.addCustomColumn();
     H.enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
     H.popover().within(() => {
-      // TODO: QUE-726 restore test
-      // cy.findByText("Invalid expression").should("not.exist");
-      // cy.button("Done").should("be.enabled");
-      cy.findByText("Standalone constants are not supported.").should(
-        "be.visible",
-      );
-      cy.button("Done").should("be.disabled");
+      cy.findByText("Invalid expression").should("not.exist");
+      cy.button("Done").should("be.enabled");
     });
   });
 });

--- a/frontend/src/metabase-lib/v1/expressions/__support__/expressions.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/expressions.ts
@@ -94,6 +94,7 @@ const database = createMockDatabase({
     "percentile-aggregations",
     "native-parameters",
     "expressions",
+    "expression-literals",
     "advanced-math-expressions",
     "right-join",
     "left-join",

--- a/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
@@ -43,14 +43,33 @@ function aggregation(source: string) {
 
 describe("old recursive-parser tests", () => {
   it("should parse numeric literals", () => {
-    expect(expr("0")).toEqual(["value", 0, null]);
-    expect(expr("42")).toEqual(["value", 42, null]);
-    expect(expr("1.0")).toEqual(["value", 1, null]);
-    expect(expr("0.123")).toEqual(["value", 0.123, null]);
+    expect(expr("0")).toEqual(["value", 0, { base_type: "type/Integer" }]);
+    expect(expr("42")).toEqual(["value", 42, { base_type: "type/Integer" }]);
+    expect(expr("1.0")).toEqual(["value", 1, { base_type: "type/Integer" }]);
+    expect(expr("0.123")).toEqual([
+      "value",
+      0.123,
+      { base_type: "type/Float" },
+    ]);
+    expect(expr("9223372036854775807")).toEqual([
+      "value",
+      "9223372036854775807",
+      { base_type: "type/BigInteger" },
+    ]);
   });
 
   it("should parse string literals", () => {
-    // the strings are wrapped in length because top-level literals are not allowed
+    expect(expr("'Universe'")).toEqual([
+      "value",
+      "Universe",
+      { base_type: "type/Text" },
+    ]);
+    expect(expr('"answer"')).toEqual([
+      "value",
+      "answer",
+      { base_type: "type/Text" },
+    ]);
+    expect(expr('"\\""')).toEqual(["value", '"', { base_type: "type/Text" }]);
     expect(expr("length('Universe')")).toEqual(["length", "Universe"]);
     expect(expr('length("answer")')).toEqual(["length", "answer"]);
     expect(expr('length("\\"")')).toEqual(["length", '"']);
@@ -75,15 +94,15 @@ describe("old recursive-parser tests", () => {
   });
 
   it("should parse unary expressions", () => {
-    expect(expr("+6")).toEqual(["value", 6, null]);
-    expect(expr("++7")).toEqual(["value", 7, null]);
-    expect(expr("-+8")).toEqual(["value", -8, null]);
+    expect(expr("+6")).toEqual(["value", 6, { base_type: "type/Integer" }]);
+    expect(expr("++7")).toEqual(["value", 7, { base_type: "type/Integer" }]);
+    expect(expr("-+8")).toEqual(["value", -8, { base_type: "type/Integer" }]);
   });
 
   it("should flatten unary expressions", () => {
     expect(expr("--5")).toEqual(["-", -5]);
-    expect(expr("- 6")).toEqual(["value", -6, null]);
-    expect(expr("+-7")).toEqual(["value", -7, null]);
+    expect(expr("- 6")).toEqual(["value", -6, { base_type: "type/Integer" }]);
+    expect(expr("+-7")).toEqual(["value", -7, { base_type: "type/Integer" }]);
     expect(expr("sqrt(-1)")).toEqual(["sqrt", -1]);
     expect(expr("- [Total]")).toEqual(["-", total]);
     expect(expr("-[Total]")).toEqual(["-", total]);

--- a/frontend/src/metabase-lib/v1/expressions/matchers.ts
+++ b/frontend/src/metabase-lib/v1/expressions/matchers.ts
@@ -54,6 +54,14 @@ export function isNumberLiteral(expr: unknown): expr is NumericLiteral {
   return typeof expr === "number" || typeof expr === "bigint";
 }
 
+export function isIntegerLiteral(expr: unknown): expr is NumericLiteral {
+  return typeof expr === "number" && Number.isInteger(expr);
+}
+
+export function isFloatLiteral(expr: unknown): expr is NumericLiteral {
+  return typeof expr === "number" && !Number.isInteger(expr);
+}
+
 export function isValue(expr: unknown): expr is ValueExpression {
   return Array.isArray(expr) && expr[0] === "value";
 }

--- a/frontend/src/metabase-lib/v1/expressions/passes.ts
+++ b/frontend/src/metabase-lib/v1/expressions/passes.ts
@@ -9,7 +9,8 @@ import {
   isBooleanLiteral,
   isCaseOrIf,
   isCaseOrIfOperator,
-  isNumberLiteral,
+  isFloatLiteral,
+  isIntegerLiteral,
   isOptionsObject,
   isStringLiteral,
 } from "./matchers";
@@ -223,12 +224,14 @@ export const adjustBigIntLiteral: CompilerPass = (tree) =>
   });
 
 export const adjustTopLevelLiteral: CompilerPass = (tree) => {
-  if (
-    isStringLiteral(tree) ||
-    isNumberLiteral(tree) ||
-    isBooleanLiteral(tree)
-  ) {
-    return ["value", tree, null];
+  if (isStringLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Text" }];
+  } else if (isBooleanLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Boolean" }];
+  } else if (isIntegerLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Integer" }];
+  } else if (isFloatLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Float" }];
   } else {
     return tree;
   }

--- a/frontend/src/metabase-types/api/mocks/database.ts
+++ b/frontend/src/metabase-types/api/mocks/database.ts
@@ -11,6 +11,7 @@ export const COMMON_DATABASE_FEATURES: DatabaseFeature[] = [
   "binning",
   "case-sensitivity-string-filter-options",
   "expression-aggregations",
+  "expression-literals",
   "expressions",
   "native-parameters",
   "nested-queries",

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -12,10 +12,12 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -68,6 +70,7 @@
 (doseq [[feature supported?] {:actions                   true
                               :actions/custom            true
                               :datetime-diff             true
+                              :expression-literals       true
                               :full-join                 false
                               :index-info                true
                               :now                       true
@@ -396,6 +399,30 @@
 (defmethod sql.qp/->honeysql [:h2 :log]
   [driver [_ field]]
   [:log10 (sql.qp/->honeysql driver field)])
+
+(defn- literal-text-value?
+  [[_ value {base-type :base_type effective-type :effective_type} :as clause]]
+  (and (mbql.u/is-clause? :value clause)
+       (string? value)
+       (isa? (or effective-type base-type)
+             :type/Text)))
+
+(defmethod sql.qp/->honeysql [:h2 :expression]
+  [driver [_ expression-name {::add/keys [source-table]} :as clause]]
+  (let [expression-definition (mbql.u/expression-with-name sql.qp/*inner-query* expression-name)]
+    (if (and (not= source-table ::add/source)
+             (literal-text-value? expression-definition))
+      ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
+      ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown
+      ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST. We
+      ;; only need to do this for string literals, since numbers and booleans get inlined directly.
+      ;;
+      ;; https://linear.app/metabase/issue/QUE-726/
+      ;; https://github.com/h2database/h2database/issues/1383
+      (->> (sql.qp/->honeysql driver expression-definition)
+           (h2x/cast :text))
+      ((get-method sql.qp/->honeysql [:sql-jdbc :expression])
+       driver clause))))
 
 (defn- datediff
   "Like H2's `datediff` function but accounts for timestamps with time zones."

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -223,8 +223,11 @@
 
 (defn- normalize-value-opts
   [opts]
-  ;; `:value` in legacy MBQL expects `snake_case` keys for type info keys.
-  (m/update-existing opts :base_type keyword))
+  (some-> opts
+          lib.schema.common/normalize-map
+          ;; `:value` in legacy MBQL expects `snake_case` keys for type info keys.
+          (m/update-existing :base_type keyword)
+          (m/update-existing :semantic_type keyword)))
 
 (defmethod normalize-mbql-clause-tokens :value
   ;; The args of a `value` clause shouldn't be normalized.

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -63,10 +63,15 @@
     [:field 2 {"binning" {"strategy" "default"}}]
     [:field 2 {:binning {:strategy :default}}]}
 
-   ":value clauses should keep snake_case keys in the type info arg"
+   ":value clauses should keep snake_case keys in the options"
     ;; See https://github.com/metabase/metabase/issues/23354 for details
    {[:value "some value" {:some_key "some key value"}]
     [:value "some value" {:some_key "some key value"}]}
+
+   ":value clauses should keep snake_case keys in the type info args"
+    ;; See https://github.com/metabase/metabase/issues/23354 for details
+   {[:value "some value" {"base_type" "type/Text"}]
+    [:value "some value" {:base_type :type/Text}]}
 
    "nil options in aggregation and expression references should be removed"
    {[:aggregation 0 nil]   [:aggregation 0]
@@ -608,10 +613,10 @@
              :fields      [[:expression "abc" {:base-type :type/Number}]]}}}
 
    "expressions can be a literal :value"
-   {{:query {:expressions {"abc" [:value 123 nil]}
-             :fields      [[:expression "abc" {"base-type" "type/Number"}]]}}
-    {:query {:expressions {"abc" [:value 123 nil]}
-             :fields      [[:expression "abc" {:base-type :type/Number}]]}}}))
+   {{:query {:expressions {"abc" [:value 123 {"base_type" "type/Integer"}]}
+             :fields      [[:expression "abc" {"base-type" "type/Integer"}]]}}
+    {:query {:expressions {"abc" [:value 123 {:base_type :type/Integer}]}
+             :fields      [[:expression "abc" {:base-type :type/Integer}]]}}}))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  CANONICALIZE                                                  |
@@ -786,9 +791,9 @@
 (t/deftest ^:parallel canonicalize-expressions-test
   (canonicalize-tests
    "expressions can be a literal :value"
-   {{:query {:expressions {"abc" [:value false nil]}
+   {{:query {:expressions {"abc" [:value false {:base_type :type/Boolean}]}
              :fields      [[:expression "abc" {:base-type :type/Boolean}]]}}
-    {:query {:expressions {"abc" [:value false nil]}
+    {:query {:expressions {"abc" [:value false {:base_type :type/Boolean}]}
              :fields      [[:expression "abc" {:base-type :type/Boolean}]]}}}))
 
 ;;; ----------------------------------------------------- fields -----------------------------------------------------

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -394,7 +394,7 @@
     {:database 1
      :type     :query
      :query    {:source-table 224
-                :expressions {"a" [:value 1 nil]}
+                :expressions {"a" [:value 1 {:base_type :type/Integer}]}
                 :expression-idents {"a" (u/generate-nano-id)}}}
 
     ;; card__<id> source table syntax.
@@ -540,6 +540,10 @@
     {} [:value true nil]
 
     {} [:value false nil]
+
+    {} [:value true {:base_type :type/Boolean}]
+
+    {} [:value false {:base_type :type/Boolean}]
 
     {} [:field 1 {:base-type :type/Boolean}]
 

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -233,14 +233,15 @@
       (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
   (testing "simple values can be converted properly (#36459)"
     (let [query (lib.tu/venues-query)
-          legacy-expr #js ["value" 0 nil]
+          legacy-expr #js ["value" 0 {"base_type" "type/Integer"}]
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
           legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
           query-with-expr (lib/expression query 0 "expr" expr)
           expr-from-query (first (lib/expressions query-with-expr 0))
           legacy-expr-from-query (lib.js/legacy-expression-for-expression-clause query-with-expr 0 expr-from-query)
           named-expr (lib/with-expression-name expr "named")]
-      (is (=? [:value {:effective-type :type/Integer, :lib/uuid string?} 0] expr))
+      (is (=? [:value {:base-type :type/Integer :effective-type :type/Integer, :lib/uuid string?} 0]
+              expr))
       (is (= (js->clj legacy-expr) (js->clj legacy-expr') (js->clj legacy-expr-from-query)))
       (is (= "named" (lib/display-name query named-expr)))))
   (testing "simple expressions can be converted properly (#37173)"

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -3026,6 +3026,7 @@
                                   :date-arithmetics
                                   :datetime-diff
                                   :expression-aggregations
+                                  :expression-literals
                                   :expressions
                                   :inner-join
                                   :left-join

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -380,7 +380,6 @@
 
 (deftest ^:parallel literal-expressions-inside-nested-and-filtered-aggregations-test
   (testing "nested aggregated and filtered literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations :expression-literals :nested-queries)
       (is (= [[2 true "Red Medicine" 1 8 16]
               [3 true "Red Medicine" 1 2 4]
@@ -437,7 +436,7 @@
                  :joins       [{:strategy     :left-join
                                 :condition    [:= $category_id &JoinedCategories.venues.category_id]
                                 :source-query {:source-table $$venues
-                                               :expressions  {"One" [:value 1 nil]}
+                                               :expressions  {"One" [:value 1 {:base_type :type/Integer}]}
                                                :aggregation  [[:aggregation-options [:max [:expression "One"]] {:name "MaxOne"}]]
                                                :breakout     [$category_id]}
                                 :alias        "JoinedCategories"}]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -518,7 +518,6 @@
 
 (deftest ^:parallel nested-literal-expression-test
   (testing "nested literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [(into [1] standard-literal-expression-values)]
              (mt/formatted-rows
@@ -540,14 +539,13 @@
               [8  1 "25°"]]
              (mt/rows
               (mt/run-mbql-query venues
-                {:expressions {"One" [:value 1 nil]}
+                {:expressions {"One" [:value 1 {:base_type :type/Integer}]}
                  :fields      [$id [:expression "One"] $name]
                  :order-by    [[:asc [:expression "One"]]
                                [:asc $name]]
                  :limit       2})))))))
 
 (deftest ^:parallel order-by-literal-expression-test
-  ;; TODO Fix this test for H2 (QUE-726)
   (testing "order-by all literal expression types"
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [(into [1] standard-literal-expression-values)
@@ -562,7 +560,6 @@
                  :limit       2})))))))
 
 (deftest ^:parallel breakout-by-literal-expression-test
-  ;; TODO Fix this test for H2 (QUE-726)
   (testing "breakout by all literal expression types"
     (mt/test-drivers (mt/normal-drivers-with-feature :expression-literals :basic-aggregations)
       (let [orders-count 18760]
@@ -583,8 +580,8 @@
                (mt/formatted-rows
                 [mt/boolish->bool mt/boolish->bool]
                 (mt/run-mbql-query orders
-                  {:expressions {"true"  [:value true  nil]
-                                 "false" [:value false nil]}
+                  {:expressions {"true"  [:value true  {:base_type :type/Boolean}]
+                                 "false" [:value false {:base_type :type/Boolean}]}
                    :fields      [[:expression "true"]
                                  [:expression "false"]]
                    :filter      (into [op] [[:expression "true"]
@@ -609,7 +606,6 @@
 
 (deftest ^:parallel nested-and-filtered-literal-expression-test
   (testing "nested and filtered literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [[2 "Stout Burgers & Beers" true "Red Medicine" 1 2 "Bob's Burgers"]
               [3 "The Apple Pan" true "Red Medicine" 1 2 "Bob's Burgers"]
@@ -648,7 +644,6 @@
 
 (deftest ^:parallel joined-literal-expression-test
   (testing "joined literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :left-join :nested-queries)
       (is (= [[2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "25°"]
               [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "In-N-Out Burger"]
@@ -670,8 +665,8 @@
                  :joins       [{:strategy     :left-join
                                 :condition    [:= $category_id &JoinedCategories.venues.category_id]
                                 :source-query {:source-table $$venues
-                                               :expressions  {"LiteralInt"    [:value 1 nil]
-                                                              "LiteralString" [:value "Stout Burgers & Beers" nil]}
+                                               :expressions  {"LiteralInt"    [:value 1 {:base_type :type/Integer}]
+                                                              "LiteralString" [:value "Stout Burgers & Beers" {:base_type :type/Text}]}
                                                :filters     [[:!= $name [:expression "LiteralString"]]]
                                                :fields       [$category_id
                                                               $name

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -980,7 +980,6 @@
                       {:source-table "card__1"}))))))))))
 
 (deftest ^:parallel expression-literals-test
-  ;; TODO Fix this test for H2 (QUE-726)
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expression-literals)
     (let [query (mt/mbql-query venues
                   {:fields      [[:expression "one"]


### PR DESCRIPTION
Closes QUE-726

~~Currently stacked on top of #55206~~

### Description

* Add explicit CAST when compiling string literal expressions in H2 driver.
* Add `:expression-literals` feature to various mock providers used in tests
* Update diagnose-expression tests to check valid and invalid expressions with type checking enabled.
* ~~Reject badly typed literal expressions in resolver.js~~ and update e2e tests (obsoleted by #55737, will update)
* Ensure legacy `:value` options are normalized in `mbql.normalize`. Values coming from the FE in `expression-clause-for-legacy-expression` call normalize and expect to have `:value` options converted from strings to keywords.
* Add `:base_type` to `:value` literals in `adjustTopLevelLiteral`

### How to verify

1. New question -> H2 Sample Dataset -> People
2. Custom Column > Custom Expression > "Hudson Borer"
3. Name the custom column "Hudson"
4. Save the question
5. New question > Source is saved question from (4)
6. Visualize

No error. 

Alternatively:

1. New question -> H2 Sample Dataset -> People
2. Custom Column > Custom Expression > "Hudson Borer"
3. Name the custom column "Hudson"
4. Sort by `Hudson` column
5. Visualize

No error.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
