### PR TITLE
feat: run jetty with a virtual thread pool

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -273,6 +273,8 @@
                  "-Dfile.encoding=UTF-8"
                  "-Duser.language=en"
                  "-Duser.country=US"
+                 ;; Warn when virtual threads get pinned
+                 "-Djdk.tracePinnedThreads=full"
                  ;; Allow clojure goes fast tooling to work
                  "-Djdk.attach.allowAttachSelf"
                  ;; This will suppress the warning about dynamically loaded agents (like clj-memory-meter)

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  ;; !!                                   PLEASE KEEP THESE ORGANIZED ALPHABETICALLY                                  !!
  ;; !!                                   AND ADD A COMMENT EXPLAINING THEIR PURPOSE                                  !!
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- {amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
+ amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
   amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
@@ -38,18 +38,18 @@
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.0"}              ; trans dep of commons-codec
-  ; Detect the charset in uploaded CSV files
+                                                                                ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
   com.github.blagerweij/liquibase-sessionlock {:mvn/version "1.6.9"}            ; session lock for liquibase migrations
   com.github.jknack/handlebars              ^:antq/exclude                      ; 4.4.0 requires java 17+
-                                            {:mvn/version "4.3.1"}              ; templating engine
+  {:mvn/version "4.3.1"}              ; templating engine
   com.github.seancorfield/honeysql          {:mvn/version "2.7.1295"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:mvn/version "1.3.1002"}            ; Talk to JDBC DBs
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.7"}              ; Telemetry library
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.guava/guava                    {:mvn/version "33.4.5-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979
-                                            {:mvn/version "2.1.214"}            ; embedded SQL database
+  {:mvn/version "2.1.214"}            ; embedded SQL database
   com.ibm.icu/icu4j                         {:mvn/version "76.1"}               ; Used to transliterate Unicode characters into Latin characters
   com.mchange/c3p0                          {:mvn/version "0.10.1"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
@@ -158,9 +158,10 @@
   org.clojure/tools.namespace               {:mvn/version "1.5.0"}
   org.clojure/tools.reader                  {:mvn/version "1.5.2"}
   org.clojure/tools.trace                   {:mvn/version "0.8.0"}              ; function tracing
-  org.eclipse.jetty/jetty-server            ^:antq/exclude                      ; 12.x do not support Java 8
-  {:mvn/version "11.0.24"}            ; web server
-  org.eclipse.jetty.websocket/websocket-jetty-server {:mvn/version "11.0.25"}   ; ring-jetty-adapter needs that
+  org.eclipse.jetty/jetty-server            {:mvn/version "12.1.0.alpha2"}
+  org.eclipse.jetty/jetty-unixdomain-server {:mvn/version "12.1.0.alpha2"}
+  org.eclipse.jetty.ee9/jetty-ee9-servlet   {:mvn/version "12.1.0.alpha2"}
+  org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.0.alpha2"}
   org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
   org.graalvm.polyglot/js-community         {:mvn/version "24.2.0" :extension "pom"} ; JavaScript engine
   org.graalvm.polyglot/polyglot             {:mvn/version "24.2.0"}             ; GraalVM platform, required by JS engine
@@ -183,15 +184,17 @@
   redux/redux                               {:git/url "https://github.com/metabase/redux"
                                              :sha "4a37feaf817a2a6b5ef688c927f6fd4375964433"}
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.13.1"}             ; HTTP abstraction
-  ring/ring-jetty-adapter                   {:mvn/version "1.13.0"              ; Jetty adapter
-                                             :exclusions [org.eclipse.jetty/jetty-server
-                                                          org.eclipse.jetty.websocket/websocket-jetty-server]}
+  ring/ring-core                            {:mvn/version "1.14.1"}             ; HTTP abstraction
+  ring/ring-jetty-adapter                   {:mvn/version "1.14.1"              ; Ring adapter for Jetty
+                                             :exclusions  [org.eclipse.jetty/jetty-server
+                                                           org.eclipse.jetty/jetty-unixdomain-server
+                                                           org.eclipse.jetty.ee9/jetty-ee9-servlet
+                                                           org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server]}
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   user-agent/user-agent                     {:mvn/version "0.1.1"}              ; User-Agent string parser, for Login History page & elsewhere
   weavejester/dependency                    {:mvn/version "0.2.1"}              ; Dependency graphs and topological sorting
-  xerces/xercesImpl                         {:mvn/version "2.12.2"}}            ; SAX2 parser, transient dependency of batik
+ xerces/xercesImpl                          {:mvn/version "2.12.2"}}            ; SAX2 parser, transient dependency of batik
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ;; !!         PLEASE KEEP NEW DEPENDENCIES ABOVE ALPHABETICALLY ORGANIZED AND ADD COMMENTS EXPLAINING THEM.         !!

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -568,7 +568,7 @@
   [request :- :map]
   (or (some-> (not-empty (:form-params request)) (update-keys keyword))
       (when-let [body (:body request)]
-        (when-not (instance? org.eclipse.jetty.server.HttpInput body)
+        (when-not (instance? org.eclipse.jetty.ee9.nested.HttpInput body)
           body))))
 
 (mu/defn- middleware-forms

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -20,7 +20,7 @@
    (clojure.core.async.impl.channels ManyToManyChannel)
    (com.mchange.v2.c3p0 PoolBackedDataSource)
    (metabase.server.streaming_response StreamingResponse)
-   (org.eclipse.jetty.util.thread QueuedThreadPool)))
+   (org.eclipse.jetty.util.thread VirtualThreadPool)))
 
 (set! *warn-on-reflection* true)
 
@@ -55,6 +55,7 @@
     (format "%.0fms (%s DB calls)" elapsed-time db-calls)))
 
 (defn- stats [diag-info-fn]
+  ""
   (str
    (when-let [^PoolBackedDataSource pool (let [data-source (mdb/data-source)]
                                            (when (instance? PoolBackedDataSource data-source)
@@ -62,12 +63,12 @@
      (format "App DB connections: %s/%s"
              (.getNumBusyConnectionsAllUsers pool) (.getNumConnectionsAllUsers pool)))
    " "
-   (when-let [^QueuedThreadPool pool (some-> (server/instance) .getThreadPool)]
+   (when-let [^VirtualThreadPool pool (some-> (server/instance) .getThreadPool)]
      (format "Jetty threads: %s/%s (%s idle, %s queued)"
-             (.getBusyThreads pool)
+             (.getThreads pool)
              (.getMaxThreads pool)
              (.getIdleThreads pool)
-             (.getQueueSize pool)))
+             0))
    " "
    (format "(%s total active threads)" (Thread/activeCount))
    " "

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -21,8 +21,8 @@
    (java.nio.channels ClosedChannelException SocketChannel)
    (java.nio.charset StandardCharsets)
    (java.util.zip GZIPOutputStream)
-   (org.eclipse.jetty.io EofException SocketChannelEndPoint)
-   (org.eclipse.jetty.server Request)))
+   (org.eclipse.jetty.ee9.nested Request)
+   (org.eclipse.jetty.io EofException SocketChannelEndPoint)))
 
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
### Description

Avoid the hard concurrency limit placed on our app by Jetty's thread pool and instead use virtual threads to handle requests in Jetty.

Since our app is primiarly I/O bound (talking to databases) the Virtual threading model seems like it should be a better fit for us.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
