### PR TITLE
WRK-213: Adjust available intervals for 'by the minute' schedule option

### DIFF
--- a/frontend/src/metabase/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.tsx
@@ -27,7 +27,7 @@ import {
   SelectWeekday,
   SelectWeekdayOfMonth,
 } from "./components";
-import { minuteIntervals } from "./strings";
+import { byTheMinuteIntervals } from "./strings";
 import type { UpdateSchedule } from "./types";
 import { getScheduleDefaults } from "./utils";
 
@@ -150,7 +150,7 @@ export const Schedule = ({
         key="minute"
         schedule_minute={schedule_minute}
         updateSchedule={updateSchedule}
-        range={minuteIntervals}
+        range={byTheMinuteIntervals}
       />
     );
 

--- a/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.unit.spec.tsx
@@ -80,6 +80,25 @@ describe("Schedule", () => {
     expect(Math.min(...optionValues.map(Number))).toBe(1);
   });
 
+  it("presents 0,1,2,3,4,5,6,10,15,20,30 for every_n_minutes schedule", async () => {
+    setup({
+      cronString: "0 0/10 * * * ? *",
+    });
+
+    const minuteInput = screen.getByTestId("select-minute");
+    expect(minuteInput).toBeInTheDocument();
+
+    await userEvent.click(minuteInput);
+
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+
+    const options = within(listbox).getAllByRole("option");
+    const optionValues = options.map((option) => option.getAttribute("value"));
+
+    expect(optionValues.join(",")).toEqual("1,2,3,4,5,6,10,15,20,30");
+  });
+
   it("shows custom cron input", () => {
     setup({
       cronString: "0 0/5 * * * ? *",

--- a/frontend/src/metabase/components/Schedule/strings.ts
+++ b/frontend/src/metabase/components/Schedule/strings.ts
@@ -4,12 +4,19 @@ import _ from "underscore";
 import { has24HourModeSetting } from "metabase/lib/time";
 import type { ScheduleDayType, ScheduleFrameType } from "metabase-types/api";
 
-export const minutes = _.times(60, (n) => ({
-  label: n.toString(),
-  value: n.toString(),
-}));
-// 1-59 minutes
-export const minuteIntervals = minutes.slice(1);
+function intToOption(n: number) {
+  return {
+    label: n.toString(),
+    value: n.toString(),
+  };
+}
+
+export const minutes = _.times(60, intToOption);
+
+// Specific recurring intervals (see WRK-213).
+export const byTheMinuteIntervals = [1, 2, 3, 4, 5, 6, 10, 15, 20, 30].map(
+  intToOption,
+);
 
 export const getHours = () => {
   const localizedHours = [


### PR DESCRIPTION
Closes [WRK-213](https://linear.app/metabase/issue/WRK-213/limit-options-for-minute-interval-alerts)

### Description

Restrict the list of available options for "By the minute" scheduling to ensure more anticipated behavior, since the recurring period is actually calculated from the start of each hour, not the time when alert is setup.

### How to verify

1. Create an alert with "By the minute" schedule option.
2. Verify that the list is restricted to 1, 2, 3, 4, 5, 6, 10, 15, 20, 30.
3. Verify that alerts are sent correctly.

### Demo

<img width="719" alt="image" src="https://github.com/user-attachments/assets/9ae318f7-38e3-4889-a196-6080594c19b8" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
