### PR TITLE
fix: deadlock in last used at

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10542,7 +10542,7 @@ databaseChangeLog:
       changes:
         - createTable:
             tableName: metabase_cluster_lock
-            remarks: A table qo allow metabase instances to take locks across a cluster
+            remarks: A table to allow metabase instances to take locks across a cluster
             columns:
               - column:
                   name: lock_name

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10530,6 +10530,27 @@ databaseChangeLog:
             );
       rollback: # not needed, these are created on startup using deserialization
 
+  - changeSet:
+      id: v53.2025-04-02T15:25:04
+      author: edpaget
+      comment: create new cluster lock table for instance coordination
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: metabase_cluster_lock
+      changes:
+        - createTable:
+            tableName: metabase_cluster_lock
+            remarks: A table qo allow metabase instances to take locks across a cluster
+            columns:
+              - column:
+                  name: lock_name
+                  type: varchar(254)
+                  remarks: a single column that can be used to a lock across a cluster
+                  constraints:
+                    primaryKey: true
+                    nullable: false
 
   - changeSet:
       id: v54.2025-01-30T16:10:55

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -23,7 +23,7 @@
 
 (def ^:private pause-before-update-retry-seconds 1)
 
-(mu/defn- do-with-cluster-lock
+(mu/defn- do-with-pg-cluster-lock
   "TODO: Make this more reusable"
   ([lock-name thunk]
    (do-with-cluster-lock lock-name {} thunk))

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.update-used-cards
   (:require
    [java-time.api :as t]
+   [metabase.db :as mdb]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
@@ -8,11 +9,61 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   [java.sql SQLException]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:private update-used-card-interval-seconds 20)
+
+(def ^:private cluster-lock-timeout-seconds 0.5)
+
+(def ^:private max-update-retries 2)
+
+(def ^:private pause-before-update-retry-seconds 1)
+
+(mu/defn- do-with-cluster-lock
+  "TODO: Make this more reusable"
+  ([lock-name thunk]
+   (do-with-cluster-lock lock-name {} thunk))
+  ([lock-name :- :keyword {:keys [timeout max-retries]
+                           :or {timeout cluster-lock-timeout-seconds
+                                max-retries max-update-retries}} thunk]
+   (let [stringified-kw (str (namespace lock-name) "/" (name lock-name))]
+     (case (mdb/db-type)
+       ;; MySQL does not support transaction-level timeouts so this technique is not appropriate
+       ;; h2 cannot be used in cluster mode so we do not need locking
+       (:h2 :mysql) (thunk)
+       :postgres
+       (loop [retries 0]
+         (let [result (try
+                        (t2/with-transaction [_conn]
+                          (t2/query [(format "SET LOCAL lock_timeout = '%ss'" timeout)])
+                          (when-not (t2/query-one {:select [:lock.lock_name]
+                                                   :from [[:metabase_cluster_lock :lock]]
+                                                   :where [:= :lock.lock_name stringified-kw]
+                                                   :for :update})
+                            (t2/query-one {:insert-into [:metabase_cluster_lock]
+                                           :columns [:lock_name]
+                                           :values [[stringified-kw]]}))
+                          (thunk))
+                        ;; TODO: Catch SQLExceptions here and return Throwable specifying when the failure was due to lock timeout
+                        (catch Throwable e
+                          (if (and (instance? SQLException (ex-cause e)) ;; assume we want to retry on any kind of sql error
+                                   (< retries max-retries))
+                            (do
+                              (log/debugf "Retrying card update in %s seconds, %s retries remaining"
+                                          pause-before-update-retry-seconds
+                                          (- max-update-retries retries))
+                              ::retryable)
+                            (throw (ex-info "Failed to run statement with cluster lock"
+                                            {:retries retries
+                                             :lock-timeout timeout}
+                                            e)))))]
+           (when (= result ::retryable)
+             (Thread/sleep ^int (* 1000 pause-before-update-retry-seconds))
+             (recur (inc retries)))))))))
 
 (defn- update-used-cards!*
   [card-id-timestamps]
@@ -20,13 +71,15 @@
                                         (fn [xs] (apply t/max (map :timestamp xs))))]
     (log/debugf "Update last_used_at of %d cards" (count card-id->timestamp))
     (try
-      (t2/update! :model/Card :id [:in (keys card-id->timestamp)]
-                  {:last_used_at (into [:case]
-                                       (mapcat (fn [[id timestamp]]
-                                                 [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
-                                               card-id->timestamp))
-                   ;; Set updated_at to its current value to prevent it from updating automatically
-                   :updated_at :updated_at})
+      (do-with-cluster-lock ::used-at-update
+                            (fn []
+                              (t2/update! :model/Card :id [:in (keys card-id->timestamp)]
+                                          {:last_used_at (into [:case]
+                                                               (mapcat (fn [[id timestamp]]
+                                                                         [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
+                                                                       card-id->timestamp))
+                                           ;; Set updated_at to its current value to prevent it from updating automatically
+                                           :updated_at :updated_at})))
       (catch Throwable e
         (log/error e "Error updating used cards")))))
 

--- a/test/metabase/query_processor/middleware/update_used_cards_test.clj
+++ b/test/metabase/query_processor/middleware/update_used_cards_test.clj
@@ -13,7 +13,6 @@
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -134,5 +133,5 @@
     (testing "cluster locking test error if lock is released"
       (let [fin-chan (a/chan)]
         (future (#'qp.update-used-cards/do-with-cluster-lock ::test-lock #(a/<!! fin-chan)))
-        (future (do (Thread/sleep 1000) (a/>!! fin-chan :done)))
+        (future (Thread/sleep 1000) (a/>!! fin-chan :done))
         (is (nil? (#'qp.update-used-cards/do-with-cluster-lock ::test-lock #(Thread/sleep 1))))))))

--- a/test/metabase/query_processor/middleware/update_used_cards_test.clj
+++ b/test/metabase/query_processor/middleware/update_used_cards_test.clj
@@ -125,13 +125,13 @@
   (when (= (mdb/db-type) #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres)
     (testing "cluster locking test error if lock is not released"
       (let [fin-chan (a/chan)]
-        (future (#'qp.update-used-cards/do-with-cluster-lock ::test-lock #(a/<!! fin-chan)))
+        (future (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(a/<!! fin-chan)))
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo #"Failed to run statement with cluster lock"
-             (#'qp.update-used-cards/do-with-cluster-lock ::test-lock #(Thread/sleep 1))))
+             (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(Thread/sleep 1))))
         (a/>!! fin-chan :done)))
     (testing "cluster locking test error if lock is released"
       (let [fin-chan (a/chan)]
-        (future (#'qp.update-used-cards/do-with-cluster-lock ::test-lock #(a/<!! fin-chan)))
+        (future (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(a/<!! fin-chan)))
         (future (Thread/sleep 1000) (a/>!! fin-chan :done))
-        (is (nil? (#'qp.update-used-cards/do-with-cluster-lock ::test-lock #(Thread/sleep 1))))))))
+        (is (nil? (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(Thread/sleep 1))))))))


### PR DESCRIPTION
### Description

This prevents bulk updates to last used at from deadlocking by creating a new table in metabase's database that can be used by instances to take cluster wide locks. It adds an initial implementation of a customizeable db-based locking mechanism.

For the last_used_at update, a metabase instance will first set a session variable to control locking timesout then take a cluster lock using SELECT * FROM metabase_cluster_lock WHERE lock_name = 'name' then execute the update_at.

If another table is holding this lock metabase will wait .5s for the lock to be released then timeout its SQL transaction, sleep the Thread for 1s then retry taking the lock. This makes sure we're not holding DB connections waiting for locks.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
