### PR TITLE
feat(sdk): Add a Metabot SDK component

### DIFF
--- a/e2e/support/helpers/e2e-metabot-helpers.ts
+++ b/e2e/support/helpers/e2e-metabot-helpers.ts
@@ -71,7 +71,7 @@ export function userMessages() {
 
 export const mockMetabotResponse = (response: StaticResponse) => {
   return cy
-    .intercept("POST", "/api/ee/metabot-v3/agent", req => {
+    .intercept("POST", "/api/ee/metabot-v3/agent", (req) => {
       req.reply(response);
     })
     .as("metabotAgent");

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -26,6 +26,7 @@ import { LocaleProvider } from "metabase/public/LocaleProvider";
 import { setOptions } from "metabase/redux/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 import { Box } from "metabase/ui";
+import { MetabotProvider } from "metabase-enterprise/metabot/context";
 
 import { SCOPED_CSS_RESET } from "../private/PublicComponentStylesWrapper";
 import { SdkContextProvider } from "../private/SdkContext";
@@ -142,7 +143,9 @@ export const MetabaseProvider = memo(function MetabaseProvider(
 
   return (
     <MetabaseReduxProvider store={storeRef.current}>
-      <MetabaseProviderInternal store={storeRef.current} {...props} />
+      <MetabotProvider>
+        <MetabaseProviderInternal store={storeRef.current} {...props} />
+      </MetabotProvider>
     </MetabaseReduxProvider>
   );
 });

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.module.css
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.module.css
@@ -1,0 +1,144 @@
+/* TODO: rtl support */
+
+@keyframes chat-bar-slide-in {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 2rem);
+    transform-origin: top;
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+    transform-origin: top;
+  }
+}
+
+.container {
+  width: 41.5rem;
+  box-shadow: 0 2px 13.8px -1px #1871bf52;
+  border-radius: 22px;
+}
+
+.innerContainer {
+  padding: 0 1rem;
+  border-radius: 22px;
+  align-items: center;
+  box-sizing: border-box;
+  border: solid 1.5px transparent;
+  background: var(--mb-color-bg-white);
+  transition: background 150ms ease;
+}
+
+.innerContainer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(to right, #2e96f1, #d932f4);
+  z-index: -1;
+  margin: -1.5px;
+  border-radius: 24px;
+}
+
+.innerContainerLoading {
+  background: var(--mb-color-bg-light);
+}
+
+.innerContainerExpanded {
+  padding: 1rem;
+  align-items: flex-start;
+  height: 8rem;
+}
+
+.input {
+  caret-color: var(--mb-color-brand);
+}
+
+.textarea {
+  textarea {
+    box-sizing: border-box;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    outline: none;
+    width: 100%;
+    caret-color: var(--mb-color-brand);
+    padding: 0.5rem 0;
+    line-height: 1.7;
+    color: var(--mb-color-text-dark);
+  }
+}
+
+.textareaExpanded {
+  textarea {
+    padding: 0;
+  }
+}
+
+.textareaLoading {
+  textarea {
+    font-weight: bold;
+
+    &:disabled {
+      opacity: 1;
+      background: transparent;
+    }
+  }
+}
+
+/* nesting the style above keeps it from getting applied */
+.textareaLoading textarea::placeholder,
+.textareaLoading textarea:disabled::placeholder {
+  color: var(--mb-color-brand);
+}
+
+@keyframes responses-slide-in {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0.5rem);
+    transform-origin: top;
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate(0, 0);
+    transform-origin: top;
+  }
+}
+
+.responses {
+  position: absolute;
+  left: 0;
+  bottom: 100%;
+  margin-bottom: 0.25rem;
+  pointer-events: none; /* allow user to click through transparent area behind repsonses */
+  animation: responses-slide-in 150ms ease forwards;
+  transition-property: transform, opacity;
+}
+
+.response {
+  padding: 0.5rem 1rem;
+  display: flex;
+  background: var(--mb-color-brand);
+  font-size: 0.875rem;
+  font-weight: 700;
+  border-radius: 1rem;
+  color: white;
+  pointer-events: auto;
+  margin-bottom: 0.25rem;
+  position: relative;
+}
+
+.responseMessage {
+  flex-grow: 1;
+}
+
+button.responseDismissBtn {
+  color: #cbe2f7;
+  height: 1rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.module.css
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.module.css
@@ -15,6 +15,7 @@
 }
 
 .container {
+  position: relative;
   width: 41.5rem;
   box-shadow: 0 2px 13.8px -1px #1871bf52;
   border-radius: 22px;
@@ -98,7 +99,7 @@
 @keyframes responses-slide-in {
   0% {
     opacity: 0;
-    transform: translate(0, 0.5rem);
+    transform: translate(0, -0.5rem);
     transform-origin: top;
   }
 
@@ -112,8 +113,8 @@
 .responses {
   position: absolute;
   left: 0;
-  bottom: 100%;
-  margin-bottom: 0.25rem;
+  top: 100%;
+  margin-top: 0.25rem;
   pointer-events: none; /* allow user to click through transparent area behind repsonses */
   animation: responses-slide-in 150ms ease forwards;
   transition-property: transform, opacity;
@@ -128,7 +129,7 @@
   border-radius: 1rem;
   color: white;
   pointer-events: auto;
-  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
   position: relative;
 }
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Flex,
   Icon,
+  Loader,
   Textarea,
   Tooltip,
   UnstyledButton,
@@ -44,7 +45,6 @@ export const MetabotChatEmbedding = ({
     if (!trimmedInput.length || metabot.isDoingScience) {
       return;
     }
-    resetInput();
     const metabotRequestPromise = metabot.submitInput(
       trimmedInput,
       EMBEDDING_METABOT_ID,
@@ -116,9 +116,20 @@ export const MetabotChatEmbedding = ({
         )}
         gap="sm"
       >
-        <Box w="33px" h="24px">
-          <MetabotIcon isLoading={metabot.isDoingScience} />
-        </Box>
+        <Flex
+          w="33px"
+          h="24px"
+          style={{
+            flexShrink: 0,
+          }}
+          justify="center"
+        >
+          {metabot.isDoingScience ? (
+            <Loader size="sm" />
+          ) : (
+            <MetabotIcon isLoading={false} />
+          )}
+        </Flex>
         <Textarea
           data-testid="metabot-chat-input"
           w="100%"
@@ -147,18 +158,28 @@ export const MetabotChatEmbedding = ({
             }
           }}
         />
-        <UnstyledButton
-          h="1rem"
-          data-testid="metabot-cancel-request"
-          style={{
-            visibility: metabot.isDoingScience ? "visible" : "hidden",
-          }}
-          onClick={cancelRequest}
-        >
-          <Tooltip label={t`Stop generation`}>
-            <Icon name="stop" c="var(--mb-color-text-primary)" size="1rem" />
-          </Tooltip>
-        </UnstyledButton>
+        {metabot.isDoingScience ? (
+          <UnstyledButton
+            h="1rem"
+            data-testid="metabot-cancel-request"
+            onClick={cancelRequest}
+          >
+            <Tooltip label={t`Stop generation`}>
+              <Icon name="stop" c="var(--mb-color-text-primary)" size="1rem" />
+            </Tooltip>
+          </UnstyledButton>
+        ) : (
+          <UnstyledButton
+            h="1rem"
+            onClick={resetInput}
+            data-testid="metabot-close-chat"
+            style={{
+              visibility: input.length > 0 ? "visible" : "hidden",
+            }}
+          >
+            <Icon name="close" c="text-light" size="1rem" />
+          </UnstyledButton>
+        )}
       </Flex>
     </Box>
   );

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -1,0 +1,144 @@
+import cx from "classnames";
+import { useCallback, useRef, useState } from "react";
+import { t } from "ttag";
+
+import { Box, Flex, Icon, Textarea, UnstyledButton } from "metabase/ui";
+import { MetabotIcon } from "metabase-enterprise/metabot/components/MetabotIcon";
+import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+
+import Styles from "./MetabotChatEmbedding.module.css";
+
+const MIN_INPUT_HEIGHT = 42;
+
+interface MetabotChatEmbeddingProps {
+  onResult: (result: Record<string, any> | null) => void;
+}
+
+export const MetabotChatEmbedding = ({
+  onResult,
+}: MetabotChatEmbeddingProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const [input, setMessage] = useState("");
+
+  const metabot = useMetabotAgent();
+
+  const resetInput = useCallback(() => {
+    setMessage("");
+    setInputExpanded(false);
+  }, []);
+
+  const handleSend = () => {
+    const trimmedInput = input.trim();
+    if (!trimmedInput.length || metabot.isDoingScience) {
+      return;
+    }
+    resetInput();
+    metabot
+      .submitInput(trimmedInput)
+      .then(onResult)
+      .catch(err => console.error(err))
+      .finally(() => textareaRef.current?.focus());
+  };
+
+  const handleClose = useCallback(() => {
+    resetInput();
+  }, [resetInput]);
+
+  const [inputExpanded, setInputExpanded] = useState(false);
+  const handleMaybeExpandInput = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const isMultiRow = textarea.scrollHeight > MIN_INPUT_HEIGHT;
+    if (inputExpanded !== isMultiRow) {
+      setInputExpanded(isMultiRow);
+    }
+    // keep scrolled to bottom
+    textarea.scrollTop = Math.max(MIN_INPUT_HEIGHT, textarea.scrollHeight);
+  };
+
+  const handleInputChange = (value: string) => {
+    setMessage(value);
+  };
+
+  const inputPlaceholder = metabot.confirmationOptions
+    ? Object.keys(metabot.confirmationOptions).join(" or ")
+    : t`Tell me to do something, or ask a question`;
+  const placeholder = metabot.isDoingScience
+    ? t`Doing science...`
+    : inputPlaceholder;
+
+  return (
+    <Box className={Styles.container} data-testid="metabot-chat">
+      {metabot.userMessages.length > 0 && (
+        <Box className={Styles.responses} data-testid="metabot-chat-messages">
+          {metabot.userMessages.map((msg, index) => (
+            <Box
+              className={Styles.response}
+              key={msg}
+              data-testid="metabot-chat-message"
+            >
+              <Box>{msg}</Box>
+              <UnstyledButton
+                className={Styles.responseDismissBtn}
+                onClick={() => metabot.dismissUserMessage(index)}
+              >
+                <Icon name="close" size="1rem" />
+              </UnstyledButton>
+            </Box>
+          ))}
+        </Box>
+      )}
+      <Flex
+        className={cx(
+          Styles.innerContainer,
+          metabot.isDoingScience && Styles.innerContainerLoading,
+          inputExpanded && Styles.innerContainerExpanded,
+        )}
+        gap="sm"
+      >
+        <Box w="33px" h="24px">
+          <MetabotIcon isLoading={metabot.isDoingScience} />
+        </Box>
+        <Textarea
+          data-testid="metabot-chat-input"
+          w="100%"
+          autosize
+          minRows={1}
+          maxRows={4}
+          ref={textareaRef}
+          autoFocus
+          value={input}
+          disabled={metabot.isDoingScience}
+          className={cx(
+            Styles.textarea,
+            inputExpanded && Styles.textareaExpanded,
+            metabot.isDoingScience && Styles.textareaLoading,
+          )}
+          placeholder={placeholder}
+          onChange={e => handleInputChange(e.target.value)}
+          // @ts-expect-error - undocumented API for mantine Textarea - leverages the prop from react-textarea-autosize's TextareaAutosize component
+          onHeightChange={handleMaybeExpandInput}
+          onKeyDown={e => {
+            if (e.key === "Enter") {
+              // prevent event from inserting new line + interacting with other content
+              e.preventDefault();
+              e.stopPropagation();
+              handleSend();
+            }
+          }}
+        />
+        <UnstyledButton
+          h="1rem"
+          onClick={handleClose}
+          data-testid="metabot-close-chat"
+        >
+          <Icon name="close" c="text-light" size="1rem" />
+        </UnstyledButton>
+      </Flex>
+    </Box>
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -21,13 +21,13 @@ import Styles from "./MetabotChatEmbedding.module.css";
 const MIN_INPUT_HEIGHT = 42;
 
 interface MetabotChatEmbeddingProps {
-  onResult: (result: Record<string, any> | null) => void;
+  onRedirectUrl: (result: string) => void;
 }
 
 const EMBEDDING_METABOT_ID = "c61bf5f5-1025-47b6-9298-bf1827105bb6";
 
 export const MetabotChatEmbedding = ({
-  onResult,
+  onRedirectUrl,
 }: MetabotChatEmbeddingProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -54,7 +54,17 @@ export const MetabotChatEmbedding = ({
     metabotRequestPromiseRef.current = metabotRequestPromise;
 
     metabotRequestPromise
-      .then(onResult)
+      .then((result) => {
+        const redirectUrl = (
+          result.payload as any
+        )?.payload?.data?.reactions?.find(
+          (reaction: { type: string; url: string }) =>
+            reaction.type === "metabot.reaction/redirect",
+        )?.url;
+        if (redirectUrl) {
+          onRedirectUrl(redirectUrl);
+        }
+      })
       .catch((err) => console.error(err))
       .finally(() => textareaRef.current?.focus());
   };

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -37,14 +37,21 @@ export const MetabotChatEmbedding = ({
     setInputExpanded(false);
   }, []);
 
+  const metabotRequestPromiseRef = useRef<{ abort: () => void } | null>(null);
+
   const handleSend = () => {
     const trimmedInput = input.trim();
     if (!trimmedInput.length || metabot.isDoingScience) {
       return;
     }
     resetInput();
-    metabot
-      .submitInput(trimmedInput, EMBEDDING_METABOT_ID)
+    const metabotRequestPromise = metabot.submitInput(
+      trimmedInput,
+      EMBEDDING_METABOT_ID,
+    );
+    metabotRequestPromiseRef.current = metabotRequestPromise;
+
+    metabotRequestPromise
       .then(onResult)
       .catch((err) => console.error(err))
       .finally(() => textareaRef.current?.focus());
@@ -75,6 +82,10 @@ export const MetabotChatEmbedding = ({
   const placeholder = metabot.isDoingScience
     ? t`Doing science...`
     : inputPlaceholder;
+
+  function cancelRequest() {
+    metabotRequestPromiseRef.current?.abort();
+  }
 
   return (
     <Box className={Styles.container} data-testid="metabot-chat">
@@ -142,6 +153,7 @@ export const MetabotChatEmbedding = ({
           style={{
             visibility: metabot.isDoingScience ? "visible" : "hidden",
           }}
+          onClick={cancelRequest}
         >
           <Tooltip label={t`Stop generation`}>
             <Icon name="stop" c="var(--mb-color-text-primary)" size="1rem" />

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -2,7 +2,14 @@ import cx from "classnames";
 import { useCallback, useRef, useState } from "react";
 import { t } from "ttag";
 
-import { Box, Flex, Icon, Textarea, UnstyledButton } from "metabase/ui";
+import {
+  Box,
+  Flex,
+  Icon,
+  Textarea,
+  Tooltip,
+  UnstyledButton,
+} from "metabase/ui";
 import { MetabotIcon } from "metabase-enterprise/metabot/components/MetabotIcon";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
@@ -42,10 +49,6 @@ export const MetabotChatEmbedding = ({
       .catch((err) => console.error(err))
       .finally(() => textareaRef.current?.focus());
   };
-
-  const handleClose = useCallback(() => {
-    resetInput();
-  }, [resetInput]);
 
   const [inputExpanded, setInputExpanded] = useState(false);
   const handleMaybeExpandInput = () => {
@@ -135,10 +138,14 @@ export const MetabotChatEmbedding = ({
         />
         <UnstyledButton
           h="1rem"
-          onClick={handleClose}
-          data-testid="metabot-close-chat"
+          data-testid="metabot-cancel-request"
+          style={{
+            visibility: metabot.isDoingScience ? "visible" : "hidden",
+          }}
         >
-          <Icon name="close" c="text-light" size="1rem" />
+          <Tooltip label={t`Stop generation`}>
+            <Icon name="stop" c="var(--mb-color-text-primary)" size="1rem" />
+          </Tooltip>
         </UnstyledButton>
       </Flex>
     </Box>

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -177,7 +177,7 @@ export const MetabotChatEmbedding = ({
               visibility: input.length > 0 ? "visible" : "hidden",
             }}
           >
-            <Icon name="close" c="text-light" size="1rem" />
+            <Icon name="close" c="var(--mb-color-text-primary)" size="1rem" />
           </UnstyledButton>
         )}
       </Flex>

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -1,7 +1,8 @@
 import cx from "classnames";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { t } from "ttag";
 
+import { useSdkDispatch } from "embedding-sdk/store";
 import {
   Box,
   Flex,
@@ -13,6 +14,7 @@ import {
 } from "metabase/ui";
 import { MetabotIcon } from "metabase-enterprise/metabot/components/MetabotIcon";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+import { resetConversationId } from "metabase-enterprise/metabot/state";
 
 import Styles from "./MetabotChatEmbedding.module.css";
 
@@ -86,6 +88,11 @@ export const MetabotChatEmbedding = ({
   function cancelRequest() {
     metabotRequestPromiseRef.current?.abort();
   }
+
+  const dispatch = useSdkDispatch();
+  useEffect(() => {
+    dispatch(resetConversationId());
+  }, [dispatch]);
 
   return (
     <Box className={Styles.container} data-testid="metabot-chat">

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -14,6 +14,8 @@ interface MetabotChatEmbeddingProps {
   onResult: (result: Record<string, any> | null) => void;
 }
 
+const EMBEDDING_METABOT_ID = "c61bf5f5-1025-47b6-9298-bf1827105bb6";
+
 export const MetabotChatEmbedding = ({
   onResult,
 }: MetabotChatEmbeddingProps) => {
@@ -35,9 +37,9 @@ export const MetabotChatEmbedding = ({
     }
     resetInput();
     metabot
-      .submitInput(trimmedInput)
+      .submitInput(trimmedInput, EMBEDDING_METABOT_ID)
       .then(onResult)
-      .catch(err => console.error(err))
+      .catch((err) => console.error(err))
       .finally(() => textareaRef.current?.focus());
   };
 
@@ -119,10 +121,10 @@ export const MetabotChatEmbedding = ({
             metabot.isDoingScience && Styles.textareaLoading,
           )}
           placeholder={placeholder}
-          onChange={e => handleInputChange(e.target.value)}
+          onChange={(e) => handleInputChange(e.target.value)}
           // @ts-expect-error - undocumented API for mantine Textarea - leverages the prop from react-textarea-autosize's TextareaAutosize component
           onHeightChange={handleMaybeExpandInput}
-          onKeyDown={e => {
+          onKeyDown={(e) => {
             if (e.key === "Enter") {
               // prevent event from inserting new line + interacting with other content
               e.preventDefault();

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
@@ -1,0 +1,41 @@
+import type { StoryFn } from "@storybook/react";
+import type { ComponentProps } from "react";
+
+import { CommonSdkStoryWrapper } from "embedding-sdk/test/CommonSdkStoryWrapper";
+import { questionIds } from "embedding-sdk/test/storybook-id-args";
+import { Box } from "metabase/ui";
+
+import { MetabotQuestion } from "./MetabotQuestion";
+
+const QUESTION_ID = (window as any).QUESTION_ID || questionIds.numberId;
+
+type MetabotQuestionProps = ComponentProps<typeof MetabotQuestion>;
+
+export default {
+  title: "EmbeddingSDK/MetabotQuestion",
+  component: MetabotQuestion,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [CommonSdkStoryWrapper],
+};
+
+const Template: StoryFn<MetabotQuestionProps> = () => {
+  return (
+    <Box bg="var(--mb-color-background)" mih="100vh">
+      <MetabotQuestion visible={true} onClose={() => {}} />
+    </Box>
+  );
+};
+
+export const Default = {
+  render: Template,
+
+  args: {
+    questionId: QUESTION_ID,
+    isSaveEnabled: true,
+    targetCollection: undefined,
+    title: true,
+    withResetButton: true,
+  },
+};

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
@@ -22,8 +22,8 @@ export default {
 
 const Template: StoryFn<MetabotQuestionProps> = () => {
   return (
-    <Box bg="var(--mb-color-background)" mih="100vh">
-      <MetabotQuestion visible={true} onClose={() => {}} />
+    <Box bg="var(--mb-color-background)" mih="100vh" bd="1px solid #000">
+      <MetabotQuestion />
     </Box>
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
@@ -22,7 +22,12 @@ export default {
 
 const Template: StoryFn<MetabotQuestionProps> = () => {
   return (
-    <Box bg="var(--mb-color-background)" mih="100vh" bd="1px solid #000">
+    <Box
+      bg="var(--mb-color-background)"
+      mih="100vh"
+      bd="1px solid #000"
+      pt="2rem"
+    >
       <MetabotQuestion />
     </Box>
   );

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
+import { t } from "ttag";
 
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
-import { Flex } from "metabase/ui";
+import { Flex, Text } from "metabase/ui";
 import { MetabotProvider } from "metabase-enterprise/metabot/context";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
@@ -28,7 +29,14 @@ export const MetabotQuestion = () => {
             isSaveEnabled={false}
           />
         )}
+        <Disclaimer />
       </Flex>
     </MetabotProvider>
   );
 };
+
+function Disclaimer() {
+  return (
+    <Text c="var(--mb-color-text-secondary)">{t`AI can make mistakes. Double check results.`}</Text>
+  );
+}

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -2,11 +2,12 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
+import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { Flex, Text } from "metabase/ui";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 
-export const MetabotQuestion = () => {
+const MetabotQuestionInner = () => {
   const [result, setResult] = useState<Record<string, any> | null>(null);
 
   const redirectUrl = useMemo(() => {
@@ -37,3 +38,4 @@ function Disclaimer() {
     <Text c="var(--mb-color-text-secondary)">{t`AI can make mistakes. Double check results.`}</Text>
   );
 }
+export const MetabotQuestion = withPublicComponentWrapper(MetabotQuestionInner);

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
@@ -8,18 +8,11 @@ import { Flex, Text } from "metabase/ui";
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 
 const MetabotQuestionInner = () => {
-  const [result, setResult] = useState<Record<string, any> | null>(null);
-
-  const redirectUrl = useMemo(() => {
-    return result?.payload?.payload?.data?.reactions?.find(
-      (reaction: { type: string; url: string }) =>
-        reaction.type === "metabot.reaction/redirect",
-    )?.url;
-  }, [result]);
+  const [redirectUrl, setRedirectUrl] = useState<string>("");
 
   return (
     <Flex direction="column" align="center" gap="3rem">
-      <MetabotChatEmbedding onResult={setResult} />
+      <MetabotChatEmbedding onRedirectUrl={setRedirectUrl} />
       {redirectUrl && (
         <InteractiveAdHocQuestion
           questionPath={redirectUrl}

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -18,13 +18,14 @@ export const MetabotQuestion = () => {
 
   return (
     <MetabotProvider>
-      <Flex direction="column" align="center">
+      <Flex direction="column" align="center" gap="3rem">
         <MetabotChatEmbedding onResult={setResult} />
         {redirectUrl && (
           <InteractiveAdHocQuestion
             questionPath={redirectUrl}
             title={false}
             onNavigateBack={() => {}}
+            isSaveEnabled={false}
           />
         )}
       </Flex>

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -1,15 +1,12 @@
 import { useMemo, useState } from "react";
 
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
-import { MetabotChat } from "metabase-enterprise/metabot/components/MetabotChat";
+import { Flex } from "metabase/ui";
 import { MetabotProvider } from "metabase-enterprise/metabot/context";
 
-export interface MetabotQuestionProps {
-  visible: boolean;
-  onClose: () => void;
-}
+import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 
-export const MetabotQuestion = ({ visible, onClose }: MetabotQuestionProps) => {
+export const MetabotQuestion = () => {
   const [result, setResult] = useState<Record<string, any> | null>(null);
 
   const redirectUrl = useMemo(() => {
@@ -21,17 +18,16 @@ export const MetabotQuestion = ({ visible, onClose }: MetabotQuestionProps) => {
 
   return (
     <MetabotProvider>
-      {redirectUrl && (
-        <InteractiveAdHocQuestion
-          questionPath={redirectUrl}
-          title={false}
-          onNavigateBack={() => {}}
-        />
-      )}
-
-      {visible && (
-        <MetabotChat onClose={onClose} onResult={setResult} withMicrophone />
-      )}
+      <Flex direction="column" align="center">
+        <MetabotChatEmbedding onResult={setResult} />
+        {redirectUrl && (
+          <InteractiveAdHocQuestion
+            questionPath={redirectUrl}
+            title={false}
+            onNavigateBack={() => {}}
+          />
+        )}
+      </Flex>
     </MetabotProvider>
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
 import { Flex, Text } from "metabase/ui";
-import { MetabotProvider } from "metabase-enterprise/metabot/context";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 
@@ -18,20 +17,18 @@ export const MetabotQuestion = () => {
   }, [result]);
 
   return (
-    <MetabotProvider>
-      <Flex direction="column" align="center" gap="3rem">
-        <MetabotChatEmbedding onResult={setResult} />
-        {redirectUrl && (
-          <InteractiveAdHocQuestion
-            questionPath={redirectUrl}
-            title={false}
-            onNavigateBack={() => {}}
-            isSaveEnabled={false}
-          />
-        )}
-        <Disclaimer />
-      </Flex>
-    </MetabotProvider>
+    <Flex direction="column" align="center" gap="3rem">
+      <MetabotChatEmbedding onResult={setResult} />
+      {redirectUrl && (
+        <InteractiveAdHocQuestion
+          questionPath={redirectUrl}
+          title={false}
+          onNavigateBack={() => {}}
+          isSaveEnabled={false}
+        />
+      )}
+      <Disclaimer />
+    </Flex>
   );
 };
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -4,12 +4,12 @@ import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/Inter
 import { MetabotChat } from "metabase-enterprise/metabot/components/MetabotChat";
 import { MetabotProvider } from "metabase-enterprise/metabot/context";
 
-interface Props {
+export interface MetabotQuestionProps {
   visible: boolean;
   onClose: () => void;
 }
 
-export const MetabotQuestion = ({ visible, onClose }: Props) => {
+export const MetabotQuestion = ({ visible, onClose }: MetabotQuestionProps) => {
   const [result, setResult] = useState<Record<string, any> | null>(null);
 
   const redirectUrl = useMemo(() => {

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -1,0 +1,37 @@
+import { useMemo, useState } from "react";
+
+import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
+import { MetabotChat } from "metabase-enterprise/metabot/components/MetabotChat";
+import { MetabotProvider } from "metabase-enterprise/metabot/context";
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export const MetabotQuestion = ({ visible, onClose }: Props) => {
+  const [result, setResult] = useState<Record<string, any> | null>(null);
+
+  const redirectUrl = useMemo(() => {
+    return result?.payload?.payload?.data?.reactions?.find(
+      (reaction: { type: string; url: string }) =>
+        reaction.type === "metabot.reaction/redirect",
+    )?.url;
+  }, [result]);
+
+  return (
+    <MetabotProvider>
+      {redirectUrl && (
+        <InteractiveAdHocQuestion
+          questionPath={redirectUrl}
+          title={false}
+          onNavigateBack={() => {}}
+        />
+      )}
+
+      {visible && (
+        <MetabotChat onClose={onClose} onResult={setResult} withMicrophone />
+      )}
+    </MetabotProvider>
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/index.ts
@@ -1,0 +1,1 @@
+export { MetabotQuestion } from "./MetabotQuestion";

--- a/enterprise/frontend/src/embedding-sdk/components/public/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/index.ts
@@ -48,3 +48,5 @@ export { defineMetabaseTheme };
  * @internal
  */
 export { SdkDebugInfo } from "./debug/SdkDebugInfo";
+
+export { MetabotQuestion } from "./MetabotQuestion";

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/utils.ts
@@ -46,5 +46,5 @@ export function getFixedQuery(query: Lib.Query, fixes: SqlQueryFix[]) {
 }
 
 export function getFixedLineNumbers(fixes: SqlQueryFix[]) {
-  return fixes.map(fix => fix.line_number);
+  return fixes.map((fix) => fix.line_number);
 }

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-sql-fixer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-sql-fixer.ts
@@ -6,9 +6,9 @@ import type {
 import { EnterpriseApi } from "./api";
 
 export const aiSqlFixerApi = EnterpriseApi.injectEndpoints({
-  endpoints: builder => ({
+  endpoints: (builder) => ({
     getFixedSqlQuery: builder.query<FixSqlQueryResponse, FixSqlQueryRequest>({
-      query: body => ({
+      query: (body) => ({
         method: "POST",
         url: "/api/ee/ai-sql-fixer/fix",
         body,

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-sql-generation.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-sql-generation.ts
@@ -6,12 +6,12 @@ import type {
 import { EnterpriseApi } from "./api";
 
 export const aiSqlGenerationApi = EnterpriseApi.injectEndpoints({
-  endpoints: builder => ({
+  endpoints: (builder) => ({
     generateSqlQuery: builder.mutation<
       GenerateSqlQueryResponse,
       GenerateSqlQueryRequest
     >({
-      query: body => ({
+      query: (body) => ({
         method: "POST",
         url: "/api/ee/ai-sql-generation/generate",
         body,

--- a/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
@@ -6,9 +6,9 @@ import type {
 import { EnterpriseApi } from "./api";
 
 export const metabotApi = EnterpriseApi.injectEndpoints({
-  endpoints: builder => ({
+  endpoints: (builder) => ({
     metabotAgent: builder.mutation<MetabotAgentResponse, MetabotAgentRequest>({
-      query: body => ({
+      query: (body) => ({
         method: "POST",
         url: "/api/ee/metabot-v3/v2/agent",
         body,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -22,7 +22,7 @@ export const Metabot = () => {
     }
 
     return tinykeys(window, {
-      "$mod+b": e => {
+      "$mod+b": (e) => {
         e.preventDefault(); // prevent FF from opening bookmark menu
         setVisible(!visible);
       },

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -33,7 +33,7 @@ export const MetabotChat = ({ onClose }: { onClose: () => void }) => {
     resetInput();
     metabot
       .submitInput(trimmedInput)
-      .catch(err => console.error(err))
+      .catch((err) => console.error(err))
       .finally(() => textareaRef.current?.focus());
   };
 
@@ -124,10 +124,10 @@ export const MetabotChat = ({ onClose }: { onClose: () => void }) => {
             metabot.isDoingScience && Styles.textareaLoading,
           )}
           placeholder={placeholder}
-          onChange={e => handleInputChange(e.target.value)}
+          onChange={(e) => handleInputChange(e.target.value)}
           // @ts-expect-error - undocumented API for mantine Textarea - leverages the prop from react-textarea-autosize's TextareaAutosize component
           onHeightChange={handleMaybeExpandInput}
-          onKeyDown={e => {
+          onKeyDown={(e) => {
             if (e.key === "Enter") {
               // prevent event from inserting new line + interacting with other content
               e.preventDefault();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -46,11 +46,11 @@ export const useMetabotAgent = () => {
     dismissUserMessage: (messageIndex: number) =>
       dispatch(dismissUserMessage(messageIndex)),
     submitInput: useCallback(
-      async (message: string, metabotId: string) => {
+      (message: string, metabotId: string) => {
         const context = getChatContext();
         const history = sendMessageReq.data?.history || [];
         const state = sendMessageReq.data?.state || {};
-        return await dispatch(
+        return dispatch(
           submitInput({
             message,
             context,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -50,7 +50,9 @@ export const useMetabotAgent = () => {
         const context = getChatContext();
         const history = sendMessageReq.data?.history || [];
         const state = sendMessageReq.data?.state || {};
-        await dispatch(submitInput({ message, context, history, state }));
+        return await dispatch(
+          submitInput({ message, context, history, state }),
+        );
       },
       [
         dispatch,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -46,12 +46,18 @@ export const useMetabotAgent = () => {
     dismissUserMessage: (messageIndex: number) =>
       dispatch(dismissUserMessage(messageIndex)),
     submitInput: useCallback(
-      async (message: string) => {
+      async (message: string, metabotId: string) => {
         const context = getChatContext();
         const history = sendMessageReq.data?.history || [];
         const state = sendMessageReq.data?.state || {};
         return await dispatch(
-          submitInput({ message, context, history, state }),
+          submitInput({
+            message,
+            context,
+            history,
+            state,
+            metabot_id: metabotId,
+          }),
         );
       },
       [

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -46,7 +46,7 @@ export const useMetabotAgent = () => {
     dismissUserMessage: (messageIndex: number) =>
       dispatch(dismissUserMessage(messageIndex)),
     submitInput: useCallback(
-      (message: string, metabotId: string) => {
+      (message: string, metabotId?: string) => {
         const context = getChatContext();
         const history = sendMessageReq.data?.history || [];
         const state = sendMessageReq.data?.state || {};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -64,3 +64,16 @@ if (hasPremiumFeature("metabot_v3")) {
     },
   ];
 }
+
+/**
+ * This is for Metabot in embedding
+ *
+ * TODO: Move this under a feature flag, but then we need to make our
+ * store allowing injecting reducers dynamically since the store would
+ * already be created before PLUGIN_REDUCERS.* is set via the dynamic EE plugin.
+ */
+PLUGIN_METABOT.getMetabotProvider = () => MetabotProvider;
+PLUGIN_METABOT.defaultMetabotContextValue = defaultContext;
+PLUGIN_METABOT.MetabotContext = MetabotContext;
+
+PLUGIN_REDUCERS.metabotPlugin = metabotReducer;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -35,7 +35,7 @@ if (hasPremiumFeature("metabot_v3")) {
           section: "metabot",
           keywords: searchText,
           icon: "metabot",
-          perform: _currentActionImpl => {
+          perform: (_currentActionImpl) => {
             setVisible(true);
             if (searchText) {
               submitInput(searchText);
@@ -49,7 +49,7 @@ if (hasPremiumFeature("metabot_v3")) {
 
   PLUGIN_REDUCERS.metabotPlugin = metabotReducer;
 
-  PLUGIN_GO_MENU.getMenuItems = dispatch => [
+  PLUGIN_GO_MENU.getMenuItems = (dispatch) => [
     {
       title: (
         <Flex align="center" justify="space-between" gap="md">

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -94,7 +94,6 @@ const lastReqBody = async () => {
 
 describe("metabot", () => {
   describe("ui", () => {
-    // eslint-disable-next-line jest/expect-expect
     it("should be able to render metabot", async () => {
       setup();
       await assertVisible();
@@ -138,7 +137,6 @@ describe("metabot", () => {
       expect(secondConversationId).not.toBe(firstConversationId);
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("should auto-close metabot if inactive with no user input", async () => {
       jest.useFakeTimers({ advanceTimers: true });
 
@@ -180,7 +178,6 @@ describe("metabot", () => {
       jest.useRealTimers();
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("should properly auto-close metabot if route changes", async () => {
       setup();
 
@@ -189,7 +186,6 @@ describe("metabot", () => {
       await assertNotVisible();
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("should not close on route change if metabot is processing", async () => {
       const { store } = setup();
 
@@ -202,7 +198,6 @@ describe("metabot", () => {
       await assertNotVisible();
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("should not close on route change if there is user input", async () => {
       const { store } = setup();
 
@@ -213,7 +208,6 @@ describe("metabot", () => {
       await assertVisible();
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("should not close on route change if new location shares base bath segement", async () => {
       const { store } = setup();
 
@@ -226,7 +220,6 @@ describe("metabot", () => {
       await assertVisible();
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("should hide metabot when the user logs out", async () => {
       jest.spyOn(domModule, "reload").mockImplementation(() => {});
 
@@ -244,7 +237,6 @@ describe("metabot", () => {
       }
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("should not show metabot if the is not signed in user", async () => {
       // suppress expected console error
       const consoleErrorSpy = jest

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -249,7 +249,7 @@ describe("metabot", () => {
       // suppress expected console error
       const consoleErrorSpy = jest
         .spyOn(console, "error")
-        .mockImplementation(message => {
+        .mockImplementation((message) => {
           if (
             message ===
             "Metabot can not be opened while there is no signed in user"

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/api.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/api.ts
@@ -18,7 +18,7 @@ const apiEndpointToRTKQueryMap: Record<
   "POST /api/user": userApi.endpoints.createUser,
 };
 
-export const apiCall: ReactionHandler<MetabotApiCallReaction> = reaction => {
+export const apiCall: ReactionHandler<MetabotApiCallReaction> = (reaction) => {
   return async ({ dispatch }) => {
     const { method, url, body } = reaction.api_call;
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/errors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/errors.ts
@@ -6,9 +6,9 @@ import type { ReactionHandler } from "./types";
 
 type UnknownReaction = { type: string } & Record<string, unknown>;
 
-export const notifyUnknownReaction: ReactionHandler<
-  UnknownReaction
-> = reaction => {
+export const notifyUnknownReaction: ReactionHandler<UnknownReaction> = (
+  reaction,
+) => {
   return ({ dispatch }) => {
     console.error("Unknown reaction recieved", reaction);
     dispatch(clearUserMessages());

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/messages.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/messages.ts
@@ -7,9 +7,9 @@ import { addUserMessage, setConfirmationOptions } from "../state";
 
 import type { ReactionHandler } from "./types";
 
-export const showMessage: ReactionHandler<
-  MetabotMessageReaction
-> = reaction => {
+export const showMessage: ReactionHandler<MetabotMessageReaction> = (
+  reaction,
+) => {
   return ({ dispatch }) => {
     dispatch(addUserMessage(reaction.message));
   };
@@ -17,7 +17,7 @@ export const showMessage: ReactionHandler<
 
 export const requireUserConfirmation: ReactionHandler<
   MetabotConfirmationReaction
-> = reaction => {
+> = (reaction) => {
   return ({ dispatch }) => {
     dispatch(addUserMessage(reaction.description));
     dispatch(setConfirmationOptions(reaction.options));

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/metabot.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/metabot.ts
@@ -9,15 +9,17 @@ import { sendWritebackMessageRequest } from "../state";
 
 import type { ReactionHandler } from "./types";
 
-export const writeBack: ReactionHandler<
-  MetabotWriteBackReaction
-> = reaction => {
+export const writeBack: ReactionHandler<MetabotWriteBackReaction> = (
+  reaction,
+) => {
   return async ({ dispatch }) => {
     await dispatch(sendWritebackMessageRequest(reaction.message));
   };
 };
 
-export const redirect: ReactionHandler<MetabotRedirectReaction> = reaction => {
+export const redirect: ReactionHandler<MetabotRedirectReaction> = (
+  reaction,
+) => {
   const redirectUrl = new URL(`${window.location.origin}${reaction.url}`);
 
   return async ({ dispatch }) => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/queries.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/queries.ts
@@ -5,7 +5,7 @@ import type { MetabotRunQueryReaction } from "metabase-types/api";
 import type { ReactionHandler } from "./types";
 
 export const runQuery: ReactionHandler<MetabotRunQueryReaction> =
-  reaction =>
+  (reaction) =>
   async ({ dispatch, getState }) => {
     const question = getQuestion(getState());
     if (!question) {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/visualizations.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/visualizations.ts
@@ -20,7 +20,7 @@ import type { ReactionHandler } from "./types";
 export const changeTableVisualizationSettings: ReactionHandler<
   MetabotChangeVisiualizationSettingsReaction
 > =
-  reaction =>
+  (reaction) =>
   async ({ dispatch, getState }) => {
     const queryResults = getQueryResults(getState());
     const queryResultCols = queryResults?.[0]?.data?.cols ?? [];
@@ -41,7 +41,7 @@ export const changeTableVisualizationSettings: ReactionHandler<
 export const changeDisplayType: ReactionHandler<
   MetabotChangeDisplayTypeReaction
 > =
-  reaction =>
+  (reaction) =>
   async ({ dispatch, getState }) => {
     {
       const question = getQuestion(getState());
@@ -61,14 +61,14 @@ export const changeDisplayType: ReactionHandler<
 export const changeSeriesSettings: ReactionHandler<
   MetabotChangeSeriesSettingsReaction
 > =
-  reaction =>
+  (reaction) =>
   async ({ dispatch, getState }) => {
     const seriesSettings =
       getQuestion(getState())?.settings().series_settings ?? {};
 
     const newSeriesSettings = { ...seriesSettings };
 
-    reaction.series_settings.forEach(settings => {
+    reaction.series_settings.forEach((settings) => {
       const onlyIncludedSettings = Object.fromEntries(
         Object.entries(settings).filter(([_key, value]) => value !== null),
       );
@@ -87,14 +87,14 @@ export const changeSeriesSettings: ReactionHandler<
 export const changeColumnSettings: ReactionHandler<
   MetabotChangeColumnSettingsReaction
 > =
-  reaction =>
+  (reaction) =>
   async ({ dispatch, getState }) => {
     const columnSettings =
       getQuestion(getState())?.settings().column_settings ?? {};
 
     const newColumnSettings = { ...columnSettings };
 
-    reaction.column_settings.forEach(settings => {
+    reaction.column_settings.forEach((settings) => {
       const columnKey = getColumnKey({ name: settings.key });
       const onlyIncludedSettings = Object.fromEntries(
         Object.entries(settings).filter(([_key, value]) => value !== null),

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -2,7 +2,6 @@ import { t } from "ttag";
 
 import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { createAsyncThunk } from "metabase/lib/redux";
-import { uuid } from "metabase/lib/uuid";
 import {
   EnterpriseApi,
   METABOT_TAG,
@@ -27,9 +26,9 @@ export const {
   addUserMessage,
   dismissUserMessage,
   clearUserMessages,
+  resetConversationId,
   setIsProcessing,
   setConfirmationOptions,
-  setConversationId,
 } = metabot.actions;
 
 export const setVisible =
@@ -108,8 +107,8 @@ export const sendMessageRequest = createAsyncThunk(
       console.warn(
         "Metabot has no session id while open, this should never happen",
       );
-      sessionId = uuid();
-      dispatch(setConversationId(sessionId));
+      dispatch(resetConversationId());
+      sessionId = getMetabotConversationId(getState() as any) as string;
     }
 
     const metabotRequestPromise = dispatch(

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -62,6 +62,7 @@ export const submitInput = createAsyncThunk(
       context: MetabotChatContext;
       history: any[];
       state: any;
+      metabot_id?: string;
     },
     { dispatch, getState },
   ) => {
@@ -91,6 +92,7 @@ export const sendMessageRequest = createAsyncThunk(
       context: MetabotChatContext;
       history: any[];
       state: any;
+      metabot_id?: string;
     },
     { dispatch, getState },
   ) => {
@@ -142,7 +144,7 @@ export const selectUserConfirmationOption = createAsyncThunk(
     const confirmationOption = userConfirmationOptions[message];
     if (!confirmationOption) {
       const options = Object.keys(userConfirmationOptions);
-      const quotedOptions = options.map(option => `“${option}”`).join(" or ");
+      const quotedOptions = options.map((option) => `“${option}”`).join(" or ");
       dispatch(addUserMessage(t`Sorry, could you give me a ${quotedOptions}?`));
     } else {
       dispatch(clearUserMessages());

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -78,7 +78,7 @@ export const submitInput = createAsyncThunk(
       await dispatch(selectUserConfirmationOption(data.message));
     } else {
       dispatch(clearUserMessages());
-      await dispatch(sendMessageRequest(data));
+      return await dispatch(sendMessageRequest(data));
     }
   },
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -43,17 +43,17 @@ export const metabot = createSlice({
     addUserMessage: (state, action: PayloadAction<string>) => {
       state.userMessages.push(action.payload);
     },
-    clearUserMessages: state => {
+    clearUserMessages: (state) => {
       state.userMessages = [];
     },
     dismissUserMessage: (state, action: PayloadAction<number>) => {
       state.userMessages.splice(action.payload, 1);
     },
+    resetConversationId: (state) => {
+      state.conversationId = uuid();
+    },
     setIsProcessing: (state, action: PayloadAction<boolean>) => {
       state.isProcessing = action.payload;
-    },
-    setConversationId: (state, action: PayloadAction<string | undefined>) => {
-      state.conversationId = action.payload;
     },
     setVisible: (state, { payload: visible }: PayloadAction<boolean>) => {
       if (visible) {
@@ -72,7 +72,7 @@ export const metabot = createSlice({
       state.confirmationOptions = action.payload as any;
     },
   },
-  extraReducers: builder => {
+  extraReducers: (builder) => {
     builder
       .addCase(sendMessageRequest.pending, (state, action) => {
         state.lastSentContext = action.meta.arg.context;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -7,40 +7,40 @@ export const getMetabot = (state: MetabotStoreState) =>
 
 export const getMetabotVisisble = createSelector(
   getMetabot,
-  metabot => metabot.visible,
+  (metabot) => metabot.visible,
 );
 
 export const getUserMessages = createSelector(
   getMetabot,
-  metabot => metabot.userMessages,
+  (metabot) => metabot.userMessages,
 );
 
 export const getConfirmationOptions = createSelector(
   getMetabot,
-  metabot => metabot.confirmationOptions,
+  (metabot) => metabot.confirmationOptions,
 );
 
 export const getIsProcessing = createSelector(
   getMetabot,
-  metabot => metabot.isProcessing,
+  (metabot) => metabot.isProcessing,
 );
 
 export const getLastSentContext = createSelector(
   getMetabot,
-  metabot => metabot.lastSentContext,
+  (metabot) => metabot.lastSentContext,
 );
 
 export const getLastHistoryValue = createSelector(
   getMetabot,
-  metabot => metabot.lastHistoryValue,
+  (metabot) => metabot.lastHistoryValue,
 );
 
 export const getMetabotConversationId = createSelector(
   getMetabot,
-  metabot => metabot.conversationId,
+  (metabot) => metabot.conversationId,
 );
 
 export const getMetabotState = createSelector(
   getMetabot,
-  metabot => metabot.state,
+  (metabot) => metabot.state,
 );

--- a/frontend/src/metabase/dashboard/hooks/use-register-dashboard-metabot-context.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-register-dashboard-metabot-context.ts
@@ -3,7 +3,7 @@ import { useRegisterMetabotContextProvider } from "metabase/metabot";
 import { getDashboard } from "../selectors";
 
 export const useRegisterDashboardMetabotContext = () => {
-  useRegisterMetabotContextProvider(state => {
+  useRegisterMetabotContextProvider((state) => {
     const dashboard = getDashboard(state);
     if (!dashboard) {
       return {};

--- a/frontend/src/metabase/metabot-v3/selectors.ts
+++ b/frontend/src/metabase/metabot-v3/selectors.ts
@@ -23,7 +23,7 @@ export const getVisualizationMetabotContext = createSelector(
     if (typeof hydratedVisualizationSettings.series === "function") {
       const seriesSettings: ComputedVisualizationSettings["series_settings"] =
         {};
-      transformedSeries.forEach(series => {
+      transformedSeries.forEach((series) => {
         seriesSettings[keyForSingleSeries(series)] =
           hydratedVisualizationSettings.series(series);
       });
@@ -34,8 +34,8 @@ export const getVisualizationMetabotContext = createSelector(
       const columnSettings: ComputedVisualizationSettings["column_settings"] = {
         ...hydratedVisualizationSettings.column_settings,
       };
-      rawSeries.forEach(series => {
-        series.data.cols.forEach(col => {
+      rawSeries.forEach((series) => {
+        series.data.cols.forEach((col) => {
           const columnSetting = hydratedVisualizationSettings.column?.(col);
 
           if (columnSetting) {

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.ts
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.ts
@@ -3,7 +3,7 @@ import { useRegisterMetabotContextProvider } from "metabase/metabot";
 import { getQuestion } from "../selectors";
 
 export const useRegisterQueryBuilderMetabotContext = () => {
-  useRegisterMetabotContextProvider(state => {
+  useRegisterMetabotContextProvider((state) => {
     const question = getQuestion(state);
     if (!question) {
       return {};

--- a/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
+++ b/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
@@ -361,6 +361,8 @@ import star_filled_component from "./star_filled.svg?component";
 import star_filled_source from "./star_filled.svg?source";
 import stepped_component from "./stepped.svg?component";
 import stepped_source from "./stepped.svg?source";
+import stop_component from "./stop.svg?component";
+import stop_source from "./stop.svg?source";
 import store_component from "./store.svg?component";
 import store_source from "./store.svg?source";
 import straight_component from "./straight.svg?component";
@@ -1152,6 +1154,10 @@ export const Icons = {
   star: {
     component: star_component,
     source: star_source,
+  },
+  stop: {
+    component: stop_component,
+    source: stop_source,
   },
   store: {
     component: store_component,

--- a/frontend/src/metabase/ui/components/icons/Icon/icons/stop.svg
+++ b/frontend/src/metabase/ui/components/icons/Icon/icons/stop.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+  <rect width="12" height="12" rx="2" />
+</svg>


### PR DESCRIPTION
Closes EMB-297, EMB-298

### Description
This PR adds a Metabot to the SDK. Following these specs.
- [Product doc](https://www.notion.so/metabase/Embedding-Metabot-Beta-w-SDK-1c769354c901801d88add6de1998b553)
- [Figma design](https://www.figma.com/design/l9y9OEENQUYiKSbFo7WQA0/Embedding-Metabot-w--SDK-to-ask-questions-using-natural-language?node-id=17079-961&t=8jZhUlCQVzEe6alQ-0)
- [Tech doc](https://www.notion.so/metabase/Tech-Embedding-Metabot-Beta-w-SDK-1c969354c90180d19599f1e8a220f36a#1c969354c90180d19599f1e8a220f36a)

### How to verify
#### Build the SDK
1. Let's build the SDK
    ```sh
    yarn build-embedding-sdk
    ```
#### Run AI Service
1. Clone the repo https://github.com/metabase/ai-service
2. Set up env
    ```sh
    cp example.env .env
    ```
3. Change token check URL to use Staing server
    ```sh
    AI_SERVICE_MB_TOKEN_CHECK_URL=https://token-check.staging.metabase.com
    ```
4. Other env values are in 1password, search `ai-service`
5. Run it
    ```sh
    docker compose up
    ```
#### Run the Application
1. Set up Metabase env. Get the n[ew dev token from here.](https://www.notion.so/metabase/Embedding-Metabot-w-SDK-to-ask-questions-using-natural-language-1bd69354c90180e2911cea8f34430ab4?pvs=4#1c069354c90180388bcffc1b7212828d) You'll need to sign in to tools using your Metabase email account.
    ```sh
    MB_EDITION=ee
    MB_PREMIUM_EMBEDDING_TOKEN=<dev_token_ending_with_1710>
    METASTORE_DEV_SERVER_URL=https://token-check.staging.metabase.com
    ```
1. Now run Metabase normally.
1. You can opt to authenticate with JWT or API keys. Make sure you have necessary authentication settings done here before going to your own application
1. Add metrics and/or models of your choice to a new collection named [`__METABOT_EMBEDDING__`](https://github.com/metabase/metabase/blob/41a2f8e181082eecc1d6445848e179a1635b9014/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj#L467). AI service should now query against resources within this collection.

#### Starting your own application
I tested with both Next.js (React 18) and Vite (React 18)
- to use vite
  ```sh
  npm create vite@latest
  ```
- to use Next. I haven't tested with React 19. I don't think this `metabot-v3-branch` has the change. But to use Next 14 with React 18 use this command. You can use `@latest` with pages router and downgrade React to v18 manually as well.
    ```sh
    npx create-next-app@next-14
    ```
- Set up the SDK with your authentication of choice and import the Metabot component
```typescript
<MetabotQuestion />
```

Now play with it
- Ask questions
- Cancel queries
- Ask weird questions
- Unmount and remount the `<MetabotQuestion />`: If you inspect the network request. Requests to `POST: /api/ee/metabot-v3/v2/agent` should contain the same `conversation_id` in the request body, as long as the Metabot question component stays mounted. Only when it's unmounted and mounted again then this `conversation_id` would change.

### Demo (on Vite + React)
![Screenshot 2025-04-04 at 6 16 44 PM](https://github.com/user-attachments/assets/d3f339a4-a75c-4f74-8620-11f6e1d983d9)
![Screenshot 2025-04-04 at 6 16 50 PM](https://github.com/user-attachments/assets/06c71925-7ffc-4188-9500-753612390aed)
![image](https://github.com/user-attachments/assets/b90b3e08-e846-4ee9-9709-b9eff3caebaf)
![image](https://github.com/user-attachments/assets/ba8a935e-16a8-4e2e-a121-b293b35b3cf5)


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
