### PR TITLE
Fix - Column sorting does not work well with predefined column orders

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -338,7 +338,9 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       H.modal().findByLabelText("Sort").should("have.text", "Custom");
 
-      cy.log("should allow predefined order afterwards (metabase#56482)");
+      cy.log(
+        "should allow switching to predefined order afterwards (metabase#56482)",
+      );
       setTableOrder("Database");
 
       H.modal()
@@ -346,6 +348,22 @@ describe("scenarios > admin > datamodel > editor", () => {
         .should(($items) => {
           expect($items[0].textContent).to.equal("ID");
           expect($items[1].textContent).to.equal("Ean");
+        });
+
+      cy.log("should allow drag & drop afterwards (metabase#56482)"); // extra sanity check
+      H.moveDnDKitElement(H.modal().findByLabelText("ID"), {
+        vertical: 50,
+      });
+      cy.wait("@updateFieldOrder");
+
+      cy.log("should not show loading state after an update (metabase#56482)");
+      cy.findByTestId("loading-indicator", { timeout: 0 }).should("not.exist");
+
+      H.modal()
+        .findAllByRole("listitem")
+        .should(($items) => {
+          expect($items[0].textContent).to.equal("Ean");
+          expect($items[1].textContent).to.equal("ID");
         });
     });
 

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -297,6 +297,10 @@ describe("scenarios > admin > datamodel > editor", () => {
         vertical: 50,
       });
       cy.wait("@updateFieldOrder");
+
+      cy.log("should not show loading state after an update (metabase#56482)");
+      cy.findByTestId("loading-indicator", { timeout: 0 }).should("not.exist");
+
       H.modal().findByLabelText("Sort").should("have.text", "Custom");
       H.openProductsTable();
       assertTableHeader([

--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
@@ -37,14 +37,14 @@ interface OwnProps {
 
 interface Props extends OwnProps {
   error: unknown;
-  loading: boolean;
+  fetched: boolean;
   table?: Table;
 }
 
 const FieldOrderSidesheetBase = ({
   error,
+  fetched,
   isOpen,
-  loading,
   table,
   onClose,
 }: Props) => {
@@ -60,6 +60,7 @@ const FieldOrderSidesheetBase = ({
   );
   const sortedItems = useMemo(() => sortItems(items, order), [items, order]);
   const isDragDisabled = sortedItems.length <= 1;
+  const isLoading = !fetched; // matches condition from EntityObjectLoader
 
   const handleSortEnd = ({ itemIds }: DragEndEvent) => {
     setCustomOrder(itemIds);
@@ -70,10 +71,10 @@ const FieldOrderSidesheetBase = ({
     dispatch(Tables.actions.updateProperty(table, "field_order", value));
   };
 
-  if (loading || error || !table) {
+  if (isLoading || error || !table) {
     return (
       <Sidesheet isOpen={isOpen} title={t`Edit column order`} onClose={onClose}>
-        <LoadingAndErrorWrapper error={error} loading={loading} />
+        <LoadingAndErrorWrapper error={error} loading={isLoading} />
       </Sidesheet>
     );
   }

--- a/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
+++ b/frontend/src/metabase/metadata/components/FieldOrderSidesheet/FieldOrderSidesheet.tsx
@@ -1,5 +1,6 @@
 import { PointerSensor, useSensor } from "@dnd-kit/core";
 import { useMemo, useState } from "react";
+import { useDeepCompareEffect } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -27,8 +28,6 @@ import { getId, getItems, getItemsOrder, sortItems } from "./lib";
  */
 const BUTTON_OUTLINE_WIDTH = 2;
 
-type OrderItemId = string | number;
-
 interface OwnProps {
   tableId: TableId;
   isOpen: boolean;
@@ -52,24 +51,39 @@ const FieldOrderSidesheetBase = ({
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: { distance: 15 },
   });
-  const items = useMemo(() => getItems(table?.fields), [table?.fields]);
-  const [customOrder, setCustomOrder] = useState<OrderItemId[] | null>(null);
-  const order = useMemo(
-    () => customOrder ?? getItemsOrder(items),
-    [customOrder, items],
+  const initialItems = useMemo(() => getItems(table?.fields), [table?.fields]);
+  const initialOrder = useMemo(
+    () => getItemsOrder(initialItems),
+    [initialItems],
   );
+  const [items, setItems] = useState(initialItems);
+  const [order, setOrder] = useState(initialOrder);
   const sortedItems = useMemo(() => sortItems(items, order), [items, order]);
   const isDragDisabled = sortedItems.length <= 1;
   const isLoading = !fetched; // matches condition from EntityObjectLoader
 
   const handleSortEnd = ({ itemIds }: DragEndEvent) => {
-    setCustomOrder(itemIds);
+    setOrder(itemIds);
     dispatch(Tables.actions.setFieldOrder(table, itemIds));
   };
 
   const handleFieldOrderChange = (value: TableFieldOrder) => {
     dispatch(Tables.actions.updateProperty(table, "field_order", value));
   };
+
+  /**
+   * Right after performing drag and drop the items would shortly flicker back to the original order,
+   * and then back to the new one. These deep compare effects help avoid this flicker.
+   *
+   * Fields are mapped to items because using a field as a dep here results in an infinite loop.
+   */
+  useDeepCompareEffect(() => {
+    setOrder(initialOrder);
+  }, [initialOrder]);
+
+  useDeepCompareEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
 
   if (isLoading || error || !table) {
     return (


### PR DESCRIPTION
Fixes #56482 ([SEM-231](https://linear.app/metabase/issue/SEM-231/column-sorting-does-not-work-well-with-predefined-column-orders))

### Description

- Reverts 69a7c65c99b76436f62bfc62aaab1e7cba353add (see https://github.com/metabase/metabase/pull/56060#discussion_r2028774665) 
- Fixes loading state appearing after drag & drop (regression due to #56369)

### How to verify

1. Admin > Table Metadata > Choose any table
2. Click "Edit column order"
3. Drag & drop a column to change the order

Loading spinner should not be shown after this action

4. Change "Custom" order to e.g. "Database" order

Orders of fields should be reflected in the sidesheet.
