### PR TITLE
Limit tsvector inserts to 1048575 bytes

### DIFF
--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [metabase.search.appdb.specialization.api :as specialization]
    [metabase.util :as u]
+   [metabase.util.string :as u.str]
    [toucan2.core :as t2]))
 
 (def ^:private tsv-language "english")
@@ -116,7 +117,8 @@
                " @@ query")])})
 
 (defn- weighted-tsvector [weight text]
-  [:setweight [:to_tsvector [:inline tsv-language] [:cast text :text]] [:inline weight]])
+  ;; tsvector has a max value size of 1048575 bytes
+  [:setweight [:to_tsvector [:inline tsv-language] [:cast (u.str/limit-bytes text 1048575) :text]] [:inline weight]])
 
 (defmethod specialization/extra-entry-fields :postgres [entity]
   {:search_vector

--- a/src/metabase/util/string.clj
+++ b/src/metabase/util/string.clj
@@ -63,6 +63,29 @@
     (str (subs s 0 (- max-length 3)) "...")
     s))
 
+(defn- remove-chars
+  "Removes individual chars until it fits in the required bytes"
+  [s max-bytes]
+  (if (nil? s)
+    s
+    (loop [index (count s)]
+      (let [truncated (subs s 0 index)
+            bytes (.getBytes truncated "UTF-8")]
+        (if (<= (count bytes) max-bytes)
+          truncated
+          (recur (dec index)))))))
+
+(defn limit-bytes
+  "Limits the string to the given number of bytes, ensuring it's still a valid UTF-8 string"
+  [s max-bytes]
+  (if (nil? s)
+    s
+    (let [bytes (.getBytes s "UTF-8")]
+      (if (<= (count bytes) max-bytes)
+        s
+        ;; first do big first-pass at truncating, then truncate the rest of the way to preserve a valid string
+        (remove-chars (String. (byte-array (take max-bytes bytes)) "UTF-8") max-bytes)))))
+
 (defn random-string
   "Returns a string of `n` random alphanumeric characters.
 

--- a/src/metabase/util/string.clj
+++ b/src/metabase/util/string.clj
@@ -70,7 +70,7 @@
     s
     (loop [index (count s)]
       (let [truncated (subs s 0 index)
-            bytes (.getBytes truncated "UTF-8")]
+            bytes (.getBytes ^String truncated "UTF-8")]
         (if (<= (count bytes) max-bytes)
           truncated
           (recur (dec index)))))))
@@ -80,7 +80,7 @@
   [s max-bytes]
   (if (nil? s)
     s
-    (let [bytes (.getBytes s "UTF-8")]
+    (let [bytes (.getBytes ^String s "UTF-8")]
       (if (<= (count bytes) max-bytes)
         s
         ;; first do big first-pass at truncating, then truncate the rest of the way to preserve a valid string


### PR DESCRIPTION
### Description

The tsvector values used by search cannot be larger than 1048575 bytes. Truncate too-large values before sending them to the database

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
