### PR TITLE
Fix native editor sidebar

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -527,3 +527,22 @@ describe("issue 54799", () => {
       .should("be.visible");
   });
 });
+
+describe("issue 56570", () => {
+  const questionDetails = {
+    native: {
+      query: `select '${"ab".repeat(200)}'`,
+    },
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("should not push the toolbar off-screen (metabase#56570)", () => {
+    cy.findByTestId("visibility-toggler").click();
+    cy.findByTestId("native-query-editor-sidebar").should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -1,6 +1,9 @@
 :global {
   :local(.editor) {
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    flex-shrink: 1;
     height: 100%;
     color: var(--mb-color-text-dark);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56570

### Description

Closes the issue by preventing the sidebar being pushed off screen.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New -> SQL Query 
2. Type
``` 
select 'abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab'
```
3. The sidebar needs to be still visible

### Demo

<img width="749" alt="Screenshot 2025-04-11 at 15 23 46" src="https://github.com/user-attachments/assets/2e433533-2f7e-4266-8d22-e2d779e3024a" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
