### PR TITLE
Add option to preserve whitespace in table visualizations

### DIFF
--- a/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.module.css
+++ b/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.module.css
@@ -20,6 +20,17 @@
   text-overflow: ellipsis;
 }
 
+.preserveWhitespace {
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preserveWhitespaceWrap {
+  white-space: pre-wrap;
+  overflow: hidden;
+}
+
 .clickable {
   cursor: pointer;
 }

--- a/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.tsx
+++ b/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.tsx
@@ -14,6 +14,7 @@ import S from "./BodyCell.module.css";
 export interface BodyCellProps<TValue> extends BodyCellBaseProps<TValue> {
   variant?: "text" | "pill";
   contentTestId?: string;
+  preserveWhitespace?: boolean;
 }
 
 export const BodyCell = memo(function BodyCell<TValue>({
@@ -30,6 +31,7 @@ export const BodyCell = memo(function BodyCell<TValue>({
   className,
   style,
   contentTestId = "cell-data",
+  preserveWhitespace = false,
   onExpand,
 }: BodyCellProps<TValue>) {
   const theme = useDataGridTheme();
@@ -77,7 +79,9 @@ export const BodyCell = memo(function BodyCell<TValue>({
           style={contentStyle}
           data-grid-cell-content
           className={cx(S.content, {
-            [S.noWrap]: !wrap,
+            [S.noWrap]: !wrap && !preserveWhitespace,
+            [S.preserveWhitespace]: preserveWhitespace && !wrap,
+            [S.preserveWhitespaceWrap]: preserveWhitespace && wrap,
           })}
           data-testid={contentTestId}
         >

--- a/frontend/src/metabase/data-grid/types.ts
+++ b/frontend/src/metabase/data-grid/types.ts
@@ -20,6 +20,7 @@ declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData, TValue> {
     wrap?: boolean;
+    preserveWhitespace?: boolean;
     enableReordering?: boolean;
     enableSelection?: boolean;
     headerClickTargetSelector?: string;
@@ -38,6 +39,7 @@ export type BodyCellBaseProps<TValue> = {
   backgroundColor?: string;
   align?: CellAlign;
   wrap?: boolean;
+  preserveWhitespace?: boolean;
   canExpand?: boolean;
   columnId: string;
   rowIndex: number;
@@ -88,6 +90,9 @@ export interface ColumnOptions<TRow extends RowData, TValue = unknown> {
 
   /** Whether text should wrap in this column */
   wrap?: boolean;
+
+  /** Whether to preserve whitespace (including multiple spaces) in this column */
+  preserveWhitespace?: boolean;
 
   /** Initial sort direction for this column */
   sortDirection?: "asc" | "desc";

--- a/frontend/src/metabase/data-grid/utils/columns/data-column.tsx
+++ b/frontend/src/metabase/data-grid/utils/columns/data-column.tsx
@@ -22,6 +22,7 @@ const getDefaultCellTemplate = <TRow, TValue>(
     formatter,
     cellVariant,
     wrap,
+    preserveWhitespace,
     getCellClassName,
     getCellStyle,
   }: ColumnOptions<TRow, TValue>,
@@ -49,6 +50,7 @@ const getDefaultCellTemplate = <TRow, TValue>(
         onExpand={onExpand}
         variant={cellVariant}
         wrap={wrap}
+        preserveWhitespace={preserveWhitespace}
         className={getCellClassName?.(value, row.index)}
         style={getCellStyle?.(value, row.index)}
       />
@@ -82,8 +84,15 @@ export const getDataColumn = <TRow, TValue>(
   truncateWidth: number,
   onExpand: (columnName: string, content: React.ReactNode) => void,
 ): ColumnDef<TRow, TValue> => {
-  const { id, accessorFn, wrap, cell, header, headerClickTargetSelector } =
-    columnOptions;
+  const {
+    id,
+    accessorFn,
+    wrap,
+    preserveWhitespace,
+    cell,
+    header,
+    headerClickTargetSelector,
+  } = columnOptions;
   const columnWidth = columnSizing[id] ?? 0;
   const measuredColumnWidth = measuredColumnSizing[id] ?? 0;
 
@@ -110,6 +119,7 @@ export const getDataColumn = <TRow, TValue>(
     enableResizing: true,
     meta: {
       wrap,
+      preserveWhitespace,
       enableReordering: true,
       enableSelection: true,
       headerClickTargetSelector,

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -419,6 +419,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
       const wrap =
         !settings["table.pagination"] &&
         Boolean(columnSettings["text_wrapping"]);
+      const preserveWhitespace = Boolean(columnSettings["preserve_whitespace"]);
       const isMinibar = columnSettings["show_mini_bar"];
       const cellVariant = getBodyCellVariant(col);
       const headerVariant = mode != null || isDashboard ? "light" : "outline";
@@ -484,6 +485,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
         headerClickTargetSelector: "[data-header-click-target]",
         align,
         wrap,
+        preserveWhitespace,
         sortDirection,
         enableResizing: true,
         getBackgroundColor,

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -274,6 +274,19 @@ class Table extends Component<TableProps, TableState> {
           return !canWrapText(columnSettings);
         },
       };
+
+      settings["preserve_whitespace"] = {
+        title: t`Preserve whitespace`,
+        default: false,
+        widget: "toggle",
+        inline: true,
+        isValid: (_column, columnSettings) => {
+          return canWrapText(columnSettings);
+        },
+        getHidden: (_column, columnSettings) => {
+          return !canWrapText(columnSettings);
+        },
+      };
     }
 
     let defaultValue = !column.semantic_type || isURL(column) ? "link" : null;


### PR DESCRIPTION
Claude code PR experiment

Summary

  This PR adds the ability to preserve whitespace characters (including multiple spaces) in table visualizations. Previously, multiple spaces were
  condensed to a single space when displaying string data, which could break formatting for text that relies on precise spacing.

  Problem

  When displaying string data in table visualizations, multiple consecutive spaces were automatically reduced to a single space due to HTML's
  default whitespace handling behavior. This made it impossible to maintain exact spacing in displayed text.

  Solution

  - Added a new "Preserve whitespace" toggle option in table column settings for string columns
  - Added new CSS classes with white-space: pre and white-space: pre-wrap properties
  - Extended necessary TypeScript interfaces to support the new functionality
  - Connected the new option through the visualization pipeline

  How to use

  1. Create a question with string columns containing multiple spaces
  2. In the visualization settings, click the gear icon for the column
  3. Toggle on "Preserve whitespace" to maintain all spaces exactly as in the source data

  Testing

  The changes have been verified with:
  - TypeScript type checking (yarn type-check)
  - ESLint (yarn lint-eslint)
  - Manual testing with string data containing multiple spaces

  Fixes #30351