### PR TITLE
Deploy SDK with Metabot

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -15,6 +15,7 @@ on:
           - release-x.52.x
           - release-x.53.x
           - release-x.54.x
+          - metabot-v3-main
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -391,7 +392,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "metabot-v3-main": "55-metabot"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.54.x`) deployment
         if: ${{ inputs.branch == 'release-x.54.x' }}


### PR DESCRIPTION
> [!note]
> This requires https://github.com/metabase/metabase/pull/56281 to be merged first.

Closes EMB-299
### Backport reason
I don't wanna backport this until we merge `metabot-v3-main` back to `master`. Because this change is probably removed again.

### Description

This modifies the workflow on master because we always deploy from master workflow.

