### PR TITLE
fix visualizer series settings

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-visualizer.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-visualizer.cy.spec.js
@@ -402,19 +402,51 @@ describe("scenarios > dashboard > visualizer", () => {
           .click();
         H.goalLine().should("exist");
 
-        // TODO Fix multi-series chart settings and extend the test
-        chartLegend().findByText("Series B").should("not.exist");
-        cy.findAllByTestId("series-name-input")
-          .eq(1)
-          .type("{selectall}{del}Series B")
-          .blur();
-        chartLegend().findByText("Series B").should("exist");
+        // Ensure the chart legend contains original series name
+        chartLegend().within(() => {
+          cy.findByText("Count (Products by Created At (Month))").should(
+            "exist",
+          );
+        });
 
+        // Edit series settings
+        cy.findAllByTestId("series-settings").within(() => {
+          // Update series name
+          cy.findAllByTestId("series-name-input")
+            .eq(1)
+            .type("{selectall}{del}Series B")
+            .blur();
+
+          // Update series display type
+          cy.icon("chevrondown").eq(1).click();
+          cy.icon("bar").click();
+
+          // Update series color
+          cy.findAllByTestId("color-selector-button").eq(1).click();
+        });
+      });
+
+      H.popover().findByLabelText("#DCDFE0").click();
+
+      const assertUpdatedVizSettingsApplied = () => {
+        H.goalLine().should("exist");
+        // Ensure the chart legend contains renamed series
+        chartLegend().within(() => {
+          cy.findByText("Series B").should("exist");
+          cy.findByText("Count (Products by Created At (Month))").should(
+            "not.exist",
+          );
+        });
+        H.chartPathWithFillColor("#DCDFE0");
+      };
+
+      H.modal().within(() => {
+        assertUpdatedVizSettingsApplied();
         cy.button("Save").click();
       });
+
       H.getDashboardCard(0).within(() => {
-        H.goalLine().should("exist");
-        chartLegend().findByText("Series B").should("exist");
+        assertUpdatedVizSettingsApplied();
       });
     });
 

--- a/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
+++ b/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
@@ -6,6 +6,7 @@ import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/setting
 import {
   getVisualizerComputedSettings,
   getVisualizerRawSeries,
+  getVisualizerTransformedSeries,
 } from "metabase/visualizer/selectors";
 import { updateSettings } from "metabase/visualizer/visualizer.slice";
 import type { VisualizationSettings } from "metabase-types/api";
@@ -18,7 +19,7 @@ const HIDDEN_SETTING_WIDGETS = [
 
 export function VizSettingsSidebar({ className }: { className?: string }) {
   const series = useSelector(getVisualizerRawSeries);
-  const transformedSeries = useSelector(getVisualizerRawSeries);
+  const transformedSeries = useSelector(getVisualizerTransformedSeries);
   const settings = useSelector(getVisualizerComputedSettings);
   const dispatch = useDispatch();
 


### PR DESCRIPTION
Closes [VIZ-562](https://linear.app/metabase/issue/VIZ-562/series-settings-are-ignored)
Closes [VIZ-561](https://linear.app/metabase/issue/VIZ-561/series-colors-in-settings-do-not-match-chart-legend) 

### Description

Fixes series settings did not work in the visualizer.

### How to verify

- Create a cartesian chart in the visualizer with multiple series
- Try edit series settings
- Ensure they update the actual chart

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
