### PR TITLE
Support formatting postgres and oracle concatenation operator

### DIFF
--- a/src/metabase/driver/sql/util.clj
+++ b/src/metabase/driver/sql/util.clj
@@ -167,7 +167,7 @@
    :tsql        Dialect/TSql})
 
 (def ^:private ^java.util.List additional-operators
-  ["#>>" "!="])
+  ["#>>" "!=" "||"])
 
 (defn- add-operators
   ^SqlFormatter$Formatter [^SqlFormatter$Formatter formatter]


### PR DESCRIPTION
Fixes #55961

### Description

For some reason, the formatter for the Postgres dialect doesn't recognize `||` as an operator. I've added it to the list of custom operators, which means it won't be split to `| |` for other dialects either, but I think that's OK.

### How to verify

Going through the repro steps in #55961 should not result in an error.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
