### PR TITLE
fix visualizer crashes on some unsupported display type questions

### DIFF
--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -11,10 +11,7 @@ import type {
 } from "metabase-types/api";
 
 import type { RemappingHydratedDatasetColumn } from "./types";
-import type {
-  Visualization,
-  VisualizationSettingDefinition,
-} from "./types/visualization";
+import type { Visualization } from "./types/visualization";
 
 const visualizations = new Map<VisualizationDisplay, Visualization>();
 const aliases = new Map<string, Visualization>();
@@ -157,23 +154,6 @@ export function isCartesianChart(display: VisualizationDisplay) {
     settingNames.includes("graph.dimensions") &&
     settingNames.includes("graph.metrics")
   );
-}
-
-const isDataSetting = ({
-  widget,
-}: VisualizationSettingDefinition<unknown, unknown>) => {
-  // TODO Come up with a better condition
-  return widget === "field" || widget === "fields";
-};
-
-export function getColumnVizSettings(display: VisualizationDisplay) {
-  const visualization = visualizations.get(display);
-  const settings = visualization?.settings ?? {};
-
-  // TODO Come up with a better condition
-  return Object.keys(settings).filter((key) => {
-    return isDataSetting(settings[key] ?? {});
-  });
 }
 
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -1,5 +1,4 @@
 import { isNotNull } from "metabase/lib/types";
-import { getColumnVizSettings } from "metabase/visualizations";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import {
   getDefaultDimensionFilter,
@@ -19,6 +18,7 @@ import {
   isVisualizerSupportedVisualization,
 } from "./dashboard-card-supports-visualizer";
 import { createDataSource } from "./data-source";
+import { getColumnVizSettings } from "./viz-settings";
 
 function pickColumnsFromTableToBarChart(
   originalColumns: DatasetColumn[],

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -1,5 +1,4 @@
 import { isNotNull } from "metabase/lib/types";
-import { getColumnVizSettings } from "metabase/visualizations";
 import type { Card, DatasetColumn, RawSeries } from "metabase-types/api";
 import type {
   VisualizerColumnReference,
@@ -13,6 +12,7 @@ import {
   extractReferencedColumns,
 } from "./column";
 import { createDataSource } from "./data-source";
+import { getColumnVizSettings } from "./viz-settings";
 
 type ColumnInfo = {
   columnRef: VisualizerColumnReference;

--- a/frontend/src/metabase/visualizer/utils/index.ts
+++ b/frontend/src/metabase/visualizer/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./viz-settings";
 export * from "./click-actions";
 export * from "./column";
 export * from "./dashboard-card-supports-visualizer";

--- a/frontend/src/metabase/visualizer/utils/viz-settings.ts
+++ b/frontend/src/metabase/visualizer/utils/viz-settings.ts
@@ -1,0 +1,28 @@
+import { getVisualization } from "metabase/visualizations";
+import type { VisualizationSettingDefinition } from "metabase/visualizations/types";
+import type { VisualizationDisplay } from "metabase-types/api";
+
+import {
+  DEFAULT_VISUALIZER_DISPLAY,
+  isVisualizerSupportedVisualization,
+} from "./dashboard-card-supports-visualizer";
+
+const isDataSetting = ({
+  widget,
+}: VisualizationSettingDefinition<unknown, unknown>) => {
+  // TODO Come up with a better condition
+  return widget === "field" || widget === "fields";
+};
+
+export function getColumnVizSettings(cardDisplay: VisualizationDisplay) {
+  const display = isVisualizerSupportedVisualization(cardDisplay)
+    ? cardDisplay
+    : DEFAULT_VISUALIZER_DISPLAY;
+  const visualization = getVisualization(display);
+  const settings = visualization?.settings ?? {};
+
+  // TODO Come up with a better condition
+  return Object.keys(settings).filter((key) => {
+    return isDataSetting(settings[key] ?? {});
+  });
+}

--- a/frontend/src/metabase/visualizer/utils/viz-settings.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/viz-settings.unit.spec.ts
@@ -1,0 +1,22 @@
+import { registerVisualization } from "metabase/visualizations";
+import { BarChart } from "metabase/visualizations/visualizations/BarChart";
+import { Map } from "metabase/visualizations/visualizations/Map/Map";
+
+import { getColumnVizSettings } from "./viz-settings";
+
+// @ts-expect-error: incompatible prop types with registerVisualization
+registerVisualization(Map);
+// @ts-expect-error: incompatible prop types with registerVisualization
+registerVisualization(BarChart);
+
+describe("getColumnVizSettings", () => {
+  it("should return column settings for visualizer supported display", () => {
+    const settings = getColumnVizSettings("bar");
+    expect(settings).toStrictEqual(["graph.dimensions", "graph.metrics"]);
+  });
+
+  it("should return bar column settings for visualizer not supported display", () => {
+    const settings = getColumnVizSettings("map");
+    expect(settings).toStrictEqual(["graph.dimensions", "graph.metrics"]);
+  });
+});

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -10,10 +10,7 @@ import _ from "underscore";
 import { cardApi } from "metabase/api";
 import { createAsyncThunk } from "metabase/lib/redux";
 import { copy } from "metabase/lib/utils";
-import {
-  getColumnVizSettings,
-  isCartesianChart,
-} from "metabase/visualizations";
+import { isCartesianChart } from "metabase/visualizations";
 import type {
   Card,
   CardId,
@@ -37,6 +34,7 @@ import {
   createDataSource,
   createVisualizerColumnReference,
   extractReferencedColumns,
+  getColumnVizSettings,
   getDataSourceIdFromNameRef,
   getDefaultVisualizationName,
   getInitialStateForCardDataSource,


### PR DESCRIPTION
Can be related to [VIZ-660](https://linear.app/metabase/issue/VIZ-660/selecting-unaggregated-data-can-crash-dashboard) 

### Description

Fixes visualizer crashing when you select questions with unsupported display type such as `map`. When a question viz types is unsupported in visualizer, we need to compute the initial visualizer state for the default display type. But before this PR we still used the original `display` type to compute its data viz settings.

### How to verify

- Create a map question
- Try opening it in the visualizer

### Demo

[Loom](https://www.loom.com/share/1602426f742b4e42941fba7d87520d5c?sid=c55aee34-e1f9-40be-82bc-f757da2b9814)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
