### PR TITLE
Fix compilation of case with clauses that need pre-processing

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/compiler.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.ts
@@ -51,10 +51,10 @@ export function compileExpression({
     const expression = applyPasses(compiled, [
       adjustOptions,
       adjustOffset,
-      adjustCaseOrIf,
       adjustMultiArgOptions,
       adjustBigIntLiteral,
       adjustTopLevelLiteral,
+      adjustCaseOrIf,
       shouldResolve &&
         resolverPass({
           database,

--- a/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
@@ -240,6 +240,65 @@ describe("old recursive-parser tests", () => {
       expression: ["ends-with", { "case-sensitive": false }, "A", "B", "C"],
     },
     {
+      source: "case(contains('A', 'B', 'C'), 1, 2)",
+      expression: [
+        "case",
+        [[["contains", {}, "A", "B", "C"], 1]],
+        { default: 2 },
+      ],
+    },
+    {
+      source: "case(contains('A', 'B', 'case-insensitive'), 1, 2)",
+      expression: [
+        "case",
+        [[["contains", "A", "B", { "case-sensitive": false }], 1]],
+        { default: 2 },
+      ],
+    },
+    {
+      source: "case(contains('A', 'B', 'C', 'case-insensitive'), 1, 2)",
+      expression: [
+        "case",
+        [[["contains", { "case-sensitive": false }, "A", "B", "C"], 1]],
+        { default: 2 },
+      ],
+    },
+    {
+      source:
+        "case(contains('A', 'B', 'C', 'case-insensitive'), 1, contains('D', 'E', 'F', 'case-insensitive'), 2, 3)",
+      expression: [
+        "case",
+        [
+          [["contains", { "case-sensitive": false }, "A", "B", "C"], 1],
+          [["contains", { "case-sensitive": false }, "D", "E", "F"], 2],
+        ],
+        { default: 3 },
+      ],
+    },
+    {
+      source:
+        "case(contains('A', 'B', 'case-insensitive'), 9223372036854775807, 0)",
+      expression: [
+        "case",
+        [
+          [
+            ["contains", "A", "B", { "case-sensitive": false }],
+            ["value", "9223372036854775807", { base_type: "type/BigInteger" }],
+          ],
+        ],
+        { default: 0 },
+      ],
+    },
+    {
+      source:
+        "case(contains('A', 'B', 'case-insensitive'), 0, 9223372036854775807)",
+      expression: [
+        "case",
+        [[["contains", "A", "B", { "case-sensitive": false }], 0]],
+        { default: "9223372036854775807" },
+      ],
+    },
+    {
       source: "interval([Created At], -1, 'days', 'include-current')",
       expression: [
         "time-interval",

--- a/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
@@ -295,7 +295,13 @@ describe("old recursive-parser tests", () => {
       expression: [
         "case",
         [[["contains", "A", "B", { "case-sensitive": false }], 0]],
-        { default: "9223372036854775807" },
+        {
+          default: [
+            "value",
+            "9223372036854775807",
+            { base_type: "type/BigInteger" },
+          ],
+        },
       ],
     },
     {

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -772,7 +772,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: "caseInsensitive",
+        name: '"case-insensitive"',
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },
@@ -801,7 +801,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: "caseInsensitive",
+        name: '"case-insensitive"',
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },
@@ -830,7 +830,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: "caseInsensitive",
+        name: '"case-insensitive"',
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },
@@ -859,7 +859,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: "caseInsensitive",
+        name: '"case-insensitive"',
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -772,7 +772,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: '"case-insensitive"',
+        name: "caseInsensitive",
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },
@@ -801,7 +801,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: '"case-insensitive"',
+        name: "caseInsensitive",
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },
@@ -830,7 +830,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: '"case-insensitive"',
+        name: "caseInsensitive",
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },
@@ -859,7 +859,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: t`Medium`,
       },
       {
-        name: '"case-insensitive"',
+        name: "caseInsensitive",
         description: t`Optional. To perform a case-insensitive match.`,
         example: "case-insensitive",
       },

--- a/frontend/src/metabase-lib/v1/expressions/identifier.ts
+++ b/frontend/src/metabase-lib/v1/expressions/identifier.ts
@@ -71,7 +71,7 @@ export function parseSegment(
     expressionIndex,
   ).find((field) => {
     const displayInfo = Lib.displayInfo(query, stageIndex, field);
-    return displayInfo.name.toLowerCase() === segmentName.toLowerCase();
+    return displayInfo.displayName.toLowerCase() === segmentName.toLowerCase();
   });
 
   if (column && Lib.isBoolean(column)) {

--- a/frontend/src/metabase-lib/v1/expressions/passes.ts
+++ b/frontend/src/metabase-lib/v1/expressions/passes.ts
@@ -1,8 +1,4 @@
-import type {
-  CallExpression,
-  CaseOptions,
-  Expression,
-} from "metabase-types/api";
+import type { CallExpression, Expression } from "metabase-types/api";
 
 import { MBQL_CLAUSES } from "./config";
 import {
@@ -12,7 +8,6 @@ import {
   isNumberLiteral,
   isOptionsObject,
   isStringLiteral,
-  isValue,
 } from "./matchers";
 
 export type CompilerPass = (expr: Expression) => Expression;
@@ -55,17 +50,9 @@ export const adjustCaseOrIf: CompilerPass = (tree) =>
       }
       if (operands.length > 2 * pairCount) {
         const lastOperand = operands[operands.length - 1];
-        let options: CaseOptions = {};
-        if (isOptionsObject(lastOperand)) {
-          options = lastOperand;
-        } else if (isValue(lastOperand)) {
-          const valueLiteral = lastOperand[1];
-          if (valueLiteral != null) {
-            options = { default: valueLiteral };
-          }
-        } else {
-          options = { default: lastOperand };
-        }
+        const options = isOptionsObject(lastOperand)
+          ? lastOperand
+          : { default: lastOperand };
         return withAST([operator, pairs, options], node);
       }
       return withAST([operator, pairs], node);

--- a/frontend/src/metabase-lib/v1/expressions/passes.ts
+++ b/frontend/src/metabase-lib/v1/expressions/passes.ts
@@ -59,9 +59,9 @@ export const adjustCaseOrIf: CompilerPass = (tree) =>
         if (isOptionsObject(lastOperand)) {
           options = lastOperand;
         } else if (isValue(lastOperand)) {
-          const defaultValue = lastOperand[1];
-          if (defaultValue != null) {
-            options = { default: defaultValue };
+          const valueLiteral = lastOperand[1];
+          if (valueLiteral != null) {
+            options = { default: valueLiteral };
           }
         } else {
           options = { default: lastOperand };


### PR DESCRIPTION
https://metaboat.slack.com/archives/C864UT5CZ/p1743195004794629

`modify` doesn't work on `case` "pairs", so the `case` pass should always go last (this is how it's done here), or we need to make `modify` work on case pairs. 

This PR also improves the help text for `case-insensitive` option and makes sure it gets inserted as a correct string.

How to verify:
- New -> Question -> Products -> Custom column - `case(contains('A', 'B', 'C', 'case-insensitive'), 1, 2)` -> Done
- Open the expression again. It should not be changed

<img width="580" alt="Screenshot 2025-03-28 at 20 32 05" src="https://github.com/user-attachments/assets/0f8e0581-7738-4f3e-84be-46b212918c55" />
