### PR TITLE
Prevent panning off the world in Leaflet map

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -28,6 +28,13 @@ export default class LeafletMap extends Component {
         minZoom: 2,
         drawControlTooltips: false,
         zoomSnap: false,
+        // Set max bounds for latitude only, allowing longitude to wrap
+        maxBounds: [
+          [-90, -Infinity], // Southwest corner (limit south, no limit west)
+          [90, Infinity], // Northeast corner (limit north, no limit east)
+        ],
+        maxBoundsViscosity: 1.0, // Completely prevent panning outside latitude bounds
+        worldCopyJump: true, // Enable smooth horizontal wrapping
       }));
 
       const drawnItems = new L.FeatureGroup();


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/5405

Demo: https://www.loom.com/share/3c60c75a0c8348298777a7091d517dd2

Sets latitude bounds for our leaflet map, prevents panning beyond those to the north/south, and enables smooth horizontal wrapping.