### PR TITLE
fix(sdk): fix dataset endpoint being called on every re-render

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -3,6 +3,7 @@ import {
   InteractiveDashboard,
   InteractiveQuestion,
 } from "@metabase/embedding-sdk-react";
+import { useState } from "react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -189,5 +190,48 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
         });
       cy.findByText("New question").should("be.visible");
     });
+  });
+
+  it("should only call POST /dataset once when parent component re-renders (EMB-288)", () => {
+    cy.intercept("POST", "/api/dataset").as("datasetQuery");
+
+    const TestComponent = ({ dashboardId }: { dashboardId: string }) => {
+      const [counter, setCounter] = useState(0);
+
+      return (
+        <div>
+          <button onClick={() => setCounter((c) => c + 1)}>
+            Trigger parent re-render ({counter})
+          </button>
+
+          <InteractiveDashboard dashboardId={dashboardId} />
+        </div>
+      );
+    };
+
+    cy.get<string>("@dashboardId").then((dashboardId) => {
+      mountSdkContent(<TestComponent dashboardId={dashboardId} />);
+    });
+
+    // Drill down to "See these Orders"
+    cy.wait("@dashcardQuery");
+    cy.get("[data-dataset-index=0] > [data-column-id='PRODUCT_ID']").click();
+
+    H.popover()
+      .findByText(/View this Product/)
+      .click();
+
+    cy.wait("@datasetQuery");
+
+    // Trigger multiple parent re-renders
+    getSdkRoot().within(() => {
+      cy.findByText(/Trigger parent re-render/).click();
+      cy.findByText(/Trigger parent re-render/).click();
+      cy.findByText(/Trigger parent re-render/).click();
+    });
+
+    // Verify no additional dataset queries were made after re-renders
+    cy.wait(500);
+    cy.get("@datasetQuery.all").should("have.length", 1);
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -3,7 +3,7 @@ import {
   InteractiveQuestion,
   type MetabaseQuestion,
 } from "@metabase/embedding-sdk-react";
-import { type ComponentProps, useState } from "react";
+import type { ComponentProps } from "react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -322,42 +322,6 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         <InteractiveQuestion questionId={questionId} />,
       );
     });
-  });
-
-  it("should only call POST /dataset once when parent component re-renders (EMB-288)", () => {
-    cy.intercept("POST", "/api/dataset").as("datasetQuery");
-
-    const TestComponent = ({ questionId }: { questionId: string }) => {
-      const [counter, setCounter] = useState(0);
-
-      return (
-        <Box p="lg">
-          <Button onClick={() => setCounter((c) => c + 1)}>
-            Trigger parent re-render ({counter})
-          </Button>
-          <InteractiveQuestion questionId={questionId}>
-            <InteractiveQuestion.QuestionVisualization />
-          </InteractiveQuestion>
-        </Box>
-      );
-    };
-
-    cy.get<string>("@questionId").then((questionId) => {
-      mountSdkContent(<TestComponent questionId={questionId} />);
-    });
-
-    // Wait for initial dataset query
-    cy.wait("@datasetQuery");
-
-    // Trigger multiple parent re-renders
-    getSdkRoot().within(() => {
-      cy.findByText(/Trigger parent re-render/).click();
-      cy.findByText(/Trigger parent re-render/).click();
-      cy.findByText(/Trigger parent re-render/).click();
-    });
-
-    // Verify dataset query was only called once
-    cy.get("@datasetQuery.all").should("have.length", 1);
   });
 
   describe("loading behavior for both entity IDs and number IDs (metabase#49581)", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -3,7 +3,7 @@ import {
   InteractiveQuestion,
   type MetabaseQuestion,
 } from "@metabase/embedding-sdk-react";
-import type { ComponentProps } from "react";
+import { type ComponentProps, useState } from "react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -322,6 +322,42 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         <InteractiveQuestion questionId={questionId} />,
       );
     });
+  });
+
+  it("should only call POST /dataset once when parent component re-renders (EMB-288)", () => {
+    cy.intercept("POST", "/api/dataset").as("datasetQuery");
+
+    const TestComponent = ({ questionId }: { questionId: string }) => {
+      const [counter, setCounter] = useState(0);
+
+      return (
+        <Box p="lg">
+          <Button onClick={() => setCounter((c) => c + 1)}>
+            Trigger parent re-render ({counter})
+          </Button>
+          <InteractiveQuestion questionId={questionId}>
+            <InteractiveQuestion.QuestionVisualization />
+          </InteractiveQuestion>
+        </Box>
+      );
+    };
+
+    cy.get<string>("@questionId").then((questionId) => {
+      mountSdkContent(<TestComponent questionId={questionId} />);
+    });
+
+    // Wait for initial dataset query
+    cy.wait("@datasetQuery");
+
+    // Trigger multiple parent re-renders
+    getSdkRoot().within(() => {
+      cy.findByText(/Trigger parent re-render/).click();
+      cy.findByText(/Trigger parent re-render/).click();
+      cy.findByText(/Trigger parent re-render/).click();
+    });
+
+    // Verify dataset query was only called once
+    cy.get("@datasetQuery.all").should("have.length", 1);
   });
 
   describe("loading behavior for both entity IDs and number IDs (metabase#49581)", () => {

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveAdHocQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveAdHocQuestion.tsx
@@ -36,8 +36,12 @@ export const InteractiveAdHocQuestion = ({
   // If we cannot extract an entity ID from the slug, assume we are creating a new question.
   const questionId = Urls.extractEntityId(params.slug) ?? null;
 
-  const { options, serializedCard } = parseHash(location.hash);
-  const deserializedCard = serializedCard && deserializeCard(serializedCard);
+  const { options, deserializedCard } = useMemo(() => {
+    const { options, serializedCard } = parseHash(location.hash);
+    const deserializedCard = serializedCard && deserializeCard(serializedCard);
+
+    return { options, deserializedCard };
+  }, [location.hash]);
 
   return (
     <InteractiveQuestionProvider


### PR DESCRIPTION
Closes EMB-288

We forgot to memoize the `deserializedCard` and `options` which are both objects (!) in `InteractiveAdHocQuestion`, so at each render `parseHash` and `deserializeCard` returns a new object, and that always render a new question on every render, causing us to call `POST /dataset` multiple times.