### PR TITLE
Add CI job checking an outdated Embedding SDK API documentation

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -91,6 +91,49 @@ jobs:
       - name: Run frontend embedding SDK snippets type check
         run: yarn run embedding-sdk:docs-snippets:type-check
 
+  # We want to compare if there are any changes to the generated docs compared to the HEAD commit of a PR.
+  # To checkout the HEAD commit we must set `ref: ${{ github.event.pull_request.head.sha }}` for actions/checkout/
+  embedding-sdk-docs-update-check:
+    needs: [files-changed]
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cljs"
+      # we should build Embedding SDK dist based on ${{ github.event.pull_request.head.sha }}
+      - name: Build Embedding SDK package
+        run: yarn build-embedding-sdk
+      - name: Generate embedding SDK docs
+        run: yarn run embedding-sdk:docs:generate:pure
+      - name: Check for uncommitted documentation changes
+        id: check-docs-changes
+        run: |
+          if [[ -n "$(git status --porcelain | grep 'embedding/sdk/api/')" ]]; then
+            echo "docs_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Comment on PR if docs need update
+        if: steps.check-docs-changes.outputs.docs_changed == 'true'
+        uses: ./.github/actions/notify-pull-request
+        with:
+          include-log: false
+          message: "📝 Changes to Embedding SDK files affecting the API documentation have been detected. Please regenerate, review, and commit the updated documentation manually by running `yarn embedding-sdk:docs:generate` locally."
+          remove-previous-comment: true
+      - name: Fail if docs need update
+        if: steps.check-docs-changes.outputs.docs_changed == 'true'
+        run: exit 1
+
   sdk-e2e-tests:
     uses: ./.github/workflows/e2e-component-tests-embedding-sdk.yml
     needs: [build]
@@ -107,6 +150,7 @@ jobs:
     needs:
       - embedding-sdk-cli-snippets-type-check
       - embedding-sdk-docs-snippets-type-check
+      - embedding-sdk-docs-update-check
       - sdk-e2e-tests
       - e2e-component-tests-embedding-sdk-cross-version
     if: always() && !cancelled()

--- a/package.json
+++ b/package.json
@@ -424,7 +424,7 @@
     "embedding-sdk:test-unit": "yarn test-unit enterprise/frontend/src/embedding-sdk/",
     "embedding-sdk:tsc": "tsc --project tsconfig.sdk.json",
     "embedding-sdk:docs:generate:pure": "typedoc --options ./.typedoc/typedoc.config.mjs",
-    "embedding-sdk:docs:generate": "yarn run build && yarn run build-embedding-sdk && yarn run embedding-sdk:docs:generate:pure",
+    "embedding-sdk:docs:generate": "yarn run build-embedding-sdk && yarn run embedding-sdk:docs:generate:pure",
     "embedding-sdk:cli-snippets:type-check": "./bin/embedding-sdk/type-check-embedding-sdk-cli-snippets.sh",
     "embedding-sdk:docs-snippets:type-check": "./bin/embedding-sdk/type-check-embedding-sdk-docs-snippets.sh",
     "embedding-sdk:clean": "rm -rf resources/embedding-sdk/dist && rm -rf resources/embedding-sdk/.tsbuildinfo",


### PR DESCRIPTION
Setup CI for automatic documentation generation for @metabase/embedding-sdk

Also it refactors embedding SDK CI a bit:
- it builds the SDK dist once and then other steps/workflows use it

Closes: https://linear.app/metabase/issue/EMB-301/setup-a-ci-job-that-notifies-when-documentation-should-be-updated

Check passed:
https://github.com/metabase/metabase/actions/runs/14377390334/job/40312959139?pr=56452

Check failed:
![image](https://github.com/user-attachments/assets/688f3d96-763a-4307-831e-f6b51ad0d922)


How to verify:
- check code and a link and a screenshot above
