### PR TITLE
Fix dissappearing string escapes

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -13,7 +13,7 @@ on:
       - "frontend/src/metabase-lib/expressions/**"
 
 jobs:
-  fe-fuzz-tokenizer:
+  fe-fuzz-lexifier:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -24,10 +24,10 @@ jobs:
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: "cljs"
-      - run: yarn test-unit frontend/src/metabase-lib/v1/expressions/tokenizer/fuzz.unit.spec.ts
+      - run: yarn test-unit frontend/src/metabase-lib/v1/expressions/pratt/fuzz.lexifier.unit.spec.ts
         env:
           MB_FUZZ: 1
-        name: Run fuzz testing on the tokenizer
+        name: Run fuzz testing on the lexifier
 
   fe-fuzz-compiler:
     runs-on: ubuntu-22.04

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -44,3 +44,19 @@ jobs:
         env:
           MB_FUZZ: 1
         name: Run fuzz testing on the custom expression compiler
+
+  fe-fuzz-string-quoting:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cljs"
+      - run: yarn test-unit frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
+        env:
+          MB_FUZZ: 1
+        name: Run fuzz testing on the custom expression string quoter

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1612,3 +1612,46 @@ describe("issue 56152", () => {
     H.CustomExpressionEditor.helpText().should("be.visible");
   });
 });
+
+describe("issue 56596", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+
+    const questionDetails = {
+      query: {
+        "source-table": PRODUCTS_ID,
+        fields: [["field", PRODUCTS.ID, null]],
+        limit: 1,
+      },
+    };
+
+    H.createQuestion(questionDetails, { visitQuestion: true });
+
+    H.openNotebook();
+  });
+
+  it("should not remove backslashes from escaped characters (metabase#56596)", () => {
+    H.addCustomColumn();
+    const expr = dedent`
+      regexextract([Vendor], "\\s.*")
+    `;
+    H.enterCustomColumnDetails({
+      formula: expr,
+      name: "Last name",
+    });
+    H.CustomExpressionEditor.format();
+    H.CustomExpressionEditor.value().should("equal", expr);
+    H.expressionEditorWidget().button("Done").click();
+
+    H.getNotebookStep("expression").findByText("Last name").click();
+    H.CustomExpressionEditor.value().should("equal", expr);
+    H.expressionEditorWidget().button("Cancel").click();
+
+    H.visualize();
+    H.assertTableData({
+      columns: ["ID", "Last name"],
+      firstRows: [["1", " Casper and Hilll"]],
+    });
+  });
+});

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -11,8 +11,8 @@ export const EDITOR_QUOTES = {
     '"': "literal",
   },
   // specifies the default quoting style:
-  literalQuoteDefault: '"',
-  identifierQuoteDefault: "[",
+  literalQuoteDefault: '"' as const,
+  identifierQuoteDefault: "[" as const,
   // always quote identifiers even if they have non-word characters or conflict with reserved words
   identifierAlwaysQuoted: true,
 };

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
@@ -49,7 +49,7 @@ export type FormatOptions = {
   stageIndex: number;
   expressionIndex?: number | undefined;
   printWidth?: number;
-  quotes?: typeof EDITOR_QUOTES;
+  delimiters?: typeof EDITOR_QUOTES;
 };
 
 export async function format(expression: Expression, options: FormatOptions) {

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
@@ -211,3 +211,29 @@ describe("if printWidth = Infinity, it should return the same results as the sin
     );
   });
 });
