### PR TITLE
Decrease the pool size for mirror DBs

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -132,8 +132,10 @@ For setting the maximum, see [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#mb_ap
    "acquireRetryAttempts"         (if config/is-test? 1 0)
    ;; [From dox] Seconds a Connection can remain pooled but unused before being discarded.
    "maxIdleTime"                  (* 3 60 60) ; 3 hours
-   "minPoolSize"                  1
-   "initialPoolSize"              1
+   "minPoolSize"                  (if (:router-database-id database)
+                                    0 1)
+   "initialPoolSize"              (if (:router-database-id database)
+                                    0 1)
    "maxPoolSize"                  (jdbc-data-warehouse-max-connection-pool-size)
    ;; [From dox] If true, an operation will be performed at every connection checkout to verify that the connection is
    ;; valid. [...] ;; Testing Connections in checkout is the simplest and most reliable form of Connection testing,

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -63,7 +63,7 @@
                                          #_resolved-query clojure.lang.IPersistentMap]
   [query-type model parsed-args honeysql]
   (merge (next-method query-type model parsed-args honeysql)
-         {:select [:id :engine :name :dbms_version :settings :is_audit :details :timezone]}))
+         {:select [:id :engine :name :dbms_version :settings :is_audit :details :timezone :router_database_id]}))
 
 (t2/define-after-select :metadata/database
   [database]


### PR DESCRIPTION
DB metadata seems like an odd thing - it's the Metabase Database converted to a snake-hating map, so `router_database_id` becomes `router-database-id`.

We can't write a function of `:model/Database` that decides whether we're looking at a mirror database (because we're not looking at a `:model/Database` here). So we're reduced to just checking the key. Feels weird, but I think the cleanest way available here?