### PR TITLE
Fixing typo in embed type ui

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -145,7 +145,7 @@ export function SelectEmbedTypePane({
             <List>
               {/* eslint-disable-next-line no-literal-metabase-strings -- only admin sees this */}
               <List.Item>{t`Embed all of Metabase in an iframe.`}</List.Item>
-              <List.Item>{t`Let people can click on to explore.`}</List.Item>
+              <List.Item>{t`Let people click to explore.`}</List.Item>
               <List.Item>{t`Customize appearance with your logo, font, and colors.`}</List.Item>
             </List>
             {!isInteractiveEmbeddingAvailable && (


### PR DESCRIPTION
Just a small typo fix in copy of `SelectEmbedTypePane`

How it is currently (minus the purple rectangle)
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/57a2beed-4b2a-40c7-89b0-e15e464851f4" />
