### PR TITLE
Remove `card__:id` from the public MBQL lib API

### DIFF
--- a/frontend/src/metabase-lib/breakout.unit.spec.ts
+++ b/frontend/src/metabase-lib/breakout.unit.spec.ts
@@ -21,7 +21,9 @@ describe("breakout", () => {
       const breakouts = Lib.breakouts(nextQuery, 0);
 
       expect(breakouts).toHaveLength(1);
-      expect(Lib.displayName(nextQuery, breakouts[0])).toBe("Title");
+      expect(Lib.displayInfo(nextQuery, 0, breakouts[0]).displayName).toBe(
+        "Title",
+      );
     });
 
     it("should preserve breakout positions between v1-v2 roundtrip", () => {
@@ -117,7 +119,9 @@ describe("breakout", () => {
         productCategory,
       );
       const nextBreakouts = Lib.breakouts(nextQuery, 0);
-      expect(Lib.displayName(nextQuery, nextBreakouts[0])).toBe("Category");
+      expect(Lib.displayInfo(nextQuery, 0, nextBreakouts[0]).displayName).toBe(
+        "Category",
+      );
       expect(breakouts[0]).not.toEqual(nextBreakouts[0]);
     });
   });

--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -1,10 +1,5 @@
 import * as ML from "cljs/metabase.lib.js";
-import type {
-  CardId,
-  ConcreteTableId,
-  DatabaseId,
-  VirtualTableId,
-} from "metabase-types/api";
+import type { CardId, ConcreteTableId, DatabaseId } from "metabase-types/api";
 
 import { expressionParts } from "./expression";
 import { isColumnMetadata } from "./internal";
