### PR TITLE
Expression literals milestone 2

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,6 +4,10 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
+## Metabase 0.55.0
+
+- Added a feature `:expression-literals` for drivers that support expressions consisting of a single string, number, or boolean literal value.
+
 ## Metabase 0.54.0
 
 - Added the multi-method `allowed-promotions` that allows driver control over which column type promotions are supported for uploads.

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -1,7 +1,10 @@
 const { H } = cy;
 
-// TODO: QUE-726 restore test
-describe.skip("scenarios > custom column > literals", () => {
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > custom column > literals", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
@@ -139,6 +142,59 @@ describe.skip("scenarios > custom column > literals", () => {
     H.assertTableData({
       columns: ["Column", "Average of Column"],
       firstRows: [["10", "10"]],
+    });
+  });
+
+  it("should support custom columns in nested questions (QUE-726)", () => {
+    const baseQuestionDetails = {
+      name: "QUE-726 Base question",
+      query: {
+        "source-table": PRODUCTS_ID,
+        fields: [
+          ["field", PRODUCTS.ID, { "base-type": "type/Integer" }],
+          ["field", PRODUCTS.TITLE, { "base-type": "type/Text" }],
+          ["field", PRODUCTS.PRICE, { "base-type": "type/Float" }],
+          ["expression", "Rustic"],
+          ["expression", "MinPrice"],
+        ],
+        expressions: {
+          Rustic: ["value", "Rustic Paper Wallet", { base_type: "type/Text" }],
+          MinPrice: ["value", 20.0, { base_type: "type/Float" }],
+        },
+      },
+    };
+
+    H.createQuestion(baseQuestionDetails).then(({ body: { id } }) => {
+      const nestedQuestion = {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: {
+            "source-table": `card__${id}`,
+            filter: [
+              "and",
+              [
+                "=",
+                ["field", "TITLE", { "base-type": "type/Text" }],
+                ["field", "Rustic", { "base-type": "type/Text" }],
+              ],
+              [
+                ">",
+                ["field", "PRICE", { "base-type": "type/Float" }],
+                ["field", "MinPrice", { "base-type": "type/Float" }],
+              ],
+            ],
+          },
+          type: "query",
+        },
+      };
+
+      H.visitQuestionAdhoc(nestedQuestion);
+      H.assertTableData({
+        columns: ["ID", "Title", "Price", "Rustic", "MinPrice"],
+        firstRows: [
+          ["1", "Rustic Paper Wallet", "29.46", "Rustic Paper Wallet", "20"],
+        ],
+      });
     });
   });
 });

--- a/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-literals.cy.spec.ts
@@ -1,5 +1,6 @@
 const { H } = cy;
 
