### PR TITLE
Unified tests for `splitPart()`

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -1275,29 +1275,3 @@
                                 [[[:= $name "Won"] [:datetime-add $created_at 0 :month]]]
                                 {:default [:datetime-add $birth_date 0 :month]}]}
                  :filter [:time-interval [:expression "asdfdsa"] -12 :month]}))))))
-
-(deftest ^:parallel split-part-test
-  (mt/test-driver :bigquery-cloud-sdk
-    (let [mp (mt/metadata-provider)
-          main-strings [(lib.metadata/field mp (mt/id :people :name))
-                        (lib.metadata/field mp (mt/id :people :zip))
-                        (lib.metadata/field mp (mt/id :people :password))
-                        (lib.metadata/field mp (mt/id :people :address))]
-          delimiters [" "
-                      "7"
-                      (lib/concat "-" "")]
-          indexes [1 (lib/+ 0 2)]]
-      (doseq [main-string main-strings
-              delimiter delimiters
-              index indexes]
-        (testing "split part"
-          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
-                          (lib/with-fields [main-string])
-                          (lib/expression "SPLITPART" (lib/split-part main-string delimiter index))
-                          (lib/limit 100))
-                result (-> query qp/process-query)
-                cols (mt/cols result)
-                rows (mt/rows result)]
-            (is (= :type/Text (-> cols last :base_type)))
-            (doseq [row rows]
-              (is (string? (last row)) (str "Not actually a string: " (pr-str (last row)))))))))))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -679,29 +679,3 @@
               (is (= :type/BigInteger (-> cols first :base_type)))
               (doseq [[casted-value _equals? _uncasted-value] rows]
                 (is (int? casted-value))))))))))
-
-(deftest ^:parallel split-part-test
-  (mt/test-driver :redshift
-    (let [mp (mt/metadata-provider)
-          main-strings [(lib.metadata/field mp (mt/id :people :name))
-                        (lib.metadata/field mp (mt/id :people :zip))
-                        (lib.metadata/field mp (mt/id :people :password))
-                        (lib.metadata/field mp (mt/id :people :address))]
-          delimiters [" "
-                      "-"
-                      "7"
-                      (lib/concat "-" " ")]
-          indexes [1 2 (lib/+ 0 2)]]
-      (doseq [main-string main-strings
-              delimiter delimiters
-              index indexes]
-        (testing "split part"
-          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
-                          (lib/expression "SPLITPART" (lib/split-part main-string delimiter index))
-                          (lib/limit 100))
-                result (-> query qp/process-query)
-                cols (mt/cols result)
-                rows (mt/rows result)]
-            (is (= :type/Text (-> cols last :base_type)))
-            (doseq [row rows]
-              (is (string? (last row))))))))))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -462,7 +462,7 @@
      ""
 
      :else
-     [:split_part (sql.qp/->honeysql driver text) (sql.qp/->honeysql driver divider)]]))
+     [:split_part (sql.qp/->honeysql driver text) (sql.qp/->honeysql driver divider) position]]))
 
 (defn- db-name
   "As mentioned above, old versions of the Snowflake driver used `details.dbname` to specify the physical database, but

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -456,7 +456,13 @@
 
 (defmethod sql.qp/->honeysql [:snowflake :split-part]
   [driver [_ text divider position]]
-  [:split_part (sql.qp/->honeysql driver text) (sql.qp/->honeysql driver divider) (sql.qp/->honeysql driver position)])
+  (let [position (sql.qp/->honeysql driver position)]
+    [:case
+     [:< position 1]
+     ""
+
+     :else
+     [:split_part (sql.qp/->honeysql driver text) (sql.qp/->honeysql driver divider)]]))
 
 (defn- db-name
   "As mentioned above, old versions of the Snowflake driver used `details.dbname` to specify the physical database, but

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -1344,28 +1344,3 @@
               (is (= :type/Number (-> cols first :base_type)))
               (doseq [[casted-value _equals? _uncasted-value] rows]
                 (is (number? casted-value))))))))))
