### PR TITLE
feat(sdk): Add question details to Metabot

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/Breakout.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/Breakout.tsx
@@ -1,7 +1,6 @@
 import { useDisclosure } from "@mantine/hooks";
 import { t } from "ttag";
 
-import type { QuestionStateParams } from "embedding-sdk/types/question";
 import { Group, Popover } from "metabase/ui";
 
 import { useInteractiveQuestionContext } from "../../context";
@@ -25,11 +24,8 @@ const AddBreakoutPopover = () => {
   );
 };
 
-export const BreakoutInner = ({
-  question,
-  updateQuestion,
-}: QuestionStateParams) => {
-  const breakoutItems = useBreakoutData({ question, updateQuestion });
+export const BreakoutInner = () => {
+  const breakoutItems = useBreakoutData();
 
   return (
     <Group>
@@ -59,11 +55,11 @@ export const BreakoutInner = ({
  * @category InteractiveQuestion
  */
 export const Breakout = () => {
-  const { question, updateQuestion } = useInteractiveQuestionContext();
+  const { question } = useInteractiveQuestionContext();
 
   if (!question) {
     return null;
   }
 
-  return <BreakoutInner question={question} updateQuestion={updateQuestion} />;
+  return <BreakoutInner />;
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/BreakoutBadgeList.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/BreakoutBadgeList.tsx
@@ -5,22 +5,19 @@ import {
   useBreakoutData,
 } from "embedding-sdk/components/private/InteractiveQuestion/components/Breakout/use-breakout-data";
 import { useInteractiveQuestionContext } from "embedding-sdk/components/private/InteractiveQuestion/context";
-import type { QuestionStateParams } from "embedding-sdk/types/question";
 
 import { BadgeList } from "../util/BadgeList";
 
 export const BreakoutBadgeListInner = ({
-  question,
-  updateQuestion,
   onSelectItem,
   onAddItem,
   onRemoveItem,
-}: QuestionStateParams & {
+}: {
   onSelectItem: (item: SDKBreakoutItem, index: number) => void;
   onAddItem: (item: SDKBreakoutItem | undefined) => void;
   onRemoveItem: (item: SDKBreakoutItem, index: number) => void;
 }) => {
-  const breakoutItems = useBreakoutData({ question, updateQuestion });
+  const breakoutItems = useBreakoutData();
 
   return (
     <BadgeList
@@ -45,7 +42,7 @@ export const BreakoutBadgeList = ({
   onAddItem: (item: SDKBreakoutItem | undefined) => void;
   onRemoveItem: (item: SDKBreakoutItem, index: number) => void;
 }) => {
-  const { question, updateQuestion } = useInteractiveQuestionContext();
+  const { question } = useInteractiveQuestionContext();
 
   if (!question) {
     return null;
@@ -53,8 +50,6 @@ export const BreakoutBadgeList = ({
 
   return (
     <BreakoutBadgeListInner
-      question={question}
-      updateQuestion={updateQuestion}
       onSelectItem={onSelectItem}
       onAddItem={onAddItem}
       onRemoveItem={onRemoveItem}

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.tsx
@@ -6,7 +6,6 @@ import {
   MultiStepPopover,
   type MultiStepState,
 } from "embedding-sdk/components/private/util/MultiStepPopover";
-import type { QuestionStateParams } from "embedding-sdk/types/question";
 import type { PopoverProps } from "metabase/ui";
 
 import { useInteractiveQuestionContext } from "../../../context";
@@ -24,12 +23,10 @@ export type InteractiveQuestionBreakoutDropdownProps = Omit<
   "children" | "onClose" | "opened"
 >;
 
-export const BreakoutDropdownInner = ({
-  question,
-  updateQuestion,
-  ...popoverProps
-}: QuestionStateParams & InteractiveQuestionBreakoutDropdownProps) => {
-  const items = useBreakoutData({ question, updateQuestion });
+export const BreakoutDropdownInner = (
+  popoverProps: InteractiveQuestionBreakoutDropdownProps,
+) => {
+  const items = useBreakoutData();
 
   const [step, setStep] = useState<MultiStepState<"picker" | "list">>(null);
 
@@ -104,17 +101,11 @@ export const BreakoutDropdownInner = ({
 export const BreakoutDropdown = (
   props: InteractiveQuestionBreakoutDropdownProps,
 ) => {
-  const { question, updateQuestion } = useInteractiveQuestionContext();
+  const { question } = useInteractiveQuestionContext();
 
   if (!question) {
     return null;
   }
 
-  return (
-    <BreakoutDropdownInner
-      question={question}
-      updateQuestion={updateQuestion}
-      {...props}
-    />
-  );
+  return <BreakoutDropdownInner {...props} />;
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/use-breakout-data.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Breakout/use-breakout-data.ts
@@ -1,10 +1,12 @@
-import type { QuestionStateParams } from "embedding-sdk/types/question";
 import {
   type ListItem as BreakoutListItem,
   getBreakoutListItem,
 } from "metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList";
 import { useBreakoutQueryHandlers } from "metabase/query_builder/hooks";
 import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+
+import { useInteractiveQuestionContext } from "../../context";
 
 export interface SDKBreakoutItem extends BreakoutListItem {
   breakoutIndex: number;
@@ -13,10 +15,10 @@ export interface SDKBreakoutItem extends BreakoutListItem {
   replaceBreakoutColumn: (column: Lib.ColumnMetadata) => void;
 }
 
-export const useBreakoutData = ({
-  question,
-  updateQuestion,
-}: QuestionStateParams): SDKBreakoutItem[] => {
+export const useBreakoutData = (): SDKBreakoutItem[] => {
+  const { updateQuestion, ...interactiveQuestionContext } =
+    useInteractiveQuestionContext();
+  const question = interactiveQuestionContext.question as Question;
   const onQueryChange = (query: Lib.Query) => {
     if (question) {
       updateQuestion(question.setQuery(query), { run: true });

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -2,10 +2,13 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
+import { InteractiveQuestionDefaultView } from "embedding-sdk/components/private/InteractiveQuestionDefaultView";
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
-import { Flex, Text } from "metabase/ui";
+import { Flex, Stack, Text } from "metabase/ui";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
+import { QuestionDetails } from "./QuestionDetails";
+import { QuestionTitle } from "./QuestionTitle";
 
 const MetabotQuestionInner = () => {
   const [redirectUrl, setRedirectUrl] = useState<string>("");
@@ -19,7 +22,16 @@ const MetabotQuestionInner = () => {
           title={false}
           onNavigateBack={() => {}}
           isSaveEnabled={false}
-        />
+        >
+          <InteractiveQuestionDefaultView
+            title={
+              <Stack gap="sm" mb="1rem">
+                <QuestionTitle />
+                <QuestionDetails />
+              </Stack>
+            }
+          />
+        </InteractiveAdHocQuestion>
       )}
       <Disclaimer />
     </Flex>

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/QuestionDetails.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/QuestionDetails.tsx
@@ -1,0 +1,82 @@
+import { t } from "ttag";
+
+import { useBreakoutData } from "embedding-sdk/components/private/InteractiveQuestion/components/Breakout/use-breakout-data";
+import { useFilterData } from "embedding-sdk/components/private/InteractiveQuestion/components/Filter/hooks/use-filter-data";
+import { useSummarizeData } from "embedding-sdk/components/private/InteractiveQuestion/components/Summarize/use-summarize-data";
+import { useInteractiveQuestionContext } from "embedding-sdk/components/private/InteractiveQuestion/context";
+import { isNotNull } from "metabase/lib/types";
+import { Text } from "metabase/ui";
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+
+export function QuestionDetails() {
+  const { question } = useInteractiveQuestionContext();
+  const tableSection = getTableSection(question);
+
+  const filterItems = useFilterData();
+  const filterSection =
+    filterItems.length > 0
+      ? t`Filtered by ` +
+        filterItems.map((filter) => filter.longDisplayName).join(" and ") +
+        "."
+      : "";
+
+  const summarizationItems = useSummarizeData();
+  const summarizationSection =
+    summarizationItems.length > 0
+      ? t`Summarized by ` +
+        summarizationItems.map((filter) => filter.displayName).join(" and ") +
+        "."
+      : "";
+
+  const groupingItems = useBreakoutData();
+  const groupingSection =
+    groupingItems.length > 0
+      ? t`Grouped by ` +
+        groupingItems.map((filter) => filter.longDisplayName).join(" and ") +
+        "."
+      : "";
+
+  const sections = [
+    tableSection,
+    filterSection,
+    summarizationSection,
+    groupingSection,
+  ].filter((section) => section.length > 0);
+
+  return (
+    <Text size="0.75rem" c="var(--mb-color-text-tertiary)">
+      {sections.join(" ")}
+    </Text>
+  );
+}
+
+function getTableSection(question?: Question) {
+  return (
+    getAllTables(question)
+      .map((table) => table.displayName())
+      .join(" + ") + "."
+  );
+}
+
+function getAllTables(question?: Question) {
+  if (!question) {
+    return [];
+  }
+
+  const metadata = question.metadata();
+  const query = question.query();
+  const table = metadata.table(Lib.sourceTableOrCardId(query));
+  return [
+    table,
+    ...Lib.joins(query, -1)
+      .map((join) => Lib.pickerInfo(query, Lib.joinedThing(query, join)))
+      .map((pickerInfo) => {
+        if (pickerInfo?.tableId != null) {
+          return metadata.table(pickerInfo.tableId);
+        }
+
+        return undefined;
+      }),
+  ].filter(isNotNull);
+}

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/QuestionTitle.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/QuestionTitle.tsx
@@ -1,0 +1,14 @@
+import { useInteractiveQuestionContext } from "embedding-sdk/components/private/InteractiveQuestion/context";
+import { getQuestionTitle } from "embedding-sdk/components/private/QuestionTitle";
+import { Text } from "metabase/ui";
+
+export function QuestionTitle() {
+  const { question } = useInteractiveQuestionContext();
+  const titleText = getQuestionTitle({ question });
+
+  return (
+    <Text fw={700} c="var(--mb-color-text-primary)" fz="xl">
+      {titleText}
+    </Text>
+  );
+}


### PR DESCRIPTION
Closes EMB-307

### Description

This PR add a question detail, so questions rendered by Metabot with filters, summarizations, or Grouping are obvious what these values are at glance. That way, users can know if Metabot has worked to their expectations or not.

### How to verify
See https://github.com/metabase/metabase/pull/56584 on how to test this.

You can also modify `MetabotQuestion` component to set the default redirect URL to your own question of choice. You can grab the URL from Metabse when playing around with query builder.

```ts
const [redirectUrl, setRedirectUrl] = useState<string>(
    "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjIsImFnZ3JlZ2F0aW9uIjpbWyJjb3VudCJdXSwiYnJlYWtvdXQiOltbImZpZWxkIiwxMyx7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWUiLCJ0ZW1wb3JhbC11bml0IjoibW9udGgifV1dfX0sImRpc3BsYXkiOiJsaW5lIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e30sInR5cGUiOiJxdWVzdGlvbiJ9",
  );
```

Try to set different filters, summarizations, groupings and see how the question details change.

### Demo
Look at the row below the question title. That's a new question details component.
<img width="1446" alt="Screenshot 2025-04-11 at 9 58 44 PM" src="https://github.com/user-attachments/assets/a86242a1-9d3d-46fe-a116-62598704158e" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
