### PR TITLE
Fix impersonation with Database Routing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
@@ -13,3 +13,13 @@
                  (lib.metadata/database (qp.store/metadata-provider)))]
     (assoc query :impersonation/role role)
     query))
+
+(defenterprise apply-impersonation-postprocessing
+  "Post-processing middleware. Binds the dynamic var"
+  :feature :advanced-permissions
+  [qp]
+  (fn [query rff]
+    (if-let [role (:impersonation/role query)]
+      (binding [impersonation.driver/*impersonation-role* role]
+        (qp query rff))
+      (qp query rff))))

--- a/src/metabase/query_processor/execute.clj
+++ b/src/metabase/query_processor/execute.clj
@@ -44,6 +44,7 @@
 
     (f (f query rff)) -> (f query rff)"
   [#'qp.middleware.enterprise/swap-mirror-db-middleware
+   #'qp.middleware.enterprise/apply-impersonation-postprocessing-middleware
    #'update-used-cards/update-used-cards!
    #'add-native-form-to-result-metadata
    #'add-preprocessed-query-to-result-metadata-for-userland-query

--- a/src/metabase/query_processor/middleware/enterprise.clj
+++ b/src/metabase/query_processor/middleware/enterprise.clj
@@ -34,6 +34,19 @@
   [query]
   query)
 
+(defenterprise apply-impersonation-postprocessing
+  "Post-processing middleware to actually bind what's needed for impersonation"
+  metabase-enterprise.impersonation.middleware
+  [query]
+  query)
+
+(defn apply-impersonation-postprocessing-middleware
+  "Helper middleware wrapper for [[apply-impersonation-postprocessing]] to make sure we do [[defenterprise]] dispatch
+  correctly on each QP run rather than just once when we combine all of the QP middleware"
+  [qp]
+  (fn [query rff]
+    ((apply-impersonation-postprocessing qp) query rff)))
+
 (defenterprise apply-download-limit
   "Pre-processing middleware to apply row limits to MBQL export queries if the user has `limited` download perms. This
   does not apply to native queries, which are instead limited by the [[limit-download-result-rows]] post-processing


### PR DESCRIPTION
Database routing was not working with impersonation, because by the time the driver calls `set-role-if-supported!` the router database (which is configured for impersonation) has already been swapped out for the mirror database (which is not).

To fix this, have a new impersonation middleware set a dynamic var, `*impersonation-role*`, which is preferred by `set-role-if-supported!` if set. This way, in queries, `set-role-if-supported!` will use the pre-calculated role (which seems better than computing it twice anyway).