### PR TITLE
fix: Ensure that local timestamps params work

### DIFF
--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -635,10 +635,7 @@
                          :type         :dimension
                          :widget-type :date/relative
                          :dimension    [:field (mt/id
-                                                :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]}}})
-              hours (assoc query :parameters [{:type   :date/relative
-                                               :value  "past3hours"
-                                               :target [:dimension [:template-tag "date_filter"]]}])]
+                                                :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]}}})]
           (doseq [value ["past30days" "past3hours"]
                   :let [query-with-params (assoc query :parameters [{:type   :date/relative
                                                                      :value  value

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -39,7 +39,7 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
-   (java.time LocalDate LocalDateTime)))
+   (java.time LocalDateTime)))
 
 (set! *warn-on-reflection* true)
 
@@ -639,13 +639,13 @@
               hours (assoc query :parameters [{:type   :date/relative
                                                :value  "past3hours"
                                                :target [:dimension [:template-tag "date_filter"]]}])]
-          (doseq [[expected value] [[LocalDate "past30days"] [LocalDateTime "past3hours"]]
+          (doseq [value ["past30days" "past3hours"]
                   :let [query-with-params (assoc query :parameters [{:type   :date/relative
                                                                      :value  value
                                                                      :target [:dimension [:template-tag "date_filter"]]}])
                         parameters (:params (qp.compile/compile query-with-params))]]
             (is (= 2 (count parameters)))
-            (is (= [expected expected] (map type parameters)))))))))
+            (is (= [LocalDateTime LocalDateTime] (map type parameters)))))))))
 
 (deftest nest-window-functions-test
   (mt/test-driver

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -21,6 +21,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor :as qp]
    [metabase.query-processor-test.order-by-test :as qp-test.order-by-test]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.store :as qp.store]
    [metabase.sync.core :as sync]
@@ -36,7 +37,9 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.time LocalDate LocalDateTime)))
 
 (set! *warn-on-reflection* true)
 
@@ -616,6 +619,33 @@
                 results (qp/process-query query)]
             (is (str/includes? (get-in results [:data :native_form]) y))
             (is (= [[1000]] (mt/formatted-rows [int] results)))))))))
+
+(deftest native-relative-dates-against-date-test
+  (testing "Relate date times against native queries use appropriate parameter types"
+    (mt/test-driver
+      :oracle
+      (mt/dataset
+        date-cols-with-datetime-values
+        (let [query (mt/native-query
+                      {:query "SELECT * FROM \"mb_test\".\"date_cols_with_datetime_values_dates_with_time\" WHERE {{date_filter}}"
+                       :template-tags
+                       {"date_filter"
+                        {:name         "date_filter"
+                         :display-name "Date Filter"
+                         :type         :dimension
+                         :widget-type :date/relative
+                         :dimension    [:field (mt/id
+                                                :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]}}})
+              hours (assoc query :parameters [{:type   :date/relative
+                                               :value  "past3hours"
+                                               :target [:dimension [:template-tag "date_filter"]]}])]
+          (doseq [[expected value] [[LocalDate "past30days"] [LocalDateTime "past3hours"]]
+                  :let [query-with-params (assoc query :parameters [{:type   :date/relative
+                                                                     :value  value
+                                                                     :target [:dimension [:template-tag "date_filter"]]}])
+                        parameters (:params (qp.compile/compile query-with-params))]]
+            (is (= 2 (count parameters)))
+            (is (= [expected expected] (map type parameters)))))))))
 
 (deftest nest-window-functions-test
   (mt/test-driver

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -483,6 +483,13 @@
            (catch Throwable _
              (t/offset-date-time y M d h m s 0 (t/zone-offset (qp.timezone/results-timezone-id))))))))
 
