### PR TITLE
Multi line help text

### DIFF
--- a/e2e/support/helpers/e2e-custom-column-helpers.ts
+++ b/e2e/support/helpers/e2e-custom-column-helpers.ts
@@ -182,7 +182,7 @@ export const CustomExpressionEditor = {
       const unexpanded = part.replaceAll(/→/g, "->");
 
       const alphabet =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789^[]()-,.;_!@#$%&*+=/<>\" ':;\\";
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789^[]()-,.;_!@#$%&*+=/<>\" ':;\\\n";
       if (unexpanded.split("").some((char) => !alphabet.includes(char))) {
         throw new Error(
           `unknown character in CustomExpressionEditor.type in ${part}`,

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1594,3 +1594,21 @@ describe("issue 55622", () => {
     H.assertQueryBuilderRowCount(1);
   });
 });
+
+describe("issue 56152", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("Should show the help text popover when typing a multi-line expression (metabase#56152)", () => {
+    H.openPeopleTable({ mode: "notebook" });
+    H.addCustomColumn();
+    H.CustomExpressionEditor.type(dedent`
+      datetimeDiff(
+        [Created At],
+    `);
+
+    H.CustomExpressionEditor.helpText().should("be.visible");
+  });
+});

--- a/frontend/src/metabase-lib/v1/expressions/position.ts
+++ b/frontend/src/metabase-lib/v1/expressions/position.ts
@@ -14,7 +14,8 @@ export function enclosingFunction(doc: string, pos: number) {
       cursor.to >= pos
     ) {
       const value = doc.slice(cursor.from, cursor.to);
-      const structure = value.replace(/\(.*\)?$/, "");
+      const argsIndex = value.indexOf("(") ?? value.length;
+      const structure = value.slice(0, argsIndex).trim();
 
       const args =
         cursor.node.getChildren("ArgList")?.[0]?.getChildren("Arg") ?? [];

--- a/frontend/src/metabase-lib/v1/expressions/position.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/position.unit.spec.ts
@@ -1,3 +1,5 @@
+import expression from "ts-dedent";
+
 import { enclosingFunction } from "./position";
 
 describe("enclosingFunction", () => {
@@ -76,5 +78,60 @@ describe("enclosingFunction", () => {
   it("should handle empty input", () => {
     expect(setup("|")).toEqual(null);
     expect(setup(" |")).toEqual(null);
+  });
+
+  it("should handle multiline input", () => {
+    expect(
+      setup(expression`
+        datetimeDif|f(
+          [CreatedAt],
+          [UpdatedAt],
+          "minute"
+        )
+      `),
+    ).toEqual({
+      name: "datetime-diff",
+      from: 0,
+      to: 56,
+      arg: null,
+    });
+
+    expect(
+      setup(expression`
+        datetimeDiff(
+          [CreatedAt]|,
+          [UpdatedAt],
+          "minute"
+        )
+      `),
+    ).toEqual({
+      name: "datetime-diff",
+      from: 0,
+      to: 56,
+      arg: {
+        index: 0,
+        from: 16,
+        to: 27,
+      },
+    });
+
+    expect(
+      setup(expression`
+        datetimeDiff(
+          [CreatedAt],
+          [UpdatedAt],
+          "minute"|
+        )
+      `),
+    ).toEqual({
+      name: "datetime-diff",
+      from: 0,
+      to: 56,
+      arg: {
+        index: 2,
+        from: 46,
+        to: 54,
+      },
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/56152

## To verify

1. New -> Question -> Sample database -> Orders
2. Custom Column
3. Type the following custom expression (including newlines):
   ```
   datetimeDiff(
     [Created At],
     [Created At],
     "minute"
   )
   ```
4. Move around the cursor inside the parentheses. The `datetimeDiff` helptext should be shown.


<img width="732" alt="Screenshot 2025-04-02 at 17 28 05" src="https://github.com/user-attachments/assets/eaf3fbed-265c-4416-ad9b-53f60d3303e0" />
