### PR TITLE
Swap tokens to make CI Run on Translation Update PRs

### DIFF
--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -53,6 +54,8 @@ jobs:
             -e=uz
 
       - name: Prepare translation resources
+        env:
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: | # sh
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -85,6 +88,8 @@ jobs:
 
       - name: Open PR
         id: create_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: | # sh
           DATE=$(date +'%Y-%m-%d')
 
@@ -103,7 +108,7 @@ jobs:
       - name: Auto approve PR
         uses: juliangruber/approve-pull-request-action@v1
         with:
-          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.create_pr.outputs.pr_number }}
 
       - name: Enable Pull Request Automerge


### PR DESCRIPTION

### Description

On translation update PRs, CI was not running automatically for the default github token ([example](https://github.com/metabase/metabase/pull/56418)). This swaps that token to make the committer the automation PAT so that CI will run.

