### PR TITLE
task: update ee-extra to understand noop from registry

### DIFF
--- a/.github/actions/build-ee-extra/action.yml
+++ b/.github/actions/build-ee-extra/action.yml
@@ -72,21 +72,25 @@ runs:
 
           return extraDrivers;
     - name: Download Firebolt driver
+      if: ${{ fromJson(steps.drivers_registry.outputs.result).firebolt != 'noop' }}
       run: |
         curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).firebolt }}
       working-directory: modules
       shell: bash
     - name: Download Starburst driver
+      if: ${{ fromJson(steps.drivers_registry.outputs.result).starburst != 'noop' }}
       run: |
         curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).starburst }}
       shell: bash
       working-directory: modules
     - name: Download Clickhouse driver
+      if: ${{ fromJson(steps.drivers_registry.outputs.result).clickhouse != 'noop' }}
       run: |
         curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).clickhouse }}
       shell: bash
       working-directory: modules
     - name: Download Materialize driver
+      if: ${{ fromJson(steps.drivers_registry.outputs.result).materialize != 'noop' }}
       run: |
         curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).materialize }}
       shell: bash


### PR DESCRIPTION
Ending the bundled partner program.
> We've brought development of certain drivers in house for v54 and later, so we don't need to pull them in from the registry anymore.

[metaboat.slack.com/archives/C010ZSXQY87/p1742576059497049](https://metaboat.slack.com/archives/C010ZSXQY87/p1742576059497049)

https://github.com/metabase/metabase-ee-extra/pull/499

metabase/metabase-registry#26