### PR TITLE
ci: claude label workflow

### DIFF
--- a/.claude/commands/fix-issue-ci.md
+++ b/.claude/commands/fix-issue-ci.md
@@ -1,0 +1,5 @@
+Use the preconfigured git user, do not configure a different one or add co-authors.
+
+Fix issue $ARGUMENTS
+
+Make a new branch for this issue in the format of `claude/issue-{ISSUE_NUMBER}-{ATTEMPT_NUMBER}`, commit changes in it, then make a new PR that references that it fixes the issue.

--- a/.claude/commands/fix-pr-ci.md
+++ b/.claude/commands/fix-pr-ci.md
@@ -1,0 +1,9 @@
+Use the preconfigured git user, do not configure a different one or add co-authors.
+
+Fetch unresolved review items for this branch's PR.
+
+Ignore the backport and CLA-related items, a human will deal with those.
+
+Fix the unresolved review items in new commits.
+
+Push the changes to the existing branch.

--- a/.github/workflows/claude-label.yml
+++ b/.github/workflows/claude-label.yml
@@ -1,0 +1,62 @@
+name: Handle Claude Label
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  claude:
+    # This job only runs if a label starting with `claude:` was added.
+    # It will extract the claude slash command name as whatever is after the `claude:` label prefix,
+    # then call claude in headless mode with the project command and the URL of the labelled issue/pr as prompt
+
+    # e.g. if you label https://github.com/metabase/metabase/issues/56587 with `claude:fix-issue-ci`,
+    # the prompt will be `/project:fix-issue-ci https://github.com/metabase/metabase/issues/56587`
+
+    # The two labels we're using right now are `claude:fix-issue-ci` and `claude:fix-pr-ci`.
+
+    # To add new functionality, add a new project command in `.claude/commands/NAME.md`, then make a GitHub label called `claude:NAME`.
+    # More on project commands at https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#create-custom-slash-commands
+    if: startsWith(github.event.label.name, 'claude:')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+
+      - name: Extract values
+        id: extract
+        run: |
+          # Extract command part from label
+          LABEL="${{ github.event.label.name }}"
+          COMMAND="${LABEL#claude:}"
+          echo "Command part: $COMMAND"
+          echo "command=$COMMAND" >> $GITHUB_OUTPUT
+
+          # Extract URL based on whether it's an issue or PR
+          if [[ "${{ github.event_name }}" == "issues" ]]; then
+            URL="${{ github.event.issue.html_url }}"
+          else
+            URL="${{ github.event.pull_request.html_url }}"
+          fi
+          echo "URL: $URL"
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+
+      - name: Set git user
+        run: |
+          git config --global user.name "Metabase Automation"
+          git config --global user.email "github-automation@metabase.com"
+
+      - name: Run Claude Code
+        run: ./bin/claude-print /project:${{ steps.extract.outputs.command }} ${{ steps.extract.outputs.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ modules/drivers/*/.lsp/*
 .aider*
 /config.yml
 CLAUDE.local.md
+claude-print-output.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 - Work autonomously in small, testable increments
 - Run targeted tests, and lint continuously during development
 - Prioritize understanding existing patterns before implementing
-- Don't commit changes, leave it for the user to review and make commits
+- Don't commit changes unless requested
 
 ## Quick Commands
 

--- a/bin/claude-print
+++ b/bin/claude-print
@@ -6,6 +6,16 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-set -o xtrace
+# Uncomment if you want to debug the script invocation
+# set -o xtrace
 
-claude --print "$(printf "%q " "$@")" --allowedTools "Bash(./bin/mage:*)" "Bash(clj-kondo:*)" "Bash(clojure:*)", "Bash(grep:*)" "Bash(ls:*)" "Bash(yarn lint:*)" "Bash(yarn test-unit:*)" "WebFetchTool(domain:github.com)" Edit
+# JSON output will be in claude-print-output.json
+# suggested in https://github.com/anthropics/claude-code/issues/733#issuecomment-2790100083
+yarn --silent claude --print --output-format stream-json "$(printf "%q " "$@")" --allowedTools "Bash(./bin/mage:*)" "Bash(clj-kondo:*)" "Bash(clojure:*)", "Bash(grep:*)" "Bash(ls:*)" "Bash(yarn lint:*)" "Bash(yarn test-unit:*)" "WebFetchTool(domain:github.com)" "Bash(git:*)" "Bash(gh:*)" Edit  | tee claude-print-output.json | jq -r '
+  if .content != null and (.content | type) == "array" then
+    # Extract text content
+    (.content[] | select(.type == "text") | "TEXT: " + .text),
+    # Extract tool use
+    (.content[] | select(.type == "tool_use") | "TOOL: " + (.name) + " - " + (.input|tostring))
+  else empty
+  end'

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-code": "^0.2.67",
     "@babel/cli": "^7.23.0",
     "@babel/core": "^7.23.3",
     "@babel/node": "^7.22.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,16 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@anthropic-ai/claude-code@^0.2.67":
+  version "0.2.67"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-code/-/claude-code-0.2.67.tgz#7c5dbd7f0527740586fa2cb7e45809e9040028ac"
+  integrity sha512-z+9luCzhbmTzi/s550fMZCPbDOdc7sre4v0Ig72Svu+Ny+bNQ4TfGua5BP6E97hIummHq0DnYblkev8+RnCmlg==
+  optionalDependencies:
+    "@img/sharp-darwin-arm64" "^0.33.5"
+    "@img/sharp-linux-arm" "^0.33.5"
+    "@img/sharp-linux-x64" "^0.33.5"
+    "@img/sharp-win32-x64" "^0.33.5"
+
 "@babel/cli@^7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.23.0.tgz#1d7f37c44d4117c67df46749e0c86e11a58cc64b"
@@ -1940,6 +1950,47 @@
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
+
+"@img/sharp-darwin-arm64@^0.33.5":
+  version "0.33.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz#ef5b5a07862805f1e8145a377c8ba6e98813ca08"
+  integrity sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-arm64" "1.0.4"
+
+"@img/sharp-libvips-darwin-arm64@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz#447c5026700c01a993c7804eb8af5f6e9868c07f"
+  integrity sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==
+
+"@img/sharp-libvips-linux-arm@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz#99f922d4e15216ec205dcb6891b721bfd2884197"
+  integrity sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==
+
+"@img/sharp-libvips-linux-x64@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz#d4c4619cdd157774906e15770ee119931c7ef5e0"
+  integrity sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==
+
+"@img/sharp-linux-arm@^0.33.5":
+  version "0.33.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz#422c1a352e7b5832842577dc51602bcd5b6f5eff"
+  integrity sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.0.5"
+
+"@img/sharp-linux-x64@^0.33.5":
+  version "0.33.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz#d806e0afd71ae6775cc87f0da8f2d03a7c2209cb"
+  integrity sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.0.4"
+
+"@img/sharp-win32-x64@^0.33.5":
+  version "0.33.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz#56f00962ff0c4e0eb93d34a047d29fa995e3e342"
+  integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
 
 "@inquirer/checkbox@^2.4.7":
   version "2.4.7"
@@ -19568,7 +19619,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19585,6 +19636,15 @@ string-width@^4.0.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0:
   version "5.1.0"
@@ -19685,7 +19745,14 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21745,7 +21812,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21758,6 +21825,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This CI job only runs if a label starting with `claude:` was added.

It will extract the claude slash command name as whatever is after the `claude:` label prefix, then call claude in headless mode with the project command and the URL of the labelled issue/pr as prompt

So if you label https://github.com/metabase/metabase/issues/56587 with `claude:fix-issue-ci`, the prompt will be `/project:fix-issue-ci https://github.com/metabase/metabase/issues/56587`

The two labels we're using right now are `claude:fix-issue-ci` and `claude:fix-pr-ci`.

To add new functionality, add a new project command in `.claude/commands/NAME.md`, then make a GitHub label called `claude:NAME`.

More on project commands at https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#create-custom-slash-commands