### PR TITLE
perf: Optimize available-drivers-info

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -95,8 +95,7 @@
     driver.common/cloud-ip-address-info
     driver.common/advanced-options-start
     driver.common/default-advanced-options]
-   (map u/one-or-many)
-   (apply concat)))
+   (into [] (mapcat u/one-or-many))))
 
 (defn- malicious-property-value
   "Checks an h2 connection string for connection properties that could be malicious. Markers of this include semi-colons

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -196,8 +196,7 @@
     (assoc driver.common/additional-options
            :placeholder  "tinyInt1isBit=false")
     driver.common/default-advanced-options]
-   (map u/one-or-many)
-   (apply concat)))
+   (into [] (mapcat u/one-or-many))))
 
 (defmethod sql.qp/add-interval-honeysql-form :mysql
   [driver hsql-form amount unit]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -207,8 +207,7 @@
     (assoc driver.common/additional-options
            :placeholder "prepareThreshold=0")
     driver.common/default-advanced-options]
-   (map u/one-or-many)
-   (apply concat)))
+   (into [] (mapcat u/one-or-many))))
 
 (defmethod driver/db-start-of-week :postgres
   [_]

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -4,7 +4,6 @@
    [clojure.core.memoize :as memoize]
    [clojure.set :as set]
    [clojure.string :as str]
-   [medley.core :as m]
    [metabase.auth-provider :as auth-provider]
    [metabase.config :as config]
    [metabase.db :as mdb]
@@ -21,6 +20,7 @@
    [metabase.util.i18n :refer [deferred-tru trs]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf]
    [metabase.util.snake-hating-map :refer [snake-hating-map?]])
   (:import
    (java.io ByteArrayInputStream)
@@ -287,10 +287,8 @@
 (defn available-drivers
   "Return a set of all currently available drivers."
   []
-  (set (for [driver (descendants driver/hierarchy :metabase.driver/driver)
-             :when  (and (driver/available? driver)
-                         (supported-in-environment? driver))]
-         driver)))
+  (into #{} (filter #(and (driver/available? %) (supported-in-environment? %)))
+        (descendants driver/hierarchy :metabase.driver/driver)))
 
 (mu/defn semantic-version-gte :- :boolean
   "Returns true if xv is greater than or equal to yv according to semantic versioning.
@@ -435,58 +433,62 @@
    if one was provided."
   {:added "0.42.0"}
   [driver conn-props]
-  (let [res (reduce (fn [acc conn-prop]
-                      ;; TODO: change this to expanded- and use that as the basis for all calcs below (not conn-prop)
-                      (let [expanded-props (case (keyword (:type conn-prop))
-                                             :secret
-                                             (expand-secret-conn-prop conn-prop)
+  (let [final-props
+        (persistent!
+         (reduce (fn [acc conn-prop]
+                   ;; TODO: change this to expanded- and use that as the basis for all calcs below (not conn-prop)
+                   (let [expanded-props (case (keyword (:type conn-prop))
+                                          :secret
+                                          (expand-secret-conn-prop conn-prop)
 
-                                             :info
-                                             (if-let [conn-prop' (resolve-info-conn-prop conn-prop)]
-                                               [conn-prop']
-                                               [])
+                                          :info
+                                          (if-let [conn-prop' (resolve-info-conn-prop conn-prop)]
+                                            [conn-prop']
+                                            [])
 
-                                             :checked-section
-                                             (resolve-checked-section-conn-prop conn-prop)
+                                          :checked-section
+                                          (resolve-checked-section-conn-prop conn-prop)
 
-                                             :schema-filters
-                                             (expand-schema-filters-prop conn-prop)
+                                          :schema-filters
+                                          (expand-schema-filters-prop conn-prop)
 
-                                             [conn-prop])]
-                        (-> (update acc ::final-props concat expanded-props)
-                            (update ::props-by-name merge (into {} (map (fn [p]
-                                                                          [(:name p) p])) expanded-props)))))
-                    {::final-props [] ::props-by-name {}}
-                    conn-props)
-        {::keys [final-props props-by-name]} res]
+                                          [conn-prop])]
+                     (reduce conj! acc expanded-props)))
+                 (transient [])
+                 conn-props))
+        props-by-name (reduce #(assoc %1 (:name %2) %2) {} final-props)]
     ;; now, traverse the visible-if-edges and update all visible-if entries with their full set of "transitive"
     ;; dependencies (if property x depends on y having a value, but y itself depends on z having a value, then x
     ;; should be hidden if y is)
     (mapv (fn [prop]
-            (let [v-ifs* (loop [props* [prop]
-                                acc    {}]
-                           (if (seq props*)
-                             (let [all-visible-ifs  (m/filter-kv
-                                                     (fn [prop-name v]
-                                                       (or (contains? props-by-name (->str prop-name))
-                                                            ;; If v is false then this depended on a removed :checked-section
-                                                            ;; and the dependency should be dropped.
-                                                           (not (false? v))))
-                                                     (apply merge (map :visible-if props*)))
-                                   transitive-props (map (comp (partial get props-by-name) ->str)
-                                                         (keys all-visible-ifs))
-                                   next-acc         (merge all-visible-ifs acc)
-                                   cyclic-props     (set/intersection (into #{} (keys all-visible-ifs))
-                                                                      (into #{} (keys acc)))]
-                               (if (empty? cyclic-props)
-                                 (recur transitive-props next-acc)
-                                 (-> (trs "Cycle detected resolving dependent visible-if properties for driver {0}: {1}"
-                                          driver cyclic-props)
-                                     (ex-info {:type               qp.error-type/driver
-                                               :driver             driver
-                                               :cyclic-visible-ifs cyclic-props})
-                                     throw)))
-                             acc))]
+            (let [v-ifs*
+                  (loop [props* [prop]
+                         acc    {}]
+                    (if (seq props*)
+                      (let [all-visible-ifs  (reduce
+                                              #(reduce-kv (fn [acc prop-name v]
+                                                            (if (or (contains? props-by-name (->str prop-name))
+                                                                    ;; If v is false then this depended on a removed :checked-section
+                                                                    ;; and the dependency should be dropped.
+                                                                    (not (false? v)))
+                                                              (assoc acc prop-name v)
+                                                              acc))
+                                                          %1 (:visible-if %2))
+                                              {} props*)
+                            visible-keys     (keys all-visible-ifs)
+                            transitive-props (perf/mapv (comp (partial get props-by-name) ->str) visible-keys)
+                            next-acc         (into acc all-visible-ifs)]
+                        (if-not (perf/some #(contains? acc %) visible-keys)
+                          (recur transitive-props next-acc)
+                          (let [cyclic-props (set/intersection (set visible-keys)
+                                                               (set (keys acc)))]
+                            (-> (trs "Cycle detected resolving dependent visible-if properties for driver {0}: {1}"
+                                     driver cyclic-props)
+                                (ex-info {:type               qp.error-type/driver
+                                          :driver             driver
+                                          :cyclic-visible-ifs cyclic-props})
+                                throw))))
+                      acc))]
               (cond-> prop
                 (seq v-ifs*) (assoc :visible-if v-ifs*)
                 (empty? v-ifs*) (dissoc :visible-if))))
@@ -535,19 +537,21 @@
   features. The output of `driver/connection-properties` is passed through `connection-props-server->client` before
   being returned, to handle any transformation between the server side and client side representation."
   []
-  (into {} (for [driver (available-drivers)
-                 :let   [props (try
-                                 (->> (driver/connection-properties driver)
-                                      (connection-props-server->client driver))
-                                 (catch Throwable e
-                                   (log/errorf e "Unable to determine connection properties for driver %s" driver)))]
-                 :when  props]
-             ;; TODO - maybe we should rename `details-fields` -> `connection-properties` on the FE as well?
-             [driver {:source {:type (driver-source (name driver))
-                               :contact (driver/contact-info driver)}
-                      :details-fields props
-                      :driver-name    (driver/display-name driver)
-                      :superseded-by  (driver/superseded-by driver)}])))
+  (persistent!
+   (reduce (fn [acc driver]
+             (if-some [props (try
+                               (->> (driver/connection-properties driver)
+                                    (connection-props-server->client driver))
+                               (catch Throwable e
+                                 (log/errorf e "Unable to determine connection properties for driver %s" driver)))]
+               ;; TODO - maybe we should rename `details-fields` -> `connection-properties` on the FE as well?
+               (assoc! acc driver {:source {:type (driver-source (name driver))
+                                            :contact (driver/contact-info driver)}
+                                   :details-fields props
+                                   :driver-name    (driver/display-name driver)
+                                   :superseded-by  (driver/superseded-by driver)})
+               acc))
+           (transient {}) (available-drivers))))
 
 (defsetting engines
   "Available database engines"

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -41,9 +41,7 @@
   referring to one of the default maps in `driver.common`, a entire custom map, or a list of maps to `merge:` (e.g.
   for overriding part, but not all, of a default option)."
   [{:keys [connection-properties]}]
-  (->> (map parse-connection-property connection-properties)
-       (map u/one-or-many)
-       (apply concat)))
+  (into [] (mapcat #(u/one-or-many (parse-connection-property %))) connection-properties))
 
 (defn- make-initialize! [driver add-to-classpath! init-steps]
   (fn [_]


### PR DESCRIPTION
Since the idea to cache available-drivers-info (#55596) may not work, here's the attempt to optimize it. The main focus is on reducing allocations, getting rid of lazy sequences in favor of vectors, and being a bit smarter about the overall algorithm.

```
BEFORE:
Time per call: 1.27 ms   Alloc per call: 2,932,885b
Time per call: 1.23 ms   Alloc per call: 2,932,713b
Time per call: 1.23 ms   Alloc per call: 2,932,721b

AFTER:
Time per call: 463.75 us   Alloc per call: 888,376b
Time per call: 456.28 us   Alloc per call: 888,032b
Time per call: 458.39 us   Alloc per call: 888,032b
```

Allocation diffgraph: https://flamebin.dev/PTWcnh. Not terribly useful as it's just all blue:).