### PR TITLE
Fix - In some circumstances the type dropdown is not visible in full on table metadata page

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -558,6 +558,37 @@ describe("scenarios > admin > datamodel > metadata", () => {
     });
   });
 
+  it("semantic picker should not overflow the screen on smaller viewports (metabase#56442)", () => {
+    const viewportHeight = 400;
+
+    cy.viewport(1280, viewportHeight);
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
+    cy.findAllByTestId("admin-metadata-table-list-item")
+      .contains("Reviews")
+      .scrollIntoView()
+      .click();
+    cy.findByTestId("column-ID")
+      .scrollIntoView()
+      .findByPlaceholderText("Select a semantic type")
+      .click();
+
+    H.popover().scrollTo("top");
+    H.popover()
+      .findByText("Entity Key")
+      .should(($element) => {
+        const rect = $element[0].getBoundingClientRect();
+        expect(rect.top).greaterThan(0);
+      });
+
+    H.popover().scrollTo("bottom");
+    H.popover()
+      .findByText("No semantic type")
+      .should(($element) => {
+        const rect = $element[0].getBoundingClientRect();
+        expect(rect.bottom).lessThan(viewportHeight);
+      });
+  });
+
   it("display value 'custom mapping' should be available regardless of the chosen filtering type (metabase#16322)", () => {
     cy.visit(
       `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${REVIEWS_ID}/field/${REVIEWS.RATING}/general`,

--- a/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
+++ b/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
@@ -28,7 +28,7 @@ export const CurrencyPicker = ({ value, onChange, ...props }: Props) => {
         middlewares: {
           flip: true,
           size: {
-            padding: 8,
+            padding: 6,
           },
         },
         position: "bottom-start",

--- a/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
+++ b/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
@@ -27,6 +27,9 @@ export const CurrencyPicker = ({ value, onChange, ...props }: Props) => {
       comboboxProps={{
         middlewares: {
           flip: true,
+          size: {
+            padding: 8,
+          },
         },
         position: "bottom-start",
         width: 300,

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -51,6 +51,9 @@ export const FkTargetPicker = ({
       comboboxProps={{
         middlewares: {
           flip: true,
+          size: {
+            padding: 8,
+          },
         },
         position: "bottom-start",
         width: 300,

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -52,7 +52,7 @@ export const FkTargetPicker = ({
         middlewares: {
           flip: true,
           size: {
-            padding: 8,
+            padding: 6,
           },
         },
         position: "bottom-start",

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
@@ -34,6 +34,9 @@ export const SemanticTypePicker = ({
       comboboxProps={{
         middlewares: {
           flip: true,
+          size: {
+            padding: 8,
+          },
         },
         position: "bottom-start",
         width: 300,

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
@@ -35,7 +35,7 @@ export const SemanticTypePicker = ({
         middlewares: {
           flip: true,
           size: {
-            padding: 8,
+            padding: 6,
           },
         },
         position: "bottom-start",


### PR DESCRIPTION
Fixes #56428 ([SEM-228](https://linear.app/metabase/issue/SEM-228/in-some-circumstances-the-type-dropdown-is-not-visible-in-full-on))

### Description

Pickers will now shrink in size when there's not enough room in the viewport.

### Before

![image](https://github.com/user-attachments/assets/3fc74498-8884-49a4-ba00-121442c0bb7c)



### After

![image](https://github.com/user-attachments/assets/b81f5c5f-081e-4c12-8b9f-ad7da6814487)
