### PR TITLE
Closes viz-618 hiding a series in Safari throws an error

### DIFF
--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
@@ -33,7 +33,7 @@ export const EChartsRenderer = forwardRef<HTMLDivElement, EChartsRendererProps>(
       width,
       height,
       onInit,
-      notMerge = true,
+      notMerge = false,
     }: EChartsRendererProps,
     ref,
   ) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #56249
Closes [VIZ-618: Clicking legend item raises error: null is not an object (evaluating 'e.removeChild') in Safari](https://linear.app/metabase/issue/VIZ-618/clicking-legend-item-raises-error-null-is-not-an-object-evaluating)

### Description

Not merging the options in eCharts when updating a chart seems to throw in Safari under certain circumstances. Since this was done without any clear reason, I changed the default value back. Let's see what CI says.

### How to verify

Open any multi series chart in Safari and hide a series by clicking on the corresponding legend item. It should not throw.
