### PR TITLE
Webhook ingestion

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -763,6 +763,10 @@
   {:api #{}
    :uses #{api actions driver events lib query-processor upload util}}
 
+  enterprise/data-editing-public
+  {:api #{}
+   :uses #{api actions enterprise/data-editing driver events lib query-processor upload util}}
+
   enterprise/task
   {:api  #{metabase-enterprise.task.truncate-audit-tables}
    :uses #{premium-features query-processor task util enterprise/cache}}

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -11,6 +11,7 @@
    [metabase-enterprise.audit-app.api.routes]
    [metabase-enterprise.billing.api.routes]
    [metabase-enterprise.content-verification.api.routes]
+   [metabase-enterprise.data-editing-public.api]
    [metabase-enterprise.data-editing.api]
    [metabase-enterprise.gsheets.api :as gsheets.api]
    [metabase-enterprise.llm.api]
@@ -64,6 +65,7 @@
    "/autodescribe"               (premium-handler 'metabase-enterprise.llm.api :llm-autodescription)
    "/billing"                    metabase-enterprise.billing.api.routes/routes
    "/data-editing"               (premium-handler metabase-enterprise.data-editing.api/routes :table-data-editing)
+   "/data-editing-public"        (premium-handler metabase-enterprise.data-editing-public.api/routes :table-data-editing)
    "/gsheets"                    (-> gsheets.api/routes ;; gsheets requires both features.
                                      (premium-handler :attached-dwh)
                                      (premium-handler :etl-connections))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.data :refer [diff]]
    [medley.core :as m]
-   [metabase-enterprise.data-editing.coerce :as data-editing.coerce]
+   [metabase-enterprise.data-editing.data-editing :as data-editing]
    [metabase.actions.core :as actions]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -18,14 +18,6 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
-
-(defn- perform-bulk-action! [action-kw table-id rows]
-  (api/check-superuser)
-  (actions/perform-action! action-kw
-                           {:database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
-                            :table-id table-id
-                            :arg      rows}
-                           :policy   :data-editing))
 
 (doseq [topic [:event/data-editing-row-create
                :event/data-editing-row-update
@@ -68,61 +60,36 @@
                qp-result->row-map
                (m/index-by #(get-row-pk pk-field %))))))))
 
-(defn- apply-coercions
-  "For fields that have a coercion_strategy, apply the coercion function (defined in data-editing.coerce) to the corresponding value in each row.
-  Intentionally does not coerce primary key values (behaviour for pks with coercion strategies is undefined)."
-  [table-id input-rows]
-  (let [input-keys  (into #{} (mapcat keys) input-rows)
-        field-names (map name input-keys)
-        ;; TODO not sure how to do an :in clause with toucan2
-        fields      (mapv #(t2/select-one :model/Field :table_id table-id :name %) field-names)
-        coerce-fn   (->> (for [{field-name :name, :keys [coercion_strategy, semantic_type]} fields
-                               :when (not (isa? semantic_type :type/PK))]
-                           [(keyword field-name)
-                            (or (when (nil? coercion_strategy) identity)
-                                (data-editing.coerce/input-coercion-fn coercion_strategy)
-                                (throw (ex-info "Coercion strategy has no defined coercion function"
-                                                {:status 400
-                                                 :field field-name
-                                                 :coercion_strategy coercion_strategy})))])
-                         (into {}))
-        coerce      (fn [k v] (some-> v ((coerce-fn k identity))))]
-    (for [row input-rows]
-      (m/map-kv-vals coerce row))))
-
 (api.macros/defendpoint :post "/table/:table-id"
   "Insert row(s) into the given table."
   [{:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]
    {}
    {:keys [rows]} :- [:map [:rows [:sequential {:min 1} :map]]]]
-  (let [rows (apply-coercions table-id rows)
-        res  (perform-bulk-action! :bulk/create table-id rows)]
-    (doseq [row (:created-rows res)]
-      (events/publish-event! :event/data-editing-row-create
-                             {:table_id    table-id
-                              :created_row row
-                              :actor_id    api/*current-user-id*}))
-    (let [pk-field   (table-id->pk table-id)
-          ;; actions code does not return coerced values
-          ;; right now the FE works off qp outputs, which coerce output row data
-          ;; still feels messy, revisit this
-          id->db-row (query-db-rows table-id pk-field (map #(update-keys % keyword) (:created-rows res)))]
-      {:created-rows (vals id->db-row)})))
+  (api/check-superuser)
+  (let [rows'      (data-editing/apply-coercions table-id rows)
+        res        (data-editing/insert! table-id rows')
+        pk-field   (table-id->pk table-id)
+         ;; actions code does not return coerced values
+         ;; right now the FE works off qp outputs, which coerce output row data
+         ;; still feels messy, revisit this
+        id->db-row (query-db-rows table-id pk-field (map #(update-keys % keyword) (:created-rows res)))]
+    {:created-rows (vals id->db-row)}))
 
 (api.macros/defendpoint :put "/table/:table-id"
   "Update row(s) within the given table."
   [{:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]
    {}
    {:keys [rows]} :- [:map [:rows [:sequential {:min 1} :map]]]]
+  (api/check-superuser)
   (if (empty? rows)
     {:updated []}
-    (let [rows         (apply-coercions table-id rows)
+    (let [rows         (data-editing/apply-coercions table-id rows)
           pk-field     (table-id->pk table-id)
           id->db-row   (query-db-rows table-id pk-field rows)
           updated-rows (volatile! [])]
       (doseq [row rows]
         (let [;; well, this is a trick, but I haven't figured out how to do single row update
-              result        (:rows-updated (perform-bulk-action! :bulk/update table-id [row]))
+              result        (:rows-updated (data-editing/perform-bulk-action! :bulk/update table-id [row]))
               after-row     (-> (query-db-rows table-id pk-field [row]) vals first)
               row-before    (get id->db-row (get-row-pk pk-field row))
               [_ changes _] (diff row-before row)]
@@ -141,9 +108,10 @@
   [{:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]
    {}
    {:keys [rows]} :- [:map [:rows [:sequential {:min 1} :map]]]]
+  (api/check-superuser)
   (let [pk-field    (table-id->pk table-id)
         id->db-rows (query-db-rows table-id pk-field rows)
-        res         (perform-bulk-action! :bulk/delete table-id rows)]
+        res         (data-editing/perform-bulk-action! :bulk/delete table-id rows)]
     (doseq [row rows]
       (events/publish-event! :event/data-editing-row-delete
                              {:table_id    table-id
@@ -200,6 +168,41 @@
                           [column-name (ensure-database-type driver column-type)])
                         (into {}))]
     (driver/create-table! driver db-id table-name column-map :primary-key (map keyword primary_key))))
+
+(api.macros/defendpoint :post "/webhook"
+  "Creates a new webhook endpoint token.
+  The token can be used with the unauthenticated ingestion endpoint.
+  POST /ee/data-editing-public/webhook/{token} to insert rows."
+  [_
+   _
+   {:keys [table-id]}] :- [:map [:table-id ms/PositiveInt]]
+  (api/check-superuser)
+  (let [_       (api/check-404 (t2/select-one :model/Table table-id))
+        token   (str (random-uuid))
+        user-id api/*current-user-id*]
+    (t2/insert! :table_webhook_token {:token token, :table_id table-id, :creator_id user-id})
+    {:table_id table-id
+     :token token}))
+
+(api.macros/defendpoint :delete "/webhook/:token"
+  "Deletes a webhook endpoint token."
+  [{:keys [token]}
+   _
+   _]
+  (api/check-superuser)
+  (let [deleted-count (t2/delete! :table_webhook_token :token token)]
+    (api/check-404 (pos? deleted-count)))
+  {})
+
+(api.macros/defendpoint :get "/webhook"
+  "Lists webhook endpoints tokens for a table.
+  Behaviour is currently undefined if no table-id parameter is specified"
+  [_
+   {:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]]
+  (api/check-superuser)
+  (api/check-404 (t2/select-one :model/Table table-id))
+  (let [include-cols [:token :table_id :creator_id]]
+    {:tokens (t2/select (into [:table_webhook_token] include-cols) :table_id table-id)}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -1,0 +1,55 @@
+(ns metabase-enterprise.data-editing.data-editing
+  (:require
+   [medley.core :as m]
+   [metabase-enterprise.data-editing.coerce :as data-editing.coerce]
+   [metabase.actions.core :as actions]
+   [metabase.api.common :as api]
+   [metabase.events :as events]
+   [toucan2.core :as t2]))
+
+(defn apply-coercions
+  "For fields that have a coercion_strategy, apply the coercion function (defined in data-editing.coerce) to the corresponding value in each row.
+  Intentionally does not coerce primary key values (behaviour for pks with coercion strategies is undefined)."
+  [table-id input-rows]
+  (let [input-keys  (into #{} (mapcat keys) input-rows)
+        field-names (map name input-keys)
+        ;; TODO not sure how to do an :in clause with toucan2
+        fields      (mapv #(t2/select-one :model/Field :table_id table-id :name %) field-names)
+        coerce-fn   (->> (for [{field-name :name, :keys [coercion_strategy, semantic_type]} fields
+                               :when (not (isa? semantic_type :type/PK))]
+                           [(keyword field-name)
+                            (or (when (nil? coercion_strategy) identity)
+                                (data-editing.coerce/input-coercion-fn coercion_strategy)
+                                (throw (ex-info "Coercion strategy has no defined coercion function"
+                                                {:status 400
+                                                 :field field-name
+                                                 :coercion_strategy coercion_strategy})))])
+                         (into {}))
+        coerce      (fn [k v] (some-> v ((coerce-fn k identity))))]
+    (for [row input-rows]
+      (m/map-kv-vals coerce row))))
+
+(defn perform-bulk-action!
+  "Operates on rows in the database, supply an action-kw: :bulk/create, :bulk/update, :bulk/delete.
+  The input `rows` is given different semantics depending on the action type, see actions/perform-action!."
+  [action-kw table-id rows]
+  (actions/perform-action! action-kw
+                           {:database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
+                            :table-id table-id
+                            :arg      rows}
+                           :policy   :data-editing))
+
+(defn insert!
+  "Inserts rows into the table, recording their creation as an event. Returns the inserted records.
+  Expects rows that are acceptable directly by [[actions/perform-action!]]. If casts or reversing coercion strategy
+  are required, that work must be done before calling this function."
+  [table-id rows]
+  (let [res (perform-bulk-action! :bulk/create table-id rows)]
+    ;; TODO if we are inserting via webhook endpoint, we have no user id - but schema requires it.
+    (when-some [user-id api/*current-user-id*]
+      (doseq [row (:created-rows res)]
+        (events/publish-event! :event/data-editing-row-create
+                               {:table_id    table-id
+                                :created_row row
+                                :actor_id    user-id})))
+    res))

--- a/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
@@ -1,0 +1,30 @@
+(ns metabase-enterprise.data-editing-public.api
+  (:require
+   [metabase-enterprise.data-editing.data-editing :as data-editing]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [toucan2.core :as t2]))
+
+(api.macros/defendpoint :post "/webhook/:token/data"
+  "Inserts rows into the table associated with the token. See routes for ee/data-editing/webhook for token CRUD.
+
+  Accepts either a single row or multiple rows in an array.
+  Expects all required columns to be provided.
+
+  The provided row JSON must be compatible with the underlying types of the table.
+  e.g if you have set up a casting rule for a unix epoch seconds field to present it as a datetime, callers must provide the integer value to this API.
+
+  Callers should expect 400 errors on constraint violation (e.g the primary key already exists) or the schema is not met."
+  [{:keys [token]}
+   _
+   row-or-rows]
+  (let [table-id (api/check-404 (t2/select-one-fn :table_id :table_webhook_token :token token))
+        rows     (if (map? row-or-rows) [row-or-rows] row-or-rows)]
+    (when (seq rows)
+      (api/check-400 (every? seq rows))
+      (data-editing/insert! table-id rows))
+    {}))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/ee/data-editing routes."
+  (api.macros/ns-handler *ns*))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11025,7 +11025,6 @@ databaseChangeLog:
               - column:
                   name: query_execution_id
             indexName: idx_field_usage_query_execution_id
-
   - changeSet:
       id: v54.2025-03-27T17:52:01
       author: luizarakaki
@@ -11121,6 +11120,98 @@ databaseChangeLog:
               - column:
                   name: card_schema
             indexName: idx_report_card_card_schema
+
+  - changeSet:
+      id: v55.2025-03-31T11:01:55
+      author: wotbrew
+      comment: Add table webhook token
+      preConditions:
+      rollback:
+        dropTable:
+            tableName: table_webhook_token
+      changes:
+        - createTable:
+            tableName: table_webhook_token
+            remarks: Table containing webhook tokens, that permit writing or modifying tables without a metabase admin session
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  remarks: The table the token permits edits for
+                  name: table_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    referencedTableName: metabase_table
+                    referencedColumnNames: id
+                    foreignKeyName: fk_table_webhook_token_table_id
+                    deleteCascade: true
+              - column:
+                  remarks: The token value
+                  name: token
+                  type: varchar(254)
+                  constraints:
+                    unique: true
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the token was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The user that created the token
+                  name: creator_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    referencedTableName: core_user
+                    referencedColumnNames: id
+                    foreignKeyName: fk_table_webhook_token_creator_id
+                    deleteCascade: true
+  - changeSet:
+      id: v55.2025-04-02T10:52:01
+      author: wotbrew
+      comment: Add an index for `table_webhook_token.table_id`
+      rollback: # will be removed with the column
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: table_webhook_token
+                indexName: idx_table_webhook_token_table_id
+      changes:
+        - createIndex:
+            indexName: idx_table_webhook_token_table_id
+            tableName: table_webhook_token
+            columns:
+              - column:
+                  name: table_id
+  - changeSet:
+      id: v55.2025-04-02T10:52:02
+      author: wotbrew
+      comment: Add an index for `table_webhook_token.creator_id`
+      rollback: # will be removed with the column
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: table_webhook_token
+                indexName: idx_table_webhook_token_creator_id
+      changes:
+        - createIndex:
+            indexName: idx_table_webhook_token_creator_id
+            tableName: table_webhook_token
+            columns:
+              - column:
+                  name: creator_id
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
Adds ingestion support for webhooks, by allowing admins to dynamically create 'tokens' that can be used to insert data into tables without authentication.

Allows admins to create new tokens, list them (for a table) and delete them. 

- create: `POST /ee/data-editing/webhook` supplying `{"table-id": $table-id}`
- list:      `GET /ee/data-editing/webhook?table-id=$table-id` A table-id query param _must_ be supplied for now.
- delete: `DELETE /ee/data-editing/webhook/{token}` to delete

Once created, the token can be used to insert rows into the table without authentication: 

- ingest: `POST /ee/data-editing-public/webhook/{token}`

The new `data-editing-public` routes inherit the existing data editing feature.

Backend notes:
- Table write events do not work due to a schema issue with unauthenticated writes (I'd like to resolve this with a follow up)
- No reverse coercion, rows must be directly coercable to JDBC types by the actions code (otherwise a random admin changing a field would change the effective integration interface with a webhook).
- No policy, limits defined 
- Return type undefined
- Table is very minimal, I can add extra stuff later (audit etc). I've really not solved any auditing or safety requirements with this PR, IMO its quite dangerous - but for demos etc should be fine! :)

Closes WRK-183.