### PR TITLE
Use PAT for sending release notes to docs repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,6 +443,7 @@ jobs:
       - name: Publish draft release notes to github
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           result-encoding: string
           script: | # js
             const {


### PR DESCRIPTION
## Description	

This was getting a 404 because the default token isn't scoped to call repository dispatch events in other repos 🤦 