+// TODO: QUE-726 restore test
 describe.skip("scenarios > custom column > literals", () => {
   beforeEach(() => {
     H.restore();
@@ -98,6 +99,16 @@ describe.skip("scenarios > custom column > literals", () => {
     testFilterLiteral({
       filterExpression: "[FalseColumn]",
       filterDisplayName: "FalseColumn",
+      expectedRowCount: 0,
+    });
+    testFilterLiteral({
+      filterExpression: "[TrueColumn] OR [FalseColumn]",
+      filterDisplayName: "TrueColumn or FalseColumn",
+      expectedRowCount: 200,
+    });
+    testFilterLiteral({
+      filterExpression: "[TrueColumn] = [FalseColumn]",
+      filterDisplayName: "TrueColumn is FalseColumn",
       expectedRowCount: 0,
     });
   });

--- a/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
@@ -20,22 +20,31 @@ const { H } = cy;
 const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 const { PRODUCTS_ID, ORDERS_ID, ORDERS, PRODUCTS } = SAMPLE_DATABASE;
 
-type CustomColumnType = "boolean" | "string" | "number";
+const customColumnTypeToFormulaUntyped = {
+  booleanExpr: '[Category]="Gizmo"',
+  stringExpr: 'concat("Category is ",[Category])',
+  numberExpr: 'if([Category] = "Gizmo", 1, 0)',
+  booleanLiteral: "true",
+  stringLiteral: '"fixed literal string"',
+  numberLiteral: "1",
+} as const;
+
+type CustomColumnType = keyof typeof customColumnTypeToFormulaUntyped;
 type CustomViewType = "Question" | "Model";
 
 type SandboxPolicy = {
   filterTableBy: "column" | "custom_view";
   customViewType?: CustomViewType;
   customViewName?: string;
-  customColumnType?: "number" | "string" | "boolean";
+  customColumnType?: CustomColumnType;
   filterColumn?: string;
 };
 
-const customColumnTypeToFormula: Record<CustomColumnType, string> = {
-  boolean: '[Category]="Gizmo"',
-  string: 'concat("Category is ",[Category])',
-  number: 'if([Category] = "Gizmo", 1, 0)',
-};
+const customColumnTypeToFormula: Record<CustomColumnType, string> =
+  customColumnTypeToFormulaUntyped;
+const customColumnTypes = Object.keys(
+  customColumnTypeToFormula,
+) as CustomColumnType[];
 
 const addCustomColumnToQuestion = (customColumnType: CustomColumnType) => {
   cy.log("Add a custom column");
@@ -163,9 +172,7 @@ export const adhocQuestionData = {
 function addCustomColumnsToQuestion() {
   H.openNotebook();
   H.getNotebookStep("data").button("Custom column").click();
-  addCustomColumnToQuestion("boolean");
-  addCustomColumnToQuestion("number");
-  addCustomColumnToQuestion("string");
+  customColumnTypes.forEach((type) => addCustomColumnToQuestion(type));
   H.visualize();
 
   // for some reason we can't use the saveQuestion helper here

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -162,12 +162,18 @@ describe(
     describe("we expect an error - and no data to be shown - when applying a sandbox policy...", () => {
       (
         [
-          ["Question", "boolean", "true"],
-          ["Question", "string", "Category is Gizmo"],
-          ["Question", "number", "11"],
-          ["Model", "boolean", "true"],
-          ["Model", "string", "Category is Gizmo"],
-          ["Model", "number", "11"],
+          ["Question", "booleanExpr", "true"],
+          ["Question", "booleanLiteral", "true"],
+          ["Question", "stringExpr", "Category is Gizmo"],
+          ["Question", "stringLiteral", "fixed literal string"],
+          ["Question", "numberExpr", "1"],
+          ["Question", "numberLiteral", "1"],
+          ["Model", "booleanExpr", "true"],
+          ["Model", "booleanLiteral", "true"],
+          ["Model", "stringExpr", "Category is Gizmo"],
+          ["Model", "stringLiteral", "fixed literal string"],
+          ["Model", "numberExpr", "1"],
+          ["Model", "numberLiteral", "1"],
         ] as const
       ).forEach(([customViewType, customColumnType, customColumnValue]) => {
         it(`...to a table filtered by a custom ${customColumnType} column in a ${customViewType}`, () => {

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -530,13 +530,8 @@ describe("issue 41381", () => {
     H.addCustomColumn();
     H.enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
     H.popover().within(() => {
-      // TODO: QUE-726 restore test
-      // cy.findByText("Invalid expression").should("not.exist");
-      // cy.button("Done").should("be.enabled");
-      cy.findByText("Standalone constants are not supported.").should(
-        "be.visible",
-      );
-      cy.button("Done").should("be.disabled");
+      cy.findByText("Invalid expression").should("not.exist");
+      cy.button("Done").should("be.enabled");
     });
   });
 });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -525,11 +525,14 @@ describe("issue 41381", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should show an error message when adding a constant-only custom expression (metabase#41381)", () => {
+  it("should not show an error message when adding a constant-only custom expression (metabase#41381)", () => {
     H.openOrdersTable({ mode: "notebook" });
     H.addCustomColumn();
     H.enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
     H.popover().within(() => {
+      // TODO: QUE-726 restore test
+      // cy.findByText("Invalid expression").should("not.exist");
+      // cy.button("Done").should("be.enabled");
       cy.findByText("Standalone constants are not supported.").should(
         "be.visible",
       );

--- a/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
@@ -43,14 +43,33 @@ function aggregation(source: string) {
 
 describe("old recursive-parser tests", () => {
   it("should parse numeric literals", () => {
-    expect(expr("0")).toEqual(["value", 0, null]);
-    expect(expr("42")).toEqual(["value", 42, null]);
-    expect(expr("1.0")).toEqual(["value", 1, null]);
-    expect(expr("0.123")).toEqual(["value", 0.123, null]);
+    expect(expr("0")).toEqual(["value", 0, { base_type: "type/Integer" }]);
+    expect(expr("42")).toEqual(["value", 42, { base_type: "type/Integer" }]);
+    expect(expr("1.0")).toEqual(["value", 1, { base_type: "type/Integer" }]);
+    expect(expr("0.123")).toEqual([
+      "value",
+      0.123,
+      { base_type: "type/Float" },
+    ]);
+    expect(expr("9223372036854775807")).toEqual([
+      "value",
+      "9223372036854775807",
+      { base_type: "type/BigInteger" },
+    ]);
   });
 
   it("should parse string literals", () => {
-    // the strings are wrapped in length because top-level literals are not allowed
+    expect(expr("'Universe'")).toEqual([
+      "value",
+      "Universe",
+      { base_type: "type/Text" },
+    ]);
+    expect(expr('"answer"')).toEqual([
+      "value",
+      "answer",
+      { base_type: "type/Text" },
+    ]);
+    expect(expr('"\\""')).toEqual(["value", '"', { base_type: "type/Text" }]);
     expect(expr("length('Universe')")).toEqual(["length", "Universe"]);
     expect(expr('length("answer")')).toEqual(["length", "answer"]);
     expect(expr('length("\\"")')).toEqual(["length", '"']);
@@ -75,15 +94,15 @@ describe("old recursive-parser tests", () => {
   });
 
   it("should parse unary expressions", () => {
-    expect(expr("+6")).toEqual(["value", 6, null]);
-    expect(expr("++7")).toEqual(["value", 7, null]);
-    expect(expr("-+8")).toEqual(["value", -8, null]);
+    expect(expr("+6")).toEqual(["value", 6, { base_type: "type/Integer" }]);
+    expect(expr("++7")).toEqual(["value", 7, { base_type: "type/Integer" }]);
+    expect(expr("-+8")).toEqual(["value", -8, { base_type: "type/Integer" }]);
   });
 
   it("should flatten unary expressions", () => {
     expect(expr("--5")).toEqual(["-", -5]);
-    expect(expr("- 6")).toEqual(["value", -6, null]);
-    expect(expr("+-7")).toEqual(["value", -7, null]);
+    expect(expr("- 6")).toEqual(["value", -6, { base_type: "type/Integer" }]);
+    expect(expr("+-7")).toEqual(["value", -7, { base_type: "type/Integer" }]);
     expect(expr("sqrt(-1)")).toEqual(["sqrt", -1]);
     expect(expr("- [Total]")).toEqual(["-", total]);
     expect(expr("-[Total]")).toEqual(["-", total]);

--- a/frontend/src/metabase-lib/v1/expressions/matchers.ts
+++ b/frontend/src/metabase-lib/v1/expressions/matchers.ts
@@ -54,6 +54,14 @@ export function isNumberLiteral(expr: unknown): expr is NumericLiteral {
   return typeof expr === "number" || typeof expr === "bigint";
 }
 
+export function isIntegerLiteral(expr: unknown): expr is NumericLiteral {
+  return typeof expr === "number" && Number.isInteger(expr);
+}
+
+export function isFloatLiteral(expr: unknown): expr is NumericLiteral {
+  return typeof expr === "number" && !Number.isInteger(expr);
+}
+
 export function isValue(expr: unknown): expr is ValueExpression {
   return Array.isArray(expr) && expr[0] === "value";
 }

--- a/frontend/src/metabase-lib/v1/expressions/passes.ts
+++ b/frontend/src/metabase-lib/v1/expressions/passes.ts
@@ -5,7 +5,8 @@ import {
   isBooleanLiteral,
   isCaseOrIf,
   isCaseOrIfOperator,
-  isNumberLiteral,
+  isFloatLiteral,
+  isIntegerLiteral,
   isOptionsObject,
   isStringLiteral,
 } from "./matchers";
@@ -218,12 +219,14 @@ export const adjustBigIntLiteral: CompilerPass = (tree) =>
   });
 
 export const adjustTopLevelLiteral: CompilerPass = (tree) => {
-  if (
-    isStringLiteral(tree) ||
-    isNumberLiteral(tree) ||
-    isBooleanLiteral(tree)
-  ) {
-    return ["value", tree, null];
+  if (isStringLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Text" }];
+  } else if (isBooleanLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Boolean" }];
+  } else if (isIntegerLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Integer" }];
+  } else if (isFloatLiteral(tree)) {
+    return ["value", tree, { base_type: "type/Float" }];
   } else {
     return tree;
   }

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -21,6 +21,7 @@ export type DatabaseFeature =
   | "datetime-diff"
   | "dynamic-schema"
   | "expression-aggregations"
+  | "expression-literals"
   | "expressions"
   | "expressions/date"
   | "expressions/integer"

--- a/frontend/src/metabase-types/api/mocks/database.ts
+++ b/frontend/src/metabase-types/api/mocks/database.ts
@@ -11,6 +11,7 @@ export const COMMON_DATABASE_FEATURES: DatabaseFeature[] = [
   "binning",
   "case-sensitivity-string-filter-options",
   "expression-aggregations",
+  "expression-literals",
   "expressions",
   "native-parameters",
   "nested-queries",

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -676,7 +676,8 @@
                               ;; timezone_trunc() rather than literally using SET TIMEZONE, but we need to flag it as
                               ;; supporting set-timezone anyway so that reporting timezones are returned and used, and
                               ;; tests expect the converted values.
-                              :set-timezone             true}]
+                              :set-timezone             true
+                              :expression-literals      true}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))
 
 ;; BigQuery is always in UTC

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -42,6 +42,7 @@
 (doseq [[feature supported?] {:connection-impersonation  true
                               :describe-fields           true
                               :describe-fks              true
+                              :expression-literals       false
                               :identifiers-with-spaces   false
                               :uuid-type                 false
                               :nested-field-columns      false

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -55,9 +55,10 @@
                               :connection-impersonation-requires-role true
                               :convert-timezone                       true
                               :datetime-diff                          true
-                              :identifiers-with-spaces                true
                               :describe-fields                        true
+                              :expression-literals                    true
                               :expressions/integer                    true
+                              :identifiers-with-spaces                true
                               :split-part                             true
                               :now                                    true}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -578,6 +578,9 @@
     ;; \"avg(x + y)\"
     :expression-aggregations
 
+    ;; Does the driver support expressions consisting of a single literal value like `1`, `\"hello\"`, and `false`.
+    :expression-literals
+
     ;; Does the driver support using a query as the `:source-query` of another MBQL query? Examples are CTEs or
     ;; subselects in SQL queries.
     :nested-queries

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -12,10 +12,12 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -68,6 +70,7 @@
 (doseq [[feature supported?] {:actions                   true
                               :actions/custom            true
                               :datetime-diff             true
+                              :expression-literals       true
                               :full-join                 false
                               :index-info                true
                               :now                       true
@@ -396,6 +399,30 @@
 (defmethod sql.qp/->honeysql [:h2 :log]
   [driver [_ field]]
   [:log10 (sql.qp/->honeysql driver field)])
+
+(defn- literal-text-value?
+  [[_ value {base-type :base_type effective-type :effective_type} :as clause]]
+  (and (mbql.u/is-clause? :value clause)
+       (string? value)
+       (isa? (or effective-type base-type)
+             :type/Text)))
+
+(defmethod sql.qp/->honeysql [:h2 :expression]
+  [driver [_ expression-name {::add/keys [source-table]} :as clause]]
+  (let [expression-definition (mbql.u/expression-with-name sql.qp/*inner-query* expression-name)]
+    (if (and (not= source-table ::add/source)
+             (literal-text-value? expression-definition))
+      ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
+      ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown
+      ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST. We
+      ;; only need to do this for string literals, since numbers and booleans get inlined directly.
+      ;;
+      ;; https://linear.app/metabase/issue/QUE-726/
+      ;; https://github.com/h2database/h2database/issues/1383
+      (->> (sql.qp/->honeysql driver expression-definition)
+           (h2x/cast :text))
+      ((get-method sql.qp/->honeysql [:sql-jdbc :expression])
+       driver clause))))
 
 (defn- datediff
   "Like H2's `datediff` function but accounts for timestamps with time zones."

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -75,7 +75,8 @@
                               ;; MySQL doesn't let you have lag/lead in the same part of a query as a `GROUP BY`; to
                               ;; fully support `offset` we need to do some kooky query transformations just for MySQL
                               ;; and make this work.
-                              :window-functions/offset                false}]
+                              :window-functions/offset                false
+                              :expression-literals                    true}]
   (defmethod driver/database-supports? [:mysql feature] [_driver _feature _db] supported?))
 
 ;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -79,6 +79,7 @@
                               :uuid-type                true
                               :split-part               true
                               :uploads                  true
+                              :expression-literals      true
                               :expressions/text         true
                               :expressions/integer      true
                               :expressions/date         true}]

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -223,8 +223,11 @@
 
 (defn- normalize-value-opts
   [opts]
-  ;; `:value` in legacy MBQL expects `snake_case` keys for type info keys.
-  (m/update-existing opts :base_type keyword))
+  (some-> opts
+          lib.schema.common/normalize-map
+          ;; `:value` in legacy MBQL expects `snake_case` keys for type info keys.
+          (m/update-existing :base_type keyword)
+          (m/update-existing :semantic_type keyword)))
 
 (defmethod normalize-mbql-clause-tokens :value
   ;; The args of a `value` clause shouldn't be normalized.

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -326,8 +326,7 @@
 
   ([query :- ::lib.schema/query
     stage-number :- :int]
-   (let [db-features (or (:features (lib.metadata/database query)) #{})
-         stage (lib.util/query-stage query stage-number)
+   (let [stage (lib.util/query-stage query stage-number)
          columns (lib.metadata.calculation/visible-columns query stage-number stage)
          with-columns (fn [{:keys [requires-column? supported-field] :as operator}]
                         (cond
@@ -346,7 +345,7 @@
       (into []
             (comp (filter (fn [op]
                             (let [feature (:driver-feature op)]
-                              (or (nil? feature) (db-features feature)))))
+                              (or (nil? feature) (lib.metadata/database-supports? query feature)))))
                   (keep with-columns)
                   (map #(assoc % :lib/type :operator/aggregation)))
             lib.schema.aggregation/aggregation-operators)))))

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
    [metabase.lib.hierarchy :as lib.hierarchy]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
@@ -533,6 +534,7 @@
                      (lib.util.match/match-one expr :offset))
             {:message  (i18n/tru "OFFSET is not supported in custom filters")
              :friendly true})
-          (when (= (first expr) :value)
+          (when (and (lib.schema.common/is-clause? :value expr)
+                     (not (lib.metadata/database-supports? query :expression-literals)))
             {:message  (i18n/tru "Standalone constants are not supported.")
              :friendly true})))))

--- a/src/metabase/lib/extraction.cljc
+++ b/src/metabase/lib/extraction.cljc
@@ -26,9 +26,7 @@
             :display-name (lib.temporal-bucket/describe-temporal-unit unit)}))))
 
 (defn- regex-available? [metadata-providerable]
-  (-> (lib.metadata/database metadata-providerable)
-      :features
-      (contains? :regex)))
+  (lib.metadata/database-supports? metadata-providerable :regex))
 
 (defn- domain-extraction [column]
   {:lib/type     ::extraction

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -423,7 +423,7 @@
 (defmethod lib.binning/available-binning-strategies-method :metadata/column
   [query _stage-number {:keys [effective-type fingerprint semantic-type] :as field-metadata}]
   (if (not= (:lib/source field-metadata) :source/expressions)
-    (let [binning?    (some-> query lib.metadata/database :features (contains? :binning))
+    (let [binning?    (lib.metadata/database-supports? query :binning)
           fingerprint (get-in fingerprint [:type :type/Number])
           existing    (lib.binning/binning field-metadata)
           strategies  (cond

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -607,12 +607,10 @@
   ;; stage number is not currently used, but it is taken as a parameter for consistency with the rest of MLv2
   ([query         :- ::lib.schema/query
     _stage-number :- :int]
-   (let [database (lib.metadata/database query)
-         features (:features database)]
-     (into []
-           (comp (filter (partial contains? features))
-                 (map raw-join-strategy->strategy-option))
-           [:left-join :right-join :inner-join :full-join]))))
+   (into []
+         (comp (filter (partial lib.metadata/database-supports? query))
+               (map raw-join-strategy->strategy-option))
+         [:left-join :right-join :inner-join :full-join])))
 
 (mu/defn join-clause :- lib.join.util/PartialJoin
   "Create an MBQL join map from something that can conceptually be joined against. A `Table`? An MBQL or native query? A

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -169,10 +169,13 @@
       (editable-stages? query stages))))
 
 (mu/defn database-supports? :- :boolean
-  "Does `query`s [[database]] support the given `feature`?"
-  [query   :- ::lib.schema/query
-   feature :- :keyword]
-  (-> query
+  "Does `metadata-providerable`'s [[database]] support the given `feature`?
+
+  Minimize the use of this function. Using it is often a code smell. The lib should not normally be concerned with
+  driver features. See https://github.com/metabase/metabase/pull/55206#discussion_r2017378181"
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   feature               :- :keyword]
+  (-> metadata-providerable
       database
       :features
       (contains? feature)))

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -168,6 +168,15 @@
     (mu/disable-enforcement
       (editable-stages? query stages))))
 
+(mu/defn database-supports? :- :boolean
+  "Does `query`s [[database]] support the given `feature`?"
+  [query   :- ::lib.schema/query
+   feature :- :keyword]
+  (-> query
+      database
+      :features
+      (contains? feature)))
+
 ;;; TODO -- I'm wondering if we need both this AND [[bulk-metadata-or-throw]]... most of the rest of the stuff here
 ;;; throws if we can't fetch the metadata, not sure what situations we wouldn't want to do that in places that use
 ;;; this (like QP middleware). Maybe we should only have a throwing version.

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -127,11 +127,10 @@
 (mu/defn required-native-extras :- set?
   "Returns the extra keys that are required for this database's native queries, for example `:collection` name is
   needed for MongoDB queries."
-  [metadata-provider :- ::lib.schema.metadata/metadata-providerable]
-  (let [db (lib.metadata/database metadata-provider)]
-    (cond-> #{}
-      (get-in db [:features :native-requires-specified-collection])
-      (conj :collection))))
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable]
+  (cond-> #{}
+    (lib.metadata/database-supports? metadata-providerable :native-requires-specified-collection)
+    (conj :collection)))
 
 (mu/defn with-native-extras :- ::lib.schema/query
   "Updates the extras required for the db to run this query.

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -34,11 +34,6 @@
           [nil, -1]))
       [query, i])))
 
-(mu/defn- query-database-supports? :- :boolean
-  [query   :- ::lib.schema/query
-   feature :- :keyword]
-  (contains? (-> query lib.metadata/database :features) feature))
-
 (mu/defn top-level-query :- ::lib.schema/query
   "Returns the \"top-level\" query for the given query.
 
@@ -47,7 +42,7 @@
 
   If the database does not support nested queries, this also returns the original query."
   [query :- ::lib.schema/query]
-  (or (when (query-database-supports? query :nested-queries)
+  (or (when (lib.metadata/database-supports? query :nested-queries)
         (first (pop-until-aggregation-or-breakout query)))
       query))
 
@@ -56,7 +51,7 @@
 
   If there are no such stages, or if the database does not supported nested queries, returns -1."
   [query :- ::lib.schema/query]
-  (or (when (query-database-supports? query :nested-queries)
+  (or (when (lib.metadata/database-supports? query :nested-queries)
         (second (pop-until-aggregation-or-breakout query)))
       -1))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -166,6 +166,11 @@
     (boolean? expression)
     {:base_type :type/Boolean}
 
+    (mbql.u/is-clause? :value expression)
+    (let [[_ value options] expression]
+      (or (not-empty (select-keys options type-info-columns))
+          (select-keys (infer-expression-type value) type-info-columns)))
+
     (mbql.u/is-clause? :field expression)
     (col-info-for-field-clause {} expression)
 

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -185,18 +185,19 @@
 
   1. there are some expression definitions in the inner query, AND
 
-  2. there are some breakouts OR some aggregations in the inner query
+  2. there are some breakouts OR aggregations OR order-by in the inner query
 
-  3. AND the breakouts/aggregations contain at least `:expression` reference."
-  [{:keys [expressions], breakouts :breakout, aggregations :aggregation, :as _inner-query}]
+  3. AND the breakouts/aggregations/order-bys contain at least one `:expression` reference."
+  [{:keys [expressions], breakouts :breakout, aggregations :aggregation, order-bys :order-by, :as _inner-query}]
   (and
    ;; 1. has some expression definitions
    (seq expressions)
-   ;; 2. has some breakouts or aggregations
+   ;; 2. has some breakouts or aggregations or order-by
    (or (seq breakouts)
-       (seq aggregations))
+       (seq aggregations)
+       (seq order-bys))
    ;; 3. contains an `:expression` ref
-   (lib.util.match/match-one (concat breakouts aggregations)
+   (lib.util.match/match-one (concat breakouts aggregations order-bys)
      :expression)))
 
 (defn nest-expressions

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -605,6 +605,12 @@
    {{:query {:expressions {"abc" [+ 1 2]}
              :fields      [[:expression "abc" {"base-type" "type/Number"}]]}}
     {:query {:expressions {"abc" [+ 1 2]}
+             :fields      [[:expression "abc" {:base-type :type/Number}]]}}}
+
+   "expressions can be a literal :value"
+   {{:query {:expressions {"abc" [:value 123 nil]}
+             :fields      [[:expression "abc" {"base-type" "type/Number"}]]}}
+    {:query {:expressions {"abc" [:value 123 nil]}
              :fields      [[:expression "abc" {:base-type :type/Number}]]}}}))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -774,6 +780,16 @@
 
     {:query {:breakout [[:field 1000 nil]]}}
     {:query {:breakout [[:field 1000 nil]]}}}))
+
+;;; ----------------------------------------------------- expressions ------------------------------------------------
+
+(t/deftest ^:parallel canonicalize-expressions-test
+  (canonicalize-tests
+   "expressions can be a literal :value"
+   {{:query {:expressions {"abc" [:value false nil]}
+             :fields      [[:expression "abc" {:base-type :type/Boolean}]]}}
+    {:query {:expressions {"abc" [:value false nil]}
+             :fields      [[:expression "abc" {:base-type :type/Boolean}]]}}}))
 
 ;;; ----------------------------------------------------- fields -----------------------------------------------------
 

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -63,10 +63,15 @@
     [:field 2 {"binning" {"strategy" "default"}}]
     [:field 2 {:binning {:strategy :default}}]}
 
-   ":value clauses should keep snake_case keys in the type info arg"
+   ":value clauses should keep snake_case keys in the options"
     ;; See https://github.com/metabase/metabase/issues/23354 for details
    {[:value "some value" {:some_key "some key value"}]
     [:value "some value" {:some_key "some key value"}]}
+
+   ":value clauses should keep snake_case keys in the type info args"
+    ;; See https://github.com/metabase/metabase/issues/23354 for details
+   {[:value "some value" {"base_type" "type/Text"}]
+    [:value "some value" {:base_type :type/Text}]}
 
    "nil options in aggregation and expression references should be removed"
    {[:aggregation 0 nil]   [:aggregation 0]
@@ -608,10 +613,10 @@
              :fields      [[:expression "abc" {:base-type :type/Number}]]}}}
 
    "expressions can be a literal :value"
-   {{:query {:expressions {"abc" [:value 123 nil]}
-             :fields      [[:expression "abc" {"base-type" "type/Number"}]]}}
-    {:query {:expressions {"abc" [:value 123 nil]}
-             :fields      [[:expression "abc" {:base-type :type/Number}]]}}}))
+   {{:query {:expressions {"abc" [:value 123 {"base_type" "type/Integer"}]}
+             :fields      [[:expression "abc" {"base-type" "type/Integer"}]]}}
+    {:query {:expressions {"abc" [:value 123 {:base_type :type/Integer}]}
+             :fields      [[:expression "abc" {:base-type :type/Integer}]]}}}))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  CANONICALIZE                                                  |
@@ -786,9 +791,9 @@
 (t/deftest ^:parallel canonicalize-expressions-test
   (canonicalize-tests
    "expressions can be a literal :value"
-   {{:query {:expressions {"abc" [:value false nil]}
+   {{:query {:expressions {"abc" [:value false {:base_type :type/Boolean}]}
              :fields      [[:expression "abc" {:base-type :type/Boolean}]]}}
-    {:query {:expressions {"abc" [:value false nil]}
+    {:query {:expressions {"abc" [:value false {:base_type :type/Boolean}]}
              :fields      [[:expression "abc" {:base-type :type/Boolean}]]}}}))
 
 ;;; ----------------------------------------------------- fields -----------------------------------------------------

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -164,6 +164,33 @@
       @#'mbql.s/EqualityComparable
       [:or mbql.s/absolute-datetime mbql.s/value])))
 
+(deftest ^:parallel expression-value-wrapped-literals-test
+  (are [value] (not (me/humanize (mr/explain mbql.s/MBQLQuery
+                                             {:source-table 1, :expressions {"expr" [:value value nil]}})))
+    ""
+    "192.168.1.1"
+    "2025-03-11"
+    -1
+    0
+    1
+    1.23
+    true
+    false))
+
+(deftest ^:parallel expression-unwrapped-literals-test
+  (are [value] (= {:expressions {"expr" ["valid instance of one of these MBQL clauses: :expression, :field"]}}
+                  (me/humanize (mr/explain mbql.s/MBQLQuery
+                                           {:source-table 1, :expressions {"expr" value}})))
+    ""
+    "192.168.1.1"
+    "2025-03-11"
+    -1
+    0
+    1
+    1.23
+    true
+    false))
+
 (deftest ^:parallel or-test
   (are [schema expected] (= expected
                             (mu.humanize/humanize (mr/explain schema [:value "192.168.1.1" {:base_type :type/FK}])))
@@ -194,5 +221,8 @@
   (are [x] (not (me/humanize (mr/explain ::mbql.s/Filter x)))
     [:value true nil]
     [:value false nil]
+    [:expression "boolexpr"]
     [:field 1 nil]
-    [:segment 1]))
+    [:segment 1]
+    [:and [:expression "bool1"] [:expression "bool2"]]
+    [:or  [:expression "bool1"] [:expression "bool2"]]))

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -453,6 +453,15 @@
                   :lib/source     :source/aggregations}]
                 (lib/aggregations-metadata agg-query)))))))
 
+(deftest ^:parallel available-aggregation-operators-missing-feature-test
+  (let [provider-without-feature  (meta/updated-metadata-provider
+                                   update :features disj :basic-aggregations :percentile-aggregations)
+        query-without-feature     (lib/query provider-without-feature (meta/table-metadata :venues))
+        operators-without-feature (lib/available-aggregation-operators query-without-feature)]
+    (is (=? [{:short :stddev
+              :driver-feature :standard-deviation-aggregations}]
+            operators-without-feature))))
+
 (deftest ^:parallel selected-aggregation-operator-test
   (let [query (-> (lib.tu/venues-query)
                   (lib/expression "double-price" (lib/* (meta/field-metadata :venues :price) 2))

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -424,6 +424,137 @@
                             {:name "Additional Information", :display-name "Additional Information"}]]
              :aggregation-idents {0 (u/generate-nano-id)}}}))
 
+(deftest ^:parallel round-trip-literal-expression-test
+  ;; Some cases of literal expressions are already covered in round-trip-test, above.
+  (are [query] (test-round-trip query)
+    [:value false {:base_type :type/Boolean}]
+
+    [:value true nil]
+
+    [:value false nil]
+
+    [:value "123" {:base_type :type/Text}]
+
+    [:value "" nil]
+
+    [:value "foo" nil]
+
+    [:value 12345 {:base_type :type/Integer}]
+
+    [:value -1 nil]
+
+    [:value 0 nil]
+
+    [:value 1 nil]
+
+    [:value 1e10 {:base_type :type/Float}]
+
+    [:value 1.23 nil]
+
+    {:database 123
+     :query {:middleware {:disable-remaps? true}
+             :source-card-id 1301
+             :source-query {:source-table 224
+                            :expressions {"a" [:value 1 nil]
+                                          "b" [:value false nil]}
+                            :expression-idents {"a" (u/generate-nano-id)
+                                                "b" (u/generate-nano-id)}}
+             :expressions {"c" [:value "cee" nil]
+                           "d" [:value 1.23 nil]}
+             :expression-idents {"c" (u/generate-nano-id)
+                                 "d" (u/generate-nano-id)}}
+     :type :query}
+
+    {:database 1
+     :type     :query
+     :query    {:source-table 224
+                :expressions {"a" [:value 1 nil]
+                              "b" [:value 0 nil]
+                              "c" [:value true nil]
+                              "d" [:value false nil]
+                              "e" [:value 2.71828 nil]
+                              "f" [:value "foo" nil]
+                              "g" [:value "" nil]}
+                :expression-idents {"a" (u/generate-nano-id)
+                                    "b" (u/generate-nano-id)
+                                    "c" (u/generate-nano-id)
+                                    "d" (u/generate-nano-id)
+                                    "e" (u/generate-nano-id)
+                                    "f" (u/generate-nano-id)
+                                    "g" (u/generate-nano-id)}}}
+
+    {:type :query
+     :database 5
+     :query {:source-table 5822
+             :expressions {"literal expression" [:value false nil]
+                           "coalesce"           [:coalesce
+                                                 [:expression "literal expression"]
+                                                 [:field 519196 nil]
+                                                 "None"]
+                           "case expression 1"  [:case
+                                                 [[[:= [:expression "literal expression"] false]
+                                                   "No"]]
+                                                 {:default "Yes"}]
+                           "case expression 2"  [:case
+                                                 [[[:expression "literal expression"]
+                                                   "No"]]
+                                                 {:default "Yes"}]}
+             :expression-idents {"literal expression" (u/generate-nano-id)
+                                 "coalesce"           (u/generate-nano-id)
+                                 "case expression 1"  (u/generate-nano-id)
+                                 "case expression 2"  (u/generate-nano-id)}
+             :filter [:= [:field 518086 nil] [:expression "literal expression"]]
+             :aggregation [[:aggregation-options
+                            [:share [:= [:expression "literal expression"] true]]
+                            {:name "Additional Information", :display-name "Additional Information"}]]
+             :aggregation-idents {0 (u/generate-nano-id)}}}))
+
+(deftest ^:parallel round-trip-literal-expression-test-2
+  (are [literal] (test-round-trip {:database 1
+                                   :type     :query
+                                   :query    {:source-table 224
+                                              :expressions {"a" [:value literal nil]}
+                                              :expression-idents {"a" (u/generate-nano-id)}}})
+    true
+    false
+    0
+    10
+    -10
+    10.15
+    "abc"
+    "2020-10-20"
+    "2020-10-20T10:20:00"
+    "2020-10-20T10:20:00Z"
+    "10:20:00"))
+
+(deftest ^:parallel round-trip-filter-expression-test
+  (are [expressions filter-expression]
+       (test-round-trip {:database 1
+                         :type     :query
+                         :query    (merge {:source-table 224
+                                           :filter       filter-expression}
+                                          (when (seq expressions)
+                                            {:expressions expressions
+                                             :expression-idents (update-vals expressions
+                                                                             (fn [_] (u/generate-nano-id)))}))})
+    {} [:value true nil]
+
+    {} [:value false nil]
+
+    {} [:field 1 {:base-type :type/Boolean}]
+
+    {"true"  [:value true nil]}
+    [:expression "true"]
+
+    {"false" [:value false nil]}
+    [:expression "false"]
+
+    {"eq"  [:= 1 2]}
+    [:expression "eq"]
+
+    {"and"  [:and [:field 1 nil] [:field 2 nil]]}
+    [:expression "and"]))
+
 (deftest ^:parallel round-trip-segments-test
   (test-round-trip {:database 282
                     :type :query
@@ -985,7 +1116,7 @@
               (lib.convert/->legacy-MBQL query))))))
 
 (deftest ^:parallel convert-with-broken-expression-types-test
-  (testing "be flexible when converting from legacy, metadata type overrides are soometimes dropped (#41122)"
+  (testing "be flexible when converting from legacy, metadata type overrides are sometimes dropped (#41122)"
     (let [legacy {:database (meta/id)
                   :type     :query
                   :query    {:filter [:between [:+

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -394,7 +394,7 @@
     {:database 1
      :type     :query
      :query    {:source-table 224
-                :expressions {"a" [:value 1 nil]}
+                :expressions {"a" [:value 1 {:base_type :type/Integer}]}
                 :expression-idents {"a" (u/generate-nano-id)}}}
 
     ;; card__<id> source table syntax.
@@ -540,6 +540,10 @@
     {} [:value true nil]
 
     {} [:value false nil]
+
+    {} [:value true {:base_type :type/Boolean}]
+
+    {} [:value false {:base_type :type/Boolean}]
 
     {} [:field 1 {:base-type :type/Boolean}]
 

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -10,7 +10,6 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
@@ -553,9 +552,7 @@
 
 (deftest ^:parallel diagnose-expression-literals-without-feature-support-test
   (testing "top-level literals are not allowed if the :expression-literals feature is not supported"
-    (let [metadata-graph (.-metadata-graph meta/metadata-provider)
-          restricted-metadata-graph (update metadata-graph :features disj :expression-literals)
-          restricted-provider (meta.graph-provider/->SimpleGraphMetadataProvider restricted-metadata-graph)
+    (let [restricted-provider (meta/updated-metadata-provider update :features disj :expression-literals)
           query (lib/query restricted-provider (meta/table-metadata :orders))
           expr  (lib.expression/value true)]
       (doseq [mode [:expression :filter]]

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -10,6 +10,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
@@ -481,21 +482,21 @@
       :filter      [:= [:field 1 {:base-type :type/Integer}] 3])))
 
 (deftest ^:parallel diagnose-expression-test-2
-  (testing "correct expression are accepted silently"
-    (testing "type errors are reported"
-      (are [mode expr] (=? {:message  "Types are incompatible."
-                            :friendly true}
-                           (lib.expression/diagnose-expression
-                            (lib.tu/venues-query) 0 mode
-                            (lib.convert/->pMBQL expr)
-                            #?(:clj nil :cljs js/undefined)))
-        :expression  [:/ [:field 1 {:base-type :type/Address}] 100]
-             ;; To make this test case work, the aggregation schema has to be
-             ;; tighter and not allow anything. That's a bigger piece of work,
-             ;; because it makes expressions and aggregations mutually recursive
-             ;; or requires a large amount of duplication.
-        #_#_:aggregation [:sum [:is-empty [:field 1 {:base-type :type/Boolean}]]]
-        :filter      [:sum [:field 1 {:base-type :type/Integer}]]))))
+  (testing "type errors are reported"
+    (are [mode expr] (=? {:message  "Types are incompatible."
+                          :friendly true}
+                         (lib.expression/diagnose-expression
+                          (lib.tu/venues-query) 0 mode
+                          (lib.convert/->pMBQL expr)
+                          #?(:clj nil :cljs js/undefined)))
+      :expression  [:/ [:field 1 {:base-type :type/Address}] 100]
+        ;; To make this test case work, the aggregation schema has to be
+        ;; tighter and not allow anything. That's a bigger piece of work,
+        ;; because it makes expressions and aggregations mutually recursive
+        ;; or requires a large amount of duplication.
+      #_#_:aggregation [:sum [:is-empty [:field 1 {:base-type :type/Boolean}]]]
+      :filter      [:sum [:field 1 {:base-type :type/Integer}]]
+      :filter      [:value "not a boolean" {:base_type :type/Text}])))
 
 (deftest ^:parallel diagnose-expression-test-3
   (testing "correct expression are accepted silently"
@@ -550,14 +551,35 @@
                                                          100)
                                                   nil))))))
 
-(deftest ^:parallel diagnose-expression-literals-test
-  (testing "top-level literals are not allowed"
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))
+(deftest ^:parallel diagnose-expression-literals-without-feature-support-test
+  (testing "top-level literals are not allowed if the :expression-literals feature is not supported"
+    (let [metadata-graph (.-metadata-graph meta/metadata-provider)
+          restricted-metadata-graph (update metadata-graph :features disj :expression-literals)
+          restricted-provider (meta.graph-provider/->SimpleGraphMetadataProvider restricted-metadata-graph)
+          query (lib/query restricted-provider (meta/table-metadata :orders))
           expr  (lib.expression/value true)]
       (doseq [mode [:expression :filter]]
         (is (=? {:message  "Standalone constants are not supported."
                  :friendly true}
                 (lib.expression/diagnose-expression query 0 mode expr nil)))))))
+
+(deftest ^:parallel diagnose-expression-literal-values-test
+  (let [query     (lib/query meta/metadata-provider (meta/table-metadata :orders))
+        int-expr  [:value 1 nil]
+        str-expr  [:value "foo" nil]
+        bool-expr [:value true nil]
+        diagnose-expr (fn [mode expr]
+                        (lib.expression/diagnose-expression query 0 mode (lib.convert/->pMBQL expr) nil))]
+    (testing "valid literal expressions are accepted"
+      (are [mode expr] (nil? (diagnose-expr mode expr))
+        :expression  int-expr
+        :expression  str-expr
+        :expression  bool-expr
+        :filter      bool-expr))
+    (testing "invalid literal expressions are rejected when not suppressing type checks"
+      (are [mode expr] (=? {:message "Types are incompatible."} (diagnose-expr mode expr))
+        :filter str-expr
+        :filter int-expr))))
 
 (deftest ^:parallel date-and-time-string-literals-test-1-dates
   (are [types input] (= types (lib.schema.expression/type-of input))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -289,6 +289,14 @@
   (is (=? [[:value {:lib/expression-name "expr", :effective-type :type/Text, :ident string?} "value"]]
           (-> (lib.tu/venues-query)
               (lib/expression "expr" "value")
+              (lib/expressions))))
+  (is (=? [[:value {:lib/expression-name "expr", :effective-type :type/Float, :ident string?} 1.23]]
+          (-> (lib.tu/venues-query)
+              (lib/expression "expr" 1.23)
+              (lib/expressions))))
+  (is (=? [[:value {:lib/expression-name "expr", :effective-type :type/Boolean, :ident string?} false]]
+          (-> (lib.tu/venues-query)
+              (lib/expression "expr" false)
               (lib/expressions)))))
 
 (deftest ^:parallel expressionable-columns-test

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -407,6 +407,14 @@
                        (for [option options]
                          (:selected (lib/display-info query2 option)))))))))))))
 
+(deftest ^:parallel available-binning-strategies-missing-feature-test
+  (let [provider (meta/updated-metadata-provider update :features disj :binning)
+        query    (lib/query provider (meta/table-metadata :orders))
+        subtotal (meta/field-metadata :orders :subtotal)]
+    (testing "no available binning strategies if database does not support :binning"
+      (is (= []
+             (lib/available-binning-strategies query subtotal))))))
+
 (deftest ^:parallel available-binning-strategies-expressions-test
   (testing "There should be no binning strategies for expressions as they are not supported (#31367)"
     (let [query (-> (lib.tu/venues-query)

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -427,6 +427,13 @@
           {:lib/type :option/join.strategy, :strategy :inner-join}]
          (lib/available-join-strategies (lib.tu/query-with-join)))))
 
+(deftest ^:parallel available-join-strategies-missing-features-test
+  (is (= [{:lib/type :option/join.strategy, :strategy :inner-join}]
+         (lib/available-join-strategies
+          (-> (lib.tu/query-with-join)
+              (assoc :lib/metadata
+                     (meta/updated-metadata-provider update :features disj :left-join :right-join)))))))
+
 (deftest ^:parallel join-strategy-display-name-test
   (let [query (lib.tu/query-with-join)]
     (is (= ["Left outer join" "Right outer join" "Inner join"]

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -233,14 +233,15 @@
       (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
   (testing "simple values can be converted properly (#36459)"
     (let [query (lib.tu/venues-query)
-          legacy-expr #js ["value" 0 nil]
+          legacy-expr #js ["value" 0 {"base_type" "type/Integer"}]
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
           legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
           query-with-expr (lib/expression query 0 "expr" expr)
           expr-from-query (first (lib/expressions query-with-expr 0))
           legacy-expr-from-query (lib.js/legacy-expression-for-expression-clause query-with-expr 0 expr-from-query)
           named-expr (lib/with-expression-name expr "named")]
-      (is (=? [:value {:effective-type :type/Integer, :lib/uuid string?} 0] expr))
+      (is (=? [:value {:base-type :type/Integer :effective-type :type/Integer, :lib/uuid string?} 0]
+              expr))
       (is (= (js->clj legacy-expr) (js->clj legacy-expr') (js->clj legacy-expr-from-query)))
       (is (= "named" (lib/display-name query named-expr)))))
   (testing "simple expressions can be converted properly (#37173)"

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -240,6 +240,7 @@
           expr-from-query (first (lib/expressions query-with-expr 0))
           legacy-expr-from-query (lib.js/legacy-expression-for-expression-clause query-with-expr 0 expr-from-query)
           named-expr (lib/with-expression-name expr "named")]
+      (is (=? [:value {:effective-type :type/Integer, :lib/uuid string?} 0] expr))
       (is (= (js->clj legacy-expr) (js->clj legacy-expr') (js->clj legacy-expr-from-query)))
       (is (= "named" (lib/display-name query named-expr)))))
   (testing "simple expressions can be converted properly (#37173)"

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -65,6 +65,19 @@
     (is (lib.metadata/editable? query))
     (is (not (lib.metadata/editable? restritcted-query)))))
 
+(deftest ^:parallel database-supports?-test
+  (let [query          (lib.tu/query-with-join)
+        metadata       ^SimpleGraphMetadataProvider (:lib/metadata query)
+        metadata-graph (.-metadata-graph metadata)
+        metadata-graph-with-feature (update metadata-graph :features conj ::special-feature)
+        metadata-graph-without-feature (update metadata-graph :features disj ::special-feature)
+        provider-with-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-with-feature)
+        provider-without-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-without-feature)
+        query-with-feature (assoc query :lib/metadata provider-with-feature)
+        query-without-feature (assoc query :lib/metadata provider-without-feature)]
+    (is (lib.metadata/database-supports? query-with-feature ::special-feature))
+    (is (not (lib.metadata/database-supports? query-without-feature ::special-feature)))))
+
 (deftest ^:parallel idents-test
   (doseq [table-key (meta/tables)
           field-key (meta/fields table-key)]

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -5,10 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
-   [metabase.lib.test-util :as lib.tu])
-  #?@(:clj ((:import
-             metabase.lib.test_metadata.graph_provider.SimpleGraphMetadataProvider))))
+   [metabase.lib.test-util :as lib.tu]))
 
 (comment lib/keep-me)
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
@@ -56,23 +53,17 @@
       ["PEOPLE" "ORDERS" "VENUES"])))
 
 (deftest ^:parallel editable?-test
-  (let [query          (lib.tu/query-with-join)
-        metadata       ^SimpleGraphMetadataProvider (:lib/metadata query)
-        metadata-graph (.-metadata-graph metadata)
-        restricted-metadata-graph (update metadata-graph :tables #(into [] (remove (comp #{"CATEGORIES"} :name)) %))
-        restricted-provider (meta.graph-provider/->SimpleGraphMetadataProvider restricted-metadata-graph)
-        restritcted-query (assoc query :lib/metadata restricted-provider)]
+  (let [query               (lib.tu/query-with-join)
+        restricted-provider (meta/updated-metadata-provider
+                             update :tables #(into [] (remove (comp #{"CATEGORIES"} :name)) %))
+        restritcted-query   (assoc query :lib/metadata restricted-provider)]
     (is (lib.metadata/editable? query))
     (is (not (lib.metadata/editable? restritcted-query)))))
 
 (deftest ^:parallel database-supports?-test
   (let [query          (lib.tu/query-with-join)
-        metadata       ^SimpleGraphMetadataProvider (:lib/metadata query)
-        metadata-graph (.-metadata-graph metadata)
-        metadata-graph-with-feature (update metadata-graph :features conj ::special-feature)
-        metadata-graph-without-feature (update metadata-graph :features disj ::special-feature)
-        provider-with-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-with-feature)
-        provider-without-feature (meta.graph-provider/->SimpleGraphMetadataProvider metadata-graph-without-feature)
+        provider-with-feature (meta/updated-metadata-provider update :features conj ::special-feature)
+        provider-without-feature (meta/updated-metadata-provider update :features disj ::special-feature)
         query-with-feature (assoc query :lib/metadata provider-with-feature)
         query-without-feature (assoc query :lib/metadata provider-without-feature)]
     (is (lib.metadata/database-supports? query-with-feature ::special-feature))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -6,7 +6,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.native :as lib.native]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
    [metabase.lib.test-util :as lib.tu]
    [metabase.util.humanization :as u.humanization]
    [metabase.util.malli :as mu]))
@@ -234,8 +233,7 @@
              (lib/with-template-tags {"myid" (assoc (get original-tags "myid") :display-name "My ID")}))))))
 
 (defn ^:private metadata-provider-requiring-collection []
-  (meta.graph-provider/->SimpleGraphMetadataProvider (-> meta/metadata
-                                                         (update :features conj :native-requires-specified-collection))))
+  (meta/updated-metadata-provider update :features conj :native-requires-specified-collection))
 
 (deftest ^:parallel native-query+collection-test
   (testing "building when collection is not required"
@@ -255,8 +253,7 @@
       (is (=? {:database 9999}
               (-> query
                   (lib/with-different-database
-                    (meta.graph-provider/->SimpleGraphMetadataProvider
-                     (assoc meta/metadata :id 9999)))))))
+                    (meta/updated-metadata-provider assoc :id 9999))))))
     (is (thrown-with-msg?
          #?(:clj Throwable :cljs :default)
          #"Must be a native query"
@@ -413,8 +410,7 @@
     (testing "remove dimensions from template tags"
       (is (empty? (-> query
                       (lib/with-different-database
-                        (meta.graph-provider/->SimpleGraphMetadataProvider
-                         (assoc meta/metadata :id 9999)))
+                        (meta/updated-metadata-provider assoc :id 9999))
                       lib/template-tags
                       vals
                       (->> (filter :dimension))))))))

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -3026,6 +3026,7 @@
                                   :date-arithmetics
                                   :datetime-diff
                                   :expression-aggregations
+                                  :expression-literals
                                   :expressions
                                   :inner-join
                                   :left-join

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -261,6 +261,21 @@
     (partial u/round-to-decimals (int x))
     x))
 
+(defn boolish->bool
+  "Convert something that looks like a reasonable DB bool to a bool.
+
+  Throw an exception if the input does not seem boolish. Valid inputs are #{0 1 true false}.
+
+  Can be used with [[format-rows-by]] to normalize DB-specific bools in results."
+  [x]
+  ;; The compiler warns about performance here since (= (hash 0) (hash 0M)), so the `case` will fallback to linear
+  ;; probing for those values. It shouldn't matter for this function, but if it becomes an issue or we want to silence
+  ;; the warning, it could be rewritten to avoid the `case`.
+  (case x
+    (0 0M false) false
+    (1 1M true)  true
+    (throw (ex-info "value is not boolish" {:value x}))))
+
 (defn format-rows-by
   "Format the values in result `rows` with the fns at the corresponding indecies in `format-fns`. `rows` can be a
   sequence or any of the common map formats we expect in QP tests.

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -380,7 +380,6 @@
 
 (deftest ^:parallel literal-expressions-inside-nested-and-filtered-aggregations-test
   (testing "nested aggregated and filtered literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations :expression-literals :nested-queries)
       (is (= [[2 true "Red Medicine" 1 8 16]
               [3 true "Red Medicine" 1 2 4]
@@ -437,7 +436,7 @@
                  :joins       [{:strategy     :left-join
                                 :condition    [:= $category_id &JoinedCategories.venues.category_id]
                                 :source-query {:source-table $$venues
-                                               :expressions  {"One" [:value 1 nil]}
+                                               :expressions  {"One" [:value 1 {:base_type :type/Integer}]}
                                                :aggregation  [[:aggregation-options [:max [:expression "One"]] {:name "MaxOne"}]]
                                                :breakout     [$category_id]}
                                 :alias        "JoinedCategories"}]

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -377,3 +377,69 @@
                     mt/rows
                     (map second)
                     (map sort))))))))
+
+(deftest ^:parallel literal-expressions-inside-nested-and-filtered-aggregations-test
+  (testing "nested aggregated and filtered literal expression"
+    ;; TODO Fix this test for H2 (QUE-726)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations :expression-literals :nested-queries)
+      (is (= [[2 true "Red Medicine" 1 8 16]
+              [3 true "Red Medicine" 1 2 4]
+              [4 true "Red Medicine" 1 2 4]]
+             (mt/formatted-rows
+              [int mt/boolish->bool str int int int]
+              (mt/run-mbql-query venues
+                {:fields       [$category_id
+                                [:expression "True"]
+                                [:expression "Name"]
+                                *AvgOne/Integer
+                                *SumOne/Integer
+                                *SumTwo/Integer]
+                 :expressions  {"True"  [:value true {:base_type :type/Boolean}]
+                                "Name"  [:value "Red Medicine" {:base_type :type/Text}]}
+                 :source-query {:source-table $$venues
+                                :expressions  {"One" [:value 1.0 {:base_type :type/Float}]
+                                               "Two" [:value 2 {:base_type :type/Integer}]
+                                               "Bob" [:value "Bob's Burgers" {:base_type :type/Text}]}
+                                :aggregation  [[:aggregation-options [:avg [:expression "One"]] {:name "AvgOne"}]
+                                               [:aggregation-options [:sum [:expression "One"]] {:name "SumOne"}]
+                                               [:aggregation-options [:sum [:expression "Two"]] {:name "SumTwo"}]
+                                               [:aggregation-options [:min [:expression "Bob"]] {:name "MinBob"}]]
+                                :breakout     [$category_id]
+                                :filters      [[:= 2.0 [:* [:expression "Two"] [:expression "AvgOne"]]]]}
+                 :filters      [[:!= *MinBob/Text [:expression "Name"]]
+                                [:= true [:expression "True"]]
+                                [:= [:expression "True"] true]
+                                [:=
+                                 [:expression "Name"]
+                                 [:concat [:expression "Name"] ""]]]
+                 :order-by     [[:asc $category_id]]
+                 :limit        3})))))))
+
+(deftest ^:parallel literal-expressions-inside-joined-aggregations-test
+  (testing "joined and aggregated literal expression"
+    (mt/test-drivers (mt/normal-drivers-with-feature
+                      :expression-aggregations
+                      :expression-literals
+                      :left-join
+                      :nested-queries)
+      (is (= [[1 "Red Medicine" 3 0.33 1]
+              [2 "Stout Burgers & Beers" 2 0.50 1]
+              [3 "The Apple Pan" 2 0.5 1]]
+             (mt/formatted-rows
+              [int str int 2.0 int]
+              (mt/run-mbql-query venues
+                {:fields      [$id
+                               $name
+                               $price
+                               [:expression "InversePrice"]
+                               &JoinedCategories.*MaxOne/Integer]
+                 :expressions {"InversePrice"  [:/ &JoinedCategories.*MaxOne/Integer $price]}
+                 :joins       [{:strategy     :left-join
+                                :condition    [:= $category_id &JoinedCategories.venues.category_id]
+                                :source-query {:source-table $$venues
+                                               :expressions  {"One" [:value 1 nil]}
+                                               :aggregation  [[:aggregation-options [:max [:expression "One"]] {:name "MaxOne"}]]
+                                               :breakout     [$category_id]}
+                                :alias        "JoinedCategories"}]
+                 :order-by    [[:asc $id]]
+                 :limit       3})))))))

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -450,6 +450,240 @@
                  ffirst))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                               LITERAL EXPRESSIONS                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(def ^:private standard-literal-expression-defs
+  {"empty"  [:value ""    {:base_type :type/Text}]
+   "foo"    [:value "foo" {:base_type :type/Text}]
+   "zero"   [:value 0     {:base_type :type/Integer}]
+   "12345"  [:value 12345 {:base_type :type/Integer}]
+   "float"  [:value 1.234 {:base_type :type/Float}]
+   "True"   [:value true  {:base_type :type/Boolean}]
+   "False"  [:value false {:base_type :type/Boolean}]})
+
+(def ^:private standard-literal-expression-refs
+  [[:expression "empty"]
+   [:expression "foo"]
+   [:expression "zero"]
+   [:expression "12345"]
+   [:expression "float"]
+   [:expression "True"]
+   [:expression "False"]])
+
+(def ^:private standard-literal-expression-column-refs
+  [[:field "empty" {:base_type :type/Text}]
+   [:field "foo"   {:base_type :type/Text}]
+   [:field "zero"  {:base_type :type/Integer}]
+   [:field "12345" {:base_type :type/Integer}]
+   [:field "float" {:base_type :type/Float}]
+   [:field "True"  {:base_type :type/Boolean}]
+   [:field "False" {:base_type :type/Boolean}]])
+
+(def ^:private standard-literal-expression-row-formats
+  [str str int int 3.0 mt/boolish->bool mt/boolish->bool])
+
+(def ^:private standard-literal-expression-row-formats-with-id
+  (into [int] standard-literal-expression-row-formats))
+
+(def ^:private standard-literal-expression-values
+  (map second (vals standard-literal-expression-defs)))
+
+(deftest ^:parallel basic-literal-expression-test
+  (testing "basic literal expressions"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
+      (is (= [[1 "" "foo" 0 12345 1.234 true false]
+              [2 "" "foo" 0 12345 1.234 true false]]
+             (mt/formatted-rows
+              standard-literal-expression-row-formats-with-id
+              (mt/run-mbql-query orders
+                {:expressions standard-literal-expression-defs
+                 :fields      (into [$id] standard-literal-expression-refs)
+                 :order-by    [[:asc  $id]]
+                 :limit       2})))))))
+
+(deftest ^:parallel filter-literal-expression-with-=-!=-test
+  (doseq [[and-or eq-ne expected] [[:and :=  [standard-literal-expression-values]]
+                                   [:or  :!= []]]]
+    (testing (str "filter literal expressions with " and-or " " eq-ne)
+      (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
+        (is (= expected
+               (mt/formatted-rows
+                standard-literal-expression-row-formats
+                (mt/run-mbql-query orders
+                  {:expressions standard-literal-expression-defs
+                   :fields      standard-literal-expression-refs
+                   :filter      (into [and-or] (map #(vector eq-ne % %) standard-literal-expression-refs))
+                   :limit       1}))))))))
+
+(deftest ^:parallel nested-literal-expression-test
+  (testing "nested literal expression"
+    ;; TODO Fix this test for H2 (QUE-726)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
+      (is (= [(into [1] standard-literal-expression-values)]
+             (mt/formatted-rows
+              standard-literal-expression-row-formats-with-id
+              (mt/run-mbql-query venues
+                {:fields       (into [$id] standard-literal-expression-column-refs)
+                 :source-query {:source-table $$venues
+                                :expressions  standard-literal-expression-defs
+                                :fields       (into [$id] standard-literal-expression-refs)}
+                 :order-by     [[:asc $id]]
+                 :limit        1})))))))
+
+(deftest ^:parallel order-by-integer-literal-expression-test
+  (testing "order-by integer literal expression"
+    ;; Verify that :order-by of [:expression "One"] does NOT mean ORDER BY 1, which would result in ordering by the
+    ;; first column in the select list $id. We want this to mean "order by the expression with value 1".
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
+      (is (= [[29 1 "20th Century Cafe"]
+              [8  1 "25°"]]
+             (mt/rows
+              (mt/run-mbql-query venues
+                {:expressions {"One" [:value 1 nil]}
+                 :fields      [$id [:expression "One"] $name]
+                 :order-by    [[:asc [:expression "One"]]
+                               [:asc $name]]
+                 :limit       2})))))))
+
+(deftest ^:parallel order-by-literal-expression-test
+  ;; TODO Fix this test for H2 (QUE-726)
+  (testing "order-by all literal expression types"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
+      (is (= [(into [1] standard-literal-expression-values)
+              (into [2] standard-literal-expression-values)]
+             (mt/formatted-rows
+              standard-literal-expression-row-formats-with-id
+              (mt/run-mbql-query orders
+                {:expressions standard-literal-expression-defs
+                 :fields      (into [$id] standard-literal-expression-refs)
+                 :order-by    (into [[:asc  $id]]
+                                    (map #(vector :asc %) standard-literal-expression-refs))
+                 :limit       2})))))))
+
+(deftest ^:parallel breakout-by-literal-expression-test
+  ;; TODO Fix this test for H2 (QUE-726)
+  (testing "breakout by all literal expression types"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expression-literals :basic-aggregations)
+      (let [orders-count 18760]
+        (is (= [(conj (vec standard-literal-expression-values) orders-count)]
+               (mt/formatted-rows
+                (conj standard-literal-expression-row-formats int)
+                (mt/run-mbql-query orders
+                  {:expressions standard-literal-expression-defs
+                   :aggregation [:count]
+                   :breakout    standard-literal-expression-refs}))))))))
+
+(deftest ^:parallel filter-literal-expression-with-and-or-test
+  (doseq [[op expected] [[:and []]
+                         [:or  [[true false]]]]]
+    (testing (str "filter literal expressions with " op)
+      (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
+        (is (= expected
+               (mt/formatted-rows
+                [mt/boolish->bool mt/boolish->bool]
+                (mt/run-mbql-query orders
+                  {:expressions {"true"  [:value true  nil]
+                                 "false" [:value false nil]}
+                   :fields      [[:expression "true"]
+                                 [:expression "false"]]
+                   :filter      (into [op] [[:expression "true"]
+                                            [:expression "false"]])
+                   :limit       1}))))))))
+
+(deftest ^:parallel filter-literal-boolean-expression-with-no-operator-test
+  (doseq [[expression expected] [[[:value true nil]     [standard-literal-expression-values]]
+                                 [[:value false nil]    []]
+                                 [[:expression "True"]  [standard-literal-expression-values]]
+                                 [[:expression "False"] []]]]
+    (testing (str "filter literal expressions with " expression)
+      (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
+        (is (= expected
+               (mt/formatted-rows
+                standard-literal-expression-row-formats
+                (mt/run-mbql-query orders
+                  {:expressions standard-literal-expression-defs
+                   :fields      standard-literal-expression-refs
+                   :filter      expression
+                   :limit       1}))))))))
+
+(deftest ^:parallel nested-and-filtered-literal-expression-test
+  (testing "nested and filtered literal expression"
+    ;; TODO Fix this test for H2 (QUE-726)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
+      (is (= [[2 "Stout Burgers & Beers" true "Red Medicine" 1 2 "Bob's Burgers"]
+              [3 "The Apple Pan" true "Red Medicine" 1 2 "Bob's Burgers"]
+              [4 "Wurstküche" true "Red Medicine" 1 2 "Bob's Burgers"]]
+             (mt/formatted-rows
+              [int str mt/boolish->bool str int int str]
+              (mt/run-mbql-query venues
+                {:fields       [$id
+                                $name
+                                [:expression "True"]
+                                [:expression "Name"]
+                                *One/Integer
+                                *Two/Integer
+                                *Bob/Text]
+                 :expressions  {"True"  [:value true {:base_type :type/Boolean}]
+                                "Name"  [:value "Red Medicine" {:base_type :type/Text}]}
+                 :source-query {:source-table $$venues
+                                :fields       [$id
+                                               $name
+                                               [:expression "One"]
+                                               [:expression "Two"]
+                                               [:expression "Bob"]]
+                                :expressions  {"One" [:value 1.0 {:base_type :type/Float}]
+                                               "Two" [:value 2 {:base_type :type/Integer}]
+                                               "Bob" [:value "Bob's Burgers" {:base_type :type/Text}]}
+                                :filters      [[:= 2.0 [:* [:expression "Two"] [:expression "One"]]]]}
+                 :filters      [[:!= *Bob/Text [:expression "Name"]]
+                                [:!= $name [:expression "Name"]]
+                                [:= true [:expression "True"]]
+                                [:= [:expression "True"] true]
+                                [:=
+                                 [:expression "Name"]
+                                 [:concat [:expression "Name"] ""]]]
+                 :order-by     [[:asc $id]]
+                 :limit        3})))))))
+
+(deftest ^:parallel joined-literal-expression-test
+  (testing "joined literal expression"
+    ;; TODO Fix this test for H2 (QUE-726)
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :left-join :nested-queries)
+      (is (= [[2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "25°"]
+              [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "In-N-Out Burger"]
+              [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "The Apple Pan"]]
+             (mt/formatted-rows
+              [int str int 1.0 mt/boolish->bool int str str]
+              (mt/run-mbql-query venues
+                {:fields      [$id
+                               $name
+                               $price
+                               [:expression "InversePrice"]
+                               [:expression "NameEquals"]
+                               &JoinedCategories.*LiteralInt/Integer
+                               &JoinedCategories.*LiteralString/Text
+                               &JoinedCategories.venues.name]
+                 :expressions {"InversePrice"  [:/ &JoinedCategories.*LiteralInt/Integer $price]
+                               "NameEquals"    [:= &JoinedCategories.*LiteralString/Text $name]}
+                 :filters     [[:= true [:expression "NameEquals"]]]
+                 :joins       [{:strategy     :left-join
+                                :condition    [:= $category_id &JoinedCategories.venues.category_id]
+                                :source-query {:source-table $$venues
+                                               :expressions  {"LiteralInt"    [:value 1 nil]
+                                                              "LiteralString" [:value "Stout Burgers & Beers" nil]}
+                                               :filters     [[:!= $name [:expression "LiteralString"]]]
+                                               :fields       [$category_id
+                                                              $name
+                                                              [:expression "LiteralInt"]
+                                                              [:expression "LiteralString"]]
+                                               :order-by     [[:asc $category_id]
+                                                              [:asc $id]]}
+                                :alias        "JoinedCategories"}]
+                 :order-by    [[:asc &JoinedCategories.venues.name]]
+                 :limit       3})))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 MISC BUG FIXES                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -518,7 +518,6 @@
 
 (deftest ^:parallel nested-literal-expression-test
   (testing "nested literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [(into [1] standard-literal-expression-values)]
              (mt/formatted-rows
@@ -540,14 +539,13 @@
               [8  1 "25°"]]
              (mt/rows
               (mt/run-mbql-query venues
-                {:expressions {"One" [:value 1 nil]}
+                {:expressions {"One" [:value 1 {:base_type :type/Integer}]}
                  :fields      [$id [:expression "One"] $name]
                  :order-by    [[:asc [:expression "One"]]
                                [:asc $name]]
                  :limit       2})))))))
 
 (deftest ^:parallel order-by-literal-expression-test
-  ;; TODO Fix this test for H2 (QUE-726)
   (testing "order-by all literal expression types"
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [(into [1] standard-literal-expression-values)
@@ -562,7 +560,6 @@
                  :limit       2})))))))
 
 (deftest ^:parallel breakout-by-literal-expression-test
-  ;; TODO Fix this test for H2 (QUE-726)
   (testing "breakout by all literal expression types"
     (mt/test-drivers (mt/normal-drivers-with-feature :expression-literals :basic-aggregations)
       (let [orders-count 18760]
@@ -583,8 +580,8 @@
                (mt/formatted-rows
                 [mt/boolish->bool mt/boolish->bool]
                 (mt/run-mbql-query orders
-                  {:expressions {"true"  [:value true  nil]
-                                 "false" [:value false nil]}
+                  {:expressions {"true"  [:value true  {:base_type :type/Boolean}]
+                                 "false" [:value false {:base_type :type/Boolean}]}
                    :fields      [[:expression "true"]
                                  [:expression "false"]]
                    :filter      (into [op] [[:expression "true"]
@@ -609,7 +606,6 @@
 
 (deftest ^:parallel nested-and-filtered-literal-expression-test
   (testing "nested and filtered literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [[2 "Stout Burgers & Beers" true "Red Medicine" 1 2 "Bob's Burgers"]
               [3 "The Apple Pan" true "Red Medicine" 1 2 "Bob's Burgers"]
@@ -648,7 +644,6 @@
 
 (deftest ^:parallel joined-literal-expression-test
   (testing "joined literal expression"
-    ;; TODO Fix this test for H2 (QUE-726)
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :left-join :nested-queries)
       (is (= [[2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "25°"]
               [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "In-N-Out Burger"]
@@ -670,8 +665,8 @@
                  :joins       [{:strategy     :left-join
                                 :condition    [:= $category_id &JoinedCategories.venues.category_id]
                                 :source-query {:source-table $$venues
-                                               :expressions  {"LiteralInt"    [:value 1 nil]
-                                                              "LiteralString" [:value "Stout Burgers & Beers" nil]}
+                                               :expressions  {"LiteralInt"    [:value 1 {:base_type :type/Integer}]
+                                                              "LiteralString" [:value "Stout Burgers & Beers" {:base_type :type/Text}]}
                                                :filters     [[:!= $name [:expression "LiteralString"]]]
                                                :fields       [$category_id
                                                               $name

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -980,7 +980,6 @@
                       {:source-table "card__1"}))))))))))
 
 (deftest ^:parallel expression-literals-test
-  ;; TODO Fix this test for H2 (QUE-726)
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expression-literals)
     (let [query (mt/mbql-query venues
                   {:fields      [[:expression "one"]

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -979,6 +979,43 @@
                     (mt/run-mbql-query nil
                       {:source-table "card__1"}))))))))))
 
+(deftest ^:parallel expression-literals-test
+  ;; TODO Fix this test for H2 (QUE-726)
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expression-literals)
+    (let [query (mt/mbql-query venues
+                  {:fields      [[:expression "one"]
+                                 [:expression "foo"]
+                                 [:expression "true"]
+                                 [:expression "false"]]
+                   :expressions {"one"   [:value 1     {:base_type :type/Integer}]
+                                 "foo"   [:value "foo" {:base_type :type/Text}]
+                                 "true"  [:value true  {:base_type :type/Boolean}]
+                                 "false" [:value false {:base_type :type/Boolean}]}
+                   :limit       1})]
+      (letfn [(check-result [rows]
+                (is (= [[1 "foo" true false]]
+                       (mt/formatted-rows
+                        [int str mt/boolish->bool mt/boolish->bool]
+                        rows))))]
+        (testing "can you use nested queries that have expression literals in them?"
+          (check-result (mt/run-mbql-query nil
+                          {:source-query (:query query)}))
+          (testing "if source query with expression literals is from a Card"
+            (qp.store/with-metadata-provider (qp.test-util/metadata-provider-with-cards-for-queries
+                                              [query])
+              (check-result (mt/run-mbql-query nil
+                              {:source-table "card__1"}))))
+          (testing "if source query with expression literals is from a Model"
+            (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
+                                              (mt/application-database-metadata-provider (mt/id))
+                                              {:cards [{:id 1
+                                                        :type :model
+                                                        :name "Model 1"
+                                                        :database-id (mt/id)
+                                                        :dataset-query query}]})
+              (check-result (mt/run-mbql-query nil
+                              {:source-table "card__1"})))))))))
+
 (defmulti bucketing-already-bucketed-year-test-expected-rows
   {:arglists '([driver])}
   tx/dispatch-on-driver-with-test-extensions

--- a/test/metabase/query_processor_test/offset_test.clj
+++ b/test/metabase/query_processor_test/offset_test.clj
@@ -9,7 +9,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]))
 
@@ -42,106 +41,6 @@
                (mt/formatted-rows
                 [->local-date 2.0 2.0]
                 (qp/process-query query))))))))
-
-(deftest ^:parallel offset-expression-test
-  (testing "Should be able to use an offset as a plain expression (not an aggregation) and use top-level order-by"
-    (mt/test-drivers (mt/normal-drivers-with-feature :window-functions/offset)
-      (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-            orders            (lib.metadata/table metadata-provider (mt/id :orders))
-            orders-id         (lib.metadata/field metadata-provider (mt/id :orders :id))
-            orders-created-at (lib.metadata/field metadata-provider (mt/id :orders :created_at))
-            orders-total      (lib.metadata/field metadata-provider (mt/id :orders :total))
-            query             (as-> (-> (lib/query metadata-provider orders)
-                                        (lib/expression "offset_total" (lib/offset orders-total -1))
-                                        (lib/limit 3)) query
-                                (lib/with-fields query [orders-id
-                                                        orders-total
-                                                        (lib/expression-ref query "offset_total")]))]
-        (doseq [[message query] {"order by a plain field" (lib/order-by query orders-id)
-                                 "order by an expression" (as-> query query
-                                                            (lib/expression query "id_plus_1" (lib/+ orders-id 1))
-                                                            (lib/order-by query (lib/expression-ref query "id_plus_1")))
-                                 "order by date bucketed" (-> query
-                                                              (lib/order-by orders-id)
-                                                              (lib/order-by (lib/with-temporal-bucket orders-created-at :month)))}]
-          (testing message
-            (mt/with-native-query-testing-context query
-              (is (= [[1 39.72  nil]
-                      [2 117.03 39.72]
-                      [3 49.2   117.03]]
-                     (mt/formatted-rows
-                      [int 2.0 2.0]
-                      (qp/process-query query)))))))))))
-
-(deftest ^:parallel offset-expression-test-order-by-parameterized-expression
-  (testing "An offset as a plain expression with an order by that will get parameterized with ? placeholders"
-    (mt/test-drivers (mt/normal-drivers-with-feature :window-functions/offset :left-join)
-      (let [metadata-provider (qp.test-util/mock-fks-application-database-metadata-provider)
-            orders            (lib.metadata/table metadata-provider (mt/id :orders))
-            orders-id         (lib.metadata/field metadata-provider (mt/id :orders :id))
-            orders-total      (lib.metadata/field metadata-provider (mt/id :orders :total))
-            product-title     (m/find-first (fn [col]
-                                              (= (:id col) (mt/id :products :title)))
-                                            (lib/visible-columns (lib/query metadata-provider orders)))
-            _                 (assert (some? product-title))
-            query             (as-> (lib/query metadata-provider orders) query
-                                (lib/expression query "offset_total" (lib/offset orders-total -1))
-                                (lib/expression query "product_title" (lib/concat "TITLE: " product-title))
-                                (lib/with-fields query [(lib/expression-ref query "product_title")
-                                                        orders-id
-                                                        orders-total
-                                                        (lib/expression-ref query "offset_total")])
-                                (lib/order-by query (lib/expression-ref query "product_title"))
-                                (lib/order-by query orders-id)
-                                (lib/limit query 3))]
-        (mt/with-native-query-testing-context query
-          (let [results (qp/process-query query)]
-            (is (= ["product_title" "ID" "Total" "offset_total"]
-                   (mapv :display_name (mt/cols results))))
-            (is (= [["TITLE: Aerodynamic Bronze Hat" 121 55.54 nil]
-                    ["TITLE: Aerodynamic Bronze Hat" 362 63.65 55.54]
-                    ["TITLE: Aerodynamic Bronze Hat" 377 64.57 63.65]]
-                   (mt/formatted-rows [str int 2.0 2.0] results)))))
-        ;; make sure this still works and the nest-query transformation isn't doing something dumb.
-        (testing "without returning the order-by expression"
-          (let [query (update-in query [:stages 0 :fields] rest)]
-            (mt/with-native-query-testing-context query
-              (let [results (qp/process-query query)]
-                (is (= ["ID" "Total" "offset_total"]
-                       (mapv :display_name (mt/cols results))))
-                (is (= [[121 55.54 nil]
-                        [362 63.65 55.54]
-                        [377 64.57 63.65]]
-                       (mt/formatted-rows [int 2.0 2.0] results)))))))))))
-
-(deftest ^:parallel offset-expression-inside-other-expression-test
-  (testing "An offset as a plain expression nested inside another expression"
-    (mt/test-drivers (mt/normal-drivers-with-feature :window-functions/offset :left-join)
-      (let [metadata-provider (qp.test-util/mock-fks-application-database-metadata-provider)
-            orders            (lib.metadata/table metadata-provider (mt/id :orders))
-            orders-id         (lib.metadata/field metadata-provider (mt/id :orders :id))
-            orders-total      (lib.metadata/field metadata-provider (mt/id :orders :total))
-            product-title     (m/find-first (fn [col]
-                                              (= (:id col) (mt/id :products :title)))
-                                            (lib/visible-columns (lib/query metadata-provider orders)))
-            _                 (assert (some? product-title))
-            query             (as-> (lib/query metadata-provider orders) query
-                                (lib/expression query "offset_total" (lib/+ (lib/offset orders-total -1) 10.0))
-                                (lib/expression query "product_title" (lib/concat "TITLE: " product-title))
-                                (lib/with-fields query [orders-id
-                                                        (lib/expression-ref query "product_title")
-                                                        orders-total
-                                                        (lib/expression-ref query "offset_total")])
-                                (lib/order-by query (lib/expression-ref query "product_title"))
-                                (lib/order-by query orders-id)
-                                (lib/limit query 3))]
-        (mt/with-native-query-testing-context query
-          (is (= [[121 "TITLE: Aerodynamic Bronze Hat" 55.54 nil]
-                  [362 "TITLE: Aerodynamic Bronze Hat" 63.65 65.54]
-                  [377 "TITLE: Aerodynamic Bronze Hat" 64.57 73.65]]
-                 (mt/formatted-rows
-                  [int str 2.0 2.0]
-                  (qp/process-query query)))))))))
 
 (deftest ^:parallel offset-aggregation-test
   (testing "yearly growth (this year sales vs last year sales) (#5606)"

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -205,6 +205,7 @@
   with-metadata-provider]
 
  [qp.test-util
+  boolish->bool
   card-with-source-metadata-for-query
   col
   cols


### PR DESCRIPTION
### Description

Merge the integration branch for [milestone 2](https://linear.app/metabase/project/allow-literals-in-custom-expression-editor-97a90e48f87b/issues?projectMilestoneId=946bd371-02a5-4d1c-8198-8730368cdecc) of the Literals in custom expressions project.

Each of the PRs has been reviewed individually, though this PR also includes a rebase onto current master.

This milestone includes a couple of critical bug fixes and enables the feature for postgres, mysql, h2, bigquery, and snowflake.

### How to verify

1. New question -> Sample Dataset -> People
2. Add Custom Column
    a. value: `"Hudson Borer"`
    b. name: Hudson
3. Filter > Custom Expression
    a. `[Name] = [Hudson]`
4. Visualize
5. Save
6. Use the saved question as the source for another query, etc.

### Demo

**filter by literal column**
![Screenshot 2025-04-03 at 5 07 41 PM](https://github.com/user-attachments/assets/e360376a-1a8e-4f01-b222-ef4dcd7e1c33)

**join to question with literal column**
![Screenshot 2025-04-03 at 5 06 40 PM](https://github.com/user-attachments/assets/0912129f-4665-4849-ac3e-ead97221bc7b)

**question with literal column used as source**
![Screenshot 2025-04-03 at 5 09 23 PM](https://github.com/user-attachments/assets/6b7fc352-5b7d-4aa5-8d0e-68d3fff63b84)

**literal column used in summarize and breakout**
![Screenshot 2025-04-03 at 5 10 48 PM](https://github.com/user-attachments/assets/6485d1bd-b427-41b0-a7b0-c6214da6cba1)

**literal columns in multiple stages**
![Screenshot 2025-04-03 at 5 15 50 PM](https://github.com/user-attachments/assets/08609bb0-4468-428d-a277-3cfe0ded9483)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
