### PR TITLE
fix scatter charts freeze page

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -922,7 +922,9 @@ function getTimeSeriesXAxisInfo(
   if (range) {
     const [min, max] = range;
     // A single date counts as one interval
-    intervalsCount = Math.ceil(max.diff(min, interval.unit) / interval.count);
+    intervalsCount = Math.abs(
+      Math.ceil(max.diff(min, interval.unit) / interval.count),
+    );
   }
 
   return { interval, timezone, offsetMinutes, intervalsCount, range, unit };

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -552,6 +552,7 @@ export const GRAPH_AXIS_SETTINGS = {
     title: t`Scale`,
     index: 4,
     widget: "select",
+    persistDefault: true,
     readDependencies: [
       "graph.x_axis._is_timeseries",
       "graph.x_axis._is_numeric",

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -13,10 +13,31 @@ const TIMESERIES_UNITS = new Set([
 ]);
 
 export function dimensionIsTimeseries({ cols, rows }, i = 0) {
-  return (
-    dimensionIsExplicitTimeseries({ cols, rows }, i) ||
-    moment(rows[0] && rows[0][i], moment.ISO_8601).isValid()
-  );
+  if (dimensionIsExplicitTimeseries({ cols, rows }, i)) {
+    return true;
+  }
+
+  let hasNonNull = false;
+
+  for (const row of rows) {
+    const value = row[i];
+
+    if (value == null) {
+      continue;
+    }
+
+    hasNonNull = true;
+
+    if (typeof value === "number" && !Number.isInteger(value)) {
+      return false;
+    }
+
+    if (!moment(value, moment.ISO_8601).isValid()) {
+      return false;
+    }
+  }
+
+  return hasNonNull;
 }
 
 export function dimensionIsExplicitTimeseries({ cols }, i) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55880
Closes https://github.com/metabase/metabase/issues/30102

### Description

When detecting x-axis scale type we prioritize timeseries over numeric type. However, we are flexible enough with what can be a timeseries data, for example we assume that `1997` is an implicit timeseries value that represents year which is reasonable logic. We rely on `moment(value, moment.ISO_8601).isValid()` to detect whether a value is a date. 

There were few problems that led to this bug:
- We [checked](https://github.com/metabase/metabase/pull/56016/files) only the first dimension value. If other values are not valid dates we still assumed it is a timeseries dimension
- In that case calculation of intervals count could produce a [negative](https://github.com/metabase/metabase/pull/56016/files#diff-a925af260455ef56ff9bc97d2376ab8cc1f92bc51256d5ab0fdb4b39a9088363R925) number which led to infinite loops further
- We [did not persist](https://github.com/metabase/metabase/pull/56016/files#diff-a996e07afd884cc1340bdeffa0eb577d7828cf4e6418c547d4dc201d1511f96dR555) the default value of x-axis scale when saving question. It is possible when saving a question it has correctly determined `linear` type but later when dashboard filters are applied the returned numbers are considered as `timeseries` and the chart changes x-axis type

### How to verify

- Create the following query
```sql
select 1415 x, 1 y
union all select 20, 2
union all select 900, 3
union all select 115, 4
```
- Make it a scatter chart
- Ensure the query builder tab does not freeze and x-axis shows correct numeric values

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
