### PR TITLE
Hide raw data toggle for tables with table.pivot setting

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -926,11 +926,9 @@ export const getSnippetCollectionId = createSelector(
 
 export const getIsVisualized = createSelector(
   [getQuestion, getVisualizationSettings],
-  (question, settings) =>
-    question &&
+  (question) =>
     // table is the default
-    ((question.display() !== "table" && question.display() !== "pivot") ||
-      (settings != null && settings["table.pivot"])),
+    question?.display() !== "table" && question?.display() !== "pivot",
 );
 
 export const getIsLiveResizable = createSelector(

--- a/frontend/src/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/src/metabase/query_builder/selectors.unit.spec.js
@@ -13,9 +13,6 @@ import registerVisualizations from "metabase/visualizations/register";
 import Question from "metabase-lib/v1/Question";
 import {
   createMockCard,
-  createMockColumn,
-  createMockDataset,
-  createMockDatasetData,
   createMockTable,
   createMockTableColumnOrderSetting,
   createMockVisualizationSettings,
@@ -421,40 +418,5 @@ describe("getIsVisualized", () => {
       }),
     });
     expect(getIsVisualized(state)).toBe(false);
-  });
-
-  it("should be true when the table is implicitly visualized as a pivot table", () => {
-    const state = getBaseState({
-      card: createMockCard({
-        display: "table",
-      }),
-      queryResults: [
-        createMockDataset({
-          data: createMockDatasetData({
-            cols: [
-              createMockColumn({
-                name: "count",
-                base_type: "type/Integer",
-                effective_type: "type/Integer",
-                source: "aggregation",
-              }),
-              createMockColumn({
-                name: "CATEGORY",
-                base_type: "type/Text",
-                effective_type: "type/Text",
-                source: "breakout",
-              }),
-              createMockColumn({
-                name: "VENDOR",
-                base_type: "type/Text",
-                effective_type: "type/Text",
-                source: "breakout",
-              }),
-            ],
-          }),
-        }),
-      ],
-    });
-    expect(getIsVisualized(state)).toBe(true);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/56094

The `getIsVisualized` selector determines whether we show the raw data toggle at the bottom of a visualization. Currently this is hidden for normal tables and the pivot table visualization type, but is shown for normal tables that have the `Pivot table` viz setting enabled (i.e. the FE-only pivot table code path).

This is buggy because if you start with a table viz, click the `Pivot table` setting, and then click the raw data toggle, the question is no longer considered "visualized" even though the pivot table setting is still enabled. So the toggle disappears and any subsequent changes to the `Pivot table` setting don't have an effect.

I think the sanest thing to do here is to remove this carve out and handle both types of pivots the same, with no raw data toggle. The toggle is effectively the same as turning off the `Pivot table` viz setting anyway.