### PR TITLE
WIP Attempt to add visibility_type to the columnInfo map

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -146,6 +146,7 @@ export type ColumnDisplayInfo = {
   longDisplayName: string;
   semanticType: string | null;
   effectiveType: string;
+  visibilityType: string;
 
   isCalculated: boolean;
   isFromJoin: boolean;

--- a/frontend/src/metabase/querying/notebook/components/FieldPicker/FieldPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/FieldPicker/FieldPicker.tsx
@@ -51,7 +51,10 @@ export const FieldPicker = ({
     }));
     return items.map((item) => ({
       ...item,
-      isSelected: isColumnSelected(item, items),
+      isSelected:
+        item.columnInfo.visibilityType === "details-only"
+          ? false
+          : isColumnSelected(item, items),
       isDisabled: isColumnDisabled?.(item, items),
     }));
   }, [query, stageIndex, columns, isColumnSelected, isColumnDisabled]);

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -310,6 +310,7 @@
 
 (defmethod lib.metadata.calculation/display-info-method :metadata/column
   [query stage-number field-metadata]
+  (log/info "display-info-method :metadata/column field-metadata: " (pr-str field-metadata))
   (merge
    ((get-method lib.metadata.calculation/display-info-method :default) query stage-number field-metadata)
    ;; These have to be calculated even if the metadata has display-name to support nested fields
@@ -322,6 +323,10 @@
      {:description description})
    (when-let [fingerprint (:fingerprint field-metadata)]
      {:fingerprint fingerprint})
+   ;; Include visibility_type if present
+   (when-let [visibility-type (:visibility-type field-metadata)]
+     (log/info "Found visibility_type: " (pr-str visibility-type))
+     {:visibility-type visibility-type})
    ;; if this column comes from a source Card (Saved Question/Model/etc.) use the name of the Card as the 'table' name
    ;; rather than the ACTUAL table name.
    (when (= (:lib/source field-metadata) :source/card)

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -324,7 +324,8 @@
    ;; for binning and bucketing
    [:default {:optional true} :boolean]
    ;; for order by
-   [:direction {:optional true} [:enum :asc :desc]]])
+   [:direction {:optional true} [:enum :asc :desc]]
+   [:visibility-type {:optional true}] :string])
 
 (mu/defn display-info :- ::display-info
   "Given some sort of Cljs object, return a map with the info you'd need to implement UI for it. This is mostly meant to


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #47945
Resolves VIZ-173

WIP
Believe this PR is on the right track but I'm not seeing `visibilityType` in the returned `columnInfo`

- Includes a field's `visibility_type` in the return of `displayInfo` for columns so we can conditionally uncheck details only columns in the query builder
- Result of this will be that the column is not present in downstream visualization UIs