### PR TITLE
call e2e-component-tests-embedding-sdk-cross-version from

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -1,13 +1,7 @@
 name: E2E Cross-version Component Tests for Embedding SDK
 
 on:
-  push:
-    branches:
-      - "release-**"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - "release-**"
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -30,7 +30,7 @@ jobs:
           filters: .github/file-paths.yaml
 
   embedding-sdk-cli-snippets-type-check:
-    needs: [ files-changed ]
+    needs: [files-changed]
     if: needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -51,7 +51,7 @@ jobs:
         run: yarn run embedding-sdk:cli-snippets:type-check
 
   embedding-sdk-docs-snippets-type-check:
-    needs: [ files-changed ]
+    needs: [files-changed]
     if: needs.files-changed.outputs.documentation == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -85,6 +85,7 @@ jobs:
       - embedding-sdk-cli-snippets-type-check
       - embedding-sdk-docs-snippets-type-check
       - sdk-e2e-tests
+      - e2e-component-tests-embedding-sdk-cross-version
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -75,6 +75,11 @@ jobs:
     uses: ./.github/workflows/e2e-component-tests-embedding-sdk.yml
     secrets: inherit
 
+  e2e-component-tests-embedding-sdk-cross-version:
+    if: ${{ startsWith(inputs.branch, 'release-x.') }}
+    uses: ./.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+    secrets: inherit
+
   embedding-sdk-tests-result:
     needs:
       - embedding-sdk-cli-snippets-type-check


### PR DESCRIPTION
embedding-sdk.yml


Closes [EMB-285: Make `embedding-sdk.yaml` call the e2e cross version tests](https://linear.app/metabase/issue/EMB-285/make-embedding-sdkyaml-call-the-e2e-cross-version-tests)

With this PR, `embedding-sdk.yaml` should be the entry point for all sdk related CI jobs.

Now that `e2e-component-tests-embedding-sdk-cross-version` is part of the tests results, we should check if we need to remove it from the required checks of the releases branches
