### PR TITLE
SEM-212 Allow clicking on the Segment's name to navigate to its edit screen

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -765,20 +765,22 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.get("main").findByText("Something’s gone wrong").should("not.exist");
     });
 
-    it("should show up in UI list", () => {
+    it("should show up in UI list and should show the segment details of a specific id", () => {
       cy.visit("/admin/datamodel/segments");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains(SEGMENT_NAME);
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Filtered by Total");
-    });
 
-    it("should show the segment details of a specific id", () => {
-      cy.visit("/admin/datamodel/segment/1");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Edit Your Segment");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Preview");
+      cy.findByRole("table")
+        .findByText("Filtered by Total is less than 100")
+        .should("be.visible");
+      cy.findByRole("link", { name: /Orders < 100/ })
+        .should("be.visible")
+        .click();
+
+      cy.get("form").findByText("Edit Your Segment").should("be.visible");
+      cy.findByPlaceholderText("Something descriptive but not too long").should(
+        "have.value",
+        SEGMENT_NAME,
+      );
+      cy.findByRole("link", { name: "Preview" }).should("be.visible");
     });
 
     it("should see a newly asked question in its questions list", () => {

--- a/frontend/src/metabase/admin/datamodel/components/SegmentItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentItem.jsx
@@ -1,9 +1,10 @@
 import cx from "classnames";
 import PropTypes from "prop-types";
 import { Component } from "react";
+import { Link } from "react-router";
 
 import CS from "metabase/css/core/index.css";
-import { Icon } from "metabase/ui";
+import { Group, Icon } from "metabase/ui";
 
 import SegmentActionSelect from "./SegmentActionSelect";
 
@@ -19,10 +20,14 @@ export default class SegmentItem extends Component {
     return (
       <tr className={cx(CS.mt1, CS.mb3)}>
         <td className={cx(CS.px1, CS.py1, CS.textWrap)}>
-          <span className={cx(CS.flex, CS.alignCenter)}>
-            <Icon name="segment" className={cx(CS.mr1, CS.textMedium)} />
-            <span className={cx(CS.textDark, CS.textBold)}>{segment.name}</span>
-          </span>
+          <Link to={`/admin/datamodel/segment/${segment.id}`}>
+            <Group align="center" display="inline-flex">
+              <Icon name="segment" className={cx(CS.mr1, CS.textMedium)} />
+              <span className={cx(CS.textDark, CS.textBold)}>
+                {segment.name}
+              </span>
+            </Group>
+          </Link>
         </td>
         <td className={cx(CS.px1, CS.py1, CS.textWrap)}>
           {segment.definition_description}


### PR DESCRIPTION
Closes [SEM-212](https://linear.app/metabase/issue/SEM-212/allow-clicking-on-the-segments-name-to-navigate-to-its-edit-screen)

### Description

Turns segment name in Admin > Table Metadata > Segments into a link.

### Demo

https://github.com/user-attachments/assets/9504214a-798d-498c-90d4-2aad226ee585

