### PR TITLE
Fix console warning for end vs flex-end

### DIFF
--- a/frontend/src/metabase/data-grid/components/Footer/Footer.module.css
+++ b/frontend/src/metabase/data-grid/components/Footer/Footer.module.css
@@ -4,7 +4,7 @@
   flex-shrink: 0;
   font-weight: 600;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   border-top: 1px solid var(--mb-color-border);
 }
 


### PR DESCRIPTION
Fixes another warning about using `end` vs `flex-end` when building the frontend and SDK.

@alxnddr I think this was yours so just wanted to give you the review honors 🙂
