### PR TITLE
fix(sdk): Automatically set a sensible display to interactive questions

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -28,6 +28,7 @@ import {
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { saveInteractiveQuestionAsNewQuestion } from "e2e/support/helpers/e2e-embedding-sdk-interactive-question-helpers";
 import { Box, Button, Modal } from "metabase/ui";
+const { H } = cy;
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -379,5 +380,34 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         });
       });
     });
+  });
+
+  it("should select sensible display for new questions (EMB-308)", () => {
+    mountSdkContent(<InteractiveQuestion questionId="new" />);
+    cy.log("Select data");
+    H.popover().findByRole("link", { name: "Orders" }).click();
+
+    cy.log("Select summarization");
+    H.getNotebookStep("summarize")
+      .findByText("Pick a function or metric")
+      .click();
+    H.popover().findByRole("option", { name: "Count of rows" }).click();
+
+    cy.log("Select grouping");
+    H.getNotebookStep("summarize")
+      .findByText("Pick a column to group by")
+      .click();
+    H.popover().findByRole("heading", { name: "Created At" }).click();
+
+    cy.log("Set limit");
+    const LIMIT = 2;
+    cy.button("Row limit").click();
+    cy.findByPlaceholderText("Enter a limit")
+      .type(LIMIT.toString())
+      .realPress("Tab");
+
+    cy.log("Visualize");
+    H.visualize();
+    H.cartesianChartCircle().should("have.length", LIMIT);
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/lib/interactive-question/run-question-query.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/interactive-question/run-question-query.ts
@@ -1,6 +1,7 @@
 import type { SdkQuestionState } from "embedding-sdk/types/question";
 import type { Deferred } from "metabase/lib/promise";
 import { runQuestionQuery } from "metabase/services";
+import { getSensibleDisplays } from "metabase/visualizations";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
@@ -35,6 +36,10 @@ export async function runQuestionQuerySdk(
       ignoreCache: false,
       isDirty: isQueryDirty,
     });
+
+    const [{ data }] = queryResults;
+    const sensibleDisplays = getSensibleDisplays(data);
+    question = question.maybeResetDisplay(data, sensibleDisplays, undefined);
   }
 
   // FIXME: this removes "You can also get an alert when there are some results." feature for question

--- a/enterprise/frontend/src/embedding-sdk/test/auth-flow.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/auth-flow.unit.spec.tsx
@@ -19,6 +19,9 @@ import type { MetabaseAuthConfig } from "embedding-sdk/types";
 import {
   createMockCard,
   createMockCardQueryMetadata,
+  createMockColumn,
+  createMockDataset,
+  createMockDatasetData,
   createMockSettings,
   createMockTokenFeatures,
   createMockUser,
@@ -35,6 +38,18 @@ const MOCK_SESSION = {
 };
 
 const MOCK_CARD = createMockCard({ id: 1 });
+
+const MOCK_COLUMN = createMockColumn({
+  display_name: "Test Column",
+  name: "Test Column",
+});
+
+const MOCK_DATASET = createMockDataset({
+  data: createMockDatasetData({
+    cols: [MOCK_COLUMN],
+    rows: [["Test Row"]],
+  }),
+});
 
 const setup = ({
   authConfig,
@@ -75,7 +90,7 @@ describe("SDK auth and init flow", () => {
     setupCurrentUserEndpoint(createMockUser({ id: 1 }));
 
     setupCardEndpoints(MOCK_CARD);
-    setupCardQueryEndpoints(MOCK_CARD, {} as any);
+    setupCardQueryEndpoints(MOCK_CARD, MOCK_DATASET);
     setupCardQueryMetadataEndpoint(MOCK_CARD, createMockCardQueryMetadata());
   });
 


### PR DESCRIPTION
Closes EMB-310, EMB-308

### Description

Describe the overall approach and the problem being solved.

### How to verify

>[!note]
> See https://github.com/metabase/metabase/pull/56271 how to set up Metabot

Embed `InteractiveQuestion` or just visit storybook. I think the storybook route is easier, but you do you.
1. run `yarn storybook-embedding-sdk`
1. Visit interactive question and play around with drilling
1. Visit interactive question's Create question story and build Orders -> Count by Created At. You should get a line chart.

### Demo
#### After
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/ca1e9b7b-16e0-4be7-a00f-9eb2ba5b2091" />

#### Before
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/618ca90b-1d14-4ede-8313-b7cb47fadaa6" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
