### PR TITLE
Invalidate card's cache on PUT

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -21,6 +21,7 @@
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.lib.util :as lib.util]
    [metabase.models.audit-log :as audit-log]
+   [metabase.models.cache-config :as cache-config]
    [metabase.models.card.metadata :as card.metadata]
    [metabase.models.collection :as collection]
    [metabase.models.field-values :as field-values]
@@ -1201,6 +1202,9 @@
                                          :moderator_id        (:id actor)
                                          :status              nil
                                          :text                (tru "Unverified due to edit")}))
+    ;; Invalidate the cache for card
+    (cache-config/invalidate! {:questions [(:id card-before-update)]
+                               :with-overrides? true})
     ;; ok, now save the Card
     (t2/update! :model/Card (:id card-before-update)
                 ;; `collection_id` and `description` can be `nil` (in order to unset them).

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -33,10 +33,11 @@
 
 (defenterprise cache-strategy
   "Returns cache strategy for a card. In EE, this checks the hierarchy for the card, dashboard, or
-   database (in that order). In OSS returns root configuration."
+  database (in that order). In OSS returns root configuration, taking card's :cache_invalidated_at
+  into consideration."
   metabase-enterprise.cache.strategies
-  [_card _dashboard-id]
-  (cache-config/card-strategy (cache-config/root-strategy) nil))
+  [card _dashboard-id]
+  (cache-config/card-strategy (cache-config/root-strategy) card))
 
 (defn- enrich-strategy [strategy query]
   (case (:type strategy)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -16,6 +16,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.http-client :as client]
+   [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
@@ -4171,3 +4172,67 @@
                     (mt/user-http-request :crowberto :put 400 (str "card/" id-a)
                                           {:dataset_query (lib/->legacy-MBQL query-cycle)
                                            :type card-type-c})))))))))))
+
+(deftest e2e-card-update-invalidates-cache-test
+  (testing "Card update invalidates card's cache (#55955)"
+    (let [existing-config (t2/select-one :model/CacheConfig :model_id 0 :model "root")]
+      (try
+        ;; First delete the existing root config because if that exists (shouldn't, but you know..)
+        ;; with-temp will fail. This is imho simpler then checking whether that exists and based on the result of
+        ;; the query either doing update or insert.
+        (when existing-config
+          (t2/delete! :model/CacheConfig :model_id 0 :model "root"))
+        (mt/with-temp
+          [:model/CacheConfig
+           _
+           {:model_id 0
+            :model "root"
+            :strategy "ttl"
+            :config {:multiplier 99999, :min_duration_ms 1}}
+
+           :model/Card
+           model
+           {:type :model
+            :dataset_query (let [mp (mt/metadata-provider)]
+                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                 (lib/limit 10)
+                                 lib.convert/->legacy-MBQL))}]
+          (letfn [;; Query results should get cached on following request.
+                  (card-query-post-request
+                    []
+                    (mt/user-http-request :rasta :post 202 (str "card/" (:id model) "/query")
+                                          {:collection_preview false
+                                           :ignore_cache       false
+                                           :parameters         []}))
+                  ;; Query cache should get invalidated on following request.
+                  (card-put-request [result_metadata]
+                    (mt/user-http-request :rasta :put 200
+                                          (str "card/" (:id model))
+                                          {:result_metadata result_metadata}))]
+            (let [post-response (do (card-query-post-request)
+                                    (card-query-post-request))
+                  raw-results-metadata (get-in post-response [:data :results_metadata :columns])]
+              (testing "Base: Initial query is cached (2nd post request's response)"
+                (is (some? (:cached post-response))))
+              (let [put-resonse (card-put-request (cons (assoc (first raw-results-metadata) :display_name "This is ID")
+                                                        (rest raw-results-metadata)))]
+                (testing "Base: Put changes results_metadata successfully"
+                  (is (= "This is ID"
+                         (-> put-resonse :result_metadata first :display_name))))))
+            (testing "Card request not cached. Preceding post successfully invalidated the cache."
+              (let [post-response (card-query-post-request)
+                    id-display-name (-> post-response :data :results_metadata :columns first :display_name)]
+                (testing "Cache is NOT being used, cache was invalidated"
+                  (is (nil? (:cached post-response))))
+                (testing "Metadata edit persists"
+                  (is (= "This is ID" id-display-name)))))
+            (testing "Last post request cached the query successfully"
+              (let [post-response (card-query-post-request)
+                    id-display-name (-> post-response :data :results_metadata :columns first :display_name)]
+                (testing "Cache is being used."
+                  (is (some? (:cached post-response))))
+                (testing "Metadata edit persists"
+                  (is (= "This is ID" id-display-name)))))))
+        (finally
+          (when existing-config
+            (t2/insert! :model/CacheConfig existing-config)))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #55955
Closes https://linear.app/metabase/issue/SEM-215/model-metadata-changes-not-persisting-due-to-caching

### Description

I've described chain of events occurring on model's metadata update, which results in overwrite of metadata by metadata that was cached previously, [this]() slack thread.

To mitigate, this PR:
1. Adds cache invalidation into `models.card/update-card!` which is used under the hood of PUT /card/:id.
2. Extends `qp.card/cache-strategy` so card's `:cache_invalidated_at` is respected, hence `:invalidated-at` is used later in the `qp.middleware.cache`.

### How to verify

Run the new test or follow the reproduction.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
