### PR TITLE
Test that sandboxing fails closed when misconfigured

### DIFF
--- a/e2e/support/commands/permissions/updatePermissions.ts
+++ b/e2e/support/commands/permissions/updatePermissions.ts
@@ -61,8 +61,9 @@ Cypress.Commands.add(
     impersonations?: Impersonation[],
   ) => {
     cy.log("Fetch permissions graph");
-    cy.request<PermissionsGraph>("GET", "/api/permissions/graph").then(
-      ({ body: { groups, revision } }) => {
+    return cy
+      .request<PermissionsGraph>("GET", "/api/permissions/graph")
+      .then(({ body: { groups, revision } }) => {
         const UPDATED_GROUPS = Object.assign(groups, groupsPermissionsObject);
 
         const payload = {
@@ -73,8 +74,7 @@ Cypress.Commands.add(
 
         cy.log("Update/save permissions");
         cy.request("PUT", "/api/permissions/graph", payload);
-      },
-    );
+      });
   },
 );
 

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -156,7 +156,7 @@ export function assertDatasetReqIsSandboxed(options = {}) {
 }
 
 export function blockUserGroupPermissions(groupId, databaseId = SAMPLE_DB_ID) {
-  cy.updatePermissionsGraph({
+  return cy.updatePermissionsGraph({
     [groupId]: {
       [databaseId]: {
         "view-data": "blocked",

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -233,6 +233,11 @@ export function createTestRoles({ type, isWritable }) {
 }
 
 // will this work for multiple schemas?
+/**
+ * @param {Object} obj
+ * @param {string} [obj.databaseId] - Defaults to WRITABLE_DB_ID
+ * @param {string} obj.name - The table's real name, not its display name
+ */
 export function getTableId({ databaseId = WRITABLE_DB_ID, name }) {
   return cy
     .request("GET", `/api/database/${databaseId}/metadata`)

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-misconfiguration.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-misconfiguration.cy.spec.ts
@@ -1,0 +1,95 @@
+import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
+
+import {
+  assertResponseFailsClosed,
+  assignAttributeToUser,
+  configureSandboxPolicy,
+  getCardResponses,
+  gizmoViewer,
+  rowsShouldContainOnlyOneCategory,
+  signInAs,
+} from "./helpers/e2e-sandboxing-helpers";
+
+const { H } = cy;
+
+describe("admin > permissions > sandboxing > misconfiguration", () => {
+  before(() => {
+    H.restore("postgres-writable");
+
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+
+    H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP, WRITABLE_DB_ID);
+    H.blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP, WRITABLE_DB_ID);
+    H.blockUserGroupPermissions(USER_GROUPS.READONLY_GROUP, WRITABLE_DB_ID);
+
+    // @ts-expect-error - this isn't typed yet
+    cy.createUserFromRawData(gizmoViewer);
+
+    cy.log("Create a simple editable products table");
+    H.queryWritableDB("DROP TABLE IF EXISTS products");
+    H.queryWritableDB(
+      "CREATE TABLE IF NOT EXISTS products (id INT PRIMARY KEY, category VARCHAR, name VARCHAR)",
+    );
+    H.queryWritableDB(
+      "INSERT INTO products (id, name, category) VALUES (1, 'A', 'Gizmo'), (2, 'B', 'Widget')",
+    );
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "products" });
+  });
+
+  it("if we create a sandboxing policy on a column but then the column is deleted, the sandboxing system fails closed", () => {
+    assignAttributeToUser({ user: gizmoViewer, attributeValue: "Gizmo" });
+    configureSandboxPolicy(
+      {
+        filterTableBy: "column",
+        filterColumn: "Category",
+      },
+      {
+        tableName: "Products",
+        databaseId: WRITABLE_DB_ID,
+      },
+    );
+
+    const questionData = {
+      name: "Simple question based on the 'Products' table",
+      model: "card",
+    };
+
+    H.getTableId({
+      name: "products",
+    }).then((tableId) => {
+      H.createQuestion(
+        {
+          database: WRITABLE_DB_ID,
+          name: questionData.name,
+          query: {
+            "source-table": tableId,
+            limit: 20,
+          },
+        },
+        { wrapId: true },
+      );
+    });
+
+    signInAs(gizmoViewer).then(() => {
+      cy.get<number>("@questionId").then((questionId) => {
+        getCardResponses([{ ...questionData, id: questionId }]).then((data) =>
+          rowsShouldContainOnlyOneCategory({
+            ...data,
+            productCategory: "Gizmo",
+          }),
+        );
+      });
+    });
+
+    H.queryWritableDB("ALTER TABLE products DROP COLUMN category");
+
+    signInAs(gizmoViewer).then(() => {
+      cy.get<number>("@questionId").then((questionId) => {
+        getCardResponses([{ ...questionData, id: questionId }]).then(
+          ({ responses }) => responses.forEach(assertResponseFailsClosed),
+        );
+      });
+    });
+  });
+});

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -6,6 +6,7 @@ import type { CollectionItem, Dashboard } from "metabase-types/api";
 import {
   assertAllResultsAndValuesAreSandboxed,
   assertNoResultsOrValuesAreSandboxed,
+  assertResponseFailsClosed,
   assignAttributeToUser,
   configureSandboxPolicy,
   createSandboxingDashboardAndQuestions,
@@ -43,6 +44,7 @@ describe(
       cy.intercept("/api/card/*/query").as("cardQuery");
 
       H.restore("postgres-12");
+
       cy.signInAsAdmin();
       H.setTokenFeatures("all");
       preparePermissions();
@@ -62,10 +64,11 @@ describe(
       });
       // @ts-expect-error - this isn't typed yet
       cy.createUserFromRawData(gizmoViewer);
+      // @ts-expect-error - this isn't typed yet
       cy.createUserFromRawData(widgetViewer);
 
       // this setup is a bit heavy, so let's just do it once
-      H.snapshot("sandboxing-on-postgres-12");
+      H.snapshot("sandboxing-snapshot");
     });
 
     beforeEach(() => {
@@ -75,7 +78,7 @@ describe(
         "dashcardQuery",
       );
       cy.intercept("POST", "/api/dataset").as("datasetQuery");
-      H.restore("sandboxing-on-postgres-12" as any);
+      H.restore("sandboxing-snapshot" as any);
     });
 
     it("shows all data before sandboxing policy is applied", () => {
@@ -190,8 +193,7 @@ describe(
             new Array(sandboxableQuestions.length).fill("@dashcardQuery"),
           ).then((interceptions) => {
             interceptions.forEach(({ response }) => {
-              expect(response?.body.data.rows).to.have.length(0);
-              expect(response?.body.error_type).to.contain("invalid-query");
+              assertResponseFailsClosed(response);
             });
           });
 


### PR DESCRIPTION
### Background

Some sandboxing policies are based on a regular column.

For example, if you have a table with a `category` column, you can ensure that certain users only see rows in this table if they have an attribute whose value matches the category. 

This way, you can have a user whose 'can_see' attribute equals 'Gizmo' and another user whose 'can_see' attribute equals 'Widget' and you can ensure that the Gizmo-viewing user only sees rows in the table where the "category" column equals "Gizmo", and the same with the Widget-viewing user.

But what happens if the "category" column is deleted once this policy is set up?

### This PR

This PR ensures that in such a situation, the system fails closed. When the user visits a question that is based on the products table, an error occurs and no rows are shown.