### PR TITLE
Enable :expression-literals for all :sql drivers

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -676,8 +676,7 @@
                               ;; timezone_trunc() rather than literally using SET TIMEZONE, but we need to flag it as
                               ;; supporting set-timezone anyway so that reporting timezones are returned and used, and
                               ;; tests expect the converted values.
-                              :set-timezone             true
-                              :expression-literals      true}]
+                              :set-timezone             true}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))
 
 ;; BigQuery is always in UTC

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -741,3 +741,7 @@
 (defmethod driver/prettify-native-form :bigquery-cloud-sdk
   [_ native-form]
   (sql.u/format-sql-and-fix-params :mysql native-form))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk ::sql.qp/cast-to-text]
+  [driver [_ expr]]
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "STRING"]))

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -345,3 +345,7 @@
   [driver prepared-statement index object]
   (set-parameter-to-local-date-time driver prepared-statement index
                                     (t/local-date-time (t/local-date 1970 1 1) object)))
+
+(defmethod sql.qp/->honeysql [:databricks ::sql.qp/cast-to-text]
+  [driver [_ expr]]
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "STRING"]))

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -499,9 +499,9 @@
   [_ bool]
   [:inline (if bool 1 0)])
 
-(defmethod sql.qp/->honeysql [:sql ::sql.qp/cast-to-text]
+(defmethod sql.qp/->honeysql [:oracle ::sql.qp/cast-to-text]
   [driver [_ expr]]
-  (sql.qp/->honeysql driver [::sql.qp/cast expr "varchar"]))
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "varchar(4000)"]))
 
 (defmethod driver/humanize-connection-error-message :oracle
   [_ message]

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -135,6 +135,10 @@
   [_ bool]
   [:raw (if bool "TRUE" "FALSE")])
 
+(defmethod sql.qp/->honeysql [:presto-jdbc ::sql.qp/cast-to-text]
+  [driver [_ expr]]
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "varchar"]))
+
 (defmethod sql.qp/->honeysql [:presto-jdbc (Class/forName "[B")]
   [_driver bs]
   [:from_base64 (u/encode-base64-bytes bs)])

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -42,7 +42,6 @@
 (doseq [[feature supported?] {:connection-impersonation  true
                               :describe-fields           true
                               :describe-fks              true
-                              :expression-literals       false
                               :identifiers-with-spaces   false
                               :uuid-type                 false
                               :nested-field-columns      false

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -56,7 +56,6 @@
                               :convert-timezone                       true
                               :datetime-diff                          true
                               :describe-fields                        true
-                              :expression-literals                    true
                               :expressions/integer                    true
                               :identifiers-with-spaces                true
                               :split-part                             true

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -55,6 +55,10 @@
                                                        :else                   source-table)))]
     (parent-method driver field-clause)))
 
+(defmethod sql.qp/->honeysql [:sparksql ::sql.qp/cast-to-text]
+  [driver [_ expr]]
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "string"]))
+
 (defn- format-over
   "e.g. ROW_NUMBER() OVER (ORDER BY field DESC) AS __rownum__"
   [_fn [expr partition]]

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -286,6 +286,10 @@
   [_ bool]
   [:raw (if bool "TRUE" "FALSE")])
 
+(defmethod sql.qp/->honeysql [:starburst ::sql.qp/cast-to-text]
+  [driver [_ expr]]
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "varchar"]))
+
 (defmethod sql.qp/->honeysql [:starburst :regex-match-first]
   [driver [_ arg pattern]]
   [:regexp_extract (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)])

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -149,6 +149,10 @@
    nil
    args))
 
