### PR TITLE
Fix bar chart data labels jump on hover

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -85,13 +85,19 @@ export const getBarLabelLayout =
     }
 
     const barHeight = rect.height;
-    const labelOffset =
+    // Round the values to prevent fractional pixel positions
+    // which can cause the 1px jump on hover
+    const labelOffset = Math.round(
       barHeight / 2 +
-      CHART_STYLE.seriesLabels.size / 2 +
-      CHART_STYLE.seriesLabels.offset;
+        CHART_STYLE.seriesLabels.size / 2 +
+        CHART_STYLE.seriesLabels.offset,
+    );
     return {
       hideOverlap: settings["graph.label_value_frequency"] === "fit",
       dy: labelValue < 0 ? labelOffset : -labelOffset,
+      // Force the label to maintain its position during hover state
+      draggable: false,
+      cursor: "default",
     };
   };
 
@@ -147,6 +153,9 @@ export const getBarInsideLabelLayout =
     return {
       hideOverlap: settings["graph.label_value_frequency"] === "fit",
       rotate: ticksRotation === "vertical" ? 90 : 0,
+      // Force the label to maintain its position during hover state
+      draggable: false,
+      cursor: "default",
     };
   };
 


### PR DESCRIPTION
Claude code PR experiment

  Summary

  - Fixed issue where bar chart data labels would jump by 1px when hovering over bars
  - Stabilized label positioning by rounding pixel values and disabling label movement during interactions

  Technical details

  The fix addresses issue #48846 by making three key changes:
  1. Rounded the labelOffset calculation to ensure consistent pixel positioning
  2. Added draggable: false to prevent any movement during interactions
  3. Added cursor: 'default' to maintain consistent cursor styling

  These changes were applied to both getBarLabelLayout and getBarInsideLabelLayout functions to ensure consistency across all label positioning
  scenarios.

  Test plan

  1. Create a bar chart with data labels enabled
  2. Hover over bars and verify that data labels maintain their exact position without the 1px jump