### PR TITLE
[revisions] Include `card_schema` in revisions; default to 20

### DIFF
--- a/src/metabase/revisions/impl/card.clj
+++ b/src/metabase/revisions/impl/card.clj
@@ -4,7 +4,6 @@
 
 (def ^:private excluded-columns-for-card-revision
   #{:cache_invalidated_at
-    :card_schema
     :created_at
     :creator_id
     :entity_id
@@ -22,7 +21,9 @@
   ;; make sure we handle < 50 cards that had `:dataset` instead of `:type`
   (let [serialized-card (cond-> serialized-card
                           (contains? serialized-card :dataset) (-> (dissoc :dataset)
-                                                                   (assoc :type (if (:dataset serialized-card) :model :question))))]
+                                                                   (assoc :type (if (:dataset serialized-card) :model :question)))
+                          ;; Add the default `:card_schema` of 20, if it's missing.
+                          (not (:card_schema serialized-card)) (assoc :card_schema 20))]
     ((get-method revision/revert-to-revision! :default) model id user-id serialized-card)))
 
 (defn- model?

--- a/test/metabase/revisions/impl/card_test.clj
+++ b/test/metabase/revisions/impl/card_test.clj
@@ -107,6 +107,7 @@
                             (= col :type)              "model"
                             (= col :dataset_query)     (mt/mbql-query users)
                             (= col :visualization_settings) {:text "now it's a text card"}
+                            (= col :card_schema)       20
                             (int? value)               (inc value)
                             (boolean? value)           (not value)
                             (string? value)            (str value "_changed")))]
@@ -129,6 +130,9 @@
                          ;; similarly, we don't need a description for `archived_directly` because whenever
                          ;; this field changes `archived` will also change and we have a description for that.
                          :archived_directly
+                         ;; No description is needed for `card_schema`, because it is an internal, bookkeeping matter
+                         ;; and does not change independently.
+                         :card_schema
                          ;; we don't expect a description for this column because it should never change
                          ;; once created by the migration
                          :dataset_query_metrics_v2_migration_backup} col)


### PR DESCRIPTION
### Description

See details in [Slack](https://metaboat.slack.com/archives/C05NXACAG1G/p1743544469979949).

The new `:card_schema` field on `:model/Card` was wrongly excluded from Revisions.

This PR includes them, and adds a default value for old Revisions which predate `:card_schema`.

### How to verify

You can view the History of an old card that doesn't have `:card_schema` on it.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