+(defmethod sql.qp/->honeysql [:vertica ::sql.qp/cast-to-text]
+  [driver [_ expr]]
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "long varchar"]))
+
 (defmethod sql.qp/datetime-diff [:vertica :year]
   [driver _unit x y]
   (let [months (sql.qp/datetime-diff driver :month x y)]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -12,12 +12,10 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
-   [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -70,7 +68,6 @@
 (doseq [[feature supported?] {:actions                   true
                               :actions/custom            true
                               :datetime-diff             true
-                              :expression-literals       true
                               :full-join                 false
                               :index-info                true
                               :now                       true
@@ -398,30 +395,6 @@
 (defmethod sql.qp/->honeysql [:h2 :log]
   [driver [_ field]]
   [:log10 (sql.qp/->honeysql driver field)])
-
-(defn- literal-text-value?
-  [[_ value {base-type :base_type effective-type :effective_type} :as clause]]
-  (and (mbql.u/is-clause? :value clause)
-       (string? value)
-       (isa? (or effective-type base-type)
-             :type/Text)))
-
-(defmethod sql.qp/->honeysql [:h2 :expression]
-  [driver [_ expression-name {::add/keys [source-table]} :as clause]]
-  (let [expression-definition (mbql.u/expression-with-name sql.qp/*inner-query* expression-name)]
-    (if (and (not= source-table ::add/source)
-             (literal-text-value? expression-definition))
-      ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
-      ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown
-      ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST. We
-      ;; only need to do this for string literals, since numbers and booleans get inlined directly.
-      ;;
-      ;; https://linear.app/metabase/issue/QUE-726/
-      ;; https://github.com/h2database/h2database/issues/1383
-      (->> (sql.qp/->honeysql driver expression-definition)
-           (h2x/cast :text))
-      ((get-method sql.qp/->honeysql [:sql-jdbc :expression])
-       driver clause))))
 
 (defn- datediff
   "Like H2's `datediff` function but accounts for timestamps with time zones."

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -75,8 +75,7 @@
                               ;; MySQL doesn't let you have lag/lead in the same part of a query as a `GROUP BY`; to
                               ;; fully support `offset` we need to do some kooky query transformations just for MySQL
                               ;; and make this work.
-                              :window-functions/offset                false
-                              :expression-literals                    true}]
+                              :window-functions/offset                false}]
   (defmethod driver/database-supports? [:mysql feature] [_driver _feature _db] supported?))
 
 ;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.
@@ -347,6 +346,10 @@
 (defmethod sql.qp/->honeysql [:mysql :text]
   [driver [_ value]]
   (h2x/maybe-cast "CHAR" (sql.qp/->honeysql driver value)))
+
+(defmethod sql.qp/->honeysql [:mysql ::sql.qp/cast-to-text]
+  [driver [_ expr]]
+  (sql.qp/->honeysql driver [::sql.qp/cast expr "CHAR"]))
 
 (defmethod sql.qp/->honeysql [:mysql :date]
   [driver [_ value]]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -79,7 +79,6 @@
                               :uuid-type                true
                               :split-part               true
                               :uploads                  true
-                              :expression-literals      true
                               :expressions/text         true
                               :expressions/integer      true
                               :expressions/date         true}]

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -20,6 +20,7 @@
 (doseq [feature [:advanced-math-expressions
                  :binning
                  :expression-aggregations
+                 :expression-literals
                  :expressions
                  :full-join
                  :inner-join

--- a/test/metabase/driver/test_util.clj
+++ b/test/metabase/driver/test_util.clj
@@ -2,6 +2,8 @@
   (:require
    [mb.hawk.parallel]
    [metabase.driver :as driver]
+   [metabase.driver.sql.query-processor.empty-string-is-null
+    :as sql.qp.empty-string-is-null]
    [metabase.test.initialize :as initialize]))
 
 (defn -notify-all-databases-updated! []
@@ -19,3 +21,8 @@
        ~@body
        (finally
          (-notify-all-databases-updated!)))))
+
+(defn empty-string-is-null?
+  "Does driver treat an empty string as null?"
+  [driver]
+  (isa? driver/hierarchy driver ::sql.qp.empty-string-is-null/empty-string-is-null))

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -276,6 +276,19 @@
     (1 1M true)  true
     (throw (ex-info "value is not boolish" {:value x}))))
 
+(defn format-nil->empty-str
+  "Return a function that converts nil to an empty string if driver treats empty strings a null.
+
+  Can be used with [[format-rows-by]] to normalize empty strings in results (but don't forget you need to pass
+  `format-nil-values?` when calling the [[format-rows-by]])."
+  [driver]
+  (if-not (driver.tu/empty-string-is-null? driver)
+    str
+    (fn nil->empty-string [value]
+      (if (nil? value)
+        ""
+        (str value)))))
+
 (defn format-rows-by
   "Format the values in result `rows` with the fns at the corresponding indecies in `format-fns`. `rows` can be a
   sequence or any of the common map formats we expect in QP tests.

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -480,11 +480,13 @@
    [:field "MyTrue"  {:base_type :type/Boolean}]
    [:field "MyFalse" {:base_type :type/Boolean}]])
 
-(def ^:private standard-literal-expression-row-formats
-  [str str int int 3.0 mt/boolish->bool mt/boolish->bool])
+(defn- standard-literal-expression-row-formats
+  [driver]
+  [(mt/format-nil->empty-str driver) str int int 3.0 mt/boolish->bool mt/boolish->bool])
 
-(def ^:private standard-literal-expression-row-formats-with-id
-  (into [int] standard-literal-expression-row-formats))
+(defn- standard-literal-expression-row-formats-with-id
+  [driver]
+  (into [int] (standard-literal-expression-row-formats driver)))
 
 (def ^:private standard-literal-expression-values
   (map second (vals standard-literal-expression-defs)))
@@ -495,7 +497,8 @@
       (is (= [[1 "" "foo" 0 12345 1.234 true false]
               [2 "" "foo" 0 12345 1.234 true false]]
              (mt/formatted-rows
-              standard-literal-expression-row-formats-with-id
+              (standard-literal-expression-row-formats-with-id driver/*driver*)
+              #_format-nil-values? true
               (mt/run-mbql-query orders
                 {:expressions standard-literal-expression-defs
                  :fields      (into [$id] standard-literal-expression-refs)
@@ -509,7 +512,8 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
         (is (= expected
                (mt/formatted-rows
-                standard-literal-expression-row-formats
+                (standard-literal-expression-row-formats driver/*driver*)
+                #_format-nil-values? true
                 (mt/run-mbql-query orders
                   {:expressions standard-literal-expression-defs
                    :fields      standard-literal-expression-refs
@@ -521,7 +525,8 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :nested-queries)
       (is (= [(into [1] standard-literal-expression-values)]
              (mt/formatted-rows
-              standard-literal-expression-row-formats-with-id
+              (standard-literal-expression-row-formats-with-id driver/*driver*)
+              #_format-nil-values? true
               (mt/run-mbql-query venues
                 {:fields       (into [$id] standard-literal-expression-column-refs)
                  :source-query {:source-table $$venues
@@ -551,7 +556,8 @@
       (is (= [(into [1] standard-literal-expression-values)
               (into [2] standard-literal-expression-values)]
              (mt/formatted-rows
-              standard-literal-expression-row-formats-with-id
+              (standard-literal-expression-row-formats-with-id driver/*driver*)
+              #_format-nil-values? true
               (mt/run-mbql-query orders
                 {:expressions standard-literal-expression-defs
                  :fields      (into [$id] standard-literal-expression-refs)
@@ -565,7 +571,8 @@
       (let [orders-count 18760]
         (is (= [(conj (vec standard-literal-expression-values) orders-count)]
                (mt/formatted-rows
-                (conj standard-literal-expression-row-formats int)
+                (conj (standard-literal-expression-row-formats driver/*driver*) int)
+                #_format-nil-values? true
                 (mt/run-mbql-query orders
                   {:expressions standard-literal-expression-defs
                    :aggregation [:count]
@@ -634,7 +641,8 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
         (is (= expected
                (mt/formatted-rows
-                standard-literal-expression-row-formats
+                (standard-literal-expression-row-formats driver/*driver*)
+                #_format-nil-values? true
                 (mt/run-mbql-query orders
                   {:expressions standard-literal-expression-defs
                    :fields      standard-literal-expression-refs

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -570,8 +570,8 @@
 (deftest ^:parallel case-with-literal-expression-test
   (testing "CASE expression using literal expressions"
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
-      (is (= [[1 12345 true  "foo"]
-              [2 12345 false "foo"]]
+      (is (= [[1 12345 true  "foobar"]
+              [2 12345 false "foobar"]]
              (mt/formatted-rows
               [int int mt/boolish->bool str]
               (mt/run-mbql-query venues
@@ -579,24 +579,24 @@
                                     {"case 1" [:case
                                                [[[:< [:expression "zero"] 0]
                                                  [:expression "zero"]]
-                                                [[:= false [:expression "True"]]
+                                                [[:= false [:expression "MyTrue"]]
                                                  [:expression "zero"]]
                                                 [[:= "foo" [:expression "foo"]]
                                                  [:expression "12345"]]]
                                                {:default [:expression "zero"]}]
                                      "case 2" [:case
                                                [[[:= $id 1]
-                                                 [:expression "True"]]
+                                                 [:expression "MyTrue"]]
                                                 [[:= $id 2]
-                                                 [:expression "False"]]]]
+                                                 [:expression "MyFalse"]]]]
                                      "case 3" [:case
                                                [[[:= [:concat [:expression "foo"] ""] "bar"]
-                                                 [:expression "empty"]]
+                                                 [:expression "foo"]]
                                                 [[:> [:expression "zero"] 0]
-                                                 [:expression "empty"]]
+                                                 [:expression "foo"]]
                                                 [[:is-null [:expression "foo"]]
-                                                 [:expression "empty"]]]
-                                               {:default [:expression "foo"]}]})
+                                                 [:expression "foo"]]]
+                                               {:default [:concat [:expression "foo"] "bar"]}]})
                  :fields      [$id
                                [:expression "case 1"]
                                [:expression "case 2"]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -454,13 +454,13 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (def ^:private standard-literal-expression-defs
-  {"empty"  [:value ""    {:base_type :type/Text}]
-   "foo"    [:value "foo" {:base_type :type/Text}]
-   "zero"   [:value 0     {:base_type :type/Integer}]
-   "12345"  [:value 12345 {:base_type :type/Integer}]
-   "float"  [:value 1.234 {:base_type :type/Float}]
-   "True"   [:value true  {:base_type :type/Boolean}]
-   "False"  [:value false {:base_type :type/Boolean}]})
+  {"empty"    [:value ""    {:base_type :type/Text}]
+   "foo"      [:value "foo" {:base_type :type/Text}]
+   "zero"     [:value 0     {:base_type :type/Integer}]
+   "12345"    [:value 12345 {:base_type :type/Integer}]
+   "float"    [:value 1.234 {:base_type :type/Float}]
+   "MyTrue"   [:value true  {:base_type :type/Boolean}]
+   "MyFalse"  [:value false {:base_type :type/Boolean}]})
 
 (def ^:private standard-literal-expression-refs
   [[:expression "empty"]
@@ -468,17 +468,17 @@
    [:expression "zero"]
    [:expression "12345"]
    [:expression "float"]
-   [:expression "True"]
-   [:expression "False"]])
+   [:expression "MyTrue"]
+   [:expression "MyFalse"]])
 
 (def ^:private standard-literal-expression-column-refs
-  [[:field "empty" {:base_type :type/Text}]
-   [:field "foo"   {:base_type :type/Text}]
-   [:field "zero"  {:base_type :type/Integer}]
-   [:field "12345" {:base_type :type/Integer}]
-   [:field "float" {:base_type :type/Float}]
-   [:field "True"  {:base_type :type/Boolean}]
-   [:field "False" {:base_type :type/Boolean}]])
+  [[:field "empty"   {:base_type :type/Text}]
+   [:field "foo"     {:base_type :type/Text}]
+   [:field "zero"    {:base_type :type/Integer}]
+   [:field "12345"   {:base_type :type/Integer}]
+   [:field "float"   {:base_type :type/Float}]
+   [:field "MyTrue"  {:base_type :type/Boolean}]
+   [:field "MyFalse" {:base_type :type/Boolean}]])
 
 (def ^:private standard-literal-expression-row-formats
   [str str int int 3.0 mt/boolish->bool mt/boolish->bool])
@@ -617,19 +617,19 @@
                (mt/formatted-rows
                 [mt/boolish->bool mt/boolish->bool]
                 (mt/run-mbql-query orders
-                  {:expressions {"true"  [:value true  {:base_type :type/Boolean}]
-                                 "false" [:value false {:base_type :type/Boolean}]}
-                   :fields      [[:expression "true"]
-                                 [:expression "false"]]
-                   :filter      (into [op] [[:expression "true"]
-                                            [:expression "false"]])
+                  {:expressions {"MyTrue"  [:value true  {:base_type :type/Boolean}]
+                                 "MyFalse" [:value false {:base_type :type/Boolean}]}
+                   :fields      [[:expression "MyTrue"]
+                                 [:expression "MyFalse"]]
+                   :filter      (into [op] [[:expression "MyTrue"]
+                                            [:expression "MyFalse"]])
                    :limit       1}))))))))
 
 (deftest ^:parallel filter-literal-boolean-expression-with-no-operator-test
-  (doseq [[expression expected] [[[:value true nil]     [standard-literal-expression-values]]
-                                 [[:value false nil]    []]
-                                 [[:expression "True"]  [standard-literal-expression-values]]
-                                 [[:expression "False"] []]]]
+  (doseq [[expression expected] [[[:value true nil]       [standard-literal-expression-values]]
+                                 [[:value false nil]      []]
+                                 [[:expression "MyTrue"]  [standard-literal-expression-values]]
+                                 [[:expression "MyFalse"] []]]]
     (testing (str "filter literal expressions with " expression)
       (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals)
         (is (= expected
@@ -652,13 +652,13 @@
               (mt/run-mbql-query venues
                 {:fields       [$id
                                 $name
-                                [:expression "True"]
+                                [:expression "MyTrue"]
                                 [:expression "Name"]
                                 *One/Integer
                                 *Two/Integer
                                 *Bob/Text]
-                 :expressions  {"True"  [:value true {:base_type :type/Boolean}]
-                                "Name"  [:value "Red Medicine" {:base_type :type/Text}]}
+                 :expressions  {"MyTrue"  [:value true {:base_type :type/Boolean}]
+                                "Name"    [:value "Red Medicine" {:base_type :type/Text}]}
                  :source-query {:source-table $$venues
                                 :fields       [$id
                                                $name
@@ -671,8 +671,8 @@
                                 :filters      [[:= 2.0 [:* [:expression "Two"] [:expression "One"]]]]}
                  :filters      [[:!= *Bob/Text [:expression "Name"]]
                                 [:!= $name [:expression "Name"]]
-                                [:= true [:expression "True"]]
-                                [:= [:expression "True"] true]
+                                [:= true [:expression "MyTrue"]]
+                                [:= [:expression "MyTrue"] true]
                                 [:=
                                  [:expression "Name"]
                                  [:concat [:expression "Name"] ""]]]

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -984,12 +984,12 @@
     (let [query (mt/mbql-query venues
                   {:fields      [[:expression "one"]
                                  [:expression "foo"]
-                                 [:expression "true"]
-                                 [:expression "false"]]
-                   :expressions {"one"   [:value 1     {:base_type :type/Integer}]
-                                 "foo"   [:value "foo" {:base_type :type/Text}]
-                                 "true"  [:value true  {:base_type :type/Boolean}]
-                                 "false" [:value false {:base_type :type/Boolean}]}
+                                 [:expression "MyTrue"]
+                                 [:expression "MyFalse"]]
+                   :expressions {"one"     [:value 1     {:base_type :type/Integer}]
+                                 "foo"     [:value "foo" {:base_type :type/Text}]
+                                 "MyTrue"  [:value true  {:base_type :type/Boolean}]
+                                 "MyFalse" [:value false {:base_type :type/Boolean}]}
                    :limit       1})]
       (letfn [(check-result [rows]
                 (is (= [[1 "foo" true false]]

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -211,6 +211,7 @@
   cols
   first-row
   formatted-rows+column-names
+  format-nil->empty-str
   format-rows-by
   formatted-rows
   nest-query


### PR DESCRIPTION
### Description

Lift the H2 fix for literal string expression into the SQL driver and enable the `:expression-literals` feature for all `:sql` drivers. The H2 fix also fixes `:redshift`. This is a test to see if it fixes (or breaks) any other `:sql` drivers.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
