### PR TITLE
Preserve non-default effective type of column in field-ref metadata

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -186,10 +186,15 @@
                   {:lib/type        :metadata/column}
                   metadata
                   {:display-name (or (:display-name opts)
-                                     (lib.metadata.calculation/display-name query stage-number field-ref))})]
+                                     (lib.metadata.calculation/display-name query stage-number field-ref))})
+        default-type (fn [original default]
+                       (if (or (nil? original) (= original :type/*))
+                         default
+                         original))]
     (cond-> metadata
       source-uuid    (assoc :lib/source-uuid source-uuid)
-      base-type      (assoc :base-type base-type, :effective-type base-type)
+      base-type      (-> (assoc :base-type base-type)
+                         (update :effective-type default-type base-type))
       effective-type (assoc :effective-type effective-type)
       temporal-unit  (assoc ::temporal-unit temporal-unit)
       binning        (assoc ::binning binning)

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -673,6 +673,60 @@
               query
               [:field {:lib/uuid "aa0e13af-29b3-4c27-a880-a10c33e55a3e", :base-type :type/Text} 4]))))))
 
+(deftest ^:parallel base-type-in-field-ref-does-not-overwrite-everything-test
+  (testing "base-type of reference doesn't override a non-default effective-type in the column (#55171)"
+    (let [provider (lib.tu/mock-metadata-provider
+                    {:database {:id   1
+                                :name "My Database"}
+                     :tables   [{:id   2
+                                 :name "My Table"}]
+                     :cards    [{:id              3
+                                 :name            "Card 3"
+                                 :database-id     (meta/id)
+                                 :dataset-query   {:lib/type :mbql/query
+                                                   :database 1
+                                                   :stages   [{:lib/type     :mbql.stage/mbql
+                                                               :source-table 2}]}
+                                 :result-metadata [{:id                4
+                                                    :base-type         :type/Text
+                                                    :effective-type    :type/Date
+                                                    :coercion-strategy :Coercion/ISO8601->Date
+                                                    :ident             "ybTElkkGoYYBAyDRTIiUe"
+                                                    :name              "Field 4"}]}]})
+          query    (lib/query provider {:lib/type :mbql/query
+                                        :database 1
+                                        :stages   [{:lib/type    :mbql.stage/mbql
+                                                    :source-card 3}]})]
+      (is (= [{:lib/type                 :metadata/column
+               :base-type                :type/Text
+               :effective-type           :type/Date
+               :coercion-strategy        :Coercion/ISO8601->Date
+               :id                       4
+               :name                     "Field 4"
+               :ident                    "ybTElkkGoYYBAyDRTIiUe"
+               :fk-target-field-id       nil
+               :lib/source               :source/card
+               :lib/card-id              3
+               :lib/source-column-alias  "Field 4"
+               :lib/desired-column-alias "Field 4"}]
+             (lib/returned-columns query)))
+      (is (= {:lib/type                :metadata/column
+              :base-type               :type/Text
+              :effective-type          :type/Date
+              :coercion-strategy       :Coercion/ISO8601->Date
+              :id                      4
+              :name                    "Field 4"
+              :ident                   "ybTElkkGoYYBAyDRTIiUe"
+              :fk-target-field-id      nil
+              :display-name            "Field 4"
+              :lib/card-id             3
+              :lib/source              :source/card
+              :lib/source-column-alias "Field 4"
+              :lib/source-uuid         "aa0e13af-29b3-4c27-a880-a10c33e55a3e"}
+             (lib/metadata
+              query
+              [:field {:lib/uuid "aa0e13af-29b3-4c27-a880-a10c33e55a3e", :base-type :type/Text} 4]))))))
+
 (deftest ^:parallel ref-to-joined-column-from-previous-stage-test
   (let [query (-> (lib.tu/venues-query)
                   (lib/join (-> (lib/join-clause


### PR DESCRIPTION
Fixes #55171

### Description

Here we have a breakout created from a text field coerced to date, then broken out. When that is broken out again, a field ref like
```clojure
[:field {:base-type :type/Text, :effective-type :type/Date, :inherited-temporal-unit :month} "start"]
```
is converted to a legacy ref like 
```clojure
[:field "start" {:base-type :type/Text, :inherited-temporal-unit :month}]
```
that is, the reference loses the information that the column is of `:type/Date`. When the metadata for this ref is produced, the `:base-type` in the ref overrides the `:effective-type` in the column metadata, and the generated breakout column get the effective type of `:type/Test`.

The change in this PR makes sure we don't override the effective type of the column with the base type of ref, unless it's missing or has the default value `:type/*`.

### How to verify

The repro steps from #55171 should not lead to the breakout column reverting to `Text` type.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
