### PR TITLE
feat: make cluster locking reusable

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -612,7 +612,7 @@
 
   util
   {:api :any
-   :uses #{config driver legacy-mbql lib models plugins premium-features public-settings}}
+   :uses #{config db driver legacy-mbql lib models plugins premium-features public-settings}}
 
   xrays
   {:api  #{metabase.xrays.api metabase.xrays.core}

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -1,69 +1,19 @@
 (ns metabase.query-processor.middleware.update-used-cards
   (:require
    [java-time.api :as t]
-   [metabase.db :as mdb]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
+   [metabase.util.cluster-lock :as cluster-lock]
    [metabase.util.grouper :as grouper]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
-   [toucan2.core :as t2])
-  (:import
-   [java.sql SQLException]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:private update-used-card-interval-seconds 20)
-
-(def ^:private cluster-lock-timeout-seconds 0.5)
-
-(def ^:private max-update-retries 2)
-
-(def ^:private pause-before-update-retry-seconds 1)
-
-(mu/defn- do-with-pg-cluster-lock
-  "TODO: Make this more reusable"
-  ([lock-name thunk]
-   (do-with-pg-cluster-lock lock-name {} thunk))
-  ([lock-name :- :keyword {:keys [timeout max-retries]
-                           :or {timeout cluster-lock-timeout-seconds
-                                max-retries max-update-retries}} thunk]
-   (let [stringified-kw (str (namespace lock-name) "/" (name lock-name))]
-     (case (mdb/db-type)
-       ;; MySQL does not support transaction-level timeouts so this technique is not appropriate
-       ;; h2 cannot be used in cluster mode so we do not need locking
-       (:h2 :mysql) (thunk)
-       :postgres
-       (loop [retries 0]
-         (let [result (try
-                        (t2/with-transaction [_conn]
-                          (t2/query [(format "SET LOCAL lock_timeout = '%ss'" timeout)])
-                          (when-not (t2/query-one {:select [:lock.lock_name]
-                                                   :from [[:metabase_cluster_lock :lock]]
-                                                   :where [:= :lock.lock_name stringified-kw]
-                                                   :for :update})
-                            (t2/query-one {:insert-into [:metabase_cluster_lock]
-                                           :columns [:lock_name]
-                                           :values [[stringified-kw]]}))
-                          (thunk))
-                        ;; TODO: Catch SQLExceptions here and return Throwable specifying when the failure was due to lock timeout
-                        (catch Throwable e
-                          (if (and (instance? SQLException (ex-cause e)) ;; assume we want to retry on any kind of sql error
-                                   (< retries max-retries))
-                            (do
-                              (log/debugf "Retrying card update in %s seconds, %s retries remaining"
-                                          pause-before-update-retry-seconds
-                                          (- max-update-retries retries))
-                              ::retryable)
-                            (throw (ex-info "Failed to run statement with cluster lock"
-                                            {:retries retries
-                                             :lock-timeout timeout}
-                                            e)))))]
-           (when (= result ::retryable)
-             (Thread/sleep ^int (* 1000 pause-before-update-retry-seconds))
-             (recur (inc retries)))))))))
 
 (defn- update-used-cards!*
   [card-id-timestamps]
@@ -71,15 +21,14 @@
                                         (fn [xs] (apply t/max (map :timestamp xs))))]
     (log/debugf "Update last_used_at of %d cards" (count card-id->timestamp))
     (try
-      (do-with-pg-cluster-lock ::used-at-update
-                               (fn []
-                                 (t2/update! :model/Card :id [:in (keys card-id->timestamp)]
-                                             {:last_used_at (into [:case]
-                                                                  (mapcat (fn [[id timestamp]]
-                                                                            [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
-                                                                          card-id->timestamp))
-                                           ;; Set updated_at to its current value to prevent it from updating automatically
-                                              :updated_at :updated_at})))
+      (cluster-lock/with-cluster-lock ::used-at-update
+        (t2/update! :model/Card :id [:in (keys card-id->timestamp)]
+                    {:last_used_at (into [:case]
+                                         (mapcat (fn [[id timestamp]]
+                                                   [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
+                                                 card-id->timestamp))
+                     ;; Set updated_at to its current value to prevent it from updating automatically
+                     :updated_at :updated_at}))
       (catch Throwable e
         (log/error e "Error updating used cards")))))
 

--- a/src/metabase/util/cluster_lock.clj
+++ b/src/metabase/util/cluster_lock.clj
@@ -1,0 +1,89 @@
+(ns metabase.util.cluster-lock
+  "Utility for taking a cluster wide lock using the application database"
+  (:require
+   [metabase.db.query :as mdb.query]
+   [metabase.util.malli :as mu]
+   [metabase.util.retry :as retry]
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Connection PreparedStatement)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private cluster-lock-timeout-seconds 1)
+
+(defn- is-canceled-statement?
+  [err]
+  (boolean (re-find #"ERROR: canceling statement due to user request" (ex-message err))))
+
+(def ^:private default-retry-config
+  {:max-attempts 5
+   :multiplier 1.0
+   :randomization-factor 0.1
+   :initial-interval-millis 1000
+   :max-interval-millis 1000
+   :retry-on-exception-pred is-canceled-statement?})
+
+(defn prepare-statement
+  "Create a prepared statement to query cache"
+  ^PreparedStatement [^Connection conn lock-name-str timeout]
+  (let [stmt (.prepareStatement conn ^String (first (mdb.query/compile {:select [:lock.lock_name]
+                                                                        :from [[:metabase_cluster_lock :lock]]
+                                                                        :where [:= :lock.lock_name [:raw "?"]]
+                                                                        :for :update})))]
+    (try
+      (doto stmt
+        (.setQueryTimeout timeout)
+        (.setString 1 lock-name-str)
+        (.setMaxRows 1))
+      (catch Throwable e
+        (.close stmt)
+        (throw e)))))
+
+(defn- do-with-cluster-lock*
+  [lock-name-str timeout-seconds thunk]
+  (t2/with-transaction [conn]
+    (with-open [stmt (prepare-statement conn lock-name-str timeout-seconds)
+                result-set (.executeQuery stmt)]
+      (when-not (.next result-set)
+        (t2/query-one {:insert-into [:metabase_cluster_lock]
+                       :columns [:lock_name]
+                       :values [[lock-name-str]]})))
+    (thunk)))
+
+(mu/defn do-with-cluster-lock
+  "Impl for `with-cluster-lock`.
+
+  Call `thunk` after first synchronizing with the metabase cluster by taking a lock in the appdb."
+  [opts :- [:or :keyword
+            [:map
+             [:lock-name                     :keyword]
+             [:timeout-seconds   {:optional true} :int]
+             [:retry-config      {:optional true} [:map
+                                                   [:max-attempts            {:optional true} :int]
+                                                   [:initial-interval-millis {:optional true} :int]
+                                                   [:multiplier              {:optional true} :int]
+                                                   [:randomization-factor    {:optional true} :int]
+                                                   [:max-interval-millis     {:optional true} :int]]]]]
+   thunk :- ifn?]
+  (if (keyword? opts)
+    (do-with-cluster-lock {:lock-name opts} thunk)
+    (let [{:keys [timeout-seconds retry-config lock-name] :or {timeout-seconds cluster-lock-timeout-seconds}} opts
+          lock-name-str (str (namespace lock-name) "/" (name lock-name))
+          do-with-cluster-lock** (fn [] (do-with-cluster-lock* lock-name-str timeout-seconds thunk))
+          config (merge default-retry-config retry-config)
+          retrier (retry/make config)]
+      (try
+        (retrier do-with-cluster-lock**)
+        (catch Throwable e
+          (if (is-canceled-statement? e)
+            (throw (ex-info "Failed to run statement with cluster lock"
+                            {:retries (:max-attempts config)}
+                            e))
+            (throw e)))))))
+
+(defmacro with-cluster-lock
+  "Run `body` in a tranactions that tries to take a lock from the metabase_cluster_lock table of
+  the specified name to coordinate concurrency with other metabase instances sharing the appdb."
+  ([lock-options & body]
+   `(do-with-cluster-lock ~lock-options (fn [] ~@body))))

--- a/src/metabase/util/cluster_lock.clj
+++ b/src/metabase/util/cluster_lock.clj
@@ -18,8 +18,7 @@
   (let [msg (ex-message err)]
     (boolean (or (re-find #"ERROR: canceling statement due to user request" msg) ;; error text on postgres
                  (re-find #"Query timed out" msg) ;; error text on mysql
-                 (re-find #"Query execution was interrupted" msg) ;;error text on mariadb
-                 ))))
+                 (re-find #"Query execution was interrupted" msg))))) ;; error text on mariadb
 
 (def ^:private default-retry-config
   {:max-attempts 5
@@ -64,12 +63,7 @@
             [:map
              [:lock-name                     :keyword]
              [:timeout-seconds   {:optional true} :int]
-             [:retry-config      {:optional true} [:map
-                                                   [:max-attempts            {:optional true} :int]
-                                                   [:initial-interval-millis {:optional true} :int]
-                                                   [:multiplier              {:optional true} :int]
-                                                   [:randomization-factor    {:optional true} :int]
-                                                   [:max-interval-millis     {:optional true} :int]]]]]
+             [:retry-config      {:optional true} [:ref ::retry/retry-overrides]]]]
    thunk :- ifn?]
   (cond
     (= (mdb/db-type) :h2) (thunk) ;; h2 does not respect the query timeout when taking

--- a/src/metabase/util/cluster_lock.clj
+++ b/src/metabase/util/cluster_lock.clj
@@ -14,7 +14,11 @@
 
 (defn- is-canceled-statement?
   [err]
-  (boolean (re-find #"ERROR: canceling statement due to user request" (ex-message err))))
+  (let [msg (ex-message err)]
+    (boolean (or (re-find #"ERROR: canceling statement due to user request" msg) ;; error text on postgres
+                 (re-find #"Query timed out" msg) ;; error text on mysql
+                 (re-find #"Query execution was interrupted" msg) ;;error text on mariadb
+                 ))))
 
 (def ^:private default-retry-config
   {:max-attempts 5

--- a/test/metabase/query_processor/middleware/update_used_cards_test.clj
+++ b/test/metabase/query_processor/middleware/update_used_cards_test.clj
@@ -1,10 +1,8 @@
 (ns metabase.query-processor.middleware.update-used-cards-test
   (:require
-   [clojure.core.async :as a]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.dashboard-subscription-test :as dashboard-subscription-test]
-   [metabase.db :as mdb]
    [metabase.notification.test-util :as notification.tu]
    [metabase.pulse.send :as pulse.send]
    [metabase.pulse.send-test :as pulse.send-test]
@@ -119,19 +117,3 @@
                  (-> (t2/select-one-fn :last_used_at :model/Card card-id-1)
                      t/offset-date-time
                      (.withNano 0)))))))))
-
-(deftest with-cluster-locking-test
-  ;; this only works on postgres
-  (when (= (mdb/db-type) #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres)
-    (testing "cluster locking test error if lock is not released"
-      (let [fin-chan (a/chan)]
-        (future (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(a/<!! fin-chan)))
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo #"Failed to run statement with cluster lock"
-             (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(Thread/sleep 1))))
-        (a/>!! fin-chan :done)))
-    (testing "cluster locking test error if lock is released"
-      (let [fin-chan (a/chan)]
-        (future (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(a/<!! fin-chan)))
-        (future (Thread/sleep 1000) (a/>!! fin-chan :done))
-        (is (nil? (#'qp.update-used-cards/do-with-pg-cluster-lock ::test-lock #(Thread/sleep 1))))))))

--- a/test/metabase/util/cluster_lock_test.clj
+++ b/test/metabase/util/cluster_lock_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.core.async :as a]
    [clojure.test :refer :all]
+   [metabase.db :as mdb]
    [metabase.test.fixtures :as fixtures]
    [metabase.util.cluster-lock :as sut]))
 
@@ -12,24 +13,25 @@
 (deftest with-cluster-locking-test
   (testing "works when used non-concurrently"
     (is (nil? (sut/with-cluster-lock ::test-lock (Thread/sleep 1)))))
-  (testing "cluster locking test error if lock is not released"
-    (let [fin-chan (a/chan)
-          ready-chan (a/chan)]
-      (future (sut/with-cluster-lock ::test-lock (a/>!! ready-chan :ready) (a/<!! fin-chan)))
-      (a/<!! ready-chan) ;; make sure the future above starts
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"Failed to run statement with cluster lock"
-           (sut/with-cluster-lock ::test-lock (Thread/sleep 1))))
-      (a/>!! fin-chan :done)))
-  (testing "cluster no retry on other error"
-    (let [fin-chan (a/chan)]
-      (future (sut/with-cluster-lock ::test-lock (a/<!! fin-chan)))
-      (future (Thread/sleep 500) (a/>!! fin-chan :done))
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"Bad Error"
-           (sut/with-cluster-lock ::test-lock (throw (ex-info "Bad Error" {})))))))
-  (testing "cluster locking test error if lock is released"
-    (let [fin-chan (a/chan)]
-      (future (sut/with-cluster-lock ::test-lock (a/<!! fin-chan)))
-      (future (Thread/sleep 500) (a/>!! fin-chan :done))
-      (is (nil? (sut/with-cluster-lock ::test-lock (Thread/sleep 1)))))))
+  (when (not= (mdb/db-type) :h2)
+    (testing "cluster locking test error if lock is not released"
+      (let [fin-chan (a/chan)
+            ready-chan (a/chan)]
+        (future (sut/with-cluster-lock ::test-lock (a/>!! ready-chan :ready) (a/<!! fin-chan)))
+        (a/<!! ready-chan) ;; make sure the future above starts
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"Failed to run statement with cluster lock"
+             (sut/with-cluster-lock ::test-lock (Thread/sleep 1))))
+        (a/>!! fin-chan :done)))
+    (testing "cluster no retry on other error"
+      (let [fin-chan (a/chan)]
+        (future (sut/with-cluster-lock ::test-lock (a/<!! fin-chan)))
+        (future (Thread/sleep 500) (a/>!! fin-chan :done))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"Bad Error"
+             (sut/with-cluster-lock ::test-lock (throw (ex-info "Bad Error" {})))))))
+    (testing "cluster locking test error if lock is released"
+      (let [fin-chan (a/chan)]
+        (future (sut/with-cluster-lock ::test-lock (a/<!! fin-chan)))
+        (future (Thread/sleep 500) (a/>!! fin-chan :done))
+        (is (nil? (sut/with-cluster-lock ::test-lock (Thread/sleep 1))))))))

--- a/test/metabase/util/cluster_lock_test.clj
+++ b/test/metabase/util/cluster_lock_test.clj
@@ -1,0 +1,35 @@
+(ns metabase.util.cluster-lock-test
+  (:require
+   [clojure.core.async :as a]
+   [clojure.test :refer :all]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util.cluster-lock :as sut]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(deftest with-cluster-locking-test
+  (testing "works when used non-concurrently"
+    (is (nil? (sut/with-cluster-lock ::test-lock (Thread/sleep 1)))))
+  (testing "cluster locking test error if lock is not released"
+    (let [fin-chan (a/chan)
+          ready-chan (a/chan)]
+      (future (sut/with-cluster-lock ::test-lock (a/>!! ready-chan :ready) (a/<!! fin-chan)))
+      (a/<!! ready-chan) ;; make sure the future above starts
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Failed to run statement with cluster lock"
+           (sut/with-cluster-lock ::test-lock (Thread/sleep 1))))
+      (a/>!! fin-chan :done)))
+  (testing "cluster no retry on other error"
+    (let [fin-chan (a/chan)]
+      (future (sut/with-cluster-lock ::test-lock (a/<!! fin-chan)))
+      (future (Thread/sleep 500) (a/>!! fin-chan :done))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Bad Error"
+           (sut/with-cluster-lock ::test-lock (throw (ex-info "Bad Error" {})))))))
+  (testing "cluster locking test error if lock is released"
+    (let [fin-chan (a/chan)]
+      (future (sut/with-cluster-lock ::test-lock (a/<!! fin-chan)))
+      (future (Thread/sleep 500) (a/>!! fin-chan :done))
+      (is (nil? (sut/with-cluster-lock ::test-lock (Thread/sleep 1)))))))


### PR DESCRIPTION
### Description

Builds a more generic interface for cluster locking using our existing retry mechanism and jdbc level timeouts that will work with any database rather than just postgresql.

### How to verify

Running metabase instances in a cluster with any backing appdb should not deadlock updating last_used_at.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
