### PR TITLE
Respect whitelabeling when showing the instructional video

### DIFF
--- a/frontend/src/metabase/browse/models/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.tsx
@@ -88,9 +88,11 @@ export const BrowseModels = () => {
           <Stack mb="lg" gap="md" w="100%">
             {isEmpty ? (
               <Stack gap="lg" align="center" data-testid="empty-state">
-                <Box maw="45rem" w="100%">
-                  <ModelsVideo autoplay={0} />
-                </Box>
+                {showMetabaseLinks && (
+                  <Box maw="45rem" w="100%">
+                    <ModelsVideo autoplay={0} />
+                  </Box>
+                )}
                 <Stack gap="xs" maw="28rem">
                   <Title
                     order={2}

--- a/frontend/src/metabase/browse/models/ModelExplanationBanner.tsx
+++ b/frontend/src/metabase/browse/models/ModelExplanationBanner.tsx
@@ -44,7 +44,9 @@ export const ModelExplanationBanner = () => {
       mb="xl"
     >
       <Flex>
-        <ModelsVideoThumbnail onClick={() => setOpened(true)} />
+        {showMetabaseLinks && (
+          <ModelsVideoThumbnail onClick={() => setOpened(true)} />
+        )}
         <Stack gap="md">
           <Title
             order={2}


### PR DESCRIPTION
Resolves CLO-3870

The context in the isssue, but tl;dr is:
"Show Metabase links" setting should apply to all Metabase content, not just the literal documentation links.

This PR ensures that in the context of `/browse/models`