### PR TITLE
Refactor Embedding SDK CI workflow and improve `notify-pull-request` action

### DIFF
--- a/.github/actions/notify-pull-request/action.yml
+++ b/.github/actions/notify-pull-request/action.yml
@@ -5,11 +5,44 @@ inputs:
   include-log:
     required: false
     default: true
+  remove-previous-comment:
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@v7
+    - name: Remove previous pull-request comment
+      uses: actions/github-script@v7
+      if: inputs.remove-previous-comment == 'true'
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number: context.issue.number,
+          }).catch(console.error);
+
+          if (!comments) {
+            return;
+          }
+
+          const message = "${{ inputs.message }}";
+          const comment = comments.find((comment) => comment.body.includes(message));
+
+          if (comment) {
+            await github.rest.issues.deleteComment({
+              owner,
+              repo,
+              comment_id: comment.id,
+            });
+          }
+
+    - name: Notify pull-request
+      uses: actions/github-script@v7
       id: notify-pull-request
       with:
         result-encoding: string
@@ -21,7 +54,7 @@ runs:
             return;
           }
 
-          const message = "${{ inputs.message }}"
+          const message = "${{ inputs.message }}";
           const shouldIncludeLog = ${{ inputs.include-log }}.toString() === "true";
           const author = context.payload.sender.login;
 

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -2,6 +2,10 @@ name: E2E Component Tests for Embedding SDK
 
 on:
   workflow_call:
+    inputs:
+      cached-embedding-sdk-dist-artifact-name:
+        required: true
+        type: string
 
 jobs:
   files-changed:
@@ -88,45 +92,11 @@ jobs:
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
-  build-embedding-sdk:
-    needs: [files-changed, get-build-requirements]
-    if: |
-      !cancelled() &&
-      needs.files-changed.outputs.e2e_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    env:
-      MB_EDITION: ee
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Prepare front-end environment
-        uses: ./.github/actions/prepare-frontend
-
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
-
-      - name: Compile CLJS
-        run: yarn build-pure:cljs
-        shell: bash
-
-      - name: Build Embedding SDK package
-        run: yarn build-embedding-sdk
-
-      - name: Upload Embedding SDK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: embedding-sdk-build
-          path: resources/embedding-sdk
-
   e2e-tests:
-    needs: [get-build-requirements, build-uberjar, build-embedding-sdk]
+    needs: [get-build-requirements, build-uberjar]
     if: |
       !cancelled() &&
-      needs.build-uberjar.result == 'success' &&
-      needs.build-embedding-sdk.result == 'success'
+      needs.build-uberjar.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     strategy:
@@ -179,11 +149,11 @@ jobs:
         with:
           m2-cache-key: "cljs"
 
-      - name: Download Embedding SDK artifact
+      - name: Retrieve Embedding SDK dist artifact
         uses: actions/download-artifact@v4
         with:
-          name: embedding-sdk-build
-          path: resources/embedding-sdk
+          name: ${{ inputs.cached-embedding-sdk-dist-artifact-name }}
+          path: ${{ github.workspace }}/resources/embedding-sdk
 
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -29,11 +29,14 @@ jobs:
           token: ${{ github.token }}
           filters: .github/file-paths.yaml
 
-  embedding-sdk-cli-snippets-type-check:
+  build:
     needs: [files-changed]
-    if: needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true'
+    if: |
+      !cancelled() &&
+      (needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' ||
+      needs.files-changed.outputs.documentation == 'true')
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
@@ -42,38 +45,58 @@ jobs:
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: "cljs"
-      - name: Compile CLJS
-        run: yarn build-pure:cljs
-        shell: bash
       - name: Build Embedding SDK package
         run: yarn build-embedding-sdk
+      - name: Prepare Embedding SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: embedding-sdk-${{ github.event.pull_request.head.sha || github.sha }}
+          path: resources/embedding-sdk
+
+  embedding-sdk-cli-snippets-type-check:
+    needs: [files-changed, build]
+    if: |
+      needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Retrieve Embedding SDK dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: embedding-sdk-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ github.workspace }}/resources/embedding-sdk
       - name: Run frontend embedding SDK snippets type check
         run: yarn run embedding-sdk:cli-snippets:type-check
 
   embedding-sdk-docs-snippets-type-check:
-    needs: [files-changed]
-    if: needs.files-changed.outputs.documentation == 'true'
+    needs: [files-changed, build]
+    if: |
+      needs.files-changed.outputs.documentation == 'true' &&
+      needs.build.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
+      - name: Retrieve Embedding SDK dist artifact
+        uses: actions/download-artifact@v4
         with:
-          m2-cache-key: "cljs"
-      - name: Compile CLJS
-        run: yarn build-pure:cljs
-        shell: bash
-      - name: Build Embedding SDK package
-        run: yarn build-embedding-sdk
+          name: embedding-sdk-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ github.workspace }}/resources/embedding-sdk
       - name: Run frontend embedding SDK snippets type check
         run: yarn run embedding-sdk:docs-snippets:type-check
 
   sdk-e2e-tests:
     uses: ./.github/workflows/e2e-component-tests-embedding-sdk.yml
+    needs: [build]
     secrets: inherit
+    with:
+      cached-embedding-sdk-dist-artifact-name: embedding-sdk-${{ github.event.pull_request.head.sha || github.sha }}
 
   e2e-component-tests-embedding-sdk-cross-version:
     if: ${{ startsWith(inputs.branch, 'release-x.') }}


### PR DESCRIPTION
Refactor Embedding SDK CI workflow

- have a single `build` job that builds embedding-sdk dist once
- add an ability to remove a comment for the `notify-pull-request` action (we can backport it), that is needed for Docs Changed step for `emb-301`

How to verify:
- https://github.com/metabase/metabase/actions/runs/14380687076/job/40324392641?pr=56545 it's green
