### PR TITLE
Fix table alerts delete from Account Settings

### DIFF
--- a/frontend/src/metabase/account/notifications/actions.js
+++ b/frontend/src/metabase/account/notifications/actions.js
@@ -4,6 +4,7 @@ const PREFIX = `/account/notifications`;
 
 const TYPE_MAP = {
   "question-notification": "alert",
+  "table-notification": "alert",
   pulse: "pulse",
 };
 

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
@@ -1,15 +1,11 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { mockScrollIntoView, screen } from "__support__/ui";
+import { screen } from "__support__/ui";
 
 import { createNotificationForUser, setup } from "./test-utils";
 
 describe("TableNotificationsListModal", () => {
-  beforeAll(() => {
-    mockScrollIntoView();
-  });
-
   beforeEach(() => {
     fetchMock.reset();
   });


### PR DESCRIPTION
### Description

Missed to update the logic to support deleting/unsubscribing from table alert from Account Settings view.

### How to verify

1. Setup a table editing alert.
2. Go to Account Settings - Notifications.
3. Try to delete an existing alert.

### Demo

<img width="717" alt="image" src="https://github.com/user-attachments/assets/778808d9-6e8d-452c-8421-25181f29cf08" />

<img width="651" alt="image" src="https://github.com/user-attachments/assets/b965bcbd-79fd-4c61-8e94-aab7e4fe5231" />
