### PR TITLE
Enable expression literals on additional drivers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
-FROM mcr.microsoft.com/vscode/devcontainers/java:11
+FROM mcr.microsoft.com/vscode/devcontainers/java:21
 
 # Set up nodesource, install node, yarn, fontconfig for static viz, rlwrap for dev ergonomics
 
-RUN ( curl -fsSL https://deb.nodesource.com/setup_18.x | bash ) \
+RUN ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash ) \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com \
   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig
 
 # install Clojure
-RUN curl https://download.clojure.org/install/linux-install-1.11.1.1262.sh | bash
+RUN curl https://download.clojure.org/install/linux-install-1.12.0.1488.sh | bash

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -37,6 +37,7 @@
                               :nested-fields                 false
                               :uuid-type                     true
                               :connection/multiple-databases true
+                              :expression-literals           true
                               :identifiers-with-spaces       false
                               :metadata/key-constraints      false
                               :test/jvm-timezone-setting     false}]

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -43,6 +43,7 @@
                               :test/time-type                  false
                               :schemas                         true
                               :datetime-diff                   true
+                              :expression-literals             true
                               :upload-with-auto-pk             false
                               :window-functions/offset         false
                               :window-functions/cumulative     (not config/is-test?)

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -31,6 +31,7 @@
                               :describe-fields                 true
                               :describe-fks                    true
                               :expression-aggregations         true
+                              :expression-literals             true
                               :expressions                     true
                               :native-parameters               true
                               :nested-queries                  true

--- a/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
+++ b/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
@@ -28,7 +28,8 @@
 (driver/register! :druid-jdbc :parent :sql-jdbc)
 
 (doseq [[feature supported?] {:set-timezone            true
-                              :expression-aggregations true}]
+                              :expression-aggregations true
+                              :expression-literals     true}]
   (defmethod driver/database-supports? [:druid-jdbc feature] [_driver _feature _db] supported?))
 
 (defmethod sql-jdbc.conn/connection-details->spec :druid-jdbc

--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -14,6 +14,7 @@
 (driver/register! :druid)
 
 (doseq [[feature supported?] {:expression-aggregations        true
+                              :expression-literals            true
                               :schemas                        false
                               :set-timezone                   true
                               :temporal/requires-default-unit true}]

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -44,6 +44,7 @@
 (doseq [[feature supported?] {:basic-aggregations              true
                               :binning                         true
                               :expression-aggregations         true
+                              :expression-literals             true
                               :expressions                     true
                               :native-parameters               true
                               :now                             true

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -235,6 +235,7 @@
 (doseq [[feature supported?] {:basic-aggregations              true
                               :binning                         true
                               :expression-aggregations         true
+                              :expression-literals             true
                               :expressions                     true
                               :native-parameters               true
                               :nested-queries                  true

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -571,6 +571,43 @@
                    :aggregation [:count]
                    :breakout    standard-literal-expression-refs}))))))))
 
+(deftest ^:parallel case-with-literal-expression-test
+  (testing "CASE expression using literal expressions"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
+      (is (= [[1 12345 true  "foo"]
+              [2 12345 false "foo"]]
+             (mt/formatted-rows
+              [int int mt/boolish->bool str]
+              (mt/run-mbql-query venues
+                {:expressions (into standard-literal-expression-defs
+                                    {"case 1" [:case
+                                               [[[:< [:expression "zero"] 0]
+                                                 [:expression "zero"]]
+                                                [[:= false [:expression "True"]]
+                                                 [:expression "zero"]]
+                                                [[:= "foo" [:expression "foo"]]
+                                                 [:expression "12345"]]]
+                                               {:default [:expression "zero"]}]
+                                     "case 2" [:case
+                                               [[[:= $id 1]
+                                                 [:expression "True"]]
+                                                [[:= $id 2]
+                                                 [:expression "False"]]]]
+                                     "case 3" [:case
+                                               [[[:= [:concat [:expression "foo"] ""] "bar"]
+                                                 [:expression "empty"]]
+                                                [[:> [:expression "zero"] 0]
+                                                 [:expression "empty"]]
+                                                [[:is-null [:expression "foo"]]
+                                                 [:expression "empty"]]]
+                                               {:default [:expression "foo"]}]})
+                 :fields      [$id
+                               [:expression "case 1"]
+                               [:expression "case 2"]
+                               [:expression "case 3"]]
+                 :order-by    [[:asc  $id]]
+                 :limit       2})))))))
+
 (deftest ^:parallel filter-literal-expression-with-and-or-test
   (doseq [[op expected] [[:and []]
                          [:or  [[true false]]]]]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -605,7 +605,7 @@
                                [:expression "case 1"]
                                [:expression "case 2"]
                                [:expression "case 3"]]
-                 :order-by    [[:asc  $id]]
+                 :order-by    [[:asc $id]]
                  :limit       2})))))))
 
 (deftest ^:parallel filter-literal-expression-with-and-or-test


### PR DESCRIPTION
Closes QUE-780

### Description

* Enable the `:expression-literals` driver feature for additional drivers that pass the existing tests. This includes `:athena`, `:clickhouse`, `:databricks`, `:druid`, `:druid-jdbc`, `:presto-jdbc`, and `:sparksql`.
* Update dependencies in `.devcontainer/Dockerfile`. Apparently, there is a presto kerberos test that depends on it.
* Add an additional test for expression literals in `case` expressions.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
