### PR TITLE
Adm 505 collection and everywhere shortcuts

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -1,6 +1,7 @@
 const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import {
+  ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -412,6 +413,29 @@ describe("shortcuts", () => {
     cy.realPress("b").realPress("d");
     cy.location("pathname").should("contain", "browse/databases");
     cy.realPress("Escape");
+
+    cy.realPress("[");
+    H.navigationSidebar().should("not.be.visible");
+    cy.realPress("[");
+    H.navigationSidebar().should("be.visible");
+
+    cy.realPress("p");
+    cy.location("pathname").should(
+      "equal",
+      `/collection/${ADMIN_PERSONAL_COLLECTION_ID}`,
+    );
+
+    cy.realPress("t");
+    cy.location("pathname").should("equal", "/trash");
+
+    H.navigationSidebar().findByText("Our analytics").click();
+
+    cy.findAllByTestId("collection-entry-check").eq(2).click();
+    cy.findAllByTestId("collection-entry-check").eq(3).click();
+
+    cy.realPress(["MetaLeft", "m"]);
+
+    cy.findByRole("dialog", { name: "Move 2 items?" }).should("exist");
   });
 
   it("should support dashboard shortcuts", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -429,15 +429,6 @@ describe("shortcuts", () => {
 
     cy.realPress("t");
     cy.location("pathname").should("equal", "/trash");
-
-    H.navigationSidebar().findByText("Our analytics").click();
-
-    cy.findAllByTestId("collection-entry-check").eq(2).click();
-    cy.findAllByTestId("collection-entry-check").eq(3).click();
-
-    cy.realPress(["MetaLeft", "m"]);
-
-    cy.findByRole("dialog", { name: "Move 2 items?" }).should("exist");
   });
 
   it("should support dashboard shortcuts", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -392,7 +392,9 @@ describe("shortcuts", () => {
 
   it("should render a shortcuts modal, and global shortcuts should be available", () => {
     cy.visit("/");
-    cy.findByTestId("greeting-message").should("exist");
+    cy.findByTestId("home-page")
+      .findByTestId("loading-indicator")
+      .should("not.exist");
     H.openShortcutModal();
 
     H.shortcutModal().within(() => {

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
@@ -112,7 +112,7 @@ export const ArchivedBulkActions = ({
         {t`Delete permanently`}
       </BulkActionDangerButton>
 
-      {/* This should probably be external so that we can hide 
+      {/* This should probably be external so that we can hide
           the bar when any other modals are displayed */}
       <ConfirmModal
         opened={hasSelectedItems && selectedAction === "delete"}

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/UnarchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/UnarchivedBulkActions.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { archiveAndTrack } from "metabase/archive/analytics";
 import { canArchiveItem, canMoveItem } from "metabase/collections/utils";
 import { BulkActionButton } from "metabase/components/BulkActionBar";
+import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import type { Collection, CollectionItem } from "metabase-types/api";
 
 type UnarchivedBulkActionsProps = {
@@ -51,6 +52,20 @@ export const UnarchivedBulkActions = ({
     setSelectedItems(selected);
     setSelectedAction("move");
   };
+
+  useRegisterShortcut(
+    [
+      {
+        id: "collection-move",
+        perform: handleBulkMoveStart,
+      },
+      {
+        id: "collection-trash",
+        perform: handleBulkArchive,
+      },
+    ],
+    [selected],
+  );
 
   return (
     <>

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/UnarchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/UnarchivedBulkActions.tsx
@@ -57,11 +57,15 @@ export const UnarchivedBulkActions = ({
     [
       {
         id: "collection-move",
-        perform: handleBulkMoveStart,
+        perform: () => {
+          handleBulkMoveStart();
+        },
       },
       {
         id: "collection-trash",
-        perform: handleBulkArchive,
+        perform: () => {
+          handleBulkArchive();
+        },
       },
     ],
     [selected],

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/UnarchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/UnarchivedBulkActions.tsx
@@ -56,12 +56,6 @@ export const UnarchivedBulkActions = ({
   useRegisterShortcut(
     [
       {
-        id: "collection-move",
-        perform: () => {
-          handleBulkMoveStart();
-        },
-      },
-      {
         id: "collection-trash",
         perform: () => {
           handleBulkArchive();

--- a/frontend/src/metabase/components/EntityItem/EntityItem.tsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.tsx
@@ -62,9 +62,11 @@ const EntityIconCheckBox = ({
   ...props
 }: EntityIconCheckBoxProps) => {
   const iconSize = variant === "small" ? 12 : 16;
-  const handleClick: React.MouseEventHandler = (e) => {
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault();
     onToggleSelected?.();
+    // helps keyboard shortcuts work for collection items
+    e.currentTarget.focus();
   };
 
   return (

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { isMac } from "metabase/lib/browser";
+import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { Tooltip } from "metabase/ui";
 
 import { SidebarButton, SidebarIcon } from "./AppBarToggle.styled";
@@ -35,15 +36,21 @@ export function AppBarToggle({
     }
   }, [hovered]);
 
-  if (!isNavBarEnabled) {
-    return null;
-  }
-
   const handleToggleClick = () => {
     setDisableTooltip(true);
     onToggleClick?.();
   };
 
+  useRegisterShortcut([
+    {
+      id: "toggle-navbar",
+      perform: handleToggleClick,
+    },
+  ]);
+
+  if (!isNavBarEnabled) {
+    return null;
+  }
   return (
     <div ref={hoverRef as React.Ref<HTMLDivElement>}>
       <Tooltip

--- a/frontend/src/metabase/palette/constants.ts
+++ b/frontend/src/metabase/palette/constants.ts
@@ -2,4 +2,5 @@ export const GROUP_LABLES = {
   global: `General`,
   dashboard: "Dashboard",
   question: "Querying & the notebook",
+  collection: "Collection",
 };

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -18,6 +18,10 @@ import {
   getHasDatabaseWithActionsEnabled,
   getHasNativeWrite,
 } from "metabase/selectors/data";
+import {
+  getUserIsAdmin,
+  getUserPersonalCollectionId,
+} from "metabase/selectors/user";
 
 import {
   type RegisterShortcutProps,
@@ -40,6 +44,9 @@ export const useCommandPaletteBasicActions = ({
     query: { models: ["dataset"], limit: 1 },
     enabled: isLoggedIn,
   });
+
+  const personalCollectionId = useSelector(getUserPersonalCollectionId);
+  const isAdmin = useSelector(getUserIsAdmin);
 
   const hasDataAccess = getHasDataAccess(databases);
   const hasNativeWrite = getHasNativeWrite(databases);
@@ -197,8 +204,41 @@ export const useCommandPaletteBasicActions = ({
       },
     ];
 
+    if (isAdmin) {
+      actions.push({
+        id: "navigate-admin-settings",
+        perform: () => dispatch(push("/admin/settings")),
+      });
+    }
+
+    if (personalCollectionId) {
+      actions.push({
+        id: "navigate-personal-collection",
+        perform: () => dispatch(push(`/collection/${personalCollectionId}`)),
+      });
+    }
+
+    actions.push(
+      {
+        id: "navigate-user-settings",
+        perform: () => dispatch(push("/account/profile")),
+      },
+      {
+        id: "navigate-trash",
+        perform: () => dispatch(push("/trash")),
+      },
+    );
+
     return [...actions, ...browseActions];
-  }, [dispatch, hasDataAccess, hasNativeWrite, collectionId, openNewModal]);
+  }, [
+    dispatch,
+    hasDataAccess,
+    hasNativeWrite,
+    collectionId,
+    openNewModal,
+    isAdmin,
+    personalCollectionId,
+  ]);
 
   useRegisterShortcut(initialActions, [initialActions]);
 

--- a/frontend/src/metabase/palette/shortcuts/collection.ts
+++ b/frontend/src/metabase/palette/shortcuts/collection.ts
@@ -1,0 +1,14 @@
+import { t } from "ttag";
+
+export const collectionShortcuts = {
+  "collection-move": {
+    name: t`Move collection`,
+    shortcut: ["$mod+m"],
+    shortcutGroup: "collection",
+  },
+  "collection-trash": {
+    name: t`Trash collection`,
+    shortcut: ["$mod+backspace"],
+    shortcutGroup: "collection",
+  },
+};

--- a/frontend/src/metabase/palette/shortcuts/collection.ts
+++ b/frontend/src/metabase/palette/shortcuts/collection.ts
@@ -1,11 +1,6 @@
 import { t } from "ttag";
 
 export const collectionShortcuts = {
-  "collection-move": {
-    name: t`Move collection`,
-    shortcut: ["$mod+m"],
-    shortcutGroup: "collection",
-  },
   "collection-trash": {
     name: t`Trash collection`,
     shortcut: ["$mod+backspace"],

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -57,4 +57,32 @@ export const globalShortcuts = {
     shortcut: ["?"],
     shortcutGroup: "global",
   },
+
+  "navigate-trash": {
+    name: t`Open trash`,
+    shortcut: ["t"],
+    shortcutGroup: "global",
+  },
+  "navigate-personal-collection": {
+    name: t`Open personal collection`,
+    shortcut: ["p"],
+    shortcutGroup: "global",
+  },
+
+  "toggle-navbar": {
+    name: t`Toggle sidebar`,
+    shortcut: ["["],
+    shortcutGroup: "global",
+  },
+  "navigate-admin-settings": {
+    name: t`Go to admin`,
+    shortcut: ["g a"],
+    shortcutGroup: "global",
+  },
+
+  "navigate-user-settings": {
+    name: t`Go to user settings`,
+    shortcut: ["g u"],
+    shortcutGroup: "global",
+  },
 };

--- a/frontend/src/metabase/palette/shortcuts/index.ts
+++ b/frontend/src/metabase/palette/shortcuts/index.ts
@@ -1,3 +1,4 @@
+import { collectionShortcuts } from "./collection";
 import { dashboardShortcuts } from "./dashboard";
 import { globalShortcuts } from "./global";
 // import { questionShortcuts } from "./question";
@@ -5,5 +6,6 @@ import { globalShortcuts } from "./global";
 export const shortcuts = {
   ...globalShortcuts,
   ...dashboardShortcuts,
+  ...collectionShortcuts,
   // ...questionShortcuts,
 };


### PR DESCRIPTION
Closes ADM-505

### Description
Adds the remaining global keyboard shortcuts, as well as shortcuts for bulk move and archive in collections

### How to verify

Try the following shortcuts:
`p` - navigate to personal question
`t` - navigate to trash
`[` - toggle Navbar
`g > u` - user settings
`g > a` - admin settings

Check the glossary for additional info

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
