### PR TITLE
Switch css rule for <FileInput /> component

### DIFF
--- a/frontend/src/metabase/core/components/FileInput/FileInput.styled.tsx
+++ b/frontend/src/metabase/core/components/FileInput/FileInput.styled.tsx
@@ -21,7 +21,7 @@ export const InputField = styled.input<InputFieldProps>`
     outline: none;
   }
 
-  &::-webkit-file-upload-button {
+  &::file-selector-button {
     padding-top: 0.5rem;
     padding-right: 2rem;
     visibility: hidden;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41476

### Description
Swaps out the CSS rule that hides the button for <input type="file" /> from a webkit specific rule to a more generic rule that also works in Firefox

### How to verify
In both Chrome and FireFox, navigate to Admin -> Databases and open the form for `BigQuery`.  The field for `Service account JSON file` should not have a browser styled button present.

### Demo
Chrome:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/aa9c2548-9945-4e82-9388-490f0df18a0c" />

Firefox:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/2a3096b6-717b-4f00-82e0-1a0cbb13e267" />


### Checklist

- ~[ ] Tests have been added/updated to cover changes in this PR~
