### PR TITLE
Introduce metabot-id

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -630,6 +630,10 @@
   {:api #{metabase-enterprise.ai-sql-fixer.api}
    :uses #{api driver enterprise/metabot-v3 query-analysis query-processor util}}
 
+  enterprise/ai-sql-generation
+  {:api #{metabase-enterprise.ai-sql-generation.api}
+   :uses #{api driver enterprise/metabot-v3 util}}
+
   enterprise/airgap
   {:api  #{}
    :uses #{premium-features util}}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -24,7 +24,7 @@
 (defn request
   "Handles an incoming request, making all required tool invocation, LLM call loops, etc."
   [{:keys [metabot_id message context history conversation_id state]
-    :or {metabot_id 1}}]
+    :or {metabot_id metabot-v3.tools.api/internal-metabot-id}}]
   (let [initial-message (metabot-v3.envelope/user-message message)
         history (conj (vec history) initial-message)
         env (-> {:context (metabot-v3.context/create-context context)
@@ -43,7 +43,7 @@
   [_route-params
    _query-params
    {:keys [conversation_id] :as body} :- [:map
-                                          [:metabot_id {:optional true} :int]
+                                          [:metabot_id {:optional true} :string]
                                           [:message ms/NonBlankString]
                                           [:context ::metabot-v3.context/context]
                                           [:conversation_id ms/UUIDString]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -85,8 +85,9 @@
 
 (mu/defn request :- ::metabot-v3.client.schema/ai-proxy.response-v2
   "Make a V2 request to the AI Proxy."
-  [{:keys [context messages conversation-id session-id state]}
+  [{:keys [metabot-id context messages conversation-id session-id state]}
    :- [:map
+       [:metabot-id :int]
        [:context :map]
        [:messages ::metabot-v3.client.schema/messages]
        [:conversation-id :string]
@@ -99,6 +100,7 @@
                         :context  context}
                        (metabot-v3.u/recursive-update-keys metabot-v3.u/safe->snake_case_en)
                        (assoc :conversation_id conversation-id
+                              :metabot_id      metabot-id
                               :state           state
                               :user_id         api/*current-user-id*))
           _        (metabot-v3.context/log body :llm.log/be->llm)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -85,9 +85,8 @@
 
 (mu/defn request :- ::metabot-v3.client.schema/ai-proxy.response-v2
   "Make a V2 request to the AI Proxy."
-  [{:keys [metabot-id context messages conversation-id session-id state]}
+  [{:keys [context messages conversation-id session-id state]}
    :- [:map
-       [:metabot-id :int]
        [:context :map]
        [:messages ::metabot-v3.client.schema/messages]
        [:conversation-id :string]
@@ -100,7 +99,6 @@
                         :context  context}
                        (metabot-v3.u/recursive-update-keys metabot-v3.u/safe->snake_case_en)
                        (assoc :conversation_id conversation-id
-                              :metabot_id      metabot-id
                               :state           state
                               :user_id         api/*current-user-id*))
           _        (metabot-v3.context/log body :llm.log/be->llm)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
@@ -50,7 +50,11 @@
                                                      (println "🗨 " (u/colorize :blue input))
                                                      (when (and (not (#{"quit" "exit" "bye" "goodbye" "\\q"} input))
                                                                 (not (str/blank? input)))
-                                                       (let [result (api/request input context history conversation-id state)]
+                                                       (let [result (api/request {:message input
+                                                                                  :context context
+                                                                                  :history history
+                                                                                  :conversation_id conversation-id
+                                                                                  :state state})]
                                                          (handle-reactions (:reactions result))
                                                          result)))
                                                    (catch Throwable e

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -51,26 +51,26 @@
   :audit      :never)
 
 (defn- get-ai-service-token
-  [user-id]
+  [user-id metabot-id]
   (let [secret (buddy-hash/sha256 (site-uuid-for-metabot-tools))
-        claims {:user user-id, :exp (time/plus (time/now) (time/seconds (metabot-ai-service-token-ttl)))}]
+        claims {:user user-id
+                :exp (time/plus (time/now) (time/seconds (metabot-ai-service-token-ttl)))
+                :metabot-id metabot-id}]
     (jwt/encrypt claims secret {:alg :dir, :enc :a128cbc-hs256})))
 
 (defn- decode-ai-service-token
   [token]
   (try
     (when (string? token)
-      (-> token
-          (jwt/decrypt (buddy-hash/sha256 (site-uuid-for-metabot-tools)))
-          :user))
+      (jwt/decrypt token (buddy-hash/sha256 (site-uuid-for-metabot-tools))))
     (catch Exception e
       (log/error e "Bad AI service token")
       nil)))
 
 (defn handle-envelope
   "Executes the AI loop in the context of a new session. Returns the response of the AI service."
-  [e]
-  (let [session-id (get-ai-service-token api/*current-user-id*)]
+  [{:keys [metabot-id] :as e}]
+  (let [session-id (get-ai-service-token api/*current-user-id* metabot-id)]
     (try
       (metabot-v3.client/request (assoc e :session-id session-id))
       (catch Exception ex
@@ -254,9 +254,7 @@
    [:map
     [:output :string]]])
 
-(mr/def ::tool-request [:map
-                        [:metabot_id {:optional true} :int]
-                        [:conversation_id ms/UUIDString]])
+(mr/def ::tool-request [:map [:conversation_id ms/UUIDString]])
 
 (mr/def ::subscription-schedule
   (let [days ["sunday" "monday" "tuesday" "wednesday" "thursday" "friday" "saturday"]]
@@ -455,27 +453,34 @@
                          [:models  [:sequential ::full-table]]]]]
    [:map [:output :string]]])
 
+(def internal-metabot-id
+  "The ID of the internal Metabot instance."
+  "b5716059-ad40-4d83-a4e1-673af020b2d8")
+
+(def embedded-metabot-id
+  "The ID of the embedded Metabot instance."
+  "c61bf5f5-1025-47b6-9298-bf1827105bb6")
+
 (def metabot-config
   "The name of the collection exposed by the answer-sources tool."
-  {1 {:collection-name "__METABOT__"}
-   2 {:collection-name "__METABOT_EMBEDDING__"}})
+  {internal-metabot-id {:collection-name "__METABOT__"}
+   embedded-metabot-id {:collection-name "__METABOT_EMBEDDING__"}})
 
 (api.macros/defendpoint :post "/answer-sources" :- [:merge ::answer-sources-result ::tool-request]
   "Create a dashboard subscription."
   [_route-params
    _query-params
-   {:keys [metabot_id conversation_id]
-    :as body
-    :or {metabot_id 1}} :- ::tool-request]
+   {:keys [conversation_id] :as body} :- ::tool-request
+   {:keys [metabot-v3/metabot-id]}]
   (metabot-v3.context/log (assoc body :api :answer-sources) :llm.log/llm->be)
-  (if-let [collection-name (get-in metabot-config [metabot_id :collection-name])]
+  (if-let [collection-name (get-in metabot-config [metabot-id :collection-name])]
     (doto (-> (mc/decode ::answer-sources-result
                          (metabot-v3.dummy-tools/answer-sources collection-name)
                          (mtx/transformer {:name :tool-api-response}))
               (assoc :conversation_id conversation_id))
       (metabot-v3.context/log :llm.log/be->llm))
-    (throw (ex-info (i18n/tru "Invalid metabot_id {0}" metabot_id)
-                    {:metabot_id metabot_id, :status-code 400}))))
+    (throw (ex-info (i18n/tru "Invalid metabot_id {0}" metabot-id)
+                    {:metabot_id metabot-id, :status-code 400}))))
 
 (api.macros/defendpoint :post "/create-dashboard-subscription" :- [:merge
                                                                    [:map [:output :string]]
@@ -680,9 +685,11 @@
   [handler]
   (with-meta
    (fn [{:keys [headers] :as request} respond raise]
-     (if-let [user-id (decode-ai-service-token (get headers "x-metabase-session"))]
-       (request/with-current-user user-id
-         (handler request respond raise))
+     (if-let [{:keys [user metabot-id]} (-> headers
+                                            (get "x-metabase-session")
+                                            decode-ai-service-token)]
+       (request/with-current-user user
+         (handler (assoc request :metabot-v3/metabot-id metabot-id) respond raise))
        (if (:metabase-user-id request)
          (handler request respond raise)
          (respond request/response-unauthentic))))

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -25,6 +25,7 @@
                               :llm-autodescription
                               :metabot-v3
                               :ai-sql-fixer
+                              :ai-sql-generation
                               :no-upsell
                               :official-collections
                               :query-reference-validation
@@ -37,7 +38,7 @@
                               :sso-jwt
                               :sso-ldap
                               :sso-saml
-                              :upload_management
+                              :upload-management
                               :whitelabel
                               :collection-cleanup}
     (is (= {:advanced_permissions           true
@@ -58,6 +59,7 @@
             :llm_autodescription            true
             :metabot_v3                     true
             :ai_sql_fixer                   true
+            :ai_sql_generation              true
             :official_collections           true
             :query_reference_validation     true
             :sandboxes                      true
@@ -69,7 +71,7 @@
             :sso_jwt                        true
             :sso_ldap                       true
             :sso_saml                       true
-            :upload_management              false
+            :upload_management              true
             :whitelabel                     true
             :collection_cleanup             true}
            (:token-features (mt/user-http-request :crowberto :get 200 "session/properties"))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot-v3.api-test
   (:require
    [clojure.test :refer :all]
+   [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.tools.api :as metabot-v3.tools.api]
    [metabase.test :as mt]))
@@ -16,27 +17,31 @@
         agent-message {:role :assistant, :navigate-to navigation-target}
         agent-state {:key "value"}]
     (mt/with-premium-features #{:metabot-v3}
-      (testing "Trivial request"
-        (with-redefs [metabot-v3.client/request (fn [e]
-                                                  (swap! ai-requests conj e)
-                                                  {:messages [agent-message]
-                                                   :state agent-state})]
-          (let [response (mt/user-http-request :rasta :post 200 "ee/metabot-v3/v2/agent"
-                                               {:message question
-                                                :context {}
-                                                :conversation_id conversation-id
-                                                :history [historical-message]
-                                                :state {}})]
-            (is (=? [{:context {:current_user_time (every-pred string? java.time.Instant/parse)}
-                      :messages [(update historical-message :role keyword) {:role :user, :content question}]
-                      :state {}
-                      :conversation-id conversation-id
-                      :session-id #(#'metabot-v3.tools.api/decode-ai-service-token %)}]
-                    @ai-requests))
-            (is (=? {:reactions [{:type "metabot.reaction/redirect", :url navigation-target}]
-                     :history [historical-message
-                               {:role "user", :content question}
-                               (update agent-message :role name)]
-                     :state agent-state
-                     :conversation_id conversation-id}
-                    response))))))))
+      (with-redefs [metabot-v3.client/request (fn [e]
+                                                (swap! ai-requests conj e)
+                                                {:messages [agent-message]
+                                                 :state agent-state})]
+        (testing "Trivial request"
+          (doseq [metabot-id [nil 42]]
+            (reset! ai-requests [])
+            (let [response (mt/user-http-request :rasta :post 200 "ee/metabot-v3/v2/agent"
+                                                 (-> {:message question
+                                                      :context {}
+                                                      :conversation_id conversation-id
+                                                      :history [historical-message]
+                                                      :state {}}
+                                                     (m/assoc-some :metabot_id metabot-id)))]
+              (is (=? [{:context {:current_user_time (every-pred string? java.time.Instant/parse)}
+                        :messages [(update historical-message :role keyword) {:role :user, :content question}]
+                        :state {}
+                        :metabot-id (or metabot-id 1)
+                        :conversation-id conversation-id
+                        :session-id #(#'metabot-v3.tools.api/decode-ai-service-token %)}]
+                      @ai-requests))
+              (is (=? {:reactions [{:type "metabot.reaction/redirect", :url navigation-target}]
+                       :history [historical-message
+                                 {:role "user", :content question}
+                                 (update agent-message :role name)]
+                       :state agent-state
+                       :conversation_id conversation-id}
+                      response)))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -253,9 +253,11 @@
           model-data {:name "Model model"
                       :description "Model desc"
                       :dataset_query (lib/->legacy-MBQL model-source-query)
-                      :type :model}]
-      (with-redefs [metabot-v3.tools.api/metabot-collection-name (str (random-uuid))]
-        (mt/with-temp [:model/Collection {collection-id :id} {:name metabot-v3.tools.api/metabot-collection-name}
+                      :type :model}
+          collection-name (str (random-uuid))
+          metabot-id 42]
+      (with-redefs [metabot-v3.tools.api/metabot-config {metabot-id {:collection-name collection-name}}]
+        (mt/with-temp [:model/Collection {collection-id :id} {:name collection-name}
                        :model/Card {metric-id :id} (assoc metric-data :collection_id collection-id)
                        :model/Card _ignored        metric-data
                        :model/Card _ignored        model-data
@@ -272,50 +274,59 @@
                                    :type :metric}]
             (mt/with-temp [:model/Card {model-metric-id :id} (assoc model-metric-data :collection_id collection-id)]
               (ensure-field-values! :products)
-              (let [conversation-id (str (random-uuid))
-                    ai-token (ai-session-token)
-                    response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/answer-sources"
-                                                   {:request-options {:headers {"x-metabase-session" ai-token}}}
-                                                   {:conversation_id conversation-id})
-                    expected-fields
-                    [{:name "ID", :type "number", :semantic_type "pk"}
-                     {:name "Ean", :type "string", :field_values string-sequence?}
-                     {:name "Title", :type "string", :semantic_type "title", :field_values string-sequence?}
-                     {:name "Category", :type "string", :semantic_type "category", :field_values string-sequence?}
-                     {:name "Vendor", :type "string", :semantic_type "company", :field_values string-sequence?}
-                     {:name "Price", :type "number"}
-                     {:name "Rating", :type "number", :semantic_type "score"}
-                     {:name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]]
-                (is (=? {:structured_output
-                         {:metrics [(-> metric-data
-                                        (select-keys [:name :description])
-                                        (assoc :id metric-id
-                                               :type "metric"
-                                               :default_time_dimension_field_id (format "c%d/%d" metric-id 7)
-                                               :queryable_dimensions
-                                               (map-indexed #(assoc %2 :field_id (format "c%d/%d" metric-id %1))
-                                                            expected-fields)))
-                                    (-> model-metric-data
-                                        (select-keys [:name :description])
-                                        (assoc :id model-metric-id
-                                               :type "metric"
-                                               :default_time_dimension_field_id (format "c%d/%d" model-metric-id 7)
-                                               :queryable_dimensions
-                                               (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-metric-id %1))
-                                                            expected-fields)))]
-                          :models [(-> model-data
-                                       (select-keys [:name :description])
-                                       (assoc :id model-id
-                                              :type "model"
-                                              :fields (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-id %1))
-                                                                   expected-fields)
-                                              :metrics
-                                              [{:id model-metric-id
-                                                :name "Model metric"
-                                                :description "Model metric desc"
-                                                :default_time_dimension_field_id (format "c%d/%d" model-metric-id 7)}]))]}
-                         :conversation_id conversation-id}
-                        response))))))))))
+              (testing "Calling with Wrong metabot-id"
+                (let [conversation-id (str (random-uuid))
+                      ai-token (ai-session-token)]
+                  (mt/user-http-request :rasta :post 400 "ee/metabot-tools/answer-sources"
+                                        {:request-options {:headers {"x-metabase-session" ai-token}}}
+                                        {:metabot_id (dec metabot-id)
+                                         :conversation_id conversation-id})))
+              (testing "Normal call"
+                (let [conversation-id (str (random-uuid))
+                      ai-token (ai-session-token)
+                      response (mt/user-http-request :rasta :post 200 "ee/metabot-tools/answer-sources"
+                                                     {:request-options {:headers {"x-metabase-session" ai-token}}}
+                                                     {:metabot_id metabot-id
+                                                      :conversation_id conversation-id})
+                      expected-fields
+                      [{:name "ID", :type "number", :semantic_type "pk"}
+                       {:name "Ean", :type "string", :field_values string-sequence?}
+                       {:name "Title", :type "string", :semantic_type "title", :field_values string-sequence?}
+                       {:name "Category", :type "string", :semantic_type "category", :field_values string-sequence?}
+                       {:name "Vendor", :type "string", :semantic_type "company", :field_values string-sequence?}
+                       {:name "Price", :type "number"}
+                       {:name "Rating", :type "number", :semantic_type "score"}
+                       {:name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]]
+                  (is (=? {:structured_output
+                           {:metrics [(-> metric-data
+                                          (select-keys [:name :description])
+                                          (assoc :id metric-id
+                                                 :type "metric"
+                                                 :default_time_dimension_field_id (format "c%d/%d" metric-id 7)
+                                                 :queryable_dimensions
+                                                 (map-indexed #(assoc %2 :field_id (format "c%d/%d" metric-id %1))
+                                                              expected-fields)))
+                                      (-> model-metric-data
+                                          (select-keys [:name :description])
+                                          (assoc :id model-metric-id
+                                                 :type "metric"
+                                                 :default_time_dimension_field_id (format "c%d/%d" model-metric-id 7)
+                                                 :queryable_dimensions
+                                                 (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-metric-id %1))
+                                                              expected-fields)))]
+                            :models [(-> model-data
+                                         (select-keys [:name :description])
+                                         (assoc :id model-id
+                                                :type "model"
+                                                :fields (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-id %1))
+                                                                     expected-fields)
+                                                :metrics
+                                                [{:id model-metric-id
+                                                  :name "Model metric"
+                                                  :description "Model metric desc"
+                                                  :default_time_dimension_field_id (format "c%d/%d" model-metric-id 7)}]))]}
+                           :conversation_id conversation-id}
+                          response)))))))))))
 
 (deftest ^:parallel get-current-user-test
   (mt/with-premium-features #{:metabot-v3}


### PR DESCRIPTION
Fixes BOT-88

### Description

This PR introduces an _optional_ `metabot_id` parameter defaulting to 1 (the internal `__METABOT__` metabot) that's passed through to the AI service and used in the answer-sources tool to find the collection name to load models and metrics from.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
