### PR TITLE
Use MultiAutocomplete in StringInputWidget

### DIFF
--- a/frontend/src/metabase-lib/v1/parameters/utils/operators.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/operators.ts
@@ -102,13 +102,3 @@ export function getNumberParameterArity(parameter: Parameter) {
       return 1;
   }
 }
-
-export function getStringParameterArity(parameter: Parameter) {
-  switch (parameter.type) {
-    case "string/=":
-    case "string/!=":
-      return "n";
-    default:
-      return 1;
-  }
-}

--- a/frontend/src/metabase/parameters/components/ParameterDropdownWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterDropdownWidget.tsx
@@ -15,10 +15,7 @@ import type {
   FieldFilterUiParameter,
   UiParameter,
 } from "metabase-lib/v1/parameters/types";
-import {
-  getNumberParameterArity,
-  getStringParameterArity,
-} from "metabase-lib/v1/parameters/utils/operators";
+import { getNumberParameterArity } from "metabase-lib/v1/parameters/utils/operators";
 import { hasFields } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import { getQueryType } from "metabase-lib/v1/parameters/utils/parameter-source";
 import {
@@ -26,6 +23,7 @@ import {
   isNumberParameter,
   isTemporalUnitParameter,
 } from "metabase-lib/v1/parameters/utils/parameter-type";
+import { getIsMultiSelect } from "metabase-lib/v1/parameters/utils/parameter-values";
 
 import { ParameterFieldWidget } from "./widgets/ParameterFieldWidget/ParameterFieldWidget";
 import { TemporalUnitWidget } from "./widgets/TemporalUnitWidget";
@@ -150,14 +148,14 @@ export const ParameterDropdownWidget = ({
 
   return (
     <StringInputWidget
+      className={className}
+      parameter={parameter}
       value={normalizedValue}
       setValue={setValueOrDefault}
-      className={className}
-      autoFocus
-      placeholder={isEditing ? t`Enter a default value…` : undefined}
-      arity={getStringParameterArity(parameter)}
       label={getParameterWidgetTitle(parameter)}
-      parameter={parameter}
+      placeholder={isEditing ? t`Enter a default value…` : undefined}
+      autoFocus
+      isMultiSelect={getIsMultiSelect(parameter)}
     />
   );
 };

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
@@ -1,81 +1,83 @@
-import { useState } from "react";
+import { type ChangeEvent, useState } from "react";
 import { t } from "ttag";
-import { isEmpty, isString } from "underscore";
 
-import TokenField, { parseStringValue } from "metabase/components/TokenField";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
-import type { Parameter } from "metabase-types/api";
+import { deserializeStringParameterValue } from "metabase/querying/parameters/utils/parsing";
+import { Box, MultiAutocomplete, TextInput } from "metabase/ui";
+import type { Parameter, ParameterValueOrArray } from "metabase-types/api";
 
-import { Footer, TokenFieldWrapper, WidgetLabel, WidgetRoot } from "../Widget";
+import { Footer, WidgetLabel, WidgetRoot } from "../Widget";
+import { COMBOBOX_PROPS, WIDTH } from "../constants";
 
 type StringInputWidgetProps = {
-  value: string[] | undefined;
-  setValue: (value: string[] | undefined) => void;
   className?: string;
-  autoFocus?: boolean;
-  placeholder?: string;
-  arity?: 1 | "n";
-  label?: string;
   parameter?: Partial<Pick<Parameter, "required" | "default">>;
+  value: ParameterValueOrArray | null | undefined;
+  setValue: (value: string[] | undefined) => void;
+  label?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  isMultiSelect?: boolean;
 };
 
 export function StringInputWidget({
-  value,
+  parameter = {},
+  value: initialValue,
   setValue,
   className,
   autoFocus,
-  arity = 1,
   placeholder = t`Enter some text`,
   label,
-  parameter = {},
+  isMultiSelect,
 }: StringInputWidgetProps) {
-  const arrayValue = normalize(value);
-  const [unsavedArrayValue, setUnsavedArrayValue] =
-    useState<string[]>(arrayValue);
-  const multi = arity === "n";
-  const isValid = unsavedArrayValue.every(isString);
+  const normalizedValue = deserializeStringParameterValue(initialValue);
+  const [unsavedValue, setUnsavedValue] = useState(normalizedValue);
+  const [unsavedInputValue, setUnsavedInputValue] = useState(
+    normalizedValue[0] ?? "",
+  );
 
-  const onClick = () => {
-    if (isEmpty(unsavedArrayValue)) {
-      setValue(undefined);
-    } else {
-      setValue(unsavedArrayValue);
-    }
+  const handleFieldChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const inputValue = event.target.value;
+    const trimmedInputValue = inputValue.trim();
+    setUnsavedInputValue(inputValue);
+    setUnsavedValue(trimmedInputValue.length > 0 ? [trimmedInputValue] : []);
+  };
+
+  const handleUpdateClick = () => {
+    setValue(unsavedValue.length > 0 ? unsavedValue : undefined);
   };
 
   return (
-    <WidgetRoot className={className}>
+    <WidgetRoot className={className} w={WIDTH}>
       {label && <WidgetLabel>{label}</WidgetLabel>}
-      <TokenFieldWrapper>
-        <TokenField
-          value={unsavedArrayValue}
-          onChange={setUnsavedArrayValue}
-          placeholder={placeholder}
-          options={[]}
-          autoFocus={autoFocus}
-          multi={multi}
-          parseFreeformValue={parseStringValue}
-          updateOnInputChange
-        />
-      </TokenFieldWrapper>
+      <Box m="sm">
+        {isMultiSelect ? (
+          <MultiAutocomplete
+            value={unsavedValue}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+            comboboxProps={COMBOBOX_PROPS}
+            onChange={setUnsavedValue}
+          />
+        ) : (
+          <TextInput
+            value={unsavedInputValue}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+            onChange={handleFieldChange}
+          />
+        )}
+      </Box>
       <Footer>
         <UpdateFilterButton
-          value={value}
-          unsavedValue={unsavedArrayValue}
+          value={initialValue}
+          unsavedValue={unsavedValue}
           defaultValue={parameter.default}
           isValueRequired={parameter.required ?? false}
-          isValid={isValid}
-          onClick={onClick}
+          isValid
+          onClick={handleUpdateClick}
         />
       </Footer>
     </WidgetRoot>
   );
-}
-
-function normalize(value: string[] | undefined): string[] {
-  if (Array.isArray(value)) {
-    return value.filter((x) => x !== undefined);
-  } else {
-    return [];
-  }
 }

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
@@ -98,10 +98,10 @@ describe("StringInputWidget", () => {
     it("should render a token field input", () => {
       render(
         <StringInputWidget
-          arity="n"
           value={["foo", "bar"]}
           setValue={mockSetValue}
           parameter={mockParameter}
+          isMultiSelect
         />,
       );
 
@@ -112,18 +112,15 @@ describe("StringInputWidget", () => {
     it("should correctly parse number inputs", async () => {
       render(
         <StringInputWidget
-          arity="n"
           value={undefined}
           setValue={mockSetValue}
           parameter={mockParameter}
+          isMultiSelect
         />,
       );
 
-      const input = screen.getByRole("textbox");
+      const input = screen.getByRole("combobox");
       await userEvent.type(input, "foo{enter}bar{enter}baz{enter}");
-
-      const values = screen.getAllByRole("list")[0];
-      expect(values).toHaveTextContent("foobarbaz");
 
       const button = screen.getByRole("button", { name: "Add filter" });
       await userEvent.click(button);
@@ -133,14 +130,14 @@ describe("StringInputWidget", () => {
     it("should be unsettable", async () => {
       render(
         <StringInputWidget
-          arity="n"
           value={["foo", "bar"]}
           setValue={mockSetValue}
           parameter={mockParameter}
+          isMultiSelect
         />,
       );
 
-      const input = screen.getByRole("textbox");
+      const input = screen.getByRole("combobox");
       await userEvent.type(input, "{backspace}{backspace}");
 
       const button = screen.getByRole("button", { name: "Update filter" });


### PR DESCRIPTION


How to verify:
- Please follow the steps exactly as otherwise you'd get `FieldValuesWidget` which is not migrated yet
- New -> Products -> Custom column -> `concat([Category], "")` -> Save as Q1
- New -> Dashboard -> Add Q1 -> Add text filter -> Map to the custom column
- Select `Input box` in parameter settings -> Save
- Open the filter widget and type multiple values 

<img width="606" alt="Screenshot 2025-04-09 at 21 42 17" src="https://github.com/user-attachments/assets/3d6e1873-05a1-496f-b4a4-f1832688856a" />
