### PR TITLE
test: add a fix for flaky test but move to jail anyway

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.ts
+++ b/e2e/support/helpers/e2e-collection-helpers.ts
@@ -49,6 +49,8 @@ export const getUnpinnedSection = () => {
 };
 
 export const openPinnedItemMenu = (name: string) => {
+  cy.log(`open pinned item menu: ${name}`);
+
   getPinnedSection().within(() => {
     cy.findByText(name)
       .closest("a")

--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -94,36 +94,46 @@ describe("scenarios > metrics > collection", () => {
       .should("not.exist");
   });
 
-  it("should be possible to add and remove a metric from bookmarks", () => {
-    H.createQuestion(ORDERS_SCALAR_METRIC);
-    H.createQuestion({
-      ...ORDERS_TIMESERIES_METRIC,
-      collection_position: null,
-    });
-    cy.visit("/collection/root");
+  it(
+    "should be possible to add and remove a metric from bookmarks",
+    { tags: "@flaky" },
+    () => {
+      H.createQuestion(ORDERS_SCALAR_METRIC);
+      H.createQuestion({
+        ...ORDERS_TIMESERIES_METRIC,
+        collection_position: null,
+      });
+      cy.visit("/collection/root");
 
-    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    H.popover().findByText("Bookmark").click();
-    H.navigationSidebar()
-      .findByText(ORDERS_SCALAR_METRIC.name)
-      .should("be.visible");
-    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    H.popover().findByText("Remove from bookmarks").click();
-    H.navigationSidebar()
-      .findByText(ORDERS_SCALAR_METRIC.name)
-      .should("not.exist");
+      H.getPinnedSection().should("contain", "18,760");
+      H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+      H.popover().findByText("Bookmark").click();
+      H.navigationSidebar()
+        .findByText(ORDERS_SCALAR_METRIC.name)
+        .should("be.visible");
 
-    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    H.popover().findByText("Bookmark").click();
-    H.navigationSidebar()
-      .findByText(ORDERS_TIMESERIES_METRIC.name)
-      .should("be.visible");
-    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    H.popover().findByText("Remove from bookmarks").click();
-    H.navigationSidebar()
-      .findByText(ORDERS_TIMESERIES_METRIC.name)
-      .should("not.exist");
-  });
+      cy.log("pinned card should 'blink' to load and later show the data");
+      H.getPinnedSection().should("not.contain", "18,760");
+      H.getPinnedSection().should("contain", "18,760");
+
+      H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+      H.popover().findByText("Remove from bookmarks").click();
+      H.navigationSidebar()
+        .findByText(ORDERS_SCALAR_METRIC.name)
+        .should("not.exist");
+
+      H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+      H.popover().findByText("Bookmark").click();
+      H.navigationSidebar()
+        .findByText(ORDERS_TIMESERIES_METRIC.name)
+        .should("be.visible");
+      H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+      H.popover().findByText("Remove from bookmarks").click();
+      H.navigationSidebar()
+        .findByText(ORDERS_TIMESERIES_METRIC.name)
+        .should("not.exist");
+    },
+  );
 
   it("should be possible to hide the visualization for a pinned metric", () => {
     H.createQuestion(ORDERS_SCALAR_METRIC);

--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -103,17 +103,21 @@ describe("scenarios > metrics > collection", () => {
         ...ORDERS_TIMESERIES_METRIC,
         collection_position: null,
       });
+      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+
       cy.visit("/collection/root");
 
+      cy.wait("@cardQuery");
       H.getPinnedSection().should("contain", "18,760");
       H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+
       H.popover().findByText("Bookmark").click();
       H.navigationSidebar()
         .findByText(ORDERS_SCALAR_METRIC.name)
         .should("be.visible");
 
       cy.log("pinned card should 'blink' to load and later show the data");
-      H.getPinnedSection().should("not.contain", "18,760");
+      cy.wait("@cardQuery");
       H.getPinnedSection().should("contain", "18,760");
 
       H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);


### PR DESCRIPTION
Provide a fix for a flaky test but move it to jail as I'm not confident with a fix

`e2e/test/scenarios/metrics/metrics-collection.cy.spec.js` -> `should be possible to add and remove a metric from bookmarks`

✅ [stress test](https://github.com/metabase/metabase/actions/runs/14198104224/job/39778099787)