### PR TITLE
properly address metabase's bb executable

### DIFF
--- a/bin/mage.bb
+++ b/bin/mage.bb
@@ -6,6 +6,7 @@
 (ns mage
   (:require
    [babashka.tasks :as bt]
+   [clojure.string :as str]
    [mage.color :as c]
    [mage.shell :as sh]
    [mage.util :as u]))
@@ -27,14 +28,20 @@
       (println (c/red (str "Unknown task: " task-name)))
       true)))
 
+(defn- zen []
+  (mapv (comp #(str "Zen of Metabase: " %) #(apply str %) #(drop 2 %))
+        (filter (fn [x] (str/starts-with? x "-"))
+                (str/split-lines (slurp "zen.md")))))
+
 (defn tip-o-day []
   (rand-nth
-   ["Did you know? You can use `./bin/mage <task> --help` to get more information about a specific task."
-    "Pro tip: Use `./bin/mage <task>` to run a specific task."
-    "Remember: You can always check available tasks with `./bin/mage`"
-    "Fun fact: The word 'mage' comes from the Latin 'magus', meaning 'wise'"
-    "Pro tip: You can setup autocomplete for mage to speed up your workflow with mage setup-autocomplete."
-    "Tip: we reccomend aliasing mage like: `alias mage='cd $MB_DIR && ./bin/mage'`"]))
+   (concat ["Did you know? You can use `./bin/mage <task> --help` to get more information about a specific task."
+            "Pro tip: Use `./bin/mage <task>` to run a specific task."
+            "Remember: You can always check available tasks with `./bin/mage`"
+            "Fun fact: The word 'mage' comes from the Latin 'magus', meaning 'wise'"
+            "Pro tip: You can setup autocomplete for mage to speed up your workflow with mage setup-autocomplete."
+            "Tip: we reccomend aliasing mage like: `alias mage='cd $MB_DIR && ./bin/mage'`"]
+           (zen))))
 
 (defn- print-help []
   (do
@@ -59,7 +66,9 @@
     (do (print-help) (System/exit 1))
 
     :else
-    (apply sh/sh (into ["bb"] *command-line-args*))))
+    ;; at this point, we always have a valid task,
+    ;; and we know there is a bb executable at `./bin/bb`.
+    (apply sh/sh (into ["./bin/bb"] *command-line-args*))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (-main))


### PR DESCRIPTION
Testing by uninstalling a locally installed `bb` will not uncover this issue if you have `repo/path/metabase/bin` on PATH. so to test it:

- uninstall babashka
- make sure `repo/path/metabase/bin` is not on PATH
- run a mage task