### PR TITLE
support opening add series dashcards in visualizer

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -28,6 +28,7 @@ import {
   getInitialStateForCardDataSource,
   isVisualizerDashboardCard,
 } from "metabase/visualizer/utils";
+import { getInitialStateForMultipleSeries } from "metabase/visualizer/utils/get-initial-state-for-multiple-series";
 import type {
   Card,
   CardId,
@@ -321,6 +322,8 @@ function DashCardInner({
     if (isVisualizerDashboardCard(dashcard)) {
       initialState = dashcard.visualization_settings
         ?.visualization as Partial<VisualizerHistoryItem>;
+    } else if (series.length > 1) {
+      initialState = getInitialStateForMultipleSeries(series);
     } else {
       initialState = getInitialStateForCardDataSource(
         series[0].card,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -7,6 +7,7 @@ import { isActionDashCard } from "metabase/actions/utils";
 import { isLinkDashCard, isVirtualDashCard } from "metabase/dashboard/utils";
 import { Box, Icon } from "metabase/ui";
 import { getVisualizationRaw } from "metabase/visualizations";
+import { isVisualizerDashboardCard } from "metabase/visualizer/utils";
 import type {
   DashCardId,
   Dashboard,
@@ -220,7 +221,7 @@ function DashCardActionsPanelInner({
   }
 
   if (!isLoading && !hasError) {
-    if (supportsSeries) {
+    if (supportsSeries && !isVisualizerDashboardCard(dashcard)) {
       buttons.push(
         <AddSeriesButton
           key="add-series-button"

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -11,7 +11,10 @@ import type {
 } from "metabase-types/api";
 
 import type { RemappingHydratedDatasetColumn } from "./types";
-import type { Visualization } from "./types/visualization";
+import type {
+  Visualization,
+  VisualizationSettingDefinition,
+} from "./types/visualization";
 
 const visualizations = new Map<VisualizationDisplay, Visualization>();
 const aliases = new Map<string, Visualization>();
@@ -156,14 +159,20 @@ export function isCartesianChart(display: VisualizationDisplay) {
   );
 }
 
+const isDataSetting = ({
+  widget,
+}: VisualizationSettingDefinition<unknown, unknown>) => {
+  // TODO Come up with a better condition
+  return widget === "field" || widget === "fields";
+};
+
 export function getColumnVizSettings(display: VisualizationDisplay) {
   const visualization = visualizations.get(display);
   const settings = visualization?.settings ?? {};
 
   // TODO Come up with a better condition
   return Object.keys(settings).filter(key => {
-    const { widget } = settings[key] ?? {};
-    return widget === "field" || widget === "fields";
+    return isDataSetting(settings[key] ?? {});
   });
 }
 

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -1,0 +1,140 @@
+import { isNotNull } from "metabase/lib/types";
+import { getColumnVizSettings } from "metabase/visualizations";
+import type { Card, DatasetColumn, RawSeries } from "metabase-types/api";
+import type {
+  VisualizerColumnReference,
+  VisualizerDataSource,
+  VisualizerHistoryItem,
+} from "metabase-types/store/visualizer";
+
+import {
+  copyColumn,
+  createVisualizerColumnReference,
+  extractReferencedColumns,
+} from "./column";
+import { createDataSource } from "./data-source";
+
+type ColumnInfo = {
+  columnRef: VisualizerColumnReference;
+  column: DatasetColumn;
+};
+
+function mapColumnVizSettings(
+  card: Card,
+  columnInfos: ColumnInfo[],
+): Record<string, string | string[]> {
+  const entries = getColumnVizSettings(card.display)
+    .map(setting => {
+      const originalValue = card.visualization_settings[setting];
+      if (!originalValue) {
+        return null;
+      }
+
+      if (Array.isArray(originalValue)) {
+        const mappedColumns = originalValue
+          .map(originalColumnName => {
+            const columnInfo = columnInfos.find(
+              info => info.columnRef.originalName === originalColumnName,
+            );
+            return columnInfo?.columnRef.name;
+          })
+          .filter(isNotNull);
+
+        return mappedColumns.length > 0 ? [setting, mappedColumns] : null;
+      } else {
+        const columnInfo = columnInfos.find(
+          info => info.columnRef.originalName === originalValue,
+        );
+        return columnInfo?.columnRef.name
+          ? [setting, columnInfo.columnRef.name]
+          : null;
+      }
+    })
+    .filter(isNotNull);
+
+  return Object.fromEntries(entries);
+}
+
+function processColumnsForDataSource(
+  dataSource: VisualizerDataSource,
+  columns: DatasetColumn[],
+  state: VisualizerHistoryItem,
+): ColumnInfo[] {
+  const columnInfos: ColumnInfo[] = [];
+
+  columns.forEach(column => {
+    const columnRef = createVisualizerColumnReference(
+      dataSource,
+      column,
+      extractReferencedColumns(state.columnValuesMapping),
+    );
+
+    const processedColumn = copyColumn(
+      columnRef.name,
+      column,
+      dataSource.name,
+      state.columns,
+    );
+
+    state.columns.push(processedColumn);
+    state.columnValuesMapping[columnRef.name] = [columnRef];
+
+    columnInfos.push({
+      columnRef,
+      column: processedColumn,
+    });
+  });
+
+  return columnInfos;
+}
+
+export function getInitialStateForMultipleSeries(rawSeries: RawSeries) {
+  const mainCard = rawSeries[0].card;
+
+  const state: VisualizerHistoryItem = {
+    display: mainCard.display,
+    columns: [],
+    columnValuesMapping: {},
+    settings: {},
+  };
+
+  const dataSources = rawSeries.map(({ card }) =>
+    createDataSource("card", card.id, card.name),
+  );
+
+  const allColumnInfos: ColumnInfo[][] = rawSeries.map(
+    (series, seriesIndex) => {
+      return processColumnsForDataSource(
+        dataSources[seriesIndex],
+        series.data.cols,
+        state,
+      );
+    },
+  );
+
+  const settingsFromAllCards = rawSeries.map((series, seriesIndex) =>
+    mapColumnVizSettings(series.card, allColumnInfos[seriesIndex]),
+  );
+
+  const mergedSettings = settingsFromAllCards.reduce<
+    Record<string, string | string[]>
+  >((acc, settings) => {
+    Object.entries(settings).forEach(([key, value]) => {
+      const mergedValue = acc[key];
+      if (mergedValue == null) {
+        acc[key] = value;
+      } else if (Array.isArray(mergedValue) && Array.isArray(value)) {
+        mergedValue.push(...value);
+      }
+    });
+    return acc;
+  }, {});
+
+  state.settings = {
+    ...mainCard.visualization_settings,
+    ...mergedSettings,
+    "card.title": mainCard.name,
+  };
+
+  return state;
+}

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
@@ -1,0 +1,98 @@
+import { registerVisualization } from "metabase/visualizations";
+import { LineChart } from "metabase/visualizations/visualizations/LineChart";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
+
+import { getInitialStateForMultipleSeries } from "./get-initial-state-for-multiple-series";
+
+// @ts-expect-error: incompatible prop types with registerVisualization
+registerVisualization(LineChart);
+
+describe("getInitialVisualizerStateForMultipleSeries", () => {
+  it("should handle multiple series cartesian charts", () => {
+    const firstCard = createMockCard({
+      id: 1,
+      name: "First Series",
+      display: "line",
+      visualization_settings: {
+        "graph.metrics": ["Revenue"],
+        "graph.dimensions": ["Date"],
+      },
+    });
+
+    const secondCard = createMockCard({
+      id: 2,
+      name: "Second Series",
+      display: "line",
+      visualization_settings: {
+        "graph.metrics": ["Profit"],
+        "graph.dimensions": ["Date"],
+      },
+    });
+
+    const rawSeries = [
+      createMockSingleSeries(firstCard, {
+        data: createMockDatasetData({
+          cols: [
+            createMockColumn({ name: "Date" }),
+            createMockColumn({ name: "Revenue" }),
+          ],
+        }),
+      }),
+      createMockSingleSeries(secondCard, {
+        data: createMockDatasetData({
+          cols: [
+            createMockColumn({ name: "Date" }),
+            createMockColumn({ name: "Profit" }),
+          ],
+        }),
+      }),
+    ];
+
+    const initialState = getInitialStateForMultipleSeries(rawSeries);
+
+    expect(initialState.columns).toHaveLength(4);
+    expect(initialState.display).toBe("line");
+
+    expect(initialState.columnValuesMapping).toEqual({
+      COLUMN_1: [
+        {
+          name: "COLUMN_1",
+          originalName: "Date",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "Revenue",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_3: [
+        {
+          name: "COLUMN_3",
+          originalName: "Date",
+          sourceId: "card:2",
+        },
+      ],
+      COLUMN_4: [
+        {
+          name: "COLUMN_4",
+          originalName: "Profit",
+          sourceId: "card:2",
+        },
+      ],
+    });
+
+    expect(initialState.settings).toMatchObject({
+      "graph.metrics": ["COLUMN_2", "COLUMN_4"],
+      "graph.dimensions": ["COLUMN_1", "COLUMN_3"],
+      "card.title": "First Series",
+    });
+  });
+});


### PR DESCRIPTION
Closes [VIZ-481](https://linear.app/metabase/issue/VIZ-481/make-sure-existing-add-series-cards-are-editable-using-the-visualizer)

### Description

Allow opening "Add series" cards in the visualizer.
Moved from https://github.com/metabase/metabase/pull/55502 as the feature branch has changed significantly.

### How to verify

- Create a card via "Add series modal" with multiple series
- Open it in the visualizer
- Ensure it shows the series

### Demo

https://github.com/user-attachments/assets/4594ad19-abd6-413e-a578-0633711c24b2

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
