### PR TITLE
Move toast handling into useAdminSetting Hook

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -286,6 +286,7 @@ describe("scenarios > home > custom homepage", () => {
       cy.log(
         "disabling custom-homepage-setting should also remove custom-homepage-dashboard-setting",
       );
+      cy.visit("/admin/settings/general");
 
       cy.findByTestId("custom-homepage-setting").within(() => {
         cy.findByText("Enabled").should("exist");

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -197,7 +197,7 @@ describe("scenarios > admin > permissions > application", () => {
         });
 
         H.undoToast()
-          .findByText(/changes saved/)
+          .findByText(/changes saved/i)
           .should("be.visible");
       });
     });

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { useAdminSetting } from "metabase/api/utils";
-import { useToast } from "metabase/common/hooks";
 import type { GenericErrorResponse } from "metabase/lib/errors";
 import { TextInput } from "metabase/ui";
 
@@ -13,7 +12,6 @@ export function LandingPageWidget() {
   const [error, setError] = useState<string | null>(null);
   const { value, updateSetting, description } = useAdminSetting("landing-page");
   const [inputValue, setInputValue] = useState(value ?? "");
-  const [sendToast] = useToast();
 
   useEffect(() => {
     if (value) {
@@ -42,9 +40,6 @@ export function LandingPageWidget() {
         (result.error as { data: GenericErrorResponse })?.data?.message ||
         t`Something went wrong`;
       setError(message);
-      sendToast({ message, icon: "check" });
-    } else {
-      sendToast({ message: t`Changes saved`, icon: "check" });
     }
   };
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { InputSettingType } from "./actions";
+import type { DashboardId } from "./dashboard";
 import type { UserId } from "./user";
 
 export interface FormattingSettings {
@@ -360,7 +361,7 @@ interface PublicSettings {
   "cloud-gateway-ips": string[] | null;
   "custom-formatting": FormattingSettings;
   "custom-homepage": boolean;
-  "custom-homepage-dashboard": number | null;
+  "custom-homepage-dashboard": DashboardId | null;
   "ee-ai-features-enabled"?: boolean;
   "email-configured?": boolean;
   "embedding-app-origin": string | null;

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { jt, t } from "ttag";
 
-import { useAdminSetting } from "metabase/api";
+import { useAdminSetting } from "metabase/api/utils";
 import { useDocsUrl } from "metabase/common/hooks";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import {

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -2,9 +2,8 @@ import { useEffect, useState } from "react";
 import { jt, t } from "ttag";
 
 import { useAdminSetting } from "metabase/api";
-import { useDocsUrl, useToast } from "metabase/common/hooks";
+import { useDocsUrl } from "metabase/common/hooks";
 import ExternalLink from "metabase/core/components/ExternalLink";
-import type { GenericErrorResponse } from "metabase/lib/errors";
 import {
   Box,
   type BoxProps,
@@ -14,7 +13,7 @@ import {
   TextInput,
   Textarea,
 } from "metabase/ui";
-import type { SettingKey } from "metabase-types/api";
+import type { EnterpriseSettingValue, SettingKey } from "metabase-types/api";
 
 import { SettingHeader } from "../SettingHeader";
 
@@ -62,8 +61,6 @@ export function AdminSettingInput<SettingName extends SettingKey>({
   options,
   ...boxProps
 }: AdminSettingInputProps<SettingName>) {
-  const [sendToast] = useToast();
-
   const {
     value: initialValue,
     updateSetting,
@@ -72,20 +69,11 @@ export function AdminSettingInput<SettingName extends SettingKey>({
     settingDetails,
   } = useAdminSetting(name);
 
-  const handleChange = (newValue: string | boolean | number) => {
+  const handleChange = (newValue: EnterpriseSettingValue) => {
     if (newValue === initialValue) {
       return;
     }
-    updateSetting({ key: name, value: newValue }).then((response) => {
-      if (response?.error) {
-        const message =
-          (response.error as GenericErrorResponse)?.message ||
-          t`Error saving ${title}`;
-        sendToast({ message, icon: "check", toastColor: "danger" });
-      } else {
-        sendToast({ message: t`${title} changes saved`, icon: "check" });
-      }
-    });
+    updateSetting({ key: name, value: newValue });
   };
 
   if (hidden || isLoading) {

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
@@ -356,9 +356,7 @@ describe("AdminSettingInput", () => {
     expect(putUrl).toContain("/api/setting/humanization-strategy");
     expect(body).toStrictEqual({ value: "simple" });
 
-    const toast = await screen.findByText(
-      "Humanization Strategy changes saved",
-    );
+    const toast = await screen.findByText("Changes saved");
     expect(toast).toBeInTheDocument();
   });
 
@@ -383,11 +381,11 @@ describe("AdminSettingInput", () => {
     expect(putUrl).toContain("/api/setting/humanization-strategy");
     expect(body).toStrictEqual({ value: "simple" });
 
-    const toast = await screen.findByText("Error saving Humanization Strategy");
+    const toast = await screen.findByText("Error saving humanization-strategy");
     expect(toast).toBeInTheDocument();
   });
 
-  it("should display a notice isntead of input when a setting is set by an environment variable", async () => {
+  it("should display a notice instead of input when a setting is set by an environment variable", async () => {
     setup({
       title: "url",
       name: "site-url",

--- a/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
@@ -1,8 +1,6 @@
 import { t } from "ttag";
 
 import { useAdminSetting } from "metabase/api";
-import { useToast } from "metabase/common/hooks";
-import type { GenericErrorResponse } from "metabase/lib/errors";
 import { Stack } from "metabase/ui";
 
 import { trackTrackingPermissionChanged } from "../../analytics";
@@ -14,7 +12,6 @@ export function AnonymousTrackingInput() {
   const { value, updateSetting, description } = useAdminSetting(
     "anon-tracking-enabled",
   );
-  const [sendToast] = useToast();
 
   const handleChange = async (newValue: boolean) => {
     if (value) {
@@ -23,18 +20,6 @@ export function AnonymousTrackingInput() {
     await updateSetting({
       key: "anon-tracking-enabled",
       value: newValue,
-    }).then((response) => {
-      if (response?.error) {
-        const message =
-          (response.error as GenericErrorResponse)?.message ||
-          t`Error updating setting`;
-        sendToast({ message, icon: "warning", toastColor: "danger" });
-      } else {
-        sendToast({ message: t`Changes saved`, icon: "check" });
-        if (newValue) {
-          trackTrackingPermissionChanged(newValue);
-        }
-      }
     });
   };
 

--- a/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { useAdminSetting } from "metabase/api";
+import { useAdminSetting } from "metabase/api/utils";
 import { Stack } from "metabase/ui";
 
 import { trackTrackingPermissionChanged } from "../../analytics";

--- a/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
@@ -15,12 +15,16 @@ export function AnonymousTrackingInput() {
 
   const handleChange = async (newValue: boolean) => {
     if (value) {
+      // if we're changing this getting turned off, we need to track it before it's changed
       trackTrackingPermissionChanged(newValue);
     }
     await updateSetting({
       key: "anon-tracking-enabled",
       value: newValue,
     });
+    if (newValue) {
+      trackTrackingPermissionChanged(newValue);
+    }
   };
 
   return (

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
@@ -50,12 +50,12 @@ export function CustomHomepageDashboardSetting() {
     await updateSetting({
       key: "custom-homepage",
       value: newValue,
+      toast: false,
     });
     if (newValue === false) {
       await updateSetting({
         key: "custom-homepage-dashboard",
         value: null,
-        toast: false,
       });
     }
 

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import { useAdminSetting } from "metabase/api";
-import { useToast } from "metabase/common/hooks";
 import { DashboardSelector } from "metabase/components/DashboardSelector";
 import { useDispatch } from "metabase/lib/redux";
 import { refreshCurrentUser } from "metabase/redux/user";
@@ -23,12 +22,11 @@ export function CustomHomepageDashboardSetting() {
     "custom-homepage-dashboard",
   );
   const dispatch = useDispatch();
-  const [sendToast] = useToast();
 
   const handleDashboardChange = async (newDashboardId?: DashboardId) => {
     const result = await updateSetting({
       key: "custom-homepage-dashboard",
-      value: newDashboardId,
+      value: newDashboardId ?? null,
     });
 
     if (!result) {
@@ -42,9 +40,8 @@ export function CustomHomepageDashboardSetting() {
     await updateSetting({
       key: "dismissed-custom-dashboard-toast",
       value: true,
+      toast: false,
     });
-
-    sendToast({ message: t`Changes saved`, icon: "check" });
 
     await dispatch(refreshCurrentUser());
   };
@@ -58,14 +55,11 @@ export function CustomHomepageDashboardSetting() {
       await updateSetting({
         key: "custom-homepage-dashboard",
         value: null,
+        toast: false,
       });
     }
 
     await dispatch(refreshCurrentUser());
-
-    if (customHomepageDashboardId || !newValue) {
-      sendToast({ message: t`Changes saved`, icon: "check" });
-    }
   };
 
   return (

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomHomepageDashboardSetting.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { useAdminSetting } from "metabase/api";
+import { useAdminSetting } from "metabase/api/utils";
 import { DashboardSelector } from "metabase/components/DashboardSelector";
 import { useDispatch } from "metabase/lib/redux";
 import { refreshCurrentUser } from "metabase/redux/user";

--- a/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { t } from "ttag";
 
-import { useAdminSetting } from "metabase/api";
+import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { fetchWithTimeout } from "metabase/lib/fetchWithTimeout";
 

--- a/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.tsx
@@ -2,7 +2,7 @@ import type { ChangeEvent } from "react";
 import { useState } from "react";
 import { t } from "ttag";
 
-import { useAdminSetting } from "metabase/api";
+import { useAdminSetting } from "metabase/api/utils";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import InputWithSelectPrefix from "metabase/components/InputWithSelectPrefix";
 import type { GenericErrorResponse } from "metabase/lib/errors";

--- a/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { useAdminSetting } from "metabase/api";
-import { useHasTokenFeature, useToast } from "metabase/common/hooks";
+import { useHasTokenFeature } from "metabase/common/hooks";
 import InputWithSelectPrefix from "metabase/components/InputWithSelectPrefix";
 import type { GenericErrorResponse } from "metabase/lib/errors";
 import { Box, Text } from "metabase/ui";
@@ -14,7 +14,6 @@ export function SiteUrlWidget() {
   const { value, updateSetting, description } = useAdminSetting("site-url");
   const isHosted = useHasTokenFeature("hosting");
   const [errorMessage, setErrorMessage] = useState("");
-  const [sendToast] = useToast();
 
   const handleChange = (newValue: string) => {
     if (newValue === value) {
@@ -26,10 +25,7 @@ export function SiteUrlWidget() {
         const message =
           (response.error as { data: GenericErrorResponse })?.data?.message ||
           t`Error saving Site URL`;
-        sendToast({ message, icon: "warning", toastColor: "danger" });
         setErrorMessage(message);
-      } else {
-        sendToast({ message: t`Changes saved`, icon: "check" });
       }
     });
   };

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -34,4 +34,3 @@ export * from "./timeline";
 export * from "./timeline-event";
 export * from "./user-key-value";
 export * from "./user";
-export * from "./utils";

--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -27,7 +27,7 @@ export const settingsApi = Api.injectEndpoints({
       void,
       {
         key: EnterpriseSettingKey;
-        value: EnterpriseSettingValue;
+        value: EnterpriseSettingValue<EnterpriseSettingKey>;
       }
     >({
       query: ({ key, value }) => ({

--- a/frontend/src/metabase/api/utils/settings.ts
+++ b/frontend/src/metabase/api/utils/settings.ts
@@ -58,7 +58,7 @@ export const useAdminSetting = <SettingName extends EnterpriseSettingKey>(
 
         sendToast({ message, icon: "warning", toastColor: "danger" });
       } else {
-        sendToast({ message: `Changes saved`, icon: "check" });
+        sendToast({ message: t`Changes saved`, icon: "check" });
       }
       return response;
     },

--- a/frontend/src/metabase/api/utils/settings.ts
+++ b/frontend/src/metabase/api/utils/settings.ts
@@ -1,6 +1,11 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { t } from "ttag";
 
-import type { EnterpriseSettingKey } from "metabase-types/api";
+import { useToast } from "metabase/common/hooks";
+import type {
+  EnterpriseSettingKey,
+  EnterpriseSettingValue,
+} from "metabase-types/api";
 
 import { useGetSettingsQuery } from "../session";
 import {
@@ -28,13 +33,45 @@ export const useAdminSetting = <SettingName extends EnterpriseSettingKey>(
     [settingsDetails, settingName],
   );
 
+  const [sendToast] = useToast();
+
+  const handleUpdateSetting = useCallback(
+    async <K extends EnterpriseSettingKey>({
+      key,
+      value,
+      toast = true,
+    }: {
+      key: K;
+      value: EnterpriseSettingValue<K>;
+      toast?: boolean;
+    }) => {
+      const response = await updateSetting({ key, value });
+
+      if (!toast) {
+        return response;
+      }
+
+      if (response.error) {
+        const message =
+          (response.error as { data?: { message: string } })?.data?.message ||
+          t`Error saving ${key}`;
+
+        sendToast({ message, icon: "warning", toastColor: "danger" });
+      } else {
+        sendToast({ message: `Changes saved`, icon: "check" });
+      }
+      return response;
+    },
+    [updateSetting, sendToast],
+  );
+
   const settingValue = settings?.[settingName];
 
   return {
     value: settingValue,
     settingDetails,
     description: settingDetails?.description,
-    updateSetting,
+    updateSetting: handleUpdateSetting,
     updateSettingResult,
     isLoading: settingsLoading || detailsLoading,
     ...apiProps,

--- a/frontend/src/metabase/entities/collections/index.ts
+++ b/frontend/src/metabase/entities/collections/index.ts
@@ -1,6 +1,6 @@
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export { default } from "./collections";
+
 export * from "./constants";
 export * from "./collections";
 export * from "./utils";
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./collections";


### PR DESCRIPTION
### Description

Small refactor to move toast handling into the useAdminSetting hook to eliminate a bunch of duplicated code across custom settings widgets. You can still set `toast: false` to do your own toasting.