+(defn- date-str->local-dt
+  "Generate local datetime from `date-str`"
+  [date-str]
+  (when date-str
+    (let [[y M d h m s] (u.time/yyyyMMddhhmmss->parts date-str)]
+      (t/local-date-time y M d h m s 0))))
+
 (defn- date-str->unit-fn
   "Return appropriate function for interval end adjustments in [[exclusive-datetime-range-end]]."
   [date-str]
@@ -523,20 +530,23 @@
 
   First [[date-string->range]] generates range for dates (inclusive by default). Operating on that range,
   this function:
-  1. converts dates to OffsetDateTime, respecting qp's timezone, adding zero temporal padding,
+  1. converts dates to LocalDateTime or OffsetDateTime respecting qp's timezone, adding zero temporal padding,
   2. updates range to correct _end-exclusive datetime_*
   3. formats the range.
 
   This function is meant to be used for generating inclusive intervals for `:type/DateTime` field filters.
 
   * End-exclusive gte lt filters are generated for `:type/DateTime` fields."
-  [raw-date-str]
+  [raw-date-str field-type]
   (let [;; `raw-date-str` is sanitized in case it contains millis and timezone which are incompatible
         ;; with [[date-string->range]]. `substitute-field-filter-test` expects that to happen.
         range-raw (try (date-string->range raw-date-str)
                        (catch Throwable _
-                         (fallback-raw-range raw-date-str)))]
-    (-> (update-vals range-raw date-str->qp-aware-offset-dt)
+                         (fallback-raw-range raw-date-str)))
+        date-str-conversion (if (isa? field-type :type/DateTimeWithTZ)
+                              date-str->qp-aware-offset-dt
+                              date-str->local-dt)]
+    (-> (update-vals range-raw date-str-conversion)
         (m/update-existing :end exclusive-datetime-range-end (date-str->unit-fn (:end range-raw)))
         (maybe-adjust-open-range (date-str->unit-fn ((some-fn :start :end) range-raw)))
         format-date-range)))

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -11,6 +11,7 @@
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.timezone :as qp.timezone]
+   [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -11,7 +11,6 @@
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.timezone :as qp.timezone]
-   [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -329,7 +329,7 @@
 
       ;; Special handling for `FieldFilter`s on `:type/DateTime` fields. DateTime range is always generated.
       (and (params.dates/date-type? param-type)
-           (isa? ((some-fn :effective-type :base-type) field) :type/DateTime))
+           (isa? ((some-fn :effective-type :base-type) field) :type/DateTimeWithTZ))
       (field-filter->replacement-snippet-for-datetime-field driver field-filter)
 
       ;; convert other date to DateRange record types

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -297,7 +297,7 @@
   (letfn [(->datetime-replacement-snippet-info
             [range]
             (->replacement-snippet-info driver range (field->identifier driver field type value)))]
-    (-> (params.dates/date-str->datetime-range value)
+    (-> (params.dates/date-str->datetime-range value ((some-fn :effective-type :base-type) field))
         params/map->DateTimeRange
         ->datetime-replacement-snippet-info)))
 
