### PR TITLE
test: fix flake caused by data not loaded on slow network

### DIFF
--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -199,6 +199,8 @@ describe("scenarios > collection pinned items overview", () => {
       });
 
       openRootCollection();
+      cy.log("wait for data to be loaded and displayed");
+      H.getPinnedSection().should("contain", "18,760");
       H.openPinnedItemMenu(QUESTION_NAME);
       H.popover().findByText("Don’t show visualization").click();
       cy.wait("@getPinnedItems");


### PR DESCRIPTION
### Description

fix flake in `e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js` flaky test by awaiting for content to appear before processing with assertions

✅ [stress test](https://github.com/metabase/metabase/actions/runs/14172284915)