+
+it("should format escaped regex characters (metabase#56596)", async () => {
+  const { assertFormatted } = setup(Infinity);
+  await assertFormatted([
+    // "foo \s bar"
+    expression`
+      "foo \\s bar"
+    `,
+    // "^[Default]\s(.*?)\s-\s"
+    expression`
+     "^\\[Default\\]\\s(.*?)\\s-\\s"
+    `,
+    // "\\"
+    expression`
+      "\\\\"
+    `,
+    // "\\\""
+    expression`
+      "\\\\\\""
+    `,
+    // "\n\r\t\v\f\b"
+    expression`
+      "\\n\\r\\t\\v\\f\\b"
+    `,
+  ]);
+});

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
@@ -227,10 +227,6 @@ it("should format escaped regex characters (metabase#56596)", async () => {
     expression`
       "\\\\"
     `,
-    // "\\\""
-    expression`
-      "\\\\\\""
-    `,
     // "\n\r\t\v\f\b"
     expression`
       "\\n\\r\\t\\v\\f\\b"

--- a/frontend/src/metabase-lib/v1/expressions/fuzz.compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/fuzz.compiler.unit.spec.ts
@@ -1,8 +1,6 @@
-import process from "process";
-import _ from "underscore";
-
 import { query } from "./__support__/shared";
 import { compileExpression } from "./compiler";
+import { fuzz } from "./test/fuzz";
 import { generateExpression } from "./test/generator";
 import type { StartRule } from "./types";
 
@@ -16,7 +14,6 @@ jest.mock("metabase-lib", () => {
   };
 });
 
-const fuzz = process.env.MB_FUZZ ? describe : _.noop;
 const MAX_SEED = 10_000;
 
 function compile(expression: string, startRule: StartRule = "expression") {

--- a/frontend/src/metabase-lib/v1/expressions/fuzz.compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/fuzz.compiler.unit.spec.ts
@@ -36,7 +36,7 @@ describe("metabase-lib/v1/expressions/compiler", () => {
   });
 });
 
-fuzz("FUZZING metabase-lib/v1/expressions/recursive-parser", () => {
+fuzz("FUZZING metabase-lib/v1/expressions/compiler", () => {
   for (let seed = 1; seed < MAX_SEED; ++seed) {
     it("should parse generated number expression from seed " + seed, () => {
       const { expression } = generateExpression(seed, "number");

--- a/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
@@ -1,8 +1,6 @@
-import _ from "underscore";
-
 import { quoteString, unquoteString } from "./string";
+import { fuzz } from "./test/fuzz";
 
-const fuzz = process.env.MB_FUZZ ? describe : _.noop;
 const MAX_SEED = 10_000;
 
 fuzz("metabase-lib/v1/expressions/string", () => {

--- a/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
@@ -2,7 +2,7 @@ import { quoteString, unquoteString } from "./string";
 import { fuzz } from "./test/fuzz";
 import { createRandom } from "./test/generator";
 
-const MAX_SEED = 10_000;
+const MAX_SEED = 1000;
 
 const simple = [
   ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_(){}",
@@ -62,13 +62,17 @@ describe("metabase-lib/v1/expressions/compiler", () => {
 });
 
 fuzz("metabase-lib/v1/expressions/string", () => {
-  for (let seed = 0; seed <= MAX_SEED; seed++) {
-    it(`should round trip strings (seed = ${seed})`, () => {
-      const str = randomString(seed);
-      const quoted = quoteString(str, "'");
-      const unquoted = unquoteString(quoted);
+  const QUOTES = ["'", '"', "["] as const;
 
-      expect(unquoted).toEqual(str);
-    });
-  }
+  QUOTES.forEach((QUOTE) => {
+    for (let seed = 0; seed <= MAX_SEED; seed++) {
+      it(`should round trip strings through ${QUOTE} (seed=${seed})`, () => {
+        const str = randomString(seed);
+        const quoted = quoteString(str, QUOTE);
+        const unquoted = unquoteString(quoted);
+
+        expect(unquoted).toEqual(str);
+      });
+    }
+  });
 });

--- a/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
@@ -1,0 +1,29 @@
+import _ from "underscore";
+
+import { quoteString, unquoteString } from "./string";
+
+const fuzz = process.env.MB_FUZZ ? describe : _.noop;
+const MAX_SEED = 10_000;
+
+fuzz("metabase-lib/v1/expressions/string", () => {
+  it("should round trip strings", () => {
+    const alphabet = [
+      ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\n\r\t\f\b\v'\"",
+      "\\\\",
+    ];
+
+    for (let i = 0; i < MAX_SEED; i++) {
+      const len = Math.floor(Math.random() * 50);
+      let res = "";
+      for (let i = 0; i < len; i++) {
+        const index = Math.floor(Math.random() * alphabet.length);
+        res += alphabet[index];
+      }
+
+      const quoted = quoteString(res, "'");
+      const unquoted = unquoteString(quoted);
+
+      expect(unquoted).toEqual(res);
+    }
+  });
+});

--- a/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/fuzz.string.unit.spec.ts
@@ -4,8 +4,17 @@ import { createRandom } from "./test/generator";
 
 const MAX_SEED = 10_000;
 
+const simple = [
+  ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_(){}",
+];
+
+const special = ["\\n", "\\r", "\\f", "\\b", "\\t", "\\v"];
+
 const alphabet = [
-  ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\n\r\t\f\b\v'\"_-()[]",
+  ...simple,
+  ...simple.map((char) => `\\${char}`).filter((str) => !special.includes(str)),
+  ..."\n\r\t\f\b\v",
+  ..."[]'\"`",
   "\\\\",
 ];
 
@@ -22,6 +31,35 @@ function randomString(seed: number): string {
   }
   return res.join("");
 }
