### PR TITLE
Use lib.metadata/database-supports? to check for database :features

### DIFF
--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -326,8 +326,7 @@
 
   ([query :- ::lib.schema/query
     stage-number :- :int]
-   (let [db-features (or (:features (lib.metadata/database query)) #{})
-         stage (lib.util/query-stage query stage-number)
+   (let [stage (lib.util/query-stage query stage-number)
          columns (lib.metadata.calculation/visible-columns query stage-number stage)
          with-columns (fn [{:keys [requires-column? supported-field] :as operator}]
                         (cond
@@ -346,7 +345,7 @@
       (into []
             (comp (filter (fn [op]
                             (let [feature (:driver-feature op)]
-                              (or (nil? feature) (db-features feature)))))
+                              (or (nil? feature) (lib.metadata/database-supports? query feature)))))
                   (keep with-columns)
                   (map #(assoc % :lib/type :operator/aggregation)))
             lib.schema.aggregation/aggregation-operators)))))

--- a/src/metabase/lib/extraction.cljc
+++ b/src/metabase/lib/extraction.cljc
@@ -26,9 +26,7 @@
             :display-name (lib.temporal-bucket/describe-temporal-unit unit)}))))
 
 (defn- regex-available? [metadata-providerable]
-  (-> (lib.metadata/database metadata-providerable)
-      :features
-      (contains? :regex)))
+  (lib.metadata/database-supports? metadata-providerable :regex))
 
 (defn- domain-extraction [column]
   {:lib/type     ::extraction

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -423,7 +423,7 @@
 (defmethod lib.binning/available-binning-strategies-method :metadata/column
   [query _stage-number {:keys [effective-type fingerprint semantic-type] :as field-metadata}]
   (if (not= (:lib/source field-metadata) :source/expressions)
-    (let [binning?    (some-> query lib.metadata/database :features (contains? :binning))
+    (let [binning?    (lib.metadata/database-supports? query :binning)
           fingerprint (get-in fingerprint [:type :type/Number])
           existing    (lib.binning/binning field-metadata)
           strategies  (cond

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -607,12 +607,10 @@
   ;; stage number is not currently used, but it is taken as a parameter for consistency with the rest of MLv2
   ([query         :- ::lib.schema/query
     _stage-number :- :int]
-   (let [database (lib.metadata/database query)
-         features (:features database)]
-     (into []
-           (comp (filter (partial contains? features))
-                 (map raw-join-strategy->strategy-option))
-           [:left-join :right-join :inner-join :full-join]))))
+   (into []
+         (comp (filter (partial lib.metadata/database-supports? query))
+               (map raw-join-strategy->strategy-option))
+         [:left-join :right-join :inner-join :full-join])))
 
 (mu/defn join-clause :- lib.join.util/PartialJoin
   "Create an MBQL join map from something that can conceptually be joined against. A `Table`? An MBQL or native query? A

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -169,10 +169,13 @@
       (editable-stages? query stages))))
 
 (mu/defn database-supports? :- :boolean
-  "Does `query`s [[database]] support the given `feature`?"
-  [query   :- ::lib.schema/query
-   feature :- :keyword]
-  (-> query
+  "Does `metadata-providerable`'s [[database]] support the given `feature`?
+
+  Minimize the use of this function. Using it is often a code smell. The lib should not normally be concerned with
+  driver features. See https://github.com/metabase/metabase/pull/55206#discussion_r2017378181"
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   feature               :- :keyword]
+  (-> metadata-providerable
       database
       :features
       (contains? feature)))

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -127,11 +127,10 @@
 (mu/defn required-native-extras :- set?
   "Returns the extra keys that are required for this database's native queries, for example `:collection` name is
   needed for MongoDB queries."
-  [metadata-provider :- ::lib.schema.metadata/metadata-providerable]
-  (let [db (lib.metadata/database metadata-provider)]
-    (cond-> #{}
-      (get-in db [:features :native-requires-specified-collection])
-      (conj :collection))))
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable]
+  (cond-> #{}
+    (lib.metadata/database-supports? metadata-providerable :native-requires-specified-collection)
+    (conj :collection)))
 
 (mu/defn with-native-extras :- ::lib.schema/query
   "Updates the extras required for the db to run this query.

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -453,6 +453,15 @@
                   :lib/source     :source/aggregations}]
                 (lib/aggregations-metadata agg-query)))))))
 
