### PR TITLE
Add cloud-ops as codeowners of prometheus.clj

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@ frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embed
 frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 # snowplow/* @metabase/data
-
+src/metabase/analytics/prometheus.clj @metabase/cloud-ops
 .github @metabase/devexp
 .clj-kondo @metabase/devexp
 deps.edn @metabase/backend-developers


### PR DESCRIPTION
So that cloud-ops can verify new metrics are sound and usable for cloud o11y. 

See https://www.notion.so/metabase/Implementing-a-Prometheus-metric-for-your-feature-14569354c901804b97a3dfcf2fecfc22?pvs=4#15169354c90180a7a4daf6b43820cdd8
