### PR TITLE
Make mongo between condition inclusive

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -839,7 +839,7 @@
   mbql.u/dispatch-by-clause-name-or-class)
 
 (defmethod compile-cond :between [[_ field min-val max-val]]
-  (compile-cond [:and [:>= field min-val] [:< field max-val]]))
+  (compile-cond [:and [:>= field min-val] [:<= field max-val]]))
 
 (defn- index-of-code-point
   "See https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfCP/"

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -274,6 +274,17 @@
                       {:breakout     [[:field %liked {:base-type :type/Boolean}]]
                        :aggregation  [["count"]]}))))))))
 
+(deftest ^:parallel aggregation-with-between-is-consistent-test
+  (testing "an aggregation with a between clause should return consistent results #55302"
+    (mt/test-drivers (mt/normal-drivers)
+      (mt/dataset daily-bird-counts
+        (is (= [[39]]
+               (->> {:aggregation [[:sum [:case
+                                          [[[:between [:field (mt/id :bird-count :date)] "2018-09-01" "2018-09-30"]
+                                            [:field (mt/id :bird-count :count)]]]]]]}
+                    (mt/run-mbql-query bird-count)
+                    (mt/formatted-rows [int]))))))))
+
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !                                                                                                                   !
 ;; !                    tests for named aggregations can be found in `expression-aggregations-test`                    !


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55302

### Description

Mongo between filter was inclusive, but mongo between condition was not. This can lead to scenarios where the same MBQL on the same dataset gives different results between databases.

### How to verify

See steps in reported issue.

### Demo

https://github.com/user-attachments/assets/7df11ae9-7a40-47ac-ae83-333242af9a46

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
