### PR TITLE
Core table editing Undo mechanism

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -33,11 +33,14 @@
   "Operates on rows in the database, supply an action-kw: :bulk/create, :bulk/update, :bulk/delete.
   The input `rows` is given different semantics depending on the action type, see actions/perform-action!."
   [action-kw table-id rows]
-  (actions/perform-action! action-kw
-                           {:database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
-                            :table-id table-id
-                            :arg      rows}
-                           :policy   :data-editing))
+  ;; TODO make this work for multi instances by using the metabase_cluster_lock table
+  ;; https://github.com/metabase/metabase/pull/56173/files
+  (locking #'perform-bulk-action!
+    (actions/perform-action! action-kw
+                             {:database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
+                              :table-id table-id
+                              :arg      rows}
+                             :policy :data-editing)))
 
 (defn insert!
   "Inserts rows into the table, recording their creation as an event. Returns the inserted records.

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -171,6 +171,3 @@
   "Rollback the given user's last change to the given table."
   [user-id table-id]
   (undo*! false user-id table-id))
-
-
-

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -22,8 +22,6 @@
 ;; undone` is monotonic in `batch_num`, for each `table_id`, `row_pk` combination.
 ;;  i.e., it can only change from `false` to `true` for any logical "cell", as `batch_num` increases.
 
-;; TODO not serialized (yaml)
-
 (defn- next-batch [undo? user-id table-id]
   ;; For now, we assume all the changes are to the same table.
   ;; In the future, we might want to skip multi-table changes when using cmd-Z.

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -1,67 +1,204 @@
 (ns metabase-enterprise.data-editing.undo
   (:require
-   [clojure.edn :as edn]
+   [metabase-enterprise.data-editing.data-editing :as data-editing]
    [metabase.models.interface :as mi]
+   [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
 (methodical/defmethod t2/table-name :model/Undo [_model] :data_edit_undo_chain)
 
-(def transform-edn {:in pr-str, :out edn/read-string})
-
-(t2/deftransforms :model/Card
-  {:row_pk           mi/transform-json
-   :raw_value_before transform-edn
-   :raw_value_after  transform-edn})
+(t2/deftransforms :model/Undo
+  {:row_pk     mi/transform-json
+   :raw_before mi/transform-json
+   :raw_after  mi/transform-json})
 
 (doto :model/Undo
   (derive :metabase/model)
   (derive :hook/timestamped?))
 
+;; We enforce and rely on the following invariants for the data in the Undo table:
+
+;; - `undone` is monotonic in `batch_num`, for each table_id, row_pk combination.
+;;      i.e., it can only change from `false` to `true`, as `batch_num` increases.
+;; - at most one of `row_before` and `row_after` are `nil`
+
 ;; invariants
-;; for a given field, "undone" is monotonic in change_num (cannot go from true to false)
+;; for a given field, "undone" is monotonic in batch_num (cannot go from true to false)
 
-;; TODO not serialized
+;; TODO not serialized (yaml)
 
-(defn- next-undo-batch [user-id table-id]
+(defn- next-batch [undo? user-id table-id]
   ;; For now, we assume all the changes are to the same table.
   ;; In the future, we might want to skip multi-table changes when using cmd-Z.
   ;; We may also want to filter based on the type of interaction that caused the change (e.g., grid, workflow, etc)
-  ;;
-  ;; select max(change_num) where table_id, user_id, and not undone.
-  ;;
-  (when-let [change-num nil]
-    (t2/select :model/Undo :change_num change-num)))
+  (t2/select :model/Undo
+             :batch_num [:in
+                         {:select [[[(if undo? :max :min) :batch_num]]]
+                          :from   [(t2/table-name :model/Undo)]
+                          :where  [:and
+                                   [:= user-id :user_id]
+                                   [:= table-id :table_id]
+                                   (if undo?
+                                     [:not :undone]
+                                     :undone)]}]))
 
-(defn- track-change! [user-id table-id field-id->old-new-values]
-  ;; TODO single insert statement
-  (doseq [[field-id [old new]] field-id->old-new-values]
-    (t2/insert! :model/Undo
-                {:change_num [{}]
-                 :table_id table-id
-                 :field_id field-id
-                 :user_id user-id})))
+(defn- track-change! [user-id table-id->row-pk->old-new-values]
+  (t2/insert!
+   :model/Undo
+   (for [[table-id stuff] table-id->row-pk->old-new-values
+         [row-pk [old new]] stuff]
+     {:batch_num  [:+ [:inline 1] [:coalesce {:from [:data_edit_undo_chain] :select [[[:max :batch_num]]]} 0]]
+      :table_id   table-id
+      :user_id    user-id
+      :row_pk     row-pk
+      :raw_before old
+      :raw_after  new}
+     ;; TODO delete any orphaned or conflicting "undone" changes
+     )))
 
 (defn- has-undo?
   "Return whether we have any saved modifications that could be undone.
   NOTE: this does not check whether there is a conflict preventing us from actually undoing it."
   [user-id table-id]
-  (boolean (seq (next-undo-batch user-id table-id))))
+  (boolean (seq (next-batch true user-id table-id))))
+
+(defn- has-redo?
+  "Return whether we have any saved modifications that could be undone.
+  NOTE: this does not check whether there is a conflict preventing us from actually undoing it."
+  [user-id table-id]
+  (boolean (seq (next-batch false user-id table-id))))
+
+(defn- diff-keys
+  "Give the sorted list of keys on which m1 and m2 differ."
+  [m1 m2]
+  (->> (into (apply sorted-set (keys m1)) (keys m2))
+       (filter #(not= (get m1 %) (get m2 %)))))
+
+(defn- conflict?
+  "Has another change superseded this batch, making it non-undoable? Typically, will mean someone else has edited it."
+  [undo? batch]
+  (let [row-pks   (into #{} (map :row_pk) batch)
+        table-ids (into #{} (map :table_id) batch)
+        {:keys [batch_num]} (first batch)]
+    ;; TODO fix false positive conflicts when different columns were changed
+    ;; Idea: Select all potential conflicting undos, check for any whose changed keys overlap with ours.
+    ;; Can store a precalculated [[diff-keys]] on each :model/Undo row, or even normalize into its own table and do
+    ;; conflict detection completely in SQL.
+    (t2/exists? :model/Undo
+                :table_id [:in table-ids]
+                :row_pk [:in row-pks]
+                :batch_num [(if undo? :> :<) batch_num]
+                :undone (not undo?))))
+
+(defn- categorize [{:keys [raw_before raw_after]}]
+  (cond
+    (nil? raw_before) :create
+    (nil? raw_after)  :delete
+    :else             :update))
+
+(def ^:private invert
+  {:create :delete
+   :update :update
+   :delete :create})
+
+(defn- batch->rows [undo? batch]
+  (let [k (if undo? :raw_before :raw_after)]
+    (for [b batch]
+      (when-let [body (k b)]
+        (merge (:row_pk b) body)))))
+
+(defn undo*!
+  "Revert the underlying table data."
+  [undo? batch]
+  (doseq [[[table-id category] sub-batch] (u/group-by (juxt :table_id categorize) batch)
+          :let [rows (batch->rows undo? sub-batch)]]
+    #p [category rows]
+    #_(case (if redo? (invert category) category)
+        :create (data-editing/perform-bulk-action! :bulk/create table-id rows)
+        :update (data-editing/perform-bulk-action! :bulk/update table-id rows)
+        :delete (data-editing/perform-bulk-action! :bulk/delete table-id rows))))
 
 (defn- undo! [user-id table-id]
-  (let [batch     (next-undo-batch user-id table-id)
-        field-ids (map :field_id batch)
-        {:keys [change_num]} (:change_num (first batch))]
-    (if (not (seq batch))
-      :none
-      (if (t2/exists? :model/Undo
-                      :field_id [:in field-ids]             ;;  table is implicit, plus this is multi-table undo ready
-                      :change_num [:> (inc change_num)]
-                      :undone false)
-        :conflict
-        (do
-          (doseq [u batch]
-            #p (:raw_value_before u))
-          (t2/update! :model/Undo {:change_num change_num} {:undone true}))))))
+  (let [undo? true
+        batch (next-batch undo? user-id table-id)]
+    (cond
+      (not (seq batch)) (throw (ex-info "No previous versions found"
+                                        {:error    :undo/none
+                                         :user-id  user-id
+                                         :table-id table-id}))
+      (conflict? undo? batch) (throw (ex-info "Conflicting versions found"
+                                              {:error    :undo/conflict
+                                               :user-id  user-id
+                                               :table-id table-id}))
+      :else
+      (do (undo*! undo? batch)
+          (t2/update! :model/Undo
+                      {:batch_num (:batch_num (first batch))}
+                      {:undone true})
+          (batch->rows undo? batch)))))
 
-(defn- redo! [user-id table-id])
+(defn- redo! [user-id table-id]
+  (let [undo? false
+        batch (next-batch undo? user-id table-id)]
+    (cond
+      (not (seq batch)) (throw (ex-info "No subsequent versions found"
+                                        {:error    :undo/none
+                                         :user-id  user-id
+                                         :table-id table-id}))
+      (conflict? undo? batch) (throw (ex-info "Conflicting versions found"
+                                              {:error    :undo/conflict
+                                               :user-id  user-id
+                                               :table-id table-id}))
+      :else
+      (do (undo*! undo? batch)
+          (t2/update! :model/Undo
+                      {:batch_num (:batch_num (first batch))}
+                      {:undone false})
+          (batch->rows undo? batch)))))
+
+;-> table batch edit action (inv id 1) -> bulk action -> row/update (inv id 1)
+;                                                        row/update (inv id 3)
+;                                                               |
+;                                                               -> action.success -> audit log
+;                                                               -> undo snapshots (row level)
+
+; (open problem: how to atomically give them all the same batch number)
+;
+; do an undo -> bulk action -> row/update -> DO NOT create snapshot
+;
+;              {:skip-undo-snapshot true} -> use that option
+;
+; change 1 (not undone)
+; change 2 (not undone)
+; change 3 (undone)
+; change 4 - same entity
+; change 5 (not undone)
+
+;; undo until nothing to undo.
+;; redo until nothing to redo.
+;; conflict when the same field and row.
+;; no conflict for a different field.
+;; no conflict for a different row.
+
+(comment
+  (t2/delete! :model/Undo)
+  (do
+    (track-change! 1 {1 {{:id 1} [nil {:name "Chris"}]}})
+    (track-change! 1 {1 {{:id 1} [{:name "Chris"} {:name "Ngoc"}]}})
+    (track-change! 1 {1 {{:id 1} [{:name "Ngoc"} nil]}})
+
+    (track-change! 2 {2 {{:id 1} [nil {:name "Chris" :age 2}]}})
+    (track-change! 2 {2 {{:id 1} [{:name "Chris" :age 2} {:name "Ngoc" :age 9000}]}})
+    (track-change! 3 {2 {{:id 1} [{:name "Ngoc" :age 9000} {:name "Ngoc" :age 9001}]}})
+    (track-change! 2 {2 {{:id 1} [{:name "Ngoc" :age 9001} nil]}}))
+
+  (undo! 1 1)
+  (redo! 1 1)
+
+  (undo! 2 2)
+  (undo! 3 2)
+  (redo! 2 2)
+  (redo! 3 2)
+
+  (t2/select :model/Undo))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -1,3 +1,67 @@
-(ns metabase-enterprise.data-editing.undo)
+(ns metabase-enterprise.data-editing.undo
+  (:require
+   [clojure.edn :as edn]
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
 
+(methodical/defmethod t2/table-name :model/Undo [_model] :data_edit_undo_chain)
 
+(def transform-edn {:in pr-str, :out edn/read-string})
+
+(t2/deftransforms :model/Card
+  {:row_pk           mi/transform-json
+   :raw_value_before transform-edn
+   :raw_value_after  transform-edn})
+
+(doto :model/Undo
+  (derive :metabase/model)
+  (derive :hook/timestamped?))
+
+;; invariants
+;; for a given field, "undone" is monotonic in change_num (cannot go from true to false)
+
+;; TODO not serialized
+
+(defn- next-undo-batch [user-id table-id]
+  ;; For now, we assume all the changes are to the same table.
+  ;; In the future, we might want to skip multi-table changes when using cmd-Z.
+  ;; We may also want to filter based on the type of interaction that caused the change (e.g., grid, workflow, etc)
+  ;;
+  ;; select max(change_num) where table_id, user_id, and not undone.
+  ;;
+  (when-let [change-num nil]
+    (t2/select :model/Undo :change_num change-num)))
+
+(defn- track-change! [user-id table-id field-id->old-new-values]
+  ;; TODO single insert statement
+  (doseq [[field-id [old new]] field-id->old-new-values]
+    (t2/insert! :model/Undo
+                {:change_num [{}]
+                 :table_id table-id
+                 :field_id field-id
+                 :user_id user-id})))
+
+(defn- has-undo?
+  "Return whether we have any saved modifications that could be undone.
+  NOTE: this does not check whether there is a conflict preventing us from actually undoing it."
+  [user-id table-id]
+  (boolean (seq (next-undo-batch user-id table-id))))
+
+(defn- undo! [user-id table-id]
+  (let [batch     (next-undo-batch user-id table-id)
+        field-ids (map :field_id batch)
+        {:keys [change_num]} (:change_num (first batch))]
+    (if (not (seq batch))
+      :none
+      (if (t2/exists? :model/Undo
+                      :field_id [:in field-ids]             ;;  table is implicit, plus this is multi-table undo ready
+                      :change_num [:> (inc change_num)]
+                      :undone false)
+        :conflict
+        (do
+          (doseq [u batch]
+            #p (:raw_value_before u))
+          (t2/update! :model/Undo {:change_num change_num} {:undone true}))))))
+
+(defn- redo! [user-id table-id])

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -39,7 +39,9 @@
                                      [:not :undone]
                                      :undone)]}]))
 
-(defn- track-change! [user-id table-id->row-pk->old-new-values]
+(defn track-change!
+  "Insert some snapshot data based on edits made to the given table."
+  [user-id table-id->row-pk->old-new-values]
   (t2/insert!
    :model/Undo
    (for [[table-id table-updates] table-id->row-pk->old-new-values
@@ -74,6 +76,7 @@
   (boolean (seq (next-batch undo? user-id table-id))))
 
 ;; This will be used to fix conflict false positives
+#_{:clj-kondo/ignore [:unused-private-var]}
 (defn- diff-keys
   "Give the sorted list of keys on which m1 and m2 differ."
   [m1 m2]
@@ -159,10 +162,14 @@
                                 (batch->rows undo? sub-batch))])
                (into {}))))))
 
-(defn undo! [user-id table-id]
+(defn undo!
+  "Rollback the given user's last change to the given table."
+  [user-id table-id]
   (undo*! true user-id table-id))
 
-(defn redo! [user-id table-id]
+(defn redo!
+  "Rollback the given user's last change to the given table."
+  [user-id table-id]
   (undo*! false user-id table-id))
 
 

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.data-editing.undo)
+
+

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -89,6 +89,7 @@
    "Session"
    "TablePrivileges"
    "TaskHistory"
+   "Undo"
    "User"
    "UserKeyValue"
    "UserParameterValue"

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -451,7 +451,7 @@
 (deftest field-values-invalidated-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/with-empty-h2-app-db
-      (toggle-data-editing-enabled! true)
+      (data-editing.tu/toggle-data-editing-enabled! true)
       (with-open [table (data-editing.tu/open-test-table! {:id 'auto-inc-type, :n [:text]} {:primary-key [:id]})]
         (let [table-id     @table
               url          (data-editing.tu/table-url table-id)

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -32,46 +32,47 @@
 
 (deftest table-operations-test
   (mt/with-premium-features #{:table-data-editing}
-    (with-open [table-ref (data-editing.tu/open-test-table!)]
-      (let [table-id @table-ref
-            url      (data-editing.tu/table-url table-id)]
-        (data-editing.tu/toggle-data-editing-enabled! true)
-        (testing "Initially the table is empty"
-          (is (= [] (table-rows table-id))))
+    (mt/with-empty-h2-app-db
+      (with-open [table-ref (data-editing.tu/open-test-table!)]
+        (let [table-id @table-ref
+              url      (data-editing.tu/table-url table-id)]
+          (data-editing.tu/toggle-data-editing-enabled! true)
+          (testing "Initially the table is empty"
+            (is (= [] (table-rows table-id))))
 
-        (testing "POST should insert new rows"
-          (is (= {:created-rows [{:id 1 :name "Pidgey" :song "Car alarms"}
-                                 {:id 2 :name "Spearow" :song "Hold music"}
-                                 {:id 3 :name "Farfetch'd" :song "The land of lisp"}]}
-                 (mt/user-http-request :crowberto :post 200 url
-                                       {:rows [{:name "Pidgey" :song "Car alarms"}
-                                               {:name "Spearow" :song "Hold music"}
-                                               {:name "Farfetch'd" :song "The land of lisp"}]})))
+          (testing "POST should insert new rows"
+            (is (= {:created-rows [{:id 1 :name "Pidgey" :song "Car alarms"}
+                                   {:id 2 :name "Spearow" :song "Hold music"}
+                                   {:id 3 :name "Farfetch'd" :song "The land of lisp"}]}
+                   (mt/user-http-request :crowberto :post 200 url
+                                         {:rows [{:name "Pidgey" :song "Car alarms"}
+                                                 {:name "Spearow" :song "Hold music"}
+                                                 {:name "Farfetch'd" :song "The land of lisp"}]})))
 
-          (is (= [[1 "Pidgey" "Car alarms"]
-                  [2 "Spearow" "Hold music"]
-                  [3 "Farfetch'd" "The land of lisp"]]
-                 (table-rows table-id))))
+            (is (= [[1 "Pidgey" "Car alarms"]
+                    [2 "Spearow" "Hold music"]
+                    [3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
 
-        (testing "PUT should update the relevant rows and columns"
-          (is (= {:updated [{:id 1, :name "Pidgey", :song "Join us now and share the software"}
-                            {:id 2, :name "Speacolumn", :song "Hold music"}]}
-                 (mt/user-http-request :crowberto :put 200 url
-                                       {:rows [{:id 1 :song "Join us now and share the software"}
-                                               {:id 2 :name "Speacolumn"}]})))
+          (testing "PUT should update the relevant rows and columns"
+            (is (= {:updated [{:id 1, :name "Pidgey", :song "Join us now and share the software"}
+                              {:id 2, :name "Speacolumn", :song "Hold music"}]}
+                   (mt/user-http-request :crowberto :put 200 url
+                                         {:rows [{:id 1 :song "Join us now and share the software"}
+                                                 {:id 2 :name "Speacolumn"}]})))
 
-          (is (= [[1 "Pidgey" "Join us now and share the software"]
-                  [2 "Speacolumn" "Hold music"]
-                  [3 "Farfetch'd" "The land of lisp"]]
-                 (table-rows table-id))))
+            (is (= [[1 "Pidgey" "Join us now and share the software"]
+                    [2 "Speacolumn" "Hold music"]
+                    [3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
 
-        (testing "DELETE should remove the corresponding rows"
-          (is (= {:success true}
-                 (mt/user-http-request :crowberto :post 200 (str url "/delete")
-                                       {:rows [{:id 1}
-                                               {:id 2}]})))
-          (is (= [[3 "Farfetch'd" "The land of lisp"]]
-                 (table-rows table-id))))))))
+          (testing "DELETE should remove the corresponding rows"
+            (is (= {:success true}
+                   (mt/user-http-request :crowberto :post 200 (str url "/delete")
+                                         {:rows [{:id 1}
+                                                 {:id 2}]})))
+            (is (= [[3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id)))))))))
 
 (deftest editing-allowed-test
   (mt/with-premium-features #{:table-data-editing}

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -30,52 +30,48 @@
       (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :put 402 url))
       (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :post 402 (str url "/delete"))))))
 
-(defn- toggle-data-editing-enabled! [on-or-off]
-  (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing (boolean on-or-off)}}))
-
 (deftest table-operations-test
   (mt/with-premium-features #{:table-data-editing}
-    (mt/with-empty-h2-app-db
-      (with-open [table-ref (data-editing.tu/open-test-table!)]
-        (let [table-id @table-ref
-              url      (data-editing.tu/table-url table-id)]
-          (toggle-data-editing-enabled! true)
-          (testing "Initially the table is empty"
-            (is (= [] (table-rows table-id))))
+    (with-open [table-ref (data-editing.tu/open-test-table!)]
+      (let [table-id @table-ref
+            url      (data-editing.tu/table-url table-id)]
+        (data-editing.tu/toggle-data-editing-enabled! true)
+        (testing "Initially the table is empty"
+          (is (= [] (table-rows table-id))))
 
-          (testing "POST should insert new rows"
-            (is (= {:created-rows [{:id 1 :name "Pidgey"     :song "Car alarms"}
-                                   {:id 2 :name "Spearow"    :song "Hold music"}
-                                   {:id 3 :name "Farfetch'd" :song "The land of lisp"}]}
-                   (mt/user-http-request :crowberto :post 200 url
-                                         {:rows [{:name "Pidgey"     :song "Car alarms"}
-                                                 {:name "Spearow"    :song "Hold music"}
-                                                 {:name "Farfetch'd" :song "The land of lisp"}]})))
+        (testing "POST should insert new rows"
+          (is (= {:created-rows [{:id 1 :name "Pidgey" :song "Car alarms"}
+                                 {:id 2 :name "Spearow" :song "Hold music"}
+                                 {:id 3 :name "Farfetch'd" :song "The land of lisp"}]}
+                 (mt/user-http-request :crowberto :post 200 url
+                                       {:rows [{:name "Pidgey" :song "Car alarms"}
+                                               {:name "Spearow" :song "Hold music"}
+                                               {:name "Farfetch'd" :song "The land of lisp"}]})))
 
-            (is (= [[1 "Pidgey"     "Car alarms"]
-                    [2 "Spearow"    "Hold music"]
-                    [3 "Farfetch'd" "The land of lisp"]]
-                   (table-rows table-id))))
+          (is (= [[1 "Pidgey" "Car alarms"]
+                  [2 "Spearow" "Hold music"]
+                  [3 "Farfetch'd" "The land of lisp"]]
+                 (table-rows table-id))))
 
-          (testing "PUT should update the relevant rows and columns"
-            (is (= {:updated [{:id 1, :name "Pidgey", :song "Join us now and share the software"}
-                              {:id 2, :name "Speacolumn", :song "Hold music"}]}
-                   (mt/user-http-request :crowberto :put 200 url
-                                         {:rows [{:id 1 :song "Join us now and share the software"}
-                                                 {:id 2 :name "Speacolumn"}]})))
+        (testing "PUT should update the relevant rows and columns"
+          (is (= {:updated [{:id 1, :name "Pidgey", :song "Join us now and share the software"}
+                            {:id 2, :name "Speacolumn", :song "Hold music"}]}
+                 (mt/user-http-request :crowberto :put 200 url
+                                       {:rows [{:id 1 :song "Join us now and share the software"}
+                                               {:id 2 :name "Speacolumn"}]})))
 
-            (is (= [[1 "Pidgey"     "Join us now and share the software"]
-                    [2 "Speacolumn" "Hold music"]
-                    [3 "Farfetch'd" "The land of lisp"]]
-                   (table-rows table-id))))
+          (is (= [[1 "Pidgey" "Join us now and share the software"]
+                  [2 "Speacolumn" "Hold music"]
+                  [3 "Farfetch'd" "The land of lisp"]]
+                 (table-rows table-id))))
 
-          (testing "DELETE should remove the corresponding rows"
-            (is (= {:success true}
-                   (mt/user-http-request :crowberto :post 200 (str url "/delete")
-                                         {:rows [{:id 1}
-                                                 {:id 2}]})))
-            (is (= [[3 "Farfetch'd" "The land of lisp"]]
-                   (table-rows table-id)))))))))
+        (testing "DELETE should remove the corresponding rows"
+          (is (= {:success true}
+                 (mt/user-http-request :crowberto :post 200 (str url "/delete")
+                                       {:rows [{:id 1}
+                                               {:id 2}]})))
+          (is (= [[3 "Farfetch'd" "The land of lisp"]]
+                 (table-rows table-id))))))))
 
 (deftest editing-allowed-test
   (mt/with-premium-features #{:table-data-editing}
@@ -237,7 +233,7 @@
 (deftest coercion-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/with-empty-h2-app-db
-      (toggle-data-editing-enabled! true)
+      (data-editing.tu/toggle-data-editing-enabled! true)
       (let [user :crowberto
             req mt/user-http-request
             create!
@@ -391,7 +387,7 @@
 (deftest webhook-ingest-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/with-empty-h2-app-db
-      (toggle-data-editing-enabled! true)
+      (data-editing.tu/toggle-data-editing-enabled! true)
       (with-open [test-table (data-editing.tu/open-test-table!
                               {:id [:int]
                                :v [:text]}
@@ -440,12 +436,12 @@
             (is (= 400 (status token [{:id 1, :not_a_column "a"}]))))
           (testing "data editing disabled"
             (try
-              (toggle-data-editing-enabled! false)
+              (data-editing.tu/toggle-data-editing-enabled! false)
               (is (= 400 (status token [{:id 4, :v "d"}])))
-              (toggle-data-editing-enabled! true)
+              (data-editing.tu/toggle-data-editing-enabled! true)
               (is (= {:created 1} (result token [{:id 4, :v "d"}])))
               (finally
-                (toggle-data-editing-enabled! true))))
+                (data-editing.tu/toggle-data-editing-enabled! true))))
           (testing "token deleted"
             (delete token)
             (is (= 404 (status token [{:id 5, :v "e"}])))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
@@ -32,6 +32,9 @@
   [table-id]
   (format "ee/data-editing/table/%d" table-id))
 
+(defn toggle-data-editing-enabled! [on-or-off]
+  (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing (boolean on-or-off)}}))
+
 (defn open-test-table!
   "Sets up an anonymous table in the appdb. Return a box that can be deref'd for the table-id.
 

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -49,17 +49,18 @@
 
           (is (undo/has-undo? true user-id table-id))
           (is (not (undo/has-undo? false user-id table-id)))
-          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "orc"}]
+          (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
                  (undo/undo! user-id table-id)))
 
           (is (undo/has-undo? true user-id table-id))
           (is (undo/has-undo? false user-id table-id))
-          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "pork"}]
+          (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
                  (undo/undo! user-id table-id)))
 
           (is (undo/has-undo? true user-id table-id))
           (is (undo/has-undo? false user-id table-id))
-          (is (= [nil]
+          ;; This doesn't tell the FE which rows to hide
+          (is (= {table-id [[:delete {:id 1}]]}
                  (undo/undo! user-id table-id)))
 
           (is (not (undo/has-undo? true user-id table-id)))
@@ -71,17 +72,17 @@
 
           (is (not (undo/has-undo? true user-id table-id)))
           (is (undo/has-undo? false user-id table-id))
-          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "pork"}]
+          (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
                  (undo/redo! user-id table-id)))
 
           (is (undo/has-undo? true user-id table-id))
           (is (undo/has-undo? false user-id table-id))
-          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "orc"}]
+          (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
                  (undo/redo! user-id table-id)))
 
           (is (undo/has-undo? true user-id table-id))
           (is (undo/has-undo? false user-id table-id))
-          (is (= [nil]
+          (is (= {table-id [[:delete {:id 1}]]}
                  (undo/redo! user-id table-id)))
 
           (is (undo/has-undo? true user-id table-id))
@@ -100,8 +101,8 @@
                                                                :power [:int]}
                                                               {:primary-key [:id]})]
         (let [table-id @table-ref
-              user-1  (mt/user->id :crowberto)
-              user-2  (mt/user->id :rasta)]
+              user-1   (mt/user->id :crowberto)
+              user-2   (mt/user->id :rasta)]
           (data-editing.tu/toggle-data-editing-enabled! true)
 
           ;; NOTE: this test relies on the "conflicts even when different columns changed" semantics
@@ -121,7 +122,7 @@
 
           (is (undo/has-undo? true user-1 table-id))
           (is (not (undo/has-undo? false user-1 table-id)))
-          (is (= [{:id 2, :name "Moominswole", :power 9001}]
+          (is (= {table-id [[:create {:id 2, :name "Moominswole", :power 9001}]]}
                  (undo/undo! user-1 table-id)))
 
           (is (undo/has-undo? true user-1 table-id))
@@ -135,17 +136,17 @@
           (is (undo/has-undo? false user-1 table-id))
           (is (undo/has-undo? true user-2 table-id))
           (is (not (undo/has-undo? false user-2 table-id)))
-          (is (= [{:id 2, :name "Moomintroll", :power 9001}]
+          (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
                  (undo/undo! user-2 table-id)))
 
           (is (undo/has-undo? true user-1 table-id))
           (is (undo/has-undo? false user-1 table-id))
-          (is (= [{:id 2, :name "Moomintroll", :power 3}]
+          (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 3}]]}
                  (undo/undo! user-1 table-id)))
 
           (is (undo/has-undo? true user-1 table-id))
           (is (undo/has-undo? false user-1 table-id))
-          (is (= [nil]
+          (is (= {table-id [[:delete {:id 2}]]}
                  (undo/undo! user-1 table-id)))
 
           (is (not (undo/has-undo? true user-1 table-id)))
@@ -157,22 +158,22 @@
 
           (is (not (undo/has-undo? true user-1 table-id)))
           (is (undo/has-undo? false user-1 table-id))
-          (is (= [{:id 2, :name "Moomintroll", :power 3}]
+          (is (= {table-id [[:create {:id 2, :name "Moomintroll", :power 3}]]}
                  (undo/redo! user-1 table-id)))
 
           (is (undo/has-undo? true user-1 table-id))
           (is (undo/has-undo? false user-1 table-id))
-          (is (= [{:id 2, :name "Moomintroll", :power 9001}]
+          (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
                  (undo/redo! user-1 table-id)))
 
           (is (undo/has-undo? true user-1 table-id))
           (is (undo/has-undo? false user-1 table-id))
-          (is (= [{:id 2, :name "Moominswole", :power 9001}]
+          (is (= {table-id [[:update {:id 2, :name "Moominswole", :power 9001}]]}
                  (undo/redo! user-2 table-id)))
 
           (is (undo/has-undo? true user-1 table-id))
           (is (undo/has-undo? false user-1 table-id))
-          (is (= [nil]
+          (is (= {table-id [[:delete {:id 2}]]}
                  (undo/redo! user-1 table-id)))
 
           (is (undo/has-undo? true user-1 table-id))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -25,10 +25,13 @@
          states states]
     (when (seq states)
       (let [[user-id value] (first states)]
-        (#'undo/track-change! user-id {table-id {pk [prior value]}})
+        (undo/track-change! user-id {table-id {pk [prior value]}})
         (recur value (rest states))))))
 
-(deftest undo-redo-integration-test
+;; I'm OK reducing this scenario's scope once we have e2e tests.
+;; Until then, I think this is ideal.
+#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
+(deftest undo-redo-single-user-single-table-single-record-integration-test
   (mt/with-premium-features #{:table-data-editing}
     (testing "Single-user chain, non-generated pk"
       ;; TODO test with a real PK
@@ -93,8 +96,13 @@
                (undo/redo! user-id table-id)))
 
           (is (undo/has-undo? true user-id table-id))
-          (is (not (undo/has-undo? false user-id table-id))))))
+          (is (not (undo/has-undo? false user-id table-id))))))))
 
+;; I'm OK reducing this scenario's scope once we have e2e tests.
+;; Until then, I think this is ideal.
+#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
+(deftest undo-redo-multi-user-single-table-single-record-integration-test
+  (mt/with-premium-features #{:table-data-editing}
     (testing "Multi-user chain"
       (with-open [table-ref (data-editing.tu/open-test-table! {:id    [:int]
                                                                :name  [:text]

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -1,0 +1,193 @@
+(ns metabase-enterprise.data-editing.undo-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.data-editing.test-util :as data-editing.tu]
+   [metabase-enterprise.data-editing.undo :as undo]
+   [metabase.test :as mt])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+(deftest diff-keys-test
+  (testing "Detect which keys have changes"
+    (is (= [:a :b :c] (#'undo/diff-keys
+                       nil
+                       (zipmap [:a :b :c] (range)))))
+    (is (= [:a :b :c] (#'undo/diff-keys
+                       (zipmap [:a :b :c] (range))
+                       nil)))
+    (is (= [:b :c :d] (#'undo/diff-keys
+                       (zipmap [:a :b :c] (range))
+                       (zipmap [:a :c :d] (range)))))))
+
+;; TODO use actual mutations to create the history (TODO subscribe to the relevant events)
+(defn- write-sequence! [table-id pk states]
+  (loop [prior  nil
+         states states]
+    (when (seq states)
+      (let [[user-id value] (first states)]
+        (#'undo/track-change! user-id {table-id {pk [prior value]}})
+        (recur value (rest states))))))
+
+(deftest undo-redo-integration-test
+  (mt/with-premium-features #{:table-data-editing}
+    (testing "Single-user chain, non-generated pk"
+      ;; TODO test with a real PK
+      ;; Beware: h2 will not allow un-delete, we'll need to adjust the test not to include deletion in its history.
+      ;;         and, we'll want to test the failure we get when we try to un-delete
+      ;; Blocker for other drivers: https://linear.app/metabase/issue/WRK-223/pk-creation-for-non-h2-drivers
+      (with-open [table-ref (data-editing.tu/open-test-table! {:id             [:int]
+                                                               :name           [:text]
+                                                               :favourite_food [:text]}
+                                                              {:primary-key [:id]})]
+        (let [table-id @table-ref
+              user-id  (mt/user->id :crowberto)]
+          (data-editing.tu/toggle-data-editing-enabled! true)
+
+          (write-sequence! table-id {:id 1} [[user-id {:name "Snorkmaiden" :favourite_food "pork"}]
+                                             [user-id {:name "Snorkmaiden" :favourite_food "orc"}]
+                                             [user-id nil]])
+
+          (is (undo/has-undo? true user-id table-id))
+          (is (not (undo/has-undo? false user-id table-id)))
+          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "orc"}]
+                 (undo/undo! user-id table-id)))
+
+          (is (undo/has-undo? true user-id table-id))
+          (is (undo/has-undo? false user-id table-id))
+          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "pork"}]
+                 (undo/undo! user-id table-id)))
+
+          (is (undo/has-undo? true user-id table-id))
+          (is (undo/has-undo? false user-id table-id))
+          (is (= [nil]
+                 (undo/undo! user-id table-id)))
+
+          (is (not (undo/has-undo? true user-id table-id)))
+          (is (undo/has-undo? false user-id table-id))
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"No previous versions found"
+               (undo/undo! user-id table-id)))
+
+          (is (not (undo/has-undo? true user-id table-id)))
+          (is (undo/has-undo? false user-id table-id))
+          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "pork"}]
+                 (undo/redo! user-id table-id)))
+
+          (is (undo/has-undo? true user-id table-id))
+          (is (undo/has-undo? false user-id table-id))
+          (is (= [{:id 1, :name "Snorkmaiden", :favourite_food "orc"}]
+                 (undo/redo! user-id table-id)))
+
+          (is (undo/has-undo? true user-id table-id))
+          (is (undo/has-undo? false user-id table-id))
+          (is (= [nil]
+                 (undo/redo! user-id table-id)))
+
+          (is (undo/has-undo? true user-id table-id))
+          (is (not (undo/has-undo? false user-id table-id)))
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"No subsequent versions found"
+               (undo/redo! user-id table-id)))
+
+          (is (undo/has-undo? true user-id table-id))
+          (is (not (undo/has-undo? false user-id table-id))))))
+
+    (testing "Multi-user chain"
+      (with-open [table-ref (data-editing.tu/open-test-table! {:id    [:int]
+                                                               :name  [:text]
+                                                               :power [:int]}
+                                                              {:primary-key [:id]})]
+        (let [table-id @table-ref
+              user-1  (mt/user->id :crowberto)
+              user-2  (mt/user->id :rasta)]
+          (data-editing.tu/toggle-data-editing-enabled! true)
+
+          ;; NOTE: this test relies on the "conflicts even when different columns changed" semantics
+          ;; If we improve the semantics, we'll need to improve this test!
+
+          (write-sequence! table-id {:id 2} [[user-1 {:name "Moomintroll" :power 3}]
+                                             [user-1 {:name "Moomintroll" :power 9001}]
+                                             [user-2 {:name "Moominswole" :power 9001}]
+                                             [user-1 nil]])
+
+          (is (undo/has-undo? true user-2 table-id))
+          (is (not (undo/has-undo? false user-2 table-id)))
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"Blocked by other changes"
+               (undo/undo! user-2 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (not (undo/has-undo? false user-1 table-id)))
+          (is (= [{:id 2, :name "Moominswole", :power 9001}]
+                 (undo/undo! user-1 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"Blocked by other changes"
+               (undo/undo! user-1 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (undo/has-undo? true user-2 table-id))
+          (is (not (undo/has-undo? false user-2 table-id)))
+          (is (= [{:id 2, :name "Moomintroll", :power 9001}]
+                 (undo/undo! user-2 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (= [{:id 2, :name "Moomintroll", :power 3}]
+                 (undo/undo! user-1 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (= [nil]
+                 (undo/undo! user-1 table-id)))
+
+          (is (not (undo/has-undo? true user-1 table-id)))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"No previous versions found"
+               (undo/undo! user-1 table-id)))
+
+          (is (not (undo/has-undo? true user-1 table-id)))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (= [{:id 2, :name "Moomintroll", :power 3}]
+                 (undo/redo! user-1 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (= [{:id 2, :name "Moomintroll", :power 9001}]
+                 (undo/redo! user-1 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (= [{:id 2, :name "Moominswole", :power 9001}]
+                 (undo/redo! user-2 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (undo/has-undo? false user-1 table-id))
+          (is (= [nil]
+                 (undo/redo! user-1 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (not (undo/has-undo? false user-1 table-id)))
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"No subsequent versions found"
+               (undo/redo! user-1 table-id)))
+
+          (is (undo/has-undo? true user-2 table-id))
+          (is (not (undo/has-undo? false user-2 table-id)))
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"No subsequent versions found"
+               (undo/redo! user-2 table-id)))
+
+          (is (undo/has-undo? true user-1 table-id))
+          (is (not (undo/has-undo? false user-1 table-id))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -40,189 +40,191 @@
 ;; Until then, I think this is ideal.
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest undo-redo-single-user-single-table-single-record-integration-test
-  (mt/with-premium-features #{:table-data-editing}
-    (testing "Single-user chain, non-generated pk"
-      ;; TODO test with a real PK
-      ;; Beware: h2 will not allow un-delete, we'll need to adjust the test not to include deletion in its history.
-      ;;         and, we'll want to test the failure we get when we try to un-delete
-      ;; Blocker for other drivers: https://linear.app/metabase/issue/WRK-223/pk-creation-for-non-h2-drivers
-      (with-open [table-ref (data-editing.tu/open-test-table! {:id             [:int]
-                                                               :name           [:text]
-                                                               :favourite_food [:text]}
-                                                              {:primary-key [:id]})]
-        (let [table-id @table-ref
-              user-id  (mt/user->id :crowberto)]
-          (data-editing.tu/toggle-data-editing-enabled! true)
+  (mt/with-empty-h2-app-db
+    (mt/with-premium-features #{:table-data-editing}
+      (testing "Single-user chain, non-generated pk"
+        ;; TODO test with a real PK
+        ;; Beware: h2 will not allow un-delete, we'll need to adjust the test not to include deletion in its history.
+        ;;         and, we'll want to test the failure we get when we try to un-delete
+        ;; Blocker for other drivers: https://linear.app/metabase/issue/WRK-223/pk-creation-for-non-h2-drivers
+        (with-open [table-ref (data-editing.tu/open-test-table! {:id             [:int]
+                                                                 :name           [:text]
+                                                                 :favourite_food [:text]}
+                                                                {:primary-key [:id]})]
+          (let [table-id @table-ref
+                user-id  (mt/user->id :crowberto)]
+            (data-editing.tu/toggle-data-editing-enabled! true)
 
-          (write-sequence! table-id {:id 1} [[user-id {:name "Snorkmaiden" :favourite_food "pork"}]
-                                             [user-id {:name "Snorkmaiden" :favourite_food "orc"}]
-                                             [user-id nil]])
+            (write-sequence! table-id {:id 1} [[user-id {:name "Snorkmaiden" :favourite_food "pork"}]
+                                               [user-id {:name "Snorkmaiden" :favourite_food "orc"}]
+                                               [user-id nil]])
 
-          (is (= [] (table-rows table-id)))
+            (is (= [] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-id table-id))
-          (is (not (undo/has-undo? false user-id table-id)))
-          (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
+            (is (undo/has-undo? true user-id table-id))
+            (is (not (undo/has-undo? false user-id table-id)))
+            (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
+                   (undo/undo! user-id table-id)))
+            (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-id table-id))
+            (is (undo/has-undo? false user-id table-id))
+            (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
+                   (undo/undo! user-id table-id)))
+            (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-id table-id))
+            (is (undo/has-undo? false user-id table-id))
+            ;; This doesn't tell the FE which rows to hide
+            (is (= {table-id [[:delete {:id 1}]]}
+                   (undo/undo! user-id table-id)))
+            (is (= [] (table-rows table-id)))
+
+            (is (not (undo/has-undo? true user-id table-id)))
+            (is (undo/has-undo? false user-id table-id))
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"No previous versions found"
                  (undo/undo! user-id table-id)))
-          (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-id table-id))
-          (is (undo/has-undo? false user-id table-id))
-          (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
-                 (undo/undo! user-id table-id)))
-          (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
+            (is (not (undo/has-undo? true user-id table-id)))
+            (is (undo/has-undo? false user-id table-id))
+            (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
+                   (undo/redo! user-id table-id)))
+            (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-id table-id))
-          (is (undo/has-undo? false user-id table-id))
-          ;; This doesn't tell the FE which rows to hide
-          (is (= {table-id [[:delete {:id 1}]]}
-                 (undo/undo! user-id table-id)))
-          (is (= [] (table-rows table-id)))
+            (is (undo/has-undo? true user-id table-id))
+            (is (undo/has-undo? false user-id table-id))
+            (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
+                   (undo/redo! user-id table-id)))
+            (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
 
-          (is (not (undo/has-undo? true user-id table-id)))
-          (is (undo/has-undo? false user-id table-id))
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"No previous versions found"
-               (undo/undo! user-id table-id)))
+            (is (undo/has-undo? true user-id table-id))
+            (is (undo/has-undo? false user-id table-id))
+            (is (= {table-id [[:delete {:id 1}]]}
+                   (undo/redo! user-id table-id)))
+            (is (= [] (table-rows table-id)))
 
-          (is (not (undo/has-undo? true user-id table-id)))
-          (is (undo/has-undo? false user-id table-id))
-          (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
+            (is (undo/has-undo? true user-id table-id))
+            (is (not (undo/has-undo? false user-id table-id)))
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"No subsequent versions found"
                  (undo/redo! user-id table-id)))
-          (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-id table-id))
-          (is (undo/has-undo? false user-id table-id))
-          (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
-                 (undo/redo! user-id table-id)))
-          (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
-
-          (is (undo/has-undo? true user-id table-id))
-          (is (undo/has-undo? false user-id table-id))
-          (is (= {table-id [[:delete {:id 1}]]}
-                 (undo/redo! user-id table-id)))
-          (is (= [] (table-rows table-id)))
-
-          (is (undo/has-undo? true user-id table-id))
-          (is (not (undo/has-undo? false user-id table-id)))
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"No subsequent versions found"
-               (undo/redo! user-id table-id)))
-
-          (is (undo/has-undo? true user-id table-id))
-          (is (not (undo/has-undo? false user-id table-id))))))))
+            (is (undo/has-undo? true user-id table-id))
+            (is (not (undo/has-undo? false user-id table-id)))))))))
 
 ;; I'm OK reducing this scenario's scope once we have e2e tests.
 ;; Until then, I think this is ideal.
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest undo-redo-multi-user-single-table-single-record-integration-test
-  (mt/with-premium-features #{:table-data-editing}
-    (testing "Multi-user chain"
-      (with-open [table-ref (data-editing.tu/open-test-table! {:id    [:int]
-                                                               :name  [:text]
-                                                               :power [:int]}
-                                                              {:primary-key [:id]})]
-        (let [table-id @table-ref
-              user-1   (mt/user->id :crowberto)
-              user-2   (mt/user->id :rasta)]
-          (data-editing.tu/toggle-data-editing-enabled! true)
+  (mt/with-empty-h2-app-db
+    (mt/with-premium-features #{:table-data-editing}
+      (testing "Multi-user chain"
+        (with-open [table-ref (data-editing.tu/open-test-table! {:id    [:int]
+                                                                 :name  [:text]
+                                                                 :power [:int]}
+                                                                {:primary-key [:id]})]
+          (let [table-id @table-ref
+                user-1   (mt/user->id :crowberto)
+                user-2   (mt/user->id :rasta)]
+            (data-editing.tu/toggle-data-editing-enabled! true)
 
-          ;; NOTE: this test relies on the "conflicts even when different columns changed" semantics
-          ;; If we improve the semantics, we'll need to improve this test!
+            ;; NOTE: this test relies on the "conflicts even when different columns changed" semantics
+            ;; If we improve the semantics, we'll need to improve this test!
 
-          (write-sequence! table-id {:id 2} [[user-1 {:name "Moomintroll" :power 3}]
-                                             [user-1 {:name "Moomintroll" :power 9001}]
-                                             [user-2 {:name "Moominswole" :power 9001}]
-                                             [user-1 nil]])
+            (write-sequence! table-id {:id 2} [[user-1 {:name "Moomintroll" :power 3}]
+                                               [user-1 {:name "Moomintroll" :power 9001}]
+                                               [user-2 {:name "Moominswole" :power 9001}]
+                                               [user-1 nil]])
 
-          (is (= [] (table-rows table-id)))
+            (is (= [] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-2 table-id))
-          (is (not (undo/has-undo? false user-2 table-id)))
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"Blocked by other changes"
-               (undo/undo! user-2 table-id)))
-
-          (is (undo/has-undo? true user-1 table-id))
-          (is (not (undo/has-undo? false user-1 table-id)))
-          (is (= {table-id [[:create {:id 2, :name "Moominswole", :power 9001}]]}
-                 (undo/undo! user-1 table-id)))
-          (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
-
-          (is (undo/has-undo? true user-1 table-id))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"Blocked by other changes"
-               (undo/undo! user-1 table-id)))
-
-          (is (undo/has-undo? true user-1 table-id))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (undo/has-undo? true user-2 table-id))
-          (is (not (undo/has-undo? false user-2 table-id)))
-          (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
+            (is (undo/has-undo? true user-2 table-id))
+            (is (not (undo/has-undo? false user-2 table-id)))
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"Blocked by other changes"
                  (undo/undo! user-2 table-id)))
-          (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-1 table-id))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 3}]]}
+            (is (undo/has-undo? true user-1 table-id))
+            (is (not (undo/has-undo? false user-1 table-id)))
+            (is (= {table-id [[:create {:id 2, :name "Moominswole", :power 9001}]]}
+                   (undo/undo! user-1 table-id)))
+            (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-1 table-id))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"Blocked by other changes"
                  (undo/undo! user-1 table-id)))
-          (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-1 table-id))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (= {table-id [[:delete {:id 2}]]}
+            (is (undo/has-undo? true user-1 table-id))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (undo/has-undo? true user-2 table-id))
+            (is (not (undo/has-undo? false user-2 table-id)))
+            (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
+                   (undo/undo! user-2 table-id)))
+            (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-1 table-id))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 3}]]}
+                   (undo/undo! user-1 table-id)))
+            (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-1 table-id))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (= {table-id [[:delete {:id 2}]]}
+                   (undo/undo! user-1 table-id)))
+            (is (= [] (table-rows table-id)))
+
+            (is (not (undo/has-undo? true user-1 table-id)))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"No previous versions found"
                  (undo/undo! user-1 table-id)))
-          (is (= [] (table-rows table-id)))
 
-          (is (not (undo/has-undo? true user-1 table-id)))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"No previous versions found"
-               (undo/undo! user-1 table-id)))
+            (is (not (undo/has-undo? true user-1 table-id)))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (= {table-id [[:create {:id 2, :name "Moomintroll", :power 3}]]}
+                   (undo/redo! user-1 table-id)))
+            (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
 
-          (is (not (undo/has-undo? true user-1 table-id)))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (= {table-id [[:create {:id 2, :name "Moomintroll", :power 3}]]}
+            (is (undo/has-undo? true user-1 table-id))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
+                   (undo/redo! user-1 table-id)))
+            (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-1 table-id))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (= {table-id [[:update {:id 2, :name "Moominswole", :power 9001}]]}
+                   (undo/redo! user-2 table-id)))
+            (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-1 table-id))
+            (is (undo/has-undo? false user-1 table-id))
+            (is (= {table-id [[:delete {:id 2}]]}
+                   (undo/redo! user-1 table-id)))
+            (is (= [] (table-rows table-id)))
+
+            (is (undo/has-undo? true user-1 table-id))
+            (is (not (undo/has-undo? false user-1 table-id)))
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"No subsequent versions found"
                  (undo/redo! user-1 table-id)))
-          (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-1 table-id))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
-                 (undo/redo! user-1 table-id)))
-          (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
-
-          (is (undo/has-undo? true user-1 table-id))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (= {table-id [[:update {:id 2, :name "Moominswole", :power 9001}]]}
+            (is (undo/has-undo? true user-2 table-id))
+            (is (not (undo/has-undo? false user-2 table-id)))
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"No subsequent versions found"
                  (undo/redo! user-2 table-id)))
-          (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
 
-          (is (undo/has-undo? true user-1 table-id))
-          (is (undo/has-undo? false user-1 table-id))
-          (is (= {table-id [[:delete {:id 2}]]}
-                 (undo/redo! user-1 table-id)))
-          (is (= [] (table-rows table-id)))
-
-          (is (undo/has-undo? true user-1 table-id))
-          (is (not (undo/has-undo? false user-1 table-id)))
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"No subsequent versions found"
-               (undo/redo! user-1 table-id)))
-
-          (is (undo/has-undo? true user-2 table-id))
-          (is (not (undo/has-undo? false user-2 table-id)))
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"No subsequent versions found"
-               (undo/redo! user-2 table-id)))
-
-          (is (undo/has-undo? true user-1 table-id))
-          (is (not (undo/has-undo? false user-1 table-id))))))))
+            (is (undo/has-undo? true user-1 table-id))
+            (is (not (undo/has-undo? false user-1 table-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -81,6 +81,7 @@
     :model/TablePrivileges
     :model/TaskHistory
     :model/TimelineEvent
+    :model/Undo
     :model/User
     :model/UserParameterValue
     :model/UserKeyValue

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10990,24 +10990,24 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
-#  - changeSet:
-#      id: v54.2025-03-19T16:01:10
-#      author: qnkhuat
-#      comment: add fk constraint to notification_subscription.table_id
-#      preConditions:
-#        - not:
-#          - foreignKeyConstraintExists:
-#              foreignKeyName: fk_notification_subscription_table_id
-#              foreignKeyTableName: notification_subscription
-#      changes:
-#        - addForeignKeyConstraint:
-#            baseTableName: notification_subscription
-#            baseColumnNames: table_id
-#            referencedTableName: metabase_table
-#            referencedColumnNames: id
-#            constraintName: fk_notification_subscription_table_id
-#            onDelete: CASCADE
-#            nullable: true
+  - changeSet:
+      id: v54.2025-03-19T16:01:10
+      author: qnkhuat
+      comment: add fk constraint to notification_subscription.table_id
+      preConditions:
+        - not:
+          - foreignKeyConstraintExists:
+              foreignKeyName: fk_notification_subscription_table_id
+              foreignKeyTableName: notification_subscription
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: notification_subscription
+            baseColumnNames: table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            constraintName: fk_notification_subscription_table_id
+            onDelete: CASCADE
+            nullable: true
 
   - changeSet:
       id: v54.2025-03-19T16:02:00

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11234,84 +11234,83 @@ databaseChangeLog:
                   name: creator_id
 
   - changeSet:
-    id: v55.2025-04-01T16:36:36
-    author: crisptrutski
-    comment: Added undo/redo change tracking table
-    changes:
-      - createTable:
-          tableName: data_edit_undo_chain
-          remarks: Store the state necessary to power undo / redo.
-          columns:
-            - column:
-                name: id
-                type: int
-                autoIncrement: true
-                constraints:
-                  primaryKey: true
-                  nullable: false
-            - column:
-                remarks: Batch number for grouped changes (global increment)
-                name: change_num
-                type: int
-                constraints:
-                  nullable: false
-            - column:
-                remarks: Reference to the table being modified
-                name: table_id
-                type: int
-                constraints:
-                  nullable: false
-            - column:
-                remarks: PK of the row being modified, potentially composite. Stored as a sorted JSON map.
-                name: row_pk
-                type: ${text.type}
-                constraints:
-                  nullable: false
-            - column:
-                remarks: Reference to the field being modified
-                name: field_id
-                type: int
-                constraints:
-                  nullable: false
-            - column:
-                remarks: ID of the user who made the change
-                name: user_id
-                type: int
-                constraints:
-                  nullable: false
-            - column:
-                remarks: Value of the field before the change
-                name: raw_value_before
-                type: ${text.type}
-                constraints:
-                  nullable: true
-            - column:
-                remarks: Value of the field after the change
-                name: raw_value_after
-                type: ${text.type}
-                constraints:
-                  nullable: true
-            - column:
-                remarks: Whether this change has been undone
-                name: undone
-                type: boolean
-                defaultValueBoolean: false
-                constraints:
-                  nullable: false
-            - column:
-                remarks: The timestamp of when the change was created
-                name: created_at
-                type: ${timestamp_type}
-                defaultValueComputed: current_timestamp
-                constraints:
-                  nullable: false
-            - column:
-                remarks: The timestamp of when the change was updated
-                name: updated_at
-                type: ${timestamp_type}
-                defaultValueComputed: current_timestamp
-                constraints:
-                  nullable: false
+      id: v55.2025-04-03T10:52:01
+      author: crisptrutski
+      comment: Added undo/redo change tracking table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: data_edit_undo_chain
+      changes:
+        - createTable:
+            tableName: data_edit_undo_chain
+            remarks: Store the state necessary to power undo / redo.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  remarks: Batch number for grouped changes (global increment)
+                  name: batch_num
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Reference to the table being modified
+                  name: table_id
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: PK of the row being modified, potentially composite. Stored as a sorted JSON map.
+                  name: row_pk
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: ID of the user who made the change
+                  name: user_id
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Value of the field before the change
+                  name: raw_before
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+              - column:
+                  remarks: Value of the field after the change
+                  name: raw_after
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+              - column:
+                  remarks: Whether this change has been undone
+                  name: undone
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the change was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the change was updated
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
 # TODO create fk constraints
 # TODO use case indexes
 #        - createIndex:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10990,24 +10990,24 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
-  - changeSet:
-      id: v54.2025-03-19T16:01:10
-      author: qnkhuat
-      comment: add fk constraint to notification_subscription.table_id
-      preConditions:
-        - not:
-          - foreignKeyConstraintExists:
-              foreignKeyName: fk_notification_subscription_table_id
-              foreignKeyTableName: notification_subscription
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: notification_subscription
-            baseColumnNames: table_id
-            referencedTableName: metabase_table
-            referencedColumnNames: id
-            constraintName: fk_notification_subscription_table_id
-            onDelete: CASCADE
-            nullable: true
+#  - changeSet:
+#      id: v54.2025-03-19T16:01:10
+#      author: qnkhuat
+#      comment: add fk constraint to notification_subscription.table_id
+#      preConditions:
+#        - not:
+#          - foreignKeyConstraintExists:
+#              foreignKeyName: fk_notification_subscription_table_id
+#              foreignKeyTableName: notification_subscription
+#      changes:
+#        - addForeignKeyConstraint:
+#            baseTableName: notification_subscription
+#            baseColumnNames: table_id
+#            referencedTableName: metabase_table
+#            referencedColumnNames: id
+#            constraintName: fk_notification_subscription_table_id
+#            onDelete: CASCADE
+#            nullable: true
 
   - changeSet:
       id: v54.2025-03-19T16:02:00

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11318,31 +11318,13 @@ databaseChangeLog:
 #            tableName: data_edit_undo_chain
 #            columns:
 #              - column:
+#                  name: batch_num
+#              - column:
 #                  name: table_id
 #              - column:
 #                  name: user_id
 #              - column:
-#                  name: change_num
-#              - column:
 #                  name: undone
-#        - createIndex:
-#            indexName: idx_data_edit_undo_chain_conflict_detection
-#            tableName: data_edit_undo_chain
-#            columns:
-#              - column:
-#                  name: table_id
-#              - column:
-#                  name: row_id
-#              - column:
-#                  name: field_id
-#              - column:
-#                  name: change_num
-#        - createIndex:
-#            indexName: idx_data_edit_undo_chain_batch_cleanup
-#            tableName: data_edit_undo_chain
-#            columns:
-#              - column:
-#                  name: change_num
 
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11233,6 +11233,118 @@ databaseChangeLog:
               - column:
                   name: creator_id
 
+  - changeSet:
+    id: v55.2025-04-01T16:36:36
+    author: crisptrutski
+    comment: Added undo/redo change tracking table
+    changes:
+      - createTable:
+          tableName: data_edit_undo_chain
+          remarks: Store the state necessary to power undo / redo.
+          columns:
+            - column:
+                name: id
+                type: int
+                autoIncrement: true
+                constraints:
+                  primaryKey: true
+                  nullable: false
+            - column:
+                remarks: Batch number for grouped changes (global increment)
+                name: change_num
+                type: int
+                constraints:
+                  nullable: false
+            - column:
+                remarks: Reference to the table being modified
+                name: table_id
+                type: int
+                constraints:
+                  nullable: false
+            - column:
+                remarks: PK of the row being modified, potentially composite. Stored as a sorted JSON map.
+                name: row_pk
+                type: ${text.type}
+                constraints:
+                  nullable: false
+            - column:
+                remarks: Reference to the field being modified
+                name: field_id
+                type: int
+                constraints:
+                  nullable: false
+            - column:
+                remarks: ID of the user who made the change
+                name: user_id
+                type: int
+                constraints:
+                  nullable: false
+            - column:
+                remarks: Value of the field before the change
+                name: raw_value_before
+                type: ${text.type}
+                constraints:
+                  nullable: true
+            - column:
+                remarks: Value of the field after the change
+                name: raw_value_after
+                type: ${text.type}
+                constraints:
+                  nullable: true
+            - column:
+                remarks: Whether this change has been undone
+                name: undone
+                type: boolean
+                defaultValueBoolean: false
+                constraints:
+                  nullable: false
+            - column:
+                remarks: The timestamp of when the change was created
+                name: created_at
+                type: ${timestamp_type}
+                defaultValueComputed: current_timestamp
+                constraints:
+                  nullable: false
+            - column:
+                remarks: The timestamp of when the change was updated
+                name: updated_at
+                type: ${timestamp_type}
+                defaultValueComputed: current_timestamp
+                constraints:
+                  nullable: false
+# TODO create fk constraints
+# TODO use case indexes
+#        - createIndex:
+#            indexName: idx_data_edit_undo_chain_undo_lookup
+#            tableName: data_edit_undo_chain
+#            columns:
+#              - column:
+#                  name: table_id
+#              - column:
+#                  name: user_id
+#              - column:
+#                  name: change_num
+#              - column:
+#                  name: undone
+#        - createIndex:
+#            indexName: idx_data_edit_undo_chain_conflict_detection
+#            tableName: data_edit_undo_chain
+#            columns:
+#              - column:
+#                  name: table_id
+#              - column:
+#                  name: row_id
+#              - column:
+#                  name: field_id
+#              - column:
+#                  name: change_num
+#        - createIndex:
+#            indexName: idx_data_edit_undo_chain_batch_cleanup
+#            tableName: data_edit_undo_chain
+#            columns:
+#              - column:
+#                  name: change_num
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -82,6 +82,7 @@
     :model/TaskHistory                       metabase.models.task-history
     :model/Timeline                          metabase.timeline.models.timeline
     :model/TimelineEvent                     metabase.timeline.models.timeline-event
+    :model/Undo                              metabase-enterprise.data-editing.undo
     :model/User                              metabase.models.user
     :model/UserKeyValue                      metabase.user-key-value.models.user-key-value
     :model/UserParameterValue                metabase.models.user-parameter-value

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -41,6 +41,7 @@
     :model/QueryTable
     :model/SearchIndexMetadata
     :model/TaskHistory
+    :model/Undo
     :model/UserKeyValue})
 
 (defn- all-model-names []


### PR DESCRIPTION
Closes WRK-224

Does not include wiring:

1. To create these undo snapshots when we edit tables.
2. To expose "undo" and "redo" via the API.

It also does not include any pruning:

1. When snapshots get "orphaned" (after we undo them, other changes are made)
2. We have too many snapshots in general
3. We have too many snapshots for the user
4. We have too many snapshots for the table