### PR TITLE
docs(sdk): Fix redirect from internal module, replace metadata description via a plugin

### DIFF
--- a/.typedoc/page-custom-logic.js
+++ b/.typedoc/page-custom-logic.js
@@ -37,14 +37,14 @@ const navigateBack = ({ fallbackUrl }) => {
  */
 const setupRedirectsFromInternalModule = () => {
   const href = location.href;
-  const indexPage = href.replace(/(.*\/html)\/.*/, "$1/index.html");
+  const basePath = document.querySelector("html").dataset.base;
 
   const isInternalModule =
     href.endsWith(`${INTERNAL_MODULE_NAME}.html`) ||
     href.endsWith(INTERNAL_MODULE_NAME);
 
   if (isInternalModule) {
-    location.replace(indexPage);
+    location.replace(basePath);
   }
 };
 

--- a/.typedoc/typedoc-plugin-frontmatter.js
+++ b/.typedoc/typedoc-plugin-frontmatter.js
@@ -13,6 +13,11 @@ export function load(app) {
 
   app.renderer.on(PageEvent.END, (page) => {
     const frontmatterGlobals = app.options.getValue("frontmatterGlobals");
+
+    const model = page.model;
+
+    frontmatterGlobals.title = model.name || frontmatterGlobals.title;
+
     const yamlItems = Object.entries(frontmatterGlobals)
       .map(([key, value]) => `${key}: ${value}`)
       .join("\n");

--- a/.typedoc/typedoc-plugin-head.js
+++ b/.typedoc/typedoc-plugin-head.js
@@ -1,0 +1,12 @@
+import { Renderer } from "typedoc";
+
+export function load(app) {
+  app.renderer.on(Renderer.EVENT_END_PAGE, (page) => {
+    if (page.contents) {
+      page.contents = page.contents.replace(
+        /<meta\s+name="description"[^>]*>/,
+        "{% include docs/embedded-analytics-sdk-metadata.html %}",
+      );
+    }
+  });
+}

--- a/.typedoc/typedoc-plugin-remove-data-refl-attribute.js
+++ b/.typedoc/typedoc-plugin-remove-data-refl-attribute.js
@@ -1,0 +1,15 @@
+import { Renderer } from "typedoc";
+
+/**
+ * For some reason typedoc updates data-refl value having the same visual output
+ * This data attribute is used for full hierarchy page, but we don't use it, it is disabled, so we can safely remove the attribute
+ *
+ * TODO: figure out if there a better way to avoid this attribute
+ */
+export function load(app) {
+  app.renderer.on(Renderer.EVENT_END_PAGE, (page) => {
+    if (page.contents) {
+      page.contents = page.contents.replace(/ data-refl="[^"]*"/g, "");
+    }
+  });
+}

--- a/.typedoc/typedoc.config.mjs
+++ b/.typedoc/typedoc.config.mjs
@@ -3,13 +3,14 @@ const EMBEDDING_SDK_DOCS_MAIN_PAGE_URL =
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {
-  name: "Embedding SDK API",
+  name: "Embedded analytics SDK API",
   tsconfig: "./tsconfig.sdk-docs.json",
   plugin: [
     "typedoc-plugin-missing-exports",
     "typedoc-plugin-mdn-links",
     "./typedoc-plugin-frontmatter.js",
     "./typedoc-plugin-remove-data-refl-attribute.js",
+    "./typedoc-plugin-head.js",
   ],
   entryPoints: ["../resources/embedding-sdk/dist/index.d.ts"],
   router: "structure",
@@ -26,6 +27,7 @@ const config = {
         collapseInternalModule: true,
         visibilityFilters: {},
         frontmatterGlobals: {
+          title: "Embedded analytics SDK documentation",
           layout: "docs-api",
         },
         pretty: true,

--- a/.typedoc/typedoc.config.mjs
+++ b/.typedoc/typedoc.config.mjs
@@ -9,6 +9,7 @@ const config = {
     "typedoc-plugin-missing-exports",
     "typedoc-plugin-mdn-links",
     "./typedoc-plugin-frontmatter.js",
+    "./typedoc-plugin-remove-data-refl-attribute.js",
   ],
   entryPoints: ["../resources/embedding-sdk/dist/index.d.ts"],
   router: "structure",


### PR DESCRIPTION
Merge it after https://github.com/metabase/metabase/pull/56637

Some hotfixes to generated API docs for Embedding SDK:
- Fix invalid redirect from internal module
- remove `data-refl` attribute to avoid unwanted diffs between visually same files