### PR TITLE
fix: attempt no 2 to skip adding non-existent partner jars

### DIFF
--- a/.github/actions/build-ee-extra/action.yml
+++ b/.github/actions/build-ee-extra/action.yml
@@ -96,7 +96,7 @@ runs:
       shell: bash
       working-directory: modules
     - name: Bundle additional drivers into the Uberjar
-      run:  test -n "$(find modules -maxdepth 1 -name '*.jar' -print -quit)" && jar uf bin/docker/metabase.jar modules/*.jar
+      run:  if test -n "$(find modules -maxdepth 1 -name '*.jar' -print -quit)"; then jar uf bin/docker/metabase.jar modules/*.jar; fi
       shell: bash
     - name: Launch uberjar
       run: >-


### PR DESCRIPTION
Followup to https://github.com/metabase/metabase/pull/56166