### PR TITLE
[temporary] don't require athena tests

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1055,7 +1055,7 @@ jobs:
     needs:
       # if you add a driver job, you must add it to this list for it to be a required check
       - be-tests-h2
-      - be-tests-athena-ee
+      # - be-tests-athena-ee # FIXME
       - be-tests-bigquery-cloud-sdk-ee
       - be-tests-druid-ee
       - be-tests-databricks-ee


### PR DESCRIPTION
## Description	

An athena config change is causing all tests to fail. Make it non-required temporarily