### PR TITLE
Fix offset example

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1513,3 +1513,21 @@ describe("issue #55686", () => {
     H.CustomExpressionEditor.completion("notEmpty").should("be.visible");
   });
 });
+
+describe("issue #55940", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.openOrdersTable({ mode: "notebook" });
+  });
+
+  it("should show the correct example for Offset (metabase#55940)", () => {
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Custom Expression").click();
+
+    H.CustomExpressionEditor.type("Offset(");
+    H.CustomExpressionEditor.helpText()
+      .should("be.visible")
+      .should("contain", "Offset(Sum([Total]) -1)");
+  });
+});

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1528,6 +1528,6 @@ describe("issue #55940", () => {
     H.CustomExpressionEditor.type("Offset(");
     H.CustomExpressionEditor.helpText()
       .should("be.visible")
-      .should("contain", "Offset(Sum([Total]) -1)");
+      .should("contain", "Offset(Sum([Total]), -1)");
   });
 });

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Expression } from "metabase-types/api";
 
-import { adjustCaseOrIf } from "./passes";
+import { applyPasses } from "./passes";
 import type { HelpText, HelpTextConfig } from "./types";
 
 const getDescriptionForNow: HelpTextConfig["description"] = (
@@ -1417,7 +1417,7 @@ const getHelpExample = ({ name, args = [] }: HelpTextConfig): Expression => {
     }
   }
 
-  return adjustCaseOrIf([name, ...parameters]);
+  return applyPasses([name, ...parameters]);
 };
 
 export const getHelpDocsUrl = ({ docsPage }: HelpText): string => {

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
@@ -62,16 +62,23 @@ describe("getHelpText", () => {
       );
     });
 
-    it("offset", () => {
+    it("offset", async () => {
       const { database } = setup();
       const helpText = getHelpText("offset", database, reportTimezone);
 
       expect(helpText?.structure).toBe("Offset");
       expect(helpText?.example).toEqual([
         "offset",
+        {},
         ["sum", ["dimension", "Total"]],
         -1,
       ]);
+      if (!helpText?.example) {
+        throw new Error("unreachable");
+      }
+      expect(await formatExample(helpText?.example)).toEqual(
+        "Offset(Sum([Total]), -1)",
+      );
     });
 
     describe("datetimeDiff", () => {

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
@@ -133,7 +133,7 @@ describe("getHelpText", () => {
       if (!helpText) {
         continue;
       }
-      expect(() => formatExample(helpText.example)).not.toThrow();
+      expect(await formatExample(helpText.example)).toEqual(expect.any(String));
     }
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55940

The help text example was incorrectly formatted. This PR fixes that.

### To Reproduce

1. Go to New -> Question -> Orders
2. Add Aggregation -> Custom Expression
3. Type `Offset(`
4. Scroll down to see the example, it says `Offset(Sum([Total]), -1)`
