### PR TITLE
ci(sdk): mark 54 as a stable release version

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.54.4-nightly",
+  "version": "0.54.4",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
We have cut 54 gold (yay!), so it's time we remove the `-nightly` suffix. Our next `v0.54.5` release is now gonna be in the `54-stable` channel!