### PR TITLE
fix readability of map buttons

### DIFF
--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -16,6 +16,7 @@ import LeafletGridHeatMap from "./LeafletGridHeatMap";
 import LeafletHeatMap from "./LeafletHeatMap";
 import LeafletMarkerPinMap from "./LeafletMarkerPinMap";
 import LeafletTilePinMap from "./LeafletTilePinMap";
+import S from "./PinMap.module.css";
 
 const WORLD_BOUNDS = [
   [-90, -180],
@@ -245,7 +246,8 @@ export default class PinMap extends Component {
                 "PinMapUpdateButton",
                 ButtonsS.Button,
                 ButtonsS.ButtonSmall,
-                CS.mb1,
+                ButtonsS.ButtonWhite,
+                S.pinMapButton,
                 {
                   [DashboardS.PinMapUpdateButtonDisabled]: disableUpdateButton,
                 },
@@ -264,7 +266,8 @@ export default class PinMap extends Component {
                   "PinMapUpdateButton",
                   ButtonsS.Button,
                   ButtonsS.ButtonSmall,
-                  CS.mb1,
+                  ButtonsS.ButtonWhite,
+                  S.pinMapButton,
                 )}
                 onClick={() => {
                   if (

--- a/frontend/src/metabase/visualizations/components/PinMap.module.css
+++ b/frontend/src/metabase/visualizations/components/PinMap.module.css
@@ -1,0 +1,4 @@
+.pinMapButton {
+  opacity: 0.9;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20264

### Description

Makes buttons of pin/grid map more readable.

### How to verify

1. New -> Sample Dataset -> People
2. Visualize as map
3. Hover the map
4. Ensure buttons in the top right corner are readable

### Demo

Before

<img width="234" alt="Screenshot 2025-04-04 at 10 01 47 PM" src="https://github.com/user-attachments/assets/909a286a-d87b-4725-b971-7c22667872d1" />

After

<img width="291" alt="Screenshot 2025-04-04 at 10 02 22 PM" src="https://github.com/user-attachments/assets/8bd27dbd-af93-43ac-aa74-1d60d7277e4b" />

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
