### PR TITLE
Allow lhs and rhs columns to be selected in existing join

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -758,10 +758,7 @@
          join-aliases-to-ignore (into #{}
                                       (comp (map lib.join.util/current-join-alias)
                                             (drop-while #(not= % existing-join-alias)))
-                                      (joins query stage-number))
-         lhs-column-or-nil      (or lhs-column-or-nil
-                                    (when (join? join-or-joinable)
-                                      (standard-join-condition-lhs (first (join-conditions join-or-joinable)))))]
+                                      (joins query stage-number))]
      (->> (lib.metadata.calculation/visible-columns query stage-number
                                                     (lib.util/query-stage query stage-number)
                                                     {:include-implicitly-joinable? false})
@@ -800,9 +797,6 @@
                              join-or-joinable)
          join-alias        (when (join? join-or-joinable)
                              (lib.join.util/current-join-alias join-or-joinable))
-         rhs-column-or-nil (or rhs-column-or-nil
-                               (when (join? join-or-joinable)
-                                 (standard-join-condition-rhs (first (join-conditions join-or-joinable)))))
          rhs-column-or-nil (when rhs-column-or-nil
                              (cond-> rhs-column-or-nil
                                ;; Drop the :join-alias from the RHS if the joinable doesn't have one either.

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1370,36 +1370,35 @@
       (is (=? [:field {:temporal-unit :month, :join-alias "P"} integer?]
               rhs))
       (doseq [lhs          [lhs nil]
-              rhs          [rhs nil]
-              ;; if we specify lhs/rhs, then we should be able to mark things selected correctly when passing in a
-              ;; Table (joinable) instead of an actual join
               [query join] (concat
                             [[query join]]
                             (when (and lhs rhs)
                               [[orders-query (meta/table-metadata :products)]]))]
-        (testing (pr-str (list `lib/join-condition-lhs-columns 'query (:lib/type join) (when lhs 'lhs) (when rhs 'rhs)))
-          (is (= [{:name "ID", :selected? false}
-                  {:name "USER_ID", :selected? false}
-                  {:name "PRODUCT_ID", :selected? false}
-                  {:name "SUBTOTAL", :selected? false}
-                  {:name "TAX", :selected? false}
-                  {:name "TOTAL", :selected? false}
-                  {:name "DISCOUNT", :selected? false}
-                  {:name "CREATED_AT", :selected? true}
-                  {:name "QUANTITY", :selected? false}]
-                 (mapv #(select-keys % [:name :selected?])
-                       (lib/join-condition-lhs-columns query join lhs rhs)))))
-        (testing (pr-str (list `lib/join-condition-rhs-columns 'query (:lib/type join) (when lhs 'lhs) (when rhs 'rhs)))
-          (is (= [{:name "ID", :selected? false}
-                  {:name "EAN", :selected? false}
-                  {:name "TITLE", :selected? false}
-                  {:name "CATEGORY", :selected? false}
-                  {:name "VENDOR", :selected? false}
-                  {:name "PRICE", :selected? false}
-                  {:name "RATING", :selected? false}
-                  {:name "CREATED_AT", :selected? true}]
-                 (mapv #(select-keys % [:name :selected?])
-                       (lib/join-condition-rhs-columns query join lhs rhs))))))
+        (testing (pr-str (list `lib/join-condition-rhs-columns 'query (:lib/type join) (when lhs 'lhs) 'rhs))
+          (is (= ["CREATED_AT"]
+                 (->> (lib/join-condition-rhs-columns query join lhs rhs)
+                      (filter :selected?)
+                      (mapv :name)))))
+        (testing (pr-str (list `lib/join-condition-rhs-columns 'query (:lib/type join) (when lhs 'lhs) nil))
+          (is (= []
+                 (->> (lib/join-condition-rhs-columns query join lhs nil)
+                      (filter :selected?)
+                      (mapv :name))))))
+      (doseq [rhs          [rhs nil]
+              [query join] (concat
+                            [[query join]]
+                            (when (and lhs rhs)
+                              [[orders-query (meta/table-metadata :products)]]))]
+        (testing (pr-str (list `lib/join-condition-lhs-columns 'query (:lib/type join) 'lhs (when rhs 'rhs)))
+          (is (= ["CREATED_AT"]
+                 (->> (lib/join-condition-lhs-columns query join lhs rhs)
+                      (filter :selected?)
+                      (mapv :name)))))
+        (testing (pr-str (list `lib/join-condition-lhs-columns 'query (:lib/type join) nil (when rhs 'rhs)))
+          (is (= []
+                 (->> (lib/join-condition-lhs-columns query join nil rhs)
+                      (filter :selected?)
+                      (mapv :name))))))
       (testing "temporal bucket returns with column metadata"
         (let [[lhs-column] (filter :selected? (lib/join-condition-lhs-columns query 0 join lhs rhs))]
           (is (= {:lib/type :option/temporal-bucketing, :unit :month} (lib/temporal-bucket lhs-column))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40940

### Description

We didn't allow selecting a column used in the previous join condition when adding another condition to an existing join. You could, however, select the wrong column then change it to the correct column, and that would work. So let's just let them select it from the beginning.

### How to verify

1. Create a question on Orders
2. Join with People
3. Note the existing default condition: Orders.User ID = people.ID
4. Click plus to add a new join condition
5. Click the Left Hand column and select User ID (couldn't do that before!)
6. Click the Right Hand column and select ID (couldn't do that before!)
7. Note that it will disappear if it's equivalent to an existing condition.