### PR TITLE
Return just the number of rows created by webhook

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
@@ -22,7 +22,8 @@
         rows     (if (map? row-or-rows) [row-or-rows] row-or-rows)]
     (api/check-400 (seq rows) "Please supply at least one row.")
     (api/check-400 (every? seq rows) "Every row should not be empty.")
-    (data-editing/insert! table-id rows)))
+    (data-editing/insert! table-id rows)
+    {:created (count rows)}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
@@ -23,8 +23,7 @@
     (api/check-400 (seq rows) "Please supply at least one row.")
     (api/check-400 (every? seq rows) "Every row should not be empty.")
     (binding [api/*current-user-id* (:creator_id hook)]
-      (data-editing/insert! (:table_id hook) rows))
-    {:created (count rows)}))
+      {:created (count (:created-rows (data-editing/insert! (:table_id hook) rows)))})))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."


### PR DESCRIPTION
The return value of `insert!` is not ideal:

1. Insecure (e.g. exposing sensitive auto generated columns)
1. Verbose (2x transfer size for huge uploads)
2. Non-extensible (can't add extra fields without a breaking change to add a wrapper)

For now let's be conservative and just return the number of rows created. Returning nothing is a bit too opaque!