### PR TITLE
Remove a workaround which is no longer needed due to update of Apache POI

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -667,11 +667,6 @@
 
 (defmethod qp.si/streaming-results-writer :xlsx
   [_ ^OutputStream os]
-  ;; working around a bug #41919. Will be fixed when we can get a release of apache poi 5.3.1. See
-  ;; https://bz.apache.org/bugzilla/show_bug.cgi?id=69323
-  (let [f (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))]
-    (when-not (.exists f)
-      (.mkdirs f)))
   (let [workbook-data      (volatile! nil)
         cell-styles        (volatile! nil)
         typed-cell-styles  (volatile! nil)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.streaming.xlsx
   (:require
-   [clojure.java.io :as io]
    [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
    [java-time.api :as t]


### PR DESCRIPTION
This workaround was added last fall to fix a bug (https://github.com/metabase/metabase/issues/41919) and the comment says it's fixed in POI 5.3.1. We're now on 5.4.0 so I assume we can remove this piece of code (and the relevant test still passes).