### PR TITLE
feat: add basic schema for sso saml settings api

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/saml.clj
@@ -15,7 +15,22 @@
   "Update SAML related settings. You must be a superuser to do this."
   [_route-params
    _query-params
-   settings :- :map]
+   settings :- [:map
+                [:saml-identity-provider-issuer      {:optional true} :string]
+                [:saml-identity-provider-uri         {:optional true} :string]
+                [:saml-identity-provider-certificate {:optional true} :string]
+                [:saml-application-name              {:optional true} [:maybe :string]]
+                [:saml-attribute-email               {:optional true} [:maybe :string]]
+                [:saml-attribute-firstname           {:optional true} [:maybe :string]]
+                [:saml-attribute-group               {:optional true} [:maybe :string]]
+                [:saml-attribute-group-mappings      {:optional true} [:maybe :map]]
+                [:saml-attribute-lastname            {:optional true} [:maybe :string]]
+                [:saml-enabled                       {:optional true} [:maybe :boolean]]
+                [:saml-group-sync                    {:optional true} [:maybe :boolean]]
+                [:saml-keystore-alias                {:optional true} [:maybe :string]]
+                [:saml-keystore-password             {:optional true} [:maybe :string]]
+                [:saml-user-provisioning-enabled?    {:optional true} [:maybe :boolean]]
+                [:saml-keystore-path                 {:optional true} [:maybe :string]]]]
   (api/check-superuser)
   (premium-features/assert-has-feature :sso-saml (tru "SAML-based authentication"))
   (let [filename (:saml-keystore-path settings)

--- a/enterprise/backend/test/metabase_enterprise/sso/api/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/saml_test.clj
@@ -11,6 +11,12 @@
                                                                                                                                     :saml-keystore-password "123456"
                                                                                                                                     :saml-keystore-alias "sp"}))))
     (mt/with-premium-features #{:sso-saml}
+      (testing "Requires idp issuer to be non-nil if sent"
+        (mt/user-http-request :crowberto :put 400 "saml/settings" {:saml-identity-provider-issuer nil}))
+      (testing "Requires idp uri to be non-nil if sent"
+        (mt/user-http-request :crowberto :put 400 "saml/settings" {:saml-identity-provider-uri nil}))
+      (testing "Requires idp cert to be non-nil if sent"
+        (mt/user-http-request :crowberto :put 400 "saml/settings" {:saml-identity-provider-certificate nil}))
       (testing "Valid SAML settings can be saved via an API call"
         (mt/user-http-request :crowberto :put 200 "saml/settings" {:saml-keystore-path "test_resources/keystore.jks"
                                                                    :saml-keystore-password "123456"


### PR DESCRIPTION
### Description

Defines a Malli schema for the saml settings endpoint. Sets all the keys to be optional but, when set, requires non-nil values for issuer, uri, and certificate like the front end. 

In practice our frontend sends all these values on every request, but there isn't a a requirement it keeps working that way, so this accommodates that behavior. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
