### PR TITLE
Pass missing props in MultiAutocomplete

### DIFF
--- a/frontend/src/metabase-lib/v1/parameters/utils/operators.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/operators.ts
@@ -102,13 +102,3 @@ export function getNumberParameterArity(parameter: Parameter) {
       return 1;
   }
 }
-
-export function getStringParameterArity(parameter: Parameter) {
-  switch (parameter.type) {
-    case "string/=":
-    case "string/!=":
-      return "n";
-    default:
-      return 1;
-  }
-}

--- a/frontend/src/metabase/parameters/components/ParameterDropdownWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterDropdownWidget.tsx
@@ -15,10 +15,7 @@ import type {
   FieldFilterUiParameter,
   UiParameter,
 } from "metabase-lib/v1/parameters/types";
-import {
-  getNumberParameterArity,
-  getStringParameterArity,
-} from "metabase-lib/v1/parameters/utils/operators";
+import { getNumberParameterArity } from "metabase-lib/v1/parameters/utils/operators";
 import { hasFields } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import { getQueryType } from "metabase-lib/v1/parameters/utils/parameter-source";
 import {
@@ -26,6 +23,7 @@ import {
   isNumberParameter,
   isTemporalUnitParameter,
 } from "metabase-lib/v1/parameters/utils/parameter-type";
+import { getIsMultiSelect } from "metabase-lib/v1/parameters/utils/parameter-values";
 
 import { ParameterFieldWidget } from "./widgets/ParameterFieldWidget/ParameterFieldWidget";
 import { TemporalUnitWidget } from "./widgets/TemporalUnitWidget";
@@ -150,14 +148,14 @@ export const ParameterDropdownWidget = ({
 
   return (
     <StringInputWidget
+      className={className}
+      parameter={parameter}
       value={normalizedValue}
       setValue={setValueOrDefault}
-      className={className}
-      autoFocus
-      placeholder={isEditing ? t`Enter a default value…` : undefined}
-      arity={getStringParameterArity(parameter)}
       label={getParameterWidgetTitle(parameter)}
-      parameter={parameter}
+      placeholder={isEditing ? t`Enter a default value…` : undefined}
+      autoFocus
+      isMultiSelect={getIsMultiSelect(parameter)}
     />
   );
 };

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -19,6 +19,7 @@ import type {
 } from "metabase-types/api";
 
 import { Footer, TokenFieldWrapper, WidgetLabel, WidgetRoot } from "../Widget";
+import { COMBOBOX_PROPS, WIDTH } from "../constants";
 
 export type NumberInputWidgetProps = {
   value: ParameterValueOrArray | undefined;
@@ -85,7 +86,7 @@ export function NumberInputWidget({
   };
 
   return (
-    <WidgetRoot className={className}>
+    <WidgetRoot className={className} w={WIDTH}>
       {label && <WidgetLabel>{label}</WidgetLabel>}
       {arity === "n" ? (
         <TokenFieldWrapper>
@@ -94,6 +95,7 @@ export function NumberInputWidget({
             data={options}
             placeholder={placeholder}
             autoFocus={autoFocus}
+            comboboxProps={COMBOBOX_PROPS}
             onCreate={handleCreate}
             onChange={handleChange}
           />

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -90,10 +90,10 @@ export function NumberInputWidget({
       {arity === "n" ? (
         <TokenFieldWrapper>
           <MultiAutocomplete
-            values={filteredUnsavedArrayValue.map((value) => value?.toString())}
+            value={filteredUnsavedArrayValue.map((value) => value?.toString())}
+            data={options}
             placeholder={placeholder}
             autoFocus={autoFocus}
-            options={options}
             onCreate={handleCreate}
             onChange={handleChange}
           />

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -154,12 +154,17 @@ function getOption(entry: string | ParameterValue): SelectItem | null {
 }
 
 function getLabel(option: string | ParameterValue): string {
-  return option[1] ?? option[0]?.toString() ?? "";
+  if (Array.isArray(option)) {
+    return String(option[1] ?? option[0] ?? "");
+  }
+
+  return option;
 }
 
 function getValue(option: string | ParameterValue) {
-  if (typeof option === "string") {
-    return option;
+  if (Array.isArray(option)) {
+    return option[0];
   }
-  return option[0];
+
+  return option;
 }

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -142,29 +142,26 @@ type SelectItem = {
   label: string;
 };
 
-function getOption(entry: string | ParameterValue): SelectItem | null {
-  const value = getValue(entry)?.toString();
+function getOption(entry: string | number | ParameterValue): SelectItem | null {
+  const value = getValue(entry);
   const label = getLabel(entry);
 
   if (!value) {
     return null;
   }
 
-  return { value, label };
+  return { value: String(value), label: String(label ?? value) };
 }
 
-function getLabel(option: string | ParameterValue): string {
+function getLabel(option: string | number | ParameterValue) {
   if (Array.isArray(option)) {
-    return String(option[1] ?? option[0] ?? "");
+    return option[1];
   }
-
-  return option;
 }
 
-function getValue(option: string | ParameterValue) {
+function getValue(option: string | number | ParameterValue) {
   if (Array.isArray(option)) {
     return option[0];
   }
-
-  return option;
+  return String(option);
 }

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
@@ -1,81 +1,83 @@
-import { useState } from "react";
+import { type ChangeEvent, useState } from "react";
 import { t } from "ttag";
-import { isEmpty, isString } from "underscore";
 
-import TokenField, { parseStringValue } from "metabase/components/TokenField";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
-import type { Parameter } from "metabase-types/api";
+import { deserializeStringParameterValue } from "metabase/querying/parameters/utils/parsing";
+import { Box, MultiAutocomplete, TextInput } from "metabase/ui";
+import type { Parameter, ParameterValueOrArray } from "metabase-types/api";
 
-import { Footer, TokenFieldWrapper, WidgetLabel, WidgetRoot } from "../Widget";
+import { Footer, WidgetLabel, WidgetRoot } from "../Widget";
+import { COMBOBOX_PROPS, WIDTH } from "../constants";
 
 type StringInputWidgetProps = {
-  value: string[] | undefined;
-  setValue: (value: string[] | undefined) => void;
   className?: string;
-  autoFocus?: boolean;
-  placeholder?: string;
-  arity?: 1 | "n";
-  label?: string;
   parameter?: Partial<Pick<Parameter, "required" | "default">>;
+  value: ParameterValueOrArray | null | undefined;
+  setValue: (value: string[] | undefined) => void;
+  label?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  isMultiSelect?: boolean;
 };
 
 export function StringInputWidget({
-  value,
+  parameter = {},
+  value: initialValue,
   setValue,
   className,
   autoFocus,
-  arity = 1,
   placeholder = t`Enter some text`,
   label,
-  parameter = {},
+  isMultiSelect,
 }: StringInputWidgetProps) {
-  const arrayValue = normalize(value);
-  const [unsavedArrayValue, setUnsavedArrayValue] =
-    useState<string[]>(arrayValue);
-  const multi = arity === "n";
-  const isValid = unsavedArrayValue.every(isString);
+  const normalizedValue = deserializeStringParameterValue(initialValue);
+  const [unsavedValue, setUnsavedValue] = useState(normalizedValue);
+  const [unsavedInputValue, setUnsavedInputValue] = useState(
+    normalizedValue[0] ?? "",
+  );
 
-  const onClick = () => {
-    if (isEmpty(unsavedArrayValue)) {
-      setValue(undefined);
-    } else {
-      setValue(unsavedArrayValue);
-    }
+  const handleFieldChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const inputValue = event.target.value;
+    const trimmedInputValue = inputValue.trim();
+    setUnsavedInputValue(inputValue);
+    setUnsavedValue(trimmedInputValue.length > 0 ? [trimmedInputValue] : []);
+  };
+
+  const handleUpdateClick = () => {
+    setValue(unsavedValue.length > 0 ? unsavedValue : undefined);
   };
 
   return (
-    <WidgetRoot className={className}>
+    <WidgetRoot className={className} w={WIDTH}>
       {label && <WidgetLabel>{label}</WidgetLabel>}
-      <TokenFieldWrapper>
-        <TokenField
-          value={unsavedArrayValue}
-          onChange={setUnsavedArrayValue}
-          placeholder={placeholder}
-          options={[]}
-          autoFocus={autoFocus}
-          multi={multi}
-          parseFreeformValue={parseStringValue}
-          updateOnInputChange
-        />
-      </TokenFieldWrapper>
+      <Box m="sm">
+        {isMultiSelect ? (
+          <MultiAutocomplete
+            value={unsavedValue}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+            comboboxProps={COMBOBOX_PROPS}
+            onChange={setUnsavedValue}
+          />
+        ) : (
+          <TextInput
+            value={unsavedInputValue}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+            onChange={handleFieldChange}
+          />
+        )}
+      </Box>
       <Footer>
         <UpdateFilterButton
-          value={value}
-          unsavedValue={unsavedArrayValue}
+          value={initialValue}
+          unsavedValue={unsavedValue}
           defaultValue={parameter.default}
           isValueRequired={parameter.required ?? false}
-          isValid={isValid}
-          onClick={onClick}
+          isValid
+          onClick={handleUpdateClick}
         />
       </Footer>
     </WidgetRoot>
   );
-}
-
-function normalize(value: string[] | undefined): string[] {
-  if (Array.isArray(value)) {
-    return value.filter((x) => x !== undefined);
-  } else {
-    return [];
-  }
 }

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
@@ -98,10 +98,10 @@ describe("StringInputWidget", () => {
     it("should render a token field input", () => {
       render(
         <StringInputWidget
-          arity="n"
           value={["foo", "bar"]}
           setValue={mockSetValue}
           parameter={mockParameter}
+          isMultiSelect
         />,
       );
 
@@ -112,18 +112,15 @@ describe("StringInputWidget", () => {
     it("should correctly parse number inputs", async () => {
       render(
         <StringInputWidget
-          arity="n"
           value={undefined}
           setValue={mockSetValue}
           parameter={mockParameter}
+          isMultiSelect
         />,
       );
 
-      const input = screen.getByRole("textbox");
+      const input = screen.getByRole("combobox");
       await userEvent.type(input, "foo{enter}bar{enter}baz{enter}");
-
-      const values = screen.getAllByRole("list")[0];
-      expect(values).toHaveTextContent("foobarbaz");
 
       const button = screen.getByRole("button", { name: "Add filter" });
       await userEvent.click(button);
@@ -133,14 +130,14 @@ describe("StringInputWidget", () => {
     it("should be unsettable", async () => {
       render(
         <StringInputWidget
-          arity="n"
           value={["foo", "bar"]}
           setValue={mockSetValue}
           parameter={mockParameter}
+          isMultiSelect
         />,
       );
 
-      const input = screen.getByRole("textbox");
+      const input = screen.getByRole("combobox");
       await userEvent.type(input, "{backspace}{backspace}");
 
       const button = screen.getByRole("button", { name: "Update filter" });

--- a/frontend/src/metabase/parameters/components/widgets/constants.ts
+++ b/frontend/src/metabase/parameters/components/widgets/constants.ts
@@ -2,6 +2,6 @@ import type { ComboboxProps } from "metabase/ui";
 
 export const WIDTH = 380;
 export const COMBOBOX_PROPS: Partial<ComboboxProps> = {
-  width: 298,
+  width: 314,
   position: "bottom-start",
 };

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -8,7 +8,7 @@ import * as Lib from "metabase-lib";
 
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
-import { MIN_WIDTH } from "../constants";
+import { WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 
 export function BooleanFilterPicker({
@@ -54,7 +54,7 @@ export function BooleanFilterPicker({
   return (
     <Box
       component="form"
-      miw={MIN_WIDTH}
+      miw={WIDTH}
       data-testid="boolean-filter-picker"
       onSubmit={handleSubmit}
     >

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -15,7 +15,7 @@ import { NumberFilterInput } from "../../NumberFilterInput";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
-import { WIDTH } from "../constants";
+import { COMBOBOX_PROPS, WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 
 import { CoordinateColumnPicker } from "./CoordinateColumnPicker";
@@ -141,6 +141,7 @@ function CoordinateValueInput({
           column={column}
           values={values.filter(isNotNull)}
           autoFocus
+          comboboxProps={COMBOBOX_PROPS}
           onChange={onChange}
         />
       </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
@@ -7,7 +7,7 @@ import * as Lib from "metabase-lib";
 
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
-import { MIN_WIDTH } from "../constants";
+import { WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 
 export function DefaultFilterPicker({
@@ -54,7 +54,7 @@ export function DefaultFilterPicker({
   return (
     <Box
       component="form"
-      miw={MIN_WIDTH}
+      miw={WIDTH}
       data-testid="default-filter-picker"
       onSubmit={handleSubmit}
     >

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -15,7 +15,7 @@ import { NumberFilterInput } from "../../NumberFilterInput";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
-import { WIDTH } from "../constants";
+import { COMBOBOX_PROPS, WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 
 export function NumberFilterPicker({
@@ -125,6 +125,7 @@ function NumberValueInput({
           column={column}
           values={values.filter(isNotNull)}
           autoFocus
+          comboboxProps={COMBOBOX_PROPS}
           onChange={onChange}
         />
       </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -138,8 +138,7 @@ function StringValueInput({
     return (
       <Box p="md" pb={0} mah="40vh" style={{ overflow: "auto" }}>
         <MultiAutocomplete
-          values={values}
-          options={[]}
+          value={values}
           placeholder={t`Enter some text`}
           aria-label={t`Filter value`}
           onChange={onChange}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -13,7 +13,7 @@ import { StringFilterValuePicker } from "../../FilterValuePicker";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
-import { WIDTH } from "../constants";
+import { COMBOBOX_PROPS, WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 
 export function StringFilterPicker({
@@ -127,6 +127,7 @@ function StringValueInput({
           stageIndex={stageIndex}
           column={column}
           values={values}
+          comboboxProps={COMBOBOX_PROPS}
           autoFocus
           onChange={onChange}
         />
@@ -140,6 +141,7 @@ function StringValueInput({
         <MultiAutocomplete
           value={values}
           placeholder={t`Enter some text`}
+          comboboxProps={COMBOBOX_PROPS}
           aria-label={t`Filter value`}
           onChange={onChange}
         />

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { useGetFieldValuesQuery } from "metabase/api";
 import { parseNumber } from "metabase/lib/number";
 import { checkNotNull, isNotNull } from "metabase/lib/types";
-import { Center, Loader } from "metabase/ui";
+import { Center, type ComboboxProps, Loader } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { ListValuePicker } from "./ListValuePicker";
@@ -24,6 +24,7 @@ interface FilterValuePickerProps<T> {
   column: Lib.ColumnMetadata;
   values: T[];
   autoFocus?: boolean;
+  comboboxProps?: ComboboxProps;
   onCreate?: (rawValue: string) => string | null;
   onChange: (newValues: T[]) => void;
 }
@@ -39,6 +40,7 @@ function FilterValuePicker({
   values: selectedValues,
   placeholder,
   autoFocus = false,
+  comboboxProps,
   onCreate,
   onChange,
 }: FilterValuePickerOwnProps) {
@@ -83,6 +85,7 @@ function FilterValuePicker({
         selectedValues={selectedValues}
         columnDisplayName={columnInfo.displayName}
         autoFocus={autoFocus}
+        comboboxProps={comboboxProps}
         onCreate={onCreate}
         onChange={onChange}
       />
@@ -94,6 +97,7 @@ function FilterValuePicker({
       selectedValues={selectedValues}
       placeholder={placeholder}
       autoFocus={autoFocus}
+      comboboxProps={comboboxProps}
       onCreate={onCreate}
       onChange={onChange}
     />

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -3,7 +3,7 @@ import { useDebounce } from "react-use";
 import { t } from "ttag";
 
 import { useSearchFieldValuesQuery } from "metabase/api";
-import { Loader, MultiAutocomplete } from "metabase/ui";
+import { type ComboboxProps, Loader, MultiAutocomplete } from "metabase/ui";
 import type { FieldId, FieldValue } from "metabase-types/api";
 
 import { getFieldOptions } from "../utils";
@@ -22,6 +22,7 @@ interface SearchValuePickerProps {
   selectedValues: string[];
   columnDisplayName: string;
   autoFocus?: boolean;
+  comboboxProps?: ComboboxProps;
   onCreate?: (rawValue: string) => string | null;
   onChange: (newValues: string[]) => void;
 }
@@ -33,6 +34,7 @@ export function SearchValuePicker({
   selectedValues,
   columnDisplayName,
   autoFocus,
+  comboboxProps,
   onCreate,
   onChange,
 }: SearchValuePickerProps) {
@@ -94,6 +96,7 @@ export function SearchValuePicker({
       autoFocus={autoFocus}
       rightSection={isSearching ? <Loader size="xs" /> : undefined}
       nothingFoundMessage={nothingFoundMessage}
+      comboboxProps={comboboxProps}
       aria-label={t`Filter value`}
       onCreate={onCreate}
       onChange={onChange}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -88,8 +88,8 @@ export function SearchValuePicker({
 
   return (
     <MultiAutocomplete
-      values={selectedValues}
-      options={visibleOptions}
+      value={selectedValues}
+      data={visibleOptions}
       placeholder={t`Search by ${columnDisplayName}`}
       autoFocus={autoFocus}
       rightSection={isSearching ? <Loader size="xs" /> : undefined}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
@@ -19,8 +19,7 @@ export function StaticValuePicker({
 }: StaticValuePickerProps) {
   return (
     <MultiAutocomplete
-      values={selectedValues}
-      options={[]}
+      value={selectedValues}
       placeholder={placeholder}
       autoFocus={autoFocus}
       aria-label={t`Filter value`}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
@@ -1,11 +1,12 @@
 import { t } from "ttag";
 
-import { MultiAutocomplete } from "metabase/ui";
+import { type ComboboxProps, MultiAutocomplete } from "metabase/ui";
 
 interface StaticValuePickerProps {
   selectedValues: string[];
   placeholder?: string;
   autoFocus?: boolean;
+  comboboxProps?: ComboboxProps;
   onCreate?: (rawValue: string) => string | null;
   onChange: (newValues: string[]) => void;
 }
@@ -14,6 +15,7 @@ export function StaticValuePicker({
   selectedValues,
   placeholder,
   autoFocus,
+  comboboxProps,
   onCreate,
   onChange,
 }: StaticValuePickerProps) {
@@ -22,6 +24,7 @@ export function StaticValuePicker({
       value={selectedValues}
       placeholder={placeholder}
       autoFocus={autoFocus}
+      comboboxProps={comboboxProps}
       aria-label={t`Filter value`}
       onCreate={onCreate}
       onChange={onChange}

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -7,6 +7,7 @@ import {
   PillsInput,
   Text,
   Tooltip,
+  type __InputWrapperProps,
   extractStyleProps,
 } from "@mantine/core";
 import type { ReactNode } from "react";
@@ -18,6 +19,7 @@ import S from "./MultiAutocomplete.module.css";
 import { useMultiAutocomplete } from "./use-multi-autocomplete";
 
 export type MultiAutocompleteProps = BoxProps &
+  __InputWrapperProps &
   ComboboxLikeProps & {
     value: string[];
     placeholder?: string;
@@ -35,6 +37,16 @@ export function MultiAutocomplete({
   data = [],
   filter,
   limit,
+  label,
+  description,
+  error,
+  required,
+  withAsterisk,
+  labelProps,
+  descriptionProps,
+  errorProps,
+  inputContainer,
+  inputWrapperOrder,
   placeholder,
   autoFocus,
   rightSection,
@@ -44,6 +56,7 @@ export function MultiAutocomplete({
   defaultDropdownOpened,
   selectFirstOptionOnChange,
   withScrollArea,
+  comboboxProps,
   "aria-label": ariaLabel,
   onCreate,
   onChange,
@@ -99,11 +112,22 @@ export function MultiAutocomplete({
         withinPortal={false}
         floatingStrategy="fixed"
         onOptionSubmit={handleOptionSubmit}
+        {...comboboxProps}
       >
         <Combobox.DropdownTarget>
           <PillsInput
             {...styleProps}
+            label={label}
+            description={description}
+            error={error}
+            required={required}
             rightSection={rightSection ?? infoIcon}
+            withAsterisk={withAsterisk}
+            labelProps={labelProps}
+            descriptionProps={descriptionProps}
+            errorProps={errorProps}
+            inputContainer={inputContainer}
+            inputWrapperOrder={inputWrapperOrder}
             onClick={handlePillsInputClick}
           >
             <Pill.Group role="list" onClick={handlePillGroupClick}>

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -1,7 +1,7 @@
 import {
   type BoxProps,
   Combobox,
-  type ComboboxItem,
+  type ComboboxLikeProps,
   OptionsDropdown,
   Pill,
   PillsInput,
@@ -17,30 +17,40 @@ import { Icon } from "../../icons";
 import S from "./MultiAutocomplete.module.css";
 import { useMultiAutocomplete } from "./use-multi-autocomplete";
 
-export type MultiAutocompleteProps = BoxProps & {
-  values: string[];
-  options: ComboboxItem[];
-  placeholder?: string;
-  autoFocus?: boolean;
-  rightSection?: ReactNode;
-  nothingFoundMessage?: ReactNode;
-  "aria-label"?: string;
-  onCreate?: (rawValue: string) => string | null;
-  onChange: (newValues: string[]) => void;
-  onSearchChange?: (newValue: string) => void;
-};
+export type MultiAutocompleteProps = BoxProps &
+  ComboboxLikeProps & {
+    value: string[];
+    placeholder?: string;
+    autoFocus?: boolean;
+    rightSection?: ReactNode;
+    nothingFoundMessage?: ReactNode;
+    "aria-label"?: string;
+    onCreate?: (rawValue: string) => string | null;
+    onChange: (newValues: string[]) => void;
+    onSearchChange?: (newValue: string) => void;
+  };
 
 export function MultiAutocomplete({
-  values,
-  options,
+  value,
+  data = [],
+  filter,
+  limit,
   placeholder,
   autoFocus,
   rightSection,
   nothingFoundMessage,
+  maxDropdownHeight,
+  dropdownOpened,
+  defaultDropdownOpened,
+  selectFirstOptionOnChange,
+  withScrollArea,
   "aria-label": ariaLabel,
   onCreate,
   onChange,
   onSearchChange,
+  onDropdownOpen,
+  onDropdownClose,
+  onOptionSubmit,
   ...otherProps
 }: MultiAutocompleteProps) {
   const {
@@ -61,8 +71,8 @@ export function MultiAutocomplete({
     handlePillsInputClick,
     handleOptionSubmit,
   } = useMultiAutocomplete({
-    values,
-    options,
+    values: value,
+    data,
     onCreate,
     onChange,
     onSearchChange,
@@ -131,21 +141,22 @@ export function MultiAutocomplete({
           </PillsInput>
         </Combobox.DropdownTarget>
         <OptionsDropdown
+          value={value}
           data={filteredOptions}
           search={searchValue}
+          filter={filter}
+          limit={limit}
+          maxDropdownHeight={maxDropdownHeight}
           nothingFoundMessage={nothingFoundMessage}
           hiddenWhenEmpty={!nothingFoundMessage}
-          filter={undefined}
-          limit={undefined}
-          maxDropdownHeight={undefined}
           unstyled={false}
           labelId={undefined}
-          withScrollArea={undefined}
+          withScrollArea={withScrollArea}
           scrollAreaProps={undefined}
           aria-label={undefined}
         />
       </Combobox>
-      <Combobox.HiddenInput value={values} />
+      <Combobox.HiddenInput value={value} />
     </>
   );
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
@@ -6,24 +6,22 @@ import { renderWithProviders, screen } from "__support__/ui";
 
 import { MultiAutocomplete, type MultiAutocompleteProps } from "./";
 
-type TestInputProps = Omit<MultiAutocompleteProps, "values"> & {
-  initialValues: string[];
+type TestInputProps = Omit<MultiAutocompleteProps, "value"> & {
+  initialValue: string[];
 };
 
-function TestInput({ initialValues, onChange, ...props }: TestInputProps) {
-  const [values, setValues] = useState(initialValues);
+function TestInput({ initialValue, onChange, ...props }: TestInputProps) {
+  const [value, setValue] = useState(initialValue);
 
-  const handleChange = (newValues: string[]) => {
-    onChange(newValues);
-    setValues(newValues);
+  const handleChange = (newValue: string[]) => {
+    onChange(newValue);
+    setValue(newValue);
   };
 
-  return (
-    <MultiAutocomplete {...props} values={values} onChange={handleChange} />
-  );
+  return <MultiAutocomplete {...props} value={value} onChange={handleChange} />;
 }
 
-const REMAPPED_OPTIONS: ComboboxItem[] = [
+const REMAPPED_DATA: ComboboxItem[] = [
   { value: "1", label: "One" },
   { value: "2", label: "Two" },
   { value: "3", label: "Three" },
@@ -31,8 +29,8 @@ const REMAPPED_OPTIONS: ComboboxItem[] = [
 ];
 
 type SetupOpts = {
-  initialValues?: string[];
-  options?: ComboboxItem[];
+  initialValue?: string[];
+  data?: ComboboxItem[];
   placeholder?: string;
   autoFocus?: boolean;
   rightSection?: ReactNode;
@@ -42,8 +40,8 @@ type SetupOpts = {
 };
 
 function setup({
-  initialValues = [],
-  options = [],
+  initialValue = [],
+  data = [],
   placeholder = "Enter some text",
   onCreate,
 }: SetupOpts = {}) {
@@ -52,8 +50,8 @@ function setup({
 
   renderWithProviders(
     <TestInput
-      initialValues={initialValues}
-      options={options}
+      initialValue={initialValue}
+      data={data}
       placeholder={placeholder}
       onCreate={onCreate}
       onChange={onChange}
@@ -283,7 +281,7 @@ describe("MultiAutocomplete", () => {
   });
 
   it("should allow to edit a value", async () => {
-    const { input, onChange } = setup({ initialValues: ["1", "2"] });
+    const { input, onChange } = setup({ initialValue: ["1", "2"] });
     await userEvent.click(screen.getByText("1"));
     expect(input).toHaveValue("1");
     expect(onChange).not.toHaveBeenCalled();
@@ -301,8 +299,8 @@ describe("MultiAutocomplete", () => {
     expect(onChange).toHaveBeenLastCalledWith(["3", "4", "2"]);
   });
 
-  it("should display the remapped value when there are matching options", () => {
-    setup({ initialValues: ["1", "2", "5"], options: REMAPPED_OPTIONS });
+  it("should display the remapped value when there are matching data", () => {
+    setup({ initialValue: ["1", "2", "5"], data: REMAPPED_DATA });
     expect(screen.getByText("One")).toBeInTheDocument();
     expect(screen.getByText("Two")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
@@ -310,8 +308,8 @@ describe("MultiAutocomplete", () => {
 
   it("should use the remapped value when editing", async () => {
     const { input, onChange } = setup({
-      initialValues: ["1", "3"],
-      options: REMAPPED_OPTIONS,
+      initialValue: ["1", "3"],
+      data: REMAPPED_DATA,
     });
     await userEvent.click(screen.getByText("One"));
     expect(input).toHaveValue("One");
@@ -330,7 +328,7 @@ describe("MultiAutocomplete", () => {
 
   it("should quote the selected value when editing", async () => {
     const { input, onChange, onSearchChange } = setup({
-      initialValues: ["a,b"],
+      initialValue: ["a,b"],
     });
     await userEvent.click(screen.getByText("a,b"));
     expect(input).toHaveValue('"a,b"');
@@ -345,7 +343,7 @@ describe("MultiAutocomplete", () => {
 
   it("should escape the selected value when editing", async () => {
     const { input, onChange, onSearchChange } = setup({
-      initialValues: ['a"b'],
+      initialValue: ['a"b'],
     });
     await userEvent.click(screen.getByText('a"b'));
     expect(input).toHaveValue('"a\\"b"');
@@ -360,8 +358,8 @@ describe("MultiAutocomplete", () => {
 
   it("should quote the selected option label when editing", async () => {
     const { input, onChange } = setup({
-      initialValues: ["1"],
-      options: [
+      initialValue: ["1"],
+      data: [
         { value: "1", label: "a,b" },
         { value: "2", label: "a,b,c" },
         { value: "3", label: "a,b,c,d" },
@@ -387,7 +385,7 @@ describe("MultiAutocomplete", () => {
   });
 
   it("should open and close the dropdown correctly", async () => {
-    const { input, onChange } = setup({ options: REMAPPED_OPTIONS });
+    const { input, onChange } = setup({ data: REMAPPED_DATA });
     expect(queryOption("One")).not.toBeInTheDocument();
 
     await userEvent.click(input);
@@ -457,7 +455,7 @@ describe("MultiAutocomplete", () => {
   });
 
   it("should handle cases when a value is replaced with 2 values at once", async () => {
-    const { input, onChange } = setup({ initialValues: ["abc"] });
+    const { input, onChange } = setup({ initialValue: ["abc"] });
     await userEvent.click(screen.getByText("abc"));
     await userEvent.type(input, "{arrowleft},");
     expect(input).toHaveValue("");

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
@@ -1,4 +1,4 @@
-import type { ComboboxItem } from "@mantine/core";
+import type { ComboboxData, ComboboxItem } from "@mantine/core";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode, useState } from "react";
 
@@ -21,11 +21,16 @@ function TestInput({ initialValue, onChange, ...props }: TestInputProps) {
   return <MultiAutocomplete {...props} value={value} onChange={handleChange} />;
 }
 
-const REMAPPED_DATA: ComboboxItem[] = [
+const REMAPPED_DATA: ComboboxData = [
   { value: "1", label: "One" },
   { value: "2", label: "Two" },
   { value: "3", label: "Three" },
   { value: "4", label: "Four" },
+];
+
+const GROUPED_DATA: ComboboxData = [
+  { group: "A", items: ["A1", "A2"] },
+  { group: "B", items: ["B1", "B2"] },
 ];
 
 type SetupOpts = {
@@ -422,6 +427,28 @@ describe("MultiAutocomplete", () => {
     expect(queryOption("Two")).not.toBeInTheDocument();
     expect(queryOption("Three")).not.toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(["1", "2", "3"]);
+  });
+
+  it("should work with grouped options", async () => {
+    const { input, onChange } = setup({ data: GROUPED_DATA });
+    await userEvent.click(input);
+    await userEvent.click(getOption("A1"));
+    expect(onChange).toHaveBeenLastCalledWith(["A1"]);
+
+    await userEvent.click(input);
+    expect(queryOption("A1")).not.toBeInTheDocument();
+    expect(getOption("A2")).toBeInTheDocument();
+    expect(getOption("B1")).toBeInTheDocument();
+    expect(getOption("B2")).toBeInTheDocument();
+
+    await userEvent.type(input, "B");
+    expect(queryOption("A1")).not.toBeInTheDocument();
+    expect(queryOption("A2")).not.toBeInTheDocument();
+    expect(getOption("B1")).toBeInTheDocument();
+    expect(getOption("B2")).toBeInTheDocument();
+
+    await userEvent.click(getOption("B2"));
+    expect(onChange).toHaveBeenLastCalledWith(["A1", "B2"]);
   });
 
   it("should ignore duplicates when there are different string representations of the underlying value", async () => {

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
@@ -1,4 +1,4 @@
-import type { ComboboxData, ComboboxItem } from "@mantine/core";
+import type { ComboboxData } from "@mantine/core";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode, useState } from "react";
 
@@ -35,7 +35,7 @@ const GROUPED_DATA: ComboboxData = [
 
 type SetupOpts = {
   initialValue?: string[];
-  data?: ComboboxItem[];
+  data?: ComboboxData;
   placeholder?: string;
   autoFocus?: boolean;
   rightSection?: ReactNode;

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
@@ -1,4 +1,12 @@
-import { type ComboboxItem, useCombobox } from "@mantine/core";
+import {
+  type ComboboxData,
+  type ComboboxItem,
+  type ComboboxParsedItem,
+  getOptionsLockup,
+  getParsedComboboxData,
+  isOptionsGroup,
+  useCombobox,
+} from "@mantine/core";
 import { parse } from "csv-parse/browser/esm/sync";
 import {
   type ChangeEvent,
@@ -18,10 +26,16 @@ const FIELD_PLACEHOLDER = null;
 
 type UseMultiAutocompleteProps = {
   values: string[];
-  options: ComboboxItem[];
+  data: ComboboxData;
+  dropdownOpened?: boolean;
+  defaultDropdownOpened?: boolean;
+  selectFirstOptionOnChange?: boolean;
   onCreate?: (rawValue: string) => string | null;
   onChange: (newValues: string[]) => void;
   onSearchChange?: (newValue: string) => void;
+  onDropdownOpen?: () => void;
+  onDropdownClose?: () => void;
+  onOptionSubmit?: (value: string) => void;
 };
 
 type FieldState = {
@@ -37,20 +51,32 @@ type FieldSelection = {
 
 export function useMultiAutocomplete({
   values,
-  options,
+  data,
+  dropdownOpened,
+  defaultDropdownOpened,
   onCreate = defaultCreate,
   onChange,
   onSearchChange,
+  onDropdownOpen,
+  onDropdownClose,
+  onOptionSubmit,
 }: UseMultiAutocompleteProps) {
   const combobox = useCombobox({
-    onDropdownClose: () => combobox.resetSelectedOption(),
+    opened: dropdownOpened,
+    defaultOpened: defaultDropdownOpened,
+    onDropdownOpen,
+    onDropdownClose: () => {
+      onDropdownClose?.();
+      combobox.resetSelectedOption();
+    },
   });
   const [fieldValue, setFieldValue] = useState("");
   const [_fieldSelection, setFieldSelection] = useState<FieldSelection>();
   const [fieldMinWidth, setFieldMinWidth] = useState<number>();
   const fieldSelection = _fieldSelection ?? { index: values.length, length: 0 };
   const searchValue = useMemo(() => getSearchValue(fieldValue), [fieldValue]);
-  const optionByValue = useMemo(() => getOptionByValue(options), [options]);
+  const options = useMemo(() => getParsedComboboxData(data), [data]);
+  const optionByValue = useMemo(() => getOptionsLockup(options), [options]);
 
   const setFieldState = ({
     fieldValue,
@@ -211,6 +237,7 @@ export function useMultiAutocomplete({
         length: 0,
       },
     });
+    onOptionSubmit?.(value);
     combobox.closeDropdown();
     combobox.resetSelectedOption();
   };
@@ -237,10 +264,6 @@ export function useMultiAutocomplete({
     handlePillsInputClick,
     handleOptionSubmit,
   };
-}
-
-function getOptionByValue(options: ComboboxItem[]) {
-  return Object.fromEntries(options.map((option) => [option.value, option]));
 }
 
 function getSearchValue(fieldValue: string) {
@@ -274,17 +297,31 @@ function getValuesNotInSelection(
 
 function getOptionsWithoutDuplicates(
   values: string[],
-  options: ComboboxItem[],
+  options: ComboboxParsedItem[],
   fieldSelection: FieldSelection,
 ) {
   const usedValues = new Set(getValuesNotInSelection(values, fieldSelection));
-  return options.reduce((options: ComboboxItem[], option) => {
-    if (!usedValues.has(option.value)) {
-      options.push(option);
+  const newOptions: ComboboxParsedItem[] = [];
+
+  for (const option of options) {
+    if (isOptionsGroup(option)) {
+      const newGroupOptions: ComboboxItem[] = [];
+      for (const groupOption of option.items) {
+        if (!usedValues.has(groupOption.value)) {
+          newGroupOptions.push(groupOption);
+          usedValues.add(groupOption.value);
+        }
+      }
+      if (newGroupOptions.length > 0) {
+        newOptions.push({ ...option, items: newGroupOptions });
+      }
+    } else if (!usedValues.has(option.value)) {
+      newOptions.push(option);
       usedValues.add(option.value);
     }
-    return options;
-  }, []);
+  }
+
+  return newOptions;
 }
 
 function getFieldValuesWithoutDuplicates(


### PR DESCRIPTION
Changes:
- Passes missing props, following how `MultiSelect` is implemented.
- Renames props to match `MultiSelect`
- Handles options with groups