-
-(deftest ^:parallel split-part-test
-  (mt/test-driver :snowflake
-    (let [mp (mt/metadata-provider)
-          main-strings [(lib.metadata/field mp (mt/id :people :name))
-                        (lib.metadata/field mp (mt/id :people :zip))
-                        (lib.metadata/field mp (mt/id :people :password))
-                        (lib.metadata/field mp (mt/id :people :address))]
-          delimiters [" "
-                      "7"
-                      (lib/concat "-" "")]
-          indexes [1 (lib/+ 0 2)]]
-      (doseq [main-string main-strings
-              delimiter delimiters
-              index indexes]
-        (testing "split part"
-          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
-                          (lib/expression "SPLITPART" (lib/split-part main-string delimiter index))
-                          (lib/limit 100))
-                result (-> query qp/process-query)
-                cols (mt/cols result)
-                rows (mt/rows result)]
-            (is (= :type/Text (-> cols last :base_type)))
-            (doseq [row rows]
-              (is (string? (last row))))))))))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -322,9 +322,11 @@
         div  (sql.qp/->honeysql driver divider)
         pos  (sql.qp/->honeysql driver position)]
     [:case
+     ;; non-positive position
      [:< pos 1]
      ""
 
+     ;; position greater than number of parts
      [:> pos
       [:+ 1
        [:floor
@@ -334,6 +336,9 @@
          [:length div]]]]]
      ""
 
