### PR TITLE
Fix - Field order sidesheet loading state breaks metadata page layout

### DIFF
--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
@@ -35,7 +35,7 @@ interface OwnProps {
 }
 
 interface Props extends OwnProps {
-  table: Table;
+  table?: Table;
 }
 
 const FieldOrderSidesheetBase = ({ isOpen, table, onClose }: Props) => {
@@ -43,7 +43,7 @@ const FieldOrderSidesheetBase = ({ isOpen, table, onClose }: Props) => {
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: { distance: 15 },
   });
-  const items = useMemo(() => getItems(table.fields), [table.fields]);
+  const items = useMemo(() => getItems(table?.fields), [table?.fields]);
   const [customOrder, setCustomOrder] = useState<OrderItemId[] | null>(null);
   const order = useMemo(
     () => customOrder ?? getItemsOrder(items),
@@ -60,6 +60,10 @@ const FieldOrderSidesheetBase = ({ isOpen, table, onClose }: Props) => {
   const handleFieldOrderChange = (value: TableFieldOrder) => {
     dispatch(Tables.actions.updateProperty(table, "field_order", value));
   };
+
+  if (!table) {
+    return null;
+  }
 
   return (
     <Sidesheet isOpen={isOpen} title={t`Edit column order`} onClose={onClose}>
@@ -102,6 +106,7 @@ export const FieldOrderSidesheet = _.compose(
       include_sensitive_fields: true,
       ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
     },
+    loadingAndErrorWrapper: false,
     fetchType: "fetchMetadataDeprecated",
     requestType: "fetchMetadataDeprecated",
     selectorName: "getObjectUnfiltered",

--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { Sidesheet } from "metabase/common/components/Sidesheet";
+import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import {
   type DragEndEvent,
   SortableList,
@@ -35,10 +36,18 @@ interface OwnProps {
 }
 
 interface Props extends OwnProps {
+  error: unknown;
+  loading: boolean;
   table?: Table;
 }
 
-const FieldOrderSidesheetBase = ({ isOpen, table, onClose }: Props) => {
+const FieldOrderSidesheetBase = ({
+  error,
+  isOpen,
+  loading,
+  table,
+  onClose,
+}: Props) => {
   const dispatch = useDispatch();
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: { distance: 15 },
@@ -61,8 +70,12 @@ const FieldOrderSidesheetBase = ({ isOpen, table, onClose }: Props) => {
     dispatch(Tables.actions.updateProperty(table, "field_order", value));
   };
 
-  if (!table) {
-    return null;
+  if (loading || error || !table) {
+    return (
+      <Sidesheet isOpen={isOpen} title={t`Edit column order`} onClose={onClose}>
+        <LoadingAndErrorWrapper error={error} loading={loading} />
+      </Sidesheet>
+    );
   }
 
   return (

--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
@@ -54,13 +54,13 @@ describe("FieldOrderSidesheet", () => {
   });
 
   describe("isOpen is false", () => {
-    it("does not show loading state when sidesheet is closed", async () => {
+    it("does not show loading state", async () => {
       setup({ isOpen: false });
 
       expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
     });
 
-    it("does not show error state when sidesheet is closed", async () => {
+    it("does not show error state", async () => {
       setup({ error: true, isOpen: false });
 
       await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
@@ -54,13 +54,13 @@ describe("FieldOrderSidesheet", () => {
   });
 
   describe("isOpen is false", () => {
-    it("does not show loading state", async () => {
+    it("does not show loading state (metabase#56371)", async () => {
       setup({ isOpen: false });
 
       expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
     });
 
-    it("does not show error state", async () => {
+    it("does not show error state (metabase#56371)", async () => {
       setup({ error: true, isOpen: false });
 
       await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
@@ -1,0 +1,67 @@
+import fetchMock from "fetch-mock";
+
+import { setupTableQueryMetadataEndpoint } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import type { TableId } from "metabase-types/api";
+import { createMockTable } from "metabase-types/api/mocks";
+import { PRODUCTS_ID } from "metabase-types/api/mocks/presets";
+
+import { FieldOrderSidesheet } from "./FieldOrderSidesheet";
+
+interface SetupOpts {
+  error?: boolean;
+  isOpen: boolean;
+  tableId?: TableId;
+}
+
+const setup = ({ error, isOpen, tableId = PRODUCTS_ID }: SetupOpts) => {
+  const table = createMockTable({ id: tableId });
+
+  if (error) {
+    fetchMock.get(`path:/api/table/${table.id}/query_metadata`, 500);
+  } else {
+    setupTableQueryMetadataEndpoint(table);
+  }
+
+  renderWithProviders(
+    <FieldOrderSidesheet
+      isOpen={isOpen}
+      tableId={tableId}
+      onClose={jest.fn()}
+    />,
+  );
+};
+
+describe("FieldOrderSidesheet", () => {
+  it("shows loading state when sidesheet is open", async () => {
+    setup({ isOpen: true });
+
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+  });
+
+  it("does not show loading state when sidesheet is closed", async () => {
+    setup({ isOpen: false });
+
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+  });
+
+  it("shows error state when sidesheet is open", async () => {
+    setup({ error: true, isOpen: true });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByText("An error occurred")).toBeInTheDocument();
+  });
+
+  it("does not show error state when sidesheet is closed", async () => {
+    setup({ error: true, isOpen: false });
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.queryByText("An error occurred")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.unit.spec.tsx
@@ -37,31 +37,35 @@ const setup = ({ error, isOpen, tableId = PRODUCTS_ID }: SetupOpts) => {
 };
 
 describe("FieldOrderSidesheet", () => {
-  it("shows loading state when sidesheet is open", async () => {
-    setup({ isOpen: true });
+  describe("isOpen is true", () => {
+    it("shows loading state", async () => {
+      setup({ isOpen: true });
 
-    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+    });
+
+    it("shows error state", async () => {
+      setup({ error: true, isOpen: true });
+
+      await waitForLoaderToBeRemoved();
+
+      expect(screen.getByText("An error occurred")).toBeInTheDocument();
+    });
   });
 
-  it("does not show loading state when sidesheet is closed", async () => {
-    setup({ isOpen: false });
+  describe("isOpen is false", () => {
+    it("does not show loading state when sidesheet is closed", async () => {
+      setup({ isOpen: false });
 
-    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
-  });
+      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+    });
 
-  it("shows error state when sidesheet is open", async () => {
-    setup({ error: true, isOpen: true });
+    it("does not show error state when sidesheet is closed", async () => {
+      setup({ error: true, isOpen: false });
 
-    await waitForLoaderToBeRemoved();
+      await waitForLoaderToBeRemoved();
 
-    expect(screen.getByText("An error occurred")).toBeInTheDocument();
-  });
-
-  it("does not show error state when sidesheet is closed", async () => {
-    setup({ error: true, isOpen: false });
-
-    await waitForLoaderToBeRemoved();
-
-    expect(screen.queryByText("An error occurred")).not.toBeInTheDocument();
+      expect(screen.queryByText("An error occurred")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Fixes #56371 ([SEM-222](https://linear.app/metabase/issue/SEM-222/field-order-sidesheet-loading-state-breaks-metadata-page-layout))

### Description

Moves error and loading state handling inside the Sidesheet. See demo below.

### Before

https://github.com/user-attachments/assets/20764532-9383-4661-9721-d6773e7d12f5

### After

https://github.com/user-attachments/assets/8a33281f-d67e-4b6b-9321-816816690b24

