### PR TITLE
Bigquery handles nested fields in nested queries appropriately

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -679,12 +679,11 @@
             result       (cond-> result
                            (not (temporal-type result))
                            (with-temporal-type (temporal-type field-clause)))]
-        result
-        #_(if (and (lib.field/json-field? stored-field)
-                   (or (::sql.qp/forced-alias opts)
-                       (= source-table ::add/source)))
-            (keyword source-alias)
-            result)))))
+        (if (and (lib.field/json-field? stored-field)
+                 (or (::sql.qp/forced-alias opts)
+                     (= source-table ::add/source)))
+          (keyword source-alias)
+          result)))))
 
 (defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :relative-datetime]
   [driver clause]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -11,6 +11,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
    [metabase.legacy-mbql.util :as mbql.u]
+   [metabase.lib.field :as lib.field]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.models.setting :as setting]
@@ -663,7 +664,7 @@
   nfc-path)
 
 (defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :field]
-  [driver [_field _id-or-name {::add/keys [source-table], :as _opts} :as field-clause]]
+  [driver [_field id-or-name {::add/keys [source-table source-alias], :as opts} :as field-clause]]
   (let [parent-method (get-method sql.qp/->honeysql [:sql :field])]
     ;; if the Field is from a join or source table, record this fact so that we know never to qualify it with the
     ;; project ID no matter what
@@ -672,9 +673,18 @@
       ;; SQL QP parent method, and we can access that inside other things like [[sql.qp/date]] implementations which it
       ;; may call in turn.
       (let [field-clause (with-temporal-type field-clause (temporal-type field-clause))
-            result       (parent-method driver field-clause)]
-        (cond-> result
-          (not (temporal-type result)) (with-temporal-type (temporal-type field-clause)))))))
+            stored-field  (when (integer? id-or-name)
+                            (lib.metadata/field (qp.store/metadata-provider) id-or-name))
+            result       (parent-method driver field-clause)
+            result       (cond-> result
+                           (not (temporal-type result))
+                           (with-temporal-type (temporal-type field-clause)))]
+        result
+        #_(if (and (lib.field/json-field? stored-field)
+                   (or (::sql.qp/forced-alias opts)
+                       (= source-table ::add/source)))
+            (keyword source-alias)
+            result)))))
 
 (defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :relative-datetime]
   [driver clause]

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -171,4 +171,5 @@
                 (mt/run-mbql-query tips
                   {:expressions {:incremented_count ["+" [:field "count" {:base-type "type/Integer"}] 1]}
                    :source-query {:aggregation [[:count]]
-                                  :breakout    [$tips.source.service]}}))))))))
+                                  :breakout    [$tips.source.service]
+                                  :source-table $$tips}}))))))))

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -156,3 +156,19 @@
                   {:aggregation [[:count]]
                    :breakout    [$tips.source.mayor]
                    :order-by    [[:asc [:aggregation 0]]]}))))))))
+
+(deftest ^:parallel nested-query-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
+    (testing "Nested Field in a nested query"
+      (mt/dataset geographical-tips
+        (is (= [["facebook"   107 108]
+                ["flare"      105 106]
+                ["foursquare" 100 101]
+                ["twitter"     98 99]
+                ["yelp"        90 91]]
+               (mt/formatted-rows
+                [str int int]
+                (mt/run-mbql-query tips
+                  {:expressions {:incremented_count ["+" [:field "count" {:base-type "type/Integer"}] 1]}
+                   :source-query {:aggregation [[:count]]
+                                  :breakout    [$tips.source.service]}}))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55562

### Description

Before, when you had an outer query referring to something in a nested field from the inner query, the query processor would assume the field is still nested and generate invalid sql.  Now, it will just refer to the alias.

### How to verify

See case for repro

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
