### PR TITLE
Move Enterprise settings types to general types file

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/test/server-mocks/sdk-init.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/server-mocks/sdk-init.ts
@@ -9,8 +9,8 @@ import {
   createMockLoginStatusState,
   createMockSdkState,
 } from "embedding-sdk/test/mocks/state";
-import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
 import type {
+  EnterpriseSettings,
   SettingDefinition,
   TokenFeatures,
   User,

--- a/enterprise/frontend/src/metabase-enterprise/api/utils/settings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/utils/settings.ts
@@ -1,0 +1,4 @@
+import { _useAdminSetting } from "metabase/api";
+import type { EnterpriseSettingKey } from "metabase-types/api";
+
+export const useEnterpriseAdminSetting = _useAdminSetting<EnterpriseSettingKey>;

--- a/enterprise/frontend/src/metabase-enterprise/api/utils/settings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/utils/settings.ts
@@ -1,4 +1,0 @@
-import { _useAdminSetting } from "metabase/api";
-import type { EnterpriseSettingKey } from "metabase-types/api";
-
-export const useEnterpriseAdminSetting = _useAdminSetting<EnterpriseSettingKey>;

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
@@ -1,14 +1,14 @@
 import noResultsSource from "assets/img/no_results.svg";
 import type { IllustrationValue } from "metabase/plugins";
 import { getSetting, getSettings } from "metabase/selectors/settings";
+import type {
+  EnterpriseSettings,
+  IllustrationSettingValue,
+} from "metabase-types/api";
 
 import { LOADING_MESSAGE_BY_SETTING } from "../whitelabel/lib/loading-message";
 
-import type {
-  EnterpriseSettings,
-  EnterpriseState,
-  IllustrationSettingValue,
-} from "./types";
+import type { EnterpriseState } from "./types";
 
 const DEFAULT_LOGO_URL = "app/assets/img/logo.svg";
 

--- a/enterprise/frontend/src/metabase-enterprise/settings/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/types.ts
@@ -1,4 +1,4 @@
-import type { Settings } from "metabase-types/api";
+import type { EnterpriseSettings } from "metabase-types/api";
 import type { SettingsState, State } from "metabase-types/store";
 
 export interface EnterpriseState extends State {
@@ -8,32 +8,3 @@ export interface EnterpriseState extends State {
 interface EnterpriseSettingsState extends SettingsState {
   values: EnterpriseSettings;
 }
-
-export type IllustrationSettingValue = "default" | "none" | "custom";
-
-export interface EnterpriseSettings extends Settings {
-  "application-colors"?: Record<string, string>;
-  "application-logo-url"?: string;
-  "login-page-illustration"?: IllustrationSettingValue;
-  "login-page-illustration-custom"?: string;
-  "landing-page-illustration"?: IllustrationSettingValue;
-  "landing-page-illustration-custom"?: string;
-  "no-data-illustration"?: IllustrationSettingValue;
-  "no-data-illustration-custom"?: string;
-  "no-object-illustration"?: IllustrationSettingValue;
-  "no-object-illustration-custom"?: string;
-  "landing-page"?: string;
-  "ee-ai-features-enabled"?: boolean;
-  "ee-openai-api-key"?: string;
-  "ee-openai-model"?: string;
-  "saml-user-provisioning-enabled?"?: boolean;
-  "scim-enabled"?: boolean | null;
-  "scim-base-url"?: string;
-  "send-new-sso-user-admin-email?"?: boolean;
-  /**
-   * @deprecated
-   */
-  application_logo_url?: string;
-}
-
-export type EnterpriseSettingKey = keyof EnterpriseSettings;

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/UserProvisioning.tsx
@@ -23,8 +23,11 @@ import {
   useRegenerateScimTokenMutation,
 } from "metabase-enterprise/api";
 import { hasAnySsoPremiumFeature } from "metabase-enterprise/settings";
-import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
-import type { SettingValue, Settings } from "metabase-types/api";
+import type {
+  EnterpriseSettings,
+  SettingValue,
+  Settings,
+} from "metabase-types/api";
 
 import { CopyScimInput, getTextInputStyles } from "./ScimInputs";
 import { ScimTextWarning } from "./ScimTextWarning";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.tsx
@@ -9,7 +9,7 @@ import type {
   EnterpriseSettingKey,
   EnterpriseSettings,
   IllustrationSettingValue,
-} from "metabase-enterprise/settings/types";
+} from "metabase-types/api";
 
 import { ImageUploadInfoDot } from "../ImageUploadInfoDot";
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
+import type { EnterpriseSettings } from "metabase-types/api";
 
 import type { StringSetting } from "./IllustrationWidget";
 import { IllustrationWidget } from "./IllustrationWidget";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { Text } from "metabase/ui";
-import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
+import type { EnterpriseSettings } from "metabase-types/api";
 
 import { SettingInputBlurChange } from "./LandingPageWidget.styled";
 import { getRelativeLandingPageUrl } from "./utils";

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -1,10 +1,10 @@
 import dayjs from "dayjs";
 
-import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
 import type {
   Engine,
   EngineField,
   EngineSource,
+  EnterpriseSettings,
   FontFile,
   SettingDefinition,
   SettingKey,
@@ -15,7 +15,6 @@ import type {
   VersionInfo,
   VersionInfoRecord,
 } from "metabase-types/api";
-
 export const createMockEngine = (opts?: Partial<Engine>): Engine => ({
   "driver-name": "PostgreSQL",
   "details-fields": [],

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -467,3 +467,34 @@ export type Settings = InstanceSettings &
 export type SettingKey = keyof Settings;
 
 export type SettingValue<Key extends SettingKey = SettingKey> = Settings[Key];
+
+export type IllustrationSettingValue = "default" | "none" | "custom";
+export interface EnterpriseSettings extends Settings {
+  "application-colors"?: Record<string, string>;
+  "application-logo-url"?: string;
+  "login-page-illustration"?: IllustrationSettingValue;
+  "login-page-illustration-custom"?: string;
+  "landing-page-illustration"?: IllustrationSettingValue;
+  "landing-page-illustration-custom"?: string;
+  "no-data-illustration"?: IllustrationSettingValue;
+  "no-data-illustration-custom"?: string;
+  "no-object-illustration"?: IllustrationSettingValue;
+  "no-object-illustration-custom"?: string;
+  "landing-page"?: string;
+  "ee-ai-features-enabled"?: boolean;
+  "ee-openai-api-key"?: string;
+  "ee-openai-model"?: string;
+  "saml-user-provisioning-enabled?"?: boolean;
+  "scim-enabled"?: boolean | null;
+  "scim-base-url"?: string;
+  "send-new-sso-user-admin-email?"?: boolean;
+  /**
+   * @deprecated
+   */
+  application_logo_url?: string;
+}
+
+export type EnterpriseSettingKey = keyof EnterpriseSettings;
+export type EnterpriseSettingValue<
+  Key extends EnterpriseSettingKey = EnterpriseSettingKey,
+> = EnterpriseSettings[Key];

--- a/frontend/src/metabase-types/store/mocks/settings.ts
+++ b/frontend/src/metabase-types/store/mocks/settings.ts
@@ -1,5 +1,4 @@
-import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
-import type { Settings } from "metabase-types/api";
+import type { EnterpriseSettings, Settings } from "metabase-types/api";
 import { createMockSettings } from "metabase-types/api/mocks";
 import type { SettingsState } from "metabase-types/store";
 

--- a/frontend/src/metabase/api/session.ts
+++ b/frontend/src/metabase/api/session.ts
@@ -1,6 +1,9 @@
 import MetabaseSettings from "metabase/lib/settings";
 import { loadSettings } from "metabase/redux/settings";
-import type { PasswordResetTokenStatus, Settings } from "metabase-types/api";
+import type {
+  EnterpriseSettings,
+  PasswordResetTokenStatus,
+} from "metabase-types/api";
 
 import { Api } from "./api";
 
@@ -23,7 +26,7 @@ export const sessionApi = Api.injectEndpoints({
         body: { email },
       }),
     }),
-    getSessionProperties: builder.query<Settings, void>({
+    getSessionProperties: builder.query<EnterpriseSettings, void>({
       query: () => ({
         method: "GET",
         url: "/api/session/properties",

--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -1,7 +1,7 @@
 import type {
+  EnterpriseSettingKey,
+  EnterpriseSettingValue,
   SettingDefinition,
-  SettingKey,
-  SettingValue,
 } from "metabase-types/api";
 
 import { Api } from "./api";
@@ -16,7 +16,7 @@ export const settingsApi = Api.injectEndpoints({
         url: "/api/setting",
       }),
     }),
-    getSetting: builder.query<SettingValue, SettingKey>({
+    getSetting: builder.query<EnterpriseSettingValue, EnterpriseSettingKey>({
       query: (name) => ({
         method: "GET",
         url: `/api/setting/${encodeURIComponent(name)}`,
@@ -26,8 +26,8 @@ export const settingsApi = Api.injectEndpoints({
     updateSetting: builder.mutation<
       void,
       {
-        key: SettingKey;
-        value: SettingValue;
+        key: EnterpriseSettingKey;
+        value: EnterpriseSettingValue;
       }
     >({
       query: ({ key, value }) => ({
@@ -38,7 +38,10 @@ export const settingsApi = Api.injectEndpoints({
       invalidatesTags: (_, error) =>
         invalidateTags(error, [tag("session-properties")]),
     }),
-    updateSettings: builder.mutation<void, Record<SettingKey, SettingValue>>({
+    updateSettings: builder.mutation<
+      void,
+      Record<EnterpriseSettingKey, EnterpriseSettingValue>
+    >({
       query: (settings) => ({
         method: "PUT",
         url: `/api/setting`,

--- a/frontend/src/metabase/api/utils/settings.ts
+++ b/frontend/src/metabase/api/utils/settings.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import type { Settings } from "metabase-types/api";
+import type { EnterpriseSettingKey, SettingKey } from "metabase-types/api";
 
 import { useGetSettingsQuery } from "../session";
 import {
@@ -10,8 +10,9 @@ import {
 
 /**
  * One hook to get setting values and mutators for a given setting
+ * generic version, should not be used directly
  */
-export const useAdminSetting = <SettingName extends keyof Settings>(
+export const _useAdminSetting = <SettingName extends EnterpriseSettingKey>(
   settingName: SettingName,
 ) => {
   const {
@@ -39,3 +40,8 @@ export const useAdminSetting = <SettingName extends keyof Settings>(
     ...apiProps,
   };
 };
+
+/**
+ * One hook to get setting values and mutators for a given OSS setting
+ */
+export const useAdminSetting = _useAdminSetting<SettingKey>;

--- a/frontend/src/metabase/api/utils/settings.ts
+++ b/frontend/src/metabase/api/utils/settings.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import type { EnterpriseSettingKey, SettingKey } from "metabase-types/api";
+import type { EnterpriseSettingKey } from "metabase-types/api";
 
 import { useGetSettingsQuery } from "../session";
 import {
@@ -10,9 +10,8 @@ import {
 
 /**
  * One hook to get setting values and mutators for a given setting
- * generic version, should not be used directly
  */
-export const _useAdminSetting = <SettingName extends EnterpriseSettingKey>(
+export const useAdminSetting = <SettingName extends EnterpriseSettingKey>(
   settingName: SettingName,
 ) => {
   const {
@@ -40,8 +39,3 @@ export const _useAdminSetting = <SettingName extends EnterpriseSettingKey>(
     ...apiProps,
   };
 };
-
-/**
- * One hook to get setting values and mutators for a given OSS setting
- */
-export const useAdminSetting = _useAdminSetting<SettingKey>;

--- a/frontend/test/__support__/settings.ts
+++ b/frontend/test/__support__/settings.ts
@@ -1,6 +1,5 @@
 import MetabaseSettings from "metabase/lib/settings";
-import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
-import type { Settings } from "metabase-types/api";
+import type { EnterpriseSettings, Settings } from "metabase-types/api";
 import { createMockSettings } from "metabase-types/api/mocks";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 


### PR DESCRIPTION
### Description

Moves the EnterpriseSettings types to the OSS codebase. 

In order to avoid having separate fetching hooks for Regular + Enterprise settings, we need to use the broader type in the OSS code. No functional changes

[Discussion](https://metaboat.slack.com/archives/C505ZNNH4/p1743612288824479)