### PR TITLE
fix: allow metabase jars to start on JVM 24 and up

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -27,10 +27,10 @@
 
   More info: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Thread.html"
   []
-  (-> (Thread/currentThread)
-      (.getContextClassLoader)
-      (.getResource "")
-      (str/starts-with? "jar:")))
+  (= "jar" (.. (Thread/currentThread)
+               getContextClassLoader
+               (getResource ".keep-me")
+               getProtocol)))
 
 (defn- get-jar-path
   "Returns the path to the currently running jar file.

--- a/resources/.keep-me
+++ b/resources/.keep-me
@@ -1,0 +1,5 @@
+** DO NOT DELETE **
+
+This file works as a sentinel to allow us to check if we are running in a jar file on JVMs >= 24
+
+** DO NOT DELETE **


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56085

### Description

Metabase jars would crash when running on JVM 24 because the getReourse method on the ClassLoader object was changed to return null if there is no file at the provided path. This adds a ".keep-me" file to the resources directory that Metabase can use to check if it is running in a jar.

In the future we could explore if we can unify loading these with whether or not we're running in a jar. 

### How to verify

Build a metabase jar
Try running it on jvm 24

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
