### PR TITLE
fix: correct setting name check for static stats

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/internal_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/internal_stats.clj
@@ -7,14 +7,14 @@
   "Boolean values that report on the state of different embedding configurations."
   :feature :none
   [embedded-dashboard-count embedded-question-count]
-  {:enabled-embedding-static      (boolean (and (setting/get-raw-value :enable-embedding-static)
+  {:enabled-embedding-static      (boolean (and (setting/get-value-of-type :boolean :enable-embedding-static)
                                                 (or (> embedded-question-count 0)
                                                     (> embedded-dashboard-count 0))))
-   :enabled-embedding-interactive (boolean (and (setting/get-raw-value :enable-embedding-interactive)
-                                                (setting/get-raw-value :embedding-app-origins-interactive)
-                                                (or (setting/get-raw-value :jwt-enabled)
-                                                    (setting/get-raw-value :saml-enabled)
-                                                    (setting/get-raw-value :ldap-enabled)
-                                                    (setting/get-raw-value :google-auth-enabled))))
-   :enabled-embedding-sdk         (boolean  (and  (setting/get-raw-value :enable-embedding-sdk)
-                                                  (setting/get-raw-value :jwt-enabled)))})
+   :enabled-embedding-interactive (boolean (and (setting/get-value-of-type :boolean :enable-embedding-interactive)
+                                                (not-empty (setting/get-value-of-type :string :embedding-app-origins-interactive))
+                                                (or (setting/get-value-of-type :boolean :jwt-enabled)
+                                                    (setting/get-value-of-type :boolean :saml-enabled)
+                                                    (setting/get-value-of-type :boolean :ldap-enabled)
+                                                    (setting/get-value-of-type :boolean :google-auth-enabled))))
+   :enabled-embedding-sdk         (boolean  (and  (setting/get-value-of-type :boolean :enable-embedding-sdk)
+                                                  (setting/get-value-of-type :boolean :jwt-enabled)))})

--- a/enterprise/backend/src/metabase_enterprise/internal_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/internal_stats.clj
@@ -7,7 +7,7 @@
   "Boolean values that report on the state of different embedding configurations."
   :feature :none
   [embedded-dashboard-count embedded-question-count]
