### PR TITLE
Add e2e test to ensure that sandboxing on literal custom column fails closed

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
@@ -20,22 +20,35 @@ const { H } = cy;
 const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 const { PRODUCTS_ID, ORDERS_ID, ORDERS, PRODUCTS } = SAMPLE_DATABASE;
 
-type CustomColumnType = "boolean" | "string" | "number";
+type CustomColumnType =
+  | "numberExpr"
+  | "numberLiteral"
+  | "stringExpr"
+  | "stringLiteral"
+  | "booleanExpr"
+  | "booleanLiteral";
 type CustomViewType = "Question" | "Model";
 
 type SandboxPolicy = {
   filterTableBy: "column" | "custom_view";
   customViewType?: CustomViewType;
   customViewName?: string;
-  customColumnType?: "number" | "string" | "boolean";
+  customColumnType?: CustomColumnType;
   filterColumn?: string;
 };
 
 const customColumnTypeToFormula: Record<CustomColumnType, string> = {
-  boolean: '[Category]="Gizmo"',
-  string: 'concat("Category is ",[Category])',
-  number: 'if([Category] = "Gizmo", 1, 0)',
+  booleanExpr: '[Category]="Gizmo"',
+  stringExpr: 'concat("Category is ",[Category])',
+  numberExpr: 'if([Category] = "Gizmo", 1, 0)',
+  booleanLiteral: "true",
+  stringLiteral: '"fixed literal string"',
+  numberLiteral: "1",
 };
+
+const customColumnTypes = Object.keys(
+  customColumnTypeToFormula,
+) as CustomColumnType[];
 
 const addCustomColumnToQuestion = (customColumnType: CustomColumnType) => {
   cy.log("Add a custom column");
@@ -163,9 +176,7 @@ export const adhocQuestionData = {
 function addCustomColumnsToQuestion() {
   H.openNotebook();
   H.getNotebookStep("data").button("Custom column").click();
-  addCustomColumnToQuestion("boolean");
-  addCustomColumnToQuestion("number");
-  addCustomColumnToQuestion("string");
+  customColumnTypes.forEach((type) => addCustomColumnToQuestion(type));
   H.visualize();
 
   // for some reason we can't use the saveQuestion helper here

--- a/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
@@ -20,13 +20,16 @@ const { H } = cy;
 const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 const { PRODUCTS_ID, ORDERS_ID, ORDERS, PRODUCTS } = SAMPLE_DATABASE;
 
-type CustomColumnType =
-  | "numberExpr"
-  | "numberLiteral"
-  | "stringExpr"
-  | "stringLiteral"
-  | "booleanExpr"
-  | "booleanLiteral";
+const customColumnTypeToFormulaUntyped = {
+  booleanExpr: '[Category]="Gizmo"',
+  stringExpr: 'concat("Category is ",[Category])',
+  numberExpr: 'if([Category] = "Gizmo", 1, 0)',
+  booleanLiteral: "true",
+  stringLiteral: '"fixed literal string"',
+  numberLiteral: "1",
+} as const;
+
+type CustomColumnType = keyof typeof customColumnTypeToFormulaUntyped;
 type CustomViewType = "Question" | "Model";
 
 type SandboxPolicy = {
@@ -37,15 +40,8 @@ type SandboxPolicy = {
   filterColumn?: string;
 };
 
-const customColumnTypeToFormula: Record<CustomColumnType, string> = {
-  booleanExpr: '[Category]="Gizmo"',
-  stringExpr: 'concat("Category is ",[Category])',
-  numberExpr: 'if([Category] = "Gizmo", 1, 0)',
-  booleanLiteral: "true",
-  stringLiteral: '"fixed literal string"',
-  numberLiteral: "1",
-};
-
+const customColumnTypeToFormula: Record<CustomColumnType, string> =
+  customColumnTypeToFormulaUntyped;
 const customColumnTypes = Object.keys(
   customColumnTypeToFormula,
 ) as CustomColumnType[];

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -162,12 +162,18 @@ describe(
     describe("we expect an error - and no data to be shown - when applying a sandbox policy...", () => {
       (
         [
-          ["Question", "boolean", "true"],
-          ["Question", "string", "Category is Gizmo"],
-          ["Question", "number", "11"],
-          ["Model", "boolean", "true"],
-          ["Model", "string", "Category is Gizmo"],
-          ["Model", "number", "11"],
+          ["Question", "booleanExpr", "true"],
+          ["Question", "booleanLiteral", "true"],
+          ["Question", "stringExpr", "Category is Gizmo"],
+          ["Question", "stringLiteral", "fixed literal string"],
+          ["Question", "numberExpr", "1"],
+          ["Question", "numberLiteral", "1"],
+          ["Model", "booleanExpr", "true"],
+          ["Model", "booleanLiteral", "true"],
+          ["Model", "stringExpr", "Category is Gizmo"],
+          ["Model", "stringLiteral", "fixed literal string"],
+          ["Model", "numberExpr", "1"],
+          ["Model", "numberLiteral", "1"],
         ] as const
       ).forEach(([customViewType, customColumnType, customColumnValue]) => {
         it(`...to a table filtered by a custom ${customColumnType} column in a ${customViewType}`, () => {


### PR DESCRIPTION
Closes QUE-844

Currently stacked on top of #55920

### Description

Extend the existing e2e to tests for custom columns to ensure that custom columns with literal values also fail closed.

This is part of new feature being added to support literal values in custom columns. AFAICT, there's no reason anyone would want to do this since sandboxing on a fixed literal value is presumably not useful, but it seems reasonable to ensure that, if someone did, it fails closed like any other custom column.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
