### PR TITLE
fix(sdk): Fix dashboard empty state for no query creation users

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -1738,3 +1738,38 @@ describe("issue 54353", () => {
     cy.findByRole("dialog").should("not.exist");
   });
 });
+
+describe("issue 44937", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signIn("readonly");
+  });
+
+  it("dashboard empty state should not suggest creating a new question when users have no creation permission (metabase#44937)", () => {
+    cy.visit("/");
+    H.newButton().click();
+    H.popover().findByText("Dashboard").click();
+    H.modal().within(() => {
+      cy.findByPlaceholderText("What is the name of your dashboard?").type(
+        "my dashboard",
+      );
+      cy.button("Create").click();
+    });
+
+    H.main().findByText(
+      "Browse your collections to find and add existing questions.",
+    );
+
+    cy.button("Add a chart").click();
+    H.sidebar().within(() => {
+      cy.findByText("Our analytics").click();
+      cy.findByText("Orders").click();
+    });
+
+    H.createNewTab();
+
+    H.main().findByText(
+      "Browse your collections to find and add existing questions.",
+    );
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.unit.spec.tsx
@@ -11,6 +11,7 @@ import {
   setupCollectionsEndpoints,
   setupDashboardEndpoints,
   setupDashboardQueryMetadataEndpoint,
+  setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { setupDashcardQueryEndpoints } from "__support__/server-mocks/dashcard";
 import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pulse";
@@ -113,6 +114,8 @@ const setup = async ({
   setupAlertsEndpoints(tableCard, []);
 
   setupNotificationChannelsEndpoints({});
+
+  setupDatabasesEndpoints([createMockDatabase()]);
 
   const user = createMockUser();
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePrevious, useUnmount } from "react-use";
 import _ from "underscore";
 
+import { useListDatabasesQuery } from "metabase/api";
 import { deletePermanently } from "metabase/archive/actions";
 import { ArchivedEntityBanner } from "metabase/archive/components/ArchivedEntityBanner";
 import {
@@ -24,6 +25,7 @@ import type {
 import Bookmarks from "metabase/entities/bookmarks";
 import Dashboards from "metabase/entities/dashboards";
 import { useDispatch } from "metabase/lib/redux";
+import { getHasDataAccess, getHasNativeWrite } from "metabase/selectors/data";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 import { Box, Flex } from "metabase/ui";
 import type {
@@ -229,6 +231,18 @@ function Dashboard(props: DashboardProps) {
   const tabHasCards = currentTabDashcards.length > 0;
   const dashboardHasCards = dashboard && dashboard.dashcards.length > 0;
 
+  const { data: databasesResponse } = useListDatabasesQuery();
+  const databases = useMemo(
+    () => databasesResponse?.data ?? [],
+    [databasesResponse],
+  );
+  const hasDataAccess = useMemo(() => getHasDataAccess(databases), [databases]);
+  const hasNativeWrite = useMemo(
+    () => getHasNativeWrite(databases),
+    [databases],
+  );
+  const canCreateQuestions = hasDataAccess || hasNativeWrite;
+
   const shouldRenderAsNightMode = isNightMode && isFullscreen;
 
   const handleSetEditing = useCallback(
@@ -352,6 +366,7 @@ function Dashboard(props: DashboardProps) {
     if (!dashboardHasCards) {
       return canWrite ? (
         <DashboardEmptyState
+          canCreateQuestions={canCreateQuestions}
           addQuestion={handleAddQuestion}
           isDashboardEmpty={true}
           isEditing={isEditing}
@@ -368,6 +383,7 @@ function Dashboard(props: DashboardProps) {
     if (dashboardHasCards && !tabHasCards) {
       return canWrite ? (
         <DashboardEmptyState
+          canCreateQuestions={canCreateQuestions}
           addQuestion={handleAddQuestion}
           isDashboardEmpty={false}
           isEditing={isEditing}

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.tsx
@@ -10,6 +10,7 @@ interface DashboardEmptyStateProps {
   isDashboardEmpty: boolean;
   isEditing?: boolean;
   isNightMode: boolean;
+  canCreateQuestions?: boolean;
 }
 
 const getDefaultTitle = (isDashboardEmpty: boolean) =>
@@ -47,16 +48,21 @@ export function DashboardEmptyState({
   isDashboardEmpty,
   isEditing,
   isNightMode,
+  canCreateQuestions,
 }: DashboardEmptyStateProps) {
-  const defaultTitle = getDefaultTitle(isDashboardEmpty);
+  let title = getDefaultTitle(isDashboardEmpty);
+  if (isEditing) {
+    title = canCreateQuestions
+      ? t`Create a new question or browse your collections for an existing one.`
+      : t`Browse your collections to find and add existing questions.`;
+  }
+
   return (
     <EmptyStateWrapper isNightMode={isNightMode}>
       <>
         <Stack align="center" maw="25rem" gap="xs">
           <Title ta="center" order={2}>
-            {isEditing
-              ? t`Create a new question or browse your collections for an existing one.`
-              : defaultTitle}
+            {title}
           </Title>
 
           <Text ta="center" data-testid="dashboard-empty-state-copy">

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.unit.spec.tsx
@@ -8,11 +8,13 @@ import {
 type SetupOptions = {
   isDashboardEmpty: boolean;
   isEditing: boolean;
+  canCreateQuestions?: boolean;
 };
 
 const setup = ({
   isDashboardEmpty = true,
   isEditing = false,
+  canCreateQuestions = true,
 }: SetupOptions) => {
   const addQuestion = jest.fn();
 
@@ -22,6 +24,7 @@ const setup = ({
       isDashboardEmpty={isDashboardEmpty}
       isEditing={isEditing}
       addQuestion={addQuestion}
+      canCreateQuestions={canCreateQuestions}
     />,
   );
 
@@ -87,6 +90,27 @@ describe("DashboardEmptyState", () => {
       assertBodyText({
         title:
           "Create a new question or browse your collections for an existing one.",
+        description:
+          "Add link or text cards. You can arrange cards manually, or start with some default layouts by adding a section.",
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Add a chart" }));
+      expect(addQuestion).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["dashboard", "dashboard tab"])(
+    "renders %s empty state in editing mode without create questions permission",
+    (context) => {
+      const { addQuestion } = setup({
+        isDashboardEmpty: context === "dashboard",
+        isEditing: true,
+        canCreateQuestions: false,
+      });
+
+      expect(illustration()).toBeInTheDocument();
+      assertBodyText({
+        title: "Browse your collections to find and add existing questions.",
         description:
           "Add link or text cards. You can arrange cards manually, or start with some default layouts by adding a section.",
       });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44937

### Description

Fixes dashboard empty state prompts users without question creation permissions to create a question.
No-backport as it introduces new copy.

### How to verify

- Login as a user who can't create queries but has "View data" permission and who can create content in collections
- Create a new dashboard
- Ensure the empty state does not prompt you to create a query

### Demo

#### Before 

Message prompts user to create a new question although they don't have permissions for that:

<img width="1027" alt="Screenshot 2025-04-04 at 9 26 18 PM" src="https://github.com/user-attachments/assets/4510c0dd-48a7-41a5-9cb4-123378e63dff" />

#### After

<img width="1184" alt="Screenshot 2025-04-04 at 9 25 43 PM" src="https://github.com/user-attachments/assets/17f114fe-88aa-44cd-ab45-a745561c7b5c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
