### PR TITLE
ci: simulate slow network in stress test

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -32,12 +32,9 @@ on:
           - mongo
       enable_network_throttling:
         description: "Enable network throttling simulation (4g slow like in chrome dev tools)"
-        type: choice
+        type: boolean
         required: false
-        default: "true"
-        options:
-          - false
-          - true
+        default: true
 
 jobs:
   workflow-summary:

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -30,6 +30,14 @@ on:
           - none
           - sql
           - mongo
+      enable_network_throttling:
+        description: "Enable network throttling simulation (4g slow like in chrome dev tools)"
+        type: choice
+        required: false
+        default: "true"
+        options:
+          - false
+          - true
 
 jobs:
   workflow-summary:
@@ -46,6 +54,7 @@ jobs:
           echo '- `burn_in`: ${{ inputs.burn_in }}' >> $GITHUB_STEP_SUMMARY
           echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `qa_db`: "${{ inputs.qa_db }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- `enable_network_throttling`: "${{ inputs.enable_network_throttling }}"' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
 
@@ -62,6 +71,7 @@ jobs:
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       MB_EDITION: ${{ inputs.mb_edition }}
+      CYPRESS_ENABLE_NETWORK_THROTTLING: ${{ inputs.enable_network_throttling }}
       TERM: xterm
       TZ: US/Pacific # to make node match the instance tz
     steps:
@@ -106,10 +116,12 @@ jobs:
       # For all options and fine-grained control, take a look at the documentation
       # https://github.com/cypress-io/cypress/tree/develop/npm/grep
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
+        env:
+          GREP: ${{ github.event.inputs.grep }}
         run: |
           node e2e/runner/run_cypress_ci.js e2e \
           --spec '${{ github.event.inputs.spec }}' \
-          --env burn=${{ github.event.inputs.burn_in }},grep='${{ github.event.inputs.grep }}' \
+          --env burn=${{ github.event.inputs.burn_in }} \
           --config-file e2e/support/cypress-stress-test.config.js \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -53,6 +53,7 @@ const configs = {
     };
 
     const userArgs = await parseArguments(args);
+
     const finalConfig = Object.assign({}, defaultConfig, userArgs);
     return finalConfig;
   },

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -66,6 +66,10 @@ const defaultConfig = {
     // `on` is used to hook into various events Cypress emits
     // `config` is the resolved Cypress config
 
+    // CLI grep can't handle commas in the name
+    // needed when we want to run only specific tests
+    config.env.grep ??= process.env.GREP;
+
     // cypress-terminal-report
     if (isCI) {
       installLogsPrinter(on, {

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -9,6 +9,7 @@ import addContext from "mochawesome/addContext";
 import "./commands";
 
 const isCI = Cypress.env("CI");
+const isNetworkThrottlingEnabled = Cypress.env("ENABLE_NETWORK_THROTTLING");
 
 // remove default html output on test failure
 configure({
@@ -169,5 +170,16 @@ beforeEach(function () {
     console.log(`test name: ${testName}\n\n"this test should be ran against OSS jar. Make sure you have MB_EDITION=oss set and go to e2e/support/cypress.js and temporarily remove the skipOn(true) to run the test"
     `);
     cy.skipOn(true);
+  }
+
+  // enable network throttling, primarily used for stress test at CI
+  if (isNetworkThrottlingEnabled) {
+    cy.intercept("GET", "**", (req) => {
+      req.reply((res) => {
+        res.setDelay(300);
+        res.setThrottle(1440); // 1.44Mb, same as slow 4g in chrome dev tools
+        res.send();
+      });
+    }).as("globalIntercept");
   }
 });


### PR DESCRIPTION
When I debug flaky tests locally, I usually rely on Chrome dev tools, especially on network and CPU throttling.

It turned out slow network connection is one of the main reasons of flaky tests as some data can take time to load. However, we typically do not wait for this data in tests, what results in a flakiness based on the network speed.
But dev tools are not available at CI, we can't simulate slow network manually, sometimes stress test passed because of that, but it was actually flaky.

To close this gap, I added a way to slow down network requests during e2e stress test.

Additionally I changed how we work with cypress `grep` as it could use comma contained names from CLI.
there is another way to set grep - in config, what I did.

stress test [example](https://github.com/metabase/metabase/actions/runs/14366928383)


| regular network | slow network simulation |
|--------|--------|
|  <img width="1015" alt="Screenshot 2025-04-10 at 00 10 20" src="https://github.com/user-attachments/assets/6f40cfe1-0736-4b30-ad4e-84a9daeb31f3" /> | <img width="1029" alt="Screenshot 2025-04-10 at 00 10 37" src="https://github.com/user-attachments/assets/5a1a4a66-2b88-45b7-bf95-94c71b4624eb" /> | 