### PR TITLE
Fix modal reappearing issue when using browser back/forward navigation with table detail view

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -300,6 +300,16 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     cy.findByTestId("object-detail").findByText("Searsboro").click();
   });
 
+  it("should open the object detail modal when navigating back and forward (metabase#55487)", () => {
+    H.openPeopleTable({ limit: 5 });
+    H.openObjectDetail(0);
+    cy.findByTestId("object-detail").findByText("9611-9809 West Rosedale Road");
+    cy.go("back");
+    cy.findByTestId("object-detail").should("not.exist");
+    cy.go("forward");
+    cy.findByTestId("object-detail").findByText("9611-9809 West Rosedale Road");
+  });
+
   it("should work with non-numeric IDs (metabase#22768)", () => {
     cy.request("PUT", `/api/field/${PRODUCTS.ID}`, {
       semantic_type: null,

--- a/frontend/src/metabase/query_builder/actions/navigation.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.ts
@@ -43,18 +43,22 @@ export const popState = createThunkAction(
     dispatch(cancelQuery());
 
     const zoomedObjectId = getZoomedObjectId(getState());
-    if (zoomedObjectId) {
-      const { state, query } = getLocation(getState());
-      const previouslyZoomedObjectId = state?.objectId || query?.objectId;
+    const { state, query } = getLocation(getState());
+    const previouslyZoomedObjectId = state?.objectId || query?.objectId;
 
-      if (
-        previouslyZoomedObjectId &&
-        zoomedObjectId !== previouslyZoomedObjectId
-      ) {
+    // If there's a previously zoomed object ID in the browser history state
+    // and we're navigating to that state, we should zoom in on that object
+    if (previouslyZoomedObjectId) {
+      // If we're already zoomed on a different object, update to the new object
+      if (zoomedObjectId !== previouslyZoomedObjectId) {
         dispatch(zoomInRow({ objectId: previouslyZoomedObjectId }));
-      } else {
-        dispatch(resetRowZoom());
       }
+      // If we're already zoomed on the same object, do nothing (keep modal open)
+      return;
+    } else if (zoomedObjectId) {
+      // If there's no object ID in the browser history state but we have a
+      // zoomed object ID in the current state, reset the zoom (close modal)
+      dispatch(resetRowZoom());
       return;
     }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55487

### Description

Fixes browser navigation when using the object detail modal.

### How to verify

- Open Orders table
- Open object detail for any row
- Using browser navigation go back
- Using browser navigation go forward — ensure this works

### Demo

https://github.com/user-attachments/assets/c4377bc3-b0cd-471d-a4ab-f1c9bb93a09d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