+     ;; This needs some explanation.
+     ;; The inner substring_index returns the string up to the `pos` instance of `div`
+     ;; The outer substring_index returns the string from the last instance of `div` to the end
      :else
      [:substring_index
       [:substring_index text div pos]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -322,6 +322,9 @@
         div  (sql.qp/->honeysql driver divider)
         pos  (sql.qp/->honeysql driver position)]
     [:case
+     [:< pos 1]
+     ""
+
      [:> pos
       [:+ 1
        [:floor

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -318,7 +318,23 @@
 
 (defmethod sql.qp/->honeysql [:mysql :split-part]
   [driver [_ text divider position]]
-  [:substring_index (sql.qp/->honeysql driver text) (sql.qp/->honeysql driver divider) (sql.qp/->honeysql driver position)])
+  (let [text (sql.qp/->honeysql driver text)
+        div  (sql.qp/->honeysql driver divider)
+        pos  (sql.qp/->honeysql driver position)]
+    [:case
+     [:> pos
+      [:+ 1
+       [:floor
+        [:/
+         [:- [:length text]
+          [:length [:replace text div ""]]]
+         [:length div]]]]]
+     ""
+
+     :else
+     [:substring_index
+      [:substring_index text div pos]
+      div -1]]))
 
 (defmethod sql.qp/->honeysql [:mysql :regex-match-first]
   [driver [_ arg pattern]]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -661,7 +661,13 @@
 
 (defmethod sql.qp/->honeysql [:postgres :split-part]
   [driver [_ text divider position]]
-  [:split_part (sql.qp/->honeysql driver text) (sql.qp/->honeysql driver divider) (sql.qp/->honeysql driver position)])
+  (let [position (sql.qp/->honeysql driver position)]
+    [:case
+     [:< position 1]
+     ""
+
+     :else
+     [:split_part (sql.qp/->honeysql driver text) (sql.qp/->honeysql driver divider) position]]))
 
 (defmethod sql.qp/->honeysql [:postgres :text]
   [driver [_ value]]

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -545,7 +545,7 @@
   s StringExpressionArg, start IntGreaterThanZeroOrNumericExpression, length (optional NumericExpressionArg))
 
 (defclause ^{:requires-features #{:expressions :split-part}} split-part
-  text StringExpressionArg, delimiter ExpressionArg, position IntGreaterThanZeroOrNumericExpression)
+  text StringExpressionArg, delimiter [:string {:min 1}], position IntGreaterThanZeroOrNumericExpression)
 
 (defclause ^{:requires-features #{:expressions}} length
   s StringExpressionArg)

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -204,7 +204,7 @@
 (mr/def ::expressions
   [:sequential {:min 1} [:ref ::expression.definition]])
 
-(mr/def ::positive-integer
+(mr/def ::positive-integer-or-numeric-expression
   [:and
    [:ref ::integer]
    [:fn

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -203,3 +203,21 @@
 ;;; the `:expressions` definition map as found as a top-level key in an MBQL stage
 (mr/def ::expressions
   [:sequential {:min 1} [:ref ::expression.definition]])
+
+(mr/def ::positive-integer
+  [:and
+   [:ref ::integer]
+   [:fn
+    {:error/message "positive integer literal or numeric expression"}
+    #(cond
+       (vector? %) ;; non-literal (checked above)
+       true
+
+       (not (int? %))
+       false
+
+       (not (pos? %))
+       false
+
+       :else
+       true)]])

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -27,8 +27,8 @@
 
 (mbql-clause/define-tuple-mbql-clause :replace :- :type/Text
   #_str [:schema [:ref ::expression/string]]
-  #_find [:schema [:ref ::expression/string]]
-  #_replace [:schema [:ref ::expression/string]])
+  #_find [:schema :string]
+  #_replace [:schema :string])
 
 (mbql-clause/define-catn-mbql-clause :substring :- :type/Text
   [:str [:schema [:ref ::expression/string]]]

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.schema.expression.string
   (:require
+   [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]))
 
@@ -37,7 +38,7 @@
 
 (mbql-clause/define-tuple-mbql-clause :split-part :- :type/Text
   [:schema [:ref ::expression/string]]
-  [:schema [:string {:min 1}]]
+  [:schema [:ref ::common/non-blank-string]]
   [:schema [:ref ::expression/integer]])
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -36,9 +36,9 @@
   [:length [:? [:schema [:ref ::expression/integer]]]])
 
 (mbql-clause/define-tuple-mbql-clause :split-part :- :type/Text
-  [:schema [:ref ::expression/string]]
-  [:schema [:string {:min 1}]] ;; literal string
-  [:schema [:ref ::expression/positive-integer-or-numeric-expression]])
+  #_text      [:schema [:ref ::expression/string]]
+  #_delimiter [:schema [:string {:min 1}]] ;; literal string
+  #_position  [:schema [:ref ::expression/positive-integer-or-numeric-expression]])
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text
   [:args [:repeat {:min 2} [:schema [:ref ::expression/expression]]]])

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -38,7 +38,7 @@
 (mbql-clause/define-tuple-mbql-clause :split-part :- :type/Text
   [:schema [:ref ::expression/string]]
   [:schema [:string {:min 1}]] ;; literal string
-  [:schema [:ref ::expression/positive-integer]])
+  [:schema [:ref ::expression/positive-integer-or-numeric-expression]])
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text
   [:args [:repeat {:min 2} [:schema [:ref ::expression/expression]]]])

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -38,8 +38,8 @@
 
 (mbql-clause/define-tuple-mbql-clause :split-part :- :type/Text
   [:schema [:ref ::expression/string]]
-  [:schema [:ref ::common/non-blank-string]]
-  [:schema [:ref ::expression/integer]])
+  [:schema [:ref ::common/non-blank-string]] ;; literal string
+  [:schema [:ref ::expression/positive-integer]])
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text
   [:args [:repeat {:min 2} [:schema [:ref ::expression/expression]]]])

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -1,6 +1,5 @@
 (ns metabase.lib.schema.expression.string
   (:require
-   [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]))
 
@@ -38,7 +37,7 @@
 
 (mbql-clause/define-tuple-mbql-clause :split-part :- :type/Text
   [:schema [:ref ::expression/string]]
-  [:schema [:ref ::common/non-blank-string]] ;; literal string
+  [:schema [:string {:min 1}]] ;; literal string
   [:schema [:ref ::expression/positive-integer]])
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -37,7 +37,7 @@
 
 (mbql-clause/define-tuple-mbql-clause :split-part :- :type/Text
   [:schema [:ref ::expression/string]]
-  [:schema [:ref ::expression/string]]
+  [:schema [:string {:min 1}]]
   [:schema [:ref ::expression/integer]])
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -996,29 +996,3 @@
               (is (= :type/BigInteger (-> cols first :base_type)))
               (doseq [[casted-value _equals? _uncasted-value] rows]
                 (is (int? casted-value))))))))))
