### PR TITLE
Mage jar download finds latest major version

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -92,7 +92,8 @@
 
   jar-download
   {:doc        "Given a version, downloads a metabase jar"
-   :examples   [["./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/path/to/my/metabase/jars"]
+   :examples   [["./bin/mage jar-download 50" "Download the latest enterprise version of release 50 to ~/path/to/my/metabase/jars"]
+                ["./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/path/to/my/metabase/jars"]
                 ["./bin/mage jar-download 1.45.2 ~/path/to/my/jars" "Download metabase_1.45.2.jar to ~/path/to/my/jars"]
                 ["JARS=~/my-stuff ./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/my-stuff"]]
    :requires   [[mage.jar-download :as jar-download]]

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -40,7 +40,9 @@
             match (some #(when (re-matches re-pattern (get % :tag_name)) (get % :tag_name))
                         releases)]
         (cond
-          match (str/replace match #"v" "")
+          match (do
+                  (println (str (c/green "Found latest version of " major-version) ": " (c/cyan match)))
+                  (str/replace match #"v" ""))
           (empty? releases) nil
           :else (recur (inc page)))))))
 

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -2,6 +2,7 @@
   (:require
    [babashka.curl :as curl]
    [babashka.fs :as fs]
+   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.repl :refer [pst]]
    [clojure.string :as str]
@@ -25,22 +26,48 @@
    (:body (curl/get (url version) {:as :stream}))
    (dir->file version dir)))
 
+(defn latest-patch-version [major-version]
+  (let [base-url "https://api.github.com/repos/metabase/metabase/releases"
+        per-page 100
+        re-pattern (re-pattern (str "^v1\\." major-version ".*"))]
+    (loop [page 1]
+      (println (str "Looking for latest version of " major-version " on release page " page))
+      (let [url (str base-url "?page=" page "&per_page=" per-page)
+            releases (json/parse-string
+                      (:body (curl/get url
+                                       {:headers {"Accept" "application/vnd.github.v3+json"}}))
+                      keyword)
+            match (some #(when (re-matches re-pattern (get % :tag_name)) (get % :tag_name))
+                        releases)]
+        (cond
+          match (str/replace match #"v" "")
+          (empty? releases) nil
+          :else (recur (inc page)))))))
+
+(defn find-latest-version [version]
+  (cond
+    (re-matches #"\d+" version) (latest-patch-version version)
+    (re-matches #"\d+\.\d+\.\d+" version) version
+    :else (throw (ex-info (str "Invalid version format:" version)
+                          {:version version}))))
+
 (defn- download-jar! [version dir]
-  (when (fs/delete-if-exists (dir->file version dir))
-    ;; TODO: keep it?
-    (println "Found and deleted old jar."))
-  (when-not (.exists (io/file dir))
-    (println (c/blue "Creating directory " dir " ..."))
-    (fs/create-dirs dir)
-    (println (c/green "Created.\n")))
-  (try
-    (println (str "Downloading from: " (url version)
-                  "\n              to: " (dir->file version dir) " ..."))
-    (download version dir)
-    (println (str "Downloaded " version ".jar to " dir))
-    (catch Exception e
-      (println (str "Error downloading version " version ". Do both the directory and version exist?"))
-      (pst e))))
+  (let [latest-version (find-latest-version version)]
+    (when (fs/delete-if-exists (dir->file latest-version dir))
+      ;; TODO: keep it?
+      (println "Found and deleted old jar."))
+    (when-not (.exists (io/file dir))
+      (println (c/blue "Creating directory " dir " ..."))
+      (fs/create-dirs dir)
+      (println (c/green "Created.\n")))
+    (try
+      (println (str "Downloading from: " (url latest-version)
+                    "\n              to: " (dir->file latest-version dir) " ..."))
+      (download latest-version dir)
+      (println (str "Downloaded " latest-version ".jar to " dir))
+      (catch Exception e
+        (println (str "Error downloading version " latest-version ". Do both the directory and version exist?"))
+        (pst e)))))
 
 (defn- without-slash [s] (str/replace s #"/$" ""))
 


### PR DESCRIPTION
```
$ ./bin/mage jar-download 40
Warning: JARS not found in env.
Looking for latest version of 40 on release page 1
Looking for latest version of 40 on release page 2
Looking for latest version of 40 on release page 3
Looking for latest version of 40 on release page 4
Found latest version of 40: v1.40.8
Downloading from: https://downloads.metabase.com/enterprise/v1.40.8/metabase.jar
              to: /Users/bcm/dv/mb/metabase/jars/metabase_1.40.8.jar ...
```