### PR TITLE
Fix relative-time-view rendering

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -650,6 +650,9 @@
       [:time-interval _ (x :guard temporal?) n unit]
       (lib.temporal-bucket/describe-temporal-interval n unit)
 
+      [:relative-time-interval _ (x :guard temporal?) n unit offset offset-unit]
+      (lib.temporal-bucket/describe-temporal-interval-with-offset n unit offset offset-unit)
+
       _
       (lib.metadata.calculation/display-name query stage-number filter-clause))))
 

--- a/src/metabase/lib/temporal_bucket.cljc
+++ b/src/metabase/lib/temporal_bucket.cljc
@@ -107,6 +107,17 @@
       ;; else
       (lib.temporal-bucket.util/relative-datetime-tru n "unknown unit"))))
 
+(mu/defn describe-temporal-interval-with-offset :- ::lib.schema.common/non-blank-string
+  "Get a translated description of a temporal bucketing interval with offset."
+  [n           :- TemporalIntervalAmount
+   unit        :- [:maybe :keyword]
+   offset      :- TemporalIntervalAmount
+   offset-unit :- [:maybe :keyword]]
+  (str
+   (describe-temporal-interval n unit)
+   ", "
+   (describe-relative-datetime offset offset-unit)))
+
 (defmulti with-temporal-bucket-method
   "Implementation for [[temporal-bucket]]. Implement this to tell [[temporal-bucket]] how to add a bucket to a
   particular MBQL clause."

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -632,6 +632,7 @@
       "Next 10 days" (lib/time-interval created-at 10 :day)
       "Today" (lib/time-interval created-at :current :day)
       "This month" (lib/time-interval created-at :current :month)
+      "Previous 64 months, starting 7 months ago" (lib/relative-time-interval created-at -64 :month -7 :month)
       "Dec 5, 2024, 10:50 PM" (lib.filter/during created-at datetime-arg :minute)
       "Dec 5, 2024, 10:00 PM – 10:59 PM" (lib.filter/during created-at datetime-arg :hour)
       "Dec 5, 2024" (lib.filter/during created-at datetime-arg :day)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44550

### Description

Fix the display name for relative time intervals (time intervals with offsets) displayed at the bottom of the timerseries visualization.

<img width="519" alt="Screenshot 2025-04-04 at 3 10 22 PM" src="https://github.com/user-attachments/assets/64c693ce-a986-415b-8304-43be9726d523" />

### How to verify

1. Open Orders, Summarize by Count broken down by Created At: month
2. Visualize
3. Click on 'Created At' column header > Filter by this column > Relative dates
4. Choose either Previous or Next
5. Click on "<-" icon (Starting from) to add an offset
6. Apply the filter
7. Notice at the bottom that the text does not include the column name.
