### PR TITLE
test(sdk): Fix storybook not working properly when a component uses EE plugins

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/test/storybook-themes.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/storybook-themes.ts
@@ -1,5 +1,7 @@
-import { defineMetabaseTheme } from "embedding-sdk/components/public";
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
+import {
+  type MetabaseTheme,
+  defineMetabaseTheme,
+} from "metabase/embedding-sdk/theme";
 
 export const darkColors = {
   primary: "#DF75E9",


### PR DESCRIPTION
Closes EMB-290

### Description

This fixes the side-effect caused by importing a function from a barrel file. The problem was that, storybook imports component files before initializing the EE plugins.

This shouldn't change the SDK behavior whatsoever. As this file is imported after the EE plugin is initialiezd on the SDK, it's just that storybook will import `.storybook-sdk/preview.tsx` first which casued the problem.

### How to verify

1. Checkout 59b21e8f9112a09a7a4781e90c7006a5a63bc636. This contains a fix from this PR.
1. Run `yarn storybook-embedding-sdk`.
1. Visit `MetabotQuestion` story, the story should render the Metabot UI
1. Visit the commit prior `git checkout @~`
1. Visit the `MetabotQuestion` question again, refresh the page just to be sure, and it should not be rendered.

### Demo
#### After
<img width="588" alt="image" src="https://github.com/user-attachments/assets/065433a1-c7dc-47cb-8b2a-156d54146b29" />

#### Before
<img width="1079" alt="image" src="https://github.com/user-attachments/assets/2df64855-f0ee-4717-9ec6-4674609a15ad" />

