### PR TITLE
indent files with mage from lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -483,7 +483,7 @@
       "prettier --write"
     ],
     "**/*.{clj,cljc,cljs,bb}": [
-      "./bin/cljfmt_staged.sh"
+      "./bin/mage cljfmt-files"
     ],
     "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [
       "node e2e/validate-e2e-test-files.js"


### PR DESCRIPTION
This hook runs via lint-staged which will pass a list of files to scripts in package.json.

So the right command is actually `./bin/mage cljfmt-files` which will get called with any staged files matching `**/*.{clj,cljc,cljs,bb}` and indent them for us.

Thinking about deleting the script itself, but dont want to break any custom workflows using it. Worth revisiting in a few months.