### PR TITLE
fix: make saml issuer identity required

### DIFF
--- a/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
@@ -116,6 +116,10 @@ const enterSamlSettings = () => {
       /SAML Identity Provider URL/,
       "https://example.test",
     );
+    H.typeAndBlurUsingLabel(
+      /SAML Identity Provider Issuer/,
+      "https://example.test/issuer",
+    );
     // paste this long value to not waste time typing
     cy.findByLabelText(/SAML Identity Provider Certificate/)
       .click()

--- a/e2e/test/scenarios/admin-2/sso/shared/helpers.js
+++ b/e2e/test/scenarios/admin-2/sso/shared/helpers.js
@@ -23,6 +23,7 @@ export const setupSaml = () => {
       "saml-enabled": true,
       "saml-identity-provider-uri": "https://example.test",
       "saml-identity-provider-certificate": certificate,
+      "saml-identity-provider-issuer": "https://example.test/issuer",
     });
   });
 };

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
@@ -184,6 +184,7 @@ const SettingsSAMLForm = ({ elements = [], settingValues = {}, onSubmit }) => {
               <FormTextInput
                 {...fields["saml-identity-provider-issuer"]}
                 label={t`SAML Identity Provider Issuer`}
+                required
               />
             </Stack>
           </SAMLFormSection>


### PR DESCRIPTION
### Description

Update the SAML settings form to mark the issuer identity field as required since our SAML library requires this to be set.

### How to verify

Go to the SAML form
Try to configure without the identity provider
See that you are blocked.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
