### PR TITLE
Growing entity picker

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -51,6 +51,7 @@ describe("scenarios > collection defaults", () => {
       cy.findByTestId("new-collection-modal").then((modal) => {
         cy.findByPlaceholderText("My new fantastic collection").type(
           "Test collection",
+          { force: true },
         );
         cy.findByLabelText("Description").type("Test collection description");
         cy.findByTestId("collection-picker-button")

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -1022,7 +1022,7 @@ describe("scenarios > organization > entity picker", () => {
     });
   });
 
-  describe("keyboard navigation", () => {
+  describe("misc entity picker stuff", () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();
@@ -1112,6 +1112,43 @@ describe("scenarios > organization > entity picker", () => {
       closeAndAssertModal(() =>
         cy.findByRole("heading", { name: /Duplicate/ }),
       );
+    });
+
+    it("should grow in width as needed, but not shrink (metabase#55690)", () => {
+      cy.viewport(1500, 800);
+      cy.visit("/");
+
+      // New Collection Flow
+      H.newButton("Collection").click();
+      H.modal()
+        .findByLabelText(/Collection it's saved in/)
+        .click();
+      H.entityPickerModalTab("Collections").click();
+
+      //Initial width of entity picker
+      cy.findByRole("dialog", { name: "Select a collection" })
+        .should("have.css", "width")
+        .and("eq", "920px");
+
+      H.entityPickerModalItem(1, "First collection").click();
+
+      //Entity picker should grow
+      cy.findByRole("dialog", { name: "Select a collection" })
+        .should("have.css", "width")
+        .and("eq", "1095px");
+
+      H.entityPickerModalItem(2, "Second collection").click();
+
+      //Max width is 80% of the viewport. Here, we get horizontal scrolling
+      cy.findByRole("dialog", { name: "Select a collection" })
+        .should("have.css", "width")
+        .and("eq", "1200px");
+
+      H.entityPickerModalItem(0, "Our analytics").click();
+      //Entity picker should not shrink if we go back in the collection tree
+      cy.findByRole("dialog", { name: "Select a collection" })
+        .should("have.css", "width")
+        .and("eq", "1200px");
     });
   });
 });

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useDebounce, usePreviousDistinct } from "react-use";
@@ -13,6 +14,7 @@ import ErrorBoundary from "metabase/ErrorBoundary";
 import { useListRecentsQuery, useSearchQuery } from "metabase/api";
 import { useModalOpen } from "metabase/hooks/use-modal-open";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
+import resizeObserver from "metabase/lib/resize-observer";
 import { Box, Flex, Icon, Modal, Skeleton, TextInput } from "metabase/ui";
 import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
 import type {
@@ -126,6 +128,8 @@ export function EntityPickerModal<
   disableCloseOnEscape = false,
   children,
 }: EntityPickerModalProps<Id, Model, Item>) {
+  const [modalContentMinWidth, setModalContentMinWidth] = useState(920);
+  const modalContentRef = useRef<HTMLDivElement | null>(null);
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [searchScope, setSearchScope] =
     useState<EntityPickerSearchScope>("everywhere");
@@ -345,6 +349,33 @@ export function EntityPickerModal<
 
   const titleId = useUniqueId("entity-picker-modal-title-");
 
+  const modalContentResizeHandler = useCallback(
+    (entry: ResizeObserverEntry) => {
+      const width = entry.contentRect.width;
+      setModalContentMinWidth((currentWidth) =>
+        currentWidth < width ? width : currentWidth,
+      );
+    },
+    [],
+  );
+
+  const modalContentCallbackRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (element) {
+        resizeObserver.subscribe(element, modalContentResizeHandler);
+        modalContentRef.current = element;
+      } else {
+        if (modalContentRef.current) {
+          resizeObserver.unsubscribe(
+            modalContentRef.current,
+            modalContentResizeHandler,
+          );
+        }
+      }
+    },
+    [modalContentResizeHandler],
+  );
+
   return (
     <Modal.Root
       opened={open}
@@ -366,7 +397,10 @@ export function EntityPickerModal<
       <Modal.Content
         className={S.modalContent}
         aria-labelledby={titleId}
-        w="57.5rem"
+        miw={modalContentMinWidth}
+        w="fit-content"
+        maw="80vw"
+        ref={modalContentCallbackRef}
       >
         <Modal.Header
           px="2.5rem"

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -397,7 +397,7 @@ export function EntityPickerModal<
       <Modal.Content
         className={S.modalContent}
         aria-labelledby={titleId}
-        miw={modalContentMinWidth}
+        miw={`min(${modalContentMinWidth}px, 80vw)`}
         w="fit-content"
         maw="80vw"
         ref={modalContentCallbackRef}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55690

### Description
Adds the ability for the entity picker to grow if many vertical panels are needed. However, the entity picker will never shrink. This keeps the number of transitions down, while making it easier to navigate large collection paths

### How to verify

1. Go to a collection that has a few parents
2. New -> Collection -> Entity Picker
3. Notice navigate around the entity picker. It should grow to show you as much as it can until it reaches 80% of the viewport, but it should never shrink.


### Demo

https://github.com/user-attachments/assets/5cef0400-a8f5-47f1-bdda-c48a7048d064


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
