### PR TITLE
Remove copy and move shortcuts from dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -60,10 +60,6 @@ const DashboardActionMenuInner = ({
   useRegisterShortcut(
     [
       {
-        id: "move-dashboard",
-        perform: () => canEdit && dispatch(push(`${location?.pathname}/move`)),
-      },
-      {
         id: "trash-dashboard",
         perform: () => dispatch(push(`${location?.pathname}/archive`)),
       },

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -60,10 +60,6 @@ const DashboardActionMenuInner = ({
   useRegisterShortcut(
     [
       {
-        id: "copy-dashboard",
-        perform: () => dispatch(push(`${location?.pathname}/copy`)),
-      },
-      {
         id: "move-dashboard",
         perform: () => canEdit && dispatch(push(`${location?.pathname}/move`)),
       },

--- a/frontend/src/metabase/palette/shortcuts/dashboard.ts
+++ b/frontend/src/metabase/palette/shortcuts/dashboard.ts
@@ -30,11 +30,6 @@ export const dashboardShortcuts = {
     shortcutGroup: "dashboard",
     shortcutContext: "When editing",
   },
-  "move-dashboard": {
-    name: t`Move dashboard`,
-    shortcut: ["$mod+m"],
-    shortcutGroup: "dashboard",
-  },
   "trash-dashboard": {
     name: t`Send tashboard to trash`,
     shortcut: ["$mod+backspace"],

--- a/frontend/src/metabase/palette/shortcuts/dashboard.ts
+++ b/frontend/src/metabase/palette/shortcuts/dashboard.ts
@@ -30,11 +30,6 @@ export const dashboardShortcuts = {
     shortcutGroup: "dashboard",
     shortcutContext: "When editing",
   },
-  "copy-dashboard": {
-    name: t`Copy dashboard`,
-    shortcut: ["$mod+c"],
-    shortcutGroup: "dashboard",
-  },
   "move-dashboard": {
     name: t`Move dashboard`,
     shortcut: ["$mod+m"],

--- a/frontend/src/metabase/palette/shortcuts/question.ts
+++ b/frontend/src/metabase/palette/shortcuts/question.ts
@@ -51,11 +51,6 @@ export const questionShortcuts = {
     shortcut: ["d"],
     shortcutGroup: "question",
   },
-  "move-question": {
-    name: t`Move question`,
-    shortcut: ["$mod+m"],
-    shortcutGroup: "question",
-  },
   "trash-question": {
     name: t`Send question to trash`,
     shortcut: ["$mod+backspace"],

--- a/frontend/src/metabase/palette/shortcuts/question.ts
+++ b/frontend/src/metabase/palette/shortcuts/question.ts
@@ -51,11 +51,6 @@ export const questionShortcuts = {
     shortcut: ["d"],
     shortcutGroup: "question",
   },
-  "duplicate-question": {
-    name: t`Duplicate question`,
-    shortcut: ["$mod+d"],
-    shortcutGroup: "question",
-  },
   "move-question": {
     name: t`Move question`,
     shortcut: ["$mod+m"],


### PR DESCRIPTION
### Description
Removes the `$mod+c` shortcut for duplicating dashboards, as it conflicts with browser shortcuts. 

### How to verify
1.  Go to any dashboard.
2. Highlight some text
3. use keyboard shortcuts to copy and paste text to your hearts content