@@ -246,7 +241,7 @@ export function joinedThing(query: Query, join: Join): Joinable {
 
 type CardPickerInfo = {
   databaseId: DatabaseId;
-  tableId: VirtualTableId;
+  tableId?: never;
   cardId: CardId;
   isModel: boolean;
 };

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -190,7 +190,7 @@ export function cardMetadata(
   queryOrMetadataProvider: Query | MetadataProvider,
   cardId: CardId,
 ): CardMetadata | null {
-  return ML.table_metadata(queryOrMetadataProvider, cardId);
+  return ML.card_metadata(queryOrMetadataProvider, cardId);
 }
 
 /**

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -6,6 +6,7 @@ import type {
   ConcreteTableId,
   DatabaseId,
   DatasetColumn,
+  FieldId,
   TableId,
 } from "metabase-types/api";
 
@@ -176,6 +177,13 @@ export function tableMetadata(
   tableId: ConcreteTableId,
 ): TableMetadata | null {
   return ML.table_metadata(queryOrMetadataProvider, tableId);
+}
+
+export function fieldMetadata(
+  queryOrMetadataProvider: Query | MetadataProvider,
+  fieldId: FieldId,
+): ColumnMetadata | null {
+  return ML.field_metadata(queryOrMetadataProvider, fieldId);
 }
 
 export function cardMetadata(

--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -160,9 +160,10 @@ describe("order by", () => {
       const orderBys = Lib.orderBys(nextQuery, 0);
 
       expect(orderBys).toHaveLength(1);
-      expect(Lib.displayInfo(nextQuery, 0, orderBys[0]).displayName).toBe(
-        "Title ascending",
-      );
+      expect(Lib.displayInfo(nextQuery, 0, orderBys[0])).toMatchObject({
+        displayName: "Title",
+        direction: "asc",
+      });
     });
   });
 
@@ -188,9 +189,10 @@ describe("order by", () => {
         Lib.orderByClause(productCategory, "desc"),
       );
       const nextOrderBys = Lib.orderBys(nextQuery, 0);
-      expect(Lib.displayInfo(nextQuery, 0, nextOrderBys[0]).displayName).toBe(
-        "Category descending",
-      );
+      expect(Lib.displayInfo(nextQuery, 0, nextOrderBys[0])).toMatchObject({
+        displayName: "Category",
+        direction: "desc",
+      });
       expect(orderBys[0]).not.toEqual(nextOrderBys[0]);
     });
   });

--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -160,7 +160,9 @@ describe("order by", () => {
       const orderBys = Lib.orderBys(nextQuery, 0);
 
       expect(orderBys).toHaveLength(1);
-      expect(Lib.displayName(nextQuery, orderBys[0])).toBe("Title ascending");
+      expect(Lib.displayInfo(nextQuery, 0, orderBys[0]).displayName).toBe(
+        "Title ascending",
+      );
     });
   });
 
@@ -186,7 +188,7 @@ describe("order by", () => {
         Lib.orderByClause(productCategory, "desc"),
       );
       const nextOrderBys = Lib.orderBys(nextQuery, 0);
-      expect(Lib.displayName(nextQuery, nextOrderBys[0])).toBe(
+      expect(Lib.displayInfo(nextQuery, 0, nextOrderBys[0]).displayName).toBe(
         "Category descending",
       );
       expect(orderBys[0]).not.toEqual(nextOrderBys[0]);

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -127,9 +127,6 @@ export function sourceCardId(query: Query): CardId | null {
   return ML.source_card_id(query);
 }
 
-/**
- * @deprecated: use `sourceTableOrCardMetadata`
- */
 export function sourceTableOrCardId(query: Query): TableId | null {
   const tableId = sourceTableId(query);
   if (tableId != null) {

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -309,6 +309,9 @@ export const getJoinQueryHelpers = (
   tableId: TableId,
 ) => {
   const table = Lib.tableOrCardMetadata(query, tableId);
+  if (table == null) {
+    throw new Error("Table or card not found.");
+  }
 
   const findLHSColumn = columnFinder(
     query,

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -1,12 +1,12 @@
 import type {
   CardId,
+  ConcreteTableId,
   DatabaseId,
   DatasetColumn,
   FieldId,
   FieldValuesType,
   RowValue,
   SchemaId,
-  TableId,
   TableVisibilityType,
   TemporalUnit,
 } from "metabase-types/api";
@@ -649,24 +649,34 @@ export type QueryDisplayInfo = {
   isEditable: boolean;
 };
 
-export type DatabaseItem = {
+export type DatabaseDependentItem = {
   type: "database";
   id: DatabaseId;
 };
 
-export type SchemaItem = {
+export type SchemaDependentItem = {
   type: "schema";
   id: SchemaId;
 };
 
-export type TableItem = {
+export type TableDependentItem = {
   type: "table";
-  id: TableId;
+  id: ConcreteTableId;
 };
 
-export type FieldItem = {
+export type FieldDependentItem = {
   type: "field";
   id: FieldId;
 };
 
-export type DependentItem = DatabaseItem | SchemaItem | TableItem | FieldItem;
+export type CardDependentItem = {
+  type: "card";
+  id: CardId;
+};
+
+export type DependentItem =
+  | DatabaseDependentItem
+  | SchemaDependentItem
+  | TableDependentItem
+  | FieldDependentItem
+  | CardDependentItem;

--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -1,6 +1,7 @@
 import _ from "underscore";
 
 import { createThunkAction } from "metabase/lib/redux";
+import { checkNotNull } from "metabase/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import { MetabaseApi } from "metabase/services";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
@@ -88,7 +89,9 @@ export const followForeignKey = createThunkAction(
 
       const tableId = fk.origin.table.id;
       const metadataProvider = Lib.metadataProvider(databaseId, metadata);
-      const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
+      const table = checkNotNull(
+        Lib.tableOrCardMetadata(metadataProvider, tableId),
+      );
       const baseQuery = Lib.queryFromTableOrCardMetadata(
         metadataProvider,
         table,
@@ -138,7 +141,9 @@ export const loadObjectDetailFKReferences = createThunkAction(
           return;
         }
         const metadataProvider = Lib.metadataProvider(databaseId, metadata);
-        const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
+        const table = checkNotNull(
+          Lib.tableOrCardMetadata(metadataProvider, tableId),
+        );
         const baseQuery = Lib.queryFromTableOrCardMetadata(
           metadataProvider,
           table,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/SavedQuestionLeftSide/ViewOnly.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/SavedQuestionLeftSide/ViewOnly.unit.spec.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
+import { checkNotNull } from "metabase/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
@@ -93,7 +94,7 @@ const ORDERS_QUERY = (function () {
 
 const ORDERS_JOIN_PRODUCTS_QUERY = (function () {
   let query = createQuery({ databaseId: SAMPLE_DB_ID });
-  const joinTable = Lib.tableOrCardMetadata(query, PRODUCTS_ID);
+  const joinTable = checkNotNull(Lib.tableOrCardMetadata(query, PRODUCTS_ID));
 
   query = Lib.join(
     query,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders, screen } from "__support__/ui";
+import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import { columnFinder } from "metabase-lib/test-helpers";
 import {
@@ -129,7 +130,7 @@ function setup({
 
 describe("FilterPickerBody", () => {
   const provider = Lib.metadataProvider(DATABASE.id, METADATA);
-  const table = Lib.tableOrCardMetadata(provider, TABLE.id);
+  const table = checkNotNull(Lib.tableOrCardMetadata(provider, TABLE.id));
   const query = Lib.queryFromTableOrCardMetadata(provider, table);
   const stageIndex = 0;
   const columns = Lib.filterableColumns(query, stageIndex);

--- a/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.tsx
@@ -68,7 +68,7 @@ export const DataStep = ({
         <NotebookDataPicker
           query={query}
           stageIndex={stageIndex}
-          table={table}
+          table={table ?? undefined}
           title={t`Pick your starting data`}
           canChangeDatabase
           hasMetrics

--- a/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { createMockMetadata } from "__support__/metadata";
 import { fireEvent, getIcon, screen, within } from "__support__/ui";
 import { METAKEY } from "metabase/lib/browser";
+import { checkNotNull } from "metabase/lib/types";
 import type { IconName } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import {
@@ -117,9 +118,12 @@ describe("DataStep", () => {
       questions: [card],
     });
     const metadataProvider = Lib.metadataProvider(SAMPLE_DB_ID, metadata);
+    const cardMetadata = checkNotNull(
+      Lib.tableOrCardMetadata(metadataProvider, `card__${card.id}`),
+    );
     const query = Lib.queryFromTableOrCardMetadata(
       metadataProvider,
-      Lib.tableOrCardMetadata(metadataProvider, `card__${card.id}`),
+      cardMetadata,
     );
     const step = createMockNotebookStep({ query });
     setup({ step });

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -123,7 +123,7 @@ export function EmbeddingDataPicker({
   );
 }
 
-function getLegacyTableId(pickerInfo: Lib.PickerInfo | undefined) {
+function getLegacyTableId(pickerInfo: Lib.PickerInfo | undefined | null) {
   if (pickerInfo == null) {
     return undefined;
   }

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -7,6 +7,7 @@ import { DataSourceSelector } from "metabase/query_builder/components/DataSelect
 import { getEmbedOptions } from "metabase/selectors/embed";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
+import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { TableId } from "metabase-types/api";
 
 import { DataPickerTarget } from "../DataPickerTarget";
@@ -75,7 +76,7 @@ export function EmbeddingDataPicker({
     return (
       <PLUGIN_EMBEDDING_SDK.SimpleDataPicker
         filterByDatabaseId={canChangeDatabase ? null : databaseId}
-        selectedEntity={pickerInfo?.tableId}
+        selectedEntity={getLegacyTableId(pickerInfo)}
         isInitiallyOpen={!table}
         triggerElement={
           <DataPickerTarget
@@ -98,12 +99,12 @@ export function EmbeddingDataPicker({
 
   return (
     <DataSourceSelector
-      key={pickerInfo?.tableId}
+      key={getLegacyTableId(pickerInfo)}
       isInitiallyOpen={!table}
       databases={databases}
       canChangeDatabase={canChangeDatabase}
       selectedDatabaseId={databaseId}
-      selectedTableId={pickerInfo?.tableId}
+      selectedTableId={getLegacyTableId(pickerInfo)}
       selectedCollectionId={card?.collection_id}
       databaseQuery={{ saved: true }}
       canSelectModel={entityTypes.includes("model")}
@@ -120,4 +121,14 @@ export function EmbeddingDataPicker({
       setSourceTableFn={onChange}
     />
   );
+}
+
+function getLegacyTableId(pickerInfo: Lib.PickerInfo | undefined) {
+  if (pickerInfo == null) {
+    return undefined;
+  }
+  if (pickerInfo.cardId != null) {
+    return getQuestionVirtualTableId(pickerInfo.cardId);
+  }
+  return pickerInfo.tableId;
 }

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -62,7 +62,9 @@ export function NotebookDataPicker({
     const metadata = getMetadata(store.getState());
     const databaseId = checkNotNull(metadata.table(tableId)).db_id;
     const metadataProvider = Lib.metadataProvider(databaseId, metadata);
-    const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
+    const table = checkNotNull(
+      Lib.tableOrCardMetadata(metadataProvider, tableId),
+    );
     onChangeRef.current?.(table, metadataProvider);
   };
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/utils.ts
@@ -23,16 +23,14 @@ export const getUrl = ({
     return;
   }
 
-  const { isModel, cardId, tableId, databaseId } = pickerInfo;
-
-  if (cardId) {
+  if (pickerInfo.cardId != null) {
     const payload = {
-      id: cardId,
+      id: pickerInfo.cardId,
       name: tableInfo.displayName,
     };
 
-    return isModel ? Urls.model(payload) : Urls.question(payload);
+    return pickerInfo.isModel ? Urls.model(payload) : Urls.question(payload);
   } else {
-    return Urls.tableRowsQuery(databaseId, tableId);
+    return Urls.tableRowsQuery(pickerInfo.databaseId, pickerInfo.tableId);
   }
 };

--- a/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
@@ -46,9 +46,10 @@ export function DataStep({
     const metadata = getMetadata(store.getState());
     const databaseId = checkNotNull(metadata.table(tableId)).db_id;
     const metadataProvider = Lib.metadataProvider(databaseId, metadata);
-    const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
-    const newQuery = Lib.queryFromTableOrCardMetadata(metadataProvider, table);
-    onChange(newQuery);
+    const table = checkNotNull(
+      Lib.tableOrCardMetadata(metadataProvider, tableId),
+    );
+    onChange(Lib.queryFromTableOrCardMetadata(metadataProvider, table));
   };
 
   return (

--- a/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
@@ -29,13 +29,15 @@ export function DataStep({
   onChange,
 }: DataStepProps) {
   const [isOpened, setIsOpened] = useState(false);
-  const tableId = query ? Lib.sourceTableOrCardId(query) : undefined;
-  const table =
-    query && tableId ? Lib.tableOrCardMetadata(query, tableId) : undefined;
-  const tableInfo =
-    query && table ? Lib.displayInfo(query, stageIndex, table) : undefined;
-  const tableValue =
-    query && table ? getDataPickerValue(query, stageIndex, table) : undefined;
+  const dataSource = query ? Lib.sourceTableOrCardMetadata(query) : null;
+  const dataSourceInfo =
+    query != null && dataSource != null
+      ? Lib.displayInfo(query, stageIndex, dataSource)
+      : undefined;
+  const pickerValue =
+    query != null && dataSource != null
+      ? getDataPickerValue(query, stageIndex, dataSource)
+      : undefined;
   const store = useStore();
   const dispatch = useDispatch();
 
@@ -62,18 +64,18 @@ export function DataStep({
           rightSection={<Icon name="chevrondown" />}
           onClick={() => setIsOpened(true)}
         >
-          {tableInfo ? tableInfo.displayName : t`Select a table`}
+          {dataSourceInfo ? dataSourceInfo.displayName : t`Select a table`}
         </Button>
       ) : (
         <Text c="text-dark" fw="bold">
-          {tableInfo?.displayName}
+          {dataSourceInfo?.displayName}
         </Text>
       )}
       {isOpened && (
         <DataPickerModal
           title={t`Select a table`}
           models={["table"]}
-          value={tableValue}
+          value={pickerValue}
           onChange={handleChange}
           onClose={() => setIsOpened(false)}
         />

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -90,15 +90,14 @@ export const getQuestion = ({
 };
 
 function breakoutWithDefaultTemporalBucket(query, fieldId) {
-  const stageIndex = -1;
   const field = Lib.fieldMetadata(query, fieldId);
-
   if (!field) {
     return query;
   }
 
+  const stageIndex = -1;
   const newColumn = Lib.withDefaultBucket(query, stageIndex, field);
-  return Lib.replaceBreakouts(query, -1, newColumn);
+  return Lib.replaceBreakouts(query, stageIndex, newColumn);
 }
 
 function filterBySegmentId(query, segmentId) {

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -72,7 +72,7 @@ export const getQuestion = ({
     }
 
     if (fieldId) {
-      query = breakoutWithDefaultTemporalBucket(query, metadata, fieldId);
+      query = breakoutWithDefaultTemporalBucket(query, fieldId);
     }
 
     if (segmentId) {
@@ -89,21 +89,15 @@ export const getQuestion = ({
   return question.card();
 };
 
-function breakoutWithDefaultTemporalBucket(query, metadata, fieldId) {
+function breakoutWithDefaultTemporalBucket(query, fieldId) {
   const stageIndex = -1;
-  const field = metadata.field(fieldId);
+  const field = Lib.fieldMetadata(query, fieldId);
 
   if (!field) {
     return query;
   }
 
-  const column = Lib.fromLegacyColumn(query, stageIndex, field);
-
-  if (!column) {
-    return query;
-  }
-
-  const newColumn = Lib.withDefaultBucket(query, stageIndex, column);
+  const newColumn = Lib.withDefaultBucket(query, stageIndex, field);
   return Lib.replaceBreakouts(query, -1, newColumn);
 }
 

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -200,7 +200,6 @@
   extraction-expression]
  [lib.fe-util
   dependent-metadata
-  table-or-card-dependent-metadata
   expression-clause
   expression-parts
   string-filter-clause

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -722,9 +722,3 @@
            (cons {:type :table, :id (str "card__" card-id)}
                  (when-let [card (lib.metadata/card query card-id)]
                    (query-dependents query (lib.query/query query card))))))))
-
-(mu/defn table-or-card-dependent-metadata :- [:sequential DependentItem]
-  "Return the IDs and types of entities which are needed upfront to create a new query based on a table/card."
-  [_metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-   table-id               :- [:or ::lib.schema.id/table :string]]
-  [{:type :table, :id table-id}])

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -679,7 +679,7 @@
      (when-let [card-id (:source-card base-stage)]
        (let [card (lib.metadata/card metadata-providerable card-id)
              definition (:dataset-query card)]
-         (concat [{:type :table, :id (str "card__" card-id)}]
+         (concat [{:type :card, :id card-id}]
                  (when-let [card-columns (lib.card/saved-question-metadata metadata-providerable card-id)]
                    (query-dependents-foreign-keys metadata-providerable card-columns))
                  (when (and (= (:type card) :metric) definition)
@@ -701,8 +701,9 @@
    [:multi {:dispatch :type}
     [:database [:map [:id ::lib.schema.id/database]]]
     [:schema   [:map [:id ::lib.schema.id/database]]]
-    [:table    [:map [:id [:or ::lib.schema.id/table :string]]]]
-    [:field    [:map [:id ::lib.schema.id/field]]]]])
+    [:table    [:map [:id ::lib.schema.id/table]]]
+    [:field    [:map [:id ::lib.schema.id/field]]]
+    [:card     [:map [:id ::lib.schema.id/card]]]]])
 
 (mu/defn dependent-metadata :- [:sequential DependentItem]
   "Return the IDs and types of entities the metadata about is required
@@ -719,6 +720,6 @@
          (query-dependents query query)
          (when (and (some? card-id)
                     (#{:model :metric} card-type))
-           (cons {:type :table, :id (str "card__" card-id)}
+           (cons {:type :card, :id card-id}
                  (when-let [card (lib.metadata/card query card-id)]
                    (query-dependents query (lib.query/query query card))))))))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1998,6 +1998,15 @@
   [query-or-metadata-provider table-id]
   (lib.metadata/table query-or-metadata-provider table-id))
 
+(defn ^:export field-metadata
+  "Given an integer `field-id`, returns the field's metadata.
+
+  Returns `nil` (JS `null`) if no matching metadata is found.
+
+  > **Code health:** Healthy."
+  [query-or-metadata-provider field-id]
+  (lib.metadata/field query-or-metadata-provider field-id))
+
 (defn ^:export card-metadata
   "Given an integer `card-id`, returns the card's metadata.
 

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1797,7 +1797,6 @@
     :metadata/table #js {:databaseId (:database a-query)
                          :tableId (:id metadata)}
     :metadata/card  #js {:databaseId (:database a-query)
-                         :tableId (str "card__" (:id metadata))
                          :cardId (:id metadata)
                          :isModel (= (keyword (:type metadata)) :model)}
     (do
@@ -2239,12 +2238,9 @@
   (to-array (lib.core/pivot-columns-for-type a-drill-thru (keyword pivot-type))))
 
 (defn ^:export with-different-table
-  "Changes an existing `a-query` to use a different source table or card.
+  "Changes an existing `a-query` to use a different source table.
 
-  Can be passed an integer table id or a legacy `\"card__<id>\"` string.
-
-  > **Code health:** Smelly. This leaks the `card__<id>` format and how sources work. Should be refactored into a new
-  system for handling data sources."
+  > **Code health:** Healthy."
   [a-query table-id]
   (lib.core/with-different-table a-query table-id))
 

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -670,7 +670,7 @@
   (testing "source card based query"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
-                      {:type :table,    :id "card__1"}
+                      {:type :card,     :id 1}
                       {:type :table,    :id (meta/id :users)}]
                      (lib/dependent-metadata query nil :question))
       (lib.tu/query-with-source-card)
@@ -678,7 +678,7 @@
   (testing "source card based query with result metadata"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
-                      {:type :table,    :id "card__1"}
+                      {:type :card,     :id 1}
                       {:type :table,    :id (meta/id :users)}]
                      (lib/dependent-metadata query nil :question))
       (lib.tu/query-with-source-card-with-result-metadata)
@@ -687,7 +687,7 @@
     (let [query (assoc (lib.tu/query-with-source-card) :lib/metadata lib.tu/metadata-provider-with-model)]
       (are [query] (=? [{:type :database, :id (meta/id)}
                         {:type :schema,   :id (meta/id)}
-                        {:type :table,    :id "card__1"}
+                        {:type :card,     :id 1}
                         {:type :table,    :id (meta/id :users)}]
                        (lib/dependent-metadata query nil :question))
         query
@@ -696,7 +696,7 @@
     (let [query (assoc (lib.tu/query-with-source-card) :lib/metadata lib.tu/metadata-provider-with-metric)]
       (are [query] (=? [{:type :database, :id (meta/id)}
                         {:type :schema,   :id (meta/id)}
-                        {:type :table,    :id "card__1"}
+                        {:type :card,     :id 1}
                         {:type :table,    :id (meta/id :users)}
                         {:type :table,    :id (meta/id :checkins)}
                         {:type :table,    :id (meta/id :venues)}]
@@ -713,7 +713,7 @@
                         {:type :table,    :id (meta/id :checkins)}
                         {:type :table,    :id (meta/id :users)}
                         {:type :table,    :id (meta/id :venues)}
-                        {:type :table,    :id "card__1"}]
+                        {:type :card,     :id 1}]
                        (lib/dependent-metadata query 1 :model))
         query
         (lib/append-stage query))))
@@ -727,7 +727,7 @@
                         {:type :table,    :id (meta/id :checkins)}
                         {:type :table,    :id (meta/id :users)}
                         {:type :table,    :id (meta/id :venues)}
-                        {:type :table,    :id "card__1"}]
+                        {:type :card,     :id 1}]
                        (lib/dependent-metadata query 1 :metric))
         query
         (lib/append-stage query)))))

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -732,14 +732,6 @@
         query
         (lib/append-stage query)))))
 
-(deftest ^:parallel table-or-card-dependent-metadata-test
-  (testing "start from table"
-    (is (= [{:type :table, :id (meta/id :checkins)}]
-           (lib/table-or-card-dependent-metadata meta/metadata-provider (meta/id :checkins)))))
-  (testing "start from card"
-    (is (= [{:type :table, :id "card__1"}]
-           (lib/table-or-card-dependent-metadata lib.tu/metadata-provider-with-card "card__1")))))
-
 (deftest ^:parallel maybe-expand-temporal-expression-test
   (let [update-temporal-unit (fn [expr temporal-type] (update-in expr [2 1] assoc :temporal-unit temporal-type))
         expr [:=

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -387,17 +387,31 @@
           (is (=? [:metric {} metric-id] metric-expr))
           (is (= ["metric" metric-id] (js->clj (lib.js/legacy-expression-for-expression-clause query -1 metric-expr)))))))))
 
-(deftest ^:parallel source-table-or-card-id-test
+(deftest ^:parallel source-table-id-test
   (testing "returns the table-id as a number"
-    (are [query] (= (meta/id :venues) (lib.js/source-table-or-card-id query))
+    (are [query] (= (meta/id :venues) (lib.js/source-table-id query))
       (lib.tu/venues-query)
       (lib/append-stage (lib.tu/venues-query))))
-  (testing "returns the card-id in the legacy string form"
-    (are [query] (= "card__1" (lib.js/source-table-or-card-id query))
+  (testing "returns nil for questions starting from a card"
+    (are [query] (nil? (lib.js/source-table-id query))
       (lib.tu/query-with-source-card)
       (lib/append-stage (lib.tu/query-with-source-card))))
   (testing "returns nil for questions starting from a native query"
-    (are [query] (nil? (lib.js/source-table-or-card-id query))
+    (are [query] (nil? (lib.js/source-table-id query))
+      (lib.tu/native-query)
+      (lib/append-stage (lib.tu/native-query)))))
+
+(deftest ^:parallel source-card-id-test
+  (testing "returns the card-id as a number"
+    (are [query] (= 1 (lib.js/source-card-id query))
+      (lib.tu/query-with-source-card)
+      (lib/append-stage (lib.tu/query-with-source-card))))
+  (testing "returns nil for questions starting from a table"
+    (are [query] (nil? (lib.js/source-card-id query))
+      (lib.tu/venues-query)
+      (lib/append-stage (lib.tu/venues-query))))
+  (testing "returns nil for questions starting from a native query"
+    (are [query] (nil? (lib.js/source-card-id query))
       (lib.tu/native-query)
       (lib/append-stage (lib.tu/native-query)))))
 


### PR DESCRIPTION
Now `card__:id` is a FE concern, and we should refactor the places where we rely on that.