### PR TITLE
Fix frontend test flake in httpsOnlyWidget

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.unit.spec.tsx
@@ -50,13 +50,13 @@ const setup = (
   );
 };
 
-const mockAccessible = () => {
+const mockAccessible = (delay = 10) => {
   fetchMock.get(
     "https://mysite.biz/api/health",
     {
       status: 200,
     },
-    { delay: 10 },
+    { delay },
   );
 };
 
@@ -120,9 +120,15 @@ describe("HttpsOnlyWidget", () => {
   });
 
   it("should display a message while checking", async () => {
-    mockAccessible();
+    // Use a longer delay to ensure we can catch the "checking" state
+    mockAccessible(300);
     setup();
+
+    // Wait for the checking status to appear
     expect(await screen.findByText("Checking HTTPS...")).toBeInTheDocument();
+
+    // Then wait for it to complete to maintain test flow
+    expect(await screen.findByText("Redirect to HTTPS")).toBeInTheDocument();
   });
 
   it("should display the setting if the https site is reachable", async () => {


### PR DESCRIPTION
Closes adm-642

### Description

Claude code suggested increasing the loading time here, which makes sense, on slower CI runners, we may not get a render with only 10ms of loading time.

✅  [Stress Test](https://github.com/metabase/metabase/actions/runs/14405547291/job/40401078434)
