### PR TITLE
perf: Optimize settings retrieval

### DIFF
--- a/test/metabase/models/setting/cache_test.clj
+++ b/test/metabase/models/setting/cache_test.clj
@@ -42,7 +42,7 @@
 (defn reset-last-update-check!
   "Reset the value of `last-update-check` so the next cache access will check for updates."
   []
-  (reset! (var-get #'setting.cache/last-update-check) 0))
+  (.set ^java.util.concurrent.atomic.AtomicLong (var-get #'setting.cache/last-update-check) 0))
 
 (deftest update-settings-last-updated-test
   (testing "When I update a Setting, does it set/update `settings-last-updated`?"


### PR DESCRIPTION
These optimizations are primarily intended for making `available-drivers-info` function more efficient, but are beneficial on their own.

The improvement is achieved by:
- Reducing allocations (AtomicLong to enforce primitive math instead of boxed math, unrolled loop over setting sources)
- Getting rid of binding a dynamic variable unless necessary
- Caching the resolved `metabase.db/db-is-set-up?` var to avoid var resolution on every invocation.