-  {:enabled-embedding-static      (boolean (and (setting/get :enable-embedding-sdk)
+  {:enabled-embedding-static      (boolean (and (setting/get :enable-embedding-static)
                                                 (or (> embedded-question-count 0)
                                                     (> embedded-dashboard-count 0))))
    :enabled-embedding-interactive (boolean (and (setting/get :enable-embedding-interactive)

--- a/enterprise/backend/src/metabase_enterprise/internal_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/internal_stats.clj
@@ -7,14 +7,14 @@
   "Boolean values that report on the state of different embedding configurations."
   :feature :none
   [embedded-dashboard-count embedded-question-count]
-  {:enabled-embedding-static      (boolean (and (setting/get :enable-embedding-static)
+  {:enabled-embedding-static      (boolean (and (setting/get-raw-value :enable-embedding-static)
                                                 (or (> embedded-question-count 0)
                                                     (> embedded-dashboard-count 0))))
-   :enabled-embedding-interactive (boolean (and (setting/get :enable-embedding-interactive)
-                                                (setting/get :embedding-app-origins-interactive)
-                                                (or (setting/get :jwt-enabled)
-                                                    (setting/get :saml-enabled)
-                                                    (setting/get :ldap-enabled)
-                                                    (setting/get :google-auth-enabled))))
-   :enabled-embedding-sdk         (boolean  (and  (setting/get :enable-embedding-sdk)
-                                                  (setting/get :jwt-enabled)))})
+   :enabled-embedding-interactive (boolean (and (setting/get-raw-value :enable-embedding-interactive)
+                                                (setting/get-raw-value :embedding-app-origins-interactive)
+                                                (or (setting/get-raw-value :jwt-enabled)
+                                                    (setting/get-raw-value :saml-enabled)
+                                                    (setting/get-raw-value :ldap-enabled)
+                                                    (setting/get-raw-value :google-auth-enabled))))
+   :enabled-embedding-sdk         (boolean  (and  (setting/get-raw-value :enable-embedding-sdk)
+                                                  (setting/get-raw-value :jwt-enabled)))})

--- a/enterprise/backend/test/metabase_enterprise/internal_stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_stats_test.clj
@@ -20,7 +20,10 @@
 (def ^:private idp-cert (slurp "test_resources/sso/auth0-public-idp.cert"))
 
 (deftest enabled-embedding-interactive-test
-  (mt/with-premium-features #{:sso-saml :sso-jwt :embedding}
+  (mt/with-temporary-setting-values [saml-enabled        false
+                                     google-auth-enabled false
+                                     jwt-enabled         false
+                                     ldap-enabled        false]
     (testing "with saml-enabled"
       (mt/with-temporary-setting-values [saml-enabled                       true
                                          saml-identity-provider-uri         "https://idp.example.com"
@@ -61,19 +64,18 @@
             (is (:enabled-embedding-interactive (sut/embedding-settings 0 0)))))))))
 
 (deftest enabled-embedding-sdk
-  (mt/with-premium-features #{:sso-jwt}
-    (testing "with sdk enabled and jwt enabled"
-      (mt/with-temporary-setting-values [enable-embedding-sdk true
-                                         jwt-shared-secret    "asdfasdf"
-                                         jwt-enabled          true]
-        (is (:enabled-embedding-sdk (sut/embedding-settings 0 0)))))
+  (testing "with sdk enabled and jwt enabled"
+    (mt/with-temporary-setting-values [enable-embedding-sdk true
+                                       jwt-shared-secret    "asdfasdf"
+                                       jwt-enabled          true]
+      (is (:enabled-embedding-sdk (sut/embedding-settings 0 0)))))
 
-    (testing "with sdk disabled and jwt enabled"
-      (mt/with-temporary-setting-values [enable-embedding-sdk false
-                                         jwt-enabled          true]
-        (is (not (:enabled-embedding-sdk (sut/embedding-settings 0 0))))))
+  (testing "with sdk disabled and jwt enabled"
+    (mt/with-temporary-setting-values [enable-embedding-sdk false
+                                       jwt-enabled          true]
+      (is (not (:enabled-embedding-sdk (sut/embedding-settings 0 0))))))
 
-    (testing "with sdk enabled and jwt disabled"
-      (mt/with-temporary-setting-values [enable-embedding-sdk true
-                                         jwt-enabled          false]
-        (is (not (:enabled-embedding-sdk (sut/embedding-settings 0 0))))))))
+  (testing "with sdk enabled and jwt disabled"
+    (mt/with-temporary-setting-values [enable-embedding-sdk true
+                                       jwt-enabled          false]
+      (is (not (:enabled-embedding-sdk (sut/embedding-settings 0 0)))))))

--- a/enterprise/backend/test/metabase_enterprise/internal_stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_stats_test.clj
@@ -5,16 +5,16 @@
    [metabase.test :as mt]))
 
 (deftest enabled-embedding-static-test
-  (testing "true when enable embedding sdk is true and dashboard count is greater than 0"
-    (mt/with-temporary-setting-values [enable-embedding-sdk true]
+  (testing "true when enable embedding static is true and dashboard count is greater than 0"
+    (mt/with-temporary-setting-values [enable-embedding-static true]
       (is (:enabled-embedding-static (sut/embedding-settings 1 0)))))
-  (testing "true when enable embedding sdk is true and question count is greater than 0"
-    (mt/with-temporary-setting-values [enable-embedding-sdk true]
+  (testing "true when enable embedding static is true and question count is greater than 0"
+    (mt/with-temporary-setting-values [enable-embedding-static true]
       (is (:enabled-embedding-static (sut/embedding-settings 0 1)))))
-  (testing "false when enable embedding sdk is true and no cards are dashboards are enabled"
+  (testing "false when enable embedding static is true and no cards are dashboards are enabled"
     (is (not (:enabled-embedding-static (sut/embedding-settings 0 0)))))
-  (testing "false when enable embedding sdk is false"
-    (mt/with-temporary-setting-values [enable-embedding-sdk false]
+  (testing "false when enable embedding static is false"
+    (mt/with-temporary-setting-values [enable-embedding-static false]
       (is (not (:enabled-embedding-static (sut/embedding-settings 1 1)))))))
 
 (def ^:private idp-cert (slurp "test_resources/sso/auth0-public-idp.cert"))

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -95,7 +95,7 @@
 
 (defenterprise embedding-settings
   "Boolean values that report on the state of different embedding configurations."
-  metabase-enterprise.embedding-data
+  metabase-enterprise.internal-stats
   [_embedded-dashboard-count _embedded-question-count]
   {:enabled-embedding-static      false
    :enabled-embedding-interactive false


### PR DESCRIPTION
### Description

I typoed the settings name for the embedded static check and required the entirely wrong module in defenterprise so these token checks would always return false. 

### How to verify

Startup a metabase instance with some kind of embedding configured and it should print the correct values. 

### Demo



### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
