### PR TITLE
Fix chain filters on public dashboards

### DIFF
--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -626,7 +626,7 @@
   [{:keys [uuid param-key]} :- [:map
                                 [:uuid      ms/UUIDString]
                                 [:param-key ms/NonBlankString]]
-   constraint-param-key->value]
+   constraint-param-key->value :- [:map-of string? any?]]
   (let [dashboard (dashboard-with-uuid uuid)]
     (request/as-admin
       (binding [qp.perms/*param-values-query* true]

--- a/test/metabase/public_sharing/api_test.clj
+++ b/test/metabase/public_sharing/api_test.clj
@@ -1458,7 +1458,12 @@
               (is (= {:values          [[2] [3] [4] [5] [6]]
                       :has_more_values false}
                      (->> (client/client :get 200 (param-values-url :dashboard uuid (:category-id param-keys)))
-                          (chain-filter-test/take-n-values 5))))))
+                          (chain-filter-test/take-n-values 5))))
+              (testing "with constraints"
+                (is (= {:values          [[44]]
+                        :has_more_values false}
+                       (client/client :get 200 (param-values-url :dashboard uuid (:category-id param-keys))
+                                      (keyword (:id param-keys)) "7"))))))
 
           (testing "GET /api/public/dashboard/:uuid/params/:param-key/search/:query"
             (testing "parameter with source is a static list"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #56072
Fixes [QUE-838](https://linear.app/metabase/issue/QUE-838/linked-filters-are-not-working-on-public-dashboards).

### Description

Query params were getting parsed incorrectly to a map like `{:17fdc812 ...}`
with a keyword rather than a string. These failed to match any of the
dashboard's parameters (which are keyed by strings like `"17fdc812"`)
and returned no values (but did not throw any errors in prod).

It works for the equivalent request on a non-public dashboard because it specifies
the Malli schema for the query string params `[:map-of :string :any]`, rather than
accepting the default schema (apparently `[:map-of :keyword :any]` or similar).

Added a new BE unit test to guard against this regressing again.

### How to verify

Repro steps in #56072 work now.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
