### PR TITLE
fix incorrect series colors in static viz

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -21,6 +21,7 @@ import type {
   VizSettingsKey,
   WaterFallChartDataDensity,
 } from "metabase/visualizations/echarts/cartesian/model/types";
+import { getHexColor } from "metabase/visualizations/lib/color";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import {
   SERIES_COLORS_SETTING_KEY,
@@ -47,7 +48,7 @@ import {
 import { CHART_STYLE } from "../constants/style";
 import { WATERFALL_VALUE_KEY } from "../waterfall/constants";
 
-import { getFormattingOptionsWithoutScaling, getHexColor } from "./util";
+import { getFormattingOptionsWithoutScaling } from "./util";
 
 export const getSeriesVizSettingsKey = (
   column: DatasetColumn,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -47,7 +47,7 @@ import {
 import { CHART_STYLE } from "../constants/style";
 import { WATERFALL_VALUE_KEY } from "../waterfall/constants";
 
-import { getFormattingOptionsWithoutScaling } from "./util";
+import { getFormattingOptionsWithoutScaling, getHexColor } from "./util";
 
 export const getSeriesVizSettingsKey = (
   column: DatasetColumn,
@@ -185,7 +185,9 @@ export const getCardSeriesModels = (
           card.name,
         );
 
-      const color = settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey];
+      const color = getHexColor(
+        settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey],
+      );
 
       const dataKey = getDatasetKey(metric.column, cardId);
 
@@ -247,7 +249,9 @@ export const getCardSeriesModels = (
         card.name,
       );
 
-    const color = settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey];
+    const color = getHexColor(
+      settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey],
+    );
 
     const dataKey = getDatasetKey(metric.column, cardId, breakoutValue);
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.unit.spec.ts
@@ -2,6 +2,7 @@ import type {
   BreakoutChartColumns,
   CartesianChartColumns,
 } from "metabase/visualizations/lib/graph/columns";
+import { SERIES_COLORS_SETTING_KEY } from "metabase/visualizations/shared/settings/series";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type { SingleSeries } from "metabase-types/api";
 import {
@@ -147,6 +148,28 @@ describe("series", () => {
           dataKey: "1:count",
           name: "foo",
           tooltipName: "foo",
+        });
+      });
+
+      it("should convert series colors to hex format (metabase#56232)", () => {
+        const rawSeries = [metricSeries];
+        const cardsColumns = [metricColumns];
+
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          [],
+          createMockComputedVisualizationSettings({
+            [SERIES_COLORS_SETTING_KEY]: {
+              [metricColumns.metrics[0].column.name]: "hsla(358, 71%, 62%, 1)",
+            },
+          }),
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          dataKey: "1:count",
+          color: "#E3595E",
         });
       });
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
@@ -1,3 +1,5 @@
+import Color from "color";
+
 import type { OptionsType } from "metabase/lib/formatting/types";
 import type {
   ComputedVisualizationSettings,
@@ -31,4 +33,10 @@ export function getColumnScaling(
     settings.column?.(column) ?? getColumnSettings(settings, column);
   const scale = columnSettings?.scale;
   return Number.isFinite(scale) ? (scale as number) : 1;
+}
+
+export function getHexColor(color: string) {
+  // Convert color values to hex format since Apache Batik (SVG renderer used in static visualizations)
+  // doesn't support functional color notations like hsla(), rgba(), etc.
+  return Color(color).hex();
 }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
@@ -1,5 +1,3 @@
-import Color from "color";
-
 import type { OptionsType } from "metabase/lib/formatting/types";
 import type {
   ComputedVisualizationSettings,
@@ -33,10 +31,4 @@ export function getColumnScaling(
     settings.column?.(column) ?? getColumnSettings(settings, column);
   const scale = columnSettings?.scale;
   return Number.isFinite(scale) ? (scale as number) : 1;
-}
-
-export function getHexColor(color: string) {
-  // Convert color values to hex format since Apache Batik (SVG renderer used in static visualizations)
-  // doesn't support functional color notations like hsla(), rgba(), etc.
-  return Color(color).hex();
 }

--- a/frontend/src/metabase/visualizations/lib/color.ts
+++ b/frontend/src/metabase/visualizations/lib/color.ts
@@ -1,0 +1,7 @@
+import Color from "color";
+
+export function getHexColor(color: string) {
+  // Convert color values to hex format since Apache Batik (SVG renderer used in static visualizations)
+  // doesn't support functional color notations like hsla(), rgba(), etc.
+  return Color(color).hex();
+}

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -8,6 +8,7 @@ import { SLICE_THRESHOLD } from "metabase/visualizations/echarts/pie/constants";
 import { getPieColumns } from "metabase/visualizations/echarts/pie/model";
 import type { PieRow } from "metabase/visualizations/echarts/pie/model/types";
 import type { ShowWarning } from "metabase/visualizations/echarts/types";
+import { getHexColor } from "metabase/visualizations/lib/color";
 import { getNumberOr } from "metabase/visualizations/lib/settings/row-values";
 import { getDefaultDimensionsAndMetrics } from "metabase/visualizations/lib/utils";
 import { unaggregatedDataWarningPie } from "metabase/visualizations/lib/warnings";
@@ -260,11 +261,7 @@ export function getPieRows(
       // Historically we have used the dimension value in the `pie.colors`
       // setting instead of the key computed above. For compatibility with
       // existing questions we will continue to use the dimension value.
-      //
-      // Additionally, some older questions have non-hex color values such as
-      // hsl strings so we need to convert everything to hsl for compatibilty
-      // with Batik in the backend static viz rendering pipeline.
-      const color = Color(colors[String(dimensionValue)]).hex();
+      const color = getHexColor(colors[String(dimensionValue)]);
 
       const savedRow = keyToSavedPieRow.get(key);
       if (savedRow != null) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56232

### Description

Apache Batik is the library static viz uses to convert SVGs to PNGs, and it does not support functional color notations such as `hlsa()`. We didn't run into this problem because most of colors were in hex format. The color assignment logic for some series names or pie slice names picks special hardcoded colors, for example, "success" should be green, and "error" should be red. The "error" color turned out to be `hsla(358, 71%, 62%, 1)` which caused the issue.

### How to verify

```sql
select 'foo' x, 'error' x1,  100 y
union all select 'bar', 'success', 200
```

Create the following chart
<img width="1136" alt="Screenshot 2025-04-07 at 9 31 11 PM" src="https://github.com/user-attachments/assets/10343e08-7c3d-46a6-80c7-c793ac0cc56c" />

Send a test subscription and ensure the "error" series is red.

### Demo

Before
<img width="637" alt="Screenshot 2025-04-07 at 9 32 40 PM" src="https://github.com/user-attachments/assets/b9b7d8f5-267c-4ec2-91b7-1ad996a11d7d" />

After
<img width="636" alt="Screenshot 2025-04-07 at 9 31 48 PM" src="https://github.com/user-attachments/assets/535eadd2-dcd1-42d4-b41f-01dc5978601b" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
