### PR TITLE
[metrics] Add hiccup and allocation rate metrics

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,6 +36,8 @@
   com.clearspring.analytics/stream          {:mvn/version "2.9.8"               ; Various sketching algorithms
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
+  com.clojure-goes-fast/jvm-alloc-rate-meter{:mvn/version "0.1.4"}              ; Monitor heap allocation rate.
+  com.clojure-goes-fast/jvm-hiccup-meter    {:mvn/version "0.1.1"}              ; Monitor GC pauses and other system-induced pauses.
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.0"}              ; trans dep of commons-codec
   ; Detect the charset in uploaded CSV files


### PR DESCRIPTION
I propose to add these two libraries of mine:

- https://github.com/clojure-goes-fast/jvm-hiccup-meter
- https://github.com/clojure-goes-fast/jvm-alloc-rate-meter

and send their metrics to Prometheus. Then we can track the values on different instances and hopefully correlate some of the misbehaviours with these metrics.
