### PR TITLE
Fix flaky unsubscribe test

### DIFF
--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -292,22 +292,25 @@
       :below)
     :rows))
 
-(defn- send-email!
-  "Sends an email on a background thread, returning a future."
+(defn- send-email-sync!
   ([recipients subject template-path template-context]
-   (send-email! recipients subject template-path template-context false))
+   (send-email-sync! recipients subject template-path template-context false))
   ([recipients subject template-path template-context bcc?]
    (when (seq recipients)
-     (future
-       (try
-         (email/send-email-retrying!
-          {:recipients   recipients
-           :message-type :html
-           :subject      subject
-           :message      (channel.template/render template-path template-context)
-           :bcc?         bcc?})
-         (catch Exception e
-           (log/errorf e "Failed to send message to '%s' with subject '%s'" (str/join ", " recipients) subject)))))))
+     (try
+       (email/send-email-retrying!
+        {:recipients   recipients
+         :message-type :html
+         :subject      subject
+         :message      (channel.template/render template-path template-context)
+         :bcc?         bcc?})
+       (catch Exception e
+         (log/errorf e "Failed to send message to '%s' with subject '%s'" (str/join ", " recipients) subject))))))
+
+(defn- send-email!
+  "Sends an email on a background thread, returning a future."
+  [& args]
+  (future (apply send-email-sync! args)))
 
 (defn- template-path [template-name]
   (str "metabase/channel/email/" template-name ".hbs"))

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -198,20 +198,19 @@
 
 (defn summarize-multipart-single-email
   [email & regexes]
-  (testing (format "email content: \n%s\n" email)
-    (let [email-body->regex-boolean (create-email-body->regex-fn regexes)
-          body-or-content           (fn [email-body-seq]
-                                      (doall
-                                       (for [{email-type :type :as email-part} email-body-seq]
-                                         (if (string? email-type)
-                                           (email-body->regex-boolean email-part)
-                                           (summarize-attachment email-part)))))]
-      (cond-> email
-        (:recipients email) (update :recipients set)
-        (:to email)         (update :to set)
-        (:bcc email)        (update :bcc set)
-        (:message email)    (update :message body-or-content)
-        (:body email)       (update :body body-or-content)))))
+  (let [email-body->regex-boolean (create-email-body->regex-fn regexes)
+        body-or-content           (fn [email-body-seq]
+                                    (doall
+                                     (for [{email-type :type :as email-part} email-body-seq]
+                                       (if (string? email-type)
+                                         (email-body->regex-boolean email-part)
+                                         (summarize-attachment email-part)))))]
+    (cond-> email
+      (:recipients email) (update :recipients set)
+      (:to email)         (update :to set)
+      (:bcc email)        (update :bcc set)
+      (:message email)    (update :message body-or-content)
+      (:body email)       (update :body body-or-content))))
 
 (defn summarize-multipart-email
   "For text/html portions of an email, this is similar to `regex-email-bodies`, but for images in the attachments will

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -889,7 +889,7 @@
           (let [[email] (notification.tu/with-mock-inbox-email!
                           (with-send-messages-sync!
                             (mt/user-http-request :lucky :post 204 (format "notification/%d/unsubscribe" noti-1))))
-                a-href (format "<a href=\".*/question/%d\">My Card</a>."
+                a-href (format "<a href=\"https://testmb.com/question/%d\">My Card</a>."
                                (-> notification :payload :card_id))]
             (testing "sends unsubscribe confirmation email"
               (is (=? {:bcc     #{"lucky@metabase.com"}

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -892,14 +892,17 @@
                             (mt/user-http-request :lucky :post 204 (format "notification/%d/unsubscribe" noti-1))))
                 a-href (format "<a href=\".*/question/%d\">My Card</a>."
                                (-> notification :payload :card_id))]
-            (testing "sends unsubscribe confirmation email"
-              (is (=? {:bcc     #{"lucky@metabase.com"}
-                       :subject "You unsubscribed from an alert"
-                       :body    [{"You’re no longer receiving alerts about" true
-                                  a-href                                    true}]}
-                      (mt/summarize-multipart-single-email email
-                                                           #"You’re no longer receiving alerts about"
-                                                           (re-pattern a-href)))))))))))
+            (testing (format "\nEmail: %s\nNotification:%s\n"
+                             email
+                             (pr-str notification))
+              (testing "sends unsubscribe confirmation email"
+                (is (=? {:bcc     #{"lucky@metabase.com"}
+                         :subject "You unsubscribed from an alert"
+                         :body    [{"You’re no longer receiving alerts about" true
+                                    a-href                                    true}]}
+                        (mt/summarize-multipart-single-email email
+                                                             #"You’re no longer receiving alerts about"
+                                                             (re-pattern a-href))))))))))))
 
 (deftest unsubscribe-notification-audit-test
   (mt/with-model-cleanup [:model/Notification]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -223,8 +223,8 @@
   "Helper function that mocks email/send-email! to capture emails in a vector and returns them."
   [thunk]
   (let [emails (atom [])]
-    (with-redefs [email/send-email! (fn [_ email]
-                                      (swap! emails conj email))]
+    (mt/with-dynamic-fn-redefs [email/send-email! (fn [_ email]
+                                                    (swap! emails conj email))]
       (thunk)
       @emails)))
 


### PR DESCRIPTION
Ok now is the real fix, it was not leaky env like I anticipated in https://github.com/metabase/metabase/pull/56123, it's actually a race condition issue. Detail in [comment](https://github.com/metabase/metabase/pull/56472#discussion_r2034530909).

TLDR: the email we received for assertion in this test came from other tests, which make the card name and card id is off in the href.

I was able to reproduce this with putting a bit of sleep in send email function

```
@@ -310,7 +310,9 @@
 (defn- send-email!
   "Sends an email on a background thread, returning a future."
   [& args]
-  (future (apply send-email-sync! args)))
+  (future
+    (Thread/sleep 50)
+    (apply send-email-sync! args)))
```

And then run these 2 tests repeatedly
```
(doseq [_ (range 5)]
  (run-test-var #'unsubscribe-notification-only-current-notification-test)
  (run-test-var #'unsubscribe-receive-email-test))
```