### PR TITLE
Added include_metadata argument to search API

### DIFF
--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -17,8 +17,7 @@
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [ring.util.response :as response]
-   [toucan2.core :as t2]))
+   [ring.util.response :as response]))
 
 (set! *warn-on-reflection* true)
 
@@ -111,23 +110,6 @@
       (set-weights! context overrides))
     (search.config/weights context)))
 
-(defn- add-metadata [include-metadata search-results]
-  (if include-metadata
-    (let [card-ids (into #{}
-                         (comp
-                          (filter #(= (:model %) "card"))
-                          (map :id))
-                         (:data search-results))
-          card-metadata (t2/select-pk->fn :result_metadata :model/Card :id [:in card-ids])]
-      (update search-results :data
-              (fn [data]
-                (mapv (fn [item]
-                        (if (= (:model item) "card")
-                          (assoc item :result_metadata (card-metadata (:id item)))
-                          item))
-                      data))))
-    search-results))
-
 (api.macros/defendpoint :get "/"
   "Search for items in Metabase.
   For the list of supported models, check [[metabase.search.config/all-models]].
@@ -185,34 +167,34 @@
        [:include_metadata                    {:default false} [:maybe :boolean]]]]
   (api/check-valid-page-params (request/limit) (request/offset))
   (try
-    (add-metadata include-metadata
-                  (u/prog1 (search/search
-                            (search/search-context
-                             {:archived                            archived
-                              :context                             context
-                              :created-at                          created-at
-                              :created-by                          (set created-by)
-                              :current-user-id                     api/*current-user-id*
-                              :is-impersonated-user?               (perms/impersonated-user?)
-                              :is-sandboxed-user?                  (perms/sandboxed-user?)
-                              :is-superuser?                       api/*is-superuser?*
-                              :current-user-perms                  @api/*current-user-permissions-set*
-                              :filter-items-in-personal-collection filter-items-in-personal-collection
-                              :last-edited-at                      last-edited-at
-                              :last-edited-by                      (set last-edited-by)
-                              :limit                               (request/limit)
-                              :model-ancestors?                    model-ancestors
-                              :models                              (not-empty (set models))
-                              :offset                              (request/offset)
-                              :search-engine                       search-engine
-                              :search-native-query                 search-native-query
-                              :search-string                       q
-                              :table-db-id                         table-db-id
-                              :verified                            verified
-                              :ids                                 (set ids)
-                              :calculate-available-models?         calculate-available-models
-                              :include-dashboard-questions?        include-dashboard-questions}))
-                    (analytics/inc! :metabase-search/response-ok)))
+    (u/prog1 (search/search
+              (search/search-context
+               {:archived                            archived
+                :context                             context
+                :created-at                          created-at
+                :created-by                          (set created-by)
+                :current-user-id                     api/*current-user-id*
+                :is-impersonated-user?               (perms/impersonated-user?)
+                :is-sandboxed-user?                  (perms/sandboxed-user?)
+                :is-superuser?                       api/*is-superuser?*
+                :current-user-perms                  @api/*current-user-permissions-set*
+                :filter-items-in-personal-collection filter-items-in-personal-collection
+                :last-edited-at                      last-edited-at
+                :last-edited-by                      (set last-edited-by)
+                :limit                               (request/limit)
+                :model-ancestors?                    model-ancestors
+                :models                              (not-empty (set models))
+                :offset                              (request/offset)
+                :search-engine                       search-engine
+                :search-native-query                 search-native-query
+                :search-string                       q
+                :table-db-id                         table-db-id
+                :verified                            verified
+                :ids                                 (set ids)
+                :calculate-available-models?         calculate-available-models
+                :include-dashboard-questions?        include-dashboard-questions
+                :include-metadata?                   include-metadata}))
+      (analytics/inc! :metabase-search/response-ok))
     (catch Exception e
       (let [status-code (:status-code (ex-data e))]
         (when (or (not status-code) (= 5 (quot status-code 100)))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -256,7 +256,8 @@
    ;; true to search for verified items only, nil will return all items
    [:verified                            {:optional true} true?]
    [:ids                                 {:optional true} [:set {:min 1} ms/PositiveInt]]
-   [:include-dashboard-questions?        {:optional true} :boolean]])
+   [:include-dashboard-questions?        {:optional true} :boolean]
+   [:include-metadata?                   {:optional true} :boolean]])
 
 (defmulti column->string
   "Turn a complex column into a string"

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -264,7 +264,8 @@
    [:verified                            {:optional true} [:maybe true?]]
    [:ids                                 {:optional true} [:maybe [:set ms/PositiveInt]]]
    [:calculate-available-models?         {:optional true} [:maybe :boolean]]
-   [:include-dashboard-questions?        {:optional true} [:maybe boolean?]]])
+   [:include-dashboard-questions?        {:optional true} [:maybe boolean?]]
+   [:include-metadata?                   {:optional true} [:maybe boolean?]]])
 
 (mu/defn search-context :- SearchContext
   "Create a new search context that you can pass to other functions like [[search]]."
@@ -280,6 +281,7 @@
            is-impersonated-user?
            is-sandboxed-user?
            include-dashboard-questions?
+           include-metadata?
            is-superuser?
            last-edited-at
            last-edited-by
@@ -326,6 +328,7 @@
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)
+                 (some? include-metadata?)                   (assoc :include-metadata? include-metadata?)
                  (seq ids)                                   (assoc :ids ids))]
     (when (and (seq ids)
                (not= (count models) 1))
@@ -399,6 +402,19 @@
        (map #(u/update-some % :dashboard select-keys [:id :name :moderation_status]))
        (map #(dissoc % :dashboard_id))))
 
+(defn- add-metadata [search-results]
+  (let [card-ids (into #{}
+                       (comp
+                        (filter #(= (:model %) "card"))
+                        (map :id))
+                       search-results)
+        card-metadata (t2/select-pk->fn :result_metadata :model/Card :id [:in card-ids])]
+    (map (fn [{:keys [model id] :as item}]
+           (if (= model "card")
+             (assoc item :result_metadata (card-metadata id))
+             item))
+         search-results)))
+
 (mu/defn search
   "Builds a search query that includes all the searchable entities, and runs it."
   [search-ctx :- search.config/SearchContext]
@@ -413,6 +429,7 @@
         total-results     (cond->> (scoring/top-results reducible-results search.config/max-filtered-results xf)
                             true hydrate-dashboards
                             true hydrate-user-metadata
+                            (:include-metadata? search-ctx) (add-metadata)
                             (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)
                             true (add-collection-effective-location)
                             true (map serialize))]

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -408,7 +408,9 @@
                         (filter #(= (:model %) "card"))
                         (map :id))
                        search-results)
-        card-metadata (t2/select-pk->fn :result_metadata :model/Card :id [:in card-ids])]
+        card-metadata (if (empty? card-ids)
+                        {}
+                        (t2/select-pk->fn :result_metadata [:model/Card :id :card_schema :result_metadata] :id [:in card-ids]))]
     (map (fn [{:keys [model id] :as item}]
            (if (= model "card")
              (assoc item :result_metadata (card-metadata id))


### PR DESCRIPTION
### Description

Adds a new `include_metadata` argument for the search API.

If true (default is false), the `result_metadata` will be included in each result for `card` type results.

Useful when the frontend would otherwise need to make separate API calls for the metadata for each result.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
