### PR TITLE
fix visualizer crashes when removing second x-axis dimension

### DIFF
--- a/frontend/src/metabase/visualizer/utils/split-series.ts
+++ b/frontend/src/metabase/visualizer/utils/split-series.ts
@@ -15,7 +15,7 @@ export function shouldSplitVisualizerSeries(
   const dimensionDataSources = _.uniq(
     dimensions
       .map((columnName) => {
-        const mapping = columnValuesMapping[columnName];
+        const mapping = columnValuesMapping[columnName] ?? [];
         if (isDataSourceNameRef(mapping[0])) {
           return;
         }


### PR DESCRIPTION
### Description

Fix visualizer crashes when removing second x-axis dimension.

### Demo

[Loom](https://www.loom.com/share/3d870c41e3cb41ec8d087ef939fea267?sid=bd58843d-919b-442c-9799-95e5849cbd8d)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
