### PR TITLE
fix: release appdb connection on query cache miss

### DIFF
--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -87,10 +87,10 @@
                      (if-not (.next rs)
                        ::cache-miss
                        (with-open [is (encryption/maybe-decrypt-stream (.getBinaryStream rs 1))]
-                         (respond is)
-                         ::cache-hit)))))]
-    (when (= ::cache-miss result)
-      (respond nil))))
+                         (respond is))))))]
+    (if (= ::cache-miss result)
+      (respond nil)
+      result)))
 
 (defn- purge-old-cache-entries!
   "Delete any cache entries that are older than the global max age `max-cache-entry-age-seconds` (currently 3 months)."


### PR DESCRIPTION
### Description

If we hold the appdb connection after a query miss we could keep this connection out of the pool for minutes while we wait for actual db query to finish, which can starve other requests from utilizing the database.

We should return the connection to the pool while re-executing the missed query.

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
