### PR TITLE
test: fix another flakiness

### DIFF
--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -1108,6 +1108,10 @@ describe("scenarios > organization > entity picker", () => {
         .findByLabelText(/Where do you/)
         .click();
       H.entityPickerModalTab("Browse").click();
+
+      // wait for data to avoid flakiness
+      H.entityPickerModalLevel(1).should("contain", "First collection");
+
       closeAndAssertModal(H.entityPickerModal);
       closeAndAssertModal(() =>
         cy.findByRole("heading", { name: /Duplicate/ }),


### PR DESCRIPTION
Entity picker should be closed by esc, but if data from `/api/collection/root/items` is not loaded and we press esc, modal is not closed

example of failure https://github.com/metabase/metabase/actions/runs/14367207558/job/40283270716?pr=56464

### Before
<img width="641" alt="Screenshot 2025-04-10 at 20 00 37" src="https://github.com/user-attachments/assets/30b28fa0-3953-46c2-8922-361026fe0e18" />


### After

<img width="616" alt="Screenshot 2025-04-10 at 20 00 30" src="https://github.com/user-attachments/assets/089b9400-7005-43e6-940c-b09f8e138897" />

