### PR TITLE
test: fix a broken entity picker test

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -713,7 +713,22 @@ describe("issue 42957", () => {
     H.entityPickerModal().within(() => {
       H.entityPickerModalTab("Collections").click();
 
-      cy.findByText("Collection without models").should("not.exist");
+      // wait for data to load
+      H.entityPickerModalLevel(1).should("contain", "Orders, Count");
+
+      // open filter
+      cy.findByRole("button", { name: /Filter/ }).click();
+    });
+
+    H.popover().findByLabelText("Saved questions").click();
+
+    H.entityPickerModal().within(() => {
+      // close filter
+      cy.findByRole("button", { name: /Filter/ }).click();
+      H.entityPickerModalLevel(1).should(
+        "not.contain",
+        "Collection without models",
+      );
     });
   });
 });


### PR DESCRIPTION
After entity picker improvements https://github.com/metabase/metabase/pull/50527 the test became broken, but it wasn't visible as we didn't wait for data to load, so the test became false positive and actually flaky.

now we wait for data and verify that the collection without a model is not shown

initial issue https://github.com/metabase/metabase/issues/42957

caught here https://github.com/metabase/metabase/actions/runs/14398655294/job/40379742412?pr=56583

✅ [stress test](https://github.com/metabase/metabase/actions/runs/14400517670/job/40385041348)