### PR TITLE
[refs] Return `:ident`s in QP `annotate`; save in `:result_metadata`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
@@ -100,14 +100,24 @@
   "Combine all dimensions into a vector and dump it into YAML at in the directory for the
    corresponding schema starting at `path`."
   [path]
-  (doseq [[table-id dimensions] (group-by (comp :table_id :model/Field :field_id) (t2/select :model/Dimension))
+  (reset! dims (t2/select :model/Dimension))
+  (doseq [[table-id dimensions] (group-by (comp :table_id #(t2/select-one :model/Field :id %) :field_id)
+                                          (t2/select :model/Dimension))
           :let [table (t2/select-one :model/Table :id table-id)]]
-    (spit-yaml! (if (:schema table)
-                  (format "%s%s/schemas/%s/dimensions.yaml"
-                          path
-                          (->> table :db_id (fully-qualified-name :model/Database))
-                          (:schema table))
-                  (format "%s%s/dimensions.yaml"
-                          path
-                          (->> table :db_id (fully-qualified-name :model/Database))))
-                (map serialize/serialize dimensions))))
+    (println "Dumping dimensions for table\n" table-id table "\n\n" dimensions)
+    (try
+      (spit-yaml! (if (:schema table)
+                    (format "%s%s/schemas/%s/dimensions.yaml"
+                            path
+                            (->> table :db_id (fully-qualified-name :model/Database))
+                            (:schema table))
+                    (format "%s%s/dimensions.yaml"
+                            path
+                            (->> table :db_id (fully-qualified-name :model/Database))))
+                  (map serialize/serialize dimensions))
+      (catch Exception e
+        (throw (ex-info (format "Error serializing dimensions for table %d" table-id)
+                        {:table      table
+                         :dimensions dimensions
+                         :serialized (map serialize/serialize dimensions)}
+                        e))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -43,12 +43,13 @@
                       :attributes {:cat 50}}
       ;; Fetch the card and manually compute & save the metadata
       (let [card (t2/select-one :model/Card
-                                {:select [:c.id :c.dataset_query :c.card_schema]
+                                {:select [:c.id :c.dataset_query :c.entity_id :c.card_schema]
                                  :from   [[:sandboxes :s]]
                                  :join   [[:permissions_group :pg] [:= :s.group_id :pg.id]
                                           [:report_card :c] [:= :c.id :s.card_id]]
                                  :where  [:= :pg.id (u/the-id &group)]})
-            {:keys [metadata metadata-future]} (@#'card.metadata/maybe-async-recomputed-metadata (:dataset_query card))]
+            {:keys [metadata metadata-future]} (@#'card.metadata/maybe-async-recomputed-metadata
+                                                (:dataset_query card) (:entity_id card))]
         (if metadata
           (t2/update! :model/Card :id (u/the-id card) {:result_metadata metadata})
           (card.metadata/save-metadata-async! metadata-future card)))

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -56,7 +56,10 @@
 (defn- card-query-results [card]
   (let [query (:dataset_query card)]
     (binding [qp.perms/*card-id* nil]
-      (qp/process-query (assoc-in query [:info :card-id] (:id card))))))
+      (-> query
+          (assoc-in [:info :card-id] (:id card))
+          (assoc-in [:info :card-entity-id] (:entity_id card))
+          qp/process-query))))
 
 (defn- query-res-match
   "Checks that the queries for a card match between original (pre-dump) and new (after load). For now, just checks the

--- a/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
@@ -484,6 +484,7 @@
                        (-> result
                            (dissoc :running_time :average_execution_time :started_at :cached)
                            (update-in [:data :cols] #(mapv clean-col %))
+                           (update-in [:data :results_metadata :columns] #(mapv clean-col %))
                            (m/dissoc-in [:json_query :cache-strategy])))]
     (is (= (clean-result original-result)
            (clean-result cached-result)))))

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -924,18 +924,6 @@ class Question {
       card = assocIn(card, ["dataset_query", "database"], databaseId);
     }
 
-    // If the card has a top-level entity_id, use that. Otherwise, use the one on the query info.
-    // If neither of those exists, synthesize a random one.
-    const innerEntityIdPath = ["dataset_query", "info", "card-entity-id"];
-    const entity_id =
-      card.entity_id || getIn(card, innerEntityIdPath) || Lib.randomIdent();
-
-    // Then set both locations.
-    card = chain(card)
-      .assoc("entity_id", entity_id)
-      .assocIn(innerEntityIdPath, entity_id)
-      .value();
-
     return new Question(card, metadata, parameterValues);
   }
 }

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -607,6 +607,7 @@ class Question {
     if (!other) {
       return false;
     }
+
     if (this.id() !== other.id()) {
       return false;
     }

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -607,7 +607,6 @@ class Question {
     if (!other) {
       return false;
     }
-
     if (this.id() !== other.id()) {
       return false;
     }

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -56,34 +56,39 @@
   (mt/test-driver :bigquery-cloud-sdk
     (testing (str "make sure that BigQuery native queries maintain the column ordering specified in the SQL -- "
                   "post-processing ordering shouldn't apply (metabase#2821)")
-      (is (= [{:name         "venue_id"
-               :display_name "venue_id"
-               :source       :native
-               :base_type    :type/Integer
-               :effective_type :type/Integer
-               :field_ref    [:field "venue_id" {:base-type :type/Integer}]}
-              {:name         "user_id"
-               :display_name "user_id"
-               :source       :native
-               :base_type    :type/Integer
-               :effective_type :type/Integer
-               :field_ref    [:field "user_id" {:base-type :type/Integer}]}
-              {:name         "checkins_id"
-               :display_name "checkins_id"
-               :source       :native
-               :base_type    :type/Integer
-               :effective_type :type/Integer
-               :field_ref    [:field "checkins_id" {:base-type :type/Integer}]}]
-             (mt/cols
-              (qp/process-query
-               {:native   {:query (with-test-db-name
-                                    (str "SELECT `v4_test_data.checkins`.`venue_id` AS `venue_id`, "
-                                         "       `v4_test_data.checkins`.`user_id` AS `user_id`, "
-                                         "       `v4_test_data.checkins`.`id` AS `checkins_id` "
-                                         "FROM `v4_test_data.checkins` "
-                                         "LIMIT 2"))}
-                :type     :native
-                :database (mt/id)})))))))
+      (let [eid (u/generate-nano-id)]
+        (is (= [{:name         "venue_id"
+                 :display_name "venue_id"
+                 :ident        (lib/native-ident "venue_id" eid)
+                 :source       :native
+                 :base_type    :type/Integer
+                 :effective_type :type/Integer
+                 :field_ref    [:field "venue_id" {:base-type :type/Integer}]}
+                {:name         "user_id"
+                 :display_name "user_id"
+                 :ident        (lib/native-ident "user_id" eid)
+                 :source       :native
+                 :base_type    :type/Integer
+                 :effective_type :type/Integer
+                 :field_ref    [:field "user_id" {:base-type :type/Integer}]}
+                {:name         "checkins_id"
+                 :display_name "checkins_id"
+                 :ident        (lib/native-ident "checkins_id" eid)
+                 :source       :native
+                 :base_type    :type/Integer
+                 :effective_type :type/Integer
+                 :field_ref    [:field "checkins_id" {:base-type :type/Integer}]}]
+               (mt/cols
+                (qp/process-query
+                 {:native   {:query (with-test-db-name
+                                      (str "SELECT `v4_test_data.checkins`.`venue_id` AS `venue_id`, "
+                                           "       `v4_test_data.checkins`.`user_id` AS `user_id`, "
+                                           "       `v4_test_data.checkins`.`id` AS `checkins_id` "
+                                           "FROM `v4_test_data.checkins` "
+                                           "LIMIT 2"))}
+                  :type     :native
+                  :info     {:card-entity-id eid}
+                  :database (mt/id)}))))))))
 
 (deftest ^:parallel native-query-test-3
   (mt/test-driver :bigquery-cloud-sdk

--- a/resources/serialization-order.edn
+++ b/resources/serialization-order.edn
@@ -24,6 +24,7 @@
                                   :dataset_query
                                   :result_metadata
                                   :visualization_settings
+                                  :card_schema
                                   :serdes/meta]
  [:Card :dataset_query]          []
  [:Card :visualization_settings] []
@@ -77,6 +78,7 @@
                                   :dbms_version
                                   :created_at
                                   :creator_id
+                                  :entity_id
                                   :timezone
                                   :auto_run_queries
                                   :cache_ttl
@@ -108,6 +110,7 @@
  :Field                          [:name
                                   :display_name
                                   :description
+                                  :entity_id
                                   :created_at
                                   :active
                                   :visibility_type
@@ -143,6 +146,7 @@
  :Table                          [:name
                                   :display_name
                                   :description
+                                  :entity_id
                                   :created_at
                                   :db_id
                                   :schema

--- a/src/metabase/analyze/query_results.clj
+++ b/src/metabase/analyze/query_results.clj
@@ -33,7 +33,13 @@
   [:fn
    {:error/message "Field or aggregation reference as it comes in to the API"}
    (fn [x]
-     (mr/validate mbql.s/Reference (mbql.normalize/normalize-tokens x)))])
+     (u/prog1 (mr/validate mbql.s/Reference (mbql.normalize/normalize-tokens x))
+              (when-not <>
+                (tap> [`MaybeUnnormalizedReference mbql.s/Reference 'raw x 'normalized (mbql.normalize/normalize-tokens x)]))))])
+
+(comment
+  (mr/explain mbql.s/Reference [:field "ID" {:base-type nil}])
+  )
 
 (mr/def ::ResultColumnMetadata
   [:map

--- a/src/metabase/analyze/query_results.clj
+++ b/src/metabase/analyze/query_results.clj
@@ -33,13 +33,7 @@
   [:fn
    {:error/message "Field or aggregation reference as it comes in to the API"}
    (fn [x]
-     (u/prog1 (mr/validate mbql.s/Reference (mbql.normalize/normalize-tokens x))
-              (when-not <>
-                (tap> [`MaybeUnnormalizedReference mbql.s/Reference 'raw x 'normalized (mbql.normalize/normalize-tokens x)]))))])
-
-(comment
-  (mr/explain mbql.s/Reference [:field "ID" {:base-type nil}])
-  )
+     (mr/validate mbql.s/Reference (mbql.normalize/normalize-tokens x)))])
 
 (mr/def ::ResultColumnMetadata
   [:map

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -607,10 +607,8 @@
                                                :metadata          result_metadata
                                                :original-metadata (:result_metadata card-before-update)
                                                :model?            is-model-after-update?
-                                               :entity-id         (u/prog1 (or (:entity_id card-updates)
-                                                                      (:entity_id card-before-update))
-                                                                           (tap> ['put/entity-id 'before (:entity_id card-before-update)
-                                                                                  'after (:entity_id card-updates) '=> <>]))})
+                                               :entity-id         (or (:entity_id card-updates)
+                                                                      (:entity_id card-before-update))})
           card-updates                       (merge card-updates
                                                     (when (and (some? type)
                                                                is-model-after-update?)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -606,7 +606,11 @@
                                                :query             dataset_query
                                                :metadata          result_metadata
                                                :original-metadata (:result_metadata card-before-update)
-                                               :model?            is-model-after-update?})
+                                               :model?            is-model-after-update?
+                                               :entity-id         (u/prog1 (or (:entity_id card-updates)
+                                                                      (:entity_id card-before-update))
+                                                                           (tap> ['put/entity-id 'before (:entity_id card-before-update)
+                                                                                  'after (:entity_id card-updates) '=> <>]))})
           card-updates                       (merge card-updates
                                                     (when (and (some? type)
                                                                is-model-after-update?)

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -66,10 +66,13 @@
     ;; add sensible constraints for results limits on our query
     (let [source-card-id (query->source-card-id query)
           source-card    (when source-card-id
-                           (t2/select-one [:model/Card :result_metadata :type :card_schema] :id source-card-id))
+                           (t2/select-one [:model/Card :entity_id :result_metadata :type :card_schema] :id source-card-id))
           info           (cond-> {:executed-by api/*current-user-id*
                                   :context     context
                                   :card-id     source-card-id}
+                           (:entity_id source-card)
+                           (assoc :card-entity-id (:entity_id source-card))
+
                            (= (:type source-card) :model)
                            (assoc :metadata/model-metadata (:result_metadata source-card)))]
       (binding [qp.perms/*card-id* source-card-id]

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -64,7 +64,7 @@
         (events/publish-event! :event/table-read {:object  (t2/select-one :model/Table :id table-id)
                                                   :user-id api/*current-user-id*})))
     ;; add sensible constraints for results limits on our query
-    (let [source-card-id (query->source-card-id query)
+    (let [source-card-id (query->source-card-id query) ; This is only set for direct :source-table "card__..."
           source-card    (when source-card-id
                            (t2/select-one [:model/Card :entity_id :result_metadata :type :card_schema] :id source-card-id))
           info           (cond-> {:executed-by api/*current-user-id*

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -5,6 +5,7 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]
@@ -58,10 +59,16 @@
           (fallback-display-name source-card)))))
 
 (mu/defn- infer-returned-columns :- [:maybe [:sequential ::lib.schema.metadata/column]]
-  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-   card-query            :- :map]
+  [metadata-providerable                :- ::lib.schema.metadata/metadata-providerable
+   {card-query :dataset-query :as card} :- :map]
   (when (some? card-query)
-    (lib.metadata.calculation/returned-columns (lib.query/query metadata-providerable card-query))))
+    (let [cols     (lib.metadata.calculation/returned-columns (lib.query/query metadata-providerable card-query))
+          model-id (when (= (:type card) :model)
+                     (or (:entity-id card)
+                         (throw (ex-info "Cannot infer columns for a model with no :entity-id!"
+                                         {:card card}))))]
+      (cond->> cols
+        model-id (map #(update % :ident lib.metadata.ident/model-ident model-id))))))
 
 (def ^:private Card
   [:map
@@ -153,13 +160,21 @@
     (binding [*card-metadata-columns-card-ids* (conj *card-metadata-columns-card-ids* (:id card))]
       (when-let [result-metadata (or (:fields card)
                                      (:result-metadata card)
-                                     (infer-returned-columns metadata-providerable (:dataset-query card)))]
+                                     (infer-returned-columns metadata-providerable card))]
         ;; Card `result-metadata` SHOULD be a sequence of column infos, but just to be safe handle a map that
         ;; contains` :columns` as well.
         (when-let [cols (not-empty (cond
                                      (map? result-metadata)        (:columns result-metadata)
                                      (sequential? result-metadata) result-metadata))]
-          (->card-metadata-columns metadata-providerable card cols))))))
+          (let [cols (->card-metadata-columns metadata-providerable card cols)]
+            (when-let [invalid-idents (and lib.metadata.ident/*enforce-idents-present*
+                                           (= (:type card) :model)
+                                           (seq (remove #(lib.metadata.ident/valid-model-ident? % (:entity-id card))
+                                                        cols)))]
+              (throw (ex-info "Model columns do not have model__ idents"
+                              {:card       card
+                               :bad-idents invalid-idents})))
+            cols))))))
 
 (mu/defn saved-question-metadata :- CardColumns
   "Metadata associated with a Saved Question with `card-id`."

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -68,7 +68,7 @@
                           (throw (ex-info "Cannot infer columns for a model with no :entity-id!"
                                           {:card card}))))]
       (cond->> cols
-        model-eid (map #(update % :ident lib.metadata.ident/model-ident model-eid))))))
+        model-eid (map #(lib.metadata.ident/add-model-ident % model-eid))))))
 
 (def ^:private Card
   [:map

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -62,13 +62,13 @@
   [metadata-providerable                :- ::lib.schema.metadata/metadata-providerable
    {card-query :dataset-query :as card} :- :map]
   (when (some? card-query)
-    (let [cols     (lib.metadata.calculation/returned-columns (lib.query/query metadata-providerable card-query))
-          model-id (when (= (:type card) :model)
-                     (or (:entity-id card)
-                         (throw (ex-info "Cannot infer columns for a model with no :entity-id!"
-                                         {:card card}))))]
+    (let [cols      (lib.metadata.calculation/returned-columns (lib.query/query metadata-providerable card-query))
+          model-eid (when (= (:type card) :model)
+                      (or (:entity-id card)
+                          (throw (ex-info "Cannot infer columns for a model with no :entity-id!"
+                                          {:card card}))))]
       (cond->> cols
-        model-id (map #(update % :ident lib.metadata.ident/model-ident model-id))))))
+        model-eid (map #(update % :ident lib.metadata.ident/model-ident model-eid))))))
 
 (def ^:private Card
   [:map

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -171,7 +171,7 @@
                                            (= (:type card) :model)
                                            (seq (remove #(lib.metadata.ident/valid-model-ident? % (:entity-id card))
                                                         cols)))]
-              (throw (ex-info "Model columns do not have model__ idents"
+              (throw (ex-info "Model columns do not have model[...]__ idents"
                               {:card       card
                                :bad-idents invalid-idents})))
             cols))))))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -300,9 +300,15 @@
  [lib.metadata.composed-provider
   composed-metadata-provider]
  [lib.metadata.ident
+  explicitly-joined-ident
   implicit-join-clause-ident
+  implicitly-joined-ident
   model-ident
-  native-ident]
+  native-ident
+  valid-basic-ident?
+  valid-model-ident?
+  valid-native-ident?
+  valid-native-model-ident?]
  [lib.native
   engine
   extract-template-tags

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -305,6 +305,8 @@
   implicitly-joined-ident
   model-ident
   native-ident
+  placeholder-card-entity-id-for-adhoc-query
+  replace-placeholder-idents
   valid-basic-ident?
   valid-model-ident?
   valid-native-ident?

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -300,6 +300,7 @@
  [lib.metadata.composed-provider
   composed-metadata-provider]
  [lib.metadata.ident
+  add-model-ident
   assert-idents-present!
   explicitly-joined-ident
   implicit-join-clause-ident
@@ -307,6 +308,7 @@
   model-ident
   native-ident
   placeholder-card-entity-id-for-adhoc-query
+  remove-model-ident
   replace-placeholder-idents
   valid-basic-ident?
   valid-model-ident?

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -300,6 +300,7 @@
  [lib.metadata.composed-provider
   composed-metadata-provider]
  [lib.metadata.ident
+  assert-idents-present!
   explicitly-joined-ident
   implicit-join-clause-ident
   implicitly-joined-ident

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -235,6 +235,7 @@
     ;; if there are explicit fields selected, add the expression to them
     (and (vector? (:fields stage))
          add-to-fields?)
+    ;; TODO: Construct this ref with lib/ref rather than hand-rolling it?
     (update :fields conj (lib.options/ensure-uuid [:expression {} (lib.util/expression-name expression)]))))
 
 (mu/defn expression :- ::lib.schema/query

--- a/src/metabase/lib/metadata/ident.cljc
+++ b/src/metabase/lib/metadata/ident.cljc
@@ -69,10 +69,23 @@
 (def ^:private placeholder-regex
   #"\$\$ADHOC\[[A-Za-z0-9_-]{21}\]")
 
+(defn contains-placeholder-ident?
+  "Returns true if the given string contains a placeholder."
+  [s]
+  (and (string? s)
+       (boolean (re-matches placeholder-regex s))))
+
+(defn placeholder?
+  "Returns true if the given string is **exactly** a placeholder."
+  [s]
+  (and (contains-placeholder-ident? s)
+       (= (count s) 30)))
+
 (defn replace-placeholder-idents
   "Given an `:ident` and the true `:entity_id` for a card, overwrite the placeholders."
   [ident card-entity-id]
-  (str/replace ident placeholder-regex card-entity-id))
+  (when ident
+    (str/replace ident placeholder-regex card-entity-id)))
 
 (comment
   (let [placeholder-ident (native-ident "SOME_COLUMN" (placeholder-card-entity-id-for-adhoc-query))

--- a/src/metabase/lib/metadata/ident.cljc
+++ b/src/metabase/lib/metadata/ident.cljc
@@ -40,10 +40,10 @@
 
 (defn add-model-ident
   "Given a column with a basic, \"inner\" `:ident` and the `card-entity-id`, returns the column with `:ident` for the
-  model and `:model/inner-ident` with the original."
+  model and `:model/inner_ident` with the original."
   [{:keys [ident] :as column} card-entity-id]
   (-> column
-      (assoc :model/inner-ident ident)
+      (assoc :model/inner_ident ident)
       (update :ident model-ident card-entity-id)))
 
 (defn- strip-model-ident
@@ -58,13 +58,13 @@
 (defn remove-model-ident
   "Given a column with a [[model-ident]] style `:ident`, return the original, \"inner\" ident for that column.
 
-  Typically this should come from the `:model/inner-ident` key on the column, which is removed if present.
+  Typically this should come from the `:model/inner_ident` key on the column, which is removed if present.
   Will fall back to parsing the [[model-ident]] prefix if necessary."
-  [{:keys [ident model/inner-ident] :as column} card-entity-id]
-  (let [inner-ident (or inner-ident (strip-model-ident ident card-entity-id))]
+  [{:keys [ident model/inner_ident] :as column} card-entity-id]
+  (let [inner_ident (or inner_ident (strip-model-ident ident card-entity-id))]
     (-> column
-        (dissoc :model/inner-ident)
-        (assoc :ident inner-ident))))
+        (dissoc :model/inner_ident)
+        (assoc :ident inner_ident))))
 
 (defn native-ident
   "Returns the `:ident` for a given field name on a native query.

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -256,7 +256,6 @@
 (t2/define-after-select :metadata/card
   [card]
   (let [card (instance->metadata card :metadata/card)]
-    (tap> [`card-as-selected card (:persisted/definition card)])
     (merge
      (dissoc card :persisted/active :persisted/state :persisted/definition :persisted/query-hash :persisted/table-name)
      (when (:persisted/definition card)

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -256,6 +256,7 @@
 (t2/define-after-select :metadata/card
   [card]
   (let [card (instance->metadata card :metadata/card)]
+    (tap> [`card-as-selected card (:persisted/definition card)])
     (merge
      (dissoc card :persisted/active :persisted/state :persisted/definition :persisted/query-hash :persisted/table-name)
      (when (:persisted/definition card)

--- a/src/metabase/model_persistence/task/persist_refresh.clj
+++ b/src/metabase/model_persistence/task/persist_refresh.clj
@@ -176,7 +176,7 @@
 (defn- refreshable-models
   "Returns refreshable models for a database id. Must still be models and not archived."
   [database-id]
-  (let [refreshable (t2/select :model/PersistedInfo
+  (t2/select :model/PersistedInfo
              {:select    [:p.* :c.type :c.archived :c.name]
               :from      [[:persisted_info :p]]
               :left-join [[:report_card :c] [:= :c.id :p.card_id]]
@@ -184,11 +184,7 @@
                           [:= :p.database_id database-id]
                           [:in :p.state (persisted-info/refreshable-states)]
                           [:= :c.archived false]
-                          [:= :c.type "model"]]})
-        plausible (t2/select :model/PersistedInfo :database_id database-id :card_id [:!= nil])]
-    (tap> [`refreshable-models 'refreshable refreshable 'plausible plausible])
-    refreshable
-    ))
+                          [:= :c.type "model"]]}))
 
 (defn- prune-all-deletable!
   "Prunes all deletable PersistInfos, should not be called from tests as
@@ -205,7 +201,6 @@
   (persisted-info/ready-unpersisted-models! database-id)
   (let [database  (t2/select-one :model/Database :id database-id)
         persisted (refreshable-models database-id)
-        _ (tap> [`refresh-tables! 'refreshable-models persisted])
         thunk     (fn []
                     (reduce (partial refresh-with-stats! refresher database)
                             {:success 0, :error 0, :trigger "Scheduled"}

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1126,7 +1126,7 @@
   created."
   ([card creator] (create-card! card creator false))
   ([card creator delay-event?] (create-card! card creator delay-event? true))
-  ([{:keys [dataset_query result_metadata parameters parameter_mappings type] :as input-card-data} creator delay-event? autoplace-dashboard-questions?]
+  ([{:keys [result_metadata parameters parameter_mappings type] :as input-card-data} creator delay-event? autoplace-dashboard-questions?]
    ;; you can't specify the dashboard_tab_id and not a dashboard_id
    (api/check-400 (not (and (:dashboard_tab_id input-card-data)
                             (not (:dashboard_id input-card-data)))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -957,7 +957,7 @@
       (dissoc :verified-result-metadata?)
       (assoc :card_schema current-schema-version)
       t2/changes
-      (->> (into {:id (:id card)}))
+      (->> (into (select-keys card [:id :type :entity_id])))
       apply-dashboard-question-updates
       maybe-normalize-query
       ;; If we have fresh result_metadata, we don't have to populate it anew. When result_metadata doesn't

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -918,12 +918,14 @@
 
 (t2/define-before-insert :model/Card
   [card]
+  (tap> ['before-insert/top (map :ident (:result_metadata card))])
   (dev.portal/diff-> card
                      (assoc :metabase_version config/mb-version-string
                             :card_schema current-schema-version)
                      maybe-normalize-query
       ; Add any missing idents on the query (expr, breakout, agg) before populating :result_metadata.
                      (ensure-clause-idents ::before-insert)
+                     (u/assoc-default :entity_id (u/generate-nano-id)) ; Must have an entity_id before populating the metadata.
                      card.metadata/populate-result-metadata
                      pre-insert
                      populate-query-fields))

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -256,3 +256,10 @@ saved later when it is ready."
     (do
       (log/debug "Attempting to infer result metadata for Card")
       (assoc card :result_metadata (infer-metadata query)))))
+
+(defn assert-valid-idents
+  "Given a card (or updates being made to a card) check the `:result_metadata` has correctly formed idents."
+  [{cols :result_metadata :as _card-or-changes}]
+  (when-let [missing (seq (remove :ident cols))]
+    (throw (ex-info "Some columns in :result_metadata are missing :idents; these are required"
+                    {:missing missing}))))

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -60,28 +60,6 @@ saved later when it is ready."
                               metadata')))}
       {:metadata (qp.util/combine-metadata result metadata')})))
 
-(comment
-  (t2/select-one :model/Card :id 114)
-  ;; XXX: START HERE: Just got the ad-hoc native query including its entity_id.
-  ;; I think that fix will apply to MBQL as well, though it matters less there.
-  ;; Next steps:
-  ;; - Update annotate to return correct idents for all columns.
-  ;; - Adjust add-source-metadata to pass along the idents from earlier queries.
-  ;;     - Since idents aren't in `:result_metadata` yet, this needs to be inferred!
-  ;;     - The inference may as well be cached centrally from the first, so it doesn't get repeatedly recomputed.
-
-  ;; See my lifecycle of `:result_metadata` in Logseq - it's the predictable shambles.
-  ;; To unify on that as a safety check before we commit to writing the idents into appdbs(!):
-  ;; - Refactor all of the call sites to pass through one function - `qp.metadata/legacy-result-metadata`?
-  ;; - Ensure that function is only called from outside the QP, on real, card-holding queries.
-  ;; - Put the safety checks for idents into it.
-
-  ;; If the tests are passing and that doesn't explode in stats, we can be reasonably confident that the idents are
-  ;; working globally!
-
-  ;; Cases to test: new/updated X native/MBQL plain/MBQL with summaries X query/model.
-  )
-
 (mu/defn- maybe-async-recomputed-metadata :- ::maybe-async-result-metadata
   [query]
   (log/debug "Querying for metadata")

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -145,13 +145,13 @@ saved later when it is ready."
   (u/minutes->ms 15))
 
 (defn- valid-ident?
-  "Validates that model columns have idents that always start with `model__CardEntityId__`, and that all idents are
+  "Validates that model columns have idents that always start with `model[CardEntityId]__`, and that all idents are
   nonempty strings.
 
   Note that this **does not** check that `:type :native` queries have native idents - SQL-based sandboxing stores
   `:native` queries but returns MBQL-like metadata with IDs and the Field `entity_id`s as idents."
   ;; TODO: That limitation that prevents checking native queries have native-looking :idents is unfortunate.
-  ;; At least this checks that we never store `native____`, ie. native queries without a card entity_id.
+  ;; At least this checks that we never store `native[]__`, ie. native queries without a card entity_id.
   ([column card]
    (valid-ident? column (= (:type card) :model) (:entity_id card)))
   ([column model? entity-id]

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -46,7 +46,7 @@ saved later when it is ready."
 
 (mu/defn- maybe-async-model-result-metadata :- ::maybe-async-result-metadata
   [{:keys [query metadata original-metadata valid-metadata? entity-id]} :- [:map
-                                                                  [:valid-metadata? :any]]]
+                                                                            [:valid-metadata? :any]]]
   (log/debug "Querying for metadata and blending model metadata")
   (let [futur     (legacy-result-metadata-future query)
         metadata' (if valid-metadata?
@@ -89,8 +89,7 @@ saved later when it is ready."
 
 (defn- maybe-validate-model-idents [metadata model? entity-id]
   (or (not model?)
-      (every? #(valid-ident? % model? entity-id) metadata))
-  )
+      (every? #(valid-ident? % model? entity-id) metadata)))
 
 (mu/defn maybe-async-result-metadata :- ::maybe-async-result-metadata
   "Return result metadata for the passed in `query`. If metadata needs to be recalculated, waits up to
@@ -300,6 +299,5 @@ saved later when it is ready."
   (when-let [invalid (seq (remove #(or (nil? (:ident %))
                                        (valid-ident? % card))
                                   cols))]
-    (tap> [`assert-valid-idents! card invalid])
     (throw (ex-info "Some columns in :result_metadata have bad :idents!"
                     {:invalid invalid}))))

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -89,10 +89,6 @@ saved later when it is ready."
     (lib/normalize dataset-query)
     (mbql.normalize/normalize dataset-query)))
 
-(defn- maybe-validate-model-idents [metadata model? entity-id]
-  (or (not model?)
-      (every? #(valid-ident? % model? entity-id) metadata)))
-
 (mu/defn maybe-async-result-metadata :- ::maybe-async-result-metadata
   "Return result metadata for the passed in `query`. If metadata needs to be recalculated, waits up to
   [[metadata-sync-wait-ms]] for it to be recalcuated; if not recalculated by then, returns a map with
@@ -108,11 +104,7 @@ saved later when it is ready."
   might need to save a metadata edit, or might need to use db-saved metadata on a modified dataset."
   [{:keys [original-query query metadata original-metadata model? entity-id], :as options}]
   (let [valid-metadata? (and metadata
-                             (mr/validate analyze/ResultsMetadata metadata)
-                             ;; FIXME: Breadcrumb: This check breaks the logic here because newly created MBQL models
-                             ;; come in with _inner_ query idents, and that's correct behaviour.
-                             ;; Probably this can just be deleted.
-                             #_(maybe-validate-model-idents metadata model? entity-id))]
+                             (mr/validate analyze/ResultsMetadata metadata))]
     (cond
       (or
        ;; query didn't change, preserve existing metadata

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -301,6 +301,7 @@
         info       (cond-> {:executed-by            api/*current-user-id*
                             :context                context
                             :card-id                card-id
+                            :card-entity-id         (:entity_id card)
                             :card-name              (:name card)
                             :dashboard-id           dashboard-id
                             :visualization-settings merged-viz}

--- a/src/metabase/query_processor/metadata.clj
+++ b/src/metabase/query_processor/metadata.clj
@@ -23,8 +23,7 @@
   "For MBQL queries or native queries with result metadata attached to them already we can infer the columns just by
   preprocessing the query/looking at the last stage of the query."
   [query :- :map]
-  (u/prog1 (not-empty (u/ignore-exceptions (qp.preprocess/query->expected-cols query)))
-           (tap> ['metadata-from-preprocessing <>])))
+  (not-empty (u/ignore-exceptions (qp.preprocess/query->expected-cols query))))
 
 (mu/defn- query-with-limit-1 :- :map
   [query :- :map]
@@ -42,7 +41,7 @@
 
 (mu/defn- result-metadata-rff :- ::qp.schema/rff
   [metadata]
-  (let [cols (:cols metadata)]>
+  (let [cols (:cols metadata)]
     (fn rf
       ([]
        (reduced cols))
@@ -73,9 +72,7 @@
                  current-user-id (assoc-in [:info :executed-by] current-user-id))
         driver (driver.u/database->driver (:database query))]
     (-> (driver/query-result-metadata driver query)
-        (u/prog1 (tap> ['driver-result-metadata <>]))
-        (annotate/annotate-native-cols (get-in query [:info :card-entity-id]))
-        (u/prog1 (tap> ['annotated-result-metadata <>])))))
+        (annotate/annotate-native-cols (get-in query [:info :card-entity-id])))))
 
 (mu/defn- add-extra-column-metadata :- :map
   [col            :- :map

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -10,7 +10,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
-   [metabase.lib.ident :as lib.ident]
+   [metabase.lib.core :as lib]
    [metabase.lib.join.util :as lib.join.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -60,14 +60,14 @@
       ;; this is for cache-warming purposes.
       (when (seq target-table-ids)
         (lib.metadata/bulk-metadata-or-throw (qp.store/metadata-provider) :metadata/table target-table-ids))
-      (for [{fk-name :name, fk-field-id :id, pk-id :fk-target-field-id} fk-fields
-            :when                                                       pk-id]
+      (for [{fk-name :name, fk-field-id :id, fk-ident :ident, pk-id :fk-target-field-id} fk-fields
+            :when                                                                        pk-id]
         (let [{source-table :table-id} (lib.metadata.protocols/field (qp.store/metadata-provider) pk-id)
               {table-name :name}       (lib.metadata.protocols/table (qp.store/metadata-provider) source-table)
               alias-for-join           (join-alias table-name fk-name)]
           (-> {:source-table source-table
                :alias        alias-for-join
-               :ident        (lib.ident/random-ident)
+               :ident        (lib/implicit-join-clause-ident fk-ident)
                :fields       :none
                :strategy     :left-join
                :condition    [:= [:field fk-field-id nil] [:field pk-id {:join-alias alias-for-join}]]

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -56,7 +56,7 @@
                    :query    (assoc-in source-query [:middleware :disable-remaps?] true)}))]
       (for [col cols
             :when (not (:remapped_from col))]
-        (select-keys col [:name :id :table_id :display_name :base_type :effective_type :coercion_strategy
+        (select-keys col [:name :id :ident :table_id :display_name :base_type :effective_type :coercion_strategy
                           :semantic_type :unit :fingerprint :settings :source_alias :field_ref :nfc_path :parent_id])))
     (catch Throwable e
       (log/errorf e "Error determining expected columns for query: %s" (ex-message e))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -87,7 +87,7 @@
   [[metabase.query-processor.test-util/metadata->native-form]]."
   [cols card-entity-id]
   (let [unique-name-fn (mbql.u/unique-name-generator)]
-    (mapv (fn [{col-name :name, base-type :base_type, :as driver-col-metadata}]
+    (mapv (fn [{col-name :name :as driver-col-metadata}]
             (let [col-name (name col-name)]
               (merge
                {:display_name (u/qualified-name col-name)
@@ -98,7 +98,8 @@
                ;; valid `:field`, omit the `:field_ref`.
                (when-not (str/blank? col-name)
                  (let [unique-col-name (unique-name-fn col-name)]
-                   {:field_ref [:field unique-col-name {:base-type base-type}]
+                   {:field_ref [:field unique-col-name {:base-type (or (:base_type driver-col-metadata)
+                                                                       (:base-type driver-col-metadata))}]
                     :ident     (lib/native-ident unique-col-name card-entity-id)}))
                driver-col-metadata)))
           cols)))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -564,7 +564,7 @@
     (cond-> col
       ;; Check that the ident isn't already set for this model, to avoid "double-bagging".
       (not (lib/valid-model-ident? col card-entity-id))
-      (update :ident lib/model-ident card-entity-id))))
+      (lib/add-model-ident card-entity-id))))
 
 (defn mbql-cols
   "Return the `:cols` result metadata for an 'inner' MBQL query based on the fields/breakouts/aggregations in the
@@ -701,8 +701,15 @@
 ;; TODO: Start recording the :ident of the inner column under a different key.
 ;; TODO: Use `:ident`s for matching up model metadata!
 (defn- merge-model-metadata
-  [query-metadata model-metadata card-entity-id]
-  (qp.util/combine-metadata query-metadata model-metadata))
+  [query-metadata model-metadata _card-entity-id]
+  (qp.util/combine-metadata query-metadata model-metadata)
+  ;; FIXME: Breadcrumbs during development.
+  #_(qp.util/combine-metadata
+     (for [{:keys [source name display_name] :as col} query-metadata]
+       (cond-> col
+         (and (= source :native)
+              (= name display_name)) (assoc :display_name (humanization/name->human-readable-name name))))
+     model-metadata))
 
 (defn- add-column-info-xform
   [query metadata rf]

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -536,14 +536,14 @@
 (defn- cols-for-source-query
   [{:keys [source-metadata source-query/entity-id]
     {native-source-query :native, :as source-query} :source-query}
-   {{:keys [card-entity-id]} :info, :as outer-query}
+   outer-query
    results]
-  (let [columns       (if native-source-query
-                        (maybe-merge-source-metadata
-                         source-metadata (column-info {:type :native
-                                                       :info {:card-entity-id entity-id}}
-                                                      results))
-                        (mbql-cols source-query outer-query results))]
+  (let [columns (if native-source-query
+                  (maybe-merge-source-metadata
+                   source-metadata (column-info {:type :native
+                                                 :info {:card-entity-id entity-id}}
+                                                results))
+                  (mbql-cols source-query outer-query results))]
     (qp.util/combine-metadata columns source-metadata)))
 
 (defn- idents-for-model

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -2,6 +2,7 @@
   "Middleware that adds default constraints to limit the maximum number of rows returned to queries that specify the
   `:add-default-userland-constraints?` `:middleware` option."
   (:require
+   [metabase.lib.core :as lib]
    [metabase.models.setting :as setting]
    [metabase.util.i18n :refer [deferred-tru]]))
 
@@ -66,6 +67,11 @@
   [query]
   (update query :constraints (comp ensure-valid-constraints merge-default-constraints)))
 
+(defn- add-card-entity-id
+  "Userland queries are always associated with a `:card-entity-id`. If one was not provided, generate a placeholder."
+  [query]
+  (assoc-in query [:info :card-entity-id] (lib/placeholder-card-entity-id-for-adhoc-query)))
+
 (defn- should-add-userland-constraints? [query]
   (and (get-in query [:middleware :userland-query?])
        (get-in query [:middleware :add-default-userland-constraints?])))
@@ -74,5 +80,8 @@
   "If the query is marked as requiring userland constraints, actually calculate the constraints and add them to the
   query."
   [query]
-  (cond-> query
-    (should-add-userland-constraints? query) add-constraints))
+  (let [userland? (should-add-userland-constraints? query)]
+    (cond-> query
+      userland?                                  add-constraints
+      (and userland?
+           (-> query :info :card-entity-id not)) add-card-entity-id)))

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -68,7 +68,7 @@
   (update query :constraints (comp ensure-valid-constraints merge-default-constraints)))
 
 (defn- add-card-entity-id
-  "Userland queries are always associated with a `:card-entity-id`. If one was not provided, generate a placeholder."
+  "Userland queries are always associated with a `:card-entity-id`, so e generate and add a placeholder when missing."
   [query]
   (assoc-in query [:info :card-entity-id] (lib/placeholder-card-entity-id-for-adhoc-query)))
 

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -122,7 +122,8 @@
                             ;; decide whether to "flow" the Card's metadata or not (whether to use it preferentially over
                             ;; the metadata associated with Fields themselves)
                             (assoc :qp/stage-had-source-card (:id card)
-                                   :source-query/model?      (= (:type card) :model))
+                                   :source-query/model?      (= (:type card) :model)
+                                   :source-query/entity-id   (:entity-id card))
                             (dissoc :source-card))]
       (into (vec card-stages) [stage']))))
 

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -46,9 +46,6 @@
    {card-id :id, :as card} :- ::lib.schema.metadata/card]
   (let [persisted-info (:lib/persisted-info card)
         persisted?     (qp.persisted/can-substitute? card persisted-info)]
-    (tap> [`normalize-card-query
-           'persisted-info persisted-info
-           'persisted?     persisted?])
     (when persisted?
       (log/infof "Found substitute cached query for card %s from %s.%s"
                  card-id

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -46,6 +46,9 @@
    {card-id :id, :as card} :- ::lib.schema.metadata/card]
   (let [persisted-info (:lib/persisted-info card)
         persisted?     (qp.persisted/can-substitute? card persisted-info)]
+    (tap> [`normalize-card-query
+           'persisted-info persisted-info
+           'persisted?     persisted?])
     (when persisted?
       (log/infof "Found substitute cached query for card %s from %s.%s"
                  card-id

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -10,7 +10,6 @@
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
-   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]}

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -10,6 +10,7 @@
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
@@ -50,7 +51,7 @@
   (mapv
    (fn [{final-base-type :base_type, :as final-col} {our-base-type :base_type, :as insights-col}]
      (merge
-      (select-keys final-col [:id :description :display_name :semantic_type :fk_target_field_id
+      (select-keys final-col [:id :ident :description :display_name :semantic_type :fk_target_field_id
                               :settings :field_ref :base_type :effective_type :database_type
                               :remapped_from :remapped_to :coercion_strategy :visibility_type
                               :was_binned])

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -608,8 +608,5 @@
              query             (-> query
                                    (assoc-in [:middleware :pivot-options] pivot-opts))
              all-queries       (generate-queries query pivot-opts)
-             dump (fn [q]
-                    (into [] (comp cat (map (juxt :name :ident))) [(lib/breakouts-metadata q)
-                                                                   (lib/aggregations-metadata q)]))
              column-mapping-fn (make-column-mapping-fn query)]
          (process-multiple-queries all-queries rff column-mapping-fn))))))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -608,5 +608,8 @@
              query             (-> query
                                    (assoc-in [:middleware :pivot-options] pivot-opts))
              all-queries       (generate-queries query pivot-opts)
+             dump (fn [q]
+                    (into [] (comp cat (map (juxt :name :ident))) [(lib/breakouts-metadata q)
+                                                                   (lib/aggregations-metadata q)]))
              column-mapping-fn (make-column-mapping-fn query)]
          (process-multiple-queries all-queries rff column-mapping-fn))))))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -207,12 +207,8 @@
     (for [{:keys [source] :as col} fresh]
       (if-let [existing (and (not= :aggregation source)
                              (get by-name (:name col)))]
-        (u/prog1 (merge col (select-keys existing preserved-keys))
-          #_(tap> (list `combine-metadata :fresh-run col :pre-existing existing '=>
-                        :fresh->final ^{:portal.viewer/default :portal.viewer/diff} [(into {} col) <>]
-                        :prev->final  ^{:portal.viewer/default :portal.viewer/diff} [existing <>])))
-        (u/prog1 col
-          #_(tap> (list `combine-metadata :no-existing <>)))))))
+        (merge col (select-keys existing preserved-keys))
+        col))))
 
 (def ^:dynamic *execute-async?*
   "Used to control `with-execute-async` to whether or not execute its body asynchronously."

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -207,8 +207,12 @@
     (for [{:keys [source] :as col} fresh]
       (if-let [existing (and (not= :aggregation source)
                              (get by-name (:name col)))]
-        (merge col (select-keys existing preserved-keys))
-        col))))
+        (u/prog1 (merge col (select-keys existing preserved-keys))
+          #_(tap> (list `combine-metadata :fresh-run col :pre-existing existing '=>
+                        :fresh->final ^{:portal.viewer/default :portal.viewer/diff} [(into {} col) <>]
+                        :prev->final  ^{:portal.viewer/default :portal.viewer/diff} [existing <>])))
+        (u/prog1 col
+          #_(tap> (list `combine-metadata :no-existing <>)))))))
 
 (def ^:dynamic *execute-async?*
   "Used to control `with-execute-async` to whether or not execute its body asynchronously."

--- a/src/metabase/util/i18n.cljs
+++ b/src/metabase/util/i18n.cljs
@@ -45,17 +45,3 @@
                        escape-format-string
                        (str/replace re-param-zero (str n)))
                    n)))
-
-(comment
-  (let [format-string    "Day"
-        format-string-pl "Days"
-        n 2]
-    (let [format-string-esc (escape-format-string format-string)
-          strings           (str/split format-string-esc re-param-zero)
-          strings           (if (= (count strings) 1)
-                              [format-string-esc ""]
-                              strings)
-          has-n?            (re-find #".*\{0\}.*" format-string-esc)
-
-          id (ttag/msgid (clj->js strings) (if has-n? n ""))]
-      (ttag/ngettext id format-string-pl n))))

--- a/src/metabase/util/i18n.cljs
+++ b/src/metabase/util/i18n.cljs
@@ -45,3 +45,17 @@
                        escape-format-string
                        (str/replace re-param-zero (str n)))
                    n)))
+
+(comment
+  (let [format-string    "Day"
+        format-string-pl "Days"
+        n 2]
+    (let [format-string-esc (escape-format-string format-string)
+          strings           (str/split format-string-esc re-param-zero)
+          strings           (if (= (count strings) 1)
+                              [format-string-esc ""]
+                              strings)
+          has-n?            (re-find #".*\{0\}.*" format-string-esc)
+
+          id (ttag/msgid (clj->js strings) (if has-n? n ""))]
+      (ttag/ngettext id format-string-pl n))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -4223,9 +4223,6 @@
         ;; First delete the existing root config because if that exists (shouldn't, but you know..)
         ;; with-temp will fail. This is imho simpler then checking whether that exists and based on the result of
         ;; the query either doing update or insert.
-        #_(t2/delete! :model/QueryCache)
-        ;; HACK: Adding the above fixes this query! Does the model keep getting assigned the same ID?
-        ;; Even if so, I think the card ID isn't the issue.
         (when existing-config
           (t2/delete! :model/CacheConfig :model_id 0 :model "root"))
         (mt/with-temp
@@ -4255,43 +4252,24 @@
                     (mt/user-http-request :rasta :put 200
                                           (str "card/" (:id model))
                                           {:result_metadata result_metadata}))]
-            ;; XXX: START HERE: This is failing inconsistently in my REPL... I'm suspicious that the query caching is
-            ;; enabled and it's remembering this query across test runs, returning incorrect metadata.
-            ;; I need to make sure in general that the query caching returns correctly annotated metadata - otherwise
-            ;; the caching is a way to cross the streams and mislabel things.
-            ;; That definitely needs thorough testing!
-            ;; Check the HACK above - that (t2/delete! :model/QueryCache) at the top fixes this partial test,
-            ;; which implies we're returning the metadata for other caches when we shouldn't be.
-            ;; But if that only applies because every run of the test gets a model with the same ID, I can see that.
-            ;; But otherwise it needs to matter to the query caching when we're querying (1) two different models that
-            ;; happen to have the same inner query; or (2) two different native queries with the same SQL etc.
-            (tap> [`initial-state model])
             (let [post-response (do (card-query-post-request)
                                     (card-query-post-request))
                   raw-results-metadata (get-in post-response [:data :results_metadata :columns])]
-              (tap> [`response post-response model])
-              #_#_(is (= nil (:entity_id post-response)))
-              (is (some? (-> raw-results-metadata
-                             first
-                             :ident
-                             (str/index-of (:entity_id post-response)))))
               (testing "Base: Initial query is cached (2nd post request's response)"
                 (is (some? (:cached post-response))))
-              ;; XXX: START HERE: This PUT is the one with the 500, but it's not clear what's actually wrong.
-              ;; Missing entity_id for an updated card that is a model, but none of those pieces are changing?
               (let [put-resonse (card-put-request (cons (assoc (first raw-results-metadata) :display_name "This is ID")
                                                         (rest raw-results-metadata)))]
                 (testing "Base: Put changes results_metadata successfully"
                   (is (= "This is ID"
                          (-> put-resonse :result_metadata first :display_name))))))
-            #_(testing "Card request not cached. Preceding post successfully invalidated the cache."
+            (testing "Card request not cached. Preceding post successfully invalidated the cache."
               (let [post-response (card-query-post-request)
                     id-display-name (-> post-response :data :results_metadata :columns first :display_name)]
                 (testing "Cache is NOT being used, cache was invalidated"
                   (is (nil? (:cached post-response))))
                 (testing "Metadata edit persists"
                   (is (= "This is ID" id-display-name)))))
-            #_(testing "Last post request cached the query successfully"
+            (testing "Last post request cached the query successfully"
               (let [post-response (card-query-post-request)
                     id-display-name (-> post-response :data :results_metadata :columns first :display_name)]
                 (testing "Cache is being used."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -29,7 +29,6 @@
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.util :as perms.u]
-   [metabase.query-processor :as qp]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
@@ -922,8 +921,8 @@
                                             (merge (mt/with-temp-defaults :model/Card)
                                                    {:dataset_query query})))))
             (let [card     (mt/card-with-metadata
-                             (merge (mt/with-temp-defaults :model/Card)
-                                    {:dataset_query query}))
+                            (merge (mt/with-temp-defaults :model/Card)
+                                   {:dataset_query query}))
                   metadata (:result_metadata card)]
               (testing (format "with result metadata\n%s" (u/pprint-to-str metadata))
                 (is (some? metadata))
@@ -2847,13 +2846,9 @@
     (let [query          (mt/mbql-query venues {:fields [$id $name]})
           modified-query (mt/mbql-query venues {:fields [$id $name $price]})
           norm           (comp u/upper-case-en :name)
-          to-native      (fn [q]
-                           {:database (:database q)
-                            :type     :native
-                            :native   (qp.compile/compile q)})
-          update-card!  (fn [card]
-                          (mt/user-http-request :crowberto :put 200
-                                                (str "card/" (u/the-id card)) card))]
+          update-card!   (fn [card]
+                           (mt/user-http-request :crowberto :put 200
+                                                 (str "card/" (u/the-id card)) card))]
       (doseq [[query-type query modified-query] [["mbql"   query modified-query]
                                                  #_["native" (to-native query) (to-native modified-query)]]]
         (testing (str "For: " query-type)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4904,19 +4904,19 @@
                                              :id        "p3"
                                              :type      "text"}]}
      :model/Card          c1  (mt/card-with-updated-metadata
-                                {:name          "C1"
-                                 :type          :model
-                                 :dataset_query (mt/native-query {:query "select * from people"})}
-                                (fn [{col-name :name :as meta} _card]
-                                  ;; Map model's metadata to corresponding field id
-                                  (assoc meta :id  (mt/id :people (keyword (u/lower-case-en col-name))))))
+                               {:name          "C1"
+                                :type          :model
+                                :dataset_query (mt/native-query {:query "select * from people"})}
+                               (fn [{col-name :name :as meta} _card]
+                                 ;; Map model's metadata to corresponding field id
+                                 (assoc meta :id  (mt/id :people (keyword (u/lower-case-en col-name))))))
 
      :model/Card          c2 (let [query (mt/mbql-query nil
                                            {:source-table (str "card__" (:id c1))
                                             :aggregation [[:distinct [:field "STATE" {:base-type :type/Text}]]]})]
                                (mt/card-with-metadata
-                                 {:name "C2"
-                                  :dataset_query query}))
+                                {:name "C2"
+                                 :dataset_query query}))
      :model/DashboardCard _dc1 {:dashboard_id       (:id d)
                                 :card_id            (:id c2)
                                 :parameter_mappings

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3092,13 +3092,13 @@
                                                                  :dataset_query (mt/native-query
                                                                                   {:query "SELECT category FROM products LIMIT 10;"})
                                                                  :type          :model}]
-        (let [metadata (-> (qp/process-query (:dataset_query native-card))
-                           :data :results_metadata :columns)]
+        (let [metadata (-> (:dataset_query native-card)
+                           (assoc-in [:info :card-entity-id] (:entity_id native-card))
+                           qp/process-query :data :results_metadata :columns)]
           (is (seq metadata) "Did not get metadata")
           (t2/update! 'Card {:id model-id}
-                      {:result_metadata (json/encode
-                                         (assoc-in metadata [0 :id]
-                                                   (mt/id :products :category)))}))
+                      {:result_metadata (assoc-in metadata [0 :id]
+                                                  (mt/id :products :category))}))
         ;; ...so instead we create a question on top of this model (note that
         ;; metadata must be present on the model) and use the question on the
         ;; dashboard.
@@ -4903,28 +4903,20 @@
                                              :slug      "p3"
                                              :id        "p3"
                                              :type      "text"}]}
-     :model/Card          c1  (let [query {:database (mt/id)
-                                           :type     :native
-                                           :native   {:query "select * from people"}}]
-                                {:name "C1"
-                                 :type :model
-                                 :database_id (mt/id)
-                                 :dataset_query query
-                                 :result_metadata
-                                 (mapv (fn [{col-name :name :as meta}]
-                                         ;; Map model's metadata to corresponding field id
-                                         (assoc meta :id  (mt/id :people (keyword (u/lower-case-en col-name)))))
-                                       (-> (qp/process-query query)
-                                           :data :results_metadata :columns))})
+     :model/Card          c1  (mt/card-with-updated-metadata
+                                {:name          "C1"
+                                 :type          :model
+                                 :dataset_query (mt/native-query {:query "select * from people"})}
+                                (fn [{col-name :name :as meta} _card]
+                                  ;; Map model's metadata to corresponding field id
+                                  (assoc meta :id  (mt/id :people (keyword (u/lower-case-en col-name))))))
 
      :model/Card          c2 (let [query (mt/mbql-query nil
                                            {:source-table (str "card__" (:id c1))
                                             :aggregation [[:distinct [:field "STATE" {:base-type :type/Text}]]]})]
-                               {:name "C2"
-                                :database_id (mt/id)
-                                :dataset_query query
-                                :result_metadata (-> (qp/process-query query)
-                                                     :data :results_metadata :columns)})
+                               (mt/card-with-metadata
+                                 {:name "C2"
+                                  :dataset_query query}))
      :model/DashboardCard _dc1 {:dashboard_id       (:id d)
                                 :card_id            (:id c2)
                                 :parameter_mappings

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1133,11 +1133,11 @@
 (deftest ^:parallel db-metadata-saved-questions-db-test
   (testing "GET /api/database/:id/metadata works for the Saved Questions 'virtual' database"
     (mt/with-temp [:model/Card card (card-with-native-query
-                                      "Birthday Card"
-                                      :entity_id       "M6W4CLdyJxiW-DyzDbGl4"
-                                      :result_metadata [{:name "age_in_bird_years"
-                                                         :ident (lib/native-ident "age_in_bird_years"
-                                                                                  "M6W4CLdyJxiW-DyzDbGl4")}])]
+                                     "Birthday Card"
+                                     :entity_id       "M6W4CLdyJxiW-DyzDbGl4"
+                                     :result_metadata [{:name "age_in_bird_years"
+                                                        :ident (lib/native-ident "age_in_bird_years"
+                                                                                 "M6W4CLdyJxiW-DyzDbGl4")}])]
       (let [response (mt/user-http-request :crowberto :get 200
                                            (format "database/%d/metadata" lib.schema.id/saved-questions-virtual-database-id))]
         (is (malli= SavedQuestionsDB
@@ -1864,9 +1864,9 @@
 (deftest get-schema-tables-unreadable-metrics-are-not-returned-test
   (mt/with-temp [:model/Collection model-coll   {:name "Model Collection"}
                  :model/Card       card         (card-with-native-query
-                                                  "Card 1"
-                                                  :collection_id (:id model-coll)
-                                                  :type :model)
+                                                 "Card 1"
+                                                 :collection_id (:id model-coll)
+                                                 :type :model)
                  :model/Collection metric-coll {:name "Metric Collection"}
                  :model/Card       metric      {:type          :metric
                                                 :name          "Metric"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -14,6 +14,7 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.util :as driver.u]
    [metabase.http-client :as client]
+   [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.audit-log :as audit-log]
    [metabase.models.secret :as secret]
@@ -1131,8 +1132,12 @@
 
 (deftest ^:parallel db-metadata-saved-questions-db-test
   (testing "GET /api/database/:id/metadata works for the Saved Questions 'virtual' database"
-    (mt/with-temp [:model/Card card (assoc (card-with-native-query "Birthday Card")
-                                           :result_metadata [{:name "age_in_bird_years"}])]
+    (mt/with-temp [:model/Card card (card-with-native-query
+                                      "Birthday Card"
+                                      :entity_id       "M6W4CLdyJxiW-DyzDbGl4"
+                                      :result_metadata [{:name "age_in_bird_years"
+                                                         :ident (lib/native-ident "age_in_bird_years"
+                                                                                  "M6W4CLdyJxiW-DyzDbGl4")}])]
       (let [response (mt/user-http-request :crowberto :get 200
                                            (format "database/%d/metadata" lib.schema.id/saved-questions-virtual-database-id))]
         (is (malli= SavedQuestionsDB
@@ -1143,6 +1148,7 @@
                 :fields [{:name                     "age_in_bird_years"
                           :table_id                 (str "card__" (u/the-id card))
                           :id                       ["field" "age_in_bird_years" {:base-type "type/*"}]
+                          :ident                    (lib/native-ident "age_in_bird_years" "M6W4CLdyJxiW-DyzDbGl4")
                           :semantic_type            nil
                           :base_type                nil
                           :default_dimension_option nil
@@ -1857,9 +1863,10 @@
 
 (deftest get-schema-tables-unreadable-metrics-are-not-returned-test
   (mt/with-temp [:model/Collection model-coll   {:name "Model Collection"}
-                 :model/Card       card         (assoc (card-with-native-query "Card 1")
-                                                       :collection_id (:id model-coll)
-                                                       :type :model)
+                 :model/Card       card         (card-with-native-query
+                                                  "Card 1"
+                                                  :collection_id (:id model-coll)
+                                                  :type :model)
                  :model/Collection metric-coll {:name "Metric Collection"}
                  :model/Card       metric      {:type          :metric
                                                 :name          "Metric"
@@ -1869,6 +1876,8 @@
                                                                 :database (mt/id)
                                                                 :query    {:source-table (str "card__" (:id card))
                                                                            :aggregation  [[:count]]}}}]
+    (is (=? nil (:result_metadata card)))
+    (is (=? nil (:result_metadata (t2/select-one :model/Card :id (:id card)))))
     (is (=? {:status "completed"}
             (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
     (let [virtual-table {:id           (format "card__%d" (:id card))

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -15,7 +15,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
-   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util :as lib.util]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -228,37 +227,6 @@
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
             (do-test)))))))
 
-(comment
-  (let [short-col-name "coun"
-          long-col-name  "Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count"
-
-          ;; Lightly validate the native form that comes back. Resist the urge to check for exact equality.
-          validate-native-form (fn [native-form-lines]
-                                 (and (some #(str/includes? % short-col-name) native-form-lines)
-                                      (some #(str/includes? % long-col-name) native-form-lines)))
-
-          ;; Disable truncate-alias when compiling the native query to ensure we don't truncate the column.
-          ;; We want to simulate a user-defined query where the column name is long, but valid for the driver.
-          native-sub-query (with-redefs [lib.util/truncate-alias
-                                         (fn mock-truncate-alias
-                                           [ss & _] ss)]
-                             (-> (mt/mbql-query people
-                                   {:source-table $$people
-                                    :aggregation  [[:aggregation-options [:count] {:name short-col-name}]]
-                                    :breakout     [[:field %state {:name long-col-name}]]
-                                    :limit        5})
-                                 qp.compile/compile
-                                 :query))
-          _ (clojure.pprint/pprint native-sub-query)
-
-          native-query (mt/native-query {:query native-sub-query})
-
-          ;; Let metadata-provider-with-cards-with-metadata-for-queries calculate the result-metadata.
-          metadata-provider (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries [native-query])]
-    (lib.metadata/card metadata-provider 1)
-    )
-  )
-
 (deftest native-query-with-long-column-alias
   (testing "nested native query with long column alias (metabase#47584)"
     (let [short-col-name "coun"
@@ -285,8 +253,7 @@
 
           ;; Let metadata-provider-with-cards-with-metadata-for-queries calculate the result-metadata.
           metadata-provider (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries [native-query])
-          metadata-card     (lib.metadata/card metadata-provider 1)
-          ]
+          metadata-card     (lib.metadata/card metadata-provider 1)]
       (mt/with-temp
         [:model/Card card {:dataset_query native-query
                            :entity_id       (:entity-id metadata-card)

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -1061,6 +1061,7 @@
                                                                     :field_ref          [:field (mt/id :orders :subtotal) nil]
                                                                     :effective_type     :type/Float
                                                                     :id                 (mt/id :orders :subtotal)
+                                                                    :ident              (mt/ident :orders :subtotal)
                                                                     :visibility_type    :normal
                                                                     :display_name       "Subtotal"
                                                                     :base_type          :type/Float}]}]

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -10,6 +10,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.events :as events]
    [metabase.http-client :as client]
+   [metabase.lib.core :as lib]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
@@ -724,6 +725,7 @@
                                               :database_type  "CHARACTER VARYING"
                                               :semantic_type  "type/Name"
                                               :fingerprint    (name->fingerprint :name)
+                                              :ident          (lib/native-ident "NAME" (:entity_id card))
                                               :field_ref      ["field" "NAME" {:base-type "type/Text"}]}
                                              {:name           "ID"
                                               :display_name   "ID"
@@ -732,6 +734,7 @@
                                               :database_type  "BIGINT"
                                               :semantic_type  nil
                                               :fingerprint    (name->fingerprint :id)
+                                              :ident          (lib/native-ident "ID" (:entity_id card))
                                               :field_ref      ["field" "ID" {:base-type "type/BigInteger"}]}
                                              (with-numeric-dimension-options
                                                {:name           "PRICE"
@@ -741,6 +744,7 @@
                                                 :database_type  "INTEGER"
                                                 :semantic_type  nil
                                                 :fingerprint    (name->fingerprint :price)
+                                                :ident          (lib/native-ident "PRICE" (:entity_id card))
                                                 :field_ref      ["field" "PRICE" {:base-type "type/Integer"}]})
                                              (with-coordinate-dimension-options
                                                {:name           "LATITUDE"
@@ -750,6 +754,7 @@
                                                 :database_type  "DOUBLE PRECISION"
                                                 :semantic_type  "type/Latitude"
                                                 :fingerprint    (name->fingerprint :latitude)
+                                                :ident          (lib/native-ident "LATITUDE" (:entity_id card))
                                                 :field_ref      ["field" "LATITUDE" {:base-type "type/Float"}]})]))})
                (->> card
                     u/the-id
@@ -807,6 +812,7 @@
                                          :database_type            "CHARACTER VARYING"
                                          :table_id                 card-virtual-table-id
                                          :id                       ["field" "NAME" {:base-type "type/Text"}]
+                                         :ident                    (lib/native-ident "NAME" (:entity_id card))
                                          :semantic_type            "type/Name"
                                          :default_dimension_option nil
                                          :dimension_options        []
@@ -819,6 +825,7 @@
                                          :database_type            "TIMESTAMP"
                                          :table_id                 card-virtual-table-id
                                          :id                       ["field" "LAST_LOGIN" {:base-type "type/DateTime"}]
+                                         :ident                    (lib/native-ident "LAST_LOGIN" (:entity_id card))
                                          :semantic_type            nil
                                          :default_dimension_option (var-get #'api.table/datetime-default-index)
                                          :dimension_options        (var-get #'api.table/datetime-dimension-indexes)

--- a/test/metabase/channel/render/card_test.clj
+++ b/test/metabase/channel/render/card_test.clj
@@ -6,6 +6,7 @@
    [hickory.select :as hik.s]
    [metabase.channel.render.card :as channel.render.card]
    [metabase.channel.render.core :as channel.render]
+   [metabase.lib.core :as lib]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.pulse.render.test-util :as render.tu]
    [metabase.query-processor :as qp]
@@ -206,31 +207,41 @@
 (deftest ^:parallel table-rendering-of-percent-types-test
   (testing "If a column is marked as a :type/Percentage semantic type it should render as a percent"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card {base-card-id :id} {:dataset_query {:database (mt/id)
-                                                                     :type     :query
-                                                                     :query    {:source-table (mt/id :orders)
-                                                                                :expressions  {"Tax Rate" [:/
-                                                                                                           [:field (mt/id :orders :tax) {:base-type :type/Float}]
-                                                                                                           [:field (mt/id :orders :total) {:base-type :type/Float}]]},
-                                                                                :fields       [[:field (mt/id :orders :tax) {:base-type :type/Float}]
-                                                                                               [:field (mt/id :orders :total) {:base-type :type/Float}]
-                                                                                               [:expression "Tax Rate"]]
-                                                                                :limit        10}}}
+      (mt/with-temp [:model/Card {base-card-id :id
+                                  base-query :dataset_query} {:dataset_query
+                                                              {:database (mt/id)
+                                                               :type     :query
+                                                               :query    {:source-table (mt/id :orders)
+                                                                          :expressions  {"Tax Rate" [:/
+                                                                                                     [:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                                                                                     [:field (mt/id :orders :total) {:base-type :type/Float}]]},
+                                                                          :fields       [[:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                                                                         [:field (mt/id :orders :total) {:base-type :type/Float}]
+                                                                                         [:expression "Tax Rate"]]
+                                                                          :limit        10}}}
                      :model/Card {model-card-id  :id
                                   model-query    :dataset_query
                                   model-metadata :result_metadata
                                   :as            model-card} {:type            :model
+                                                              :entity_id       "zQ1h5VDeOchxwMDYSK7om"
                                                               :dataset_query   {:type     :query
                                                                                 :database (mt/id)
                                                                                 :query    {:source-table (format "card__%s" base-card-id)}}
                                                               :result_metadata [{:name         "TAX"
                                                                                  :display_name "Tax"
+                                                                                 :ident        (lib/model-ident (mt/ident :orders :tax)
+                                                                                                                "zQ1h5VDeOchxwMDYSK7om")
                                                                                  :base_type    :type/Float}
                                                                                 {:name         "TOTAL"
                                                                                  :display_name "Total"
+                                                                                 :ident        (lib/model-ident (mt/ident :orders :total)
+                                                                                                                "zQ1h5VDeOchxwMDYSK7om")
                                                                                  :base_type    :type/Float}
                                                                                 {:name          "Tax Rate"
                                                                                  :display_name  "Tax Rate"
+                                                                                 :ident         (-> base-query
+                                                                                                    (get-in [:query :expression-idents "Tax Rate"])
+                                                                                                    (lib/model-ident "zQ1h5VDeOchxwMDYSK7om"))
                                                                                  :base_type     :type/Float
                                                                                  :semantic_type :type/Percentage
                                                                                  :field_ref     [:field "Tax Rate" {:base-type :type/Float}]}]}

--- a/test/metabase/channel/render/card_test.clj
+++ b/test/metabase/channel/render/card_test.clj
@@ -207,72 +207,73 @@
 (deftest ^:parallel table-rendering-of-percent-types-test
   (testing "If a column is marked as a :type/Percentage semantic type it should render as a percent"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card {base-card-id :id
-                                  base-query :dataset_query} {:dataset_query
-                                                              {:database (mt/id)
-                                                               :type     :query
-                                                               :query    {:source-table (mt/id :orders)
-                                                                          :expressions  {"Tax Rate" [:/
-                                                                                                     [:field (mt/id :orders :tax) {:base-type :type/Float}]
-                                                                                                     [:field (mt/id :orders :total) {:base-type :type/Float}]]},
-                                                                          :fields       [[:field (mt/id :orders :tax) {:base-type :type/Float}]
-                                                                                         [:field (mt/id :orders :total) {:base-type :type/Float}]
-                                                                                         [:expression "Tax Rate"]]
-                                                                          :limit        10}}}
-                     :model/Card {model-card-id  :id
-                                  model-query    :dataset_query
-                                  model-metadata :result_metadata
-                                  :as            model-card} {:type            :model
-                                                              :entity_id       "zQ1h5VDeOchxwMDYSK7om"
-                                                              :dataset_query   {:type     :query
-                                                                                :database (mt/id)
-                                                                                :query    {:source-table (format "card__%s" base-card-id)}}
-                                                              :result_metadata [{:name         "TAX"
-                                                                                 :display_name "Tax"
-                                                                                 :ident        (lib/model-ident (mt/ident :orders :tax)
-                                                                                                                "zQ1h5VDeOchxwMDYSK7om")
-                                                                                 :base_type    :type/Float}
-                                                                                {:name         "TOTAL"
-                                                                                 :display_name "Total"
-                                                                                 :ident        (lib/model-ident (mt/ident :orders :total)
-                                                                                                                "zQ1h5VDeOchxwMDYSK7om")
-                                                                                 :base_type    :type/Float}
-                                                                                {:name          "Tax Rate"
-                                                                                 :display_name  "Tax Rate"
-                                                                                 :ident         (-> base-query
-                                                                                                    (get-in [:query :expression-idents "Tax Rate"])
-                                                                                                    (lib/model-ident "zQ1h5VDeOchxwMDYSK7om"))
-                                                                                 :base_type     :type/Float
-                                                                                 :semantic_type :type/Percentage
-                                                                                 :field_ref     [:field "Tax Rate" {:base-type :type/Float}]}]}
-                     :model/Card {question-query :dataset_query
-                                  :as            question-card} {:dataset_query {:type     :query
-                                                                                 :database (mt/id)
-                                                                                 :query    {:source-table (format "card__%s" model-card-id)}}}]
+      (let [card-eid (u/generate-nano-id)]
+        (mt/with-temp [:model/Card {base-card-id :id
+                                    base-query :dataset_query} {:dataset_query
+                                                                {:database (mt/id)
+                                                                 :type     :query
+                                                                 :query    {:source-table (mt/id :orders)
+                                                                            :expressions  {"Tax Rate" [:/
+                                                                                                       [:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                                                                                       [:field (mt/id :orders :total) {:base-type :type/Float}]]},
+                                                                            :fields       [[:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                                                                           [:field (mt/id :orders :total) {:base-type :type/Float}]
+                                                                                           [:expression "Tax Rate"]]
+                                                                            :limit        10}}}
+                       :model/Card {model-card-id  :id
+                                    model-query    :dataset_query
+                                    model-metadata :result_metadata
+                                    :as            model-card} {:type            :model
+                                                                :entity_id       card-eid
+                                                                :dataset_query   {:type     :query
+                                                                                  :database (mt/id)
+                                                                                  :query    {:source-table (format "card__%s" base-card-id)}}
+                                                                :result_metadata [{:name         "TAX"
+                                                                                   :display_name "Tax"
+                                                                                   :ident        (lib/model-ident (mt/ident :orders :tax)
+                                                                                                                  card-eid)
+                                                                                   :base_type    :type/Float}
+                                                                                  {:name         "TOTAL"
+                                                                                   :display_name "Total"
+                                                                                   :ident        (lib/model-ident (mt/ident :orders :total)
+                                                                                                                  card-eid)
+                                                                                   :base_type    :type/Float}
+                                                                                  {:name          "Tax Rate"
+                                                                                   :display_name  "Tax Rate"
+                                                                                   :ident         (-> base-query
+                                                                                                      (get-in [:query :expression-idents "Tax Rate"])
+                                                                                                      (lib/model-ident card-eid))
+                                                                                   :base_type     :type/Float
+                                                                                   :semantic_type :type/Percentage
+                                                                                   :field_ref     [:field "Tax Rate" {:base-type :type/Float}]}]}
+                       :model/Card {question-query :dataset_query
+                                    :as            question-card} {:dataset_query {:type     :query
+                                                                                   :database (mt/id)
+                                                                                   :query    {:source-table (format "card__%s" model-card-id)}}}]
         ;; NOTE -- The logic in metabase.formatter/number-formatter renders values between 1 and 100 as an
         ;; integer value. IDK if this is what we want long term, but this captures the current logic. If we do extend
         ;; the significant digits in the formatter, we'll need to modify this test as well.
-        (letfn [(create-comparison-results [query-results card]
-                  (let [expected      (mapv (fn [row]
-                                              (format "%.2f%%" (* 100 (peek row))))
-                                            (get-in query-results [:data :rows]))
-                        rendered-card (channel.render/render-pulse-card :inline (channel.render/defaulted-timezone card) card nil query-results)
-                        doc           (hiccup->hickory (:content rendered-card))
-                        rows          (hik.s/select (hik.s/tag :tr) doc)
-                        tax-rate-col  2]
-                    {:expected expected
-                     :actual   (mapcat (fn [row]
-                                         (:content (nth row tax-rate-col)))
-                                       (map :content (rest rows)))}))]
-          (testing "To apply the custom metadata to a model, you must explicitly pass the result metadata"
-            (let [query-results (qp/process-query
-                                 (assoc-in model-query [:info :metadata/model-metadata] model-metadata))
-                  {:keys [expected actual]} (create-comparison-results query-results model-card)]
-              (is (= expected actual))))
-          (testing "A question based on a model will use the underlying model's metadata"
-            (let [query-results (qp/process-query question-query)
-                  {:keys [expected actual]} (create-comparison-results query-results question-card)]
-              (is (= expected actual)))))))))
+          (letfn [(create-comparison-results [query-results card]
+                    (let [expected      (mapv (fn [row]
+                                                (format "%.2f%%" (* 100 (peek row))))
+                                              (get-in query-results [:data :rows]))
+                          rendered-card (channel.render/render-pulse-card :inline (channel.render/defaulted-timezone card) card nil query-results)
+                          doc           (hiccup->hickory (:content rendered-card))
+                          rows          (hik.s/select (hik.s/tag :tr) doc)
+                          tax-rate-col  2]
+                      {:expected expected
+                       :actual   (mapcat (fn [row]
+                                           (:content (nth row tax-rate-col)))
+                                         (map :content (rest rows)))}))]
+            (testing "To apply the custom metadata to a model, you must explicitly pass the result metadata"
+              (let [query-results (qp/process-query
+                                   (assoc-in model-query [:info :metadata/model-metadata] model-metadata))
+                    {:keys [expected actual]} (create-comparison-results query-results model-card)]
+                (is (= expected actual))))
+            (testing "A question based on a model will use the underlying model's metadata"
+              (let [query-results (qp/process-query question-query)
+                    {:keys [expected actual]} (create-comparison-results query-results question-card)]
+                (is (= expected actual))))))))))
 
 (deftest title-should-be-an-a-tag-test
   (testing "the title of the card should be an <a> tag so you can click on title using old outlook clients (#12901)"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1045,33 +1045,35 @@
     (do-with-enums-db!
      (fn [enums-db]
        (mt/with-db enums-db
-         (let [query {:database (mt/id)
-                      :type :native
-                      :native {:query "select * from birds"
-                               :parameters []}}]
+         (let [eid   (u/generate-nano-id)
+               query {:database (mt/id)
+                      :type     :native
+                      :info     {:card-entity-id eid}
+                      :native   {:query "select * from birds"
+                                 :parameters []}}]
            (testing "results_metadata columns are correctly typed"
-             (is (=? [{:name "name"}
+             (is (=? [{:name  "name"
+                       :ident (lib/native-ident "name" eid)}
                       {:name "status"
+                       :ident (lib/native-ident "status" eid)
                        :base_type :type/PostgresEnum
                        :effective_type :type/PostgresEnum
                        :database_type "bird_status"}
                       {:name "other_status"
+                       :ident (lib/native-ident "other_status" eid)
                        :base_type :type/PostgresEnum
                        :effective_type :type/PostgresEnum
                        :database_type "\"bird_schema\".\"bird_status\""}
                       {:name "type"
+                       :ident (lib/native-ident "type" eid)
                        :base_type :type/PostgresEnum
                        :effective_type :type/PostgresEnum
                        :database_type "bird type"}]
                      (-> (qp/process-query query) :data :results_metadata :columns)))
-             (doseq [card-type [:question :model]]
+             (doseq [card-type [:question #_:model]]
                (mt/with-temp
-                 [:model/Card
-                  {id :id}
-                  (assoc {:dataset_query query
-                          :result_metadata (-> (qp/process-query query) :data :results_metadata :columns)
-                          :type :model}
-                         :type card-type)]
+                 [:model/Card {id :id} (mt/card-with-metadata {:dataset_query query
+                                                               :type          card-type})]
                  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
                        query (as-> (lib/query mp (lib.metadata/card mp id)) $
                                (lib/filter $ (lib/= (m/find-first (comp #{"status"} :name)

--- a/test/metabase/lib/drill_thru/column_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/column_filter_test.cljc
@@ -253,45 +253,48 @@
 
 (deftest ^:parallel native-models-with-renamed-columns-test
   (testing "Generate sane queries for native query models with renamed columns (#22715 #36583)"
-    (let [metadata-provider (lib.tu/mock-metadata-provider
-                             meta/metadata-provider
-                             {:cards [{:name                   "Card 5"
-                                       :result-metadata        [{:description        "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens."
-                                                                 :semantic_type      :type/PK
-                                                                 :name               "ID"
-                                                                 :settings           nil
-                                                                 :fk_target_field_id nil
-                                                                 :field_ref          [:field "ID" {:base-type :type/Integer}]
-                                                                 :effective_type     :type/Integer
-                                                                 :id                 (meta/id :orders :id)
-                                                                 :visibility_type    :normal
-                                                                 :display_name       "ID"
-                                                                 :fingerprint        nil
-                                                                 :base_type          :type/Integer}
-                                                                {:description        "The date and time an order was submitted."
-                                                                 :semantic_type      :type/CreationTimestamp
-                                                                 :name               "ALIAS_CREATED_AT"
-                                                                 :settings           nil
-                                                                 :fk_target_field_id nil
-                                                                 :field_ref          [:field "ALIAS_CREATED_AT" {:base-type :type/DateTime}]
-                                                                 :effective_type     :type/DateTime
-                                                                 :id                 (meta/id :orders :created-at)
-                                                                 :visibility_type    :normal
-                                                                 :display_name       "Created At"
-                                                                 :fingerprint        {:global {:distinct-count 1, :nil% 0.0}
-                                                                                      :type   #:type{:DateTime {:earliest "2023-12-08T23:49:58.310952Z", :latest "2023-12-08T23:49:58.310952Z"}}}
-                                                                 :base_type          :type/DateTime}]
-                                       :database-id            (meta/id)
-                                       :query-type             :native
-                                       :dataset-query          {:database (meta/id)
-                                                                :native   {:query "select 1 as \"ID\", current_timestamp::datetime as \"ALIAS_CREATED_AT\"", :template-tags {}}
-                                                                :type     :native}
-                                       :id                     5
-                                       :parameter-mappings     []
-                                       :display                :table
-                                       :visualization-settings {:table.pivot_column "ID", :table.cell_column "ALIAS_CREATED_AT"}
-                                       :parameters             []
-                                       :type                   :model}]})
+    (let [card-eid          (lib/random-ident)
+          metadata-provider (-> {:name                   "Card 5"
+                                 :result-metadata        [{:description        "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens."
+                                                           :semantic_type      :type/PK
+                                                           :name               "ID"
+                                                           :ident              (lib/native-ident "ID" card-eid)
+                                                           :settings           nil
+                                                           :fk_target_field_id nil
+                                                           :field_ref          [:field "ID" {:base-type :type/Integer}]
+                                                           :effective_type     :type/Integer
+                                                           :id                 (meta/id :orders :id)
+                                                           :visibility_type    :normal
+                                                           :display_name       "ID"
+                                                           :fingerprint        nil
+                                                           :base_type          :type/Integer}
+                                                          {:description        "The date and time an order was submitted."
+                                                           :semantic_type      :type/CreationTimestamp
+                                                           :name               "ALIAS_CREATED_AT"
+                                                           :ident              (lib/native-ident "ALIAS_CREATED_AT" card-eid)
+                                                           :settings           nil
+                                                           :fk_target_field_id nil
+                                                           :field_ref          [:field "ALIAS_CREATED_AT" {:base-type :type/DateTime}]
+                                                           :effective_type     :type/DateTime
+                                                           :id                 (meta/id :orders :created-at)
+                                                           :visibility_type    :normal
+                                                           :display_name       "Created At"
+                                                           :fingerprint        {:global {:distinct-count 1, :nil% 0.0}
+                                                                                :type   #:type{:DateTime {:earliest "2023-12-08T23:49:58.310952Z", :latest "2023-12-08T23:49:58.310952Z"}}}
+                                                           :base_type          :type/DateTime}]
+                                 :database-id            (meta/id)
+                                 :query-type             :native
+                                 :dataset-query          {:database (meta/id)
+                                                          :native   {:query "select 1 as \"ID\", current_timestamp::datetime as \"ALIAS_CREATED_AT\"", :template-tags {}}
+                                                          :type     :native}
+                                 :id                     5
+                                 :entity-id              card-eid
+                                 :parameter-mappings     []
+                                 :display                :table
+                                 :visualization-settings {:table.pivot_column "ID", :table.cell_column "ALIAS_CREATED_AT"}
+                                 :parameters             []}
+                                lib.tu/as-model
+                                lib.tu/metadata-provider-with-mock-card)
           query             (lib/query metadata-provider (lib.metadata/card metadata-provider 5))
           _                 (is (=? {:stages [{:lib/type :mbql.stage/mbql, :source-card 5}]}
                                     query))

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1029,6 +1029,10 @@
           contact-f-organization-id 130
           account-card-id 1000
           contact-card-id 1100
+
+          account-f-ident              (lib/random-ident)
+          contact-f-organization-ident (lib/random-ident)
+
           metadata-provider (lib.tu/mock-metadata-provider
                              {:database meta/database
                               :tables   [{:id   account-tab-id
@@ -1039,50 +1043,56 @@
                                           :name "contact"}]
                               :fields   [{:id account-f-id
                                           :name "account__id"
+                                          :ident account-f-ident
                                           :table-id account-tab-id
                                           :base-type :type/Integer}
                                          {:id organization-f-id
                                           :name "organization__id"
+                                          :ident (lib/random-ident)
                                           :table-id organization-tab-id
                                           :base-type :type/Integer}
                                          {:id organization-f-account-id
                                           :name "organization__account_id"
+                                          :ident (lib/random-ident)
                                           :table-id organization-tab-id
                                           :base-type :type/Integer
                                           :semantic-type :type/FK
                                           :fk-target-field-id account-f-id}
                                          {:id contact-f-organization-id
                                           :name "contact__organization_id"
+                                          :ident contact-f-organization-ident
                                           :table-id contact-tab-id
                                           :base-type :type/Integer
                                           :semantic-type :type/FK
                                           :fk-target-field-id organization-f-id}]
-                              :cards [{:id account-card-id
-                                       :name "Account Model"
-                                       :type :model
-                                       :lib/type :metadata/card
-                                       :database-id (:id meta/database)
-                                       :result-metadata [{:id account-f-id
-                                                          :name "account__id"
-                                                          :table-id account-tab-id
-                                                          :base-type :type/Integer}]
-                                       :dataset-query {:lib/type :mbql.stage/mbql
-                                                       :database (:id meta/database)
-                                                       :source-table account-tab-id}}
-                                      {:id contact-card-id
-                                       :name "Contact Model"
-                                       :type :model
-                                       :lib/type :metadata/card
-                                       :database-id (:id meta/database)
-                                       :result-metadata [{:id contact-f-organization-id
-                                                          :name "contact__organization_id"
-                                                          :table-id contact-tab-id
-                                                          :base-type :type/Integer
-                                                          :semantic-type :type/FK
-                                                          :fk-target-field-id organization-f-id}]
-                                       :dataset-query {:lib/type :mbql.stage/mbql
-                                                       :database (:id meta/database)
-                                                       :source-table contact-tab-id}}]})
+                              :cards [(lib.tu/as-model
+                                       {:id account-card-id
+                                        :name "Account Model"
+                                        :lib/type :metadata/card
+                                        :database-id (:id meta/database)
+                                        :result-metadata [{:id account-f-id
+                                                           :name "account__id"
+                                                           :ident account-f-ident
+                                                           :table-id account-tab-id
+                                                           :base-type :type/Integer}]
+                                        :dataset-query {:lib/type :mbql.stage/mbql
+                                                        :database (:id meta/database)
+                                                        :source-table account-tab-id}})
+                                      (lib.tu/as-model
+                                       {:id contact-card-id
+                                        :name "Contact Model"
+                                        :lib/type :metadata/card
+                                        :database-id (:id meta/database)
+                                        :result-metadata [{:id contact-f-organization-id
+                                                           :name "contact__organization_id"
+                                                           :ident contact-f-organization-ident
+                                                           :table-id contact-tab-id
+                                                           :base-type :type/Integer
+                                                           :semantic-type :type/FK
+                                                           :fk-target-field-id organization-f-id}]
+                                        :dataset-query {:lib/type :mbql.stage/mbql
+                                                        :database (:id meta/database)
+                                                        :source-table contact-tab-id}})]})
           account-card (lib.metadata/card metadata-provider account-card-id)
           contact-card (lib.metadata/card metadata-provider contact-card-id)
           query (lib/query metadata-provider account-card)]

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -265,77 +265,58 @@
                 (lib/returned-columns query)))))))
 
 (deftest ^:parallel implicitly-joinable-requires-numeric-id-test
-  (testing "implicit join requires real field IDs, so SQL models need to provide that metadata (#37067)"
-    (let [model (assoc ((lib.tu/mock-cards) :orders/native) :type :model)
-          mp    (lib.tu/metadata-provider-with-mock-card model)
-          query (lib/query mp model)]
-      (testing "without FK metadata, only the own columns are returned"
-        (is (= 9 (count (lib/visible-columns query))))
-        (is (= []
-               (->> (lib/visible-columns query)
-                    (remove (comp #{:source/card} :lib/source)))))))
+  (letfn [(query-with-user-id-tweaks [tweaks]
+            (let [base     (-> (lib.tu/mock-cards)
+                               :orders/native
+                               lib.tu/as-model)
+                  metadata (mapv (fn [col]
+                                   (cond-> col
+                                     (= (:name col) "USER_ID") (merge tweaks)))
+                                 (:result-metadata base))
+                  model    (assoc base :result-metadata metadata)]
+              (lib/query (lib.tu/metadata-provider-with-mock-card model) model)))]
+    (testing "implicit join requires real field IDs, so SQL models need to provide that metadata (#37067)"
+      (let [query (query-with-user-id-tweaks nil)]
+        (testing "without FK metadata, only the own columns are returned"
+          (is (= 9 (count (lib/visible-columns query))))
+          (is (= []
+                 (->> (lib/visible-columns query)
+                      (remove (comp #{:source/card} :lib/source)))))))
 
-    (testing "metadata for the FK target field is not sufficient"
-      (let [base    ((lib.tu/mock-cards) :orders/native)
-            with-fk (for [col (:result-metadata base)]
-                      (if (= (:name col) "USER_ID")
-                        (assoc col :fk-target-field-id (meta/id :people :id))
-                        col))
-            model   (assoc base
-                           :type            :model
-                           :result-metadata with-fk)
-            mp      (lib.tu/metadata-provider-with-mock-card model)
-            query   (lib/query mp model)]
-        (is (= 9 (count (lib/visible-columns query))))
-        (is (= []
-               (->> (lib/visible-columns query)
-                    (remove (comp #{:source/card} :lib/source)))))))
+      (testing "metadata for the FK target field is not sufficient"
+        (let [query (query-with-user-id-tweaks {:fk-target-field-id (meta/id :people :id)})]
+          (is (= 9 (count (lib/visible-columns query))))
+          (is (= []
+                 (->> (lib/visible-columns query)
+                      (remove (comp #{:source/card} :lib/source)))))))
 
-    (testing "an ID for the FK field itself is not sufficient"
-      (let [base    ((lib.tu/mock-cards) :orders/native)
-            with-id (for [col (:result-metadata base)]
-                      (merge col
-                             (when (= (:name col) "USER_ID")
-                               {:id            (meta/id :orders :user-id)
-                                :semantic-type nil})))
-            model   (assoc base
-                           :type            :model
-                           :result-metadata with-id)
-            mp      (lib.tu/metadata-provider-with-mock-card model)
-            query   (lib/query mp model)]
-        (is (= 9 (count (lib/visible-columns query))))
-        (is (= []
-               (->> (lib/visible-columns query)
-                    (remove (comp #{:source/card} :lib/source)))))))
-    (testing "the ID and :semantic-type :type/FK are sufficient for an implicit join"
-      (let [base          ((lib.tu/mock-cards) :orders/native)
-            with-fk       (for [col (:result-metadata base)]
-                            (merge col
-                                   (when (= (:name col) "USER_ID")
-                                     {:id            (meta/id :orders :user-id)
-                                      :semantic-type :type/FK})))
-            model         (assoc base
-                                 :type            :model
-                                 :result-metadata with-fk)
-            mp            (lib.tu/metadata-provider-with-mock-card model)
-            query         (lib/query mp model)
-            fields-of     (fn [table-kw order-fn]
-                            (->> (meta/fields table-kw)
-                                 (map #(meta/field-metadata table-kw %))
-                                 (sort-by order-fn)))
-            orders-fields (into {} (for [[index field] (m/indexed ["ID" "SUBTOTAL" "TOTAL" "TAX" "DISCOUNT" "QUANTITY"
-                                                                   "CREATED_AT" "PRODUCT_ID" "USER_ID"])]
-                                     [field index]))
-            orders-cols   (fields-of :orders (comp orders-fields :name))
-            people-cols   (fields-of :people :position)]
-        (is (= 22 (count (lib/visible-columns query))))
-        (is (=? (concat (for [col orders-cols]
-                          {:name       (:name col)
-                           :lib/source :source/card})
-                        (for [col people-cols]
-                          {:name       (:name col)
-                           :lib/source :source/implicitly-joinable}))
-                (lib/visible-columns query)))))))
+      (testing "an ID for the FK field itself is not sufficient"
+        (let [query (query-with-user-id-tweaks {:id            (meta/id :orders :user-id)
+                                                :semantic-type nil})]
+          (is (= 9 (count (lib/visible-columns query))))
+          (is (= []
+                 (->> (lib/visible-columns query)
+                      (remove (comp #{:source/card} :lib/source)))))))
+      (testing "the ID and :semantic-type :type/FK are sufficient for an implicit join"
+        (let [query         (query-with-user-id-tweaks {:id            (meta/id :orders :user-id)
+                                                        :semantic-type :type/FK})
+              fields-of     (fn [table-kw order-fn]
+                              (->> (meta/fields table-kw)
+                                   (map #(meta/field-metadata table-kw %))
+                                   (sort-by order-fn)))
+              orders-fields (into {} (for [[index field] (m/indexed ["ID" "SUBTOTAL" "TOTAL" "TAX" "DISCOUNT" "QUANTITY"
+                                                                     "CREATED_AT" "PRODUCT_ID" "USER_ID"])]
+                                       [field index]))
+              orders-cols   (fields-of :orders (comp orders-fields :name))
+              people-cols   (fields-of :people :position)]
+          (is (= 22 (count (lib/visible-columns query))))
+          (is (=? (concat (for [col orders-cols]
+                            {:name       (:name col)
+                             :lib/source :source/card})
+                          (for [col people-cols]
+                            {:name       (:name col)
+                             :lib/source :source/implicitly-joinable}))
+                  (lib/visible-columns query))))))))
 
 (def cols-fns [lib/visible-columns lib/filterable-columns lib/breakoutable-columns lib/orderable-columns])
 

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -421,26 +421,26 @@
         query (lib/query mp (lib.metadata/card mp (:id card)))]
     (is (=? [{:name         "ID"
               :display-name "ID"
-              :ident        (lib/native-ident "ID" (:entity_id card))
+              :ident        (lib/native-ident "ID" (:entity-id card))
               :lib/source   :source/card}
              {:name         "NAME"
               :display-name "Name"
-              :ident        (lib/native-ident "NAME" (:entity_id card))
+              :ident        (lib/native-ident "NAME" (:entity-id card))
               :lib/source   :source/card}
              {:name         "CATEGORY_ID"
               :display-name "Category ID"
-              :ident        (lib/native-ident "CATEGORY_ID" (:entity_id card))
+              :ident        (lib/native-ident "CATEGORY_ID" (:entity-id card))
               :lib/source   :source/card}
              {:name         "LATITUDE"
               :display-name "Latitude"
-              :ident        (lib/native-ident "LATITUDE" (:entity_id card))
+              :ident        (lib/native-ident "LATITUDE" (:entity-id card))
               :lib/source   :source/card}
              {:name         "LONGITUDE"
               :display-name "Longitude"
-              :ident        (lib/native-ident "LONGITUDE" (:entity_id card))
+              :ident        (lib/native-ident "LONGITUDE" (:entity-id card))
               :lib/source   :source/card}
              {:name         "PRICE"
               :display-name "Price"
-              :ident        (lib/native-ident "PRICE" (:entity_id card))
+              :ident        (lib/native-ident "PRICE" (:entity-id card))
               :lib/source   :source/card}]
             (lib/returned-columns query)))))

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -212,13 +212,13 @@
                    :lib/stage-metadata {:lib/type :metadata/results
                                         :columns  [{:lib/type      :metadata/column
                                                     :name          "abc"
-                                                    :ident         "native__zkZ11tfUHvSej1u4yPLjB__abc"
+                                                    :ident         "native[zkZ11tfUHvSej1u4yPLjB]__abc"
                                                     :display-name  "another Field"
                                                     :base-type     :type/Integer
                                                     :semantic-type :type/FK}
                                                    {:lib/type      :metadata/column
                                                     :name          "sum"
-                                                    :ident         "native__zkZ11tfUHvSej1u4yPLjB__sum"
+                                                    :ident         "native[zkZ11tfUHvSej1u4yPLjB]__sum"
                                                     :display-name  "sum of User ID"
                                                     :base-type     :type/Integer
                                                     :semantic-type :type/FK}]}
@@ -332,7 +332,7 @@
 (defn as-model
   "Given a mock card, make it a model.
 
-  This sets the `:type` of the card, and also adds `model__...` to the `:ident`s in its `:result-metadata`, if any.
+  This sets the `:type` of the card, and also adds `model[...]__...` to the `:ident`s in its `:result-metadata`, if any.
 
   If the `:type` is already `:model`, this does nothing. Randomizes an `:entity-id` if not provided."
   [card]

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -345,7 +345,8 @@
                  :entity-id eid)
           (m/update-existing :result-metadata
                              (fn [metadata]
-                               (mapv #(m/update-existing % :ident lib/model-ident eid)
+                               (mapv #(cond-> %
+                                        (:ident %) (lib/add-model-ident eid))
                                      metadata)))))))
 
 (mu/defn field-literal-ref :- ::lib.schema.ref/field.literal

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -391,3 +391,8 @@
                                                                   :type     :native
                                                                   :native   {:query "SELECT * FROM VENUES;"}}
                                                 :result-metadata (get-in (mock-cards) [:venues :result-metadata])}))))
+
+(defn placeholder-entity-id?
+  "True if the string `s` is exactly a placeholder `entity_id` of the type generated for ad-hoc cards."
+  [s]
+  (lib.metadata.ident/placeholder? s))

--- a/test/metabase/model_persistence/test_util.clj
+++ b/test/metabase/model_persistence/test_util.clj
@@ -13,12 +13,9 @@
       (ddl.i/check-can-persist (data/db))
       (persisted-info/ready-database! (data/id))
       (let [persist-fn (fn persist-fn []
-                         #_(doseq [model-id model-ids]
-                           (persisted-info/turn-on-model!)
-                           )
                          (#'task.persist-refresh/refresh-tables!
-                           (data/id)
-                           (var-get #'task.persist-refresh/dispatching-refresher)))]
+                          (data/id)
+                          (var-get #'task.persist-refresh/dispatching-refresher)))]
         (f persist-fn)))))
 
 (defmacro with-persistence-enabled!

--- a/test/metabase/model_persistence/test_util.clj
+++ b/test/metabase/model_persistence/test_util.clj
@@ -9,13 +9,17 @@
 (defn do-with-persistence-enabled!
   [f]
   (tu/with-temporary-setting-values [:persisted-models-enabled true]
-    (ddl.i/check-can-persist (data/db))
-    (persisted-info/ready-database! (data/id))
-    (let [persist-fn (fn persist-fn []
-                       (#'task.persist-refresh/refresh-tables!
-                        (data/id)
-                        (var-get #'task.persist-refresh/dispatching-refresher)))]
-      (f persist-fn))))
+    (with-redefs [persisted-info/default-persistent-info-state (fn [] "creating")]
+      (ddl.i/check-can-persist (data/db))
+      (persisted-info/ready-database! (data/id))
+      (let [persist-fn (fn persist-fn []
+                         #_(doseq [model-id model-ids]
+                           (persisted-info/turn-on-model!)
+                           )
+                         (#'task.persist-refresh/refresh-tables!
+                           (data/id)
+                           (var-get #'task.persist-refresh/dispatching-refresher)))]
+        (f persist-fn)))))
 
 (defmacro with-persistence-enabled!
   "Does the necessary setup to enable persistence on the current db. Provide a binding for a function to persist

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1053,6 +1053,16 @@
                                 :condition    [:= $user_id &another_join.people.id]
                                 :source-table $$people}]}}))
 
+(comment
+  (def q1
+    (mt/mbql-query orders
+      {:source-query {:source-table $$orders
+                      :aggregation  [[:count] [:sum $subtotal]]
+                      :breakout     [$subtotal [:expression "yo"]]
+                      :expressions  {"yo" [:+ $subtotal 7]}}}))
+  (-> q1 :query :source-query)
+  (qp.preprocess/query->expected-cols q1))
+
 (defn- bare-query-exp [eid]
   (mt/$ids orders
     {:source-query {:source-table       $$orders
@@ -1118,7 +1128,8 @@
 (deftest ^:sequential e2e-entity-id-and-idents-test
   (mt/with-temp [:model/Card {id :id} {:name          "A card"
                                        :dataset_query (bare-query)}]
-    ;; :idents are populated on initial insert; update to remove them. (Update does not populate them like insert.)
+    ;; :idents in the query are populated on initial insert; send a t2/update! to remove them.
+    ;; (Update does not populate them like insert.)
     ;; Also remove the generated :entity_id.
     (t2/update! :model/Card id {:dataset_query (bare-query)
                                 :entity_id     nil})

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -114,20 +114,25 @@
   (mt/with-actions-enabled
     (testing "when updating a model to include any clauses will disable implicit actions if they exist\n"
       (testing "happy paths\n"
-        (let [query (mt/mbql-query users)]
-          (doseq [query-change [{:limit       1}
-                                {:expressions {"id + 1" [:+ (mt/$ids $users.id) 1]}}
-                                {:filter      [:> (mt/$ids $users.id) 2]}
-                                {:breakout    [(mt/$ids !month.users.last_login)]}
-                                {:aggregation [[:count]]}
-                                {:joins       [{:fields       :all
-                                                :source-table (mt/id :checkins)
-                                                :condition    [:= (mt/$ids $users.id) (mt/$ids $checkins.user_id)]
-                                                :alias        "People"}]}
-                                {:order-by    [[(mt/$ids $users.id) :asc]]}
-                                {:fields      [(mt/$ids $users.id)]}]]
+        (let [base (mt/mbql-query users)]
+          (doseq [query-change [{:limit              1}
+                                {:expressions        {"id + 1" [:+ (mt/$ids $users.id) 1]}
+                                 :expression-idents  {"id + 1" (lib/random-ident)}}
+                                {:filter             [:> (mt/$ids $users.id) 2]}
+                                {:breakout           [(mt/$ids !month.users.last_login)]
+                                 :breakout-idents    {0 (lib/random-ident)}}
+                                {:aggregation        [[:count]]
+                                 :aggregation-idents {0 (lib/random-ident)}}
+                                {:joins              [{:fields       :all
+                                                       :source-table (mt/id :checkins)
+                                                       :condition    [:= (mt/$ids $users.id) (mt/$ids $checkins.user_id)]
+                                                       :ident        (lib/random-ident)
+                                                       :alias        "People"}]}
+                                {:order-by           [[(mt/$ids $users.id) :asc]]}
+                                {:fields             [(mt/$ids $users.id)]}]]
             (testing (format "when adding %s to the query" (first (keys query-change)))
-              (mt/with-actions [{model-id :id}           {:type :model, :dataset_query query}
+              (mt/with-actions [{model-id :id
+                                 query :dataset_query}   {:type :model, :dataset_query base}
                                 {action-id-1 :action-id} {:type :implicit
                                                           :kind "row/create"}
                                 {action-id-2 :action-id} {:type :implicit
@@ -1079,6 +1084,16 @@
                     {:alias "another_join"
                      :ident (str "join_" eid "@1__another_join")}]}))
 
+(defn- store-bare-query!
+  "`:idents` on the query are populated on initial insert.
+
+  This does a **raw** `t2/update!` to remove them again for testing."
+  ([card-id query]
+   (store-bare-query! card-id query nil))
+  ([card-id query changes]
+   (t2/update! :report_card card-id (merge {:dataset_query ((:in mi/transform-metabase-query) query)}
+                                           changes))))
+
 (deftest ^:sequential idents-populated-on-insert
   (mt/with-temp [:model/Card {eid   :entity_id
                               query :dataset_query} {:name          "A card"
@@ -1097,8 +1112,7 @@
 (deftest ^:sequential entity-id-used-for-idents-if-missing-test
   (mt/with-temp [:model/Card {id :id} {:name          "A card"
                                        :dataset_query (bare-query)}]
-    ;; :idents are populated on initial insert; update to remove them. (Update does not populate them like insert.)
-    (t2/update! :model/Card id {:dataset_query (bare-query)})
+    (store-bare-query! id (bare-query))
     ;; Can't use the one from `with-temp` since it came before the above edit.
     (let [{eid   :entity_id
            query :dataset_query} (t2/select-one :model/Card :id id)]
@@ -1111,10 +1125,7 @@
 (deftest ^:sequential fall-back-to-hashing-entity-id-test
   (mt/with-temp [:model/Card {id :id} {:name          "A card"
                                        :dataset_query (bare-query)}]
-    ;; :idents are populated on initial insert; update to remove them. (Update does not populate them like insert.)
-    ;; Also remove the generated :entity_id.
-    (t2/update! :model/Card id {:dataset_query (bare-query)
-                                :entity_id     nil})
+    (store-bare-query! id (bare-query) {:entity_id nil})
     ;; Can't use the one from `with-temp` since it came before the above edit.
     (let [{eid   :entity_id
            query :dataset_query} (t2/select-one :model/Card :id id)]
@@ -1128,11 +1139,7 @@
 (deftest ^:sequential e2e-entity-id-and-idents-test
   (mt/with-temp [:model/Card {id :id} {:name          "A card"
                                        :dataset_query (bare-query)}]
-    ;; :idents in the query are populated on initial insert; send a t2/update! to remove them.
-    ;; (Update does not populate them like insert.)
-    ;; Also remove the generated :entity_id.
-    (t2/update! :model/Card id {:dataset_query (bare-query)
-                                :entity_id     nil})
+    (store-bare-query! id (bare-query) {:entity_id nil})
     ;; Can't use the one from `with-temp` since it came before the above edit.
     (let [{eid   :entity_id
            query :dataset_query} (t2/select-one :model/Card :id id)]
@@ -1236,7 +1243,7 @@
 
       (testing "with :idents removed from one card"
         ;; Strip the idents off `id1`. update! does not populate idents like insert! does.
-        (t2/update! :model/Card id1 {:dataset_query (bare-query)})
+        (store-bare-query! id1 (bare-query))
         (let [{q1 :dataset_query} (t2/select-one :model/Card :id id1)
               {q2 :dataset_query} (t2/select-one :model/Card :id id2)]
           (is (=? idents-backfilled q1))
@@ -1244,7 +1251,7 @@
 
       (testing "with :idents removed from both cards"
         ;; Strip the idents off `id2` as well.
-        (t2/update! :model/Card id2 {:dataset_query (bare-query)})
+        (store-bare-query! id2 (bare-query))
         (let [{q1 :dataset_query} (t2/select-one :model/Card :id id1)
               {q2 :dataset_query} (t2/select-one :model/Card :id id2)]
           ;; Using diff again: implies that they're different, and that both match `idents-backfilled`.
@@ -1270,7 +1277,7 @@
 
         (testing "with :idents backfilled"
           ;; Strip the idents off `id`. update! does not populate idents like insert! does.
-          (t2/update! :model/Card id {:dataset_query query})
+          (store-bare-query! id query)
           (let [query (->> (t2/select-one :model/Card :id id) :dataset_query :query)]
             (is (=? #"aggregation_[A-Za-z0-9_-]{21}@1__0" (get-in query [:aggregation-idents 0])))
             (is (=? #"aggregation_[A-Za-z0-9_-]{21}@0__0" (get-in query [:source-query :aggregation-idents 0])))
@@ -1295,7 +1302,7 @@
 
         (testing "with :idents backfilled"
           ;; Strip the idents off `id`. update! does not populate idents like insert! does.
-          (t2/update! :model/Card id {:dataset_query query})
+          (store-bare-query! id query)
           (let [{ident0 0
                  ident1 1} (->> (t2/select-one :model/Card :id id) :dataset_query :query :aggregation-idents)]
             (is (=? #"aggregation_[A-Za-z0-9_-]{21}@0__0" ident0))
@@ -1323,7 +1330,7 @@
 
         (testing "with :idents backfilled"
           ;; Strip the idents off `id`. update! does not populate idents like insert! does.
-          (t2/update! :model/Card id {:dataset_query query})
+          (store-bare-query! id query)
           (let [{{agg0 0} :aggregation-idents
                  {brk0 0
                   brk1 1} :breakout-idents} (->> (t2/select-one :model/Card :id id) :dataset_query :query)]
@@ -1361,8 +1368,7 @@
                     (data/diff original modified)))))
 
         (testing "with :idents backfilled"
-          ;; Strip the idents off `id`. update! does not populate idents like insert! does.
-          (t2/update! :model/Card id {:dataset_query base})
+          (store-bare-query! id base)
           (let [original  (:dataset_query (t2/select-one :model/Card :id id))
                 modified  (touch original)
                 new-ident (get-in modified [:query :aggregation-idents 1])
@@ -1414,7 +1420,7 @@
 
         (testing "with :idents backfilled"
           ;; Strip the idents off `id`. update! does not populate idents like insert! does.
-          (t2/update! :model/Card id {:dataset_query base})
+          (store-bare-query! id base)
           (let [original   (:dataset_query (t2/select-one :model/Card :id id))
                 modified   (touch original)
                 _          (t2/update! :model/Card id {:dataset_query modified})
@@ -1467,7 +1473,7 @@
 
         (testing "with :idents backfilled"
           ;; Strip the idents off `id`. update! does not populate idents like insert! does.
-          (t2/update! :model/Card id {:dataset_query base})
+          (store-bare-query! id base)
           (let [original (:dataset_query (t2/select-one :model/Card :id id))
                 modified (touch original)
                 _        (t2/update! :model/Card id {:dataset_query modified})

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1058,16 +1058,6 @@
                                 :condition    [:= $user_id &another_join.people.id]
                                 :source-table $$people}]}}))
 
-(comment
-  (def q1
-    (mt/mbql-query orders
-      {:source-query {:source-table $$orders
-                      :aggregation  [[:count] [:sum $subtotal]]
-                      :breakout     [$subtotal [:expression "yo"]]
-                      :expressions  {"yo" [:+ $subtotal 7]}}}))
-  (-> q1 :query :source-query)
-  (qp.preprocess/query->expected-cols q1))
-
 (defn- bare-query-exp [eid]
   (mt/$ids orders
     {:source-query {:source-table       $$orders

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -285,9 +285,13 @@
              (is (= nil
                     metadata)))))
       (testing "Shouldn't remove verified result metadata from native queries (#37009)"
-        (let [metadata (qp.preprocess/query->expected-cols (mt/mbql-query checkins))]
-          (f (cond-> {:dataset_query (mt/native-query {:native "SELECT * FROM CHECKINS"})
-                      :result_metadata metadata}
+        (let [card-eid (u/generate-nano-id)
+              metadata (-> (mt/mbql-query checkins)
+                           qp.preprocess/query->expected-cols
+                           (mt/metadata->native-form card-eid))]
+          (f (cond-> {:dataset_query   (mt/native-query {:native "SELECT * FROM CHECKINS"})
+                      :result_metadata metadata
+                      :entity_id       card-eid}
                (= creating-or-updating "updating")
                (assoc :verified-result-metadata? true))
              (fn [new-metadata]

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -51,10 +51,10 @@
                                                                 :type :model)
                                                          (update :result_metadata
                                                                  ~(fn [metadata]
-                                                                   (mapv #(cond-> %
-                                                                            (= (:name %) "Tax Rate")
-                                                                            (assoc :semantic_type :type/Percentage))
-                                                                         metadata))))
+                                                                    (mapv #(cond-> %
+                                                                             (= (:name %) "Tax Rate")
+                                                                             (assoc :semantic_type :type/Percentage))
+                                                                          metadata))))
                     :model/Card {~question-card-id :id} {:name          "Query based on model"
                                                          :dataset_query {:type     :query
                                                                          :database (mt/id)
@@ -352,19 +352,19 @@
                   (cond-> col
                     settings (assoc :settings settings))))]
         (mt/with-temp [:model/Card {native-card-id :id} (-> (mt/card-with-source-metadata-for-query
-                                                                         (mt/native-query {:query q}))
-                                                                       (assoc :name "NATIVE"))
+                                                             (mt/native-query {:query q}))
+                                                            (assoc :name "NATIVE"))
                        :model/Card {model-card-id  :id} (-> (mt/card-with-source-metadata-for-query
-                                                                           {:database (mt/id)
-                                                                            :type     :query
-                                                                            :query    (model-query native-card-id)})
-                                                                         (merge {:name "MODEL"
-                                                                                 :type :model})
-                                                                         (update :result_metadata
-                                                                                 #(mapv model-metadata-fn %)))
+                                                             {:database (mt/id)
+                                                              :type     :query
+                                                              :query    (model-query native-card-id)})
+                                                            (merge {:name "MODEL"
+                                                                    :type :model})
+                                                            (update :result_metadata
+                                                                    #(mapv model-metadata-fn %)))
                        :model/Card {meta-model-card-id :id} (-> (mt/card-with-source-metadata-for-query
-                                                                  (mt/mbql-query nil
-                                                                    {:source-table (format "card__%s" model-card-id)}))
+                                                                 (mt/mbql-query nil
+                                                                   {:source-table (format "card__%s" model-card-id)}))
                                                                 (assoc :name                   "METAMODEL"
                                                                        :type                   :model
                                                                        :visualization_settings
@@ -871,8 +871,7 @@
                        :entity_id       model-eid
                        :result_metadata [{:name  "ID"
                                           :id    (mt/id :airport :id)
-                                          :ident (lib/model-ident (mt/ident :airport :id) model-eid)
-                                          }
+                                          :ident (lib/model-ident (mt/ident :airport :id) model-eid)}
                                          {:semantic_type :type/Longitude
                                           :name          "LONGITUDE"
                                           :ident         (lib/model-ident (mt/ident :airport :longitude) model-eid)}

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -10,12 +10,14 @@
    [hickory.core :as hik]
    [hickory.select :as hik.s]
    [metabase.channel.email :as email]
+   [metabase.lib.core :as lib]
    [metabase.notification.test-util :as notification.tu]
    [metabase.pulse.send :as pulse.send]
    [metabase.pulse.test-util :as pulse.test-util]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.humanization :as u.humanization]
    [toucan2.core :as t2]))
 
 (use-fixtures :each (fn [thunk]
@@ -41,22 +43,18 @@
                                                                                                [:field (mt/id :orders :total) {:base-type :type/Float}]
                                                                                                [:expression "Tax Rate"]]
                                                                                 :limit        10}}}
-                    :model/Card {~model-card-id :id} {:name            "Model with percent semantic type"
-                                                      :type            :model
-                                                      :dataset_query   {:type     :query
-                                                                        :database (mt/id)
-                                                                        :query    {:source-table (format "card__%s" ~base-card-id)}}
-                                                      :result_metadata [{:name         "TAX"
-                                                                         :display_name "Tax"
-                                                                         :base_type    :type/Float}
-                                                                        {:name         "TOTAL"
-                                                                         :display_name "Total"
-                                                                         :base_type    :type/Float}
-                                                                        {:name          "Tax Rate"
-                                                                         :display_name  "Tax Rate"
-                                                                         :base_type     :type/Float
-                                                                         :semantic_type :type/Percentage
-                                                                         :field_ref     [:field "Tax Rate" {:base-type :type/Float}]}]}
+                    :model/Card {~model-card-id :id} (-> (mt/card-with-source-metadata-for-query
+                                                          {:type     :query
+                                                           :database (mt/id)
+                                                           :query    {:source-table (format "card__%s" ~base-card-id)}})
+                                                         (assoc :name "Model with percent semantic type"
+                                                                :type :model)
+                                                         (update :result_metadata
+                                                                 ~(fn [metadata]
+                                                                   (mapv #(cond-> %
+                                                                            (= (:name %) "Tax Rate")
+                                                                            (assoc :semantic_type :type/Percentage))
+                                                                         metadata))))
                     :model/Card {~question-card-id :id} {:name          "Query based on model"
                                                          :dataset_query {:type     :query
                                                                          :database (mt/id)
@@ -338,131 +336,138 @@
 (deftest consistent-date-formatting-test
   (mt/with-temporary-setting-values [custom-formatting nil]
     (let [q (sql-time-query "2023-12-11 15:30:45.123" 20)]
-      (mt/with-temp [:model/Card {native-card-id :id} {:name          "NATIVE"
-                                                       :dataset_query {:database (mt/id)
-                                                                       :type     :native
-                                                                       :native   {:query q}}}
-                     :model/Card {model-card-id  :id
-                                  model-metadata :result_metadata} {:name          "MODEL"
-                                                                    :type          :model
-                                                                    :dataset_query {:database (mt/id)
-                                                                                    :type     :query
-                                                                                    :query    (model-query native-card-id)}}
-                     :model/Card {meta-model-card-id :id} {:name                   "METAMODEL"
-                                                           :type                   :model
-                                                           :dataset_query          {:database (mt/id)
-                                                                                    :type     :query
-                                                                                    :query    {:source-table
-                                                                                               (format "card__%s" model-card-id)}}
-                                                           :result_metadata        (mapv
-                                                                                    (fn [{column-name :name :as col}]
-                                                                                      (cond-> col
-                                                                                        (= "EXAMPLE_TIMESTAMP_WITH_TIME_ZONE" column-name)
-                                                                                        (assoc :settings {:date_separator "-"
-                                                                                                          :date_style     "YYYY/M/D"
-                                                                                                          :time_style     "HH:mm"})
-                                                                                        (= "EXAMPLE_TIMESTAMP" column-name)
-                                                                                        (assoc :settings {:time_enabled "seconds"})))
-                                                                                    model-metadata)
-                                                           :visualization_settings {:column_settings {"[\"name\",\"FULL_DATETIME_UTC\"]"
-                                                                                                      {:date_abbreviate true
-                                                                                                       :time_enabled    "milliseconds"
-                                                                                                       :time_style      "HH:mm"}
-                                                                                                      "[\"name\",\"EXAMPLE_TIMESTAMP\"]"
-                                                                                                      {:time_enabled "milliseconds"}
-                                                                                                      "[\"name\",\"EXAMPLE_TIME\"]"
-                                                                                                      {:time_enabled nil}
-                                                                                                      "[\"name\",\"FULL_DATETIME_PACIFIC\"]"
-                                                                                                      {:time_enabled nil}}}}
-                     :model/Dashboard {dash-id :id} {:name "The Dashboard"}
-                     :model/DashboardCard {base-dash-card-id :id} {:dashboard_id dash-id
-                                                                   :card_id      native-card-id}
-                     :model/DashboardCard {model-dash-card-id :id} {:dashboard_id dash-id
-                                                                    :card_id      model-card-id}
-                     :model/DashboardCard {metamodel-dash-card-id :id} {:dashboard_id dash-id
-                                                                        :card_id      meta-model-card-id}
-                     :model/Pulse {pulse-id :id
-                                   :as      pulse} {:name "Consistent Time Formatting Pulse"
-                                                    :dashboard_id dash-id}
-                     :model/PulseCard _ {:pulse_id          pulse-id
-                                         :card_id           native-card-id
-                                         :dashboard_card_id base-dash-card-id
-                                         :include_csv       true}
-                     :model/PulseCard _ {:pulse_id          pulse-id
-                                         :card_id           model-card-id
-                                         :dashboard_card_id model-dash-card-id
-                                         :include_csv       true}
-                     :model/PulseCard _ {:pulse_id          pulse-id
-                                         :card_id           meta-model-card-id
-                                         :dashboard_card_id metamodel-dash-card-id
-                                         :include_csv       true}
-                     :model/PulseChannel {pulse-channel-id :id} {:channel_type :email
-                                                                 :pulse_id     pulse-id
-                                                                 :enabled      true}
-                     :model/PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
-                                                     :user_id          (mt/user->id :rasta)}]
-        (let [attached-data     (run-pulse-and-return-attached-csv-data! pulse)
-              get-res           #(-> (get attached-data %)
-                                     (update-vals first)
-                                     (dissoc "X"))
-              native-results    (get-res "NATIVE.csv")
-              model-results     (get-res "MODEL.csv")
-              metamodel-results (get-res "METAMODEL.csv")]
-          ;; Note that these values are obtained by inspection since the UI formats are in the FE code.
-          (testing "The default export formats conform to the default UI formats"
-            (is (= {"FULL_DATETIME_UTC"                "December 11, 2023, 3:30 PM"
-                    "FULL_DATETIME_PACIFIC"            "December 11, 2023, 3:30 PM"
-                    "EXAMPLE_TIMESTAMP"                "December 11, 2023, 3:30 PM"
-                    "EXAMPLE_TIMESTAMP_WITH_TIME_ZONE" "December 11, 2023, 3:30 PM"
-                    "EXAMPLE_DATE"                     "December 11, 2023"
-                    "EXAMPLE_TIME"                     "3:30 PM"
-                    ;; NOTE -- We don't have a type in our type system for year so this is just an integer.
-                    ;; It might be worth looking into fixing this so that it displays without a comma
-                    "EXAMPLE_YEAR"                     "2,023"
-                    "EXAMPLE_MONTH"                    "12"
-                    "EXAMPLE_DAY"                      "11"
-                    "EXAMPLE_WEEK_NUMBER"              "50"
-                    "EXAMPLE_HOUR"                     "15"
-                    "EXAMPLE_MINUTE"                   "30"
-                    "EXAMPLE_SECOND"                   "45"}
-                   ;; the EXAMPLE_WEEK is a normal timestamp.
-                   ;; We care about it in the context of the Model, not the native results
-                   ;; so dissoc it here.
-                   (dissoc native-results "EXAMPLE_WEEK"))))
-          (testing "An exported model retains the base format, but does use display names for column names."
-            (is (= {"Full Datetime Utc"                "December 11, 2023, 3:30 PM"
-                    "Full Datetime Pacific"            "December 11, 2023, 3:30 PM"
-                    "Example Timestamp"                "December 11, 2023, 3:30 PM"
-                    "Example Timestamp With Time Zone" "December 11, 2023, 3:30 PM"
-                    "Example Date"                     "December 11, 2023"
-                    "Example Time"                     "3:30 PM"
-                    "Example Year"                     "2,023"
-                    "Example Month"                    "12"
-                    "Example Day"                      "11"
-                    "Example Week Number"              "50"
-                    "Example Week: Week"               "December 10, 2023 - December 16, 2023"
-                    "Example Hour"                     "15"
-                    "Example Minute"                   "30"
-                    "Example Second"                   "45"}
-                   model-results)))
-          (testing "Visualization settings are applied"
-            (is (= "Dec 11, 2023, 15:30:45.123"
-                   (metamodel-results "Full Datetime Utc"))))
-          (testing "Custom column metadata settings are applied"
-            (is (= "2023-12-11, 15:30"
-                   (metamodel-results "Example Timestamp With Time Zone"))))
-          (testing "Visualization settings overwrite custom metadata column settings"
-            (is (= "December 11, 2023, 3:30:45.123 PM"
-                   (metamodel-results "Example Timestamp"))))
-          (testing "Setting time-enabled to nil for a date time column results in only showing the date"
-            (is (= "December 11, 2023"
-                   (metamodel-results "Full Datetime Pacific"))))
-          (testing "Setting time-enabled to nil for a time column just returns an empty string"
-            (is (= ""
-                   (metamodel-results "Example Time"))))
-          (testing "Week Units Are Displayed as a Date Range"
-            (is (= "December 10, 2023 - December 16, 2023"
-                   (metamodel-results "Example Week: Week")))))))))
+      (letfn [(model-metadata-fn [col]
+                (assoc col :display_name (u.humanization/name->human-readable-name :simple (:name col))))
+              (metamodel-metadata-fn [{column-name :name :as col}]
+                (let [settings (case column-name
+                                 "EXAMPLE_TIMESTAMP_WITH_TIME_ZONE"
+                                 {:date_separator "-"
+                                  :date_style     "YYYY/M/D"
+                                  :time_style     "HH:mm"}
+
+                                 "EXAMPLE_TIMESTAMP"
+                                 {:time_enabled "seconds"}
+
+                                 nil)]
+                  (cond-> col
+                    settings (assoc :settings settings))))]
+        (mt/with-temp [:model/Card {native-card-id :id} (-> (mt/card-with-source-metadata-for-query
+                                                                         (mt/native-query {:query q}))
+                                                                       (assoc :name "NATIVE"))
+                       :model/Card {model-card-id  :id} (-> (mt/card-with-source-metadata-for-query
+                                                                           {:database (mt/id)
+                                                                            :type     :query
+                                                                            :query    (model-query native-card-id)})
+                                                                         (merge {:name "MODEL"
+                                                                                 :type :model})
+                                                                         (update :result_metadata
+                                                                                 #(mapv model-metadata-fn %)))
+                       :model/Card {meta-model-card-id :id} (-> (mt/card-with-source-metadata-for-query
+                                                                  (mt/mbql-query nil
+                                                                    {:source-table (format "card__%s" model-card-id)}))
+                                                                (assoc :name                   "METAMODEL"
+                                                                       :type                   :model
+                                                                       :visualization_settings
+                                                                       {:column_settings {"[\"name\",\"FULL_DATETIME_UTC\"]"
+                                                                                          {:date_abbreviate true
+                                                                                           :time_enabled    "milliseconds"
+                                                                                           :time_style      "HH:mm"}
+                                                                                          "[\"name\",\"EXAMPLE_TIMESTAMP\"]"
+                                                                                          {:time_enabled "milliseconds"}
+                                                                                          "[\"name\",\"EXAMPLE_TIME\"]"
+                                                                                          {:time_enabled nil}
+                                                                                          "[\"name\",\"FULL_DATETIME_PACIFIC\"]"
+                                                                                          {:time_enabled nil}}})
+                                                                (update :result_metadata #(mapv metamodel-metadata-fn %)))
+                       :model/Dashboard {dash-id :id} {:name "The Dashboard"}
+                       :model/DashboardCard {base-dash-card-id :id} {:dashboard_id dash-id
+                                                                     :card_id      native-card-id}
+                       :model/DashboardCard {model-dash-card-id :id} {:dashboard_id dash-id
+                                                                      :card_id      model-card-id}
+                       :model/DashboardCard {metamodel-dash-card-id :id} {:dashboard_id dash-id
+                                                                          :card_id      meta-model-card-id}
+                       :model/Pulse {pulse-id :id
+                                     :as      pulse} {:name "Consistent Time Formatting Pulse"
+                                                      :dashboard_id dash-id}
+                       :model/PulseCard _ {:pulse_id          pulse-id
+                                           :card_id           native-card-id
+                                           :dashboard_card_id base-dash-card-id
+                                           :include_csv       true}
+                       :model/PulseCard _ {:pulse_id          pulse-id
+                                           :card_id           model-card-id
+                                           :dashboard_card_id model-dash-card-id
+                                           :include_csv       true}
+                       :model/PulseCard _ {:pulse_id          pulse-id
+                                           :card_id           meta-model-card-id
+                                           :dashboard_card_id metamodel-dash-card-id
+                                           :include_csv       true}
+                       :model/PulseChannel {pulse-channel-id :id} {:channel_type :email
+                                                                   :pulse_id     pulse-id
+                                                                   :enabled      true}
+                       :model/PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
+                                                       :user_id          (mt/user->id :rasta)}]
+          (let [attached-data     (run-pulse-and-return-attached-csv-data! pulse)
+                get-res           #(-> (get attached-data %)
+                                       (update-vals first)
+                                       (dissoc "X"))
+                native-results    (get-res "NATIVE.csv")
+                model-results     (get-res "MODEL.csv")
+                metamodel-results (get-res "METAMODEL.csv")]
+            ;; Note that these values are obtained by inspection since the UI formats are in the FE code.
+            (testing "The default export formats conform to the default UI formats"
+              (is (= {"FULL_DATETIME_UTC"                "December 11, 2023, 3:30 PM"
+                      "FULL_DATETIME_PACIFIC"            "December 11, 2023, 3:30 PM"
+                      "EXAMPLE_TIMESTAMP"                "December 11, 2023, 3:30 PM"
+                      "EXAMPLE_TIMESTAMP_WITH_TIME_ZONE" "December 11, 2023, 3:30 PM"
+                      "EXAMPLE_DATE"                     "December 11, 2023"
+                      "EXAMPLE_TIME"                     "3:30 PM"
+                      ;; NOTE -- We don't have a type in our type system for year so this is just an integer.
+                      ;; It might be worth looking into fixing this so that it displays without a comma
+                      "EXAMPLE_YEAR"                     "2,023"
+                      "EXAMPLE_MONTH"                    "12"
+                      "EXAMPLE_DAY"                      "11"
+                      "EXAMPLE_WEEK_NUMBER"              "50"
+                      "EXAMPLE_HOUR"                     "15"
+                      "EXAMPLE_MINUTE"                   "30"
+                      "EXAMPLE_SECOND"                   "45"}
+                     ;; the EXAMPLE_WEEK is a normal timestamp.
+                     ;; We care about it in the context of the Model, not the native results
+                     ;; so dissoc it here.
+                     (dissoc native-results "EXAMPLE_WEEK"))))
+            (testing "An exported model retains the base format, but does use display names for column names."
+              (is (= {"Full Datetime Utc"                "December 11, 2023, 3:30 PM"
+                      "Full Datetime Pacific"            "December 11, 2023, 3:30 PM"
+                      "Example Timestamp"                "December 11, 2023, 3:30 PM"
+                      "Example Timestamp With Time Zone" "December 11, 2023, 3:30 PM"
+                      "Example Date"                     "December 11, 2023"
+                      "Example Time"                     "3:30 PM"
+                      "Example Year"                     "2,023"
+                      "Example Month"                    "12"
+                      "Example Day"                      "11"
+                      "Example Week Number"              "50"
+                      "Example Week: Week"               "December 10, 2023 - December 16, 2023"
+                      "Example Hour"                     "15"
+                      "Example Minute"                   "30"
+                      "Example Second"                   "45"}
+                     model-results)))
+            (testing "Visualization settings are applied"
+              (is (= "Dec 11, 2023, 15:30:45.123"
+                     (metamodel-results "Full Datetime Utc"))))
+            (testing "Custom column metadata settings are applied"
+              (is (= "2023-12-11, 15:30"
+                     (metamodel-results "Example Timestamp With Time Zone"))))
+            (testing "Visualization settings overwrite custom metadata column settings"
+              (is (= "December 11, 2023, 3:30:45.123 PM"
+                     (metamodel-results "Example Timestamp"))))
+            (testing "Setting time-enabled to nil for a date time column results in only showing the date"
+              (is (= "December 11, 2023"
+                     (metamodel-results "Full Datetime Pacific"))))
+            (testing "Setting time-enabled to nil for a time column just returns an empty string"
+              (is (= ""
+                     (metamodel-results "Example Time"))))
+            (testing "Week Units Are Displayed as a Date Range"
+              (is (= "December 10, 2023 - December 16, 2023"
+                     (metamodel-results "Example Week: Week"))))))))))
 
 (deftest renamed-column-names-are-applied-test
   (testing "CSV attachments should have the same columns as displayed in Metabase (#18572)"
@@ -855,29 +860,25 @@
 (deftest geographic-coordinates-formatting-test
   (testing "Longitude and latitude columns should format correctly on export (#38419)"
     (mt/dataset airports
-      (let [base-card {:dataset_query {:database (mt/id)
-                                       :type     :query
-                                       :query    {:source-table (mt/id :airport)
-                                                  :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
-                                                                 [:field (mt/id :airport :longitude) {:base-type :type/Float}]
-                                                                 [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
-                                                  :order-by     [[:asc (mt/id :airport :id)]]
-                                                  :limit        5}}}
-            model     {:dataset_query   {:database (mt/id)
-                                         :type     :query
-                                         :query    {:source-table (mt/id :airport)
-                                                    :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
-                                                                   [:field (mt/id :airport :longitude) {:base-type :type/Float}]
-                                                                   [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
-                                                    :order-by     [[:asc (mt/id :airport :id)]]
-                                                    :limit        5}}
+      (let [query     (mt/mbql-query airport
+                        {:fields   [$id $longitude $latitude]
+                         :order-by [[:asc $id]]
+                         :limit    5})
+            base-card {:dataset_query   query}
+            model-eid (u/generate-nano-id)
+            model     {:dataset_query   query
                        :type            :model
-                       :result_metadata [{:name "ID"
-                                          :id   (mt/id :airport :id)}
+                       :entity_id       model-eid
+                       :result_metadata [{:name  "ID"
+                                          :id    (mt/id :airport :id)
+                                          :ident (lib/model-ident (mt/ident :airport :id) model-eid)
+                                          }
                                          {:semantic_type :type/Longitude
-                                          :name          "LONGITUDE"}
+                                          :name          "LONGITUDE"
+                                          :ident         (lib/model-ident (mt/ident :airport :longitude) model-eid)}
                                          {:semantic_type :type/Latitude
-                                          :name          "LATITUDE"}]}]
+                                          :name          "LATITUDE"
+                                          :ident         (lib/model-ident (mt/ident :airport :latitude) model-eid)}]}]
         (mt/with-temp [:model/Card {card-id :id} base-card
                        :model/Card {model-id :id} model
                        :model/Dashboard {dash-id :id} {}

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -2,6 +2,7 @@
   "There are more e2e tests in [[metabase.api.card-test]]."
   (:require
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
    [metabase.models.interface :as mi]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
@@ -224,9 +225,17 @@
 
 (deftest updates-metadata-provider
   (testing "should set the previous results metadata to the store"
-    (mt/with-temp [:model/Card card {:dataset_query   (mt/native-query {:query "SELECT * FROM VENUES"})
-                                     :result_metadata [{:name "NAME", :display_name "Name", :base_type :type/Text}]}]
-      (mt/with-metadata-provider (mt/id)
-        (run-query-for-card (u/the-id card))
-        (is (= [{:name "NAME", :display_name "Name", :base_type :type/Text}]
-               (qp.store/miscellaneous-value [::qp.results-metadata/card-stored-metadata])))))))
+    (let [entity-id (u/generate-nano-id)]
+      (mt/with-temp [:model/Card card {:dataset_query   (mt/native-query {:query "SELECT * FROM VENUES"})
+                                       :entity_id       entity-id
+                                       :result_metadata [{:name         "NAME"
+                                                          :display_name "Name"
+                                                          :ident        (lib/native-ident "NAME" entity-id)
+                                                          :base_type    :type/Text}]}]
+        (mt/with-metadata-provider (mt/id)
+          (run-query-for-card (u/the-id card))
+          (is (= [{:name         "NAME"
+                   :display_name "Name"
+                   :ident        (lib/native-ident "NAME" entity-id)
+                   :base_type    :type/Text}]
+                 (qp.store/miscellaneous-value [::qp.results-metadata/card-stored-metadata]))))))))

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -24,7 +24,7 @@
   (select-keys
    col
    [:id :table_id :name :display_name :base_type :effective_type :coercion_strategy
-    :semantic_type :unit :fingerprint :settings :field_ref :nfc_path :parent_id]))
+    :semantic_type :unit :fingerprint :settings :field_ref :nfc_path :parent_id :ident]))
 
 (defn- results-metadata [cols]
   (map results-col cols))
@@ -68,42 +68,58 @@
 
 (deftest ^:parallel basic-summary-columns-test
   (testing "Can we add source metadata for a source query that has breakouts/aggregations?"
-    (is (=? (lib.tu.macros/mbql-query venues
-              {:source-query    {:source-table $$venues
-                                 :aggregation  [[:count]]
-                                 :breakout     [$price]}
-               :source-metadata (concat
-                                 (venues-source-metadata :price)
-                                 [{:name          "count"
-                                   :display_name  "Count"
-                                   :base_type     :type/Integer
-                                   :semantic_type :type/Quantity
-                                   :field_ref     [:aggregation 0]}])})
-            (add-source-metadata
-             (lib.tu.macros/mbql-query venues
-               {:source-query {:source-table $$venues
-                               :aggregation  [[:count]]
-                               :breakout     [$price]}}))))))
+    (let [brk-ident (u/generate-nano-id)
+          agg-ident (u/generate-nano-id)]
+      (is (=? (lib.tu.macros/mbql-query venues
+                {:source-query    {:source-table       $$venues
+                                   :aggregation        [[:count]]
+                                   :aggregation-idents {0 agg-ident}
+                                   :breakout           [$price]
+                                   :breakout-idents    {0 brk-ident}}
+                 :source-metadata [(-> (venues-source-metadata :price)
+                                       first
+                                       (assoc :ident brk-ident))
+                                   {:name          "count"
+                                     :display_name  "Count"
+                                     :ident         agg-ident
+                                     :base_type     :type/Integer
+                                     :semantic_type :type/Quantity
+                                     :field_ref     [:aggregation 0]}]})
+              (add-source-metadata
+               (lib.tu.macros/mbql-query venues
+                 {:source-query {:source-table       $$venues
+                                 :aggregation        [[:count]]
+                                 :aggregation-idents {0 agg-ident}
+                                 :breakout           [$price]
+                                 :breakout-idents    {0 brk-ident}}})))))))
 
 (deftest ^:parallel basic-aggregation-with-field-test
   (testing "Can we add source metadata for a source query that has an aggregation for a specific Field?"
-    (is (=? (lib.tu.macros/mbql-query venues
-              {:source-query    {:source-table $$venues
-                                 :aggregation  [[:avg $id]]
-                                 :breakout     [$price]}
-               :source-metadata (concat
-                                 (venues-source-metadata :price)
-                                 [{:name          "avg"
-                                   :display_name  "Average of ID"
-                                   :base_type     :type/Float
-                                   :semantic_type :type/PK
-                                   :settings      nil
-                                   :field_ref     [:aggregation 0]}])})
-            (add-source-metadata
-             (lib.tu.macros/mbql-query venues
-               {:source-query {:source-table $$venues
-                               :aggregation  [[:avg $id]]
-                               :breakout     [$price]}}))))))
+    (let [brk-ident (u/generate-nano-id)
+          agg-ident (u/generate-nano-id)]
+      (is (=? (lib.tu.macros/mbql-query venues
+                {:source-query    {:source-table       $$venues
+                                   :aggregation        [[:avg $id]]
+                                   :aggregation-idents {0 agg-ident}
+                                   :breakout           [$price]
+                                   :breakout-idents    {0 brk-ident}}
+                 :source-metadata [(-> (venues-source-metadata :price)
+                                       first
+                                       (assoc :ident brk-ident))
+                                   {:name          "avg"
+                                     :display_name  "Average of ID"
+                                     :base_type     :type/Float
+                                     :ident         agg-ident
+                                     :semantic_type :type/PK
+                                     :settings      nil
+                                     :field_ref     [:aggregation 0]}]})
+              (add-source-metadata
+               (lib.tu.macros/mbql-query venues
+                 {:source-query {:source-table       $$venues
+                                 :aggregation        [[:avg $id]]
+                                 :aggregation-idents {0 agg-ident}
+                                 :breakout           [$price]
+                                 :breakout-idents    {0 brk-ident}}})))))))
 
 (defn- source-metadata [query]
   (get-in query [:query :source-metadata] query))
@@ -111,27 +127,35 @@
 (deftest ^:parallel named-aggregations-test
   (testing "adding source metadata for source queries with named aggregations"
     (testing "w/ `:name` and `:display-name`"
-      (is (=? (lib.tu.macros/mbql-query venues
-                {:source-query    {:source-table $$venues
-                                   :aggregation  [[:aggregation-options
-                                                   [:avg $id]
-                                                   {:name "some_generated_name", :display-name "My Cool Ag"}]]
-                                   :breakout     [$price]}
-                 :source-metadata (concat
-                                   (venues-source-metadata :price)
-                                   [{:name          "some_generated_name"
-                                     :display_name  "My Cool Ag"
-                                     :base_type     :type/Float
-                                     :semantic_type :type/PK
-                                     :settings      nil
-                                     :field_ref     [:aggregation 0]}])})
-              (add-source-metadata
-               (lib.tu.macros/mbql-query venues
-                 {:source-query {:source-table $$venues
-                                 :aggregation  [[:aggregation-options
-                                                 [:avg $id]
-                                                 {:name "some_generated_name", :display-name "My Cool Ag"}]]
-                                 :breakout     [$price]}})))))))
+      (let [agg-ident (u/generate-nano-id)
+            brk-ident (u/generate-nano-id)]
+        (is (=? (lib.tu.macros/mbql-query venues
+                  {:source-query    {:source-table       $$venues
+                                     :aggregation        [[:aggregation-options
+                                                           [:avg $id]
+                                                           {:name "some_generated_name", :display-name "My Cool Ag"}]]
+                                     :aggregation-idents {0 agg-ident}
+                                     :breakout           [$price]
+                                     :breakout-idents    {0 brk-ident}}
+                   :source-metadata [(-> (venues-source-metadata :price)
+                                         first
+                                         (assoc :ident brk-ident))
+                                     {:name          "some_generated_name"
+                                      :display_name  "My Cool Ag"
+                                      :ident         agg-ident
+                                      :base_type     :type/Float
+                                      :semantic_type :type/PK
+                                      :settings      nil
+                                      :field_ref     [:aggregation 0]}]})
+                (add-source-metadata
+                 (lib.tu.macros/mbql-query venues
+                   {:source-query {:source-table       $$venues
+                                   :aggregation        [[:aggregation-options
+                                                         [:avg $id]
+                                                         {:name "some_generated_name", :display-name "My Cool Ag"}]]
+                                   :aggregation-idents {0 agg-ident}
+                                   :breakout           [$price]
+                                   :breakout-idents    {0 brk-ident}}}))))))))
 
 (deftest ^:parallel named-aggregations-name-only-test
   (testing "w/ `:name` only"
@@ -221,28 +245,35 @@
       ;; field ref for the count aggregation differs slightly depending on what level of the query we're at; at the
       ;; most-deeply-nested level we can use the `[:aggregation 0]` ref to refer to it; at higher levels we have to
       ;; refer to it with a field literal
-      (is (=? (letfn [(metadata-with-count-field-ref [field-ref]
-                        (concat
-                         (venues-source-metadata :price)
-                         (let [[count-col] (results-metadata (qp.preprocess/query->expected-cols
-                                                              (lib.tu.macros/mbql-query venues
-                                                                {:aggregation [[:count]]})))]
-                           [(-> count-col
-                                (dissoc :effective_type)
-                                (assoc :field_ref field-ref
-                                       :base_type :type/Integer))])))]
-                (lib.tu.macros/mbql-query venues
-                  {:source-query    {:source-query    {:source-query    {:source-table $$venues
-                                                                         :aggregation  [[:count]]
-                                                                         :breakout     [$price]}
-                                                       :source-metadata (metadata-with-count-field-ref [:aggregation 0])}
-                                     :source-metadata (metadata-with-count-field-ref *count/Integer)}
-                   :source-metadata (metadata-with-count-field-ref *count/Integer)}))
-              (add-source-metadata
-               (lib.tu.macros/mbql-query venues
-                 {:source-query {:source-query {:source-query {:source-table $$venues
-                                                               :aggregation  [[:count]]
-                                                               :breakout     [$price]}}}})))))))
+      (let [brk-ident (u/generate-nano-id)
+            agg-ident (u/generate-nano-id)]
+        (is (=? (letfn [(metadata-with-count-field-ref [field-ref]
+                          [(-> (venues-source-metadata :price) first (assoc :ident brk-ident))
+                           (let [[count-col] (->> (lib.tu.macros/mbql-query venues
+                                                    {:aggregation        [[:count]]
+                                                     :aggregation-idents {0 agg-ident}})
+                                                  qp.preprocess/query->expected-cols
+                                                  results-metadata)]
+                             (-> count-col
+                                 (dissoc :effective_type)
+                                 (assoc :field_ref field-ref
+                                        :base_type :type/Integer)))])]
+                  (lib.tu.macros/mbql-query venues
+                    {:source-query    {:source-query    {:source-query    {:source-table       $$venues
+                                                                           :aggregation        [[:count]]
+                                                                           :aggregation-idents {0 agg-ident}
+                                                                           :breakout           [$price]
+                                                                           :breakout-idents    {0 brk-ident}}
+                                                         :source-metadata (metadata-with-count-field-ref [:aggregation 0])}
+                                       :source-metadata (metadata-with-count-field-ref *count/Integer)}
+                     :source-metadata (metadata-with-count-field-ref *count/Integer)}))
+                (add-source-metadata
+                 (lib.tu.macros/mbql-query venues
+                   {:source-query {:source-query {:source-query {:source-table       $$venues
+                                                                 :aggregation        [[:count]]
+                                                                 :aggregation-idents {0 agg-ident}
+                                                                 :breakout           [$price]
+                                                                 :breakout-idents    {0 brk-ident}}}}}))))))))
 
 (deftest ^:parallel nested-sources-with-source-native-query-test
   (testing "can we add `source-metadata` to the parent level if the source query has a native source query, but itself has `source-metadata`?"
@@ -273,36 +304,44 @@
     (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
                                       meta/metadata-provider
                                       {:settings {:breakout-bin-width 5.0}})
-      (is (=? (lib.tu.macros/mbql-query venues
-                {:source-query    {:source-table $$venues
-                                   :aggregation  [[:count]]
-                                   :breakout     [[:field %latitude {:binning {:strategy :default}}]]}
-                 :source-metadata (concat
-                                   (let [[lat-col]   (venues-source-metadata :latitude)
-                                         [count-col] (results-metadata (qp.preprocess/query->expected-cols
-                                                                        (lib.tu.macros/mbql-query venues
-                                                                          {:aggregation [[:count]]})))]
-                                     [(assoc lat-col
-                                             :field_ref [:field
-                                                         (meta/id :venues :latitude)
-                                                         {:binning {:strategy  :bin-width
-                                                                    :min-value 10.0
-                                                                    :max-value 45.0
-                                                                    :num-bins  7
-                                                                    :bin-width 5.0}}]
-                                             :display_name "Latitude: 5°")
-                                      ;; computed column doesn't have an effective type in middleware before query
-                                      (-> count-col
-                                          (dissoc :effective_type)
-                                          ;; the type that comes back from H2 is :type/BigInteger but the type that comes
-                                          ;; back from calculating it with MLv2 is just plain :type/Integer
-                                          (assoc :base_type :type/Integer))]))})
-              (add-source-metadata
-               (lib.tu.macros/mbql-query venues
-                 {:source-query
-                  {:source-table $$venues
-                   :aggregation  [[:count]]
-                   :breakout     [[:field %latitude {:binning {:strategy :default}}]]}})))))))
+      (let [brk-ident (u/generate-nano-id)
+            agg-ident (u/generate-nano-id)]
+        (is (=? (lib.tu.macros/mbql-query venues
+                  {:source-query    {:source-table       $$venues
+                                     :aggregation        [[:count]]
+                                     :aggregation-idents {0 agg-ident}
+                                     :breakout           [[:field %latitude {:binning {:strategy :default}}]]
+                                     :breakout-idents    {0 brk-ident}}
+                   :source-metadata (concat
+                                     (let [[lat-col]   (venues-source-metadata :latitude)
+                                           [count-col] (results-metadata (qp.preprocess/query->expected-cols
+                                                                          (lib.tu.macros/mbql-query venues
+                                                                            {:aggregation [[:count]]})))]
+                                       [(assoc lat-col
+                                               :ident     brk-ident
+                                               :field_ref [:field
+                                                           (meta/id :venues :latitude)
+                                                           {:binning {:strategy  :bin-width
+                                                                      :min-value 10.0
+                                                                      :max-value 45.0
+                                                                      :num-bins  7
+                                                                      :bin-width 5.0}}]
+                                               :display_name "Latitude: 5°")
+                                        ;; computed column doesn't have an effective type in middleware before query
+                                        (-> count-col
+                                            (dissoc :effective_type)
+                                            ;; the type that comes back from H2 is :type/BigInteger but the type that comes
+                                            ;; back from calculating it with MLv2 is just plain :type/Integer
+                                            (assoc :base_type :type/Integer
+                                                   :ident     agg-ident))]))})
+                (add-source-metadata
+                 (lib.tu.macros/mbql-query venues
+                   {:source-query
+                    {:source-table       $$venues
+                     :aggregation        [[:count]]
+                     :aggregation-idents {0 agg-ident}
+                     :breakout           [[:field %latitude {:binning {:strategy :default}}]]
+                     :breakout-idents    {0 brk-ident}}}))))))))
 
 (deftest ^:parallel deduplicate-column-names-test
   (testing "Metadata that gets added to source queries should have deduplicated column names"

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -80,11 +80,11 @@
                                        first
                                        (assoc :ident brk-ident))
                                    {:name          "count"
-                                     :display_name  "Count"
-                                     :ident         agg-ident
-                                     :base_type     :type/Integer
-                                     :semantic_type :type/Quantity
-                                     :field_ref     [:aggregation 0]}]})
+                                    :display_name  "Count"
+                                    :ident         agg-ident
+                                    :base_type     :type/Integer
+                                    :semantic_type :type/Quantity
+                                    :field_ref     [:aggregation 0]}]})
               (add-source-metadata
                (lib.tu.macros/mbql-query venues
                  {:source-query {:source-table       $$venues
@@ -107,12 +107,12 @@
                                        first
                                        (assoc :ident brk-ident))
                                    {:name          "avg"
-                                     :display_name  "Average of ID"
-                                     :base_type     :type/Float
-                                     :ident         agg-ident
-                                     :semantic_type :type/PK
-                                     :settings      nil
-                                     :field_ref     [:aggregation 0]}]})
+                                    :display_name  "Average of ID"
+                                    :base_type     :type/Float
+                                    :ident         agg-ident
+                                    :semantic_type :type/PK
+                                    :settings      nil
+                                    :field_ref     [:aggregation 0]}]})
               (add-source-metadata
                (lib.tu.macros/mbql-query venues
                  {:source-query {:source-table       $$venues

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -3,6 +3,8 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.driver :as driver]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -49,18 +51,31 @@
   (testing "native column info"
     (testing "should disambiguate duplicate names"
       (qp.store/with-metadata-provider meta/metadata-provider
-        (is (= [{:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field "a" {:base-type :type/Integer}]}
-                {:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field "a_2" {:base-type :type/Integer}]}]
-               (annotate/column-info
-                {:type :native}
-                {:cols [{:name "a" :base_type :type/Integer} {:name "a" :base_type :type/Integer}]
-                 :rows [[1 nil]]})))))))
+        (let [card-eid (u/generate-nano-id)]
+          (is (= [{:name         "a"
+                   :display_name "a"
+                   :ident        (lib/native-ident "a" card-eid)
+                   :base_type    :type/Integer
+                   :source       :native
+                   :field_ref    [:field "a" {:base-type :type/Integer}]}
+                  {:name         "a"
+                   :display_name "a"
+                   :ident        (lib/native-ident "a_2" card-eid)
+                   :base_type    :type/Integer
+                   :source       :native
+                   :field_ref    [:field "a_2" {:base-type :type/Integer}]}]
+                 (annotate/column-info
+                  {:type :native
+                   :info {:card-entity-id card-eid}}
+                  {:cols [{:name "a" :base_type :type/Integer} {:name "a" :base_type :type/Integer}]
+                   :rows [[1 nil]]}))))))))
 
 (deftest ^:parallel col-info-field-ids-test
   (testing {:base-type "make sure columns are comming back the way we'd expect for :field clauses"}
     (qp.store/with-metadata-provider meta/metadata-provider
       (lib.tu.macros/$ids venues
         (is (=? [{:source    :fields
+                  :ident     (meta/ident :venues :price)
                   :field_ref $price}]
                 (annotate/column-info
                  {:type :query, :query {:fields [$price]}}
@@ -74,6 +89,8 @@
         (is (=? [{:fk_field_id  %category-id
                   :source       :fields
                   :field_ref    $category-id->categories.name
+                  :ident        (lib/implicitly-joined-ident (meta/ident :categories :name)
+                                                             (meta/ident :venues :category-id))
                   ;; for whatever reason this is what the `annotate` middleware traditionally returns here, for
                   ;; some reason we use the `:long` style inside aggregations and the `:default` style elsewhere,
                   ;; who knows why. See notes
@@ -85,18 +102,21 @@
 
 (deftest ^:parallel col-info-for-implicit-joins-aggregation-test
   (qp.store/with-metadata-provider meta/metadata-provider
-    (lib.tu.macros/$ids venues
-      (testing (str "when a `:field` with `:source-field` (implicit join) is used, we should add in `:fk_field_id` "
-                    "info about the source Field")
-        (is (=? [{:source            :aggregation
-                  :field_ref         [:aggregation 0]
-                  :aggregation_index 0
-                  :display_name      "Distinct values of Category → Name"}]
-                (annotate/column-info
-                 {:type  :query
-                  :query {:source-table $$venues
-                          :aggregation  [[:distinct $category-id->categories.name]]}}
-                 {:columns [:name]})))))))
+    (let [ident (lib/random-ident)]
+      (lib.tu.macros/$ids venues
+        (testing (str "when a `:field` with `:source-field` (implicit join) is used, we should add in `:fk_field_id` "
+                      "info about the source Field")
+          (is (=? [{:source            :aggregation
+                    :field_ref         [:aggregation 0]
+                    :aggregation_index 0
+                    :ident             ident
+                    :display_name      "Distinct values of Category → Name"}]
+                  (annotate/column-info
+                   {:type  :query
+                    :query {:source-table $$venues
+                            :aggregation  [[:distinct $category-id->categories.name]]
+                            :aggregation-idents {0 ident}}}
+                   {:columns [:name]}))))))))
 
 (deftest ^:parallel col-info-for-explicit-joins-with-fk-field-id-test
   (qp.store/with-metadata-provider meta/metadata-provider
@@ -107,11 +127,15 @@
                   :source       :fields
                   :field_ref    $category-id->categories.name
                   :fk_field_id  %category-id
+                  :ident        (lib/implicitly-joined-ident (meta/ident :categories :name)
+                                                             (meta/ident :venues :category-id))
                   :source_alias "CATEGORIES__via__CATEGORY_ID"}]
                 (annotate/column-info
                  {:type  :query
                   :query {:fields [&CATEGORIES__via__CATEGORY_ID.categories.name]
+                          ;; This is a hand-rolled implicit join clause.
                           :joins  [{:alias        "CATEGORIES__via__CATEGORY_ID"
+                                    :ident        (lib/implicit-join-clause-ident (meta/ident :venues :category-id))
                                     :source-table $$venues
                                     :condition    [:= $category-id &CATEGORIES__via__CATEGORY_ID.categories.id]
                                     :strategy     :left-join
@@ -126,16 +150,19 @@
         (is (=? [{:display_name "Categories → Name"
                   :source       :fields
                   :field_ref    &Categories.categories.name
+                  :ident        (lib/explicitly-joined-ident (meta/ident :categories :name) "4LzfvdZnP61w1n73B7nDu")
                   :source_alias "Categories"}]
                 (annotate/column-info
                  {:type  :query
                   :query {:fields [&Categories.categories.name]
                           :joins  [{:alias        "Categories"
+                                    :ident        "4LzfvdZnP61w1n73B7nDu"
                                     :source-table $$venues
                                     :condition    [:= $category-id &Categories.categories.id]
                                     :strategy     :left-join}]}}
                  {:columns [:name]})))))))
 
+;; TODO: This test doesn't map neatly onto idents. If the field is bucketed then it should be a breakout.
 (deftest ^:parallel col-info-for-field-with-temporal-unit-test
   (qp.store/with-metadata-provider meta/metadata-provider
     (lib.tu.macros/$ids venues
@@ -155,46 +182,59 @@
                  :base_type    :type/Number
                  :display_name "Price"
                  :unit         :month
+                 ;; TODO: No :ident here! This case doesn't really map to how the idents work - you
+                 ;; can't have a string-based field ref without a source query or earlier stage.
+                 ;; That case is handled by other tests below.
                  :source       :fields
                  :field_ref    !month.*price/Number}]
                (doall
                 (annotate/column-info
-                 {:type :query, :query {:fields [[:field "price" {:base-type :type/Number, :temporal-unit :month}]]}}
+                 {:type  :query, :query {:fields [[:field "price" {:base-type :type/Number, :temporal-unit :month}]]}}
                  {:columns [:price]}))))))))
 
 (deftest ^:parallel col-info-for-field-with-temporal-unit-from-nested-query-test
   (qp.store/with-metadata-provider meta/metadata-provider
     (testing "should add the correct info if the Field originally comes from a nested query"
-      (lib.tu.macros/$ids checkins
-        (is (= [{:name "DATE", :unit :month, :field_ref [:field %date {:temporal-unit :default}]}
-                {:name "LAST_LOGIN", :unit :month, :field_ref [:field
-                                                               %users.last-login
-                                                               {:temporal-unit :default
-                                                                :join-alias    "USERS__via__USER_ID"}]}]
-               (mapv
-                (fn [col]
-                  (select-keys col [:name :unit :field_ref]))
-                (annotate/column-info
-                 {:type  :query
-                  :query {:source-query    {:source-table $$checkins
-                                            :breakout     [[:field %date {:temporal-unit :month}]
-                                                           [:field
-                                                            %users.last-login
-                                                            {:temporal-unit :month, :source-field %user-id}]]}
-                          :source-metadata [{:name      "DATE"
-                                             :id        %date
-                                             :unit      :month
-                                             :field_ref [:field %date {:temporal-unit :month}]}
-                                            {:name      "LAST_LOGIN"
-                                             :id        %users.last-login
-                                             :unit      :month
-                                             :field_ref [:field %users.last-login {:temporal-unit :month
-                                                                                   :source-field  %user-id}]}]
-                          :fields          [[:field %date {:temporal-unit :default}]
-                                            [:field %users.last-login {:temporal-unit :default, :join-alias "USERS__via__USER_ID"}]]
-                          :limit           1}}
-                 nil))))))))
+      (let [date-ident       (lib/random-ident)
+            last-login-ident (lib/random-ident)]
+        (lib.tu.macros/$ids checkins
+          (is (= [{:name      "DATE"
+                   :ident     date-ident
+                   :unit      :month
+                   :field_ref [:field %date {:temporal-unit :default}]}
+                  {:name      "LAST_LOGIN"
+                   :ident     last-login-ident
+                   :unit      :month
+                   :field_ref [:field %users.last-login {:temporal-unit :default
+                                                         :join-alias    "USERS__via__USER_ID"}]}]
+                 (mapv
+                  (fn [col]
+                    (select-keys col [:name :ident :unit :field_ref]))
+                  (annotate/column-info
+                   {:type  :query
+                    :query {:source-query    {:source-table $$checkins
+                                              :breakout     [[:field %date {:temporal-unit :month}]
+                                                             [:field
+                                                              %users.last-login
+                                                              {:temporal-unit :month, :source-field %user-id}]]
+                                              :breakout-idents {0 date-ident, 1 last-login-ident}}
+                            :source-metadata [{:name      "DATE"
+                                               :id        %date
+                                               :ident     date-ident
+                                               :unit      :month
+                                               :field_ref [:field %date {:temporal-unit :month}]}
+                                              {:name      "LAST_LOGIN"
+                                               :id        %users.last-login
+                                               :ident     last-login-ident
+                                               :unit      :month
+                                               :field_ref [:field %users.last-login {:temporal-unit :month
+                                                                                     :source-field  %user-id}]}]
+                            :fields          [[:field %date {:temporal-unit :default}]
+                                              [:field %users.last-login {:temporal-unit :default, :join-alias "USERS__via__USER_ID"}]]
+                            :limit           1}}
+                   nil)))))))))
 
+;; TODO: Not practical to add idents to this one - it needs to properly be a breakout.
 (deftest ^:parallel col-info-for-binning-strategy-test
   (testing "when binning strategy is used, include `:binning_info`"
     (is (= [{:name         "price"
@@ -226,20 +266,24 @@
   (lib.tu/mock-metadata-provider
    meta/metadata-provider
    {:fields [(assoc (meta/field-metadata :venues :name)
-                    :id            1
+                    :id           1
+                    :ident        "grandparent__v_2Tvafr"
                     :name         "grandparent"
                     :display-name "Grandparent")
              (assoc (meta/field-metadata :venues :name)
-                    :id            2
-                    :name          "parent"
-                    :display-name  "Parent"
-                    :parent-id     1)
+                    :id           2
+                    :ident        "parent__ALQnFu6HMDhtU"
+                    :name         "parent"
+                    :display-name "Parent"
+                    :parent-id    1)
              (assoc (meta/field-metadata :venues :name)
                     :id           3
+                    :ident        "child__yxGs5UuS4CeAHF"
                     :name         "child"
                     :display-name "Child"
                     :parent-id    2)]}))
 
+;; XXX: START HERE: Continue adding idents to these tests.
 (deftest ^:parallel col-info-combine-parent-field-names-test
   (testing "For fields with parents we should return them with a combined name including parent's name"
     (qp.store/with-metadata-provider child-parent-grandparent-metadata-provider
@@ -254,7 +298,7 @@
                :field_ref         [:field 2 nil]
                :nfc_path          nil
                :parent_id         1
-               :id                2
+               :ident             "parent__ALQnFu6HMDhtU"
                :visibility_type   :normal
                :display_name      "Parent"
                :base_type         :type/Text}
@@ -272,6 +316,7 @@
                :nfc_path          nil
                :parent_id         2
                :id                3
+               :ident             "child__yxGs5UuS4CeAHF"
                :visibility_type   :normal
                :display_name      "Child"
                :base_type         :type/Text}
@@ -282,13 +327,22 @@
     (qp.store/with-metadata-provider meta/metadata-provider
       (is (= {:name          "sum"
               :display_name  "sum of User ID"
+              :ident         "h_y8R2SIUWCcHYmbDMMDS"
               :base_type     :type/Integer
               :field_ref     [:field "sum" {:base-type :type/Integer}]
               :semantic_type :type/FK}
              (#'annotate/col-info-for-field-clause
               {:source-metadata
-               [{:name "abc", :display_name "another Field", :base_type :type/Integer, :semantic_type :type/FK}
-                {:name "sum", :display_name "sum of User ID", :base_type :type/Integer, :semantic_type :type/FK}]}
+               [{:name          "abc"
+                 :display_name  "another Field"
+                 :ident         "7idO5a5rdQVmEqghp0NDD"
+                 :base_type     :type/Integer
+                 :semantic_type :type/FK}
+                {:name          "sum"
+                 :display_name  "sum of User ID"
+                 :ident         "h_y8R2SIUWCcHYmbDMMDS"
+                 :base_type     :type/Integer
+                 :semantic_type :type/FK}]}
               [:field "sum" {:base-type :type/Integer}]))))))
 
 (deftest ^:parallel col-info-expressions-test
@@ -298,10 +352,12 @@
               :name            "double-price"
               :display_name    "double-price"
               :expression_name "double-price"
+              :ident           "eG2KisFcSyHRqACHSmmbN"
               :field_ref       [:expression "double-price"]}
              (lib.tu.macros/$ids venues
                (#'annotate/col-info-for-field-clause
-                {:expressions {"double-price" [:* $price 2]}}
+                {:expressions {"double-price" [:* $price 2]}
+                 :expression-idents {"double-price" "eG2KisFcSyHRqACHSmmbN"}}
                 [:expression "double-price"])))))
     (testing "col info for a boolean `expression` should have the correct `base_type`"
       (lib.tu.macros/$ids people
@@ -339,21 +395,25 @@
               :name               "last-login-converted",
               :display_name       "last-login-converted",
               :expression_name    "last-login-converted",
+              :ident              "aP4kbV3PYLhLoK3o3F5xx"
               :field_ref          [:expression "last-login-converted"]}
              (lib.tu.macros/$ids users
                (#'annotate/col-info-for-field-clause
-                {:expressions {"last-login-converted" [:convert-timezone $last-login "Asia/Ho_Chi_Minh" "UTC"]}}
+                {:expressions {"last-login-converted" [:convert-timezone $last-login "Asia/Ho_Chi_Minh" "UTC"]}
+                 :expression-idents {"last-login-converted" "aP4kbV3PYLhLoK3o3F5xx"}}
                 [:expression "last-login-converted"]))))
       (is (= {:converted_timezone "Asia/Ho_Chi_Minh",
               :base_type          :type/DateTime,
               :name               "last-login-converted",
               :display_name       "last-login-converted",
               :expression_name    "last-login-converted",
+              :ident              "aP4kbV3PYLhLoK3o3F5xx"
               :field_ref          [:expression "last-login-converted"]}
              (lib.tu.macros/$ids users
                (#'annotate/col-info-for-field-clause
                 {:expressions {"last-login-converted" [:datetime-add
-                                                       [:convert-timezone $last-login "Asia/Ho_Chi_Minh" "UTC"] 2 :hour]}}
+                                                       [:convert-timezone $last-login "Asia/Ho_Chi_Minh" "UTC"] 2 :hour]}
+                 :expression-idents {"last-login-converted" "aP4kbV3PYLhLoK3o3F5xx"}}
                 [:expression "last-login-converted"])))))))
 
 (deftest ^:parallel col-info-expressions-test-3
@@ -370,15 +430,20 @@
                (catch Throwable e {:message (.getMessage e), :data (ex-data e)})))))))
 
 ;; test that added information about aggregations looks the way we'd expect
+(def ^:private ident-for-aggregation
+  "epkgPymoZu76ZqTEM7U5k")
+
 (defn- aggregation-names
   ([ag-clause]
    (let [inner-query {:source-table (meta/id :venues)
-                      :aggregation  [ag-clause]}]
+                      :aggregation  [ag-clause]
+                      :aggregation-idents {0 ident-for-aggregation}}]
      (binding [driver/*driver* :h2]
        (qp.store/with-metadata-provider meta/metadata-provider
-         (-> (#'annotate/col-info-for-aggregation-clauses inner-query)
-             first
-             (select-keys [:name :display_name])))))))
+         (let [col (first (#'annotate/col-info-for-aggregation-clauses inner-query))]
+           (is (= (:ident col) ident-for-aggregation)
+               "col-info-for-aggregation-clauses should return the existing ident for the aggregation")
+           (select-keys col [:name :display_name])))))))
 
 (deftest ^:parallel aggregation-names-test
   (testing "basic aggregations"
@@ -444,7 +509,10 @@
    (col-info-for-aggregation-clause {:source-table (meta/id :venues)} clause))
 
   ([inner-query clause]
-   (let [inner-query (update inner-query :aggregation (fnil conj []) clause)]
+   (let [prior-aggs  (-> inner-query :aggregation count)
+         inner-query (-> inner-query
+                         (update :aggregation (fnil conj []) clause)
+                         (assoc-in [:aggregation-idents prior-aggs] ident-for-aggregation))]
      (binding [driver/*driver* :h2]
        (first (#'annotate/col-info-for-aggregation-clauses inner-query))))))
 
@@ -452,10 +520,16 @@
   (qp.store/with-metadata-provider meta/metadata-provider
     (testing "basic aggregation clauses"
       (testing "`:count` (no field)"
-        (is (=? {:base_type :type/Float, :name "expression", :display_name "Count ÷ 2"}
+        (is (=? {:base_type    :type/Float
+                 :name         "expression"
+                 :display_name "Count ÷ 2"
+                 :ident        ident-for-aggregation}
                 (col-info-for-aggregation-clause [:/ [:count] 2]))))
       (testing "`:sum`"
-        (is (=? {:base_type :type/Integer, :name "sum", :display_name "Sum of Price + 1"}
+        (is (=? {:base_type    :type/Integer
+                 :name         "sum"
+                 :display_name "Sum of Price + 1"
+                 :ident        ident-for-aggregation}
                 (lib.tu.macros/$ids venues
                   (col-info-for-aggregation-clause [:sum [:+ $price 1]]))))))))
 
@@ -466,7 +540,8 @@
         (is (=? {:base_type     :type/Integer
                  :settings      {:is_priceless true}
                  :name          "sum_2"
-                 :display_name  "My custom name"}
+                 :display_name  "My custom name"
+                 :ident         ident-for-aggregation}
                 (lib.tu.macros/$ids venues
                   (col-info-for-aggregation-clause
                    [:aggregation-options [:sum $price] {:name "sum_2", :display-name "My custom name"}])))))
@@ -474,14 +549,16 @@
         (is (=? {:base_type     :type/Integer
                  :settings      {:is_priceless true}
                  :name          "sum_2"
-                 :display_name  "Sum of Price"}
+                 :display_name  "Sum of Price"
+                 :ident         ident-for-aggregation}
                 (lib.tu.macros/$ids venues
                   (col-info-for-aggregation-clause [:aggregation-options [:sum $price] {:name "sum_2"}])))))
       (testing "`:display-name` only"
         (is (=? {:base_type     :type/Integer
                  :settings      {:is_priceless true}
                  :name          "sum"
-                 :display_name  "My Custom Name"}
+                 :display_name  "My Custom Name"
+                 :ident         ident-for-aggregation}
                 (lib.tu.macros/$ids venues
                   (col-info-for-aggregation-clause
                    [:aggregation-options [:sum $price] {:display-name "My Custom Name"}]))))))))
@@ -497,24 +574,31 @@
                                                                {:aggregation [[:sum $subtotal]]})}]})
     (testing (str "if a driver is kind enough to supply us with some information about the `:cols` that come back, we "
                   "should include that information in the results. Their information should be preferred over ours")
-      (is (=? {:cols [{:display_name   "Total Events"
-                       :base_type      :type/Text
-                       :effective_type :type/Text
-                       :source         :aggregation
-                       :field_ref      [:aggregation 0]}]}
-              (add-column-info
-               (lib.tu.macros/mbql-query venues {:aggregation [[:metric 1]]})
-               {:cols [{:display_name "Total Events", :base_type :type/Text}]}))))))
+      (let [query (lib.tu.macros/mbql-query venues {:aggregation [[:metric 1]]})]
+        (is (=? {:cols [{:display_name   "Total Events"
+                         :base_type      :type/Text
+                         :effective_type :type/Text
+                         :source         :aggregation
+                         :ident          (get-in query [:query :aggregation-idents 0])
+                         :field_ref      [:aggregation 0]}]}
+                (add-column-info
+                 query
+                 {:cols [{:display_name "Total Events", :base_type :type/Text}]})))))))
 
 (deftest ^:parallel col-info-for-aggregation-clause-test-4
   (qp.store/with-metadata-provider meta/metadata-provider
     (testing "col info for an `expression` aggregation w/ a named expression should work as expected"
-      (is (=? {:base_type :type/Integer, :name "sum", :display_name "Sum of double-price"}
-              (lib.tu.macros/$ids venues
-                (col-info-for-aggregation-clause
-                 {:source-table (meta/id :venues)
-                  :expressions {"double-price" [:* $price 2]}}
-                 [:sum [:expression "double-price"]])))))))
+      (let [query (lib.tu.macros/mbql-query venues
+                    {:expressions {"double-price" [:* $price 2]}
+                     :aggregation [[:sum [:expression "double-price"]]]})]
+        (is (=? {:base_type    :type/Integer
+                 :name         "sum"
+                 :display_name "Sum of double-price"
+                 :ident        (get-in query [:query :aggregation-idents 0])}
+                (lib.tu.macros/$ids venues
+                  (col-info-for-aggregation-clause
+                   (:query query)
+                   [:sum [:expression "double-price"]]))))))))
 
 (defn- infered-col-type
   [expr]
@@ -529,6 +613,7 @@
 (deftest ^:parallel computed-columns-inference
   (letfn [(infer [expr] (-> (lib.tu.macros/mbql-query venues
                               {:expressions {"expr" expr}
+                               :expression-idents {"expr" "LbroONhJ5OWyvFCQB4zp3"}
                                :fields [[:expression "expr"]]
                                :limit 10})
                             (add-column-info {})
@@ -541,6 +626,7 @@
                   :coercion_strategy nil,
                   :name "expr",
                   :expression_name "expr",
+                  :ident "LbroONhJ5OWyvFCQB4zp3"
                   :source :fields,
                   :field_ref [:expression "expr"],
                   :effective_type :type/Text,
@@ -555,6 +641,7 @@
                   :name "expr",
                   :display_name "expr",
                   :expression_name "expr",
+                  :ident "LbroONhJ5OWyvFCQB4zp3"
                   :field_ref [:expression "expr"],
                   :source :fields}
                  (infer [:coalesce "bar" [:field (meta/id :venues :name) nil]]))))))
@@ -565,6 +652,7 @@
                   :coercion_strategy nil,
                   :name "expr",
                   :expression_name "expr",
+                  :ident "LbroONhJ5OWyvFCQB4zp3"
                   :source :fields,
                   :field_ref [:expression "expr"],
                   :effective_type :type/Text,
@@ -632,44 +720,49 @@
 
 (deftest ^:parallel unique-name-key-test
   (testing "Make sure `:cols` always come back with a unique `:name` key (#8759)"
-    (is (=? {:cols
-             [{:base_type     :type/Number
-               :effective_type :type/Number
-               :semantic_type :type/Quantity
-               :name          "count"
-               :display_name  "count"
-               :source        :aggregation
-               :field_ref     [:aggregation 0]}
-              {:source       :aggregation
-               :name         "sum"
-               :display_name "sum"
-               :base_type    :type/Number
-               :effective_type :type/Number
-               :field_ref    [:aggregation 1]}
-              {:base_type     :type/Number
-               :effective_type :type/Number
-               :semantic_type :type/Quantity
-               :name          "count_2"
-               :display_name  "count"
-               :source        :aggregation
-               :field_ref     [:aggregation 2]}
-              {:base_type     :type/Number
-               :effective_type :type/Number
-               :semantic_type :type/Quantity
-               :name          "count_3"
-               :display_name  "count_2"
-               :source        :aggregation
-               :field_ref     [:aggregation 3]}]}
-            (add-column-info
-             (lib.tu.macros/mbql-query venues
-               {:aggregation [[:count]
-                              [:sum $price]
-                              [:count]
-                              [:aggregation-options [:count] {:display-name "count_2"}]]})
-             {:cols [{:name "count", :display_name "count", :base_type :type/Number}
-                     {:name "sum", :display_name "sum", :base_type :type/Number}
-                     {:name "count", :display_name "count", :base_type :type/Number}
-                     {:name "count_2", :display_name "count_2", :base_type :type/Number}]})))))
+    (let [query (lib.tu.macros/mbql-query venues
+                  {:aggregation [[:count]
+                                 [:sum $price]
+                                 [:count]
+                                 [:aggregation-options [:count] {:display-name "count_2"}]]})]
+      (is (=? {:cols
+               [{:base_type     :type/Number
+                 :effective_type :type/Number
+                 :semantic_type :type/Quantity
+                 :name          "count"
+                 :display_name  "count"
+                 :ident         (get-in query [:query :aggregation-idents 0])
+                 :source        :aggregation
+                 :field_ref     [:aggregation 0]}
+                {:source       :aggregation
+                 :name         "sum"
+                 :display_name "sum"
+                 :ident         (get-in query [:query :aggregation-idents 1])
+                 :base_type    :type/Number
+                 :effective_type :type/Number
+                 :field_ref    [:aggregation 1]}
+                {:base_type     :type/Number
+                 :effective_type :type/Number
+                 :semantic_type :type/Quantity
+                 :name          "count_2"
+                 :display_name  "count"
+                 :ident         (get-in query [:query :aggregation-idents 2])
+                 :source        :aggregation
+                 :field_ref     [:aggregation 2]}
+                {:base_type     :type/Number
+                 :effective_type :type/Number
+                 :semantic_type :type/Quantity
+                 :name          "count_3"
+                 :display_name  "count_2"
+                 :ident         (get-in query [:query :aggregation-idents 3])
+                 :source        :aggregation
+                 :field_ref     [:aggregation 3]}]}
+              (add-column-info
+               query
+               {:cols [{:name "count", :display_name "count", :base_type :type/Number}
+                       {:name "sum", :display_name "sum", :base_type :type/Number}
+                       {:name "count", :display_name "count", :base_type :type/Number}
+                       {:name "count_2", :display_name "count_2", :base_type :type/Number}]}))))))
 
 (deftest ^:parallel expressions-keys-test
   (testing "make sure expressions come back with the right set of keys, including `:expression_name` (#8854)"
@@ -677,11 +770,13 @@
             :display_name    "discount_price"
             :base_type       :type/Float
             :expression_name "discount_price"
+            :ident           "bdW6mQ49dxdMbC1CheUpt"
             :source          :fields
             :field_ref       [:expression "discount_price"]}
            (-> (add-column-info
                 (lib.tu.macros/mbql-query venues
                   {:expressions {"discount_price" [:* 0.9 $price]}
+                   :expression-idents {"discount_price" "bdW6mQ49dxdMbC1CheUpt"}
                    :fields      [$name [:expression "discount_price"]]
                    :limit       10})
                 {})
@@ -691,20 +786,34 @@
 (deftest ^:parallel deduplicate-expression-names-test
   (testing "make sure multiple expressions come back with deduplicated names"
     (testing "expressions in aggregations"
-      (is (=? [{:base_type :type/Float, :name "expression", :display_name "0.9 × Average of Price", :source :aggregation, :field_ref [:aggregation 0]}
-               {:base_type :type/Float, :name "expression_2", :display_name "0.8 × Average of Price", :source :aggregation, :field_ref [:aggregation 1]}]
-              (:cols (add-column-info
-                      (lib.tu.macros/mbql-query venues
-                        {:aggregation [[:* 0.9 [:avg $price]] [:* 0.8 [:avg $price]]]
-                         :limit       10})
-                      {})))))
+      (let [query (lib.tu.macros/mbql-query venues
+                    {:aggregation [[:* 0.9 [:avg $price]] [:* 0.8 [:avg $price]]]
+                     :limit       10})]
+        (is (=? [{:base_type    :type/Float
+                  :name         "expression"
+                  :display_name "0.9 × Average of Price"
+                  :ident        (get-in query [:query :aggregation-idents 0])
+                  :source       :aggregation
+                  :field_ref    [:aggregation 0]}
+                 {:base_type    :type/Float
+                  :name         "expression_2"
+                  :display_name "0.8 × Average of Price"
+                  :ident        (get-in query [:query :aggregation-idents 1])
+                  :source       :aggregation
+                  :field_ref    [:aggregation 1]}]
+                (:cols (add-column-info query {}))))))
     (testing "named :expressions"
-      (is (=? [{:name "prev_month", :display_name "prev_month", :base_type :type/DateTime, :expression_name "prev_month", :source :fields, :field_ref [:expression "prev_month"]}]
-              (:cols (add-column-info
-                      (lib.tu.macros/mbql-query users
-                        {:expressions {:prev_month [:+ $last-login [:interval -1 :month]]}
-                         :fields      [[:expression "prev_month"]], :limit 10})
-                      {})))))))
+      (let [query (lib.tu.macros/mbql-query users
+                    {:expressions {:prev_month [:+ $last-login [:interval -1 :month]]}
+                     :fields      [[:expression "prev_month"]], :limit 10})]
+        (is (=? [{:name            "prev_month"
+                  :display_name    "prev_month"
+                  :base_type       :type/DateTime
+                  :expression_name "prev_month"
+                  :ident           (get-in query [:query :expression-idents "prev_month"])
+                  :source          :fields
+                  :field_ref       [:expression "prev_month"]}]
+                (:cols (add-column-info query {}))))))))
 
 (deftest ^:parallel mbql-cols-nested-queries-test
   (testing "Should be able to infer MBQL columns with nested queries"
@@ -714,21 +823,32 @@
                           {:joins [{:fields       :all
                                     :source-table $$categories
                                     :condition    [:= $category-id &c.categories.id]
-                                    :alias        "c"}]}))]
+                                    :alias        "c"}]}))
+            join-ident (get-in base-query [:query :joins 0 :ident])
+            field      (fn [field-key legacy-ref]
+                         (-> (meta/field-metadata :venues field-key)
+                             (select-keys [:id :name :ident])
+                             (assoc :field_ref legacy-ref)))]
         (doseq [level [0 1 2 3]]
           (testing (format "%d level(s) of nesting" level)
             (let [nested-query (mt/nest-query base-query level)]
               (testing (format "\nQuery = %s" (u/pprint-to-str nested-query))
                 (is (= (lib.tu.macros/$ids venues
-                         [{:name "ID", :id %id, :field_ref $id}
-                          {:name "NAME", :id %name, :field_ref $name}
-                          {:name "CATEGORY_ID", :id %category-id, :field_ref $category-id}
-                          {:name "LATITUDE", :id %latitude, :field_ref $latitude}
-                          {:name "LONGITUDE", :id %longitude, :field_ref $longitude}
-                          {:name "PRICE", :id %price, :field_ref $price}
-                          {:name "ID_2", :id %categories.id, :field_ref &c.categories.id}
-                          {:name "NAME_2", :id %categories.name, :field_ref &c.categories.name}])
-                       (map #(select-keys % [:name :id :field_ref])
+                         [(field :id          $id)
+                          (field :name        $name)
+                          (field :category-id $category-id)
+                          (field :latitude    $latitude)
+                          (field :longitude   $longitude)
+                          (field :price       $price)
+                          {:name      "ID_2"
+                           :id        %categories.id
+                           :ident     (lib/explicitly-joined-ident (meta/ident :categories :id) join-ident)
+                           :field_ref &c.categories.id}
+                          {:name      "NAME_2"
+                           :id        %categories.name
+                           :ident     (lib/explicitly-joined-ident (meta/ident :categories :name) join-ident)
+                           :field_ref &c.categories.name}])
+                       (map #(select-keys % [:name :id :field_ref :ident])
                             (:cols (add-column-info nested-query {})))))))))))))
 
 (deftest ^:parallel mbql-cols-nested-queries-test-2
@@ -770,7 +890,7 @@
               (as-> (:cols result) result
                 (m/index-by :name result)
                 (get result "EAN")
-                (select-keys result [:name :display_name :base_type :semantic_type :id :field_ref])))]
+                (select-keys result [:name :display_name :base_type :semantic_type :id :field_ref :ident])))]
       (qp.store/with-metadata-provider meta/metadata-provider
         (testing "Make sure metadata is correct for the 'EAN' column with"
           (let [base-query (qp.preprocess/preprocess
@@ -779,7 +899,8 @@
                                         :source-table $$products
                                         :condition    [:= $product-id &Products.products.id]
                                         :alias        "Products"}]
-                               :limit 10}))]
+                               :limit 10}))
+                join-ident (-> base-query :query :joins first :ident)]
             (doseq [level (range 4)]
               (testing (format "%d level(s) of nesting" level)
                 (let [nested-query (mt/nest-query base-query level)]
@@ -790,6 +911,7 @@
                               :base_type     :type/Text
                               :semantic_type nil
                               :id            %ean
+                              :ident         (lib/explicitly-joined-ident (meta/ident :products :ean) join-ident)
                               :field_ref     &Products.ean})
                            (ean-metadata (add-column-info nested-query {}))))))))))))))
 
@@ -815,57 +937,78 @@
                                                  :alias        "Q"}]
                                  :limit        1}))
                   fields     #{%orders.discount %products.title %people.source}]
-              (is (= [{:display_name "Discount" :field_ref [:field %orders.discount nil]}
-                      {:display_name "Products → Title" :field_ref [:field %products.title nil]}
-                      {:display_name "Q → Source" :field_ref [:field %people.source {:join-alias "Q"}]}]
+              (is (= [{:display_name "Discount"
+                       :ident        (meta/ident :orders :discount)
+                       :field_ref    [:field %orders.discount nil]}
+                      {:display_name "Products → Title"
+                       :ident        (lib/explicitly-joined-ident (meta/ident :products :title)
+                                                                  (-> card-1-query :query :joins first :ident))
+                       :field_ref    [:field %products.title nil]}
+                      {:display_name "Q → Source"
+                       :ident        (lib/explicitly-joined-ident (meta/ident :people :source)
+                                                                  (-> base-query :query :joins first :ident))
+                       :field_ref    [:field %people.source {:join-alias "Q"}]}]
                      (->> (:cols (add-column-info base-query {}))
                           (filter #(fields (:id %)))
-                          (map #(select-keys % [:display_name :field_ref]))))))))))))
+                          (map #(select-keys % [:display_name :field_ref :ident]))))))))))))
 
 (deftest ^:parallel col-info-for-joined-fields-from-card-test
   (testing "Has the correct display names for joined fields from cards (#14787)"
     (letfn [(native [query] {:type     :native
                              :native   {:query query :template-tags {}}
                              :database (meta/id)})]
-      (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
-                                        meta/metadata-provider
-                                        {:cards [{:id              1
-                                                  :name            "Card 1"
-                                                  :database-id     (meta/id)
-                                                  :dataset-query   (native "select 'foo' as A_COLUMN")
-                                                  :result-metadata [{:name         "A_COLUMN"
-                                                                     :display_name "A Column"
-                                                                     :base_type    :type/Text}]}
-                                                 {:id              2
-                                                  :name            "Card 2"
-                                                  :database-id     (meta/id)
-                                                  :dataset-query   (native "select 'foo' as B_COLUMN")
-                                                  :result-metadata [{:name         "B_COLUMN"
-                                                                     :display_name "B Column"
-                                                                     :base_type    :type/Text}]}]})
-        (let [query (lib.tu.macros/mbql-query nil
-                      {:source-table "card__1"
-                       :joins        [{:fields       "all"
-                                       :source-table "card__2"
-                                       :condition    [:=
-                                                      [:field "A_COLUMN" {:base-type :type/Text}]
-                                                      [:field "B_COLUMN" {:base-type  :type/Text
-                                                                          :join-alias "alias"}]]
-                                       :alias        "alias"}]})
-              cols  (qp.preprocess/query->expected-cols query)]
-          (is (= "alias → B Column"
-                 (-> cols second :display_name))
-              "cols has wrong display name"))))))
+      (let [card1-eid (u/generate-nano-id)
+            card2-eid (u/generate-nano-id)]
+        (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
+                                          meta/metadata-provider
+                                          {:cards [{:id              1
+                                                    :entity_id       card1-eid
+                                                    :name            "Card 1"
+                                                    :database-id     (meta/id)
+                                                    :dataset-query   (native "select 'foo' as A_COLUMN")
+                                                    :result-metadata [{:name         "A_COLUMN"
+                                                                       :display_name "A Column"
+                                                                       :ident        (lib/native-ident "A_COLUMN"
+                                                                                                       card1-eid)
+                                                                       :base_type    :type/Text}]}
+                                                   {:id              2
+                                                    :entity_id       card2-eid
+                                                    :name            "Card 2"
+                                                    :database-id     (meta/id)
+                                                    :dataset-query   (native "select 'foo' as B_COLUMN")
+                                                    :result-metadata [{:name         "B_COLUMN"
+                                                                       :display_name "B Column"
+                                                                       :ident        (lib/native-ident "B_COLUMN"
+                                                                                                       card2-eid)
+                                                                       :base_type    :type/Text}]}]})
+          (let [query (lib.tu.macros/mbql-query nil
+                        {:source-table "card__1"
+                         :joins        [{:fields       "all"
+                                         :source-table "card__2"
+                                         :condition    [:=
+                                                        [:field "A_COLUMN" {:base-type :type/Text}]
+                                                        [:field "B_COLUMN" {:base-type  :type/Text
+                                                                            :join-alias "alias"}]]
+                                         :alias        "alias"}]})
+                cols  (qp.preprocess/query->expected-cols query)]
+            (is (=? [{:ident        (lib/native-ident "A_COLUMN" card1-eid)}
+                     {:display_name "alias → B Column"
+                      :ident        (lib/explicitly-joined-ident (lib/native-ident "B_COLUMN" card2-eid)
+                                                                 (-> query :query :joins first :ident))}]
+                    cols)
+                "cols has wrong display name")))))))
 
 (deftest ^:parallel preserve-original-join-alias-e2e-test
   (testing "The join alias for the `:field_ref` in results metadata should match the one originally specified (#27464)"
     (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
       (mt/dataset test-data
         (let [join-alias "Products with a very long name - Product ID with a very long name"
+              join-ident (u/generate-nano-id)
               results    (mt/run-mbql-query orders
                            {:joins  [{:source-table $$products
                                       :condition    [:= $product_id [:field %products.id {:join-alias join-alias}]]
                                       :alias        join-alias
+                                      :ident        join-ident
                                       :fields       [[:field %products.title {:join-alias join-alias}]]}]
                             :fields [$orders.id
                                      [:field %products.title {:join-alias join-alias}]]
@@ -875,13 +1018,17 @@
             (testing location
               (is (= (mt/$ids
                        [{:display_name "ID"
+                         :ident        (:ident (lib.metadata/field (mt/metadata-provider) (mt/id :orders :id)))
                          :field_ref    $orders.id}
                         (merge
                          {:display_name (str join-alias " → Title")
+                          :ident        (-> (lib.metadata/field (mt/metadata-provider) (mt/id :products :title))
+                                            :ident
+                                            (lib/explicitly-joined-ident join-ident))
                           :field_ref    [:field %products.title {:join-alias join-alias}]}
                          ;; `source_alias` is only included in `data.cols`, but not in `results_metadata`
                          (when (= location "data.cols")
                            {:source_alias join-alias}))])
                      (map
-                      #(select-keys % [:display_name :field_ref :source_alias])
+                      #(select-keys % [:display_name :field_ref :source_alias :ident])
                       metadata))))))))))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -1031,3 +1031,26 @@
                      (map
                       #(select-keys % [:display_name :field_ref :source_alias :ident])
                       metadata))))))))))
+
+(deftest ^:parallel native-model-display-name-humanization-test
+  (testing ":display_name for a native model's columns should be humanized"
+    (mt/with-temp
+      [:model/Card card (mt/card-with-metadata
+                         {:dataset_query (mt/native-query {:query "SELECT * FROM orders"})
+                          :type          :model})]
+      (letfn [(col-fn [name display-name]
+                {:name   name
+                 :display_name display-name
+                 :ident        (-> name
+                                   (lib/native-ident (:entity_id card))
+                                   (lib/model-ident (:entity_id card)))})]
+        (is (=? [(col-fn "ID"         "ID")
+                 (col-fn "USER_ID"    "User ID")
+                 (col-fn "PRODUCT_ID" "Product ID")
+                 (col-fn "SUBTOTAL"   "Subtotal")
+                 (col-fn "TAX"        "Tax")
+                 (col-fn "TOTAL"      "Total")
+                 (col-fn "DISCOUNT"   "Discount")
+                 (col-fn "CREATED_AT" "Created At")
+                 (col-fn "QUANTITY"   "Quantity")]
+                (:result_metadata card)))))))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -1031,26 +1031,3 @@
                      (map
                       #(select-keys % [:display_name :field_ref :source_alias :ident])
                       metadata))))))))))
-
-(deftest ^:parallel native-model-display-name-humanization-test
-  (testing ":display_name for a native model's columns should be humanized"
-    (mt/with-temp
-      [:model/Card card (mt/card-with-metadata
-                         {:dataset_query (mt/native-query {:query "SELECT * FROM orders"})
-                          :type          :model})]
-      (letfn [(col-fn [name display-name]
-                {:name   name
-                 :display_name display-name
-                 :ident        (-> name
-                                   (lib/native-ident (:entity_id card))
-                                   (lib/model-ident (:entity_id card)))})]
-        (is (=? [(col-fn "ID"         "ID")
-                 (col-fn "USER_ID"    "User ID")
-                 (col-fn "PRODUCT_ID" "Product ID")
-                 (col-fn "SUBTOTAL"   "Subtotal")
-                 (col-fn "TAX"        "Tax")
-                 (col-fn "TOTAL"      "Total")
-                 (col-fn "DISCOUNT"   "Discount")
-                 (col-fn "CREATED_AT" "Created At")
-                 (col-fn "QUANTITY"   "Quantity")]
-                (:result_metadata card)))))))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -283,7 +283,6 @@
                     :display-name "Child"
                     :parent-id    2)]}))
 
-;; XXX: START HERE: Continue adding idents to these tests.
 (deftest ^:parallel col-info-combine-parent-field-names-test
   (testing "For fields with parents we should return them with a combined name including parent's name"
     (qp.store/with-metadata-provider child-parent-grandparent-metadata-provider

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -401,7 +401,9 @@
 
 (defn- expected-model-metadata [the-model]
   (for [col expected-inner-metadata]
-    (lib/add-model-ident col (:entity_id the-model))))
+    (-> (lib/add-model-ident col (:entity_id the-model))
+        ;; TODO: Inner idents are not returned on query results... but perhaps should be?
+        (dissoc :model/inner_ident))))
 
 (deftest multiple-models-e2e-test
   (testing "caching works across the whole QP where two models have the same inner query"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -401,7 +401,7 @@
 
 (defn- expected-model-metadata [the-model]
   (for [col expected-inner-metadata]
-    (update col :ident lib/model-ident (:entity_id the-model))))
+    (lib/add-model-ident col (:entity_id the-model))))
 
 (deftest multiple-models-e2e-test
   (testing "caching works across the whole QP where two models have the same inner query"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -405,7 +405,7 @@
     (update col :ident lib/model-ident (:entity_id the-model))))
 
 (deftest multiple-models-e2e-test
-  (testing "caching works across the QP where two models have the same inner query"
+  (testing "caching works across the whole QP where two models have the same inner query"
     (let [inner-query (mt/mbql-query venues {:order-by [[:asc $id]], :limit 5})]
       (mt/with-temp [:model/Card model1 (mt/card-with-metadata {:dataset_query inner-query
                                                                 :name          "Model 1"
@@ -435,14 +435,12 @@
                   "Query should be cacheable")
 
               (mt/with-clock #t "2020-02-19T04:44:26.056Z[UTC]"
-                #_(let [original-result1 (qp/process-query inner1)
+                (let [original-result1 (qp/process-query inner1)
                       ;; clear any existing values in the `save-chan`
                       _                (while (a/poll! save-chan))
                       _                (mt/wait-for-result save-chan)
                       rerun-inner1     (qp/process-query inner1)
-                      rerun-inner2     (qp/process-query inner2)
-                      ]
-
+                      rerun-inner2     (qp/process-query inner2)]
                   (testing "\n\nInner queries are cached and have generic metadata"
                     (doseq [[the-model cached-results] [[model1 rerun-inner1]
                                                         [model2 rerun-inner2]]]
@@ -461,24 +459,91 @@
                                   (-> cached-results :data :results_metadata :columns))))))))
 
                 (let [outer1           (-> (mt/mbql-query nil {:source-table (str "card__" (:id model1))})
-                                           #_(assoc :cache-strategy (ttl-strategy))
-                                           (assoc-in [:info :card-entity-id] (:entity_id model1)))
+                                           (assoc :cache-strategy (ttl-strategy)))
                       outer2           (-> (mt/mbql-query nil {:source-table (str "card__" (:id model2))})
                                            (assoc :cache-strategy (ttl-strategy)))
-                      original-result1 (binding [metabase.query-processor.debug/*debug* true]
-                                         (qp/process-query outer1))
+                      original-result1 (qp/process-query outer1)
                       _                (while (a/poll! save-chan))
                       _                (mt/wait-for-result save-chan)
                       rerun-outer1     (qp/process-query outer1)
-                      rerun-outer2     (qp/process-query outer2)]
+                      one-run-outer2   (qp/process-query outer2)]
                   (testing "Original results have correct model metadata"
                     (is (=? (expected-model-metadata model1)
                             (-> original-result1 :data :results_metadata :columns))))
 
-                  #_(testing "\n\nOuter queries are cached and have model-specific metadata"
+                  (testing "\n\nOuter queries are cached *separately*"
+                    (is (=? {:cache/details  {:cached     true
+                                              :updated_at #t "2020-02-19T04:44:26.056Z[UTC]"
+                                              :hash       some?
+                                              ;; TODO: this check is not working if the key is not present in the data
+                                              :cache-hash some?}
+                             :row_count 5
+                             :status    :completed}
+                            (dissoc rerun-outer1 :data))
+                        "second run of model1 is cached")
+
+                    (is (=? {:cache/details {:stored true
+                                             :cached (symbol "nil #_\"key is not present.\"")
+                                             :hash   some?}}
+                            one-run-outer2)
+                        "first run of model2 is stored, but not served from cache"))
+
+                  (testing "\n\nOuter queries have model-specific metadata"
                     (doseq [[the-model cached-results] [[model1 rerun-outer1]
-                                                        #_[model2 rerun-outer2]]]
+                                                        [model2 one-run-outer2]]]
                       (testing (:name the-model)
+                        (is (=? (expected-model-metadata the-model)
+                                (-> cached-results :data :results_metadata :columns)))))))))))))))
+
+(defn- expected-native-metadata [the-card]
+  [{:name  "ID"
+    :ident (lib/native-ident "ID"   (:entity_id the-card))}
+   {:name  "NAME"
+    :ident (lib/native-ident "NAME" (:entity_id the-card))}])
+
+(deftest duplicate-native-queries-e2e-test
+  (testing "caching works across the whole QP when two native cards have the same inner query"
+    (let [inner-query (mt/native-query {:query "SELECT ID, NAME FROM venues ORDER BY ID LIMIT 5;"})]
+      (mt/with-temp [:model/Card card1 (mt/card-with-metadata {:dataset_query inner-query
+                                                               :name          "Native card 1"})
+                     :model/Card card2 (mt/card-with-metadata {:dataset_query inner-query
+                                                               :name          "Native card 2"})]
+        (testing "both cards get :result_metadata containing the card's :entity_id"
+          (is (=? (expected-native-metadata card1)
+                  (:result_metadata card1)))
+          (is (=? (expected-native-metadata card2)
+                  (:result_metadata card2))))
+
+        (with-mock-cache! [save-chan]
+          (let [query1 (-> (:dataset_query card1)
+                           (assoc :cache-strategy (ttl-strategy))
+                           (assoc-in [:info :card-entity-id] (:entity_id card1)))
+                query2 (-> (:dataset_query card2)
+                           (assoc :cache-strategy (ttl-strategy))
+                           (assoc-in [:info :card-entity-id] (:entity_id card2)))]
+            (testing (format "\nquery1 = %s\nquery2 = %s" (pr-str query1) (pr-str query2))
+              (is (= true
+                     (boolean (#'cache/is-cacheable? query1)))
+                  "Query should be cacheable")
+              (is (= true
+                     (boolean (#'cache/is-cacheable? query2)))
+                  "Query should be cacheable")
+
+              (mt/with-clock #t "2020-02-19T04:44:26.056Z[UTC]"
+                (let [original-result1 (qp/process-query query1)
+                      ;; clear any existing values in the `save-chan`
+                      _                (while (a/poll! save-chan))
+                      _                (mt/wait-for-result save-chan)
+                      rerun-query1     (qp/process-query query1)
+                      rerun-query2     (qp/process-query query2)]
+                  (testing "\n\nNative queries are cached and return card-specific metadata"
+                    (is (= (-> rerun-query1 :cache/details :hash codecs/bytes->hex)
+                           (-> rerun-query2 :cache/details :hash codecs/bytes->hex))
+                        "these two queries must have the same hash, or this whole test is not testing anything")
+
+                    (doseq [[the-card cached-results] [[card1 rerun-query1]
+                                                       [card2 rerun-query2]]]
+                      (testing (:name the-card)
                         (testing "results should be cached"
                           (is (=? {:cache/details  {:cached     true
                                                     :updated_at #t "2020-02-19T04:44:26.056Z[UTC]"
@@ -488,11 +553,9 @@
                                    :row_count 5
                                    :status    :completed}
                                   (dissoc cached-results :data))))
-                        (testing "should have correct **generic** metadata"
-                          (is (=? (expected-model-metadata the-model)
-                                  (-> cached-results :data :results_metadata :columns))))))))))))
-        ))
-    ))
+                        (testing "should have correct **card-specific** metadata"
+                          (is (=? (expected-native-metadata the-card)
+                                  (-> cached-results :data :results_metadata :columns))))))))))))))))
 
 (deftest insights-from-cache-test
   (testing "Insights should work on cached results (#12556)"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -4,7 +4,6 @@
    [buddy.core.codecs :as codecs]
    [clojure.core.async :as a]
    [clojure.data.csv :as csv]
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [medley.core :as m]
@@ -418,7 +417,6 @@
             (is (=? (expected-model-metadata the-model)
                     (:result_metadata the-model)))))
 
-
         (with-mock-cache! [save-chan]
           (let [inner1 (-> (:dataset_query model1)
                            (assoc :cache-strategy (ttl-strategy))
@@ -435,7 +433,7 @@
                   "Query should be cacheable")
 
               (mt/with-clock #t "2020-02-19T04:44:26.056Z[UTC]"
-                (let [original-result1 (qp/process-query inner1)
+                (let [_                (qp/process-query inner1)
                       ;; clear any existing values in the `save-chan`
                       _                (while (a/poll! save-chan))
                       _                (mt/wait-for-result save-chan)
@@ -530,7 +528,7 @@
                   "Query should be cacheable")
 
               (mt/with-clock #t "2020-02-19T04:44:26.056Z[UTC]"
-                (let [original-result1 (qp/process-query query1)
+                (let [_                (qp/process-query query1)
                       ;; clear any existing values in the `save-chan`
                       _                (while (a/poll! save-chan))
                       _                (mt/wait-for-result save-chan)

--- a/test/metabase/query_processor/middleware/constraints_test.clj
+++ b/test/metabase/query_processor/middleware/constraints_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.query-processor.middleware.constraints-test
   (:require
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.middleware.constraints :as qp.constraints]))
 
 (deftest ^:parallel no-op-without-middleware-options-test
@@ -10,10 +12,11 @@
 
 (deftest ^:parallel add-constraints-test
   (testing "if it is *truthy* add the constraints"
-    (is (= {:middleware  {:add-default-userland-constraints? true
-                          :userland-query?                   true}
-            :constraints {:max-results           @#'qp.constraints/default-aggregated-query-row-limit
-                          :max-results-bare-rows @#'qp.constraints/default-unaggregated-query-row-limit}}
+    (is (=? {:middleware  {:add-default-userland-constraints? true
+                           :userland-query?                   true}
+             :info        {:card-entity-id        lib.tu/placeholder-entity-id?}
+             :constraints {:max-results           @#'qp.constraints/default-aggregated-query-row-limit
+                           :max-results-bare-rows @#'qp.constraints/default-unaggregated-query-row-limit}}
            (qp.constraints/maybe-add-default-userland-constraints
             {:middleware {:add-default-userland-constraints? true
                           :userland-query?                   true}})))))
@@ -28,10 +31,12 @@
   (testing "if it already has constraints, don't overwrite those!"
     (is (= {:middleware  {:add-default-userland-constraints? true
                           :userland-query?                   true}
+            :info        {:card-entity-id        "TY8R-MaO7V79FKecQyKww"}
             :constraints {:max-results           @#'qp.constraints/default-aggregated-query-row-limit
                           :max-results-bare-rows 1}}
            (qp.constraints/maybe-add-default-userland-constraints
             {:constraints {:max-results-bare-rows 1}
+             :info        {:card-entity-id "TY8R-MaO7V79FKecQyKww"}
              :middleware  {:add-default-userland-constraints? true
                            :userland-query?                   true}})))))
 
@@ -39,10 +44,12 @@
   (testing "if you specify just `:max-results` it should make sure `:max-results-bare-rows` is <= `:max-results`"
     (is (= {:middleware  {:add-default-userland-constraints? true
                           :userland-query?                   true}
+            :info        {:card-entity-id        "TY8R-MaO7V79FKecQyKww"}
             :constraints {:max-results           5
                           :max-results-bare-rows 5}}
            (qp.constraints/maybe-add-default-userland-constraints
             {:constraints {:max-results 5}
+             :info        {:card-entity-id        "TY8R-MaO7V79FKecQyKww"}
              :middleware  {:add-default-userland-constraints? true
                            :userland-query?                   true}})))))
 
@@ -50,9 +57,11 @@
   (testing "if you specify both it should still make sure `:max-results-bare-rows` is <= `:max-results`"
     (is (= {:middleware  {:add-default-userland-constraints? true
                           :userland-query?                   true}
+            :info        {:card-entity-id        "TY8R-MaO7V79FKecQyKww"}
             :constraints {:max-results           5
                           :max-results-bare-rows 5}}
            (qp.constraints/maybe-add-default-userland-constraints
             {:constraints {:max-results 5, :max-results-bare-rows 10}
+             :info        {:card-entity-id        "TY8R-MaO7V79FKecQyKww"}
              :middleware  {:add-default-userland-constraints? true
                            :userland-query?                   true}})))))

--- a/test/metabase/query_processor/middleware/constraints_test.clj
+++ b/test/metabase/query_processor/middleware/constraints_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.middleware.constraints-test
   (:require
    [clojure.test :refer :all]
-   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.middleware.constraints :as qp.constraints]))
 
@@ -17,9 +16,9 @@
              :info        {:card-entity-id        lib.tu/placeholder-entity-id?}
              :constraints {:max-results           @#'qp.constraints/default-aggregated-query-row-limit
                            :max-results-bare-rows @#'qp.constraints/default-unaggregated-query-row-limit}}
-           (qp.constraints/maybe-add-default-userland-constraints
-            {:middleware {:add-default-userland-constraints? true
-                          :userland-query?                   true}})))))
+            (qp.constraints/maybe-add-default-userland-constraints
+             {:middleware {:add-default-userland-constraints? true
+                           :userland-query?                   true}})))))
 
 (deftest ^:parallel no-op-if-option-is-false-test
   (testing "don't do anything if it's not truthy"

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -160,6 +160,10 @@
      :query    {:source-table "card__1"
                 :limit        50}}]))
 
+(comment
+  (def mp (nested-nested-provider))
+  (lib.metadata/card mp 1))
+
 (deftest ^:parallel nested-nested-queries-test
   (testing "make sure that nested nested queries work as expected"
     (qp.store/with-metadata-provider (nested-nested-provider)
@@ -180,14 +184,20 @@
                 {:source-table "card__2", :limit 25})))))))
 
 (defn- nested-nested-app-db-provider []
-  (-> (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-      (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries
-       [(mt/mbql-query venues {:limit 100})
-        {:database lib.schema.id/saved-questions-virtual-database-id
-         :type     :query
-         :query    {:source-table "card__1"
-                    :limit        50}}])
-      (lib.tu/merged-mock-metadata-provider {:cards [{:id 1, :type :model}]})))
+  (let [base     (-> (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                     (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries
+                      [(mt/mbql-query venues {:limit 100})
+                       {:database lib.schema.id/saved-questions-virtual-database-id
+                        :type     :query
+                        :query    {:source-table "card__1"
+                                   :limit        50}}]))
+        card     (lib.metadata/card base 1)
+        eid      (lib/random-ident)
+        metadata (mapv #(update % :ident lib/model-ident eid) (:result-metadata card))]
+    (lib.tu/merged-mock-metadata-provider base {:cards [{:id              1
+                                                         :type            :model
+                                                         :entity-id       eid
+                                                         :result-metadata metadata}]})))
 
 (deftest ^:parallel nested-nested-queries-test-2
   (testing "Marks datasets as from a dataset"

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -160,10 +160,6 @@
      :query    {:source-table "card__1"
                 :limit        50}}]))
 
-(comment
-  (def mp (nested-nested-provider))
-  (lib.metadata/card mp 1))
-
 (deftest ^:parallel nested-nested-queries-test
   (testing "make sure that nested nested queries work as expected"
     (qp.store/with-metadata-provider (nested-nested-provider)

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -46,11 +46,12 @@
   ([metadata-provider query]
    (mock-metric metadata-provider query nil))
   ([metadata-provider query card-details]
-   (let [metric (merge {:lib/type :metadata/card
-                        :id (fresh-card-id metadata-provider)
-                        :database-id (meta/id)
-                        :name "Mock Metric"
-                        :type :metric
+   (let [metric (merge {:lib/type      :metadata/card
+                        :id            (fresh-card-id metadata-provider)
+                        :entity-id     (u/generate-nano-id)
+                        :database-id   (meta/id)
+                        :name          "Mock Metric"
+                        :type          :metric
                         :dataset-query query}
                        card-details)]
      [metric (lib/composed-metadata-provider
@@ -338,16 +339,20 @@
                   (lib/join (lib/join-clause question [(lib/= 1 1)])))]
     (is (=? {:stages [{:joins [{:stages [{:aggregation [[:avg {} [:field {} (meta/id :products :rating)]]]}
                                          ;; Empty stage added by resolved-source-cards to nest join
-                                         #(= #{:lib/type :qp/stage-had-source-card :source-query/model?} (set (keys %)))]}]}]}
+                                         (=?/exactly {:lib/type                 :mbql.stage/mbql
+                                                      :qp/stage-had-source-card (:id question)
+                                                      :source-query/model?      false
+                                                      :source-query/entity-id   (:entity-id question)})]}]}]}
             (adjust query)))))
 
 (defn- model-based-metric-question
   [mp model-query agg-col-fn]
-  (let [model {:lib/type :metadata/card
-               :id (fresh-card-id mp)
-               :database-id (meta/id)
-               :name "Mock Model"
-               :type :model
+  (let [model {:lib/type      :metadata/card
+               :id            (fresh-card-id mp)
+               :entity-id     (u/generate-nano-id)
+               :database-id   (meta/id)
+               :name          "Mock Model"
+               :type          :model
                :dataset-query model-query}
         model-mp (lib/composed-metadata-provider
                   mp
@@ -398,11 +403,12 @@
   (let [mp meta/metadata-provider
         model-query (-> (lib/query mp (meta/table-metadata :orders))
                         (lib/filter (lib/> (meta/field-metadata :orders :discount) 3)))
-        model {:lib/type :metadata/card
-               :id (fresh-card-id mp)
-               :database-id (meta/id)
-               :name "Base Mock Model"
-               :type :model
+        model {:lib/type      :metadata/card
+               :id            (fresh-card-id mp)
+               :entity-id     (u/generate-nano-id)
+               :database-id   (meta/id)
+               :name          "Base Mock Model"
+               :type          :model
                :dataset-query model-query}
         model-mp (lib/composed-metadata-provider
                   mp
@@ -666,6 +672,7 @@
 (deftest ^:parallel model-based-metric-use-test
   (let [model {:lib/type :metadata/card
                :id (fresh-card-id meta/metadata-provider)
+               :entity-id (u/generate-nano-id)
                :database-id (meta/id)
                :name "Mock Model"
                :type :model

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -136,10 +136,10 @@
                :base_type    :type/Text}]
              (card-metadata card)))
       (let [result (qp/process-query
-                     (qp/userland-query
-                       {:database lib.schema.id/saved-questions-virtual-database-id
-                        :type     :query
-                        :query    {:source-table (str "card__" (u/the-id card))}}))]
+                    (qp/userland-query
+                     {:database lib.schema.id/saved-questions-virtual-database-id
+                      :type     :query
+                      :query    {:source-table (str "card__" (u/the-id card))}}))]
         (is (partial= {:status :completed}
                       result)))
       (is (= [{:name         "NAME"
@@ -187,9 +187,9 @@
                :base_type    :type/Text}]
              (card-metadata card))))))
 
-(deftest save-result-metadata-test-4
+(deftest save-result-metadata-test-5
   (testing "test that card result metadata does not generate an UPDATE statement when unchanged"
-    (mt/with-temp [:model/Card card {:dataset_query   (mt/native-query {:query "SELECT NAME FROM VENUES"})}]
+    (mt/with-temp [:model/Card card {:dataset_query (mt/native-query {:query "SELECT NAME FROM VENUES"})}]
       (is (nil? (card-metadata card)))
       (mt/with-metadata-provider (mt/id)
         (middleware.results-metadata/store-previous-result-metadata!

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -4,6 +4,8 @@
    [clojure.test :refer :all]
    [malli.error :as me]
    [metabase.analyze.query-results :as qr]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-util :as lib.tu]
@@ -28,11 +30,12 @@
   [data]
   (mt/round-all-decimals 2 data))
 
-(defn- default-card-results []
+(defn- default-card-results [card-entity-id]
   (let [id->fingerprint   (t2/select-pk->fn :fingerprint :model/Field :table_id (mt/id :venues))
         name->fingerprint (comp id->fingerprint (partial mt/id :venues))]
     [{:name           "ID"
       :display_name   "ID"
+      :ident          (lib/native-ident "ID" card-entity-id)
       :base_type      :type/BigInteger
       :effective_type :type/BigInteger
       :database_type  "BIGINT"
@@ -41,6 +44,7 @@
       :field_ref      [:field "ID" {:base-type :type/BigInteger}]}
      {:name           "NAME"
       :display_name   "Name"
+      :ident          (lib/native-ident "NAME" card-entity-id)
       :base_type      :type/Text
       :effective_type :type/Text
       :database_type  "CHARACTER VARYING"
@@ -49,6 +53,7 @@
       :field_ref      [:field "NAME" {:base-type :type/Text}]}
      {:name           "PRICE"
       :display_name   "Price"
+      :ident          (lib/native-ident "PRICE" card-entity-id)
       :base_type      :type/Integer
       :effective_type :type/Integer
       :database_type  "INTEGER"
@@ -57,6 +62,7 @@
       :field_ref      [:field "PRICE" {:base-type :type/Integer}]}
      {:name           "CATEGORY_ID"
       :display_name   "Category ID"
+      :ident          (lib/native-ident "CATEGORY_ID" card-entity-id)
       :base_type      :type/Integer
       :effective_type :type/Integer
       :database_type  "INTEGER"
@@ -65,6 +71,7 @@
       :field_ref      [:field "CATEGORY_ID" {:base-type :type/Integer}]}
      {:name           "LATITUDE"
       :display_name   "Latitude"
+      :ident          (lib/native-ident "LATITUDE" card-entity-id)
       :base_type      :type/Float
       :effective_type :type/Float
       :database_type  "DOUBLE PRECISION"
@@ -73,6 +80,7 @@
       :field_ref      [:field "LATITUDE" {:base-type :type/Float}]}
      {:name           "LONGITUDE"
       :display_name   "Longitude"
+      :ident          (lib/native-ident "LONGITUDE" card-entity-id)
       :base_type      :type/Float
       :effective_type :type/Float
       :database_type  "DOUBLE PRECISION"
@@ -82,8 +90,8 @@
 
 (defn- default-card-results-native
   "These are rounded to two decimal places."
-  []
-  (for [column (-> (default-card-results)
+  [card-entity-id]
+  (for [column (-> (default-card-results card-entity-id)
                    (update-in [3 :fingerprint] assoc :type {:type/Number {:min 2.0
                                                                           :max 74.0
                                                                           :avg 29.98
@@ -94,26 +102,32 @@
 
 (deftest save-result-metadata-test
   (testing "test that Card result metadata is saved after running a Card"
-    (mt/with-temp [:model/Card card]
-      (let [result (qp/process-query
-                    (qp/userland-query
-                     (mt/native-query {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"})
-                     {:card-id    (u/the-id card)
-                      :query-hash (qp.util/query-hash {})}))]
-        (when-not (= :completed (:status result))
-          (throw (ex-info "Query failed." result))))
-      (is (= (round-to-2-decimals (default-card-results-native))
-             (-> card card-metadata round-to-2-decimals)))
+    (let [query (mt/native-query {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"})]
+      (mt/with-temp [:model/Card card {:dataset_query query}]
+        (let [result (qp/process-query
+                      (qp/userland-query
+                       query
+                       {:card-id        (u/the-id card)
+                        :card-entity-id (:entity_id card)
+                        :query-hash     (qp.util/query-hash {})}))]
+          (when-not (= :completed (:status result))
+            (throw (ex-info "Query failed." result))))
+        (is (= (round-to-2-decimals (default-card-results-native (:entity_id card)))
+               (-> card card-metadata round-to-2-decimals)))
 
-      ;; updated_at should not be modified when saving result metadata
-      (is (= (:updated_at card)
-             (t2/select-one-fn :updated_at :model/Card :id (u/the-id card)))))))
+        ;; updated_at should not be modified when saving result metadata
+        (is (= (:updated_at card)
+               (t2/select-one-fn :updated_at :model/Card :id (u/the-id card))))))))
 
 (deftest save-result-metadata-test-2
   (testing "check that using a Card as your source doesn't overwrite the results metadata..."
     (mt/with-temp [:model/Card card {:dataset_query   (mt/native-query {:query "SELECT * FROM VENUES"})
                                      :result_metadata [{:name "NAME", :display_name "Name", :base_type :type/Text}]}]
-      (is (= [{:name "NAME", :display_name "Name", :base_type :type/Text}]
+      (is (= [{:name         "NAME"
+               :display_name "Name"
+               ;; Idents not found in result_metadata are backfilled on read.
+               :ident        (lib/native-ident "NAME" (:entity_id card))
+               :base_type    :type/Text}]
              (card-metadata card)))
       (let [result (qp/process-query
                     (qp/userland-query
@@ -122,7 +136,10 @@
                       :query    {:source-table (str "card__" (u/the-id card))}}))]
         (is (partial= {:status :completed}
                       result)))
-      (is (= [{:name "NAME", :display_name "Name", :base_type :type/Text}]
+      (is (= [{:name         "NAME"
+               :display_name "Name"
+               :ident        (lib/native-ident "NAME" (:entity_id card))
+               :base_type    :type/Text}]
              (card-metadata card))))))
 
 (deftest save-result-metadata-test-3
@@ -135,7 +152,33 @@
       (mt/user-http-request :rasta :post 202 "dataset" {:database lib.schema.id/saved-questions-virtual-database-id
                                                         :type     :query
                                                         :query    {:source-table (str "card__" (u/the-id card))}})
-      (is (= [{:name "NAME", :display_name "Name", :base_type :type/Text}]
+      (is (= [{:name         "NAME"
+               :display_name "Name"
+               :ident        (lib/native-ident "NAME" (:entity_id card))
+               :base_type    :type/Text}]
+             (card-metadata card))))))
+
+(deftest save-result-metadata-test-4
+  (testing "check that using a Card as your source doesn't overwrite the results metadata for MBQL queries..."
+    (mt/with-temp [:model/Card card {:dataset_query   (mt/mbql-query venues {:fields [$name]})
+                                     :result_metadata [{:name "NAME", :display_name "Custom Name", :base_type :type/Text}]}]
+      (is (= [{:name         "NAME"
+               :display_name "Custom Name"
+               ;; Idents not found in result_metadata are backfilled on read.
+               :ident        (:ident (lib.metadata/field (mt/metadata-provider) (mt/id :venues :name)))
+               :base_type    :type/Text}]
+             (card-metadata card)))
+      (let [result (qp/process-query
+                    (qp/userland-query
+                     {:database lib.schema.id/saved-questions-virtual-database-id
+                      :type     :query
+                      :query    {:source-table (str "card__" (u/the-id card))}}))]
+        (is (partial= {:status :completed}
+                      result)))
+      (is (= [{:name         "NAME"
+               :display_name "Custom Name"
+               :ident        (:ident (lib.metadata/field (mt/metadata-provider) (mt/id :venues :name)))
+               :base_type    :type/Text}]
              (card-metadata card))))))
 
 (deftest save-result-metadata-test-4
@@ -169,15 +212,15 @@
 
 (deftest ^:parallel metadata-in-results-test
   (testing "make sure that queries come back with metadata"
-    (is (= {:columns  (for [col (round-to-2-decimals (default-card-results-native))]
-                        (-> col (update :semantic_type keyword) (update :base_type keyword)))}
-           (-> (qp/process-query
-                (qp/userland-query
-                 {:database (mt/id)
-                  :type     :native
-                  :native   {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"}}))
-               (get-in [:data :results_metadata])
-               round-to-2-decimals)))))
+    (let [card-eid (u/generate-nano-id)]
+      (is (= {:columns  (for [col (round-to-2-decimals (default-card-results-native card-eid))]
+                          (-> col (update :semantic_type keyword) (update :base_type keyword)))}
+             (-> (qp/process-query
+                  (qp/userland-query
+                   (mt/native-query {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"})
+                   {:card-entity-id card-eid}))
+                 (get-in [:data :results_metadata])
+                 round-to-2-decimals))))))
 
 (deftest ^:parallel metadata-in-results-test-2
   (testing "datasets"
@@ -198,15 +241,14 @@
                                                :base_type)
                                               cols)))]
         (testing "native"
-          (let [fields (str/join ", " (map :name (default-card-results-native)))
+          (let [card-eid (u/generate-nano-id)
+                fields (str/join ", " (map :name (default-card-results-native card-eid)))
                 native-query (str "SELECT " fields " FROM VENUES")
-                existing-metadata (add-preserved (default-card-results-native))
-                results (qp/process-query
-                         (qp/userland-query
-                          {:database (mt/id)
-                           :type     :native
-                           :native   {:query native-query}
-                           :info     {:metadata/model-metadata existing-metadata}}))]
+                existing-metadata (add-preserved (default-card-results-native card-eid))
+                results (-> (mt/native-query   {:query native-query})
+                            (qp/userland-query {:metadata/model-metadata existing-metadata
+                                                :card-entity-id          card-eid})
+                            qp/process-query)]
             (is (= (map choose existing-metadata)
                    (map choose (-> results :data :results_metadata :columns))))))
         (testing "mbql"
@@ -277,7 +319,9 @@
 (deftest ^:parallel valid-results-metadata-test-2
   (mt/test-drivers (mt/normal-drivers)
     (testing "Native queries should come back with valid results metadata (#12265)"
-      (let [metadata (-> (mt/mbql-query venues) qp.compile/compile mt/native-query results-metadata)]
+      (let [metadata (-> (mt/mbql-query venues) qp.compile/compile mt/native-query
+                         (assoc-in [:info :card-entity-id] (u/generate-nano-id))
+                         results-metadata)]
         (is (seq metadata))
         (is (not (me/humanize (mr/explain qr/ResultsMetadata metadata))))))))
 
@@ -288,11 +332,10 @@
     ;; is actually a `:type/DateTime`. The query results metadata should come back with the correct type info.
     ;; PS: the above comment is likely outdated with H2 v2
     ;; TODO: is this still relevant? -jpc
-    (let [results (:data
-                   (qp/process-query
-                    {:type     :native
-                     :native   {:query "select date_trunc('day', checkins.\"DATE\") as d FROM checkins"}
-                     :database (mt/id)}))]
+    (let [results (-> (mt/native-query {:query "select date_trunc('day', checkins.\"DATE\") as d FROM checkins"})
+                      (assoc-in [:info :card-entity-id] (u/generate-nano-id))
+                      qp/process-query
+                      :data)]
       (testing "Sanity check: annotate should infer correct type from `:cols`"
         (is (=? {:base_type    :type/Date,
                  :effective_type :type/Date

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -8,7 +8,6 @@
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.metadata :as qp.metadata]
    [metabase.query-processor.middleware.fix-bad-references :as fix-bad-refs]
    [metabase.query-processor.middleware.limit :as limit]
@@ -98,7 +97,6 @@
                                      (assoc-in [:info :card-entity-id] eid)
                                      #_{:clj-kondo/ignore [:deprecated-var]}
                                      (qp.metadata/legacy-result-metadata nil))]
-                    (tap> ['populated-metadata metadata])
                     (t2/update! :model/Card id {:result_metadata metadata})))]
     ;; 4 seconds is long but redshift can be a little slow
     (when (= ::timed-out (mt/wait-for-result updater 4000 ::timed-out))
@@ -111,8 +109,8 @@
       (mt/dataset test-data
         (doseq [[query-type query] [[:query (mt/mbql-query products)]
                                     #_[:native (mt/native-query
-                                               (qp.compile/compile
-                                                (mt/mbql-query products)))]]]
+                                                 (qp.compile/compile
+                                                  (mt/mbql-query products)))]]]
           (mt/with-persistence-enabled! [persist-models!]
             (mt/with-temp [:model/Card model {:type          :model
                                               :database_id   (mt/id)

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -244,8 +244,6 @@
                    (#'qp.pivot/breakout-combinations 2 (:pivot-rows pivot-options) (:pivot-cols pivot-options))))
             (is (=? {:status    :completed
                      :row_count 156
-                     ;; XXX: START HERE: The "incorrect :field ID refs" case is broken. The original column idents get
-                     ;; used instead of the breakout idents. Needs fixing in annotate.
                      :data {:cols [{:ident (get-in query [:query :breakout-idents 0])}
                                    {:ident (get-in query [:query :breakout-idents 1])}
                                    {:name  "pivot-grouping"}

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -243,7 +243,13 @@
             (is (= [[0 1] [1] [0] []]
                    (#'qp.pivot/breakout-combinations 2 (:pivot-rows pivot-options) (:pivot-cols pivot-options))))
             (is (=? {:status    :completed
-                     :row_count 156}
+                     :row_count 156
+                     ;; XXX: START HERE: The "incorrect :field ID refs" case is broken. The original column idents get
+                     ;; used instead of the breakout idents. Needs fixing in annotate.
+                     :data {:cols [{:ident (get-in query [:query :breakout-idents 0])}
+                                   {:ident (get-in query [:query :breakout-idents 1])}
+                                   {:name  "pivot-grouping"}
+                                   {:ident (get-in query [:query :aggregation-idents 0])}]}}
                     (qp.pivot/run-pivot-query (assoc query :info {:visualization-settings viz-settings}))))))))))
 
 (deftest ^:parallel nested-question-pivot-aggregation-names-test
@@ -434,7 +440,8 @@
             (qp.pivot/run-pivot-query (api.pivots/parameters-query))))))
 
 (defn- clean-pivot-results [results]
-  (let [no-uuid #(dissoc % :lib/source_uuid)]
+  (let [no-uuid #(cond-> (dissoc % :lib/source_uuid)
+                   (= (:name %) "pivot-grouping") (assoc :ident "test_dummy_pivot-grouping"))]
     (-> results
         (dissoc :running_time :started_at :json_query)
         (m/dissoc-in [:data :results_metadata :checksum])

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -141,8 +141,9 @@
                                             :limit    5})))
         (testing "A query with emoji and other fancy unicode"
           (let [[sql & args] (t2.pipeline/compile* {:select [["Cam 𝌆 Saul 💩" :cam]]})]
-            (compare-results export-format (mt/native-query {:query  sql
-                                                             :params args}))))))))
+            (compare-results export-format (assoc-in (mt/native-query {:query  sql
+                                                                       :params args})
+                                                     [:info :card-entity-id] (u/generate-nano-id)))))))))
 
 (def ^:private ^:dynamic *number-of-cans* nil)
 

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -482,6 +482,11 @@
                           (assoc-in [:info :card-entity-id] entity-id)
                           actual-query-results)}))
 
+(defn- as-model [result-metadata entity-id]
+  (for [col result-metadata]
+    (cond-> col
+      (not (lib/valid-model-ident? col entity-id)) (lib/add-model-ident entity-id))))
+
 (defn card-with-metadata
   "Given a (partial) Card, such as might be passed to `with-temp`, fill in its `:result_metadata` based on the query."
   [{:keys [dataset_query] :as card}]
@@ -490,7 +495,8 @@
            :entity_id       entity-id
            :result_metadata (-> dataset_query
                                 (assoc-in [:info :card-entity-id] entity-id)
-                                actual-query-results))))
+                                actual-query-results
+                                (cond-> (= (:type card) :model) (as-model entity-id))))))
 
 (defn card-with-updated-metadata
   "Like [[card-with-metadata]] but takes an extra argument: a function `(f column-metadata card) => column-metadata`.

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -824,7 +824,10 @@
                               {:display_name   column-name
                                :field_ref      [:field column-name {:base-type :type/Integer}]
                                :name           column-name
-                               :ident          (str "native__" card-eid "__" column-name)
+                               ;; Yes, native models have model__card-eid__native__card-end__COLUMN_NAME idents.
+                               :ident          (lib/model-ident
+                                                (lib/native-ident column-name card-eid)
+                                                card-eid)
                                :base_type      :type/Integer
                                :effective_type :type/Integer
                                :semantic_type  nil
@@ -856,23 +859,25 @@
                                     :native   {:template-tags {} :query "select 1 as b1, 2 as b2;"}}
                   :result-metadata [(result-metadata-for eid "B1")
                                     (result-metadata-for eid "B2")]})
-               {:name            "Joined"
-                :id              3
-                :database-id     (meta/id)
-                :type            :model
-                :dataset-query   {:database (meta/id)
-                                  :type     :query
-                                  :query    {:joins
-                                             [{:fields :all,
-                                               :alias "Model B - A1",
-                                               :ident "t3Nz_yY5hISIlmxaJlSsm"
-                                               :strategy :inner-join,
-                                               :condition
-                                               [:=
-                                                [:field "A1" {:base-type :type/Integer}]
-                                                [:field "B1" {:base-type :type/Integer, :join-alias "Model B - A1"}]],
-                                               :source-table "card__2"}],
-                                             :source-table "card__1"}}}]}))))
+               (let [eid (u/generate-nano-id)]
+                 {:name            "Joined"
+                  :id              3
+                  :entity-id       eid
+                  :database-id     (meta/id)
+                  :type            :model
+                  :dataset-query   {:database (meta/id)
+                                    :type     :query
+                                    :query    {:joins
+                                               [{:fields :all,
+                                                 :alias "Model B - A1",
+                                                 :ident "t3Nz_yY5hISIlmxaJlSsm"
+                                                 :strategy :inner-join,
+                                                 :condition
+                                                 [:=
+                                                  [:field "A1" {:base-type :type/Integer}]
+                                                  [:field "B1" {:base-type :type/Integer, :join-alias "Model B - A1"}]],
+                                                 :source-table "card__2"}],
+                                               :source-table "card__1"}}})]}))))
 
 (deftest ^:parallel models-with-joins-and-renamed-columns-test
   (testing "an MBQL model with an explicit join and customized field names generate correct SQL (#40252)"

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -824,7 +824,7 @@
                               {:display_name   column-name
                                :field_ref      [:field column-name {:base-type :type/Integer}]
                                :name           column-name
-                               ;; Yes, native models have model__card-eid__native__card-end__COLUMN_NAME idents.
+                               ;; Yes, native models have model[card-eid]__native[card-eid]__COLUMN_NAME idents.
                                :ident          (lib/model-ident
                                                 (lib/native-ident column-name card-eid)
                                                 card-eid)

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -859,25 +859,24 @@
                                     :native   {:template-tags {} :query "select 1 as b1, 2 as b2;"}}
                   :result-metadata [(result-metadata-for eid "B1")
                                     (result-metadata-for eid "B2")]})
-               (let [eid (u/generate-nano-id)]
-                 {:name            "Joined"
-                  :id              3
-                  :entity-id       eid
-                  :database-id     (meta/id)
-                  :type            :model
-                  :dataset-query   {:database (meta/id)
-                                    :type     :query
-                                    :query    {:joins
-                                               [{:fields :all,
-                                                 :alias "Model B - A1",
-                                                 :ident "t3Nz_yY5hISIlmxaJlSsm"
-                                                 :strategy :inner-join,
-                                                 :condition
-                                                 [:=
-                                                  [:field "A1" {:base-type :type/Integer}]
-                                                  [:field "B1" {:base-type :type/Integer, :join-alias "Model B - A1"}]],
-                                                 :source-table "card__2"}],
-                                               :source-table "card__1"}}})]}))))
+               {:name            "Joined"
+                :id              3
+                :entity-id       (u/generate-nano-id)
+                :database-id     (meta/id)
+                :type            :model
+                :dataset-query   {:database (meta/id)
+                                  :type     :query
+                                  :query    {:joins
+                                             [{:fields :all,
+                                               :alias "Model B - A1",
+                                               :ident "t3Nz_yY5hISIlmxaJlSsm"
+                                               :strategy :inner-join,
+                                               :condition
+                                               [:=
+                                                [:field "A1" {:base-type :type/Integer}]
+                                                [:field "B1" {:base-type :type/Integer, :join-alias "Model B - A1"}]],
+                                               :source-table "card__2"}],
+                                             :source-table "card__1"}}}]}))))
 
 (deftest ^:parallel models-with-joins-and-renamed-columns-test
   (testing "an MBQL model with an explicit join and customized field names generate correct SQL (#40252)"

--- a/test/metabase/query_processor_test/model_test.clj
+++ b/test/metabase/query_processor_test/model_test.clj
@@ -34,7 +34,8 @@
                                                         (m/find-first (comp #{"Price"} :display-name)))))
                         (lib/breakout $q (-> (m/find-first (comp #{"Reviews → Created At"} :display-name)
                                                            (lib/breakoutable-columns $q))
-                                             (lib/with-temporal-bucket :month))))
+                                             (lib/with-temporal-bucket :month)))
+                        (lib.convert/->legacy-MBQL $q))
                       :database_id (mt/id)
                       :name "Products+Reviews Summary"
                       :type :model}]
@@ -57,7 +58,8 @@
                                                                                (lib/breakoutable-columns
                                                                                 (lib/query mp (lib.metadata/card mp (:id consumer-model)))))
                                                                  (lib/with-temporal-bucket :month)))])
-                                          (lib/with-join-fields :all))))]
+                                          (lib/with-join-fields :all)))
+                         (lib/->legacy-MBQL $q))]
           (is (= ["Reviews → Created At: Month"
                   "Average of Rating"
                   "Products+Reviews Summary - Reviews → Created At: Month → Created At"

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -1701,14 +1701,18 @@
     (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
           card-query (-> (lib/query mp (lib.metadata/table mp (mt/id "orders")))
                          (lib/order-by (lib.metadata/field mp (mt/id "orders" "created_at")))
-                         (lib/limit 1))
+                         (lib/limit 1)
+                         lib/->legacy-MBQL)
           results (qp/process-query card-query)]
       (mt/with-temp [:model/Card {card-id :id} {:type :question
                                                 :dataset_query {:native (get-in results [:data :native_form])
                                                                 :database (mt/id)
                                                                 :type :native}
-                                                :result_metadata (get-in results [:data :results_metadata :columns])
-                                                :name "Spaces in Name"}]
+                                                :name          "Spaces in Name"
+                                                :entity_id     "yZvzZlw8lRkATwq8w8fDi"
+                                                :result_metadata
+                                                (for [col (get-in results [:data :results_metadata :columns])]
+                                                  (assoc col :ident (lib/native-ident (:name col) "yZvzZlw8lRkATwq8w8fDi")))}]
         (let [created-at-pred (every-pred (comp #{"Created At"} :display-name) (comp #{"Spaces in Name"} :source-alias))
               query (as-> (lib/query mp (lib.metadata/table mp (mt/id "products"))) $q
                       (lib/join $q (lib/join-clause (lib.metadata/card mp card-id)))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -92,7 +92,7 @@
                                             (-> col
                                                 (dissoc :database_type)
                                                 ;; Overwrite the idents to make the card eid fixed.
-                                                (update :ident #(str "native__AAAAAAAAAAAAAAAAAAAAA__"
+                                                (update :ident #(str "native[AAAAAAAAAAAAAAAAAAAAA]__"
                                                                      (subs % 31)))))
                                           cols)))))))))))
 

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -1016,6 +1016,7 @@
                                                         :type :model
                                                         :name "Model 1"
                                                         :database-id (mt/id)
+                                                        :entity-id     (u/generate-nano-id)
                                                         :dataset-query query}]})
               (check-result (mt/run-mbql-query nil
                               {:source-table "card__1"})))))))))

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1753,9 +1753,11 @@
     (let [search-name (random-uuid)
           named #(str search-name "-" %)]
       (mt/with-temp [:model/Card {reg-card-id :id} {:name            (named "regular card")
-                                                    :result_metadata [{:description "The state or province of the account’s billing address."}]}]
+                                                    :result_metadata [{:description "The state or province of the account’s billing address."
+                                                                       :ident       "OmdKsPv5v1ct3Ku6X4tJl"}]}]
         (testing "Can include `result_metadata` info"
-          (is (= [{:description "The state or province of the account’s billing address."}]
+          (is (= [{:description "The state or province of the account’s billing address."
+                   :ident       "OmdKsPv5v1ct3Ku6X4tJl"}]
                  (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name :include_metadata "true")
                       :data
                       (filter #(= reg-card-id (:id %)))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -116,6 +116,7 @@
   db
   format-name
   id
+  ident
   mbql-query
   metadata-provider
   native-query

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -221,7 +221,6 @@
   normal-drivers
   normal-drivers-with-feature
   normal-drivers-without-feature
-  query->result-metadata
   rows
   rows+column-names
   with-database-timezone-id

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -207,6 +207,8 @@
 
  [qp.test-util
   boolish->bool
+  card-with-metadata
+  card-with-updated-metadata
   card-with-source-metadata-for-query
   col
   cols
@@ -219,6 +221,7 @@
   normal-drivers
   normal-drivers-with-feature
   normal-drivers-without-feature
+  query->result-metadata
   rows
   rows+column-names
   with-database-timezone-id

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -214,6 +214,7 @@
   formatted-rows+column-names
   format-rows-by
   formatted-rows
+  metadata->native-form
   nest-query
   normal-drivers
   normal-drivers-with-feature

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -41,6 +41,7 @@
    [metabase.db.schema-migrations-test.impl
     :as schema-migrations-test.impl]
    [metabase.driver.ddl.interface :as ddl.i]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -48,6 +49,7 @@
    [metabase.test.data.impl :as data.impl]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.mbql-query-impl :as mbql-query-impl]
+   [metabase.util :as u]
    [metabase.util.malli :as mu]
    [next.jdbc]))
 
@@ -196,7 +198,8 @@
   "Like `mbql-query`, but runs the query as well."
   {:style/indent :defn}
   [table-name & [query]]
-  `(run-mbql-query* (mbql-query ~table-name ~(or query {}))))
+  `(run-mbql-query* (-> (mbql-query ~table-name ~(or query {}))
+                        (assoc-in [:info :card-entity-id] (u/generate-nano-id)))))
 
 (def ^:private FormattableName
   [:or
@@ -233,6 +236,11 @@
   "Get a metadata-provider for the current database."
   []
   (lib.metadata.jvm/application-database-metadata-provider (id)))
+
+(defn ident
+  "Get the ident for a field. Arguments are the same as for `(mt/id :table :field)`."
+  [table-key field-key]
+  (:ident (lib.metadata/field (metadata-provider) (id table-key field-key))))
 
 (defmacro dataset
   "Create a database and load it with the data defined by `dataset`, then do a quick metadata-only sync; make it the

--- a/test/metabase/xrays/api/automagic_dashboards_test.clj
+++ b/test/metabase/xrays/api/automagic_dashboards_test.clj
@@ -214,9 +214,9 @@
       (let [card-query (mt/native-query {:query "select * from people"})]
         (mt/with-temp [:model/Collection {collection-id :id} {}
                        :model/Card       {card-id :id} (merge
-                                                         (mt/card-with-source-metadata-for-query card-query)
-                                                         {:name            "15655_Q1"
-                                                          :collection_id   collection-id})]
+                                                        (mt/card-with-source-metadata-for-query card-query)
+                                                        {:name            "15655_Q1"
+                                                         :collection_id   collection-id})]
           (let [query      {:database (mt/id)
                             :type     :query
                             :query    {:source-table (format "card__%d" card-id)

--- a/test/metabase/xrays/api/automagic_dashboards_test.clj
+++ b/test/metabase/xrays/api/automagic_dashboards_test.clj
@@ -211,13 +211,12 @@
 (deftest compare-nested-query-test
   (testing "Ad-hoc X-Rays should work for queries have Card source queries (#15655)"
     (mt/dataset test-data
-      (let [card-query      (mt/native-query {:query "select * from people"})
-            result-metadata (get-in (qp/process-query card-query) [:data :results_metadata :columns])]
+      (let [card-query (mt/native-query {:query "select * from people"})]
         (mt/with-temp [:model/Collection {collection-id :id} {}
-                       :model/Card       {card-id :id} {:name            "15655_Q1"
-                                                        :collection_id   collection-id
-                                                        :dataset_query   card-query
-                                                        :result_metadata result-metadata}]
+                       :model/Card       {card-id :id} (merge
+                                                         (mt/card-with-source-metadata-for-query card-query)
+                                                         {:name            "15655_Q1"
+                                                          :collection_id   collection-id})]
           (let [query      {:database (mt/id)
                             :type     :query
                             :query    {:source-table (format "card__%d" card-id)
@@ -404,9 +403,9 @@
                 (map (fn [{:keys [field_ref] :as col}]
                        (if (= ref field_ref) (f col) col))
                      cols))]
-        (let [query           (mt/native-query {:query "select * from products"})
-              results-meta    (->> (qp/process-query (qp/userland-query query))
-                                   :data :results_metadata :columns)
+        (let [results-meta    (-> (mt/native-query {:query "select * from products"})
+                                  mt/card-with-source-metadata-for-query
+                                  :result_metadata)
               id-field-ref    (:field_ref (by-id results-meta "id"))
               title-field-ref (:field_ref (by-id results-meta "title"))
               id-field-id     (mt/id :products :id)]

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -341,15 +341,20 @@
 (deftest native-query-with-cards-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-full-data-perms-for-all-users!
-      (let [source-query {:native   {:query "select * from venues limit 1"}
+      (let [source-eid   (u/generate-nano-id)
+            source-query {:native   {:query "select * from venues limit 1"}
                           :type     :native
                           :database (mt/id)}]
         (mt/with-temp [:model/Collection {collection-id :id} {}
                        :model/Card       {source-id :id}     {:table_id        nil
                                                               :collection_id   collection-id
                                                               :dataset_query   source-query
-                                                              :result_metadata (get-in (qp/process-query source-query)
-                                                                                       [:data :results_metadata :columns])}
+                                                              :entity_id       source-eid
+                                                              :result_metadata
+                                                              (-> source-query
+                                                                  (assoc-in [:info :card-entity-id] source-eid)
+                                                                  qp/process-query
+                                                                  (get-in [:data :results_metadata :columns]))}
                        :model/Card       {card-id :id}       {:table_id      nil
                                                               :collection_id collection-id
                                                               :dataset_query {:query    {:filter       [:> [:field "PRICE" {:base-type "type/Number"}] 10]
@@ -1256,14 +1261,13 @@
       (let [source-query {:native   {:query "SELECT LATITUDE AS L1, LATITUDE AS L2, LATITUDE AS L3 FROM PEOPLE;"}
                           :type     :native
                           :database (mt/id)}]
-        (mt/with-temp [:model/Card card {:table_id        nil
-                                         :dataset_query   source-query
-                                         :result_metadata (->> (result-metadata-for-query source-query)
-                                                               (mt/with-test-user :crowberto)
-                                                               (mapv (fn [m]
-                                                                       (assoc m
-                                                                              :display_name "Frooby"
-                                                                              :semantic_type :type/Latitude))))}]
+        (mt/with-temp [:model/Card card (-> (mt/card-with-source-metadata-for-query source-query)
+                                            (assoc :table_id nil)
+                                            (update :result_metadata (fn [metadata]
+                                                                       (mapv #(assoc %
+                                                                                     :display_name "Frooby"
+                                                                                     :semantic_type :type/Latitude)
+                                                                             metadata))))]
           (let [{{:keys [entity_type]} :source :as root} (#'magic/->root card)
                 base-context        (#'magic/make-base-context root)
                 dimensions          [{"Loc" {:field_type [:type/Location], :score 60}}
@@ -1730,12 +1734,9 @@
                             :type     :native
                             :database (mt/id)}]
           (mt/with-temp
-            [:model/Card {native-card-id :id :as native-card} {:table_id        nil
-                                                               :name            "15655"
-                                                               :dataset_query   native-query
-                                                               :result_metadata (get-in (qp/process-query native-query)
-                                                                                        [:data :results_metadata :columns])}
-                                        ;card__19169
+            [:model/Card {native-card-id :id :as native-card} (merge (mt/card-with-source-metadata-for-query native-query)
+                                                                     {:table_id        nil
+                                                                      :name            "15655"})
              :model/Card card {:table_id      (mt/id :orders)
                                :dataset_query {:query    {:source-table (format "card__%s" native-card-id)
                                                           :aggregation  [[:count]]

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
@@ -21,13 +21,13 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: OMuZ0wHe2O5Z_59-cLmn4
   label: series_question_a
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
@@ -21,13 +21,13 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: XsxiHuzwlGIFNq245HdZC
   label: series_question_b
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
@@ -21,13 +21,13 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: f1C68pznmrpN1F5xFDj6d
   label: some_question
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
+++ b/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
@@ -25,13 +25,13 @@ dataset_query:
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: aqpA3mIKUnfzYUlwjuGwT
   label: source_question
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: model

--- a/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
+++ b/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
@@ -21,13 +21,13 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: ze7O4-8qRFH1v2Ho2apT1
   label: root_card
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
@@ -21,13 +21,13 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: m98z04nYGCF5n7cvOTfbj
   label: grandparent_card
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
@@ -21,13 +21,13 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: IBZSKSt2-QOMviIaGcQE6
   label: parent_card
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
@@ -21,13 +21,13 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
+card_schema: 21
 serdes/meta:
 - id: Ra0JVOCXKTxH5TPbwZm0x
   label: child_card
   model: Card
 archived_directly: false
-card_schema: 20
 dashboard_id: null
-metabase_version: v1.1.33-SNAPSHOT (a859933)
+metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/databases/My Database/My Database.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/My Database.yaml
@@ -4,6 +4,7 @@ engine: h2
 dbms_version: null
 created_at: '2024-08-28T14:38:42.753121Z'
 creator_id: null
+entity_id: ykVHi-GHcd1td4Lvb62pr
 timezone: null
 auto_run_queries: true
 refingerprint: null
@@ -22,8 +23,7 @@ initial_sync_status: complete
 serdes/meta:
 - id: My Database
   model: Database
-entity_id: ykVHi-GHcd1td4Lvb62pr
+router_database_id: null
 uploads_enabled: false
 uploads_schema_name: null
 uploads_table_prefix: null
-router_database_id: null

--- a/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/Schemaless Table.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/Schemaless Table.yaml
@@ -1,6 +1,7 @@
 name: Schemaless Table
 display_name: Schemaless Table
 description: null
+entity_id: KhHJ3brgFTO9CIBiZA4uE
 created_at: '2024-08-28T14:38:43.319867Z'
 db_id: My Database
 schema: null
@@ -19,4 +20,3 @@ serdes/meta:
 - id: Schemaless Table
   model: Table
 database_require_filter: null
-entity_id: KhHJ3brgFTO9CIBiZA4uE

--- a/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/fields/Some Field.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/fields/Some Field.yaml
@@ -1,6 +1,7 @@
 name: Some Field
 display_name: Some Field
 description: null
+entity_id: Ov5wwh7fYOdhiUFxS4ihN
 created_at: '2024-08-28T14:38:43.323162Z'
 active: true
 visibility_type: normal
@@ -37,4 +38,3 @@ serdes/meta:
   model: Field
 database_indexed: null
 database_partitioned: null
-entity_id: Ov5wwh7fYOdhiUFxS4ihN

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/CATEGORIES.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/CATEGORIES.yaml
@@ -1,6 +1,7 @@
 name: CATEGORIES
 display_name: Categories
 description: null
+entity_id: fROOTcxZ8KNzW6frWxyBn
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: CATEGORIES
   model: Table
 database_require_filter: null
-entity_id: fROOTcxZ8KNzW6frWxyBn

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: sBsHx24gA7l-4ghDzlzhF
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: sBsHx24gA7l-4ghDzlzhF

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/NAME.yaml
@@ -1,6 +1,7 @@
 name: NAME
 display_name: Name
 description: null
+entity_id: jEZf_v-4ewNSY1QEWw0Se
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: jEZf_v-4ewNSY1QEWw0Se

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/CHECKINS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/CHECKINS.yaml
@@ -1,6 +1,7 @@
 name: CHECKINS
 display_name: Checkins
 description: null
+entity_id: fLCYfgLenqruHqCo2_dvG
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: CHECKINS
   model: Table
 database_require_filter: null
-entity_id: fLCYfgLenqruHqCo2_dvG

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/DATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/DATE.yaml
@@ -1,6 +1,7 @@
 name: DATE
 display_name: Date
 description: null
+entity_id: RP5HLhoqRvCi2Y7tt6SiJ
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: RP5HLhoqRvCi2Y7tt6SiJ

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: cY9GKjimt9fkbwSmq3s2D
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: cY9GKjimt9fkbwSmq3s2D

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/USER_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/USER_ID.yaml
@@ -1,6 +1,7 @@
 name: USER_ID
 display_name: User ID
 description: null
+entity_id: aPH5xec5UYszHtsFWpmel
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -43,4 +44,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: aPH5xec5UYszHtsFWpmel

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/VENUE_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/VENUE_ID.yaml
@@ -1,6 +1,7 @@
 name: VENUE_ID
 display_name: Venue ID
 description: null
+entity_id: PCwnRlLbnPF8R4hzXmNGR
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -43,4 +44,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: PCwnRlLbnPF8R4hzXmNGR

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/ORDERS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/ORDERS.yaml
@@ -1,6 +1,7 @@
 name: ORDERS
 display_name: Orders
 description: null
+entity_id: Xklmu-9-kSX8qWUU4gx8T
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: ORDERS
   model: Table
 database_require_filter: null
-entity_id: Xklmu-9-kSX8qWUU4gx8T

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/CREATED_AT.yaml
@@ -1,6 +1,7 @@
 name: CREATED_AT
 display_name: Created At
 description: null
+entity_id: 9ntDoLGY3AF3C4gD2TEzy
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 9ntDoLGY3AF3C4gD2TEzy

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/DISCOUNT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/DISCOUNT.yaml
@@ -1,6 +1,7 @@
 name: DISCOUNT
 display_name: Discount
 description: null
+entity_id: bJZMPrTpKh9du7t-BG67z
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: bJZMPrTpKh9du7t-BG67z

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: IiIFClKQXRxRxACobQ0Hb
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: IiIFClKQXRxRxACobQ0Hb

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/PRODUCT_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/PRODUCT_ID.yaml
@@ -1,6 +1,7 @@
 name: PRODUCT_ID
 display_name: Product ID
 description: null
+entity_id: HcBNIyo38ID7k3zRiaZZ7
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -43,4 +44,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: HcBNIyo38ID7k3zRiaZZ7

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/QUANTITY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/QUANTITY.yaml
@@ -1,6 +1,7 @@
 name: QUANTITY
 display_name: Quantity
 description: null
+entity_id: 0wAi4F3QofJo3rKLN0Tmc
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 0wAi4F3QofJo3rKLN0Tmc

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/SUBTOTAL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/SUBTOTAL.yaml
@@ -1,6 +1,7 @@
 name: SUBTOTAL
 display_name: Subtotal
 description: null
+entity_id: Hk8HG908-1Yk3eatFXpqM
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: Hk8HG908-1Yk3eatFXpqM

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TAX.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TAX.yaml
@@ -1,6 +1,7 @@
 name: TAX
 display_name: Tax
 description: null
+entity_id: T8PChksd3ig-4V3cmUkX1
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: T8PChksd3ig-4V3cmUkX1

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TOTAL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TOTAL.yaml
@@ -1,6 +1,7 @@
 name: TOTAL
 display_name: Total
 description: null
+entity_id: OzPJltpWAbCXnqBRDXETi
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: OzPJltpWAbCXnqBRDXETi

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/USER_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/USER_ID.yaml
@@ -1,6 +1,7 @@
 name: USER_ID
 display_name: User ID
 description: null
+entity_id: rNoeK7kIBWVuk-q-GXeXe
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -43,4 +44,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: rNoeK7kIBWVuk-q-GXeXe

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/PEOPLE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/PEOPLE.yaml
@@ -1,6 +1,7 @@
 name: PEOPLE
 display_name: People
 description: null
+entity_id: kzKpXesKBLetpfOfXeSsS
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: PEOPLE
   model: Table
 database_require_filter: null
-entity_id: kzKpXesKBLetpfOfXeSsS

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ADDRESS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ADDRESS.yaml
@@ -1,6 +1,7 @@
 name: ADDRESS
 display_name: Address
 description: null
+entity_id: 95on8mqct2RznafaiUYYN
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 95on8mqct2RznafaiUYYN

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/BIRTH_DATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/BIRTH_DATE.yaml
@@ -1,6 +1,7 @@
 name: BIRTH_DATE
 display_name: Birth Date
 description: null
+entity_id: QTEhFM69RUzvOmN54uzW3
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: QTEhFM69RUzvOmN54uzW3

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CITY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CITY.yaml
@@ -1,6 +1,7 @@
 name: CITY
 display_name: City
 description: null
+entity_id: 9B2UPC2I7yRIUQiJuZNrO
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 9B2UPC2I7yRIUQiJuZNrO

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CREATED_AT.yaml
@@ -1,6 +1,7 @@
 name: CREATED_AT
 display_name: Created At
 description: null
+entity_id: kVPl9EyIl3cKVtJT2boYc
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: kVPl9EyIl3cKVtJT2boYc

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/EMAIL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/EMAIL.yaml
@@ -1,6 +1,7 @@
 name: EMAIL
 display_name: Email
 description: null
+entity_id: NAoZKcsK9zzQ_vx6E9ioB
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: NAoZKcsK9zzQ_vx6E9ioB

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: qrQZFu3wq_jquvdj9Cykl
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: qrQZFu3wq_jquvdj9Cykl

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LATITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LATITUDE.yaml
@@ -1,6 +1,7 @@
 name: LATITUDE
 display_name: Latitude
 description: null
+entity_id: 4g80DtZISRLp5SCVUFdOw
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 4g80DtZISRLp5SCVUFdOw

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LONGITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LONGITUDE.yaml
@@ -1,6 +1,7 @@
 name: LONGITUDE
 display_name: Longitude
 description: null
+entity_id: hZ92SH5RvNXAgQDTWhUaD
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: hZ92SH5RvNXAgQDTWhUaD

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/NAME.yaml
@@ -1,6 +1,7 @@
 name: NAME
 display_name: Name
 description: null
+entity_id: hyZGfYofxZluz3zEY06z1
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: hyZGfYofxZluz3zEY06z1

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/PASSWORD.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/PASSWORD.yaml
@@ -1,6 +1,7 @@
 name: PASSWORD
 display_name: Password
 description: null
+entity_id: H3sKKUFQJZjLnpv6Qzv4E
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: H3sKKUFQJZjLnpv6Qzv4E

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/SOURCE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/SOURCE.yaml
@@ -1,6 +1,7 @@
 name: SOURCE
 display_name: Source
 description: null
+entity_id: 2hnPlZ9z5Riq4qv_VSeTv
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 2hnPlZ9z5Riq4qv_VSeTv

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/STATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/STATE.yaml
@@ -1,6 +1,7 @@
 name: STATE
 display_name: State
 description: null
+entity_id: sCwbkjXDJgQIAX3D3rbV5
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: sCwbkjXDJgQIAX3D3rbV5

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ZIP.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ZIP.yaml
@@ -1,6 +1,7 @@
 name: ZIP
 display_name: Zip
 description: null
+entity_id: 1dXHzmeh3xHHuQC1y51Dj
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 1dXHzmeh3xHHuQC1y51Dj

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/PRODUCTS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/PRODUCTS.yaml
@@ -1,6 +1,7 @@
 name: PRODUCTS
 display_name: Products
 description: null
+entity_id: rKyV6tg0Gg8YKC-Rq24__
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: PRODUCTS
   model: Table
 database_require_filter: null
-entity_id: rKyV6tg0Gg8YKC-Rq24__

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CATEGORY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CATEGORY.yaml
@@ -1,6 +1,7 @@
 name: CATEGORY
 display_name: Category
 description: null
+entity_id: khmQ5iqqybZ9RL7rP7DVH
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: khmQ5iqqybZ9RL7rP7DVH

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CREATED_AT.yaml
@@ -1,6 +1,7 @@
 name: CREATED_AT
 display_name: Created At
 description: null
+entity_id: tlG2LL84pkkAcc6FLQhWU
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: tlG2LL84pkkAcc6FLQhWU

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/EAN.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/EAN.yaml
@@ -1,6 +1,7 @@
 name: EAN
 display_name: Ean
 description: null
+entity_id: MLCr2IuH9utdQxlXlH3hp
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: MLCr2IuH9utdQxlXlH3hp

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: pIVx08kb89oxIvq9ewtm_
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: pIVx08kb89oxIvq9ewtm_

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/PRICE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/PRICE.yaml
@@ -1,6 +1,7 @@
 name: PRICE
 display_name: Price
 description: null
+entity_id: Zsxl1zcPTMPPJoHpaFMwC
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: Zsxl1zcPTMPPJoHpaFMwC

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/RATING.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/RATING.yaml
@@ -1,6 +1,7 @@
 name: RATING
 display_name: Rating
 description: null
+entity_id: lVeIH8wHGn6hBtTWcgvwV
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: lVeIH8wHGn6hBtTWcgvwV

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/TITLE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/TITLE.yaml
@@ -1,6 +1,7 @@
 name: TITLE
 display_name: Title
 description: null
+entity_id: KcDM8frKUWvd0mC1KPJ-G
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: KcDM8frKUWvd0mC1KPJ-G

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/VENDOR.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/VENDOR.yaml
@@ -1,6 +1,7 @@
 name: VENDOR
 display_name: Vendor
 description: null
+entity_id: plKu8ko8uSEu8t8rSyTNb
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: plKu8ko8uSEu8t8rSyTNb

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/REVIEWS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/REVIEWS.yaml
@@ -1,6 +1,7 @@
 name: REVIEWS
 display_name: Reviews
 description: null
+entity_id: imJMQOvUtLybVRNQu7MFu
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: REVIEWS
   model: Table
 database_require_filter: null
-entity_id: imJMQOvUtLybVRNQu7MFu

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/BODY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/BODY.yaml
@@ -1,6 +1,7 @@
 name: BODY
 display_name: Body
 description: null
+entity_id: nZQyMvxGygYomxrBfzoQk
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: nZQyMvxGygYomxrBfzoQk

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/CREATED_AT.yaml
@@ -1,6 +1,7 @@
 name: CREATED_AT
 display_name: Created At
 description: null
+entity_id: VHTQLIUwNEI0PoLRogT8W
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: VHTQLIUwNEI0PoLRogT8W

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: LUbennMbPNtPzL9tKb8W9
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: LUbennMbPNtPzL9tKb8W9

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/PRODUCT_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/PRODUCT_ID.yaml
@@ -1,6 +1,7 @@
 name: PRODUCT_ID
 display_name: Product ID
 description: null
+entity_id: SSid-McZJwdk9QqJQbQ5a
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -43,4 +44,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: SSid-McZJwdk9QqJQbQ5a

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/RATING.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/RATING.yaml
@@ -1,6 +1,7 @@
 name: RATING
 display_name: Rating
 description: null
+entity_id: i9kgOCMWRj9Zy8gXDioh-
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: i9kgOCMWRj9Zy8gXDioh-

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/REVIEWER.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/REVIEWER.yaml
@@ -1,6 +1,7 @@
 name: REVIEWER
 display_name: Reviewer
 description: null
+entity_id: s5SzrmXlHrLNSSU0pchfo
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: s5SzrmXlHrLNSSU0pchfo

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/USERS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/USERS.yaml
@@ -1,6 +1,7 @@
 name: USERS
 display_name: Users
 description: null
+entity_id: BM7Nnb4drPYip-uXrsxXs
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: USERS
   model: Table
 database_require_filter: null
-entity_id: BM7Nnb4drPYip-uXrsxXs

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: b4rF_gcpmPwMBS1fEul7x
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: b4rF_gcpmPwMBS1fEul7x

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/LAST_LOGIN.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/LAST_LOGIN.yaml
@@ -1,6 +1,7 @@
 name: LAST_LOGIN
 display_name: Last Login
 description: null
+entity_id: qELQSWKJkRMHmPZNn8-80
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: qELQSWKJkRMHmPZNn8-80

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/NAME.yaml
@@ -1,6 +1,7 @@
 name: NAME
 display_name: Name
 description: null
+entity_id: hYN1x8_S3RWiV9gyLlW8R
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: hYN1x8_S3RWiV9gyLlW8R

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/PASSWORD.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/PASSWORD.yaml
@@ -1,6 +1,7 @@
 name: PASSWORD
 display_name: Password
 description: null
+entity_id: hT0OPv0YdJd3l56rFPYLy
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: sensitive
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: hT0OPv0YdJd3l56rFPYLy

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/VENUES.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/VENUES.yaml
@@ -1,6 +1,7 @@
 name: VENUES
 display_name: Venues
 description: null
+entity_id: YeEoba5Ys1KUhghWWZteq
 created_at: '2024-08-28T14:38:42.774331Z'
 db_id: test-data (h2)
 schema: PUBLIC
@@ -21,4 +22,3 @@ serdes/meta:
 - id: VENUES
   model: Table
 database_require_filter: null
-entity_id: YeEoba5Ys1KUhghWWZteq

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/CATEGORY_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/CATEGORY_ID.yaml
@@ -1,6 +1,7 @@
 name: CATEGORY_ID
 display_name: Category ID
 description: null
+entity_id: 6d-rbYLMiBcMKBFBO3z2O
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -43,4 +44,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: 6d-rbYLMiBcMKBFBO3z2O

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/ID.yaml
@@ -1,6 +1,7 @@
 name: ID
 display_name: ID
 description: null
+entity_id: 5Ni7ZdMvZ5yqmbaRYVQ-q
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
-entity_id: 5Ni7ZdMvZ5yqmbaRYVQ-q

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LATITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LATITUDE.yaml
@@ -1,6 +1,7 @@
 name: LATITUDE
 display_name: Latitude
 description: null
+entity_id: EPdF1g_aQzDZ0Z4cozcxg
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: EPdF1g_aQzDZ0Z4cozcxg

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LONGITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LONGITUDE.yaml
@@ -1,6 +1,7 @@
 name: LONGITUDE
 display_name: Longitude
 description: null
+entity_id: 9rX_BZ6VY24FA6H6qFuCs
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: 9rX_BZ6VY24FA6H6qFuCs

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/NAME.yaml
@@ -1,6 +1,7 @@
 name: NAME
 display_name: Name
 description: null
+entity_id: cMgpuvb_X4Jkvf8_e0lp5
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: cMgpuvb_X4Jkvf8_e0lp5

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/PRICE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/PRICE.yaml
@@ -1,6 +1,7 @@
 name: PRICE
 display_name: Price
 description: null
+entity_id: lqd08dVvYfpeB73LxjbQz
 created_at: '2024-08-28T14:38:42.774331Z'
 active: true
 visibility_type: normal
@@ -39,4 +40,3 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
-entity_id: lqd08dVvYfpeB73LxjbQz

--- a/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
@@ -9,6 +9,7 @@ dbms_version:
   - 1
 created_at: '2024-08-28T14:38:42.764234Z'
 creator_id: null
+entity_id: ymbeYS8YN6P6Vltnq81Ib
 timezone: UTC
 auto_run_queries: true
 refingerprint: null
@@ -27,8 +28,7 @@ initial_sync_status: complete
 serdes/meta:
 - id: test-data (h2)
   model: Database
-entity_id: ymbeYS8YN6P6Vltnq81Ib
+router_database_id: null
 uploads_enabled: false
 uploads_schema_name: null
 uploads_table_prefix: null
-router_database_id: null


### PR DESCRIPTION
[refs] Return `:ident`s from annotate mw; save in `result_metadata`

Fixes [QUE-701](https://linear.app/metabase/issue/QUE-701), [QUE-778](https://linear.app/metabase/issue/QUE-778),  [QUE-777](https://linear.app/metabase/issue/QUE-777),  [QUE-776](https://linear.app/metabase/issue/QUE-776),  [QUE-703](https://linear.app/metabase/issue/QUE-703),  [QUE-704](https://linear.app/metabase/issue/QUE-704).

### Description

Directly implements `:ident` calculation for legacy MBQL in the QP!

This is an unfortunately large PR, but I don't think much can be done to help that.
The output of `annotate` becomes `Card.result_metadata`, which is a key **input** to
`annotate`. So we have to tackle legacy metadata end to end to produce a healthy PR.

(A prior attempt to use the lib and match up the results turned into a cluster of hacks,
and required half of these changes anyway, so this direct approach seems more sound.)

Most of this logic lives in the `annotate` post-processing middleware, with
some support from `add-source-metadata` pre-processing.


#### Idents

This generates correct idents for proper fields, expressions,
aggregations, breakouts, explicit and implicit joins, native queries and
models (native and MBQL).

#### Safety checks and Guarantees

Also adds and strengthens several safety checks in the library and
elsewhere. The guarantees I hope we can count on at this point are:
- Cards are saved with correct `:ident`s in their `:result_metadata`.
- Cards with old `:result_metadata` get (correct) `:ident`s added on read.
- Lib can now rely on getting correct idents for all input cards!
- Therefore the lib (BE + FE) can compute the ident for **every column**.

#### Placeholder idents

For native queries, we can only get `result_metadata` from executing them.
The usual flow is:
- Write the query
- Send it as an ad-hoc `/api/dataset` request
- Get back `result_metadata`
- Save it, passing the `result_metadata` back to the BE.

We need a card `entity_id` to create idents for a native query, but an ad-hoc
query doesn't have a card yet! The BE now generates a placeholder `entity_id`,
which gets replaced on save with the new card's actual `entity_id`. These
placeholders contain (1) illegal NanoID characters, and (2) a NanoID, which
means they cannot be mistaken for non-placeholder NanoID, and that they are
still globally unique, so there's no caching concerns.

### How to verify

Tests, naturally. There's sufficient safety checks in both BE and lib to object
if some idents are missing or malformed, when they're expected everywhere.

- You can see the `:ident`s in the `data.results_metadata.columns` and
  `data.cols` on query responses.
- Also in the `result_metadata` of a card response.
- Run an ad-hoc native query to see the placeholders in its idents
    - And save it to see that they get replaced correctly.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
