### PR TITLE
Fix - Visibility explanation copy is the same across all 3 options

### DIFF
--- a/frontend/src/metabase/admin/datamodel/metadata/components/FieldVisibilityPicker/FieldVisibilityPicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/FieldVisibilityPicker/FieldVisibilityPicker.tsx
@@ -44,7 +44,9 @@ export const FieldVisibilityPicker = ({
       placeholder={t`Select a field visibility`}
       renderOption={(item) => {
         const selected = item.option.value === value;
-        const option = DATA.find((option) => option.value === value);
+        const option = DATA.find(
+          (option) => option.value === item.option.value,
+        );
 
         return (
           <SelectItem selected={selected}>

--- a/frontend/src/metabase/admin/datamodel/metadata/components/FieldVisibilityPicker/FieldVisibilityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/FieldVisibilityPicker/FieldVisibilityPicker.unit.spec.tsx
@@ -1,0 +1,44 @@
+import userEvent from "@testing-library/user-event";
+
+import { createMockMetadata } from "__support__/metadata";
+import { render, screen, within } from "__support__/ui";
+import { checkNotNull } from "metabase/lib/types";
+import { ORDERS, createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { FieldVisibilityPicker } from "./FieldVisibilityPicker";
+
+const setup = () => {
+  const metadata = createMockMetadata({
+    databases: [createSampleDatabase()],
+  });
+  const field = checkNotNull(metadata.field(ORDERS.ID));
+
+  render(<FieldVisibilityPicker field={field} onUpdateField={jest.fn()} />);
+};
+
+describe("FieldVisibilityPicker", () => {
+  it("shows correct visibility descriptions (metabase#56077)", async () => {
+    setup();
+
+    const picker = screen.getByPlaceholderText("Select a field visibility");
+    await userEvent.click(picker);
+
+    const dropdown = within(screen.getByRole("listbox"));
+
+    expect(
+      dropdown.getByText(
+        "The default setting. This field will be displayed normally in tables and charts.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      dropdown.getByText(
+        "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      dropdown.getByText(
+        "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries.",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #56077 ([SEM-202](https://linear.app/metabase/issue/SEM-202/visibility-explanation-copy-is-the-same-across-all-3-options))

### How to verify

1. Go to Admin > Table Metadata
2. Open a table
3. Open the Visibility dropdown

All options should have different descriptions
