### PR TITLE
fix: avoid deadlocks by not holding connection

### DIFF
--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -1,18 +1,15 @@
 (ns metabase.query-processor.middleware.cache-backend.db
   (:require
    [java-time.api :as t]
-   [metabase.db :as mdb]
-   [metabase.db.query :as mdb.query]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.util.date-2 :as u.date]
    [metabase.util.encryption :as encryption]
    [metabase.util.log :as log]
-   [toucan2.connection :as t2.connection]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import
-   (java.sql Connection PreparedStatement ResultSet Types)))
+   (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
 
@@ -22,69 +19,53 @@
 (defn- seconds-ago [n]
   (ms-ago (long (* 1000 n))))
 
-;; this is memoized for a given application DB so we can deliver cached results EXTRA FAST and not have to spend an
-;; extra microsecond compiling the same exact query every time. :shrug:
-;;
-;; Since application DB can change at run time (during tests) it's not just a plain delay
-(let [f (memoize (fn [_db-type]
-                   (first (mdb.query/compile {:select   [:results]
-                                              :from     [:query_cache]
-                                              :where    [:and
-                                                         [:= :query_hash [:raw "?"]]
-                                                         [:>= :updated_at [:raw "?"]]]
-                                              :order-by [[:updated_at :desc]]
-                                              :limit    [:inline 1]}))))]
-  (defn- cached-results-query-sql []
-    (f (mdb/db-type))))
+(defmulti results-as-bytes
+  "Handles converting the results db column into a byte array"
+  {:arglists '([cached])}
+  (comp type :results))
 
-(defn prepare-statement
-  "Create a prepared statement to query cache"
-  ^PreparedStatement [^Connection conn query-hash updated-at]
-  (let [stmt (.prepareStatement conn ^String (cached-results-query-sql)
-                                ResultSet/TYPE_FORWARD_ONLY
-                                ResultSet/CONCUR_READ_ONLY
-                                ResultSet/CLOSE_CURSORS_AT_COMMIT)]
-    (try
-      (doto stmt
-        (.setFetchDirection ResultSet/FETCH_FORWARD)
-        (.setBytes 1 query-hash)
-        (.setObject 2 updated-at Types/TIMESTAMP_WITH_TIMEZONE)
-        (.setMaxRows 1))
-      (catch Throwable e
-        (log/error e "Error preparing statement to fetch cached query results")
-        (.close stmt)
-        (throw e)))))
+;; H2 returns a blob type
+(defmethod results-as-bytes org.h2.jdbc.JdbcBlob
+  [{:keys [^org.h2.jdbc.JdbcBlob results]}]
+  (.getBytes results 1 (.length results)))
+
+;; MySQL/Mariadb/Postgresql return a byte array
+(defmethod results-as-bytes :default
+  [{:keys [results]}]
+  results)
+
+(defn select-cache
+  "Select the result form the cache"
+  [query-hash updated-at]
+  (t2/select-one-fn results-as-bytes :model/QueryCache
+                    {:select [:results]
+                     :where [:and
+                             [:= :query_hash query-hash]
+                             [:>= :updated_at updated-at]]
+                     :order-by [[:updated_at :desc]]}))
 
 (defn fetch-cache-stmt-ttl
   "Make a prepared statement for :ttl caching strategy"
-  ^PreparedStatement [strategy query-hash ^Connection conn]
+  [strategy query-hash]
   (if-not (:avg-execution-ms strategy)
     (log/debugf "Caching strategy %s needs :avg-execution-ms to work" (pr-str strategy))
     (let [max-age-ms     (* (:multiplier strategy)
                             (:avg-execution-ms strategy))
           invalidated-at (t/max (ms-ago max-age-ms) (:invalidated-at strategy))]
-      (prepare-statement conn query-hash invalidated-at))))
+      (select-cache query-hash invalidated-at))))
 
 (defenterprise fetch-cache-stmt
   "Returns prepared statement for a given strategy and query hash - on EE. Returns `::oss` on OSS."
   metabase-enterprise.cache.strategies
-  [strategy hash conn]
+  [strategy hash]
   (when (= :ttl (:type strategy))
-    (fetch-cache-stmt-ttl strategy hash conn)))
+    (fetch-cache-stmt-ttl strategy hash)))
 
 (defn- cached-results [query-hash strategy respond]
-  ;; VERY IMPORTANT! Open up a connection (which internally binds [[toucan2.connection/*current-connectable*]] so it
-  ;; will get reused elsewhere for the duration of results reduction, otherwise we can potentially end up deadlocking if
-  ;; we need to acquire another connection for one reason or another, such as recording QueryExecutions
-  (t2/with-connection [conn]
-    (when-let [stmt (fetch-cache-stmt strategy query-hash conn)]
-      (with-open [stmt ^PreparedStatement stmt
-                  rs   (.executeQuery stmt)]
-        (assert (= t2.connection/*current-connectable* conn))
-        (if-not (.next rs)
-          (respond nil)
-          (with-open [is (encryption/maybe-decrypt-stream (.getBinaryStream rs 1))]
-            (respond is)))))))
+  (if-let [cached (fetch-cache-stmt strategy query-hash)]
+    (with-open [is (encryption/maybe-decrypt-stream (ByteArrayInputStream. cached))]
+      (respond is))
+    (respond nil)))
 
 (defn- purge-old-cache-entries!
   "Delete any cache entries that are older than the global max age `max-cache-entry-age-seconds` (currently 3 months)."


### PR DESCRIPTION
### Description

Avoid the possiblity of deadlocks during cached query processing by not taking the connection using with-connection and instead just selecting the cached result using toucan.

I _think_ this connection holding was introduced under the assumption that we could 'stream' a binary column from postgresql using the .getBinaryStreaming jdbc method. However postgres requires binary columns to be fully read and written and so we are unable to stream results from that column, so this operation ends up being the same as just querying the column normally.

Likewise the [mysql JDBC](https://github.com/mysql/mysql-connector-j/blob/a3909bfeb62d5a517ab444bb88ba7ecf26100297/src/main/user-impl/java/com/mysql/cj/jdbc/Blob.java#L109) driver loads the full results from a binary column and .getBinaryStream just returns that as a stream, so neither supported app db let's us truly read this data streamed a chunk at a time. 

Because we are not streaming the result in it seems safe to just yeild the connection back to pool so it can shared with other requests.

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
