### PR TITLE
Make category semantic type available for all types

### DIFF
--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
@@ -196,8 +196,8 @@ describe("SemanticTypePicker", () => {
         setup({ fieldId: field.id });
 
         await assertSemanticTypesVisibility({
-          visibleTypes: ["Field containing JSON"],
-          hiddenTypes: ["Category", "Title"],
+          visibleTypes: ["Category", "Field containing JSON"],
+          hiddenTypes: ["Title"],
         });
       },
     );

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/utils.ts
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/utils.ts
@@ -32,8 +32,9 @@ export function getCompatibleSemanticTypes(
       return false;
     }
 
-    // "Category" is the semantic type for Booleans
-    if (option.id === TYPE.Category && isa(fieldType, TYPE.Boolean)) {
+    // "Category" semantic type of any field
+    // This should be removed when when Category derivation in types.cljc is handled properly.
+    if (option.id === TYPE.Category) {
       return true;
     }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56504

### Description

This is rather quick fix. Proper fix entails making the category derive L1 types. That seem problematic as per [this](https://metaboat.slack.com/archives/C08E17FN206/p1744205384116869?thread_ts=1744201269.806259&cid=C08E17FN206) discussion and should be resolved in follow-up.

### How to verify

Check the table metadata page, every field has now category semantic type available.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
