### PR TITLE
v53: Allow escape square brackets in identifier

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1310,3 +1310,36 @@ describe("issue 53682", () => {
     });
   });
 });
+
+describe("issue 55128", () => {
+  const name = "email (hello) [hi]";
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+
+    const questionDetails = {
+      query: {
+        "source-table": PRODUCTS_ID,
+        expressions: {
+          [name]: ["concat", "foo", "bar"],
+        },
+      },
+    };
+
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.openNotebook();
+  });
+
+  it("should be possible to use (0 and [] in custom expressions references (metabase#55128)", () => {
+    H.getNotebookStep("expression").icon("add").click();
+    H.enterCustomColumnDetails({
+      formula: 'concat("", [email (hello) \\[hi\\]])',
+      name: "Ok",
+    });
+    H.popover().within(() => {
+      cy.findByText("Missing a closing bracket").should("not.exist");
+      cy.button("Done").click();
+    });
+  });
+});

--- a/frontend/src/metabase-lib/v1/expressions/tokenizer.ts
+++ b/frontend/src/metabase-lib/v1/expressions/tokenizer.ts
@@ -298,8 +298,20 @@ export function tokenize(expression: string): {
   };
 
   const isInsideBracketIdentifier = () => {
+    let escape = false;
+
     for (let i = index + 1; i < length; ++i) {
       const character = source[i];
+
+      if (character === "\\") {
+        escape = true;
+        continue;
+      }
+
+      if (escape) {
+        escape = false;
+        continue;
+      }
 
       if (character === "]") {
         return true;

--- a/frontend/src/metabase-lib/v1/expressions/tokenizer.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/tokenizer.unit.spec.ts
@@ -52,4 +52,11 @@ describe("tokenizer", () => {
       { type: TOKEN.Identifier, start: 3, end: 10 }, // [Price]
     ]);
   });
+
+  it("allows escaping brackets in identifiers", () => {
+    const { tokens, errors } = tokenize("[email (hello) \\[hi\\]]");
+
+    expect(tokens).toEqual([{ type: TOKEN.Identifier, start: 0, end: 22 }]);
+    expect(errors).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55128

Fix the escaping logic for identifiers in the custom expression editor.

## To verify


1. Rename the email column in sample.account to "email (hello) [hi]"
2. Create a question with the accounts table
3. Try to concat that field to an empty string, it should not return an error

Note that the syntax highlighting might not work correctly. This does not affect the results whatsoever.

<img width="584" alt="Screenshot 2025-04-01 at 16 18 37" src="https://github.com/user-attachments/assets/28d046a6-8bc6-4bef-9395-d8a59f7b39a0" />
