### PR TITLE
keep metadata store on metadata provider swap

### DIFF
--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -163,7 +163,8 @@
 
     (or *DANGER-allow-replacing-metadata-provider*
         (not (miscellaneous-value [::metadata-provider])))
-    (do
+    ;; Allow replacing the metadata provider once, but it shouldn't affect later calls.
+    (binding [*DANGER-allow-replacing-metadata-provider* false]
       (set-metadata-provider! database-id-or-metadata-providerable)
       (thunk))
 

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -157,21 +157,19 @@
   [database-id-or-metadata-providerable :- ::database-id-or-metadata-providerable
    thunk                                :- [:=> [:cat] :any]]
   (cond
-    (or (not (initialized?))
-        *DANGER-allow-replacing-metadata-provider*)
-    (binding [*store*                                        (atom {})
-              *DANGER-allow-replacing-metadata-provider* false]
+    (not (initialized?))
+    (binding [*store* (atom {})]
       (do-with-metadata-provider database-id-or-metadata-providerable thunk))
 
-    ;; existing provider
-    (miscellaneous-value [::metadata-provider])
+    (or *DANGER-allow-replacing-metadata-provider*
+        (not (miscellaneous-value [::metadata-provider])))
     (do
-      (validate-existing-provider database-id-or-metadata-providerable)
+      (set-metadata-provider! database-id-or-metadata-providerable)
       (thunk))
 
     :else
     (do
-      (set-metadata-provider! database-id-or-metadata-providerable)
+      (validate-existing-provider database-id-or-metadata-providerable)
       (thunk))))
 
 (defmacro with-metadata-provider


### PR DESCRIPTION
Before, we would blow away the existing QP store entirely when using `*DANGER-allow-replacing-metadata-provider*` to swap out the existing metadata provider.

Instead we can only initialize the QP store when it was truly uninitialized, and replace *only* the metadata provider when we're trying to do that.

This is just in case something in QP post-processing needs data from the original store, e.g. something that was stored with `qp.store/store-miscellaneous-value!`.

Note that the only place we're using this dynamic var is in tests, and in the DB Routing middleware that swaps the metadata provider immediately before calling the driver to actually execute a query, so I think this is a low risk change.