### PR TITLE
Flaky test fix: unsubscribe-receive-email-test

### DIFF
--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -198,6 +198,7 @@
 
 (defn summarize-multipart-single-email
   [email & regexes]
+  (testing (format "email content: \n%s\n" email))
   (let [email-body->regex-boolean (create-email-body->regex-fn regexes)
         body-or-content           (fn [email-body-seq]
                                     (doall

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -198,20 +198,20 @@
 
 (defn summarize-multipart-single-email
   [email & regexes]
-  (testing (format "email content: \n%s\n" email))
-  (let [email-body->regex-boolean (create-email-body->regex-fn regexes)
-        body-or-content           (fn [email-body-seq]
-                                    (doall
-                                     (for [{email-type :type :as email-part} email-body-seq]
-                                       (if (string? email-type)
-                                         (email-body->regex-boolean email-part)
-                                         (summarize-attachment email-part)))))]
-    (cond-> email
-      (:recipients email) (update :recipients set)
-      (:to email)         (update :to set)
-      (:bcc email)        (update :bcc set)
-      (:message email)    (update :message body-or-content)
-      (:body email)       (update :body body-or-content))))
+  (testing (format "email content: \n%s\n" email)
+    (let [email-body->regex-boolean (create-email-body->regex-fn regexes)
+          body-or-content           (fn [email-body-seq]
+                                      (doall
+                                       (for [{email-type :type :as email-part} email-body-seq]
+                                         (if (string? email-type)
+                                           (email-body->regex-boolean email-part)
+                                           (summarize-attachment email-part)))))]
+      (cond-> email
+        (:recipients email) (update :recipients set)
+        (:to email)         (update :to set)
+        (:bcc email)        (update :bcc set)
+        (:message email)    (update :message body-or-content)
+        (:body email)       (update :body body-or-content)))))
 
 (defn summarize-multipart-email
   "For text/html portions of an email, this is similar to `regex-email-bodies`, but for images in the attachments will

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -144,7 +144,7 @@
                                                           (notification.tu/with-mock-inbox-email!
                                                             (with-send-messages-sync!
                                                               (mt/user-http-request :crowberto :post 200 "notification" notification))))
-                a-card-url (format "<a href=\"https://testmb.com/question/%d\">My Card</a>." card-id)]
+                a-card-url (format "<a href=\".*/question/%d\">My Card</a>." card-id)]
             (testing (format "send email with %s condition" send_condition)
               (testing "recipients will get you were added to a card email"
                 (is (=? {:bcc     #{"rasta@metabase.com" "ngoc@metabase.com"}
@@ -890,7 +890,7 @@
           (let [[email] (notification.tu/with-mock-inbox-email!
                           (with-send-messages-sync!
                             (mt/user-http-request :lucky :post 204 (format "notification/%d/unsubscribe" noti-1))))
-                a-href (format "<a href=\"https://testmb.com/question/%d\">My Card</a>."
+                a-href (format "<a href=\".*/question/%d\">My Card</a>."
                                (-> notification :payload :card_id))]
             (testing "sends unsubscribe confirmation email"
               (is (=? {:bcc     #{"lucky@metabase.com"}
@@ -930,7 +930,7 @@
                                                                 {:type    :notification-recipient/raw-value
                                                                  :details {:value "test@metabase.com"}}]}]}
               make-card-url-tag (fn [notification]
-                                  (format "<a href=\"https://testmb.com/question/%d\">Test Card</a>."
+                                  (format "<a href=\".*/question/%d\">Test Card</a>."
                                           (-> notification :payload :card_id)))
               update-notification! (fn [noti-id notification updates]
                                      (notification.tu/with-mock-inbox-email!


### PR DESCRIPTION
```clojure
expected: {:bcc #{"lucky@metabase.com"},
           :body [{"<a href=\"[https://testmb.com/question/86\](https://testmb.com/question/86/)">My Card</a>." true,
                   "You’re no longer receiving alerts about" true}],
           :subject "You unsubscribed from an alert"}
  actual: {:bcc #{"lucky@metabase.com"},
           :body ({"<a href=\"[https://testmb.com/question/86\](https://testmb.com/question/86/)">My Card</a>." false,
                   "You’re no longer receiving alerts about" true}),
           :from "notifications@metabase.com",
           :subject "You unsubscribed from an alert"}
```

Suspect that the site-url setting is somehow changed within the test, maybe it's leaked from another test?

Fix by wildcard the domain, also add the email content to the context to make it easier to debug if it's still flaky.