### PR TITLE
Remove opacity from viz settings gear icon

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewButton.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.module.css
@@ -30,8 +30,4 @@
       );
     }
   }
-
-  .ViewButtonIcon {
-    opacity: 0.6;
-  }
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
@@ -19,7 +19,6 @@ const ViewButton = ({ className, active, color, ...props }: Props) => {
     <Button
       classNames={{
         root: cx(S.ViewButton, { [S.active]: active }, className),
-        icon: S.ViewButtonIcon,
       }}
       style={
         {


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/56138

I noticed that the gear icon for viz settings is lighter than the `Visualization` text:
<img width="155" alt="image" src="https://github.com/user-attachments/assets/3480e17f-77f9-41cd-a317-c20e522bd7d8" />

This is due to an opacity of 60%. I'm not sure why this was being applied but removing it makes the button look more consistent:

<img width="155" alt="image" src="https://github.com/user-attachments/assets/b0377460-430f-4fa3-b562-42c5bdfb06a4" />
