### PR TITLE
Enable expression-literals for redshift and vertica

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -42,7 +42,7 @@
 (doseq [[feature supported?] {:connection-impersonation  true
                               :describe-fields           true
                               :describe-fks              true
-                              :expression-literals       false
+                              :expression-literals       true
                               :identifiers-with-spaces   false
                               :uuid-type                 false
                               :nested-field-columns      false
@@ -395,6 +395,11 @@
 (defmethod sql.qp/datetime-diff [:redshift :second]
   [_driver _unit x y]
   (h2x/- (extract :epoch y) (extract :epoch x)))
+
+(defmethod sql.qp/->honeysql [:redshift ::sql.qp/expression-literal-text-value]
+  [driver [_ value]]
+  (->> (sql.qp/->honeysql driver value)
+       (h2x/cast :text)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         metabase.driver.sql-jdbc impls                                         |

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -30,6 +30,7 @@
 
 (doseq [[feature supported?] {:convert-timezone          true
                               :datetime-diff             true
+                              :expression-literals       true
                               :now                       true
                               :identifiers-with-spaces   true
                               :percentile-aggregations   false
@@ -253,6 +254,11 @@
 (defmethod sql.qp/->honeysql [:vertica java.time.ZonedDateTime]
   [driver t]
   (sql.qp/->honeysql driver (t/offset-date-time t)))
+
+(defmethod sql.qp/->honeysql [:vertica ::sql.qp/expression-literal-text-value]
+  [driver [_ value]]
+  (->> (sql.qp/->honeysql driver value)
+       (h2x/cast "long varchar")))
 
 (defmethod sql.qp/add-interval-honeysql-form :vertica
   [_ hsql-form amount unit]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -402,8 +402,7 @@
   [driver [_ value]]
   ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
   ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown
-  ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST. We
-  ;; only need to do this for string literals, since numbers and booleans get inlined directly.
+  ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST.
   ;;
   ;; https://linear.app/metabase/issue/QUE-726/
   ;; https://github.com/h2database/h2database/issues/1383

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -12,12 +12,10 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
-   [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -400,29 +398,17 @@
   [driver [_ field]]
   [:log10 (sql.qp/->honeysql driver field)])
 
-(defn- literal-text-value?
-  [[_ value {base-type :base_type effective-type :effective_type} :as clause]]
-  (and (mbql.u/is-clause? :value clause)
-       (string? value)
-       (isa? (or effective-type base-type)
-             :type/Text)))
-
-(defmethod sql.qp/->honeysql [:h2 :expression]
-  [driver [_ expression-name {::add/keys [source-table]} :as clause]]
-  (let [expression-definition (mbql.u/expression-with-name sql.qp/*inner-query* expression-name)]
-    (if (and (not= source-table ::add/source)
-             (literal-text-value? expression-definition))
-      ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
-      ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown
-      ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST. We
-      ;; only need to do this for string literals, since numbers and booleans get inlined directly.
-      ;;
-      ;; https://linear.app/metabase/issue/QUE-726/
-      ;; https://github.com/h2database/h2database/issues/1383
-      (->> (sql.qp/->honeysql driver expression-definition)
-           (h2x/cast :text))
-      ((get-method sql.qp/->honeysql [:sql-jdbc :expression])
-       driver clause))))
+(defmethod sql.qp/->honeysql [:h2 ::sql.qp/expression-literal-text-value]
+  [driver [_ value]]
+  ;; A literal text value gets compiled to a parameter placeholder like "?". H2 attempts to compile the prepared
+  ;; statement immediately, presumably before the types of the params are known, and sometimes raises an "Unknown
+  ;; data type" error if it can't deduce the type. The recommended workaround is to insert an explicit CAST. We
+  ;; only need to do this for string literals, since numbers and booleans get inlined directly.
+  ;;
+  ;; https://linear.app/metabase/issue/QUE-726/
+  ;; https://github.com/h2database/h2database/issues/1383
+  (->> (sql.qp/->honeysql driver value)
+       (h2x/cast :text)))
 
 (defn- datediff
   "Like H2's `datediff` function but accounts for timestamps with time zones."

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -597,12 +597,24 @@
                        (h2x/with-type-info value {:database-type "varchar"}))))
       (->honeysql driver value))))
 
+(defn- literal-text-value?
+  [[_ value {base-type :base_type effective-type :effective_type} :as clause]]
+  (and (mbql.u/is-clause? :value clause)
+       (string? value)
+       (isa? (or effective-type base-type)
+             :type/Text)))
+
 (defmethod ->honeysql [:sql :expression]
   [driver [_ expression-name {::add/keys [source-table source-alias]} :as _clause]]
   (let [expression-definition (mbql.u/expression-with-name *inner-query* expression-name)]
-    (->honeysql driver (if (= source-table ::add/source)
-                         (apply h2x/identifier :field source-query-alias source-alias)
-                         expression-definition))))
+    (->honeysql driver (cond (= source-table ::add/source)
+                             (apply h2x/identifier :field source-query-alias source-alias)
+
+                             (literal-text-value? expression-definition)
+                             [::expression-literal-text-value expression-definition]
+
+                             :else
+                             expression-definition))))
 
 (defmethod ->honeysql [:sql :now]
   [driver _clause]
@@ -1410,6 +1422,17 @@
   ;; sqlserver limits varchar to 30 in casts,
   ;; athena cannot cast uuid to bounded varchars
   (->honeysql driver [::cast expr "text"]))
+
+(defmethod ->honeysql [:sql ::expression-literal-text-value]
+  [driver [_ value]]
+  ;; When compiling with driver/*compile-with-inline-parameters* bound to false, a literal string expression will
+  ;; usually get replaced with a parameter placeholder like ?. For some databases, this causes a problem as the
+  ;; database engine cannot determine the type of the value in an expression like `SELECT ? AS "FOO"`. Drivers that
+  ;; need special handling for literal string expressions can provide an implementation for this method, e.g. to add
+  ;; an explicit CAST to the appropriate text type for the given driver. See the H2 driver for an example.
+  ;;
+  ;; Most databases don't require special handling, so just compile the unwrapped value.
+  (->honeysql driver value))
 
 (defmethod ->honeysql [:sql :starts-with]
   [driver [_ field arg options]]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1429,7 +1429,8 @@
   ;; usually get replaced with a parameter placeholder like ?. For some databases, this causes a problem as the
   ;; database engine cannot determine the type of the value in an expression like `SELECT ? AS "FOO"`. Drivers that
   ;; need special handling for literal string expressions can provide an implementation for this method, e.g. to add
-  ;; an explicit CAST to the appropriate text type for the given driver. See the H2 driver for an example.
+  ;; an explicit CAST to the appropriate text type for the given driver. See the H2 driver for an example. We
+  ;; only need to do this for string literals, since numbers and booleans get inlined directly.
   ;;
   ;; Most databases don't require special handling, so just compile the unwrapped value.
   (->honeysql driver value))


### PR DESCRIPTION
Closes QUE-849
Closes QUE-857

~~Currently stacked on top of #56533~~

### Description

* Add a new `->honeysql` method to support drivers that need special handling for literal string expressions, and convert the H2 fix to use this new method. This approach is similar in spirit to the existing `::cast-to-text` method.
* Enable the `:expression-literals` feature for redshift and vertica

### How to verify

Existing literal expressions tests now pass for redshift and vertica.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
