### PR TITLE
Show a more user-friendly error message when there are incompatible types

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -838,7 +838,7 @@ describe("issue 29094", () => {
       H.enterCustomColumnDetails({ formula: "[Tax] * 22" });
       cy.realPress("Tab");
       cy.button("Done").should("be.disabled");
-      cy.findByText("Invalid expression").should("exist");
+      cy.findByText("Incompatible types detected.").should("exist");
     });
   });
 });

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -838,7 +838,7 @@ describe("issue 29094", () => {
       H.enterCustomColumnDetails({ formula: "[Tax] * 22" });
       cy.realPress("Tab");
       cy.button("Done").should("be.disabled");
-      cy.findByText("Incompatible types detected.").should("exist");
+      cy.findByText("Types are incompatible.").should("exist");
     });
   });
 });

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -567,7 +567,7 @@ describe("scenarios > question > filter", () => {
     H.enterCustomColumnDetails({ formula: "3.14159" });
     H.popover().within(() => {
       cy.button("Done").should("be.disabled");
-      cy.findByText("Incompatible types detected.").should("be.visible");
+      cy.findByText("Types are incompatible.").should("be.visible");
     });
   });
 
@@ -578,7 +578,7 @@ describe("scenarios > question > filter", () => {
     H.enterCustomColumnDetails({ formula: '"TheAnswer"' });
     H.popover().within(() => {
       cy.button("Done").should("be.disabled");
-      cy.findByText("Incompatible types detected.").should("be.visible");
+      cy.findByText("Types are incompatible.").should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -567,7 +567,7 @@ describe("scenarios > question > filter", () => {
     H.enterCustomColumnDetails({ formula: "3.14159" });
     H.popover().within(() => {
       cy.button("Done").should("be.disabled");
-      cy.findByText("Invalid expression").should("be.visible");
+      cy.findByText("Incompatible types detected.").should("be.visible");
     });
   });
 
@@ -578,7 +578,7 @@ describe("scenarios > question > filter", () => {
     H.enterCustomColumnDetails({ formula: '"TheAnswer"' });
     H.popover().within(() => {
       cy.button("Done").should("be.disabled");
-      cy.findByText("Invalid expression").should("be.visible");
+      cy.findByText("Incompatible types detected.").should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1137,7 +1137,7 @@ describe("issue 33441", () => {
       name: "Date",
     });
     H.popover().within(() => {
-      cy.findByText("Invalid expression").should("be.visible");
+      cy.findByText("Incompatible types detected.").should("be.visible");
       cy.button("Done").should("be.disabled");
     });
   });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1137,7 +1137,7 @@ describe("issue 33441", () => {
       name: "Date",
     });
     H.popover().within(() => {
-      cy.findByText("Incompatible types detected.").should("be.visible");
+      cy.findByText("Types are incompatible.").should("be.visible");
       cy.button("Done").should("be.disabled");
     });
   });

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace])
   (:require
    [clojure.string :as str]
-   [malli.error :as me]
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
    [metabase.lib.hierarchy :as lib.hierarchy]

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -524,7 +524,7 @@
       (or (when-not (validator expr)
             (let [error (explainer expr)
                   humanized (str/join ", " (me/humanize error))]
-              {:message  (i18n/tru "Incompatible types detected.")
+              {:message  (i18n/tru "Types are incompatible.")
                :friendly true}))
           (when-let [dependency-path (and (= expression-mode :expression)
                                           expression-position

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -461,20 +461,11 @@
              (assoc :lib/expression-name new-name))
          (assoc opts :name new-name :display-name new-name))))))
 
-(def ^:private expression-explainer
-  (mr/explainer ::lib.schema.expression/expression))
-
 (def ^:private aggregation-validator
   (mr/validator ::lib.schema.aggregation/aggregation))
 
-(def ^:private aggregation-explainer
-  (mr/explainer ::lib.schema.aggregation/aggregation))
-
 (def ^:private filter-validator
   (mr/validator ::lib.schema/filterable))
-
-(def ^:private filter-explainer
-  (mr/explainer ::lib.schema/filterable))
 
 (defn- expression->name
   [expr]
@@ -517,15 +508,13 @@
    expr                :- :any
    expression-position :- [:maybe :int]]
   (binding [lib.schema.expression/*suppress-expression-type-check?* false]
-    (let [[validator explainer] (clojure.core/case expression-mode
-                                  :expression [expression-validator expression-explainer]
-                                  :aggregation [aggregation-validator aggregation-explainer]
-                                  :filter [filter-validator filter-explainer])]
+    (let [validator (clojure.core/case expression-mode
+                      :expression expression-validator
+                      :aggregation aggregation-validator
+                      :filter filter-validator)]
       (or (when-not (validator expr)
-            (let [error (explainer expr)
-                  humanized (str/join ", " (me/humanize error))]
-              {:message  (i18n/tru "Types are incompatible.")
-               :friendly true}))
+            {:message  (i18n/tru "Types are incompatible.")
+             :friendly true})
           (when-let [dependency-path (and (= expression-mode :expression)
                                           expression-position
                                           (let [exprs (expressions query stage-number)

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -524,7 +524,8 @@
       (or (when-not (validator expr)
             (let [error (explainer expr)
                   humanized (str/join ", " (me/humanize error))]
-              {:message (i18n/tru "Type error: {0}" humanized)}))
+              {:message  (i18n/tru "Incompatible types detected.")
+               :friendly true}))
           (when-let [dependency-path (and (= expression-mode :expression)
                                           expression-position
                                           (let [exprs (expressions query stage-number)

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -475,7 +475,8 @@
 (deftest ^:parallel diagnose-expression-test-2
   (testing "correct expression are accepted silently"
     (testing "type errors are reported"
-      (are [mode expr] (=? {:message #"Type error: .*"}
+      (are [mode expr] (=? {:message  "Incompatible types detected."
+                            :friendly true}
                            (lib.expression/diagnose-expression
                             (lib.tu/venues-query) 0 mode
                             (lib.convert/->pMBQL expr)

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -475,7 +475,7 @@
 (deftest ^:parallel diagnose-expression-test-2
   (testing "correct expression are accepted silently"
     (testing "type errors are reported"
-      (are [mode expr] (=? {:message  "Incompatible types detected."
+      (are [mode expr] (=? {:message  "Types are incompatible."
                             :friendly true}
                            (lib.expression/diagnose-expression
                             (lib.tu/venues-query) 0 mode


### PR DESCRIPTION
https://metaboat.slack.com/archives/C0645JP1W81/p1743186267935829

Instead of showing our generic `Invalid expression`, show a more useful error.

<img width="819" alt="Screenshot 2025-03-28 at 14 40 49" src="https://github.com/user-attachments/assets/bd11ab24-5346-447b-bfb0-b4aebdeabefb" />
