### PR TITLE
Fix FK display in a dashboard editable table

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
@@ -10,7 +10,6 @@ import {
 } from "metabase/data-grid";
 import { formatValue } from "metabase/lib/formatting/value";
 import { Box } from "metabase/ui";
-import { extractRemappedColumns } from "metabase/visualizations";
 import type {
   DatasetData,
   FieldWithMetadata,
@@ -38,7 +37,7 @@ export const EditTableDataGrid = ({
   onCellValueUpdate,
   onRowExpandClick,
 }: EditTableDataGridProps) => {
-  const { cols, rows } = useMemo(() => extractRemappedColumns(data), [data]);
+  const { cols, rows } = data;
 
   const { editingCellId, onCellClickToEdit, onCellEditCancel } =
     useTableEditing();


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/WRK-211/fk-display-in-a-dashboard-should-respect-display-value-settings

### Description

This fixes FK display in a dashboard editable table caused by double remapping 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
