### PR TITLE
test: use mousemove instead of realHover for echart tooltip

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -539,13 +539,15 @@ describe("issue 21452", () => {
       .findByDisplayValue("Cumulative sum of Quantity")
       .clear()
       .type("Foo");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Display type").click();
-    // Dismiss the popup and close settings
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Done").click();
 
-    H.cartesianChartCircle().first().realHover();
+    H.popover().findByText("Display type").click();
+
+    cy.log("Dismiss the popup and close settings");
+    H.leftSidebar().button("Done").click();
+
+    // trigger("mousemove") is more reliable than realHover
+    // maybe related to https://github.com/dmtrKovalenko/cypress-real-events/issues/691
+    H.cartesianChartCircle().first().trigger("mousemove");
 
     H.assertEChartsTooltip({
       header: "2022",


### PR DESCRIPTION
`realHover` caused flakiness on x6 CPU throttling and at CI

failure example https://github.com/metabase/metabase/actions/runs/14388503700/job/40350178597

[passed stress test after a change](https://github.com/metabase/metabase/actions/runs/14398806644/job/40379730947)
[failed stress test from master](https://github.com/metabase/metabase/actions/runs/14398673726)

broken test is addressed https://github.com/metabase/metabase/pull/56586