### PR TITLE
Support binning by column with a single numerical value

### DIFF
--- a/src/metabase/lib/binning/util.cljc
+++ b/src/metabase/lib/binning/util.cljc
@@ -13,8 +13,11 @@
   [min-value :- number?
    max-value :- number?
    num-bins  :- ::lib.schema.binning/num-bins]
-  (u/round-to-decimals 5 (/ (- max-value min-value)
-                            num-bins)))
+  (let [width (u/round-to-decimals 5 (/ (- max-value min-value)
+                                        num-bins))]
+    (if (zero? width)
+      1                         ; a nice (in the sense of [[nicer-bin-width]]), positive but otherwise arbitrary width
+      width)))
 
 (mu/defn- calculate-num-bins :- ::lib.schema.binning/num-bins
   "Calculate number of bins of width `bin-width` required to cover interval [`min-value`, `max-value`]."

--- a/test/metabase/lib/binning/util_test.cljc
+++ b/test/metabase/lib/binning/util_test.cljc
@@ -4,6 +4,15 @@
    [metabase.lib.binning.util :as lib.binning.util]
    [metabase.lib.test-metadata :as meta]))
 
+(deftest ^:parallel calculate-bin-width-single-value-test
+  (are [minv maxv bins] (= 1 (#'lib.binning.util/calculate-bin-width minv maxv bins))
+    0     0     1
+    -3    -3    14
+    7N    7N    25
+    7N    7     25
+    0.25  0.25  5
+    42M   42M   42))
+
 (deftest ^:parallel floor-to-test
   (are [x expected] (= expected
                        (#'lib.binning.util/floor-to 1.0 x))


### PR DESCRIPTION
Fixes #53521

### Description

Make sure that when we have a single value and therefore max-value - min-value = 0, we still produce a positive bin width. (The actual width is not really important, since there is just one bin anyway.)

### How to verify

Use the repro steps from #53521 (or break out by any other column with a single numeric value).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
