### PR TITLE
Add `./bin/mage start-maildev` command

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -57,6 +57,11 @@
    :requires [[mage.kondo :as kondo]]
    :task     (kondo/kondo-updated (:arguments (cli/parse! (current-task))))}
 
+  start-maildev
+  {:doc      "Start Maildev"
+   :requires [[mage.start-maildev :as start-maildev]]
+   :task     (mage.start-maildev/start-maildev!)}
+
   start-db
   {:doc        "Start a db on a default port in docker"
    :examples   [["./bin/mage start-db postgres latest" "start the latest postgres db we support"]

--- a/bb.edn
+++ b/bb.edn
@@ -60,7 +60,7 @@
   start-maildev
   {:doc      "Start Maildev"
    :requires [[mage.start-maildev :as start-maildev]]
-   :task     (mage.start-maildev/start-maildev!)}
+   :task     (do (cli/parse! (current-task)) (start-maildev/start-maildev!))}
 
   start-db
   {:doc        "Start a db on a default port in docker"

--- a/mage/mage/start_maildev.clj
+++ b/mage/mage/start_maildev.clj
@@ -1,0 +1,21 @@
+(ns mage.start-maildev
+  (:require
+   [clojure.string :as str]
+   [mage.color :as c]
+   [mage.shell :as shell]))
+
+(defn start-maildev!
+  "Start Maildev"
+  []
+  (println (c/red "Killing existing `mb-maildev` container..."))
+  (shell/sh* {:quiet? true} "docker" "kill" "mb-maildev")
+  (shell/sh* {:quiet? true} "docker" "rm" "mb-maildev")
+  (let [cmd ["docker" "run" "-d"
+             "-p" "1080:1080"
+             "-p" "1025:1025"
+             "--name" "mb-maildev"
+             "maildev/maildev"]]
+    (println "Running:" (c/magenta (str/join " " cmd)))
+    (apply shell/sh cmd)
+    (println (str "Configure Metabase to send emails using " (c/cyan "localhost:1025")))
+    (println (str "View Maildev UI at " (c/cyan "http://localhost:1080")))))


### PR DESCRIPTION
```
$ ./bin/mage start-maildev
Killing existing `mb-maildev` container...
Running: docker run -d -p 1080:1080 -p 1025:1025 --name mb-maildev maildev/maildev
8b01ba798a18192d02d1fdc3e7874fd03586f91063069db017d44baf30a38c47
Configure Metabase to send emails using localhost:1025
View Maildev UI at http://localhost:1080
```