+(deftest ^:parallel available-aggregation-operators-missing-feature-test
+  (let [provider-without-feature  (meta/updated-metadata-provider
+                                   update :features disj :basic-aggregations :percentile-aggregations)
+        query-without-feature     (lib/query provider-without-feature (meta/table-metadata :venues))
+        operators-without-feature (lib/available-aggregation-operators query-without-feature)]
+    (is (=? [{:short :stddev
+              :driver-feature :standard-deviation-aggregations}]
+            operators-without-feature))))
+
 (deftest ^:parallel selected-aggregation-operator-test
   (let [query (-> (lib.tu/venues-query)
                   (lib/expression "double-price" (lib/* (meta/field-metadata :venues :price) 2))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -10,7 +10,6 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
@@ -551,9 +550,7 @@
 
 (deftest ^:parallel diagnose-expression-literals-without-feature-support-test
   (testing "top-level literals are not allowed if the :expression-literals feature is not supported"
-    (let [metadata-graph (.-metadata-graph meta/metadata-provider)
-          restricted-metadata-graph (update metadata-graph :features disj :expression-literals)
-          restricted-provider (meta.graph-provider/->SimpleGraphMetadataProvider restricted-metadata-graph)
+    (let [restricted-provider (meta/updated-metadata-provider update :features disj :expression-literals)
           query (lib/query restricted-provider (meta/table-metadata :orders))
           expr  (lib.expression/value true)]
       (doseq [mode [:expression :filter]]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -407,6 +407,14 @@
                        (for [option options]
                          (:selected (lib/display-info query2 option)))))))))))))
 
+(deftest ^:parallel available-binning-strategies-missing-feature-test
+  (let [provider (meta/updated-metadata-provider update :features disj :binning)
+        query    (lib/query provider (meta/table-metadata :orders))
+        subtotal (meta/field-metadata :orders :subtotal)]
+    (testing "no available binning strategies if database does not support :binning"
+      (is (= []
+             (lib/available-binning-strategies query subtotal))))))
+
 (deftest ^:parallel available-binning-strategies-expressions-test
   (testing "There should be no binning strategies for expressions as they are not supported (#31367)"
     (let [query (-> (lib.tu/venues-query)

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -427,6 +427,13 @@
           {:lib/type :option/join.strategy, :strategy :inner-join}]
          (lib/available-join-strategies (lib.tu/query-with-join)))))
 
+(deftest ^:parallel available-join-strategies-missing-features-test
+  (is (= [{:lib/type :option/join.strategy, :strategy :inner-join}]
+         (lib/available-join-strategies
+          (-> (lib.tu/query-with-join)
+              (assoc :lib/metadata
+                     (meta/updated-metadata-provider update :features disj :left-join :right-join)))))))
+
 (deftest ^:parallel join-strategy-display-name-test
   (let [query (lib.tu/query-with-join)]
     (is (= ["Left outer join" "Right outer join" "Inner join"]

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -5,10 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
-   [metabase.lib.test-util :as lib.tu])
-  #?@(:clj ((:import
-             metabase.lib.test_metadata.graph_provider.SimpleGraphMetadataProvider))))
+   [metabase.lib.test-util :as lib.tu]))
 
 (comment lib/keep-me)
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
@@ -56,23 +53,17 @@
       ["PEOPLE" "ORDERS" "VENUES"])))
 
 (deftest ^:parallel editable?-test
-  (let [query          (lib.tu/query-with-join)
-        metadata       ^SimpleGraphMetadataProvider (:lib/metadata query)
-        metadata-graph (.-metadata-graph metadata)
-        restricted-metadata-graph (update metadata-graph :tables #(into [] (remove (comp #{"CATEGORIES"} :name)) %))
-        restricted-provider (meta.graph-provider/->SimpleGraphMetadataProvider restricted-metadata-graph)
-        restritcted-query (assoc query :lib/metadata restricted-provider)]
+  (let [query               (lib.tu/query-with-join)
+        restricted-provider (meta/updated-metadata-provider
+                             update :tables #(into [] (remove (comp #{"CATEGORIES"} :name)) %))
+        restritcted-query   (assoc query :lib/metadata restricted-provider)]
     (is (lib.metadata/editable? query))
     (is (not (lib.metadata/editable? restritcted-query)))))
 
 (deftest ^:parallel database-supports?-test
   (let [query          (lib.tu/query-with-join)
-        metadata       ^SimpleGraphMetadataProvider (:lib/metadata query)
-        metadata-graph (.-metadata-graph metadata)
-        metadata-graph-with-feature (update metadata-graph :features conj ::special-feature)
-        metadata-graph-without-feature (update metadata-graph :features disj ::special-feature)
-        provider-with-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-with-feature)
-        provider-without-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-without-feature)
+        provider-with-feature (meta/updated-metadata-provider update :features conj ::special-feature)
+        provider-without-feature (meta/updated-metadata-provider update :features disj ::special-feature)
         query-with-feature (assoc query :lib/metadata provider-with-feature)
         query-without-feature (assoc query :lib/metadata provider-without-feature)]
     (is (lib.metadata/database-supports? query-with-feature ::special-feature))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -6,7 +6,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.native :as lib.native]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
    [metabase.lib.test-util :as lib.tu]
    [metabase.util.humanization :as u.humanization]
    [metabase.util.malli :as mu]))
@@ -254,8 +253,7 @@
       (is (=? {:database 9999}
               (-> query
                   (lib/with-different-database
-                    (meta.graph-provider/->SimpleGraphMetadataProvider
-                     (assoc meta/metadata :id 9999)))))))
+                    (meta/updated-metadata-provider assoc :id 9999))))))
     (is (thrown-with-msg?
          #?(:clj Throwable :cljs :default)
          #"Must be a native query"
@@ -412,8 +410,7 @@
     (testing "remove dimensions from template tags"
       (is (empty? (-> query
                       (lib/with-different-database
-                        (meta.graph-provider/->SimpleGraphMetadataProvider
-                         (assoc meta/metadata :id 9999)))
+                        (meta/updated-metadata-provider assoc :id 9999))
                       lib/template-tags
                       vals
                       (->> (filter :dimension))))))))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -234,8 +234,7 @@
              (lib/with-template-tags {"myid" (assoc (get original-tags "myid") :display-name "My ID")}))))))
 
 (defn ^:private metadata-provider-requiring-collection []
-  (meta.graph-provider/->SimpleGraphMetadataProvider (-> meta/metadata
-                                                         (update :features conj :native-requires-specified-collection))))
+  (meta/updated-metadata-provider update :features conj :native-requires-specified-collection))
 
 (deftest ^:parallel native-query+collection-test
   (testing "building when collection is not required"


### PR DESCRIPTION
Closes QUE-836

### Description

Refactor lib code that checks database `:features` to call `lib.metadata/database-supports?`.

https://github.com/metabase/metabase/pull/55206#discussion_r2017378181

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