-
-(deftest ^:parallel split-part-test
-  (mt/test-driver :mysql
-    (let [mp (mt/metadata-provider)
-          main-strings [(lib.metadata/field mp (mt/id :people :name))
-                        (lib.metadata/field mp (mt/id :people :zip))
-                        (lib.metadata/field mp (mt/id :people :password))
-                        (lib.metadata/field mp (mt/id :people :address))]
-          delimiters [" "
-                      "-"
-                      "7"
-                      (lib/concat "-" " ")]
-          indexes [1 2 (lib/+ 0 2)]]
-      (doseq [main-string main-strings
-              delimiter delimiters
-              index indexes]
-        (testing "split part"
-          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
-                          (lib/expression "SPLITPART" (lib/split-part main-string delimiter index))
-                          (lib/limit 100))
-                result (-> query qp/process-query)
-                cols (mt/cols result)
-                rows (mt/rows result)]
-            (is (= :type/Text (-> cols last :base_type)))
-            (doseq [row rows]
-              (is (string? (last row))))))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1698,32 +1698,6 @@
                           (lib/limit 1))]
             (is (->> query qp/process-query mt/rows))))))))
 
-(deftest ^:parallel split-part-test
-  (mt/test-driver :postgres
-    (let [mp (mt/metadata-provider)
-          main-strings [(lib.metadata/field mp (mt/id :people :name))
-                        (lib.metadata/field mp (mt/id :people :zip))
-                        (lib.metadata/field mp (mt/id :people :password))
-                        (lib.metadata/field mp (mt/id :people :address))]
-          delimiters [" "
-                      "-"
-                      "7"
-                      (lib/concat "-" " ")]
-          indexes [1 2 (lib/+ 0 2)]]
-      (doseq [main-string main-strings
-              delimiter delimiters
-              index indexes]
-        (testing "split part"
-          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
-                          (lib/expression "SPLITPART" (lib/split-part main-string delimiter index))
-                          (lib/limit 100))
-                result (-> query qp/process-query)
-                cols (mt/cols result)
-                rows (mt/rows result)]
-            (is (= :type/Text (-> cols last :base_type)))
-            (doseq [row rows]
-              (is (string? (last row))))))))))
-
 (defn- check-query
   ([query db-type uncasted-field]
    (check-query query db-type uncasted-field "\"subquery\".\"TEXTCAST\""))

--- a/test/metabase/query_processor_test/split_part_test.clj
+++ b/test/metabase/query_processor_test/split_part_test.clj
@@ -65,3 +65,54 @@
                          (str/split (re-pattern delimiter))
                          (get (dec index) ""))
                      split-string)))))))))
