### PR TITLE
Make editables models instead of questions

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -882,7 +882,7 @@
                   :display                "table-editable"
                   :name                   (:name table)
                   :result_metadata        nil
-                  :type                   "question"
+                  :type                   "model"
                   ;; Redundant with :display, but just in case it's useful. Revisit once FE is built.
                   :visualization_settings {:editable? true}}
         card-id (if keep?

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -554,8 +554,13 @@
         invalid? (or (and (contains? card :collection_id)
                           (not= correct-collection-id (:collection_id card)))
                      ;(not (contains? #{:question "question" nil} (:type card)))
-                     ;; TODO this might cause havoc somewhere?
-                     (not (contains? #{:question "question" :model "model" nil} (:type card)))
+                     (case (some-> (:type card) name)
+                       nil false
+                       "question" false
+                       ;; allow editables
+                       ;; TODO there may be other places in the dashboard-question code paths that break with models
+                       "model" (= "editable-table" (:display card))
+                       true)
                      (some? (:collection_position card)))]
     (when invalid?
       (throw (ex-info (tru "Invalid dashboard-internal card")

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -553,7 +553,9 @@
   (let [correct-collection-id (t2/select-one-fn :collection_id [:model/Dashboard :collection_id] (:dashboard_id card))
         invalid? (or (and (contains? card :collection_id)
                           (not= correct-collection-id (:collection_id card)))
-                     (not (contains? #{:question "question" nil} (:type card)))
+                     ;(not (contains? #{:question "question" nil} (:type card)))
+                     ;; TODO this might cause havoc somewhere?
+                     (not (contains? #{:question "question" :model "model" nil} (:type card)))
                      (some? (:collection_position card)))]
     (when invalid?
       (throw (ex-info (tru "Invalid dashboard-internal card")


### PR DESCRIPTION
Make "editables" into models, so that actions "just work" with them.

In some ways it also makes more sense as well, they are more like a "table++" than a "saved view".