### PR TITLE
Update Java and Node versions in devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/vscode/devcontainers/java:11
+FROM mcr.microsoft.com/vscode/devcontainers/java:21
 
 # Set up nodesource, install node, yarn, fontconfig for static viz, rlwrap for dev ergonomics
 
-RUN ( curl -fsSL https://deb.nodesource.com/setup_18.x | bash ) \
+RUN ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash ) \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com \
   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

### Description

JVM and Node versions for Devcontainer setup are outdated. This PR updates JVM to version 21 and Node to version 22.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open project in VS Code in devcontainer mode
2. Follow Development environment guide to run project locally

### Demo

N/A

### Checklist

N/A