+
+(deftest ^:parallel split-part-test-examples
+  (mt/test-drivers (mt/normal-drivers-with-feature :split-part)
+    (let [mp (mt/metadata-provider)
+          examples [{:text "ABC-123" :delimiter "-" :position 1 :expected "ABC" :msg "Easy case."}
+                    {:text "ABC-123" :delimiter "-" :position 2 :expected "123" :msg "Easy case."}
+                    ;;{:text "ABC-123" :delimiter "-" :position 0 :expected ""    :msg "Position too low."}
+                    {:text "ABC-123" :delimiter "-" :position 3 :expected ""    :msg "Position too high."}
+
+                    {:text "/ABC/123/" :delimiter "/" :position 1 :expected "" :msg "Empty part when delimiter is first char."}
+                    {:text "/ABC/123/" :delimiter "/" :position 2 :expected "ABC" :msg "First part of path."}
+                    {:text "/ABC/123/" :delimiter "/" :position 3 :expected "123" :msg "Second part of path."}
+                    {:text "/ABC/123/" :delimiter "/" :position 4 :expected "" :msg "Empty part when delimiter is last char."}
+                    {:text "/ABC/123/" :delimiter "/" :position 40 :expected "" :msg "Empty part when position out of bounds."}
+
+                    {:text "ABC-123" :delimiter "," :position 1 :expected "ABC-123"    :msg "Delimiter doesn't exist."}
+
+                    {:text "ABC-123" :delimiter "ABC-123" :position 1 :expected ""    :msg "Delimiter matches whole string."}
+                    {:text "ABC-123" :delimiter "ABC-123" :position 2 :expected ""    :msg "Delimiter matches whole string."}
+
+                    {:text "ABC-123" :delimiter "ABC-1235" :position 1 :expected "ABC-123"    :msg "Delimiter longer than whole string."}]]
+      (doseq [{:keys [text delimiter position expected msg]} examples]
+        (testing (str "split part: " msg)
+          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
+                          (lib/with-fields [(lib.metadata/field mp (mt/id :people :id))])
+                          (lib/expression "SPLITPART" (lib/split-part text delimiter position))
+                          (lib/limit 1))
+                result (-> query qp/process-query)
+                cols (mt/cols result)
+                rows (mt/rows result)]
+            (is (= :type/Text (-> cols last :base_type)))
+            (doseq [[_id split-string] rows]
+              (is (string? split-string))
+              (is (= expected split-string)
+                  (str "Full field: " (pr-str text) ", Delimiter: " (pr-str delimiter) ", position: " position "; " msg)))))))))
+
+(deftest ^:parallel split-part-test-corner-cases
+  (mt/test-drivers (mt/normal-drivers-with-feature :split-part)
+    (let [mp (mt/metadata-provider)]
+      (testing "split part: empty delimiter should be empty string"
+        (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
+                        (lib/with-fields [(lib.metadata/field mp (mt/id :people :id))])
+                        (lib/expression "SPLITPART" (lib/split-part "ABC-123-XYZ" "-" (lib/- 0 1)))
+                        (lib/limit 1))
+              result (-> query qp/process-query)
+              cols (mt/cols result)
+              rows (mt/rows result)]
+          (is (= :type/Text (-> cols last :base_type)))
+          (doseq [[_id split-string] rows]
+            (is (string? split-string))
+            (is (= "" split-string))))))))

