### PR TITLE
Fix row create

### DIFF
--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -220,7 +220,7 @@
                             (tru "Sorry, the row you''re trying to delete doesn''t exist")
                             (tru "Sorry, this would delete {0} rows, but you can only act on 1" rows-deleted))
                           {:staus-code 400})))
-        {:rows-deleted [1]}))))
+        {:rows-deleted 1}))))
 
 (defmethod actions/perform-action!* [:sql-jdbc :row/update]
   [driver action database {database-id :database :keys [update-row] :as query}]
@@ -240,7 +240,7 @@
                             (tru "Sorry, the row you''re trying to update doesn''t exist")
                             (tru "Sorry, this would update {0} rows, but you can only act on 1" rows-updated))
                           {:status-code 400})))
-        {:rows-updated [1]}))))
+        {:rows-updated 1}))))
 
 (defmulti select-created-row
   "Multimethod for converting the result of an insert into the created row.
@@ -539,7 +539,7 @@
                                                        {:status-code 400, :errors errors})))
                                      ;; `:bulk/update` returns {:rows-updated <number-of-rows-updated>} on success.
                                      (transduce
-                                      (map (comp first :rows-updated))
+                                      (map :rows-updated)
                                       (completing +
                                                   (fn [num-rows-updated]
                                                     {:rows-updated num-rows-updated}))

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -72,7 +72,7 @@
   (testing "row/update"
     (mt/test-drivers (mt/normal-drivers-with-feature :actions)
       (with-actions-test-data-and-actions-permissively-enabled!
-        (is (= {:rows-updated [1]}
+        (is (= {:rows-updated 1}
                (actions/perform-action! :row/update
                                         (assoc (mt/mbql-query categories {:filter [:= $id 50]})
                                                :update_row {(format-field-name :name) "updated_row"})))
@@ -85,7 +85,7 @@
   (testing "row/delete"
     (mt/test-drivers (mt/normal-drivers-with-feature :actions)
       (with-actions-test-data-and-actions-permissively-enabled!
-        (is (= {:rows-deleted [1]}
+        (is (= {:rows-deleted 1}
                (actions/perform-action! :row/delete
                                         (mt/mbql-query categories {:filter [:= $id 50]})))
             "Delete should return the right shape")
@@ -113,7 +113,7 @@
     :expected     {:rows-updated [1]}}
    {:action       :row/delete
     :request-body (mt/mbql-query categories {:filter [:= $id 1]})
-    :expected     {:rows-deleted [1]}}
+    :expected     {:rows-deleted 1}}
    {:action       :row/update
     :request-body (assoc (mt/mbql-query categories {:filter [:= $id 10]})
                          :update_row {(format-field-name :name) "new-category-name"})
@@ -582,7 +582,7 @@
   (testing "row/update with uuids"
     (mt/test-drivers (mt/normal-drivers-with-feature :actions :uuid-type)
       (with-uuids-test-data-and-actions-permissively-enabled!
-        (is (= {:rows-updated [1]}
+        (is (= {:rows-updated 1}
                (actions/perform-action!
                 :row/update
                 (assoc (mt/mbql-query ants {:filter [:= $id "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]})
@@ -619,7 +619,7 @@
   (testing "row/delete with uuids"
     (mt/test-drivers (mt/normal-drivers-with-feature :actions :uuid-type)
       (with-uuids-test-data-and-actions-permissively-enabled!
-        (is (= {:rows-deleted [1]}
+        (is (= {:rows-deleted 1}
                (actions/perform-action!
                 :row/delete
                 (mt/mbql-query ants {:filter [:= $id "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]})))


### PR DESCRIPTION
Fixes [WRK-194: Fix syntax error when creating new records with FK relationships](https://linear.app/metabase/issue/WRK-194/fix-syntax-error-when-creating-new-records-with-fk-relationships)