### PR TITLE
Allow selecting multiple ranges and running those in native editor

### DIFF
--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -102,7 +102,9 @@ export function enterParameterizedQuery(query, options = {}) {
 }
 
 export function getRunQueryButton() {
-  return cy.findByTestId("native-query-editor-sidebar").button("Get Answer");
+  return cy
+    .findByTestId("native-query-editor-sidebar")
+    .findByTestId("run-button");
 }
 
 export function getSaveQueryButton() {

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -476,3 +476,37 @@ describe("issue 55951", () => {
     }));
   }
 });
+
+describe("issue 54799", () => {
+  const questionDetails = {
+    native: {
+      query: "select 100, 200",
+    },
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("it should be possible to select multiple ranges and run those (metabase#54799)", () => {
+    cy.findByTestId("visibility-toggler").click();
+
+    cy.get("[data-testid=cell-data]").contains("100").should("be.visible");
+    cy.get("[data-testid=cell-data]").contains("200").should("be.visible");
+
+    const macOSX = Cypress.platform === "darwin";
+
+    H.NativeEditor.get().findByText("select").dblclick();
+    H.NativeEditor.get().findByText("200").dblclick({
+      metaKey: macOSX,
+      ctrlKey: !macOSX,
+    });
+
+    getRunQueryButton().click();
+
+    cy.get("[data-testid=cell-data]").contains("100").should("not.exist");
+    cy.get("[data-testid=cell-data]").contains("200").should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/querying.ts
+++ b/frontend/src/metabase/query_builder/actions/querying.ts
@@ -14,11 +14,11 @@ import type { Dataset } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
 
 import {
+  getAllNativeEditorSelectedText,
   getCard,
   getFirstQueryResult,
   getIsResultDirty,
   getIsRunning,
-  getNativeEditorSelectedText,
   getOriginalQuestion,
   getOriginalQuestionWithParameterValues,
   getQueryResults,
@@ -283,7 +283,7 @@ export const runQuestionOrSelectedQuery =
 
     const query = question.query();
     const queryInfo = Lib.queryDisplayInfo(query);
-    const selectedText = getNativeEditorSelectedText(getState());
+    const selectedText = getAllNativeEditorSelectedText(getState());
     if (queryInfo.isNative && selectedText) {
       const selectedQuery = Lib.withNativeQuery(query, selectedText);
       dispatch(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -23,7 +23,7 @@ export type CodeMirrorEditorProps = {
   onRunQuery?: () => void;
   onCursorMoveOverCardTag?: (id: CardId) => void;
   onRightClickSelection?: () => void;
-  onSelectionChange?: (range: SelectionRange) => void;
+  onSelectionChange?: (range: SelectionRange[]) => void;
 };
 
 export interface CodeMirrorEditorRef {
@@ -34,8 +34,9 @@ export interface CodeMirrorEditorRef {
 import S from "./CodeMirrorEditor.module.css";
 import { useExtensions } from "./extensions";
 import {
-  convertSelectionToRange,
+  areAllRangesEqual,
   getPlaceholderText,
+  getSelectedRanges,
   matchCardIdAtCursor,
 } from "./util";
 
@@ -73,22 +74,12 @@ export const CodeMirrorEditor = forwardRef<
   const handleUpdate = useCallback(
     (update: ViewUpdate) => {
       // handle selection changes
-      const value = update.state.doc.toString();
       if (onSelectionChange) {
-        const beforeRange = convertSelectionToRange(
-          update.startState.doc.toString(),
-          update.startState.selection.main,
-        );
-        const afterRange = convertSelectionToRange(
-          value,
-          update.state.selection.main,
-        );
+        const beforeRanges = getSelectedRanges(update.startState);
+        const afterRanges = getSelectedRanges(update.state);
 
-        if (
-          beforeRange.start !== afterRange.start ||
-          beforeRange.end !== afterRange.end
-        ) {
-          onSelectionChange(afterRange);
+        if (!areAllRangesEqual(beforeRanges, afterRanges)) {
+          onSelectionChange(afterRanges);
         }
       }
       if (onCursorMoveOverCardTag) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -271,3 +271,18 @@ export const getPlaceholderText = (engine?: string | null): string => {
       return "";
   }
 };
+
+export function getSelectedRanges(state: EditorState): Range[] {
+  const value = state.doc.toString();
+  return state.selection.ranges.map((range) =>
+    convertSelectionToRange(value, range),
+  );
+}
+
+export function areRangesEqual(a: Range, b: Range): boolean {
+  return a.start === b.start && a.end === b.end;
+}
+
+export function areAllRangesEqual(a: Range[], b: Range[]): boolean {
+  return a.length === b.length && a.every((a, i) => areRangesEqual(a, b[i]));
+}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -96,7 +96,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
     overrideWithQuestion?: Question;
     shouldUpdateUrl?: boolean;
   }) => void;
-  setNativeEditorSelectedRange: (range: SelectionRange) => void;
+  setNativeEditorSelectedRange: (range: SelectionRange[]) => void;
   openDataReferenceAtQuestion: (id: CardId) => void;
   openSnippetModalWithSelectedText: () => void;
   insertSnippet: (snippet: NativeQuerySnippet) => void;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -218,7 +218,7 @@ const getLastRunDatasetQuery = createSelector(
   [getLastRunCard],
   (card) => card && card.dataset_query,
 );
-const getNextRunDatasetQuery = createSelector(
+export const getNextRunDatasetQuery = createSelector(
   [getCard],
   (card) => card && card.dataset_query,
 );
@@ -748,7 +748,12 @@ export const getIsNativeEditorOpen = createSelector(
   (isNative, uiControls) => isNative && uiControls.isNativeEditorOpen,
 );
 
-const getNativeEditorSelectedRange = createSelector(
+export const getNativeEditorSelectedRange = createSelector(
+  [getUiControls],
+  (uiControls) => uiControls && uiControls.nativeEditorSelectedRange?.[0],
+);
+
+const getNativeEditorSelectedRanges = createSelector(
   [getUiControls],
   (uiControls) => uiControls && uiControls.nativeEditorSelectedRange,
 );
@@ -877,7 +882,7 @@ export const getVisibleTimelineEvents = createSelector(
       .value(),
 );
 
-function getOffsetForQueryAndPosition(queryText, { row, column }) {
+export function getOffsetForQueryAndPosition(queryText, { row, column }) {
   const queryLines = queryText.split("\n");
   return (
     // the total length of the previous rows
@@ -911,6 +916,28 @@ export const getNativeEditorSelectedText = createSelector(
     const start = getOffsetForQueryAndPosition(queryText, selectedRange.start);
     const end = getOffsetForQueryAndPosition(queryText, selectedRange.end);
     return queryText.slice(start, end);
+  },
+);
+
+export const getAllNativeEditorSelectedText = createSelector(
+  [getNativeEditorSelectedRanges, getNextRunDatasetQuery],
+  (selectedRanges, query) => {
+    if (
+      selectedRanges == null ||
+      selectedRanges.length === 0 ||
+      query == null ||
+      query.native == null
+    ) {
+      return null;
+    }
+    const queryText = query.native.query;
+    const selectedText = selectedRanges.map((range) =>
+      queryText.slice(
+        getOffsetForQueryAndPosition(queryText, range.start),
+        getOffsetForQueryAndPosition(queryText, range.end),
+      ),
+    );
+    return selectedText.join(" ");
   },
 );
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -937,7 +937,7 @@ export const getAllNativeEditorSelectedText = createSelector(
         getOffsetForQueryAndPosition(queryText, range.end),
       ),
     );
-    return selectedText.join(" ");
+    return selectedText.join("");
   },
 );
 

--- a/frontend/src/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/src/metabase/query_builder/selectors.unit.spec.js
@@ -324,7 +324,7 @@ describe("getIsResultDirty", () => {
         }),
       );
 
-      it("should correctly get selected text when there is are multiple selected ranges", () => {
+      it("should correctly get selected text when there are multiple selected ranges", () => {
         const state = getStateWithSelectedQueryText([
           { start: { row: 2, column: 0 }, end: { row: 2, column: 2 } },
           { start: { row: 0, column: 0 }, end: { row: 0, column: 2 } },

--- a/frontend/src/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/src/metabase/query_builder/selectors.unit.spec.js
@@ -282,7 +282,7 @@ describe("getIsResultDirty", () => {
     });
 
     describe("native editor selection/cursor", () => {
-      function getStateWithSelectedQueryText(start, end) {
+      function getStateWithSelectedQueryText(ranges) {
         return getBaseState({
           card: getBaseCard({
             dataset_query: {
@@ -291,7 +291,7 @@ describe("getIsResultDirty", () => {
             },
           }),
           uiControls: {
-            nativeEditorSelectedRange: { start, end },
+            nativeEditorSelectedRange: ranges,
           },
         });
       }
@@ -304,7 +304,9 @@ describe("getIsResultDirty", () => {
         it(`should correctly determine the cursor offset for ${JSON.stringify(
           position,
         )}`, () => {
-          const state = getStateWithSelectedQueryText(position, position);
+          const state = getStateWithSelectedQueryText([
+            { start: position, end: position },
+          ]);
           expect(getNativeEditorCursorOffset(state)).toBe(offset);
         }),
       );
@@ -317,10 +319,18 @@ describe("getIsResultDirty", () => {
         it(`should correctly get selected text from ${JSON.stringify(
           start,
         )} to ${JSON.stringify(end)}`, () => {
-          const state = getStateWithSelectedQueryText(start, end);
+          const state = getStateWithSelectedQueryText([{ start, end }]);
           expect(getNativeEditorSelectedText(state)).toBe(text);
         }),
       );
+
+      it("should correctly get selected text when there is are multiple selected ranges", () => {
+        const state = getStateWithSelectedQueryText([
+          { start: { row: 2, column: 0 }, end: { row: 2, column: 2 } },
+          { start: { row: 0, column: 0 }, end: { row: 0, column: 2 } },
+        ]);
+        expect(getNativeEditorSelectedText(state)).toBe("33");
+      });
     });
   });
 


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/54799

### Description

Fixes the issue by passing all selection ranges to the redux store.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New -> SQL Query
2. `select ID, USER_ID from ORDERS`
3. Select `select ID` and `from ORDERS` (on Mac you can use the meta key to allow multiple selection)
4. Run the query
5. See only results for the `ID` column, not `USER_ID`

### Demo

<img width="1474" alt="Screenshot 2025-04-08 at 09 34 22" src="https://github.com/user-attachments/assets/d88699c2-a69c-4b86-8bf4-bcf430777b90" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
