### PR TITLE
fix: mock time to middle of a utc day

### DIFF
--- a/test/metabase/internal_stats/query_executions_test.clj
+++ b/test/metabase/internal_stats/query_executions_test.clj
@@ -18,74 +18,76 @@
    :started_at   (t/offset-date-time)})
 
 (deftest query-execution-24h-filtering-test
-  (let [before (sut/query-executions-all-time-and-last-24h)
-        one-year-ago-defaults (assoc query-execution-defaults
-                                     :started_at (-> (t/offset-date-time)
-                                                     (t/minus (t/years 1))))]
-    (mt/with-temp [:model/User           u {}
-                   :model/QueryExecution _ one-year-ago-defaults
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-sdk-react")
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc one-year-ago-defaults
-                                                  :embedding_client "embedding-iframe"
-                                                  :executor_id (u/the-id u))
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-question)
-                   :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-csv-download)
-                   :model/QueryExecution _ query-execution-defaults
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
-                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
-      (let [after (sut/query-executions-all-time-and-last-24h)
-            before-internal (-> before :query-executions :internal)
-            after-internal (-> after :query-executions :internal)
-            before-24h-internal (-> before :query-executions-24h :internal)
-            after-24h-internal (-> after :query-executions-24h :internal)]
-        (is (= 2 (- after-internal before-internal)))
-        (is (= 1 (- after-24h-internal before-24h-internal)))
-        (is (= 2 (- (-> after :query-executions :sdk_embed)
-                    (-> before :query-executions :sdk_embed))))
-        (is (= 4 (- (-> after :query-executions :static_embed)
-                    (-> before :query-executions :static_embed))))
-        (is (= 4 (- (-> after :query-executions :public_link)
-                    (-> before :query-executions :public_link))))
-        (is (= 1 (- (-> after :query-executions :interactive_embed)
-                    (-> before :query-executions :interactive_embed))))
-        (is (= 1 (- (-> after :query-executions-24h :sdk_embed)
-                    (-> before :query-executions-24h :sdk_embed))))
-        (is (= 2 (- (-> after :query-executions-24h :static_embed)
-                    (-> before :query-executions-24h :static_embed))))
-        (is (= 2 (- (-> after :query-executions-24h :public_link)
-                    (-> before :query-executions-24h :public_link))))
-        (is (= 0 (- (-> after :query-executions-24h :interactive_embed)
-                    (-> before :query-executions-24h :interactive_embed))))))))
+  (t/with-clock (t/mock-clock 1583351015000)
+    (let [before (sut/query-executions-all-time-and-last-24h)
+          one-year-ago-defaults (assoc query-execution-defaults
+                                       :started_at (-> (t/offset-date-time)
+                                                       (t/minus (t/years 1))))]
+      (mt/with-temp [:model/User           u {}
+                     :model/QueryExecution _ one-year-ago-defaults
+                     :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-sdk-react")
+                     :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc one-year-ago-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc one-year-ago-defaults
+                                                    :embedding_client "embedding-iframe"
+                                                    :executor_id (u/the-id u))
+                     :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-question)
+                     :model/QueryExecution _ (assoc one-year-ago-defaults :context :public-csv-download)
+                     :model/QueryExecution _ query-execution-defaults
+                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
+                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
+                     :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
+        (let [after (sut/query-executions-all-time-and-last-24h)
+              before-internal (-> before :query-executions :internal)
+              after-internal (-> after :query-executions :internal)
+              before-24h-internal (-> before :query-executions-24h :internal)
+              after-24h-internal (-> after :query-executions-24h :internal)]
+          (is (= 2 (- after-internal before-internal)))
+          (is (= 1 (- after-24h-internal before-24h-internal)))
+          (is (= 2 (- (-> after :query-executions :sdk_embed)
+                      (-> before :query-executions :sdk_embed))))
+          (is (= 4 (- (-> after :query-executions :static_embed)
+                      (-> before :query-executions :static_embed))))
+          (is (= 4 (- (-> after :query-executions :public_link)
+                      (-> before :query-executions :public_link))))
+          (is (= 1 (- (-> after :query-executions :interactive_embed)
+                      (-> before :query-executions :interactive_embed))))
+          (is (= 1 (- (-> after :query-executions-24h :sdk_embed)
+                      (-> before :query-executions-24h :sdk_embed))))
+          (is (= 2 (- (-> after :query-executions-24h :static_embed)
+                      (-> before :query-executions-24h :static_embed))))
+          (is (= 2 (- (-> after :query-executions-24h :public_link)
+                      (-> before :query-executions-24h :public_link))))
+          (is (= 0 (- (-> after :query-executions-24h :interactive_embed)
+                      (-> before :query-executions-24h :interactive_embed)))))))))
 
 (deftest query-execution-last-utc-day-test
   (testing "count query exeuections over the previous utc day")
-  (let [yesterday-defaults (assoc query-execution-defaults
-                                  :started_at (-> (t/offset-date-time (t/zone-offset "+00"))
-                                                  (t/minus (t/days 1))))]
-    (mt/with-temp [:model/User           u {}
-                   :model/QueryExecution _ yesterday-defaults
-                   :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-sdk-react")
-                   :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc yesterday-defaults
-                                                  :embedding_client "embedding-iframe"
-                                                  :executor_id (u/the-id u))
-                   :model/QueryExecution _ (assoc yesterday-defaults :context :public-question)
-                   :model/QueryExecution _ (assoc yesterday-defaults :context :public-csv-download)
-                   :model/QueryExecution _ query-execution-defaults
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
-                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
-                   :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
-      (is (= {:query_executions_sdk_embed 1,
-              :query_executions_interactive_embed 1,
-              :query_executions_static_embed 2,
-              :query_executions_public_link 2,
-              :query_executions_internal 1}
-             (sut/query-execution-last-utc-day))))))
+  (t/with-clock (t/mock-clock 1583351015000)
+    (let [yesterday-defaults (assoc query-execution-defaults
+                                    :started_at (-> (t/offset-date-time (t/zone-offset "+00"))
+                                                    (t/minus (t/days 1))))]
+      (mt/with-temp [:model/User           u {}
+                     :model/QueryExecution _ yesterday-defaults
+                     :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-sdk-react")
+                     :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc yesterday-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc yesterday-defaults
+                                                    :embedding_client "embedding-iframe"
+                                                    :executor_id (u/the-id u))
+                     :model/QueryExecution _ (assoc yesterday-defaults :context :public-question)
+                     :model/QueryExecution _ (assoc yesterday-defaults :context :public-csv-download)
+                     :model/QueryExecution _ query-execution-defaults
+                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-sdk-react")
+                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc query-execution-defaults :embedding_client "embedding-iframe")
+                     :model/QueryExecution _ (assoc query-execution-defaults :context :public-question)
+                     :model/QueryExecution _ (assoc query-execution-defaults :context :public-csv-download)]
+        (is (= {:query_executions_sdk_embed 1,
+                :query_executions_interactive_embed 1,
+                :query_executions_static_embed 2,
+                :query_executions_public_link 2,
+                :query_executions_internal 1}
+               (sut/query-execution-last-utc-day)))))))


### PR DESCRIPTION
### Description

This test was flaking if it was run close to the boundary of a UTC day where the models could be created one day and then the clock ticked over to a new day before the query ran.