@@ -329,7 +329,7 @@
 
       ;; Special handling for `FieldFilter`s on `:type/DateTime` fields. DateTime range is always generated.
       (and (params.dates/date-type? param-type)
-           (isa? ((some-fn :effective-type :base-type) field) :type/DateTimeWithTZ))
+           (isa? ((some-fn :effective-type :base-type) field) :type/DateTime))
       (field-filter->replacement-snippet-for-datetime-field driver field-filter)
 
       ;; convert other date to DateRange record types

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -159,7 +159,7 @@
   ;; TIMEZONE FIXME — The excluded drivers don't have TIME types, so the `attempted-murders` dataset doesn't currently
   ;; work. We should use the closest equivalent types (e.g. `DATETIME` or `TIMESTAMP` so we can still load the dataset
   ;; and run tests using this dataset such as these, which doesn't even use the TIME type.
-  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters)
+  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :test/dynamic-dataset-loading)
     (testing "temporal field filters"
       (mt/dataset attempted-murders-no-time
         (doseq [field

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -156,9 +156,6 @@
              (run-count-query query))))))
 
 (deftest ^:parallel field-filter-param-test
-  ;; TIMEZONE FIXME — The excluded drivers don't have TIME types, so the `attempted-murders` dataset doesn't currently
-  ;; work. We should use the closest equivalent types (e.g. `DATETIME` or `TIMESTAMP` so we can still load the dataset
-  ;; and run tests using this dataset such as these, which doesn't even use the TIME type.
   (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :test/dynamic-dataset-loading)
     (testing "temporal field filters"
       (mt/dataset attempted-murders-no-time

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -159,9 +159,9 @@
   ;; TIMEZONE FIXME — The excluded drivers don't have TIME types, so the `attempted-murders` dataset doesn't currently
   ;; work. We should use the closest equivalent types (e.g. `DATETIME` or `TIMESTAMP` so we can still load the dataset
   ;; and run tests using this dataset such as these, which doesn't even use the TIME type.
-  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :test/time-type)
+  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters)
     (testing "temporal field filters"
-      (mt/dataset attempted-murders
+      (mt/dataset attempted-murders-no-time
         (doseq [field
                 [:datetime
                  :date

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -214,6 +214,46 @@
        (t/offset-time t)                ; time-tz
        cnt])]])                         ; num-crows
 
+(tx/defdataset attempted-murders-no-time
+  "A dataset for testing temporal values with and without timezones. Records of number of crow counts spoted and the
+  date/time when they spotting occured in several different column types.
+
+  No Database we support supports all of these different types, so the expectation is that we'll use the closest
+  equivalent for each column."
+  [["attempts"
+    [{:field-name "date",           :base-type :type/Date}
+     {:field-name "datetime",       :base-type :type/DateTime}
+     {:field-name "datetime_ltz",   :base-type :type/DateTimeWithLocalTZ}
+     {:field-name "datetime_tz",    :base-type :type/DateTimeWithZoneOffset}
+     {:field-name "datetime_tz_id", :base-type :type/DateTimeWithZoneID}
+     {:field-name "num_crows",      :base-type :type/Integer}]
+    (for [[cnt t] [[6 #t "2019-11-01T00:23:18.331-07:00[America/Los_Angeles]"]
+                   [8 #t "2019-11-02T00:14:14.246-07:00[America/Los_Angeles]"]
+                   [6 #t "2019-11-03T23:35:17.906-08:00[America/Los_Angeles]"]
+                   [7 #t "2019-11-04T01:04:09.593-08:00[America/Los_Angeles]"]
+                   [8 #t "2019-11-05T14:23:46.411-08:00[America/Los_Angeles]"]
+                   [4 #t "2019-11-06T18:51:16.270-08:00[America/Los_Angeles]"]
+                   [6 #t "2019-11-07T02:45:34.443-08:00[America/Los_Angeles]"]
+                   [4 #t "2019-11-08T19:51:39.753-08:00[America/Los_Angeles]"]
+                   [3 #t "2019-11-09T09:59:10.483-08:00[America/Los_Angeles]"]
+                   [1 #t "2019-11-10T08:41:35.860-08:00[America/Los_Angeles]"]
+                   [5 #t "2019-11-11T08:09:08.892-08:00[America/Los_Angeles]"]
+                   [3 #t "2019-11-12T07:36:16.088-08:00[America/Los_Angeles]"]
+                   [2 #t "2019-11-13T04:28:40.489-08:00[America/Los_Angeles]"]
+                   [9 #t "2019-11-14T09:52:17.242-08:00[America/Los_Angeles]"]
+                   [7 #t "2019-11-15T16:07:25.292-08:00[America/Los_Angeles]"]
+                   [7 #t "2019-11-16T13:32:16.936-08:00[America/Los_Angeles]"]
+                   [1 #t "2019-11-17T14:11:38.076-08:00[America/Los_Angeles]"]
+                   [3 #t "2019-11-18T20:47:27.902-08:00[America/Los_Angeles]"]
+                   [5 #t "2019-11-19T00:35:23.146-08:00[America/Los_Angeles]"]
+                   [1 #t "2019-11-20T20:09:55.752-08:00[America/Los_Angeles]"]]]
+      [(t/local-date t)                 ; date
+       (t/local-date-time t)            ; datetime
+       (t/offset-date-time t)           ; datetime-ltz
+       (t/offset-date-time t)           ; datetime-tz
+       t                                ; datetime-tz-id
+       cnt])]])
+
 (tx/defdataset dots-in-names
   [["objects.stuff"
     [{:field-name "dotted.name", :base-type :type/Text}]


### PR DESCRIPTION
Fixes #53371

By filtering a timestamp or date column on an OffsetDateTime it results in an index being missed since the lhs needs to be upcast by the db engine to a `timestamp with timezone`.

This ensures we only pass OffsetDateTime to `timestamp with timezone` columns.

Context about decision here:
https://metaboat.slack.com/archives/C0645JP1W81/p1743111964032089
