### PR TITLE
Closes metabase#56307: faint line on tooltip arrow in FF

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
@@ -24,6 +24,7 @@ export const tooltipOverrides: MantineThemeOverride["components"] = {
     },
     classNames: {
       tooltip: cx(TooltipStyles.tooltip, ZIndex.Overlay),
+      arrow: TooltipStyles.arrow,
     },
   }),
 };

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.module.css
@@ -5,3 +5,11 @@
   padding: 0.6rem 0.75rem;
   white-space: unset;
 }
+
+.arrow {
+  /*
+  * Disabling the clip-path property to prevent the arrow from being cut off
+  * (metabase#56307)
+  */
+  clip-path: unset !important;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56307