### PR TITLE
Retain formatting for links with no URL

### DIFF
--- a/frontend/src/metabase/lib/formatting/url.tsx
+++ b/frontend/src/metabase/lib/formatting/url.tsx
@@ -37,9 +37,9 @@ export function formatUrl(value: string, options: OptionsType = {}) {
   const { jsx, rich } = options;
 
   const url = getLinkUrl(value, options);
+  const text = getLinkText(value, options);
 
   if (jsx && rich && url) {
-    const text = getLinkText(value, options);
     const className = cx(CS.link, CS.linkWrappable);
 
     // (metabase#51099) prevent url from being rendered as a link when in sdk
@@ -60,7 +60,9 @@ export function formatUrl(value: string, options: OptionsType = {}) {
       </ExternalLink>
     );
   } else {
-    return value;
+    // Even when no URL is found, return the formatted text value
+    // rather than the raw value to preserve other formatting options
+    return text;
   }
 }
 
@@ -79,7 +81,10 @@ function getLinkText(value: string, options: OptionsType) {
 
   return (
     getRemappedValue(value, options) ||
-    formatValue(value, { ...options, view_as: null })
+    formatValue(value, {
+      ...options,
+      view_as: null,
+    })
   );
 }
 

--- a/frontend/src/metabase/lib/formatting/url.tsx
+++ b/frontend/src/metabase/lib/formatting/url.tsx
@@ -34,12 +34,12 @@ export function getUrlProtocol(url: string) {
 }
 
 export function formatUrl(value: string, options: OptionsType = {}) {
-  const { jsx, rich } = options;
+  const { jsx, rich, column } = options;
 
   const url = getLinkUrl(value, options);
-  const text = getLinkText(value, options);
 
   if (jsx && rich && url) {
+    const text = getLinkText(value, options);
     const className = cx(CS.link, CS.linkWrappable);
 
     // (metabase#51099) prevent url from being rendered as a link when in sdk
@@ -59,10 +59,11 @@ export function formatUrl(value: string, options: OptionsType = {}) {
         {text}
       </ExternalLink>
     );
+  } else if (!url && !isURL(column)) {
+    // Even when no URL is found, return a formatted value
+    return formatValue(value, { ...options, view_as: null });
   } else {
-    // Even when no URL is found, return the formatted text value
-    // rather than the raw value to preserve other formatting options
-    return text;
+    return value;
   }
 }
 
@@ -81,10 +82,7 @@ function getLinkText(value: string, options: OptionsType) {
 
   return (
     getRemappedValue(value, options) ||
-    formatValue(value, {
-      ...options,
-      view_as: null,
-    })
+    formatValue(value, { ...options, view_as: null })
   );
 }
 

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -71,4 +71,23 @@ describe("link", () => {
     });
     expect(screen.getByText("23.12346")).toBeInTheDocument();
   });
+
+  it("should preserve number separator formatting when displayed as a link with no URL set", () => {
+    setup(100000.0, {
+      view_as: "link",
+      number_style: "decimal",
+      number_separators: ".,",
+    });
+    expect(screen.getByText("100,000")).toBeInTheDocument();
+  });
+
+  it("should preserve number separator formatting when displayed as a link with a custom URL", () => {
+    setup(100000.0, {
+      view_as: "link",
+      number_style: "decimal",
+      number_separators: ".,",
+      link_url: "http://example.com",
+    });
+    expect(screen.getByText("100,000")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/19807

Ensures that if you have a column set to use link formatting, but haven't specified a URL, we still display a value with other formatting applied and not the raw value.