### PR TITLE
Revert search engine default to in-place

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -49,6 +49,7 @@ jobs:
       CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
       MB_EXPERIMENTAL_SEARCH_BLOCK_ON_QUEUE: true
+      MB_SEARCH_ENGINE: appdb
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       TZ: US/Pacific # to make node match the instance tz

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -1025,7 +1025,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   (deferred-tru "Which engine to use when performing search. Supported values are :in-place and :appdb")
   :visibility :internal
   :export?    false
-  :default    :appdb
+  :default    :in-place
   :type       :keyword)
 
 (defsetting experimental-search-weight-overrides


### PR DESCRIPTION
We're still ironing out some kinks, so don't want this going out with 54.

Rolling it back in master too, to make sure we're intentional next time.