### PR TITLE
Make mr/def assert that the docstring is a compile time string

### DIFF
--- a/src/metabase/util/malli/registry.cljc
+++ b/src/metabase/util/malli/registry.cljc
@@ -121,6 +121,7 @@
      ([type schema]
       `(register! ~type ~schema))
      ([type docstring schema]
+      (assert (string? docstring))
       `(metabase.util.malli.registry/def ~type
          (-with-doc ~schema ~docstring)))))
 


### PR DESCRIPTION
This is to make adding typos more difficult.

### Description

I managed messing up the parentheses, and my `mr/def` became a two-arity def, the first part (a vector) taken as the docstring, the second as the definition itself. It resulted in a strange debugging session.
