### PR TITLE
Don't need to be running "configure the scheduler" liquibase tasks during testing

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -28,7 +28,6 @@
    [metabase.db.custom-migrations.metrics-v2 :as metrics-v2]
    [metabase.db.custom-migrations.pulse-to-notification :as pulse-to-notification]
    [metabase.db.custom-migrations.util :as custom-migrations.util]
-   [metabase.plugins.classloader :as classloader]
    [metabase.task.bootstrap]
    [metabase.util.date-2 :as u.date]
    [metabase.util.encryption :as encryption]
@@ -194,17 +193,11 @@
 ;;; |                                           Quartz Scheduler Helpers                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- set-jdbc-backend-properties! []
-  (metabase.task.bootstrap/set-jdbc-backend-properties! (mdb.connection/db-type)))
-
 (define-migration DeleteAbandonmentEmailTask
-  (classloader/the-classloader)
-  (set-jdbc-backend-properties!)
-  (let [scheduler (qs/initialize)]
-    (qs/start scheduler)
-    (qs/delete-trigger scheduler (triggers/key "metabase.task.abandonment-emails.trigger"))
-    (qs/delete-job scheduler (jobs/key "metabase.task.abandonment-emails.job"))
-    (qs/shutdown scheduler)))
+  (define-migration DeleteTruncateAuditLogTask
+    (custom-migrations.util/with-temp-schedule! [scheduler]
+      (qs/delete-trigger scheduler (triggers/key "metabase.task.abandonment-emails.trigger"))
+      (qs/delete-job scheduler (jobs/key "metabase.task.abandonment-emails.job")))))
 
 (define-migration FillJSONUnfoldingDefault
   (let [db-ids-to-not-update (->> (t2/query {:select [:id :details]
@@ -1114,19 +1107,15 @@
   ;; then we shouldn't schedule a trigger for scan field values. Turns out it wasn't like that since forever, so we need
   ;; this migraiton to remove triggers for any existing DB that have this option on.
   ;; See #40715
-  (when-let [;; find all dbs which are configured not to scan field values
-             dbs (seq (filter #(and (-> % :details encrypted-json-out :let-user-control-scheduling)
-                                    (false? (:is_full_sync %)))
-                              (t2/select :metabase_database)))]
-    (classloader/the-classloader)
-    (set-jdbc-backend-properties!)
-    (let [scheduler (qs/initialize)]
-      (qs/start scheduler)
+  (custom-migrations.util/with-temp-schedule! [scheduler]
+    (when-let [;; find all dbs which are configured not to scan field values
+               dbs (seq (filter #(and (-> % :details encrypted-json-out :let-user-control-scheduling)
+                                      (false? (:is_full_sync %)))
+                                (t2/select :metabase_database)))]
       (doseq [db dbs]
         (qs/delete-trigger scheduler (triggers/key (format "metabase.task.update-field-values.trigger.%d" (:id db)))))
       ;; use the table, not model/Database because we don't want to trigger the hooks
-      (t2/update! :metabase_database :id [:in (map :id dbs)] {:cache_field_values_schedule nil})
-      (qs/shutdown scheduler))))
+      (t2/update! :metabase_database :id [:in (map :id dbs)] {:cache_field_values_schedule nil}))))
 
 (defn- hash-bcrypt
   "Hashes a given plaintext password using bcrypt.  Should be used to hash

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -194,10 +194,9 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (define-migration DeleteAbandonmentEmailTask
-  (define-migration DeleteTruncateAuditLogTask
-    (custom-migrations.util/with-temp-schedule! [scheduler]
-      (qs/delete-trigger scheduler (triggers/key "metabase.task.abandonment-emails.trigger"))
-      (qs/delete-job scheduler (jobs/key "metabase.task.abandonment-emails.job")))))
+  (custom-migrations.util/with-temp-schedule! [scheduler]
+    (qs/delete-trigger scheduler (triggers/key "metabase.task.abandonment-emails.trigger"))
+    (qs/delete-job scheduler (jobs/key "metabase.task.abandonment-emails.job"))))
 
 (define-migration FillJSONUnfoldingDefault
   (let [db-ids-to-not-update (->> (t2/query {:select [:id :details]

--- a/src/metabase/db/custom_migrations/util.clj
+++ b/src/metabase/db/custom_migrations/util.clj
@@ -8,15 +8,32 @@
 (defn- set-jdbc-backend-properties! []
   (metabase.task.bootstrap/set-jdbc-backend-properties! (mdb.connection/db-type)))
 
+(def ^:dynamic *allow-temp-scheduling*
+  "If true, the scheduler will be started temporarily for migrations that require it. If false, migrations that use `do-with-temp-schedule` will be a no-op."
+  true)
+
 (defn do-with-temp-schedule
-  "Internal implementation of with-temp-schedule!"
+  "This is used by migrations which modify the persistent scheduler configuration so it needs a scheduler running.
+  BUT: liquibase is ran before the scheduler is officially/fully started.
+
+  So this function temporarily starts the scheduler and runs the given function then shuts the scheduler back down.
+
+  However, we have to be careful about running this after the scheduler has been fully started (such as running tests in a running REPL)
+  because `(qs/initialize)` _doesn't_ return a new instance but will return the normal scheduler instance which will them be incorrectly shut down.
+
+  Since we don't really need to run migrations against the scheduler in tests, this function will throw an exception if it sees an already-running scheduler.
+  The various 'run this test with a temp database' functions should set `*allow-temp-scheduling*` to false so this call does nothing, so you should still never see the exception."
   [f]
-  (classloader/the-classloader)
-  (set-jdbc-backend-properties!)
-  (let [scheduler (qs/initialize)]
-    (qs/start scheduler)
-    (f scheduler)
-    (qs/shutdown scheduler)))
+  (when  *allow-temp-scheduling*
+    (classloader/the-classloader)
+    (set-jdbc-backend-properties!)
+    (let [scheduler (qs/initialize)]
+      (when (qs/started? scheduler)
+        (throw (ex-info "Scheduler is already started, cannot start temporary one" {})))
+
+      (qs/start scheduler)
+      (f scheduler)
+      (qs/shutdown scheduler))))
 
 (defmacro with-temp-schedule!
   "Execute the body with a temporary Quartz scheduler.

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -290,6 +290,7 @@
     (task/job-info \"metabase.task.sync-and-analyze.job\")"
   [job-key]
   (when-let [scheduler (scheduler)]
+    (qs/shutdown? scheduler)
     (let [job-key (->job-key job-key)]
       (try
         (assoc (job-detail->info (qs/get-job scheduler job-key))

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -14,6 +14,7 @@
    [java-time.api :as t]
    [metabase.db :as mdb]
    [metabase.db.connection :as mdb.connection]
+   [metabase.db.custom-migrations.util :as custom-migrations.util]
    [metabase.db.data-source :as mdb.data-source]
    [metabase.db.liquibase :as liquibase]
    [metabase.db.test-util :as mdb.test-util]
@@ -74,10 +75,11 @@
   (do-with-temp-empty-app-db*
    driver
    (fn [^javax.sql.DataSource data-source]
-     ;; it should be ok to open multiple connections to this `data-source`; it should stay open as long as `conn` is
-     ;; open
+      ;; it should be ok to open multiple connections to this `data-source`; it should stay open as long as `conn` is
+      ;; open
      (with-open [conn (.getConnection data-source)]
-       (binding [mdb.connection/*application-db* (mdb.connection/application-db driver data-source)]
+       (binding [mdb.connection/*application-db* (mdb.connection/application-db driver data-source)
+                 custom-migrations.util/*allow-temp-scheduling* false]
          (f conn))))))
 
 (defmacro with-temp-empty-app-db


### PR DESCRIPTION
### Description

The liquibase changesets which setup persistent quartz tasks cause problems with the running quartz scheduler when they run. Both because of how they shut down the (actual) scheduler, and also make unneeded (and maybe unexpected) changes to the schedule.

This PR finished cleanup of the liquibase custom changes to always use `with-temp-schedule!` and then makes the logic in there not actually schedule anything when creating a temporary appdb for test to avoid shutting down the main scheduler and also make the test db setup faster.

### How to verify

1. Run tests such as `metabase/search/appdb/index_test.clj` twice

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