--- a/test/metabase/query_processor_test/split_part_test.clj
+++ b/test/metabase/query_processor_test/split_part_test.clj
@@ -33,7 +33,8 @@
               (is (= (-> main-string
                          (str/split (re-pattern delimiter))
                          (get (dec index) ""))
-                     split-string)))))))))
+                     split-string)
+                  (str "Full field: " (pr-str main-string) ", Delimiter: " (pr-str delimiter) ", position: " index)))))))))
 
 (deftest ^:parallel split-part-test-expressions
   (mt/test-drivers (mt/normal-drivers-with-feature :split-part)

--- a/test/metabase/query_processor_test/split_part_test.clj
+++ b/test/metabase/query_processor_test/split_part_test.clj
@@ -43,7 +43,7 @@
                         (lib.metadata/field mp (mt/id :people :zip))
                         (lib.metadata/field mp (mt/id :people :password))
                         (lib.metadata/field mp (mt/id :people :address))]
-          delimiters [(fn [] (lib/concat " " ""))]
+          delimiters [" "]
           indexes [(fn [] (lib/+ 0 1))]]
       (doseq [main-string main-strings
               delimiter delimiters

--- a/test/metabase/query_processor_test/split_part_test.clj
+++ b/test/metabase/query_processor_test/split_part_test.clj
@@ -110,7 +110,7 @@
         (testing (str "split part: " msg)
           (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
                           (lib/with-fields [(lib.metadata/field mp (mt/id :people :id))])
-                          (lib/expression "SPLITPART" (lib/split-part "ABC-123-XYZ" "-") position)
+                          (lib/expression "SPLITPART" (lib/split-part "ABC-123-XYZ" "-" position))
                           (lib/limit 1))
                 result (-> query qp/process-query)
                 cols (mt/cols result)

--- a/test/metabase/query_processor_test/split_part_test.clj
+++ b/test/metabase/query_processor_test/split_part_test.clj
@@ -51,7 +51,6 @@
         (testing "split part"
           (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
                           (lib/with-fields [main-string])
-                          (lib/expression "DELIMITER" delimiter)
                           (lib/expression "INDEX" (index))
                           (lib/expression "SPLITPART" (lib/split-part main-string delimiter (index)))
                           (lib/limit 100))
@@ -59,7 +58,7 @@
                 cols (mt/cols result)
                 rows (mt/rows result)]
             (is (= :type/Text (-> cols last :base_type)))
-            (doseq [[main-string delimiter index split-string] rows]
+            (doseq [[main-string index split-string] rows]
               (is (string? split-string))
               (is (= (-> main-string
                          (str/split (re-pattern delimiter))

--- a/test/metabase/query_processor_test/split_part_test.clj
+++ b/test/metabase/query_processor_test/split_part_test.clj
@@ -1,0 +1,66 @@
+(ns ^:mb/driver-tests metabase.query-processor-test.split-part-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.query-processor :as qp]
+   [metabase.test :as mt]))
+
+(deftest ^:parallel split-part-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :split-part)
+    (let [mp (mt/metadata-provider)
+          main-strings [(lib.metadata/field mp (mt/id :people :name))
+                        (lib.metadata/field mp (mt/id :people :zip))
+                        (lib.metadata/field mp (mt/id :people :password))
+                        (lib.metadata/field mp (mt/id :people :address))]
+          delimiters [" " "-" "7"]
+          indexes [1 2 3]]
+      (doseq [main-string main-strings
+              delimiter delimiters
+              index indexes]
+        (testing "split part"
+          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
+                          (lib/with-fields [main-string])
+                          (lib/expression "SPLITPART" (lib/split-part main-string delimiter index))
+                          (lib/limit 100))
+                result (-> query qp/process-query)
+                cols (mt/cols result)
+                rows (mt/rows result)]
+            (is (= :type/Text (-> cols last :base_type)))
+            (doseq [[main-string split-string] rows]
+              (is (string? split-string))
+              (is (= (-> main-string
+                         (str/split (re-pattern delimiter))
+                         (get (dec index) ""))
+                     split-string)))))))))
+
+(deftest ^:parallel split-part-test-expressions
+  (mt/test-drivers (mt/normal-drivers-with-feature :split-part)
+    (let [mp (mt/metadata-provider)
+          main-strings [(lib.metadata/field mp (mt/id :people :name))
+                        (lib.metadata/field mp (mt/id :people :zip))
+                        (lib.metadata/field mp (mt/id :people :password))
+                        (lib.metadata/field mp (mt/id :people :address))]
+          delimiters [(fn [] (lib/concat " " ""))]
+          indexes [(fn [] (lib/+ 0 1))]]
+      (doseq [main-string main-strings
+              delimiter delimiters
+              index indexes]
+        (testing "split part"
+          (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
+                          (lib/with-fields [main-string])
+                          (lib/expression "DELIMITER" (delimiter))
+                          (lib/expression "INDEX" (index))
+                          (lib/expression "SPLITPART" (lib/split-part main-string (delimiter) (index)))
+                          (lib/limit 100))
+                result (-> query qp/process-query)
+                cols (mt/cols result)
+                rows (mt/rows result)]
+            (is (= :type/Text (-> cols last :base_type)))
+            (doseq [[main-string delimiter index split-string] rows]
+              (is (string? split-string))
+              (is (= (-> main-string
+                         (str/split (re-pattern delimiter))
+                         (get (dec index) ""))
+                     split-string)))))))))

--- a/test/metabase/query_processor_test/split_part_test.clj
+++ b/test/metabase/query_processor_test/split_part_test.clj
@@ -105,7 +105,7 @@
 (deftest ^:parallel split-part-test-corner-cases
   (mt/test-drivers (mt/normal-drivers-with-feature :split-part)
     (let [mp (mt/metadata-provider)]
-      (testing "split part: empty delimiter should be empty string"
+      (testing "split part: negative position should be empty string"
         (let [query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
                         (lib/with-fields [(lib.metadata/field mp (mt/id :people :id))])
                         (lib/expression "SPLITPART" (lib/split-part "ABC-123-XYZ" "-" (lib/- 0 1)))


### PR DESCRIPTION
Closes QUE-835

Effort to unify the tests for `splitPart()`, reducing the number of lines of code, lessening the burden of adding new drivers to `:split`, and ensuring consistent behavior across drivers.