### PR TITLE
Fix sandbox on a routed DB with question as filter

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -44,7 +44,7 @@
 (defn table-field-names->cols
   "Return a mapping of field names to corresponding cols for given table."
   [table-id]
-  (into {} (for [col (request/with-current-user nil
+  (into {} (for [col (request/as-admin
                        ((requiring-resolve 'metabase.query-processor.preprocess/query->expected-cols)
                         {:database (database/table-id->database-id table-id)
                          :type     :query


### PR DESCRIPTION
This only affected turning on sandboxing, and was not an error for sandboxing itself.

When we configure sandboxing, we want to make sure the column types for the query we're using match the columns in the sandboxed table.

As part of this, we ran the query anonymously with `(request/with-current-user nil ...)`. With Database Routing, however, we added a new constraint: you can't run any queries against a database with routing configured anonymously.

Instead just run the query as a superuser. This is effectively the same, and it's consistent with what we do when actually *enforcing* the row level restrictions anyway: we preprocess the source query as an admin and then splice it into the user's query.

The one thing that gives me pause: I'm not really sure why we would have done `(request/with-current-user nil ...)` in the first place here.