+
+describe("metabase-lib/v1/expressions/compiler", () => {
+  it("should parse a convoluted string with single quotes", () => {
+    const str = alphabet.join("");
+
+    const quoted = quoteString(str, "'");
+    const unquoted = unquoteString(quoted);
+
+    expect(unquoted).toEqual(str);
+  });
+
+  it("should parse a convoluted string with double quotes", () => {
+    const str = alphabet.join("");
+
+    const quoted = quoteString(str, '"');
+    const unquoted = unquoteString(quoted);
+
+    expect(unquoted).toEqual(str);
+  });
+
+  it("should parse a convoluted string with brackets", () => {
+    const str = alphabet.join("");
+
+    const quoted = quoteString(str, "[");
+    const unquoted = unquoteString(quoted);
+
+    expect(unquoted).toEqual(str);
+  });
+});
 
 fuzz("metabase-lib/v1/expressions/string", () => {
   for (let seed = 0; seed <= MAX_SEED; seed++) {

--- a/frontend/src/metabase-lib/v1/expressions/identifier.ts
+++ b/frontend/src/metabase-lib/v1/expressions/identifier.ts
@@ -7,16 +7,16 @@ import { quoteString } from "./string";
 // can be double-quoted, but are not by default unless they have non-word characters or are reserved
 export function formatIdentifier(
   name: string,
-  { quotes = EDITOR_QUOTES } = {},
+  { delimiters = EDITOR_QUOTES } = {},
 ) {
   if (
-    !quotes.identifierAlwaysQuoted &&
+    !delimiters.identifierAlwaysQuoted &&
     /^\w+$/.test(name) &&
     !isReservedWord(name)
   ) {
     return name;
   }
-  return quoteString(name, quotes.identifierQuoteDefault);
+  return quoteString(name, delimiters.identifierQuoteDefault);
 }
 
 function isReservedWord(word: string) {

--- a/frontend/src/metabase-lib/v1/expressions/pratt/compiler.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/compiler.ts
@@ -6,7 +6,6 @@ import type { Expression } from "metabase-types/api";
 
 import { getMBQLName as defaultGetMBQLName } from "../config";
 import { CompileError } from "../errors";
-import { unescapeString } from "../string";
 
 import {
   ADD,
@@ -57,9 +56,9 @@ export function compile(
 function compileField(node: Node): Expression {
   assert(node.type === FIELD, "Invalid Node Type");
   assert(node.token?.text, "Empty field name");
-  // Slice off the leading and trailing brackets
-  const name = node.token.text.slice(1, node.token.text.length - 1);
-  return withNode(["dimension", unescapeString(name)], node);
+  assert(node.token?.value, "Empty field value");
+  const name = node.token.value;
+  return withNode(["dimension", name], node);
 }
 
 function compileIdentifier(node: Node): Expression {

--- a/frontend/src/metabase-lib/v1/expressions/pratt/fuzz.lexifier.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/fuzz.lexifier.unit.spec.ts
@@ -9,7 +9,7 @@ describe("metabase-lib/v1/expressions/tokenizer", () => {
   });
 });
 
-fuzz("FUZZING metabase-lib/v1/expressions/tokenizer", () => {
+fuzz("FUZZING metabase-lib/v1/expressions/lexifier", () => {
   const MAX_SEED = 2e4;
 
   for (let seed = 0; seed < MAX_SEED; ++seed) {

--- a/frontend/src/metabase-lib/v1/expressions/pratt/fuzz.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/fuzz.unit.spec.ts
@@ -1,10 +1,6 @@
-import process from "process";
-import _ from "underscore";
-
 import { lexify } from "../pratt/lexifier";
+import { fuzz } from "../test/fuzz";
 import { generateExpression } from "../test/generator";
-
-const fuzz = process.env.MB_FUZZ ? describe : _.noop;
 
 describe("metabase-lib/v1/expressions/tokenizer", () => {
   // quick sanity check before the real fuzzing

--- a/frontend/src/metabase-lib/v1/expressions/pratt/lexifier.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/lexifier.ts
@@ -70,19 +70,15 @@ export function lexify(source: string) {
 
     if (node.type.name === "Reference") {
       const value = source.slice(node.from, node.to);
-      let start = node.from + 1;
-      let end = node.to - 1;
       if (value.at(0) !== "[") {
-        start = node.from;
         error(node, t`Missing opening bracket`);
       } else if (value.at(-1) !== "]") {
-        end = node.to;
         error(node, t`Missing a closing bracket`);
       }
 
       return token(node, {
         type: FIELD,
-        value: source.slice(start, end),
+        value: unquoteString(source.slice(node.from, node.to)),
       });
     }
 

--- a/frontend/src/metabase-lib/v1/expressions/pratt/lexifier.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/lexifier.unit.spec.ts
@@ -451,8 +451,8 @@ describe("lexify", () => {
 
     it("handles invalid escape sequences", () => {
       const cases = [
-        ["'\\x22'", "x22"],
-        ["'\\wat'", "wat"],
+        ["'\\x22'", "\\x22"],
+        ["'\\wat'", "\\wat"],
       ];
 
       for (const [expression, value] of cases) {
@@ -667,8 +667,12 @@ describe("lexify", () => {
     });
 
     it("should allow escaping brackets within bracket identifiers", () => {
-      const cases = ["[T\\[]", "[T\\]]", "[T\\[A\\]]"];
-      for (const expression of cases) {
+      const cases = [
+        ["[T\\[]", "T["],
+        ["[T\\]]", "T]"],
+        ["[T\\[A\\]]", "T[A]"],
+      ];
+      for (const [expression, value] of cases) {
         const { tokens, errors } = lexify(expression);
         expect(errors).toHaveLength(0);
         expect(tokens).toEqual(
@@ -677,7 +681,7 @@ describe("lexify", () => {
               type: FIELD,
               pos: 0,
               text: expression,
-              value: expression.slice(1, -1),
+              value,
             },
             { type: END_OF_INPUT, pos: expression.length, text: "\n" },
           ].map(asToken),

--- a/frontend/src/metabase-lib/v1/expressions/string.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.ts
@@ -6,6 +6,12 @@ const OPEN_BRACKET = "[";
 const CLOSE_BRACKET = "]";
 const BACKSLASH = "\\";
 
+export type Delimiter =
+  | typeof DOUBLE_QUOTE
+  | typeof SINGLE_QUOTE
+  | typeof OPEN_BRACKET
+  | typeof CLOSE_BRACKET;
+
 export type StartDelimiter =
   | typeof DOUBLE_QUOTE
   | typeof SINGLE_QUOTE
@@ -31,6 +37,12 @@ const STRING_UNESCAPE: Record<string, string> = {
   '"': '"',
 };
 
+const DELIMITER_PAIRS: Record<StartDelimiter, Delimiter> = {
+  "'": "'",
+  '"': '"',
+  "[": "]",
+};
+
 export function formatStringLiteral(
   node: string,
   {
@@ -43,7 +55,9 @@ export function formatStringLiteral(
 }
 
 export function quoteString(string: string, delimiter: StartDelimiter) {
-  const [OPEN, CLOSE] = getDelimiters(delimiter);
+  const OPEN = delimiter;
+  assertStartDelimiter(OPEN);
+  const CLOSE = DELIMITER_PAIRS[delimiter];
 
   let str = "";
   for (let i = 0; i < string.length; i++) {
@@ -64,7 +78,9 @@ export function quoteString(string: string, delimiter: StartDelimiter) {
 }
 
 export function unquoteString(string: string) {
-  const [OPEN, CLOSE] = getDelimiters(string.charAt(0));
+  const OPEN = string.charAt(0);
+  assertStartDelimiter(OPEN);
+  const CLOSE = DELIMITER_PAIRS[OPEN];
 
   let str = "";
   let escaping = false;
@@ -97,11 +113,10 @@ export function unquoteString(string: string) {
   return str;
 }
 
-function getDelimiters(delimiter: string) {
-  if (delimiter === DOUBLE_QUOTE || delimiter === SINGLE_QUOTE) {
-    return [delimiter, delimiter];
-  } else if (delimiter === OPEN_BRACKET) {
-    return [OPEN_BRACKET, CLOSE_BRACKET];
+function assertStartDelimiter(str: string): asserts str is StartDelimiter {
+  if (str in DELIMITER_PAIRS) {
+    return;
   }
-  throw new Error("Unknown quoting: " + delimiter);
+
+  throw new Error(`Unknown string delimiter: ${str}`);
 }

--- a/frontend/src/metabase-lib/v1/expressions/string.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.ts
@@ -103,7 +103,7 @@ export function unquoteString(string: string) {
         str += BACKSLASH + ch;
       }
     } else if (ch === CLOSE) {
-      // skip last quote
+      // skip last delimiter
       return str;
     } else {
       str += ch;

--- a/frontend/src/metabase-lib/v1/expressions/string.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.ts
@@ -10,6 +10,7 @@ const STRING_ESCAPE: Record<string, string> = {
   "\n": "\\n",
   "\f": "\\f",
   "\r": "\\r",
+  "\v": "\\v",
 };
 
 const STRING_UNESCAPE: Record<string, string> = {
@@ -18,6 +19,7 @@ const STRING_UNESCAPE: Record<string, string> = {
   n: "\n",
   f: "\f",
   r: "\r",
+  v: "\v",
 };
 
 export function formatStringLiteral(

--- a/frontend/src/metabase-lib/v1/expressions/string.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.ts
@@ -6,6 +6,11 @@ const OPEN_BRACKET = "[";
 const CLOSE_BRACKET = "]";
 const BACKSLASH = "\\";
 
+export type Quote =
+  | typeof DOUBLE_QUOTE
+  | typeof SINGLE_QUOTE
+  | typeof OPEN_BRACKET;
+
 const STRING_ESCAPE: Record<string, string> = {
   "\b": "\\b",
   "\t": "\\t",
@@ -31,13 +36,13 @@ export function formatStringLiteral(
   {
     quotes = EDITOR_QUOTES,
   }: {
-    quotes?: { literalQuoteDefault: string };
+    quotes?: { literalQuoteDefault: Quote };
   } = {},
 ) {
   return quoteString(node, quotes.literalQuoteDefault);
 }
 
-export function quoteString(string: string, quote: string) {
+export function quoteString(string: string, quote: Quote) {
   const [OPEN, CLOSE] = getQuotePair(quote);
 
   let str = "";

--- a/frontend/src/metabase-lib/v1/expressions/string.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.ts
@@ -6,7 +6,7 @@ const OPEN_BRACKET = "[";
 const CLOSE_BRACKET = "]";
 const BACKSLASH = "\\";
 
-export type Quote =
+export type StartDelimiter =
   | typeof DOUBLE_QUOTE
   | typeof SINGLE_QUOTE
   | typeof OPEN_BRACKET;
@@ -34,16 +34,16 @@ const STRING_UNESCAPE: Record<string, string> = {
 export function formatStringLiteral(
   node: string,
   {
-    quotes = EDITOR_QUOTES,
+    delimiters = EDITOR_QUOTES,
   }: {
-    quotes?: { literalQuoteDefault: Quote };
+    delimiters?: { literalQuoteDefault: StartDelimiter };
   } = {},
 ) {
-  return quoteString(node, quotes.literalQuoteDefault);
+  return quoteString(node, delimiters.literalQuoteDefault);
 }
 
-export function quoteString(string: string, quote: Quote) {
-  const [OPEN, CLOSE] = getQuotePair(quote);
+export function quoteString(string: string, delimiter: StartDelimiter) {
+  const [OPEN, CLOSE] = getDelimiters(delimiter);
 
   let str = "";
   for (let i = 0; i < string.length; i++) {
@@ -64,8 +64,7 @@ export function quoteString(string: string, quote: Quote) {
 }
 
 export function unquoteString(string: string) {
-  const quote = string.charAt(0);
-  const [OPEN, CLOSE] = getQuotePair(quote);
+  const [OPEN, CLOSE] = getDelimiters(string.charAt(0));
 
   let str = "";
   let escaping = false;
@@ -98,11 +97,11 @@ export function unquoteString(string: string) {
   return str;
 }
 
-function getQuotePair(quote: string) {
-  if (quote === DOUBLE_QUOTE || quote === SINGLE_QUOTE) {
-    return [quote, quote];
-  } else if (quote === OPEN_BRACKET) {
+function getDelimiters(delimiter: string) {
+  if (delimiter === DOUBLE_QUOTE || delimiter === SINGLE_QUOTE) {
+    return [delimiter, delimiter];
+  } else if (delimiter === OPEN_BRACKET) {
     return [OPEN_BRACKET, CLOSE_BRACKET];
   }
-  throw new Error("Unknown quoting: " + quote);
+  throw new Error("Unknown quoting: " + delimiter);
 }

--- a/frontend/src/metabase-lib/v1/expressions/string.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.ts
@@ -88,14 +88,15 @@ export function unquoteString(string: string) {
     }
     return str;
   } else if (quote === "[") {
-    return unescapeString(string).slice(1, -1);
+    const end = string.endsWith("]") ? string.length - 1 : string.length;
+    return unescapeString(string.slice(1, end));
   } else {
     throw new Error("Unknown quoting: " + string);
   }
 }
 
 // The opposite of escapeString
-export function unescapeString(string: string) {
+function unescapeString(string: string) {
   let str = "";
   for (let i = 0; i < string.length; ++i) {
     const ch1 = string[i];

--- a/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
@@ -66,7 +66,7 @@ describe("expressions", () => {
       expect(rt("CR: \r")).toEqual("CR: \r");
       expect(rt("LF: \n")).toEqual("LF: \n");
       expect(rt("FF: \f")).toEqual("FF: \f");
-      expect(rt("Backslash: \\")).toEqual("Backslash: \\");
+      expect(rt("Backslash: \\\\")).toEqual("Backslash: \\\\");
       expect(rt("\b\t\r\n\f\\").length).toEqual(6);
     });
   });

--- a/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
@@ -1,16 +1,11 @@
 import { quoteString, unquoteString } from "./string";
 
-describe("expressions", () => {
-  // double- and single-quote
-  const dq = (str: string) => quoteString(str, '"');
-  const sq = (str: string) => quoteString(str, "'");
+const dq = (str: string) => quoteString(str, '"');
+const sq = (str: string) => quoteString(str, "'");
+const bq = (str: string) => quoteString(str, "[");
 
-  describe("quoteString", () => {
-    it("should enclose a string literal with double quotes", () => {
-      expect(dq(`A`)).toEqual(`"A"`);
-      expect(dq(`XYZ`)).toEqual(`"XYZ"`);
-    });
-
+describe("quoteString", () => {
+  describe("single quotes", () => {
     it("should enclose a string literal with single quotes", () => {
       expect(sq(`B`)).toEqual(`'B'`);
       expect(sq(`PQR`)).toEqual(`'PQR'`);
@@ -18,9 +13,24 @@ describe("expressions", () => {
       expect(sq(`\\\\`)).toEqual(`'\\\\'`);
     });
 
+    it("should escape some special characters in a single-quoted string", () => {
+      expect(sq(`\b`)).toEqual(`'\\b'`);
+      expect(sq(`Tab: \t`)).toEqual(`'Tab: \\t'`);
+      expect(sq(`CR: \r`)).toEqual(`'CR: \\r'`);
+      expect(sq(`LF: \n`)).toEqual(`'LF: \\n'`);
+      expect(sq(`FF: \f`)).toEqual(`'FF: \\f'`);
+      expect(sq(`Backslash: \\\\`)).toEqual(`'Backslash: \\\\'`);
+    });
+
     it("should escape quotes inside the string literal", () => {
-      expect(dq(`C"D`)).toEqual(`"C\\"D"`);
       expect(sq(`E'F`)).toEqual(`'E\\'F'`);
+    });
+  });
+
+  describe("double quotes", () => {
+    it("should enclose a string literal with double quotes", () => {
+      expect(dq(`A`)).toEqual(`"A"`);
+      expect(dq(`XYZ`)).toEqual(`"XYZ"`);
     });
 
     it("should escape some special characters in a double-quoted string", () => {
@@ -32,60 +42,81 @@ describe("expressions", () => {
       expect(dq(`Backslash: \\\\`)).toEqual(`"Backslash: \\\\"`);
     });
 
-    it("should escape some special characters in a single-quoted string", () => {
-      expect(sq(`\b`)).toEqual(`'\\b'`);
-      expect(sq(`Tab: \t`)).toEqual(`'Tab: \\t'`);
-      expect(sq(`CR: \r`)).toEqual(`'CR: \\r'`);
-      expect(sq(`LF: \n`)).toEqual(`'LF: \\n'`);
-      expect(sq(`FF: \f`)).toEqual(`'FF: \\f'`);
-      expect(sq(`Backslash: \\\\`)).toEqual(`'Backslash: \\\\'`);
+    it("should escape quotes inside the string literal", () => {
+      expect(dq(`C"D`)).toEqual(`"C\\"D"`);
     });
   });
 
-  describe("unquoteString", () => {
-    it("should handle double-quoted strings", () => {
-      expect(unquoteString('"A"')).toEqual("A");
-      expect(unquoteString('"PQ"')).toEqual("PQ");
-      expect(unquoteString('"XYZ"')).toEqual("XYZ");
-      expect(unquoteString('"foo bar"')).toEqual("foo bar");
-      expect(unquoteString(`"'"`)).toEqual(`'`);
-      expect(unquoteString(`"\\""`)).toEqual(`"`);
-      expect(unquoteString(`"[]"`)).toEqual(`[]`);
-      expect(unquoteString(`"\\[\\]"`)).toEqual(`\\[\\]`);
-      expect(unquoteString(`"a\\\\b"`)).toEqual(`a\\\\b`);
-      expect(unquoteString(`"\n"`)).toEqual(`\n`);
-      expect(unquoteString(`"unfinished`)).toEqual(`unfinished`);
+  describe("brackets", () => {
+    it("should enclose a string literal with double quotes", () => {
+      expect(bq(`A`)).toEqual(`[A]`);
+      expect(bq(`XYZ`)).toEqual(`[XYZ]`);
     });
 
-    it("should handle single-quoted strings", () => {
-      expect(unquoteString(`'A'`)).toEqual(`A`);
-      expect(unquoteString(`'PQ'`)).toEqual(`PQ`);
-      expect(unquoteString(`'XYZ'`)).toEqual(`XYZ`);
-      expect(unquoteString(`'foo bar'`)).toEqual(`foo bar`);
-      expect(unquoteString(`'\\''`)).toEqual(`'`);
-      expect(unquoteString(`'"'`)).toEqual(`"`);
-      expect(unquoteString(`'[]'`)).toEqual(`[]`);
-      expect(unquoteString(`'\\[\\]'`)).toEqual(`\\[\\]`);
-      expect(unquoteString(`'a\\\\b'`)).toEqual(`a\\\\b`);
-      expect(unquoteString(`'\n'`)).toEqual(`\n`);
-      expect(unquoteString(`'unfinished`)).toEqual(`unfinished`);
+    it("should escape some special characters in a double-quoted string", () => {
+      expect(bq(`\b`)).toEqual(`[\\b]`);
+      expect(bq(`Tab: \t`)).toEqual(`[Tab: \\t]`);
+      expect(bq(`CR: \r`)).toEqual(`[CR: \\r]`);
+      expect(bq(`LF: \n`)).toEqual(`[LF: \\n]`);
+      expect(bq(`FF: \f`)).toEqual(`[FF: \\f]`);
+      expect(bq(`Backslash: \\\\`)).toEqual(`[Backslash: \\\\]`);
     });
 
-    it("should handle bracket-quoted strings", () => {
-      expect(unquoteString(`[A]`)).toEqual(`A`);
-      expect(unquoteString(`[PQ]`)).toEqual(`PQ`);
-      expect(unquoteString(`[XYZ]`)).toEqual(`XYZ`);
-      expect(unquoteString(`[foo bar]`)).toEqual(`foo bar`);
-      expect(unquoteString(`[']`)).toEqual(`'`);
-      expect(unquoteString(`["]`)).toEqual(`"`);
-      expect(unquoteString(`[a\\[\\]b]`)).toEqual(`a[]b`);
-      expect(unquoteString(`[\\\\]`)).toEqual(`\\\\`);
-      expect(unquoteString(`[\n]`)).toEqual(`\n`);
-      expect(unquoteString(`[unfinished`)).toEqual(`unfinished`);
+    it("should escape quotes inside the string literal", () => {
+      expect(bq(`C[D`)).toEqual(`[C\\[D]`);
+      expect(bq(`C]D`)).toEqual(`[C\\]D]`);
     });
+  });
+});
 
-    it("should perform faithful round-trip operations with double-quoted strings", () => {
-      const rt = (str: string) => unquoteString(quoteString(str, "'"));
+describe("unquoteString", () => {
+  it("should handle double-quoted strings", () => {
+    expect(unquoteString('"A"')).toEqual("A");
+    expect(unquoteString('"PQ"')).toEqual("PQ");
+    expect(unquoteString('"XYZ"')).toEqual("XYZ");
+    expect(unquoteString('"foo bar"')).toEqual("foo bar");
+    expect(unquoteString(`"'"`)).toEqual(`'`);
+    expect(unquoteString(`"\\""`)).toEqual(`"`);
+    expect(unquoteString(`"[]"`)).toEqual(`[]`);
+    expect(unquoteString(`"\\[\\]"`)).toEqual(`\\[\\]`);
+    expect(unquoteString(`"a\\\\b"`)).toEqual(`a\\\\b`);
+    expect(unquoteString(`"\n"`)).toEqual(`\n`);
+    expect(unquoteString(`"unfinished`)).toEqual(`unfinished`);
+  });
+
+  it("should handle single-quoted strings", () => {
+    expect(unquoteString(`'A'`)).toEqual(`A`);
+    expect(unquoteString(`'PQ'`)).toEqual(`PQ`);
+    expect(unquoteString(`'XYZ'`)).toEqual(`XYZ`);
+    expect(unquoteString(`'foo bar'`)).toEqual(`foo bar`);
+    expect(unquoteString(`'\\''`)).toEqual(`'`);
+    expect(unquoteString(`'"'`)).toEqual(`"`);
+    expect(unquoteString(`'[]'`)).toEqual(`[]`);
+    expect(unquoteString(`'\\[\\]'`)).toEqual(`\\[\\]`);
+    expect(unquoteString(`'a\\\\b'`)).toEqual(`a\\\\b`);
+    expect(unquoteString(`'\n'`)).toEqual(`\n`);
+    expect(unquoteString(`'unfinished`)).toEqual(`unfinished`);
+  });
+
+  it("should handle bracket-quoted strings", () => {
+    expect(unquoteString(`[A]`)).toEqual(`A`);
+    expect(unquoteString(`[PQ]`)).toEqual(`PQ`);
+    expect(unquoteString(`[XYZ]`)).toEqual(`XYZ`);
+    expect(unquoteString(`[foo bar]`)).toEqual(`foo bar`);
+    expect(unquoteString(`[']`)).toEqual(`'`);
+    expect(unquoteString(`["]`)).toEqual(`"`);
+    expect(unquoteString(`[a\\[\\]b]`)).toEqual(`a[]b`);
+    expect(unquoteString(`[\\\\]`)).toEqual(`\\\\`);
+    expect(unquoteString(`[\n]`)).toEqual(`\n`);
+    expect(unquoteString(`[unfinished`)).toEqual(`unfinished`);
+  });
+
+  const QUOTES = ["'", '"', "["] as const;
+
+  it.each(QUOTES)(
+    "should perform faithful round-trip operations with %s-quoted strings",
+    (QUOTE) => {
+      const rt = (str: string) => unquoteString(quoteString(str, QUOTE));
       expect(rt(`A`)).toEqual(`A`);
       expect(rt(`PQ`)).toEqual(`PQ`);
       expect(rt(`XYZ`)).toEqual(`XYZ`);
@@ -97,6 +128,6 @@ describe("expressions", () => {
       expect(rt(`FF: \f`)).toEqual(`FF: \f`);
       expect(rt(`Backslash: \\\\`)).toEqual(`Backslash: \\\\`);
       expect(rt(`\b\t\r\n\f\\\\`)).toEqual(`\b\t\r\n\f\\\\`);
-    });
-  });
+    },
+  );
 });

--- a/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
@@ -24,6 +24,9 @@ describe("quoteString", () => {
 
     it("should escape quotes inside the string literal", () => {
       expect(sq(`E'F`)).toEqual(`'E\\'F'`);
+      expect(sq(`'foo bar`)).toEqual(`'\\'foo bar'`);
+      expect(sq(`foo bar'`)).toEqual(`'foo bar\\''`);
+      expect(sq(`'foo bar'`)).toEqual(`'\\'foo bar\\''`);
     });
   });
 
@@ -31,6 +34,8 @@ describe("quoteString", () => {
     it("should enclose a string literal with double quotes", () => {
       expect(dq(`A`)).toEqual(`"A"`);
       expect(dq(`XYZ`)).toEqual(`"XYZ"`);
+      expect(dq(`\\s`)).toEqual(`"\\s"`);
+      expect(dq(`\\\\`)).toEqual(`"\\\\"`);
     });
 
     it("should escape some special characters in a double-quoted string", () => {
@@ -44,6 +49,9 @@ describe("quoteString", () => {
 
     it("should escape quotes inside the string literal", () => {
       expect(dq(`C"D`)).toEqual(`"C\\"D"`);
+      expect(dq(`"foo bar`)).toEqual(`"\\"foo bar"`);
+      expect(dq(`foo bar"`)).toEqual(`"foo bar\\""`);
+      expect(dq(`"foo bar"`)).toEqual(`"\\"foo bar\\""`);
     });
   });
 
@@ -51,6 +59,8 @@ describe("quoteString", () => {
     it("should enclose a string literal with double quotes", () => {
       expect(bq(`A`)).toEqual(`[A]`);
       expect(bq(`XYZ`)).toEqual(`[XYZ]`);
+      expect(bq(`\\s`)).toEqual(`[\\s]`);
+      expect(bq(`\\\\`)).toEqual(`[\\\\]`);
     });
 
     it("should escape some special characters in a double-quoted string", () => {
@@ -65,6 +75,9 @@ describe("quoteString", () => {
     it("should escape quotes inside the string literal", () => {
       expect(bq(`C[D`)).toEqual(`[C\\[D]`);
       expect(bq(`C]D`)).toEqual(`[C\\]D]`);
+      expect(bq(`[foo bar`)).toEqual(`[\\[foo bar]`);
+      expect(bq(`foo bar]`)).toEqual(`[foo bar\\]]`);
+      expect(bq(`[foo bar]`)).toEqual(`[\\[foo bar\\]]`);
     });
   });
 });

--- a/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/string.unit.spec.ts
@@ -7,36 +7,38 @@ describe("expressions", () => {
 
   describe("quoteString", () => {
     it("should enclose a string literal with double quotes", () => {
-      expect(dq("A")).toEqual('"A"');
-      expect(dq("XYZ")).toEqual('"XYZ"');
+      expect(dq(`A`)).toEqual(`"A"`);
+      expect(dq(`XYZ`)).toEqual(`"XYZ"`);
     });
 
     it("should enclose a string literal with single quotes", () => {
-      expect(sq("B")).toEqual("'B'");
-      expect(sq("PQR")).toEqual("'PQR'");
+      expect(sq(`B`)).toEqual(`'B'`);
+      expect(sq(`PQR`)).toEqual(`'PQR'`);
+      expect(sq(`\\s`)).toEqual(`'\\s'`);
+      expect(sq(`\\\\`)).toEqual(`'\\\\'`);
     });
 
     it("should escape quotes inside the string literal", () => {
-      expect(dq('C"D')).toEqual('"C\\"D"');
-      expect(sq("E'F")).toEqual("'E\\'F'");
+      expect(dq(`C"D`)).toEqual(`"C\\"D"`);
+      expect(sq(`E'F`)).toEqual(`'E\\'F'`);
     });
 
     it("should escape some special characters in a double-quoted string", () => {
-      expect(dq("\b")).toEqual('"\\b"');
-      expect(dq("Tab: \t")).toEqual('"Tab: \\t"');
-      expect(dq("CR: \r")).toEqual('"CR: \\r"');
-      expect(dq("LF: \n")).toEqual('"LF: \\n"');
-      expect(dq("FF: \f")).toEqual('"FF: \\f"');
-      expect(dq("Backslash: \\")).toEqual('"Backslash: \\"');
+      expect(dq(`\b`)).toEqual(`"\\b"`);
+      expect(dq(`Tab: \t`)).toEqual(`"Tab: \\t"`);
+      expect(dq(`CR: \r`)).toEqual(`"CR: \\r"`);
+      expect(dq(`LF: \n`)).toEqual(`"LF: \\n"`);
+      expect(dq(`FF: \f`)).toEqual(`"FF: \\f"`);
+      expect(dq(`Backslash: \\\\`)).toEqual(`"Backslash: \\\\"`);
     });
 
     it("should escape some special characters in a single-quoted string", () => {
-      expect(sq("\b")).toEqual("'\\b'");
-      expect(sq("Tab: \t")).toEqual("'Tab: \\t'");
-      expect(sq("CR: \r")).toEqual("'CR: \\r'");
-      expect(sq("LF: \n")).toEqual("'LF: \\n'");
-      expect(sq("FF: \f")).toEqual("'FF: \\f'");
-      expect(sq("Backslash: \\")).toEqual("'Backslash: \\'");
+      expect(sq(`\b`)).toEqual(`'\\b'`);
+      expect(sq(`Tab: \t`)).toEqual(`'Tab: \\t'`);
+      expect(sq(`CR: \r`)).toEqual(`'CR: \\r'`);
+      expect(sq(`LF: \n`)).toEqual(`'LF: \\n'`);
+      expect(sq(`FF: \f`)).toEqual(`'FF: \\f'`);
+      expect(sq(`Backslash: \\\\`)).toEqual(`'Backslash: \\\\'`);
     });
   });
 
@@ -46,28 +48,55 @@ describe("expressions", () => {
       expect(unquoteString('"PQ"')).toEqual("PQ");
       expect(unquoteString('"XYZ"')).toEqual("XYZ");
       expect(unquoteString('"foo bar"')).toEqual("foo bar");
+      expect(unquoteString(`"'"`)).toEqual(`'`);
+      expect(unquoteString(`"\\""`)).toEqual(`"`);
+      expect(unquoteString(`"[]"`)).toEqual(`[]`);
+      expect(unquoteString(`"\\[\\]"`)).toEqual(`\\[\\]`);
+      expect(unquoteString(`"a\\\\b"`)).toEqual(`a\\\\b`);
+      expect(unquoteString(`"\n"`)).toEqual(`\n`);
+      expect(unquoteString(`"unfinished`)).toEqual(`unfinished`);
     });
 
     it("should handle single-quoted strings", () => {
-      expect(unquoteString("'A'")).toEqual("A");
-      expect(unquoteString("'PQ'")).toEqual("PQ");
-      expect(unquoteString("'XYZ'")).toEqual("XYZ");
-      expect(unquoteString("'foo bar'")).toEqual("foo bar");
+      expect(unquoteString(`'A'`)).toEqual(`A`);
+      expect(unquoteString(`'PQ'`)).toEqual(`PQ`);
+      expect(unquoteString(`'XYZ'`)).toEqual(`XYZ`);
+      expect(unquoteString(`'foo bar'`)).toEqual(`foo bar`);
+      expect(unquoteString(`'\\''`)).toEqual(`'`);
+      expect(unquoteString(`'"'`)).toEqual(`"`);
+      expect(unquoteString(`'[]'`)).toEqual(`[]`);
+      expect(unquoteString(`'\\[\\]'`)).toEqual(`\\[\\]`);
+      expect(unquoteString(`'a\\\\b'`)).toEqual(`a\\\\b`);
+      expect(unquoteString(`'\n'`)).toEqual(`\n`);
+      expect(unquoteString(`'unfinished`)).toEqual(`unfinished`);
+    });
+
+    it("should handle bracket-quoted strings", () => {
+      expect(unquoteString(`[A]`)).toEqual(`A`);
+      expect(unquoteString(`[PQ]`)).toEqual(`PQ`);
+      expect(unquoteString(`[XYZ]`)).toEqual(`XYZ`);
+      expect(unquoteString(`[foo bar]`)).toEqual(`foo bar`);
+      expect(unquoteString(`[']`)).toEqual(`'`);
+      expect(unquoteString(`["]`)).toEqual(`"`);
+      expect(unquoteString(`[a\\[\\]b]`)).toEqual(`a[]b`);
+      expect(unquoteString(`[\\\\]`)).toEqual(`\\\\`);
+      expect(unquoteString(`[\n]`)).toEqual(`\n`);
+      expect(unquoteString(`[unfinished`)).toEqual(`unfinished`);
     });
 
     it("should perform faithful round-trip operations with double-quoted strings", () => {
       const rt = (str: string) => unquoteString(quoteString(str, "'"));
-      expect(rt("A")).toEqual("A");
-      expect(rt("PQ")).toEqual("PQ");
-      expect(rt("XYZ")).toEqual("XYZ");
-      expect(rt("foo bar")).toEqual("foo bar");
-      expect(rt("\b")).toEqual("\b");
-      expect(rt("Tab: \t")).toEqual("Tab: \t");
-      expect(rt("CR: \r")).toEqual("CR: \r");
-      expect(rt("LF: \n")).toEqual("LF: \n");
-      expect(rt("FF: \f")).toEqual("FF: \f");
-      expect(rt("Backslash: \\\\")).toEqual("Backslash: \\\\");
-      expect(rt("\b\t\r\n\f\\").length).toEqual(6);
+      expect(rt(`A`)).toEqual(`A`);
+      expect(rt(`PQ`)).toEqual(`PQ`);
+      expect(rt(`XYZ`)).toEqual(`XYZ`);
+      expect(rt(`foo bar`)).toEqual(`foo bar`);
+      expect(rt(`\b`)).toEqual(`\b`);
+      expect(rt(`Tab: \t`)).toEqual(`Tab: \t`);
+      expect(rt(`CR: \r`)).toEqual(`CR: \r`);
+      expect(rt(`LF: \n`)).toEqual(`LF: \n`);
+      expect(rt(`FF: \f`)).toEqual(`FF: \f`);
+      expect(rt(`Backslash: \\\\`)).toEqual(`Backslash: \\\\`);
+      expect(rt(`\b\t\r\n\f\\\\`)).toEqual(`\b\t\r\n\f\\\\`);
     });
   });
 });

--- a/frontend/src/metabase-lib/v1/expressions/test/fuzz.ts
+++ b/frontend/src/metabase-lib/v1/expressions/test/fuzz.ts
@@ -1,0 +1,3 @@
+import _ from "underscore";
+
+export const fuzz = process.env.MB_FUZZ ? describe : _.noop;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56596

### Description

Fixes the issue by using the same string escaping everywhere and by handling backslash properly.


This PR simplifies the quoting/unquoting spaghetti logic, cleans up the tests and adds fuzz tests for string quoting and unquoting.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Custom Column -> `regexextract([User → Name], "\s.*")` > name: `Last name` > Click done
3. open the custom column again and verify the expression did not change
4. Visualize and verify the new column correctly extracts the last name


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
