### PR TITLE
test: several fixes for flaky tests

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1215,13 +1215,23 @@ describe("scenarios > dashboard", () => {
   });
 
   describe("warn before leave", () => {
+    beforeEach(() => {
+      cy.intercept("GET", "/api/card/*/query_metadata").as("queryMetadata");
+    });
+
     it("should warn a user before leaving after adding, editing, or removing a card on a dashboard", () => {
       cy.visit("/");
+
+      cy.findByTestId("home-page").should(
+        "contain",
+        "Try out these sample x-rays to see what Metabase can do.",
+      );
 
       // add
       createNewDashboard();
       cy.findByTestId("dashboard-header").icon("add").click();
       cy.findByTestId("add-card-sidebar").findByText("Orders").click();
+      cy.wait("@queryMetadata");
       assertPreventLeave({ openSidebar: false });
       H.saveDashboard();
 

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -510,7 +510,9 @@ describe("scenarios > filters > bulk filtering", () => {
     it("adds multiple is text filters", () => {
       H.popover().within(() => {
         cy.findByText("City").click();
-        cy.findByLabelText("Filter value").type("Indiantown,Indian Valley");
+        cy.findByLabelText("Filter value")
+          .type("Indiantown,Indian Valley")
+          .blur();
         cy.button("Add filter").click();
       });
       applyFilters();

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -413,9 +413,13 @@ describe("issue 52806", () => {
     "should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)",
     { tags: "@flaky" },
     () => {
+      cy.intercept("/api/automagic-dashboards/database/*/candidates").as(
+        "candidates",
+      );
       H.visitQuestionAdhoc(questionDetails);
       cy.findByTestId("main-logo-link").click();
       H.modal().button("Discard changes").click();
+      cy.wait("@candidates");
       cy.location().should((location) => expect(location.search).to.eq(""));
     },
   );

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -122,6 +122,10 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should preserve set widths after reordering (VIZ-439)", () => {
+    cy.intercept(
+      "GET",
+      "/api/search?models=dataset&models=table&table_db_id=*",
+    ).as("getSearchResults");
     H.startNewNativeQuestion({
       query: 'select 1 "first_column", 2 "second_column"',
       display: "table",
@@ -129,6 +133,7 @@ describe("scenarios > visualizations > table", () => {
     });
 
     cy.findByTestId("native-query-editor-container").icon("play").click();
+    cy.wait("@getSearchResults");
 
     H.tableHeaderColumn("first_column").invoke("outerWidth").as("firstWidth");
     H.tableHeaderColumn("second_column").invoke("outerWidth").as("secondWidth");
@@ -156,7 +161,7 @@ describe("scenarios > visualizations > table", () => {
 
     cy.findByTestId("native-query-editor-container").icon("play").click();
     // Wait for column widths to be set
-    cy.wait(100);
+    cy.wait("@getSearchResults");
     assertUnchangedWidths();
   });
 


### PR DESCRIPTION
a group of fixes for flaky tests

- `e2e/test/scenarios/dashboard/dashboard.cy.spec.js` - initial fix, caught by embedding cross version tests https://github.com/metabase/metabase/pull/56130
- `e2e/test/scenarios/filters/filter-bulk.cy.spec.js` - [failing job](https://github.com/metabase/metabase/actions/runs/14342493115/job/40205463710?pr=56441)
- `e2e/test/scenarios/native/native-reproductions.cy.spec.ts` - [failing job](https://github.com/metabase/metabase/actions/runs/14335841151/job/40183131280?pr=56441)
- `e2e/test/scenarios/visualizations-tabular/table.cy.spec.js` - [failing job](https://github.com/metabase/metabase/actions/runs/14335841151/job/40183158923?pr=56441)