### PR TITLE
dont skip mage tests when BE job is skipped

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -39,26 +39,6 @@ jobs:
           m2-cache-key: "eastwood"
       - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
         name: Run Eastwood linter
-  # run mage tests even if the rest of be isnt needed
-  mage-tests:
-    runs-on: ubuntu-22.04
-    name: Mage
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: 'kondo'
-      - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.7.0
-        with:
-          babashka-version: 1.12.197
-      - name: Check bb runs
-        run: bb --version
-      - name: bb task list
-        run: bb tasks
-      - name: Run mage tests
-        run: bb ./test/mage/runtests.clj
 
   be-tests:
     if: ${{ !inputs.skip }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -44,6 +44,11 @@ jobs:
     runs-on: ubuntu-22.04
     name: Mage
     steps:
+      - uses: actions/checkout@v4
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: 'kondo'
       - name: Setup Babashka
         uses: turtlequeue/setup-babashka@v1.7.0
         with:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -39,17 +39,11 @@ jobs:
           m2-cache-key: "eastwood"
       - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
         name: Run Eastwood linter
-
+  # run mage tests even if the rest of be isnt needed
   mage-tests:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     name: Mage
     steps:
-      - uses: actions/checkout@v4
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: 'kondo'
       - name: Setup Babashka
         uses: turtlequeue/setup-babashka@v1.7.0
         with:

--- a/.github/workflows/mage.yml
+++ b/.github/workflows/mage.yml
@@ -5,6 +5,7 @@ on:
     paths: ["mage/**", "test/mage/**"]
 
 jobs:
+  # run mage tests even if the rest of be isnt needed
   mage-tests:
     runs-on: ubuntu-22.04
     name: Mage
@@ -14,11 +15,13 @@ jobs:
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: 'kondo'
-      - name: run mage once
-        run: ./bin/mage
+      - name: Setup Babashka
+        uses: turtlequeue/setup-babashka@v1.7.0
+        with:
+          babashka-version: 1.12.197
       - name: Check bb runs
-        run: ./bin/bb --version
+        run: bb --version
       - name: bb task list
-        run: ./bin/bb tasks
+        run: bb tasks
       - name: Run mage tests
-        run: ./bin/bb ./test/mage/runtests.clj
+        run: bb ./test/mage/runtests.clj

--- a/.github/workflows/mage.yml
+++ b/.github/workflows/mage.yml
@@ -1,0 +1,24 @@
+name: Mage Tests
+
+on:
+  pull_request:
+    paths: ["mage/**", "test/mage/**"]
+
+jobs:
+  mage-tests:
+    runs-on: ubuntu-22.04
+    name: Mage
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: 'kondo'
+      - name: run mage once
+        run: ./bin/mage
+      - name: Check bb runs
+        run: ./bin/bb --version
+      - name: bb task list
+        run: ./bin/bb tasks
+      - name: Run mage tests
+        run: ./bin/bb ./test/mage/runtests.clj

--- a/bb.edn
+++ b/bb.edn
@@ -59,7 +59,7 @@
 
   start-maildev
   {:doc      "Start Maildev"
-   :examples [["John" "will write one soon"]]
+   :examples [["./bin/mage start-maildev -h" "print help for start-maildev"]]
    :requires [[mage.start-maildev :as start-maildev]]
    :task     (do (cli/parse! (current-task)) (start-maildev/start-maildev!))}
 

--- a/bb.edn
+++ b/bb.edn
@@ -153,10 +153,10 @@
    ;; map of ports.
    :data       {:a [:b :c] :b [:d]}}
 
-  -test-help {:doc      "run all mage tests"
-              :requires [[mage.core-test :as core-test]]
-              :task     (System/exit
-                         (if (= :ok (core-test/run-tests)) 0 1))}
+  -test {:doc      "run all mage tests"
+         :requires [[mage.core-test]
+                    [clojure.test :refer [run-tests]]]
+         :task     (run-tests 'mage.core-test)}
 
   -test-examples
   {:doc      "Runs every example and checks that it exits with 0"

--- a/test/mage/core_test.clj
+++ b/test/mage/core_test.clj
@@ -33,9 +33,16 @@
           (is (str/includes? result "The following tasks are available:")))))))
 
 (deftest mage-tests
+  (println "Running mage tests")
+
+  (println "  bb tasks have examples")
   (testing "bb tasks have examples"
     (mapv bb-task-has-example? (u/public-bb-tasks-list)))
+
+  (println "  bb tasks have help")
   (testing "mage has help"
     (bin-mage-has-help?))
+
+  (println "  invalid task names print help")
   (testing "Invalid task name prints help"
     (invalid-task-names-print-help-test)))

--- a/test/mage/runtests.clj
+++ b/test/mage/runtests.clj
@@ -5,9 +5,12 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private test-ns
-  '[mage.core-test mage.examples-test mage.start-db-test])
+  ['mage.core-test 'mage.start-db-test])
 
 (when (= *file* (System/getProperty "babashka.file"))
-  (run! require test-ns)
-  (run! t/run-tests test-ns)
+  (doseq [tns test-ns]
+    (println "Requiring test namespace:" tns)
+    (require tns)
+    (println "Running tests in namespace:" tns)
+    (t/run-tests tns))
   :ok)


### PR DESCRIPTION
We have tests for mage, but if no backend files are touched they got skipped.

This will run them every time, and they're quick so this won't introduce a performance hit.