### PR TITLE
Replace - with _ in Mongo join aliases

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -940,7 +940,7 @@
                                              ;; ~ in let aliases provokes a parse error in Mongo. For correct function,
                                              ;; aliases should also contain no . characters (#32182).
                                              ;; - Spaces are allowed in columns and need to be replaced in let (#52807)
-                                             (str/replace #"[~\. ]" "_")
+                                             (str/replace #"[~\. -]" "_")
                                              (str "__" (next-alias-index)))]
                                {:field f, :rvalue (->rvalue f), :alias alias}))
                      own-fields)]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53816

### Description

Not exactly sure what causes this, but there's a reproducible way to get `-` in join aliases which break Mongo queries. Solution is to replace the `-` with `_`. 

### How to verify

1. Create a Mongo DB similar to what is done in the unit test of this PR. 
2. Attempt to join the three collections in the query editor
3. You should get the expected results instead of an error.

### Demo

<details>

<summary>Video</summary>

https://github.com/user-attachments/assets/19745755-4bed-426d-b874-e1e8e382ace6

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
