### PR TITLE
test: wait for data in a flaky test

### DIFF
--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -439,6 +439,7 @@ describe("scenarios > question > native", () => {
         .should("contain", "Sample Database");
 
       cy.findByTestId("visibility-toggler").click();
+      dataReferenceSidebar().should("not.be.visible");
 
       cy.log("open editor on a small screen size");
       cy.viewport(1279, 800);

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -442,7 +442,8 @@ describe("scenarios > question > native", () => {
       dataReferenceSidebar().should("not.be.visible");
 
       cy.log("open editor on a small screen size");
-      cy.viewport(1270, 800);
+      cy.viewport(1279, 800);
+      cy.wait(100); // wait for UI to re-render
 
       cy.findByTestId("visibility-toggler").click();
       dataReferenceSidebar().should("not.be.visible");

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -428,6 +428,11 @@ describe("scenarios > question > native", () => {
         },
       };
 
+      function setViewport(width, height) {
+        cy.viewport(width, height);
+        cy.wait(100); // wait for UI to re-render to avoid flakiness
+      }
+
       H.createNativeQuestion(questionDetails, { visitQuestion: true });
 
       cy.log("open editor on a normal screen size");
@@ -442,9 +447,9 @@ describe("scenarios > question > native", () => {
       dataReferenceSidebar().should("not.be.visible");
 
       cy.log("open editor on a small screen size");
-      cy.viewport(1279, 800);
-      cy.wait(100); // wait for UI to re-render
+      setViewport(1279, 800);
 
+      cy.log("try to open data reference sidebar on a mid size screen");
       cy.findByTestId("visibility-toggler").click();
       dataReferenceSidebar().should("not.be.visible");
 
@@ -455,7 +460,7 @@ describe("scenarios > question > native", () => {
       cy.findByTestId("native-query-editor-sidebar").icon("reference").click();
 
       cy.log("set small viewport");
-      cy.viewport(800, 800);
+      setViewport(800, 800);
 
       cy.findByTestId("sidebar-left").invoke("width").should("be.gt", 350);
       cy.findByTestId("sidebar-right").invoke("width").should("be.gt", 350);

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -433,7 +433,10 @@ describe("scenarios > question > native", () => {
       cy.log("open editor on a normal screen size");
       cy.findByTestId("visibility-toggler").click();
 
-      dataReferenceSidebar().should("be.visible");
+      dataReferenceSidebar()
+        .should("be.visible")
+        // means data is loaded
+        .should("contain", "Sample Database");
 
       cy.findByTestId("visibility-toggler").click();
 

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -442,7 +442,7 @@ describe("scenarios > question > native", () => {
       dataReferenceSidebar().should("not.be.visible");
 
       cy.log("open editor on a small screen size");
-      cy.viewport(1279, 800);
+      cy.viewport(1270, 800);
 
       cy.findByTestId("visibility-toggler").click();
       dataReferenceSidebar().should("not.be.visible");


### PR DESCRIPTION
### Description

<img width="1530" alt="image" src="https://github.com/user-attachments/assets/2290f928-6f67-48da-8086-e134422b9436" />


a fix for a flaky test. it looks like JS was busy in handling data, so click on button didn't hide it.
now we wait for data to be loaded and perform click after it is completed.

`e2e/test/scenarios/native/native.cy.spec.js` -> `should be able to handle two sidebars on different screen sizes`

✅  100/100 [stress test](https://github.com/metabase/metabase/actions/runs/14259083219)