### PR TITLE
SEM-223 Show database type instead of MBQL type in UI

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -351,7 +351,7 @@ describe("issue 37907", () => {
     cy.get("main").within(() => {
       cy.findByText("My ID column").should("be.visible");
       cy.findByText("The total billed amount. Updated.").should("be.visible");
-      cy.findByText("Discount amount.").should("be.visible");
+      cy.findByText("Discount amount.").scrollIntoView().should("be.visible");
     });
 
     H.visitQuestion(ORDERS_QUESTION_ID);

--- a/frontend/src/metabase-types/api/field.ts
+++ b/frontend/src/metabase-types/api/field.ts
@@ -81,6 +81,7 @@ export interface Field {
   display_name: string;
   description: string | null;
 
+  database_type: string;
   base_type: string;
   effective_type?: string;
   semantic_type: string | null;

--- a/frontend/src/metabase-types/api/mocks/field.ts
+++ b/frontend/src/metabase-types/api/mocks/field.ts
@@ -18,6 +18,7 @@ export const createMockField = (opts?: Partial<Field>): Field => ({
 
   table_id: 1,
 
+  database_type: "varchar",
   base_type: "type/Text",
   semantic_type: null,
   fk_target_field_id: null,

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableSchema/MetadataTableSchema.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableSchema/MetadataTableSchema.tsx
@@ -75,7 +75,9 @@ const ColumnRow = ({ field, isBordered, isSecondary }: ColumnRowProps) => (
     >
       {field.name}
     </ColumnNameCell>
-    <DataTypeCell isBordered={isBordered}>{field.base_type}</DataTypeCell>
+    <DataTypeCell isBordered={isBordered}>
+      {field.getPlainObject().database_type}
+    </DataTypeCell>
     <DataTypeCell isBordered={isBordered} />
   </tr>
 );

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -277,7 +277,7 @@ export function useReferencedCardCompletion({
         },
         options: results.map((column) => ({
           label: column.field.name,
-          detail: `${column.card.name} :${column.field.database_type}`,
+          detail: `${column.card.name} ${column.field.database_type}`,
         })),
       };
     },

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -277,7 +277,7 @@ export function useReferencedCardCompletion({
         },
         options: results.map((column) => ({
           label: column.field.name,
-          detail: `${column.card.name} :${column.field.base_type}`,
+          detail: `${column.card.name} :${column.field.database_type}`,
         })),
       };
     },

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
@@ -597,8 +597,8 @@ describe("useReferencedCardCompletion", () => {
       from: 7,
       validFor: expect.any(Function),
       options: [
-        { label: "Foobar", detail: "Referenced Question :type/Text" },
-        { label: "Bar", detail: "Referenced Question :type/Text" },
+        { label: "Foobar", detail: "Referenced Question varchar" },
+        { label: "Bar", detail: "Referenced Question varchar" },
       ],
     });
 
@@ -613,8 +613,8 @@ describe("useReferencedCardCompletion", () => {
       to: 10,
       validFor: expect.any(Function),
       options: [
-        { label: "Foobar", detail: "Referenced Question :type/Text" },
-        { label: "Bar", detail: "Referenced Question :type/Text" },
+        { label: "Foobar", detail: "Referenced Question varchar" },
+        { label: "Bar", detail: "Referenced Question varchar" },
       ],
     });
     expect(fetchMock.calls(url)).toHaveLength(1);

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -97,7 +97,7 @@ const Field = ({
               </div>
             )}
           </div>
-          <div className={F.fieldDataType}>{field.base_type}</div>
+          <div className={F.fieldDataType}>{field.database_type}</div>
         </div>
         <div className={S.itemSubtitle}>
           <div className={F.fieldForeignKey}>

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -240,7 +240,7 @@ const FieldDetail = (props) => {
                     <Detail
                       id="base_type"
                       name={t`Data type`}
-                      description={entity.base_type}
+                      description={entity.database_type}
                     />
                   </li>
                 )}

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -215,7 +215,7 @@ const SegmentFieldDetail = (props) => {
                     <Detail
                       id="base_type"
                       name={t`Data type`}
-                      description={entity.base_type}
+                      description={entity.database_type}
                     />
                   </li>
                 )}


### PR DESCRIPTION
Closes [SEM-223](https://linear.app/metabase/issue/SEM-223/show-database-type-instead-of-mbql-type-in-ui)

### Description

No new tests because all these UIs are going away soon.

Autocomplete endpoint will be handled separately ([SEM-225](https://linear.app/metabase/issue/SEM-225/do-not-show-mbql-type-in-autocomplete-suggestions)) since it's a backend change.

### Before

https://github.com/user-attachments/assets/6b071214-25ee-4151-8f0a-54a5c7001507

### After

https://github.com/user-attachments/assets/aacb96bb-bc7b-41a4-89cb-924d61eaef52


