### PR TITLE
Remove duplicate function for example column extractions, translate dates

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
@@ -2,13 +2,14 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker";
+import { getExample } from "metabase/querying/drills/utils/column-extract-drill";
 import { Box, Button, Flex, Stack, Text, Title } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { ExpressionWidgetHeader } from "../ExpressionWidgetHeader";
 
 import styles from "./ExtractColumn.module.css";
-import { getExample, getName } from "./util";
+import { getName } from "./util";
 
 type Props = {
   query: Lib.Query;

--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/util.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/util.ts
@@ -1,36 +1,5 @@
 import * as Lib from "metabase-lib";
 
-export function getExample(info: Lib.ColumnExtractionInfo) {
-  // @todo this should eventually be moved into Lib.displayInfo
-  // to avoid the keys going out of sync with the MLv2-defined extractions.
-  //
-  // @see https://github.com/metabase/metabase/issues/42039
-  switch (info.tag) {
-    case "hour-of-day":
-      return "0, 1";
-    case "day-of-month":
-      return "1, 2";
-    case "day-of-week":
-      return "Monday, Tuesday";
-    case "month-of-year":
-      return "Jan, Feb";
-    case "quarter-of-year":
-      return "Q1, Q2";
-    case "year":
-      return "2023, 2024";
-    case "domain":
-      return "example, online";
-    case "host":
-      return "example.com, online.com";
-    case "subdomain":
-      return "www, maps";
-    case "path":
-      return "/en/docs/feature";
-  }
-
-  return undefined;
-}
-
 function getNextName(names: string[], name: string, index: number): string {
   const suffixed = index === 0 ? name : `${name} (${index})`;
   if (!names.includes(suffixed)) {

--- a/frontend/src/metabase/querying/drills/utils/column-extract-drill.tsx
+++ b/frontend/src/metabase/querying/drills/utils/column-extract-drill.tsx
@@ -1,3 +1,5 @@
+import { c } from "ttag";
+
 import { useDispatch } from "metabase/lib/redux";
 import { setUIControls } from "metabase/query_builder/actions";
 import { trackColumnExtractViaHeader } from "metabase/querying/analytics";
@@ -77,9 +79,9 @@ export function getExample(info: Lib.ColumnExtractionInfo) {
     case "day-of-month":
       return "1, 2";
     case "day-of-week":
-      return "Monday, Tuesday";
+      return c("Example of days of the week").t`Monday, Tuesday`;
     case "month-of-year":
-      return "Jan, Feb";
+      return c("Example of months in the year").t`Jan, Feb`;
     case "quarter-of-year":
       return "Q1, Q2";
     case "year":


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55492

### Description
Removes duplicate function, and sets up translation for the datetime examples in column extractions.

### How to verify
_You will need to update the po files with the new keys for translations_

1. Set your user language to something other than english
2. New question -> Sample Dataset -> Orders
3. Click the column header for created_at
4. click "extract day, month"
5. See the examples are translated.
6. Open the notebook editor and start adding a custom column
7. in the popover, click extract column, and click on a datetime column
8. See the examples are translated.

### Demo
<img width="279" alt="image" src="https://github.com/user-attachments/assets/41e138b2-5e92-4747-92d7-b299ddfe0122" />
