### PR TITLE
fix: ee-build should skip adding jars when there are none

### DIFF
--- a/.github/actions/build-ee-extra/action.yml
+++ b/.github/actions/build-ee-extra/action.yml
@@ -92,7 +92,7 @@ runs:
       shell: bash
       working-directory: modules
     - name: Bundle additional drivers into the Uberjar
-      run: jar uf bin/docker/metabase.jar modules/*.jar
+      run:  test -n "$(find modules -maxdepth 1 -name '*.jar' -print -quit)" && jar uf bin/docker/metabase.jar modules/*.jar
       shell: bash
     - name: Launch uberjar
       run: >-


### PR DESCRIPTION
Sicne we're no longer adding partner drivers in 54, we were running into:

```
Run jar uf bin/docker/metabase.jar modules/*.jar
modules/*.jar : no such file or directory
```

This stops trying to add non-existent jar files.