### PR TITLE
Redo manual backport of #53000 (Shared FE/BE pivots) 

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -383,6 +383,10 @@
            metabase.permissions.util}
    :uses #{api audit config db integrations models plugins premium-features request server util}}
 
+  pivot
+  {:api #{metabase.pivot.core}
+   :uses #{util models}}
+
   plugins
   {:api  #{metabase.plugins metabase.plugins.classloader}
    :uses #{config driver util}}
@@ -463,6 +467,7 @@
            lib
            models
            permissions
+           pivot
            premium-features
            public-settings
            request

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -458,7 +458,7 @@ describe("issue 23076", () => {
   });
 
   it("should correctly translate dates (metabase#23076)", () => {
-    cy.findAllByText(/^Summen für/)
+    cy.findAllByText(/^Summen für/, { timeout: 10000 })
       .should("be.visible")
       .eq(1)
       .invoke("text")

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -1,8 +1,7 @@
-import { getIn } from "icepick";
-import { t } from "ttag";
 import _ from "underscore";
 
-import { displayNameForColumn, formatValue } from "metabase/lib/formatting";
+import * as Pivot from "cljs/metabase.pivot.js";
+import { formatValue } from "metabase/lib/formatting";
 import { makeCellBackgroundGetter } from "metabase/visualizations/lib/table_format";
 import { migratePivotColumnSplitSetting } from "metabase-lib/v1/queries/utils/pivot";
 
@@ -26,97 +25,26 @@ export function multiLevelPivot(data, settings) {
     settings[COLUMN_SPLIT_SETTING] ?? { rows: [], columns: [], values: [] },
     data.cols,
   );
-  const columnsWithoutPivotGroup = data.cols.filter(
-    (col) => !isPivotGroupColumn(col),
-  );
+
+  const columns = Pivot.columns_without_pivot_group(data.cols);
 
   const {
-    columns: columnColumnIndexes,
-    rows: rowColumnIndexes,
-    values: valueColumnIndexes,
+    columns: columnIndexes,
+    rows: rowIndexes,
+    values: valueIndexes,
   } = _.mapObject(columnSplit, (columnNames) =>
     columnNames
-      .map((columnName) =>
-        columnsWithoutPivotGroup.findIndex((col) => col.name === columnName),
-      )
+      .map((columnName) => columns.findIndex((col) => col.name === columnName))
       .filter((index) => index !== -1),
   );
 
-  const { pivotData, columns } = splitPivotData(data);
   const columnSettings = columns.map((column) => settings.column(column));
-  const allCollapsedSubtotals = settings[COLLAPSED_ROWS_SETTING].value;
-  const collapsedSubtotals = filterCollapsedSubtotals(
-    allCollapsedSubtotals,
-    rowColumnIndexes.map((index) => columnSettings[index]),
-  );
-
-  // we build a tree for each tuple of pivoted column/row values seen in the data
-  const columnColumnTree = [];
-  const rowColumnTree = [];
-
-  // this stores pivot table values keyed by all pivoted columns
-  const valuesByKey = {};
-
-  // loop over the primary rows to build trees of column/row header data
-  const primaryRowsKey = JSON.stringify(
-    _.range(columnColumnIndexes.length + rowColumnIndexes.length),
-  );
-  for (const row of pivotData[primaryRowsKey]) {
-    // mutate the trees to add the tuple from the current row
-    updateValueObject(
-      row,
-      columnColumnIndexes,
-      columnSettings,
-      columnColumnTree,
-    );
-    updateValueObject(
-      row,
-      rowColumnIndexes,
-      columnSettings,
-      rowColumnTree,
-      collapsedSubtotals,
-    );
-
-    // save the value columns keyed by the values in the column/row pivoted columns
-    const valueKey = JSON.stringify(
-      columnColumnIndexes.concat(rowColumnIndexes).map((index) => row[index]),
-    );
-    const values = valueColumnIndexes.map((index) => row[index]);
-    const valueColumns = valueColumnIndexes.map(
-      (index) => columnSettings[index]?.column,
-    );
-
-    valuesByKey[valueKey] = {
-      values,
-      valueColumns,
-      data: row.map((value, index) => ({ value, col: columns[index] })),
-      dimensions: row
-        .map((value, index) => ({
-          value,
-          column: columns[index],
-        }))
-        .filter(({ column }) => column.source === "breakout"),
-    };
-  }
-
-  // build objects to look up subtotal values
-  const subtotalValues = {};
-  for (const [subtotalName, subtotal] of Object.entries(pivotData)) {
-    const indexes = JSON.parse(subtotalName);
-    subtotalValues[subtotalName] = {};
-    for (const row of subtotal) {
-      const valueKey = JSON.stringify(indexes.map((index) => row[index]));
-      subtotalValues[subtotalName][valueKey] = valueColumnIndexes.map(
-        (index) => row[index],
-      );
-    }
-  }
 
   // pivot tables have a lot of repeated values, so we use memoized formatters for each column
   const [valueFormatters, topIndexFormatters, leftIndexFormatters] = [
-    valueColumnIndexes,
-    columnColumnIndexes,
-    rowColumnIndexes,
+    valueIndexes,
+    columnIndexes,
+    rowIndexes,
   ].map((indexes) =>
     indexes.map((index) =>
       _.memoize(
@@ -126,88 +54,38 @@ export function multiLevelPivot(data, settings) {
     ),
   );
 
-  const topIndexColumns = columnColumnIndexes.map((index) => columns[index]);
-  const formattedColumnTreeWithoutValues = formatValuesInTree(
-    columnColumnTree,
-    topIndexFormatters,
-    topIndexColumns,
-  );
-  if (
-    formattedColumnTreeWithoutValues.length > 1 &&
-    settings["pivot.show_row_totals"]
-  ) {
-    // if there are multiple columns, we should add another for row totals
-    formattedColumnTreeWithoutValues.push({
-      value: t`Row totals`,
-      children: [],
-      isSubtotal: true,
-      isGrandTotal: true,
-    });
-  }
+  // makeCellBackgroundGetter is wrapped in another callback because `rows` is
+  // computed in CLJS by metabase.pivot.core/get-rows-from-pivot-data, and we
+  // want to avoid an extra round trip to CLJS (this can probably be improved,
+  // maybe by computing background color right before rendering)
+  const makeColorGetter = (rows) => {
+    return makeCellBackgroundGetter(
+      rows,
+      columns,
+      settings["table.column_formatting"] ?? [],
+      true,
+    );
+  };
 
-  const columnIndex = addEmptyIndexItem(
-    formattedColumnTreeWithoutValues.flatMap((root) => enumeratePaths(root)),
-  );
-  const valueColumns = valueColumnIndexes.map((index) => [
-    columns[index],
-    columnSettings[index],
-  ]);
-  const formattedColumnTree = addValueColumnNodes(
-    formattedColumnTreeWithoutValues,
-    valueColumns,
-  );
-
-  const leftIndexColumns = rowColumnIndexes.map((index) => columns[index]);
-  const formattedRowTreeWithoutSubtotals = formatValuesInTree(
-    rowColumnTree,
-    leftIndexFormatters,
-    leftIndexColumns,
-  );
-  const showSubtotalsByColumn = rowColumnIndexes.map(
-    (index) => getIn(columnSettings, [index, COLUMN_SHOW_TOTALS]) !== false,
-  );
-
-  const formattedRowTree = settings["pivot.show_column_totals"]
-    ? addSubtotals(formattedRowTreeWithoutSubtotals, showSubtotalsByColumn)
-    : formattedRowTreeWithoutSubtotals;
-
-  if (
-    formattedRowTreeWithoutSubtotals.length > 1 &&
-    settings["pivot.show_column_totals"]
-  ) {
-    // if there are multiple columns, we should add another for row totals
-    formattedRowTree.push({
-      value: t`Grand totals`,
-      isSubtotal: true,
-      isGrandTotal: true,
-      children: [],
-    });
-  }
-
-  const rowIndex = addEmptyIndexItem(
-    formattedRowTree.flatMap((root) => enumeratePaths(root)),
-  );
-
-  const leftHeaderItems = treeToArray(formattedRowTree.flat());
-  const topHeaderItems = treeToArray(formattedColumnTree.flat());
-
-  const colorGetter = makeCellBackgroundGetter(
-    pivotData[primaryRowsKey],
-    columns,
-    settings["table.column_formatting"] ?? [],
-    true,
-  );
-
-  const getRowSection = createRowSectionGetter({
-    valuesByKey,
-    subtotalValues,
-    valueFormatters,
-    columnColumnIndexes,
-    rowColumnIndexes,
+  const {
     columnIndex,
     rowIndex,
-    colorGetter,
-  });
+    leftHeaderItems,
+    topHeaderItems,
+    getRowSection,
+  } = Pivot.process_pivot_table(
+    data,
+    rowIndexes,
+    columnIndexes,
+    valueIndexes,
+    columns,
+    topIndexFormatters,
+    leftIndexFormatters,
+    valueFormatters,
+    settings,
+    columnSettings,
+    makeColorGetter,
+  );
 
   return {
     leftHeaderItems,
@@ -216,324 +94,11 @@ export function multiLevelPivot(data, settings) {
     columnCount: columnIndex.length,
     rowIndex,
     getRowSection,
-    rowIndexes: rowColumnIndexes,
-    columnIndexes: columnColumnIndexes,
-    valueIndexes: valueColumnIndexes,
+    rowIndexes: rowIndexes,
+    columnIndexes: columnIndexes,
+    valueIndexes: valueIndexes,
+    columnsWithoutPivotGroup: columns,
   };
-}
-
-// This pulls apart the different aggregations that were packed into one result set.
-// There's a column indicating which breakouts were used to compute that row.
-// We use that column to split apart the data and convert the field refs to indexes.
-function splitPivotData(data) {
-  const groupIndex = data.cols.findIndex(isPivotGroupColumn);
-  const columns = data.cols.filter((col) => !isPivotGroupColumn(col));
-  const breakouts = columns.filter((col) => col.source === "breakout");
-
-  const pivotData = _.chain(data.rows)
-    .groupBy((row) => row[groupIndex])
-    .pairs()
-    .map(([key, rows]) => {
-      key = parseInt(key);
-      const indexes = _.range(breakouts.length).filter(
-        (index) => !((1 << index) & key),
-      );
-      const keyAsIndexes = JSON.stringify(indexes);
-      const rowsWithoutColumn = rows.map((row) =>
-        row.slice(0, groupIndex).concat(row.slice(groupIndex + 1)),
-      );
-
-      return [keyAsIndexes, rowsWithoutColumn];
-    })
-    .object()
-    .value();
-  return { pivotData, columns };
-}
-
-function addEmptyIndexItem(index) {
-  // we need a single item even if all columns are on the other axis
-  return index.length === 0 ? [[]] : index;
-}
-
-// A path can't be collapsed if subtotals are turned off for that column.
-// TODO: can we move this to the COLLAPSED_ROW_SETTING itself?
-function filterCollapsedSubtotals(collapsedSubtotals, columnSettings) {
-  const columnIsCollapsible = columnSettings.map(
-    (settings) => settings[COLUMN_SHOW_TOTALS] !== false,
-  );
-  return collapsedSubtotals.filter((pathOrLengthString) => {
-    const pathOrLength = JSON.parse(pathOrLengthString);
-    const length = Array.isArray(pathOrLength)
-      ? pathOrLength.length
-      : pathOrLength;
-    return columnIsCollapsible[length - 1];
-  });
-}
-
-// The getter returned from this function returns the value(s) at given (column, row) location
-function createRowSectionGetter({
-  valuesByKey,
-  subtotalValues,
-  valueFormatters,
-  columnColumnIndexes,
-  rowColumnIndexes,
-  columnIndex,
-  rowIndex,
-  colorGetter,
-}) {
-  const formatValues = (values) =>
-    values === undefined
-      ? Array(valueFormatters.length).fill({ value: null })
-      : values.map((v, i) => ({ value: valueFormatters[i](v) }));
-  const getSubtotals = (breakoutIndexes, values, otherAttrs) =>
-    formatValues(
-      getIn(
-        subtotalValues,
-        [breakoutIndexes, values].map((a) =>
-          JSON.stringify(
-            _.sortBy(a, (_value, index) => breakoutIndexes[index]),
-          ),
-        ),
-      ),
-    ).map((value) => ({ ...value, isSubtotal: true, ...otherAttrs }));
-
-  const getter = (columnIdx, rowIdx) => {
-    const columnValues = columnIndex[columnIdx] || [];
-    const rowValues = rowIndex[rowIdx] || [];
-    const indexValues = columnValues.concat(rowValues);
-    if (
-      rowValues.length < rowColumnIndexes.length ||
-      columnValues.length < columnColumnIndexes.length
-    ) {
-      // if we don't have a full-length key, we're looking for a subtotal
-      const rowIndexes = rowColumnIndexes.slice(0, rowValues.length);
-      const columnIndexes = columnColumnIndexes.slice(0, columnValues.length);
-      const indexes = columnIndexes.concat(rowIndexes);
-      const otherAttrs = rowValues.length === 0 ? { isGrandTotal: true } : {};
-      return getSubtotals(indexes, indexValues, otherAttrs);
-    }
-    const { values, data, dimensions, valueColumns } =
-      valuesByKey[JSON.stringify(indexValues)] || {};
-    return formatValues(values).map((o, index) =>
-      data === undefined
-        ? o
-        : {
-            ...o,
-            clicked: { data, dimensions },
-            backgroundColor: colorGetter(
-              values[index],
-              o.rowIndex,
-              valueColumns[index].name,
-            ),
-          },
-    );
-  };
-  return _.memoize(getter, (i1, i2) => [i1, i2].join());
-}
-
-// Given a tree representation of an index, enumeratePaths produces a list of all paths to leaf nodes
-function enumeratePaths(
-  { rawValue, isGrandTotal, children, isValueColumn },
-  path = [],
-) {
-  if (isGrandTotal) {
-    return [[]];
-  }
-  if (isValueColumn) {
-    return [path];
-  }
-  const pathWithValue = [...path, rawValue];
-  return children.length === 0
-    ? [pathWithValue]
-    : children.flatMap((child) => enumeratePaths(child, pathWithValue));
-}
-
-function formatValuesInTree(
-  rowColumnTree,
-  [formatter, ...formatters],
-  [column, ...columns],
-) {
-  return rowColumnTree.map(({ value, children, ...rest }) => ({
-    ...rest,
-    value: formatter(value),
-    rawValue: value,
-    children: formatValuesInTree(children, formatters, columns),
-    clicked: { value, column, data: [{ value, col: column }] },
-  }));
-}
-
-// This might add value column(s) to the bottom of the top header tree.
-// We display the value column names if there are multiple
-// or if there are no columns pivoted to the top header.
-function addValueColumnNodes(nodes, valueColumns) {
-  const leafNodes = valueColumns.map(([column, columnSettings]) => {
-    return {
-      value: columnSettings.column_title || displayNameForColumn(column),
-      children: [],
-      isValueColumn: true,
-    };
-  });
-  if (nodes.length === 0) {
-    return leafNodes;
-  }
-  if (valueColumns.length <= 1) {
-    return nodes;
-  }
-  function updateNode(node) {
-    const children =
-      node.children.length === 0 ? leafNodes : node.children.map(updateNode);
-    return { ...node, children };
-  }
-  return nodes.map(updateNode);
-}
-
-// This inserts nodes into the left header tree for subtotals.
-// We also mark nodes with `hasSubtotal` to display collapsing UI
-function addSubtotals(rowColumnTree, showSubtotalsByColumn) {
-  // For top-level items we want to show subtotal even if they have only one child
-  // Except the case when top-level items have flat structure
-  // (meaning all of the items have just one child)
-  // If top-level items are flat, subtotals will just repeat their corresponding row
-  // https://github.com/metabase/metabase/issues/15211
-  // https://github.com/metabase/metabase/pull/16566
-  const notFlat = rowColumnTree.some((item) => item.children.length > 1);
-
-  return rowColumnTree.flatMap((item) =>
-    addSubtotal(item, showSubtotalsByColumn, {
-      shouldShowSubtotal: notFlat || item.children.length > 1,
-    }),
-  );
-}
-
-function addSubtotal(
-  item,
-  [isSubtotalEnabled, ...showSubtotalsByColumn],
-  { shouldShowSubtotal = false } = {},
-) {
-  const hasSubtotal = isSubtotalEnabled && shouldShowSubtotal;
-  const subtotal = hasSubtotal
-    ? [
-        {
-          value: t`Totals for ${item.value}`,
-          rawValue: item.rawValue,
-          span: 1,
-          isSubtotal: true,
-          children: [],
-        },
-      ]
-    : [];
-  if (item.isCollapsed) {
-    return subtotal;
-  }
-  const node = {
-    ...item,
-    hasSubtotal,
-    children: item.children.flatMap((child) =>
-      // add subtotals until the last level
-      child.children.length > 0
-        ? addSubtotal(child, showSubtotalsByColumn, {
-            shouldShowSubtotal: child.children.length > 1 || child.isCollapsed,
-          })
-        : child,
-    ),
-  };
-
-  return [node, ...subtotal];
-}
-
-// Update the tree with a row of data
-function updateValueObject(
-  row,
-  indexes,
-  columnSettings,
-  seenValues,
-  collapsedSubtotals = [],
-) {
-  let currentLevelSeenValues = seenValues;
-  const prefix = [];
-  for (const index of indexes) {
-    const value = row[index];
-    prefix.push(value);
-    let seenValue = currentLevelSeenValues.find((d) => d.value === value);
-    const isCollapsed =
-      // the specific path is collapsed
-      collapsedSubtotals.includes(JSON.stringify(prefix)) ||
-      // the entire column is collapsed
-      collapsedSubtotals.includes(JSON.stringify(prefix.length));
-    if (seenValue === undefined) {
-      seenValue = { value, children: [], isCollapsed };
-      currentLevelSeenValues.push(seenValue);
-      sortLevelOfTree(currentLevelSeenValues, columnSettings[index]);
-    }
-    currentLevelSeenValues = seenValue.children;
-  }
-}
-
-// Sorts the array of nodes in place if a sort order is set for that column
-function sortLevelOfTree(array, { [COLUMN_SORT_ORDER]: sortOrder } = {}) {
-  if (sortOrder == null) {
-    // don't sort unless there's a column sort order set
-    return;
-  }
-  array.sort((a, b) => {
-    if (a.value === b.value) {
-      return 0;
-    }
-    // by default use "<" to compare values
-    let result = a.value < b.value ? -1 : 1;
-    // strings should use localeCompare to handle accents, etc
-    if (typeof a.value === "string") {
-      result = a.value.localeCompare(b.value);
-    }
-    // flip the comparison for descending
-    if (sortOrder === COLUMN_SORT_ORDER_DESC) {
-      result *= -1;
-    }
-    return result;
-  });
-}
-
-// Take a tree and produce a flat list used to layout the top/left headers.
-// We track the depth, offset, etc to know how to line items up in the headers.
-function treeToArray(nodes) {
-  const a = [];
-  function dfs(nodes, depth, offset, path = []) {
-    if (nodes.length === 0) {
-      return { span: 1, maxDepth: 0 };
-    }
-    let totalSpan = 0;
-    let maxDepth = 0;
-    for (const {
-      children,
-      rawValue,
-      isGrandTotal,
-      isValueColumn,
-      ...rest
-    } of nodes) {
-      const pathWithValue =
-        isValueColumn || isGrandTotal ? null : [...path, rawValue];
-      const item = {
-        ...rest,
-        rawValue,
-        isGrandTotal,
-        depth,
-        offset,
-        hasChildren: children.length > 0,
-        path: pathWithValue,
-      };
-      a.push(item);
-      const result = dfs(children, depth + 1, offset, pathWithValue);
-      item.span = result.span;
-      item.maxDepthBelow = result.maxDepth;
-      offset += result.span;
-      totalSpan += result.span;
-      maxDepth = Math.max(maxDepth, result.maxDepth);
-    }
-    return { span: totalSpan, maxDepth: maxDepth + 1 };
-  }
-
-  dfs(nodes, 0, 0);
-  return a;
 }
 
 // This is the pivot function used in the normal table visualization.

--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -8,7 +8,7 @@ const CELL_ALPHA = 0.65;
 const ROW_ALPHA = 0.2;
 const GRADIENT_ALPHA = 0.75;
 
-// for simplicity wheb typing assume all values are numbers, since you can only pick numeric columns
+// for simplicity when typing assume all values are numbers, since you can only pick numeric columns
 
 export function makeCellBackgroundGetter(
   rows,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -222,22 +222,24 @@ export const BodyCell = ({
   return (
     <div style={style} className={CS.flex}>
       {rowSection.map(
-        ({ value, isSubtotal, clicked, backgroundColor }, index) => (
-          <Cell
-            isNightMode={isNightMode}
-            key={index}
-            style={{
-              flexBasis: cellWidths[index],
-            }}
-            value={value}
-            isEmphasized={isSubtotal}
-            isBold={isSubtotal}
-            showTooltip={showTooltip}
-            isBody
-            onClick={getCellClickHandler(clicked)}
-            backgroundColor={backgroundColor}
-          />
-        ),
+        ({ value, isSubtotal, clicked, backgroundColor }, index) => {
+          return (
+            <Cell
+              isNightMode={isNightMode}
+              key={index}
+              style={{
+                flexBasis: cellWidths[index],
+              }}
+              value={value}
+              isEmphasized={isSubtotal}
+              isBold={isSubtotal}
+              showTooltip={showTooltip}
+              isBody
+              onClick={getCellClickHandler(clicked)}
+              backgroundColor={backgroundColor}
+            />
+          );
+        },
       )}
     </div>
   );

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
@@ -1,6 +1,22 @@
+import type { ClickObjectDataRow, ClickObjectDimension } from "metabase-lib";
 import type { DatasetColumn } from "metabase-types/api";
 
-export type PivotTableClicked = { value: string; column: DatasetColumn };
+type PivotTableClickDimension = ClickObjectDimension & {
+  colIdx?: number;
+};
+
+type PivotTableClickDataRow = ClickObjectDataRow & {
+  colIdx?: number;
+};
+
+export type PivotTableClicked = {
+  value: string;
+  colIdx?: number;
+  column?: DatasetColumn;
+  data?: PivotTableClickDataRow[];
+  dimensions?: PivotTableClickDimension[];
+};
+
 export interface HeaderItem {
   clicked: PivotTableClicked;
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -24,6 +24,8 @@
                 metabase.lib.types.isa
                 metabase.models.dashboard.constants
                 metabase.models.params.shared
+                metabase.pivot.core
+                metabase.pivot.js
                 metabase.types
                 metabase.util.currency
                 metabase.util.devtools

--- a/src/metabase/models/visualization_settings.cljc
+++ b/src/metabase/models/visualization_settings.cljc
@@ -380,25 +380,28 @@
   (set/map-invert db->norm-click-behavior-keys))
 
 (def ^:private db->norm-column-settings-keys
-  {:column_title       ::column-title
-   :date_style         ::date-style
-   :date_separator     ::date-separator
-   :date_abbreviate    ::date-abbreviate
-   :time_enabled       ::time-enabled
-   :time_style         ::time-style
-   :number_style       ::number-style
-   :currency           ::currency
-   :currency_style     ::currency-style
-   :currency_in_header ::currency-in-header
-   :number_separators  ::number-separators
-   :decimals           ::decimals
-   :scale              ::scale
-   :prefix             ::prefix
-   :suffix             ::suffix
-   :view_as            ::view-as
-   :link_text          ::link-text
-   :link_url           ::link-url
-   :show_mini_bar      ::show-mini-bar})
+  {:column_title                  ::column-title
+   :date_style                    ::date-style
+   :date_separator                ::date-separator
+   :date_abbreviate               ::date-abbreviate
+   :time_enabled                  ::time-enabled
+   :time_style                    ::time-style
+   :number_style                  ::number-style
+   :currency                      ::currency
+   :currency_style                ::currency-style
+   :currency_in_header            ::currency-in-header
+   :number_separators             ::number-separators
+   :decimals                      ::decimals
+   :scale                         ::scale
+   :prefix                        ::prefix
+   :suffix                        ::suffix
+   :view_as                       ::view-as
+   :link_text                     ::link-text
+   :link_url                      ::link-url
+   :show_mini_bar                 ::show-mini-bar
+   ;; TODO: keeping these the same for FE/BE consistency
+   :pivot_table.column_sort_order  :pivot_table.column_sort_order
+   :pivot_table.column_show_totals :pivot_table.column_show_totals})
 
 (def ^:private norm->db-column-settings-keys
   (set/map-invert db->norm-column-settings-keys))

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -1,0 +1,618 @@
+(ns metabase.pivot.core
+  (:require
+   #?(:clj [metabase.util.json :as json])
+   [flatland.ordered.map :as ordered-map]
+   [medley.core :as m]
+   [metabase.models.visualization-settings :as mb.viz]
+   [metabase.util :as u]
+   [metabase.util.i18n :as i18n])
+  (:import
+   #?(:clj (java.text Collator))))
+
+#?(:clj
+   (set! *warn-on-reflection* true))
+
+(defn- json-parse
+  "Parses a JSON string in Clojure or ClojureScript into  "
+  [x]
+  #?(:cljs (js->clj (js/JSON.parse x))
+     :clj (json/decode x)))
+
+(defn- pivot-group-column?
+  "Is the given column the pivot-grouping column?"
+  [col]
+  (= (:name col) "pivot-grouping"))
+
+(defn columns-without-pivot-group
+  "Removes the pivot-grouping column from a list of columns, identifying it by name."
+  [columns]
+  (filter #(not (pivot-group-column? %)) columns))
+
+(def ^:private get-active-breakout-indexes
+  "For a given pivot group value (k), returns the indexes of active breakouts.
+  The pivot group value is a bitmask where each bit represents a breakout. If a
+  bit is 0, the corresponding breakout is active for this group."
+  (memoize
+   (fn [pivot-group num-breakouts]
+     (let [breakout-indexes (range num-breakouts)]
+       (into [] (filter #(zero? (bit-and (bit-shift-left 1 %) pivot-group)) breakout-indexes))))))
+
+(defn- process-grouped-rows
+  "Processes rows for a specific pivot group value (k).
+   Returns a tuple of [active-breakout-indexes, rows-with-pivot-column-removed]."
+  [pivot-group rows pivot-group-index num-breakouts]
+  (let [active-indexes (get-active-breakout-indexes pivot-group num-breakouts)
+        processed-rows (mapv
+                        (fn [row]
+                          (let [before (subvec row 0 pivot-group-index)
+                                after (subvec row (inc pivot-group-index))]
+                            (into before after)))
+                        rows)]
+    [active-indexes processed-rows]))
+
+(defn split-pivot-data
+  "Pulls apart different aggregations that were packed into one result set returned from the QP.
+  The pivot-grouping column indicates which breakouts were used to compute a given row. We used that column
+  to split apart the data and convert field refs to indices"
+  [data]
+  (let [group-index   (u/index-of pivot-group-column? (:cols data))
+        columns       (columns-without-pivot-group (:cols data))
+        breakouts     (filter #(= (keyword (:source %)) :breakout) columns)
+        num-breakouts (count breakouts)
+        pivot-data    (->> (:rows data)
+                           (group-by #(nth % group-index))
+                           (m/map-kv #(process-grouped-rows %1 %2 group-index num-breakouts)))]
+    {:pivot-data pivot-data
+     :primary-rows-key (into [] (range num-breakouts))
+     :columns columns}))
+
+(defn- get-subtotal-values
+  "For each split of the pivot data returned by `split-pivot-data`, aside from
+  the primary rows, returns a mapping from the column values in each row to the
+  measure values."
+  [pivot-data val-indexes primary-rows-key]
+  (let [pivot-data-without-primary (dissoc pivot-data primary-rows-key)]
+    (persistent!
+     (reduce-kv
+      (fn [result column-indexes rows]
+        (let [processed-rows
+              (persistent!
+               (reduce
+                (fn [acc row]
+                  (let [grouping-key (mapv #(nth row %) column-indexes)
+                        values (mapv #(nth row %) val-indexes)]
+                    (assoc! acc grouping-key values)))
+                (transient {})
+                rows))]
+          (assoc! result column-indexes processed-rows)))
+      (transient {})
+      pivot-data-without-primary))))
+
+(defn- collapse-level
+  "Marks all nodes at the given level as collapsed. 1 = root node; 2 = children
+  of the root, etc."
+  [tree level]
+  (m/map-vals
+   (if (= level 1)
+     #(assoc % :isCollapsed true)
+     #(update % :children (fn [subtree] (collapse-level subtree (dec level)))))
+   tree))
+
+(defn- add-is-collapsed
+  "Annotates a row tree with :isCollapsed values, based on the contents of
+  collapsed-subtotals"
+  [tree collapsed-subtotals]
+  (let [parsed-collapsed-subtotals (map json-parse collapsed-subtotals)]
+    (reduce
+     (fn [tree collapsed-subtotal]
+       (cond
+         ;; A plain integer represents an entire level of the tree which is
+         ;; collapsed (1-indexed)
+         (int? collapsed-subtotal)
+         (collapse-level tree collapsed-subtotal)
+
+         ;; A seq represents a specific path in the tree which is collapsed
+         (sequential? collapsed-subtotal)
+         (let [key-path (conj (into [] (interpose :children collapsed-subtotal))
+                              :isCollapsed)]
+           (assoc-in tree key-path true))))
+     tree
+     parsed-collapsed-subtotals)))
+
+(defn- add-path-to-tree
+  "Adds a path of values to a row or column tree. Each level of the tree is an
+  ordered map with values as keys, each associated with a sub-map like
+  {:children (ordered-map/ordered-map)}."
+  [path tree]
+  (if (seq path)
+    (let [v       (first path)
+          subtree (or (get-in tree [v :children]) (ordered-map/ordered-map))]
+      (-> tree
+          (assoc-in [v :children] (add-path-to-tree (rest path) subtree))
+          (assoc-in [v :isCollapsed] false)))
+    tree))
+
+(defn- select-indexes
+  "Given a row, returns a subset of its values according to the provided indexes."
+  [row indexes]
+  (map #(nth row %) indexes))
+
+(defn- build-values-by-key
+  "Creates a mapping from row and column indexes to the values, as well as
+  metadata used for conditional formatting and drill-throughs."
+  [rows cols row-indexes col-indexes val-indexes]
+  (let [col-and-row-indexes (concat col-indexes row-indexes)]
+    (reduce
+     (fn [acc row]
+       (let [value-key  (select-indexes row col-and-row-indexes)
+             values     (select-indexes row val-indexes)
+             data       (map-indexed
+                         (fn [index value]
+                           {:value value
+                            :colIdx index})
+                         row)
+             dimensions (->> row
+                             (map-indexed (fn [index value]
+                                            {:value value
+                                             :column (nth cols index)
+                                             :colIdx index}))
+                             (filter (fn [{column :column}] (= (column :source) "breakout")))
+                             (map #(dissoc % :column)))
+             col-names  (->> (select-indexes cols val-indexes)
+                             (map :name)
+                             (into []))]
+         (assoc acc
+                value-key
+                {:values values
+                 :valueColNames col-names
+                 :data data
+                 :dimensions dimensions})))
+     {}
+     rows)))
+
+(defn- sort-orders-from-settings
+  [col-settings indexes]
+  (->> (map (into [] col-settings) indexes)
+       (map :pivot_table.column_sort_order)))
+
+#?(:clj (def ^:private collator (Collator/getInstance)))
+
+(defn- compare-fn
+  [sort-order]
+  (let [locale-compare
+        (fn [a b]
+          (cond
+            (= a b)
+            0
+
+            (string? a)
+            #?(:clj (.compare ^Collator collator (str a) (str b))
+               :cljs (.localeCompare (str a) (str b)))
+            :else
+            (compare a b)))]
+    (case (keyword sort-order)
+      :ascending  locale-compare
+      :descending #(locale-compare %2 %1)
+      nil)))
+
+(defn- sort-tree
+  "Converts each level of a tree to a sorted map as needed, based on the values
+  in `sort-orders`."
+  [tree sort-orders]
+  (into
+   (if-let [curr-compare-fn (compare-fn (first sort-orders))]
+     (sorted-map-by curr-compare-fn)
+     (ordered-map/ordered-map))
+   (for [[k v] tree]
+     [k (assoc v :children (sort-tree (:children v) (rest sort-orders)))])))
+
+;; TODO: can we move this to the COLLAPSED_ROW_SETTING itself?
+(defn- filter-collapsed-subtotals
+  [row-indexes settings col-settings]
+  (let [all-collapsed-subtotals (-> settings :pivot_table.collapsed_rows :value)
+        pivot-row-settings (map #(nth col-settings %) row-indexes)
+        column-is-collapsible? (map #(not= false (:pivot_table.column_show_totals %)) pivot-row-settings)]
+    ;; A path can't be collapsed if subtotals are turned off for that column
+    (filter (fn [path-or-length]
+              (let [path-or-length (json-parse path-or-length)
+                    length (if (sequential? path-or-length)
+                             (count path-or-length)
+                             path-or-length)]
+                (nth column-is-collapsible? (dec length) false)))
+            all-collapsed-subtotals)))
+
+(defn- postprocess-tree
+  "Converts a tree of sorted maps to a tree of vectors. This allows the tree to
+  make a round trip to JavaScript and back to CLJS in `process-pivot-table`
+  without losing ordering information."
+  [tree]
+  (if (empty? tree)
+    []
+    (persistent!
+     (reduce-kv
+      (fn [result value tree-node]
+        (let [children (:children tree-node)
+              processed-children (postprocess-tree children)]
+          (conj! result (assoc tree-node
+                               :value value
+                               :children processed-children))))
+      (transient [])
+      tree))))
+
+(defn build-pivot-trees
+  "Constructs the pivot table's tree structures for rows and columns.
+
+  Takes raw pivot data and generates hierarchical tree structures for both rows
+  and columns, along with a lookup map for cell values."
+  [rows cols row-indexes col-indexes val-indexes settings col-settings]
+  (let [collapsed-subtotals (filter-collapsed-subtotals row-indexes settings col-settings)
+        ; rows (get-rows-from-pivot-data pivot-data row-indexes col-indexes)
+        {:keys [row-tree col-tree]}
+        (reduce
+         (fn [{:keys [row-tree col-tree]} row]
+           (let [row-path (select-indexes row row-indexes)
+                 col-path (select-indexes row col-indexes)]
+             {:row-tree (add-path-to-tree row-path row-tree)
+              :col-tree (add-path-to-tree col-path col-tree)}))
+         {:row-tree (ordered-map/ordered-map)
+          :col-tree (ordered-map/ordered-map)}
+         rows)
+        collapsed-row-tree (add-is-collapsed row-tree collapsed-subtotals)
+        row-sort-orders (sort-orders-from-settings col-settings row-indexes)
+        col-sort-orders (sort-orders-from-settings col-settings col-indexes)
+        sorted-row-tree (sort-tree collapsed-row-tree row-sort-orders)
+        sorted-col-tree (sort-tree col-tree col-sort-orders)
+        values-by-key   (build-values-by-key rows cols row-indexes col-indexes val-indexes)]
+    {:row-tree (postprocess-tree sorted-row-tree)
+     :col-tree (postprocess-tree sorted-col-tree)
+     :values-by-key values-by-key}))
+
+(defn- format-values-in-tree
+  "Walks a tree, formatting values and annotating each value with its color for
+  conditional formatting, as well as data that powers drill-throughs on the
+  FE."
+  [tree formatters cols col-indexes]
+  (let [formatter (first formatters)
+        col-idx   (first col-indexes)]
+    (map
+     (fn [{:keys [value children] :as node}]
+       (assoc node
+              :value (formatter value)
+              :children (format-values-in-tree children (rest formatters) (rest cols) (rest col-indexes))
+              :rawValue value
+              :clicked {:value value
+                        :colIdx col-idx}))
+     tree)))
+
+(defn- should-show-row-totals?
+  [settings]
+  (get settings :pivot.show_row_totals true))
+
+(defn- should-show-column-totals?
+  [settings]
+  (get settings :pivot.show_column_totals true))
+
+(defn- maybe-add-row-totals-column
+  "If needed, adds a column header to the end of the column tree for the column containing row totals"
+  [col-tree settings]
+  (if (and (> (count col-tree) 1)
+           (should-show-row-totals? settings))
+    (conj
+     col-tree
+     {:value (i18n/tru "Row totals")
+      :children []
+      :isSubtotal true
+      :isGrandTotal true})
+    col-tree))
+
+(defn- maybe-add-grand-totals-row
+  "If needed, adds a row header to the end of the row tree for the row containing the grand total at the bottom-right of the table."
+  [row-tree settings]
+  (if (should-show-column-totals? settings)
+    (conj
+     row-tree
+     {:value (i18n/tru "Grand totals")
+      :children []
+      :isSubtotal true
+      :isGrandTotal true})
+    row-tree))
+
+(defn- create-subtotal-node
+  "Creates a subtotal node for the given row item."
+  [row-item]
+  {:value (i18n/tru "Totals for {0}" (:value row-item))
+   :rawValue (:rawValue row-item)
+   :span 1
+   :isSubtotal true
+   :children []})
+
+(defn- should-create-subtotal?
+  "Determines if a subtotal should be created based on settings and row structure."
+  [is-subtotal-enabled should-show-subtotal]
+  (and is-subtotal-enabled should-show-subtotal))
+
+(declare add-subtotal)
+
+(defn- process-children
+  "Recursively processes children nodes to add subtotals."
+  [children rest-subtotal-settings should-show-fn]
+  (mapcat (fn [child]
+            (if (not-empty (:children child))
+              (add-subtotal child
+                            rest-subtotal-settings
+                            (should-show-fn child))
+              [child]))
+          children))
+
+(defn- add-subtotal
+  "Adds subtotal nodes to a row item based on subtotal settings.
+   Returns a sequence of nodes (the original node and possibly a subtotal node)."
+  [row-item subtotal-settings-by-col should-show-subtotal]
+  (let [current-col-setting    (first subtotal-settings-by-col)
+        remaining-col-settings (rest subtotal-settings-by-col)
+        subtotal-enabled?      (should-create-subtotal? current-col-setting should-show-subtotal)
+        subtotal-nodes         (if subtotal-enabled?
+                                 [(create-subtotal-node row-item)]
+                                 [])]
+    (if (:isCollapsed row-item)
+      ;; For collapsed items, just return subtotal if applicable
+      subtotal-nodes
+      ;; For expanded items, process children recursively
+      (let [should-show-fn     (fn [child]
+                                 (or (> (count (:children child)) 1)
+                                     (:isCollapsed child)))
+            processed-children (process-children (:children row-item)
+                                                 remaining-col-settings
+                                                 should-show-fn)
+            updated-node       (merge row-item
+                                      {:hasSubtotal subtotal-enabled?
+                                       :children processed-children})]
+        (if (not-empty subtotal-nodes)
+          [updated-node (first subtotal-nodes)]
+          [updated-node])))))
+
+(defn- add-subtotals
+  "Adds subtotal rows to the pivot table based on settings.
+   Returns the tree with subtotals added where appropriate."
+  [row-tree row-indexes settings col-settings]
+  (if-not (should-show-column-totals? settings)
+    row-tree
+    (let [subtotal-settings-by-col (map (fn [idx]
+                                          (not= ((nth col-settings idx) :pivot_table.column_show_totals)
+                                                false))
+                                        row-indexes)
+          has-multiple-children    (some #(> (count (:children %)) 1) row-tree)
+          should-show-root-total   (fn [row-item]
+                                     (or has-multiple-children
+                                         (> (count (:children row-item)) 1)))]
+      (mapcat (fn [row-item]
+                (add-subtotal row-item
+                              subtotal-settings-by-col
+                              (should-show-root-total row-item)))
+              row-tree))))
+
+(defn display-name-for-col
+  "Translated from frontend/src/metabase/lib/formatting/column.ts"
+  [column col-settings format-values?]
+  (or (if format-values?
+        (or
+         (:column_title col-settings)
+         (::mb.viz/column-title col-settings)
+         (:display_name (:remapped_to_column column))
+         (:display_name column))
+        (:display_name column))
+      (i18n/tru "(empty)")))
+
+(defn- update-node
+  [node leaf-nodes]
+  (let [new-children (if (empty? (:children node))
+                       leaf-nodes
+                       (map #(update-node % leaf-nodes) (:children node)))]
+    (merge node {:children new-children})))
+
+(defn add-value-column-nodes
+  "This might add value column(s) to the bottom of the top header tree. We
+  display the value column names if there are multiple or if there are no
+  columns pivoted to the top header."
+  [col-tree cols col-indexes col-settings format-rows?]
+  (let [val-cols (map (fn [idx] [(nth cols idx) (nth col-settings idx)]) col-indexes)
+        leaf-nodes (map (fn [[col col-settings]] {:value (display-name-for-col col col-settings format-rows?)
+                                                  :children []
+                                                  :isValueColumn true})
+                        val-cols)]
+    (cond
+      (empty? col-tree) leaf-nodes
+      (<= (count val-cols) 1) col-tree
+      :else (map #(update-node % leaf-nodes) col-tree))))
+
+(defn- maybe-add-empty-path [paths]
+  (if (empty? paths)
+    [[]]
+    paths))
+
+(defn- enumerate-paths
+  "Given a node of a row or column tree, generates all paths to leaf nodes."
+  [{:keys [rawValue isGrandTotal children isValueColumn]} & [path]]
+  (let [path (or path [])]
+    (cond
+      isGrandTotal [[]]
+      isValueColumn [path]
+      (empty? children) [(conj path rawValue)]
+      :else (mapcat #(enumerate-paths % (conj path rawValue)) children))))
+
+(defn- format-values
+  [values value-formatters]
+  (if values
+    (map (fn [value formatter] {:value (formatter value)}) values value-formatters)
+    (repeat (count value-formatters) {:value nil})))
+
+(defn- sort-by-indexed
+  "Variant of `sort-by` which sorts the items in `coll` based on a `key-fn`
+  which takes the arguments `idx` (the index of `val` in `coll`) and `val`
+  itself."
+  [key-fn coll]
+  (->> coll
+       (map-indexed vector)
+       (sort-by (fn [[idx val]] (key-fn val idx)))
+       (map second)))
+
+(defn- format-subtotal-values
+  "Formats subtotal values and adds additional attributes."
+  [raw-values value-formatters other-attrs]
+  (map #(merge % {:isSubtotal true} other-attrs)
+       (format-values raw-values value-formatters)))
+
+(defn- get-subtotals
+  "Returns formatted subtotal values for a position in the pivot table.
+   Handles both regular subtotals and grand totals."
+  [subtotal-values breakout-indexes values other-attrs value-formatters]
+  (let [breakout-key (vec (sort-by-indexed (fn [_ index] (nth breakout-indexes index)) breakout-indexes))
+        value-key (vec (sort-by-indexed (fn [_ index] (nth breakout-indexes index)) values))
+        raw-values (get-in subtotal-values [breakout-key value-key])]
+    (format-subtotal-values raw-values value-formatters other-attrs)))
+
+(defn- get-grand-total
+  "Special case handler for grand total cells."
+  [subtotal-values indexes index-values value-formatters]
+  (get-subtotals subtotal-values indexes index-values {:isGrandTotal true} value-formatters))
+
+(defn- get-regular-subtotal
+  "Handler for regular subtotal cells (not grand totals)."
+  [subtotal-values indexes index-values value-formatters]
+  (get-subtotals subtotal-values indexes index-values {} value-formatters))
+
+(defn- get-normal-cell-values
+  "Processes and formats values for normal data cells (non-subtotal)."
+  [values-by-key index-values value-formatters color-getter]
+  (let [{:keys [values valueColNames data dimensions]} (get values-by-key index-values) formatted-values (format-values values value-formatters)]
+    (if-not data
+      formatted-values
+      (map-indexed
+       (fn [index value]
+         (assoc value
+                :clicked {:data       data
+                          :dimensions dimensions}
+                :backgroundColor (color-getter
+                                  (nth values index)
+                                  index
+                                  (nth valueColNames index))))
+       formatted-values))))
+
+(defn- is-subtotal?
+  "Determines if a cell is a subtotal based on its position."
+  [row-values col-values row-indexes col-indexes]
+  (or (< (count row-values) (count row-indexes))
+      (< (count col-values) (count col-indexes))))
+
+(defn- handle-subtotal-cell
+  "Processes subtotal cells, including grand totals."
+  [subtotal-values row-values col-values row-indexes col-indexes value-formatters]
+  (let [row-idxs (take (count row-values) row-indexes)
+        col-idxs (take (count col-values) col-indexes)
+        indexes (concat col-idxs row-idxs)
+        index-values (concat col-values row-values)]
+    (if (zero? (count row-values))
+      (get-grand-total subtotal-values indexes index-values value-formatters)
+      (get-regular-subtotal subtotal-values indexes index-values value-formatters))))
+
+(defn- create-row-section-getter
+  "Returns a memoized function that retrieves and formats values for a specific cell
+  position in the pivot table."
+  [values-by-key subtotal-values value-formatters col-indexes row-indexes col-paths row-paths color-getter]
+  (fn [col-index row-index]
+    (let [col-values (nth col-paths col-index [])
+          row-values (nth row-paths row-index [])
+          index-values (concat col-values row-values)
+          result (if (is-subtotal? row-values col-values row-indexes col-indexes)
+                   (handle-subtotal-cell subtotal-values row-values col-values row-indexes col-indexes value-formatters)
+                   (get-normal-cell-values values-by-key index-values value-formatters color-getter))]
+      ;; Convert to JavaScript object if in ClojureScript context
+      #?(:cljs (clj->js result)
+         :clj result))))
+
+(defn- tree-to-array
+  "Flattens a hierarchical tree structure into an array of nodes with positioning information.
+   Each node in the result contains:
+   - Original node properties (except :children)
+   - :depth - How deep the node is in the tree
+   - :offset - Horizontal position in the flattened representation
+   - :span - How many leaf nodes this node spans
+   - :hasChildren - Whether this node has any children
+   - :path - The path of rawValues from root to this node
+   - :maxDepthBelow - Maximum depth of the subtree below this node
+
+   Note - some keywords are camelCase to match expected object keys in TypeScript."
+  [tree]
+  (let [result (transient [])]
+    (letfn [(process-tree [nodes depth offset path]
+              (if (empty? nodes)
+                {:span 1 :max-depth 0}
+                (loop [remaining nodes
+                       total-span 0
+                       max-depth 0
+                       current-offset offset]
+                  (if (empty? remaining)
+                    {:span total-span :max-depth (inc max-depth)}
+                    (let [{:keys [children rawValue isGrandTotal isValueColumn] :as node} (first remaining)
+                          path-with-value (if (or isValueColumn isGrandTotal) nil (conj path rawValue))
+                          item            (-> (dissoc node :children)
+                                              (assoc :depth depth
+                                                     :offset current-offset
+                                                     :hasChildren (boolean (seq children))
+                                                     :path path-with-value))
+                          item-index      (count result)
+                          _               (conj! result item)
+                          result-value    (process-tree children (inc depth) current-offset path-with-value)
+                          _               (assoc! result item-index (assoc (nth result item-index)
+                                                                           :span (:span result-value)
+                                                                           :maxDepthBelow (:max-depth result-value)))]
+                      (recur (rest remaining)
+                             (long (+ total-span (:span result-value)))
+                             (long (max max-depth (:max-depth result-value)))
+                             (+ current-offset (:span result-value))))))))]
+      (process-tree tree 0 0 [])
+      (persistent! result))))
+
+(defn- compute-row-paths [columns row-indexes row-tree left-formatters settings col-settings]
+  (let [left-index-columns (select-indexes columns row-indexes)
+        formatted-row-tree-without-subtotals (format-values-in-tree row-tree left-formatters left-index-columns row-indexes)
+        formatted-row-tree (into [] (add-subtotals formatted-row-tree-without-subtotals row-indexes settings col-settings))
+        formatted-row-tree-with-totals (if (> (count formatted-row-tree-without-subtotals) 1)
+                                         (maybe-add-grand-totals-row formatted-row-tree settings)
+                                         formatted-row-tree)]
+    {:formatted-row-tree-with-totals formatted-row-tree-with-totals
+     :row-paths (->> formatted-row-tree-with-totals (mapcat enumerate-paths) maybe-add-empty-path (into []))}))
+
+(defn- compute-col-paths [columns col-indexes col-tree top-formatters settings]
+  (let [top-index-columns (select-indexes columns col-indexes)
+        formatted-col-tree-without-values (into [] (format-values-in-tree col-tree top-formatters top-index-columns col-indexes))
+        formatted-col-tree-with-totals (maybe-add-row-totals-column formatted-col-tree-without-values settings)]
+    {:formatted-col-tree-with-totals formatted-col-tree-with-totals
+     :col-paths (->> formatted-col-tree-with-totals (mapcat enumerate-paths) maybe-add-empty-path (into []))}))
+
+(defn process-pivot-table
+  "Formats rows, columns, and measure values in a pivot table according to
+  provided formatters."
+  ([data row-indexes col-indexes val-indexes columns top-formatters left-formatters value-formatters format-rows? settings col-settings]
+   (process-pivot-table data row-indexes col-indexes val-indexes columns top-formatters left-formatters value-formatters format-rows? settings col-settings (constantly (constantly nil))))
+  ([data row-indexes col-indexes val-indexes columns top-formatters left-formatters value-formatters format-rows? settings col-settings make-color-getter]
+   (let [{:keys [pivot-data primary-rows-key]} (split-pivot-data data)
+         primary-rows (get pivot-data primary-rows-key)
+         color-getter #?(:cljs (make-color-getter (clj->js primary-rows))
+                         :clj (make-color-getter))
+         {:keys [row-tree col-tree values-by-key]}
+         (build-pivot-trees primary-rows columns row-indexes col-indexes val-indexes settings col-settings)
+
+         {:keys [row-paths formatted-row-tree-with-totals]}
+         (compute-row-paths columns row-indexes row-tree left-formatters settings col-settings)
+
+         {:keys [col-paths formatted-col-tree-with-totals]}
+         (compute-col-paths columns col-indexes col-tree top-formatters settings)
+
+         formatted-col-tree (into [] (add-value-column-nodes formatted-col-tree-with-totals columns val-indexes col-settings format-rows?))
+         subtotal-values (get-subtotal-values pivot-data val-indexes primary-rows-key)]
+     {:columnIndex col-paths
+      :rowIndex row-paths
+      :leftHeaderItems (tree-to-array formatted-row-tree-with-totals)
+      :topHeaderItems (tree-to-array formatted-col-tree)
+      :getRowSection (create-row-section-getter values-by-key subtotal-values value-formatters col-indexes row-indexes col-paths row-paths color-getter)})))

--- a/src/metabase/pivot/js.cljs
+++ b/src/metabase/pivot/js.cljs
@@ -1,0 +1,50 @@
+(ns metabase.pivot.js
+  "Javascript-facing interface for pivot table postprocessing. Wraps functions in metabase.pivot.core."
+  (:require
+   [metabase.pivot.core :as pivot]))
+
+(defn ^:export columns-without-pivot-group
+  "Removes the pivot-grouping column from a list of columns, identifying it by name."
+  [cols]
+  (let [cols (js->clj cols :keywordize-keys true)]
+    (clj->js
+     (pivot/columns-without-pivot-group cols))))
+
+(defn ^:export split-pivot-data
+  "Pulls apart different aggregations that were packed into one result set returned from the QP.
+  The pivot-grouping column indicates which breakouts were used to compute a given row. We used that column
+  to split apart the data and convert field refs to indices"
+  [data]
+  (let [{:keys [pivot-data primary-rows-key columns]}
+        (pivot/split-pivot-data (js->clj data :keywordize-keys true))]
+    (clj->js
+     {:pivotData pivot-data
+      :primaryRowsKey (str primary-rows-key)
+      :columns columns})))
+
+(defn ^:export process-pivot-table
+  "Formats rows, columns, and measure values in a pivot table according to
+  provided formatters."
+  [data row-indexes col-indexes val-indexes cols top-formatters left-formatters value-formatters settings col-settings make-color-getter]
+  (let [data         (js->clj data :keywordize-keys true)
+        row-indexes  (js->clj row-indexes)
+        col-indexes  (js->clj col-indexes)
+        val-indexes  (js->clj val-indexes)
+        cols         (js->clj cols :keywordize-keys true)
+        settings     (js->clj settings :keywordize-keys true)
+        col-settings (js->clj col-settings :keywordize-keys true)
+        ;; On the FE, always format rows (false only applies to downloads)
+        format-rows? true
+        result       (pivot/process-pivot-table data
+                                                row-indexes
+                                                col-indexes
+                                                val-indexes
+                                                cols
+                                                top-formatters
+                                                left-formatters
+                                                value-formatters
+                                                format-rows?
+                                                settings
+                                                col-settings
+                                                make-color-getter)]
+    (clj->js result)))

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -98,9 +98,9 @@
 (defn- send-pulse!*
   [{:keys [channels channel-ids] :as pulse} dashboard async?]
   (let [;; `channel-ids` is the set of channels to send to now, so only send to those. Note the whole set of channels
-        channels   (if (seq channel-ids)
-                     (filter #((set channel-ids) (:id %)) channels)
-                     channels)]
+        channels (if (seq channel-ids)
+                   (filter #((set channel-ids) (:id %)) channels)
+                   channels)]
     (doseq [pulse-channel channels]
       (try
         (send-notification! (notification-info pulse dashboard pulse-channel) :notification/sync? (not async?))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -606,7 +606,8 @@
                                 (pivot-options query (get query :viz-settings))
                                 (pivot-options query (get-in query [:info :visualization-settings]))
                                 (not-empty (select-keys query [:pivot-rows :pivot-cols :pivot-measures])))
-             query             (assoc-in query [:middleware :pivot-options] pivot-opts)
+             query             (-> query
+                                   (assoc-in [:middleware :pivot-options] pivot-opts))
              all-queries       (generate-queries query pivot-opts)
              column-mapping-fn (make-column-mapping-fn query)]
          (process-multiple-queries all-queries rff column-mapping-fn))))))

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -7,15 +7,13 @@
   (:refer-clojure :exclude [run!])
   (:require
    [clojure.set :as set]
-   [clojure.string :as str]
-   [flatland.ordered.map :as ordered-map]
-   [flatland.ordered.set :as ordered-set]
-   [metabase.query-processor.streaming.common :as streaming.common]
+   [metabase.formatter :as formatter]
+   [metabase.models.visualization-settings :as mb.viz]
+   [metabase.pivot.core :as pivot]
+   [metabase.query-processor.streaming.common :as common]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [run!]])
-  (:import
-   (java.util ArrayList)))
+   [metabase.util.performance :as perf]))
 
 (set! *warn-on-reflection* true)
 
@@ -33,12 +31,6 @@
 
 ;; The 'pivot-grouping' is the giveaway. If you ever see that column, you know you're dealing with raw pivot rows.
 
-(def NON_PIVOT_ROW_GROUP
-  "Pivot query results have a 'pivot-grouping' column. Rows whose pivot-grouping value is 0 are expected results.
-  Rows whose pivot-grouping values are greater than 0 represent subtotals, and should not be included in non-pivot result outputs."
-  0)
-
-;; Most of the post processing functions use a 'pivot-spec' map.
 (mr/def ::pivot-spec
   [:map
    [:column-titles  [:sequential [:string]]]
@@ -49,11 +41,15 @@
    [:pivot-measures {:optional true}
     [:sequential [:int {:min 0}]]]])
 
+(def NON_PIVOT_ROW_GROUP
+  "Pivot query results have a 'pivot-grouping' column. Rows whose pivot-grouping value is 0 are expected results.
+  Rows whose pivot-grouping values are greater than 0 represent subtotals, and should not be included in non-pivot result outputs."
+  0)
+
 (defn pivot-grouping-key
   "Get the index into the raw pivot rows for the 'pivot-grouping' column."
   [column-titles]
-  ;; a vector is kinda sorta a map of indices->values, so
-  ;; we can use map-invert to create the map
+  ;; A vector is kinda sorta a map of indices->values, so we can use map-invert to create the map
   (get (set/map-invert (vec column-titles)) "pivot-grouping"))
 
 (mu/defn- pivot-measures
@@ -84,448 +80,136 @@
                                                                   indices)))
       true                       (assoc :pivot-grouping pivot-grouping-key))))
 
-(mu/defn add-totals-settings :- ::pivot-spec
-  "Given a pivot-spec map and `viz-settings`, add the `:row-totals?` and `:col-totals?` keys."
-  [pivot-spec :- ::pivot-spec viz-settings]
-  (let [row-totals (if (contains? viz-settings :pivot.show_row_totals)
-                     (:pivot.show_row_totals viz-settings)
-                     true)
-        col-totals (if (contains? viz-settings :pivot.show_column_totals)
-                     (:pivot.show_column_totals viz-settings)
-                     true)]
-    (-> pivot-spec
-        (assoc :row-totals? row-totals)
-        (assoc :col-totals? col-totals))))
+;; TODO: Better way to manage column settings similar to the FE?
+(defn- merge-column-settings
+  "Correlates column viz settings with columns by name in order to produce column settings closer
+  to what the FE gets."
+  [cols settings]
+  (let [col-settings (::mb.viz/column-settings settings)]
+    (map
+     (fn [col]
+       (merge
+        {:column col}
+        (get col-settings {::mb.viz/column-name (:name col)})))
+     cols)))
 
-(mu/defn init-pivot
-  "Initiate the pivot data structure."
-  [pivot-spec :- ::pivot-spec]
-  (let [{:keys [pivot-measures]} pivot-spec]
-    {:config         pivot-spec
-     :data           {}
-     ;; A nested tree of ordered maps & sets, representing all combinations of row values in the data
-     :row-paths      (ordered-map/ordered-map)
-     ;; A nested tree of ordered maps & sets, representing all combinations of column values in the data
-     :col-paths      (ordered-map/ordered-map)
-     :measure-values (zipmap pivot-measures (repeat (sorted-set)))}))
+(defn- get-formatter
+  "Returns a memoized formatter for a column"
+  [timezone settings format-rows?]
+  (memoize
+   (fn [column]
+     (formatter/create-formatter timezone column settings format-rows?))))
 
-(defn- add-to-path-tree
-  "Assocs a list of values in a path tree, which should consist of a hierarchy of ordered-maps, with leaf values stored in
-  ordered-sets."
-  [tree ks]
-  (let [step
-        (fn step [tree [k & ks]]
-          (if ks
-            (let [next-map (or (get tree k) (ordered-map/ordered-map))]
-              (assoc tree k (step next-map ks)))
-            (let [leaf-set (if (set? tree) tree (ordered-set/ordered-set))]
-              (conj leaf-set k))))]
-    (step tree ks)))
+(defn- create-formatters
+  [columns indexes timezone settings format-rows?]
+  (let [formatter-fn (get-formatter timezone settings format-rows?)]
+    (mapv (fn [idx]
+            (let [column (nth columns idx)
+                  formatter (formatter-fn column)]
+              (fn [value]
+                (formatter (common/format-value value)))))
+          indexes)))
 
-(defn- measure->agg-fn
-  "Aggregators for the column totals"
-  [k]
-  (case k
+(defn- make-formatters
+  [columns row-indexes col-indexes val-indexes settings timezone format-rows?]
+  {:row-formatters (create-formatters columns row-indexes timezone settings format-rows?)
+   :col-formatters (create-formatters columns col-indexes timezone settings format-rows?)
+   :val-formatters (create-formatters columns val-indexes timezone settings format-rows?)})
 
-    (:sum :count :total)
-    (fn [prev v]
-      (if (number? v)
-        (-> (merge {:result 0} prev)
-            (update :result #(+ % v)))
-        v))
+(defn- build-top-headers
+  [top-left-header top-header-items]
+  (if (empty? top-header-items)
+    [(vec top-left-header)]  ;; Return just the top-left header for empty input
+    (let [max-depth   (apply max (map :depth top-header-items))
+          left-width  (count top-left-header)
+          ;; Initialize rows - all rows except the last one are filled with nil
+          header-rows (-> (vec (repeat max-depth (vec (repeat left-width nil))))
+                          (conj (vec top-left-header)))]
+      ;; Fill in the header values for each item
+      (reduce
+       (fn [rows {:keys [depth value span]}]
+         (let [current-row (get rows depth)
+               ;; Add the value and repeat it for the span
+               new-row     (-> current-row
+                               (conj value)
+                               (into (repeat (dec span) value)))]
+           (assoc rows depth new-row)))
+       header-rows
+       top-header-items))))
 
-    :avg
-    (fn [prev v]
-      (if (number? v)
-        (-> (merge {:total 0
-                    :count 0}
-                   prev)
-            (update :total #(+ % v))
-            (update :count inc))
-        v))
+(defn- build-left-headers
+  [left-header-items]
+  (if (empty? left-header-items)
+    []
+    (let [max-depth        (apply max (map :depth left-header-items))
+          span-by-position (reduce (fn [acc {:keys [depth offset span]}]
+                                     (update acc depth
+                                             (fnil #(max % (+ offset span)) 0)))
+                                   {}
+                                   left-header-items)
+          result-height    (apply max (vals span-by-position))
+          column-count     (inc max-depth)]
+      ;; Fill in the header values
+      (reduce
+       (fn [grid {:keys [depth value span offset]}]
+         ;; For each row this header spans, set the value at the correct depth
+         (reduce (fn [g row-idx]
+                   (assoc-in g [row-idx depth] value))
+                 grid
+                 (range offset (+ offset span))))
+       ;; Start with an empty grid of appropriate dimensions
+       (vec (repeat result-height (vec (repeat column-count nil))))
+       left-header-items))))
 
-    :min
-    (fn [prev v]
-      (if (number? v)
-        (update prev :min
-                (fn [x] (if x
-                          (min x v)
-                          v)))
-        v))
-
-    :max
-    (fn [prev v]
-      (if (number? v)
-        (update prev :max
-                (fn [x] (if x
-                          (max x v)
-                          v)))
-        v))
-
-    ;; else
-    (fn [_prev v] v)))
-
-(defn- update-aggregate
-  "Update the given `measure-aggregations` with `new-values` using the appropriate function in the `agg-fns` map.
-
-  Measure aggregations is a map whose keys are each pivot-measure; often just 1 key, but could be several depending on how the user has set up their measures.
-  `new-values` are the values being added and have the same keys as `measure-aggregations`.
-  `agg-fns` is also a map of the measure keys indicating the type of aggregation.
-  For now (2024-09-10), agg-fn is `+`, which actually works fine for every aggregation type in our implementation. This is because the pivot qp
-  returns rows that have already done the aggregation set by the user in the query (eg. count or sum, or whatever), so the post-processing done here
-  will always work. For each 'cell', there will only ever be 1 value per measure (the already-aggregated value from the qp)."
-  [measure-aggregations new-values agg-fns]
-  (into {}
-        (map
-         (fn [[measure-key agg]]
-           (let [agg-fn-key (get agg-fns measure-key :total)
-                 new-v      (get new-values measure-key)]
-             [measure-key (if new-v
-                            (let [agg-fn (measure->agg-fn agg-fn-key)]
-                              (agg-fn agg new-v))
-                            agg)])))
-        measure-aggregations))
-
-(defn add-row
-  "Aggregate the given `row` into the `pivot` datastructure."
-  [pivot row]
-  (let [{:keys [pivot-rows
-                pivot-cols
-                pivot-measures
-                measures]} (:config pivot)
-        row-path           (mapv row pivot-rows)
-        col-path           (mapv row pivot-cols)
-        measure-vals       (select-keys row pivot-measures)
-        total-fn*          (fn [m path]
-                             (if (seq path)
-                               (update-in m path
-                                          #(update-aggregate (or % (zipmap pivot-measures (repeat {}))) measure-vals measures))
-                               m))
-        total-fn           (fn [m paths]
-                             (reduce total-fn* m paths))]
-    (-> pivot
-        (update :row-count (fn [v] (if v (inc v) 0)))
-        (update :data update-in (concat row-path col-path)
-                #(update-aggregate (or % (zipmap pivot-measures (repeat {}))) measure-vals measures))
-        (update :row-paths
-                #(when (seq row-path) (add-to-path-tree % row-path)))
-        (update :col-paths
-                #(when (seq col-path) (add-to-path-tree % col-path)))
-        (update :totals (fn [totals]
-                          (-> totals
-                              (total-fn [[:grand-total]
-                                         row-path
-                                         col-path
-                                         [:section-totals (first row-path)]])
-                              (total-fn (map (fn [part]
-                                               ;; here, the `:rows-part` and `:cols-part` keys exist to
-                                               ;; force paths into the :totals map to be unique.
-                                               ;; without this, it is possible that a path is already written to
-                                               ;; if a pivot-col value by chance happens to be the same number
-                                               ;; of an idx into the row, such as a product ID of 4 matching
-                                               ;; the pivot-measure idx of 4 if 2 pivot-rows and 1 pivot-col are configured.
-                                               ;; Previously, in such a case, the measure map (the second deepest 'nesting')
-                                               ;; can be erroneously accessed when later aggregating
-                                               ;; to try illustrate, let's say that earlier, these 2 steps occurred:
-
-                                               ;; `(assoc-in totals-map [:column-totals "RowA"] {4 {:result 1}})`
-                                               ;; `(assoc-in totals-map [:column-totals "RowA" 3] {4 {:result 1}})`
-
-                                               ;; the result will look like:
-                                               ;; {:column-totals {"RowA" {4 {:result 1}
-                                               ;;                          3 {4 {:result 1}}}}}
-
-                                               ;; Now, you're attempting to (update-aggregate totals-map [:column-totals "RowA"])
-                                               ;; but, you'll be operating on an unexpected map shape (the key 3 does not correspond to a measure)
-                                               ;; This is why in issue #50207, when switching around the pivot-rows, things broke. It wasn't
-                                               ;; the switching, but rather that the second pivot-row's values were IDs, thus the integer 4
-                                               ;; was part of some totals paths, breaking aggregating in later steps.
-                                               (concat [:column-totals :rows-part] part [:cols-part] col-path))
-                                             (rest (reductions conj [] row-path))))))))))
-
-(defn- fmt
-  "Format a value using the provided formatter or identity function."
-  [formatter v-map]
-  (let [value (if (map? v-map)
-                (or (:result v-map)
-                    (when (contains? v-map :total)
-                      (/ (double (:total v-map)) (:count v-map)))
-                    (:min v-map)
-                    (:max v-map)
-                    (seq v-map))
-                v-map)]
-    (when value
-      ((or formatter identity) (streaming.common/format-value value)))))
-
-(defn- build-column-headers
-  "Build multi-level column headers."
-  [{:keys [pivot-cols pivot-measures column-titles row-totals?]} col-combos col-formatters]
-  (perf/concat
-   (if (= 1 (count pivot-measures))
-     (mapv (fn [col-combo] (perf/mapv fmt col-formatters col-combo)) col-combos)
-     (into [] (mapcat (fn [col-combo]
-                        (let [formatted (perf/mapv fmt col-formatters col-combo)
-                              it (.iterator ^Iterable pivot-measures)]
-                          (loop [acc (transient [])]
-                            (if (.hasNext it)
-                              (recur (conj! acc (conj formatted (get column-titles (.next it)))))
-                              (persistent! acc))))))
-           col-combos))
-   (when row-totals?
-     (repeat (count pivot-measures)
-             (perf/concat
-              (when (and row-totals? (> (count pivot-cols) 0)) ["Row totals"])
-              (repeat (dec (count pivot-cols)) nil)
-              (when (and (seq pivot-cols) (> (count pivot-measures) 1)) [nil]))))))
-
-(defn- build-headers
-  "Combine row keys with column headers."
-  [column-headers {:keys [pivot-cols pivot-rows column-titles]}]
-  (some->> (not-empty (filterv seq column-headers))
-           perf/transpose
-           (mapv (fn [h]
-                   (perf/concat
-                    (perf/mapv #(get column-titles %)
-                               (if (and (seq pivot-cols) (empty? pivot-rows))
-                                 pivot-cols pivot-rows))
-                    h)))))
-
-(defn- build-row
-  "Build a single row of the pivot table."
-  [row-combo col-combos pivot-measures data totals row-totals? ordered-formatters row-formatters config]
-  ;; This implementation is very unorthodox, but this function is incredibly hot, so it must avoid allocation at all
-  ;; readability costs. Any iterator-based iteration allocates, but also constructing an internal mapping lambda that
-  ;; encloses the outer value is so so expensive.
-  (let [row-path       (vec row-combo)
-        row-data       (get-in data row-path)
-        n (count col-combos)
-        m (count pivot-measures)
-        result (ArrayList. (* (max 1 n) m))]
-    (when-not (seq row-formatters)
-      (dotimes [_ (count pivot-measures)] (.add result nil)))
-    ;; We first add the pivot row values before the actual row values. It is intentional that we don't format pivot
-    ;; row values just yet, because they will be used as data later on during grouping.
-    (perf/run! #(.add result %) row-combo)
-    (if (seq col-combos)
-      (loop [i 0, j -1, col-combo nil, vals nil]
-        ;; we need to lead with col-combo here so that each row will alternate between all of the measures, rather
-        ;; than have all measures of one kind bunched together. That is, if you have a table with `count` and
-        ;; `avg` the row must show count-val, avg-val, count-val, avg-val ... etc
-        (if (= j -1)
-          (when (< i n)
-            (let [col-combo (nth col-combos i)]
-              (recur i (inc j) col-combo (reduce get row-data col-combo))))
-          (if (< j m)
-            (let [measure-key (nth pivot-measures j)
-                  formatter (get ordered-formatters measure-key)
-                  formatted-val (fmt formatter (get vals measure-key))]
-              (.add result formatted-val)
-              (recur i (inc j) col-combo vals))
-            (recur (inc i) -1 nil nil))))
-      ;; If there are no columns, we still fill in one column per measure value
-      (run! (fn [measure-key]
-              (let [formatter (get ordered-formatters measure-key)]
-                (.add result (fmt formatter (get row-data measure-key)))))
-            pivot-measures))
-    (when (and row-totals? (> (count (:pivot-cols config)) 0))
-      (let [row-totals (get-in totals row-path)]
-        (run! #(.add result (fmt (get ordered-formatters %) (get row-totals %)))
-              pivot-measures)))
-    result))
-
-(defn- build-column-totals
-  "Build column totals for a section."
-  [section-path col-combos pivot-measures totals row-totals? ordered-formatters pivot-rows pivot-cols]
-  (let [cols-part (get-in totals (concat [:column-totals :rows-part] section-path [:cols-part]))
-        totals-row (ArrayList. (* (count col-combos) (count pivot-measures)))]
-    (if (seq col-combos)
-      (run! (fn [col-combo]
-              (let [m (reduce get cols-part col-combo)]
-                (run! (fn [measure-key]
-                        (.add totals-row (fmt (get ordered-formatters measure-key) (get m measure-key))))
-                      pivot-measures)))
-            col-combos)
-      ;; If there are no columns, we still fill in one column per measure value
-      (run! (fn [measure-key]
-              (.add totals-row (fmt (get ordered-formatters measure-key) (get cols-part measure-key))))
-            pivot-measures))
-    (perf/concat
-     [(format "Totals for %s" (fmt (get ordered-formatters (first pivot-rows)) (last section-path)))]
-     (repeat (dec (count pivot-rows)) nil)
-     totals-row
-     (when (and row-totals? (> (count pivot-cols) 0))
-       (let [totals' (-> totals :section-totals (get-in section-path))]
-         (mapv #(fmt (get ordered-formatters %) (get totals' %))
-               pivot-measures))))))
-
-(defn- build-grand-totals
-  "Build grand totals row."
-  [{:keys [pivot-cols pivot-rows pivot-measures]} col-combos totals row-totals? ordered-formatters]
-  (perf/concat
-   ["Grand totals"]
-   (repeat (dec (count (if (and (seq pivot-cols) (not (seq pivot-rows)))
-                         pivot-cols pivot-rows)))
-           nil)
-   (when (and row-totals? (> (count pivot-cols) 0))
-     (into [] (mapcat (fn [col-combo]
-                        (let [m (reduce get totals col-combo)]
-                          (perf/mapv #(fmt (get ordered-formatters %) (get m %)) pivot-measures))))
-           col-combos))
-   (for [measure-key pivot-measures]
-     (fmt (get ordered-formatters measure-key)
-          (get-in totals [:grand-total measure-key])))))
-
-(defn- append-totals-to-subsections
-  [pivot section col-combos ordered-formatters]
-  (let [{:keys [config
-                totals]}      pivot
-        {:keys [pivot-rows
-                pivot-cols
-                pivot-measures
-                row-totals?]} config]
-    (perf/concat
-     (reduce
-      (fn [section pivot-row-idx]
-        (mapcat
-         (fn [[k rows]]
-           (let [partial-path          (take pivot-row-idx (first rows))
-                 subtotal-path         (concat partial-path [k])
-                 total-row             (vec (build-column-totals
-                                             subtotal-path
-                                             col-combos
-                                             pivot-measures
-                                             totals
-                                             row-totals?
-                                             ordered-formatters
-                                             pivot-rows
-                                             pivot-cols))
-                 ;; inside a subsection, we know that the 'parent' subsection values will all be the same
-                 ;; so we can just grab it from the first row
-                 next-subsection-value (nth (first rows) (dec pivot-row-idx))]
-             (conj (vec rows)
-                   ;; assoc the next subsection's value into the row so it stays grouped in the next reduction
-                   (if (<= (dec pivot-row-idx) 0)
-                     total-row
-                     (assoc total-row (dec pivot-row-idx) next-subsection-value)))))
-         (group-by (fn [r] (nth r pivot-row-idx)) section)))
-      section
-      (reverse (range 1 (dec (count pivot-rows)))))
-     [(vec (build-column-totals
-            [(ffirst section)]
-            col-combos
-            pivot-measures
-            totals
-            row-totals?
-            ordered-formatters
-            pivot-rows
-            pivot-cols))])))
-
-(defn sort-path-tree
-  "Takes a tree of row or column paths and returns a new tree with ordered-maps replaced as needed with sorted-maps, and
-  ordered-sets replaced with sorted-sets, based on the provided `sort-orders` config. If no sort order is provided for
-  a particular row or column, it is left as-is."
-  [tree [first-index & indices] sort-orders]
-  (let [sort-order (get sort-orders first-index)
-        compare-fn (case sort-order
-                     :ascending compare
-                     :descending #(compare %2 %1)
-                     nil)]
-    (cond
-      (associative? tree)
-      (into (if compare-fn
-              (sorted-map-by compare-fn)
-              (ordered-map/ordered-map))
-            (for [[k v] tree]
-              [k (sort-path-tree v indices sort-orders)]))
-
-      (set? tree)
-      (if compare-fn
-        (into (sorted-set-by compare-fn) tree)
-        tree)
-
-      :else tree)))
-
-(defn enumerate-paths
-  "Enumerate all paths from the root to a leaf in a tree structure composed of maps and sets."
-  [m]
-  (letfn [(enumerate [prefix m]
-            (if-not (associative? m)
-              (mapv #(conj prefix %) m)
-              (into [] (mapcat (fn [[k v]]
-                                 (enumerate (conj prefix k) v))
-                               m))))]
-    (enumerate [] m)))
-
-(defn- format-pivot-row-cells
-  "In the almost final row, the pivot row cells still contain unformatted values. We need to format them."
-  [row row-formatters pivot-rows-cnt]
-  (if (pos? pivot-rows-cnt)
-    (let [first-entry (first row)]
-      ;; Exclude rows that begin with "Totals ..."
-      (if (and (string? first-entry) (str/starts-with? first-entry "Totals"))
-        row
-        ;; This manual iterator-loop goes over the whole row but applies the formatting only to first
-        ;; `pivot-rows-cnt` values, and leaves the rest of the values unchanged (they are already formatted).
-        (let [it (.iterator ^Iterable row)]
-          (loop [res (transient []), i 0]
-            (if (.hasNext it)
-              (recur (conj! res (if (< i pivot-rows-cnt)
-                                  (fmt (nth row-formatters i) (.next it))
-                                  (.next it)))
-                     (unchecked-inc i))
-              (persistent! res))))))
-    row))
+(defn- build-full-pivot
+  [get-row-section left-headers top-headers measure-count]
+  (let [row-count (count left-headers)
+        left-width (count (first left-headers))
+        col-count (- (count (first top-headers)) left-width)
+        result (perf/concat
+                top-headers
+                ;; For each row in left-headers...
+                (for [row-idx (range (max row-count 1))]
+                  (let [left-row (nth left-headers row-idx [])
+                        ;; ...get cell values for this row
+                        cell-values (mapcat (fn [col-idx]
+                                              (let [values (get-row-section col-idx row-idx)]
+                                                (map :value values)))
+                                            (range (/ col-count measure-count)))]
+                    ;; Combine left headers with cell values
+                    (into left-row cell-values))))]
+    (vec result)))
 
 (defn build-pivot-output
-  "Arrange and format the aggregated `pivot` data."
-  [pivot ordered-formatters]
-  (let [{:keys [config
-                data
-                totals
-                row-paths
-                col-paths]} pivot
-        {:keys [pivot-rows
-                pivot-cols
-                pivot-measures
-                ;; `column` here refers to columns in the original data, which can be pivot rows *or* columns
-                column-sort-order
-                column-titles
-                row-totals?
-                col-totals?]}   config
-        row-formatters          (mapv #(get ordered-formatters %) pivot-rows)
-        col-formatters          (mapv #(get ordered-formatters %) pivot-cols)
-        sorted-row-paths        (sort-path-tree row-paths pivot-rows column-sort-order)
-        sorted-col-paths        (sort-path-tree col-paths pivot-rows column-sort-order)
-        sorted-row-combos       (enumerate-paths sorted-row-paths)
-        sorted-col-combos       (enumerate-paths sorted-col-paths)
-        column-headers          (build-column-headers config sorted-col-combos col-formatters)
-        headers                 (or (not-empty (build-headers column-headers config))
-                                    [(mapv #(get column-titles %) (into (vec pivot-rows) pivot-measures))])]
-    (perf/concat
-     headers
-     (transduce
-      (remove empty?)
-      into []
-      (let [sections-rows
-            (mapv (fn [section-row-combos]
-                    (mapv (fn [row-combo]
-                            (build-row row-combo sorted-col-combos pivot-measures data totals
-                                       row-totals? ordered-formatters row-formatters config))
-                          section-row-combos))
-                  (partition-by first sorted-row-combos))
-            pivot-rows-cnt (count pivot-rows)]
-        (perf/mapv
-         (fn [section-rows]
-           (->>
-            section-rows
-            ;; section rows are either enriched with column-totals rows or left as is
-            ((fn [rows]
-               (if (and col-totals? (> (count pivot-rows) 1))
-                 (append-totals-to-subsections pivot rows sorted-col-combos ordered-formatters)
-                 rows)))
-            ;; then, we apply the row-formatters to the pivot-rows portion of each row,
-            ;; filtering out any rows that begin with "Totals ..."
-            (mapv #(format-pivot-row-cells % row-formatters pivot-rows-cnt))))
-         sections-rows)))
-     (when col-totals?
-       [(build-grand-totals config sorted-col-combos totals row-totals? ordered-formatters)]))))
+  "Processes pivot data into the final pivot structure for exports. Calls into metabase.pivot.core, which is the
+  postprocessing code shared with the FE pivot table implementation."
+  [{:keys [data settings timezone format-rows? pivot-export-options]}]
+  (let [columns                  (pivot/columns-without-pivot-group (:cols data))
+        column-split             (:pivot_table.column_split settings)
+        row-indexes              (:pivot-rows pivot-export-options)
+        col-indexes              (:pivot-cols pivot-export-options)
+        val-indexes              (:pivot-measures pivot-export-options)
+        col-settings             (merge-column-settings columns settings)
+        {:keys [row-formatters
+                col-formatters
+                val-formatters]} (make-formatters columns row-indexes col-indexes val-indexes settings timezone format-rows?)
+        {:keys [leftHeaderItems
+                topHeaderItems
+                getRowSection]}  (pivot/process-pivot-table data
+                                                            row-indexes
+                                                            col-indexes
+                                                            val-indexes
+                                                            columns
+                                                            col-formatters
+                                                            row-formatters
+                                                            val-formatters
+                                                            format-rows?
+                                                            settings
+                                                            col-settings)
+        top-left-header          (map (fn [i] (pivot/display-name-for-col (nth columns i)
+                                                                          (nth col-settings i)
+                                                                          format-rows?))
+                                      row-indexes)
+        top-headers              (build-top-headers top-left-header topHeaderItems)
+        left-headers             (build-left-headers leftHeaderItems)]
+    (build-full-pivot getRowSection left-headers top-headers (count (:values column-split)))))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.streaming.csv
   (:require
    [clojure.data.csv]
-   [clojure.string :as str]
    [medley.core :as m]
    [metabase.formatter :as formatter]
    [metabase.models.visualization-settings :as mb.viz]
@@ -9,7 +8,6 @@
    [metabase.query-processor.pivot.postprocess :as qp.pivot.postprocess]
    [metabase.query-processor.streaming.common :as streaming.common]
    [metabase.query-processor.streaming.interface :as qp.si]
-   [metabase.util :as u]
    [metabase.util.performance :as perf])
   (:import
    (java.io BufferedWriter OutputStream OutputStreamWriter)
@@ -27,16 +25,6 @@
                                                               (or filename-prefix "query_result")
                                                               (streaming.common/export-filename-timestamp))}
     :write-keepalive-newlines? false}))
-
-;; As a first step towards hollistically solving this issue: https://github.com/metabase/metabase/issues/44556
-;; (which is basically that very large pivot tables can crash the export process),
-;; The post processing is disabled completely.
-;; This should remain `false` until it's fixed
-;; TODO: rework this post-processing once there's a clear way in app to enable/disable it, or to select alternate download options
-(def ^:dynamic *pivot-export-post-processing-enabled*
-  "Flag to enable/disable export post-processing of pivot tables.
-  Disabled by default and should remain disabled until Issue #44556 is resolved and a clear plan is made."
-  false)
 
 (defn- write-csv
   "Custom implementation of `clojure.data.csv/write-csv` with a more efficient quote? predicate and no support for
@@ -70,18 +58,6 @@
                                 string))
                (when must-quote (.write writer "\"")))))
 
-(defn- col->aggregation-fn-key
-  [{agg-name :name source :source}]
-  (when (= :aggregation source)
-    (let [agg-name (u/lower-case-en agg-name)]
-      (cond
-        (str/starts-with? agg-name "sum")    :sum
-        (str/starts-with? agg-name "avg")    :avg
-        (str/starts-with? agg-name "min")    :min
-        (str/starts-with? agg-name "max")    :max
-        (str/starts-with? agg-name "count")  :count
-        (str/starts-with? agg-name "stddev") :stddev))))
-
 (defmethod qp.si/streaming-results-writer :csv
   [_ ^OutputStream os]
   (let [writer             (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
@@ -92,52 +68,47 @@
                    :or   {format-rows? true
                           pivot?       false}} :data} viz-settings]
         (let [col-names          (vec (streaming.common/column-titles ordered-cols (::mb.viz/column-settings viz-settings) format-rows?))
-              opts               (when (and pivot? pivot-export-options)
-                                   (-> (merge {:pivot-rows []
-                                               :pivot-cols []
-                                               :measures   (mapv col->aggregation-fn-key ordered-cols)}
-                                              pivot-export-options)
-                                       (assoc :column-titles col-names)
-                                       (qp.pivot.postprocess/add-totals-settings viz-settings)
-                                       qp.pivot.postprocess/add-pivot-measures))
               pivot-grouping-key (qp.pivot.postprocess/pivot-grouping-key col-names)]
-
-          ;; initialize the pivot-data
-          ;; If exporting pivoted, init the pivot data structure
-          ;; Otherwise, just store the pivot-grouping key index
-          (when (and pivot? pivot-export-options)
-            (reset! pivot-data (qp.pivot.postprocess/init-pivot opts)))
-          (when pivot-grouping-key
-            (swap! pivot-data assoc :pivot-grouping pivot-grouping-key))
+          (cond
+            (and pivot? pivot-export-options)
+            (reset! pivot-data
+                    {:settings viz-settings
+                     :data {:cols ordered-cols
+                            :rows []}
+                     :timezone results_timezone
+                     :format-rows? format-rows?
+                     :pivot-grouping-key pivot-grouping-key
+                     :pivot-export-options pivot-export-options})
+            ;; Non-pivoted export of pivot table: sore the pivot-grouping-key so that the pivot group can be
+            ;; removed from the exported data
+            pivot-export-options
+            (reset! pivot-data {:pivot-grouping-key pivot-grouping-key}))
 
           (vreset! ordered-formatters
                    (mapv #(formatter/create-formatter results_timezone % viz-settings format-rows?) ordered-cols))
 
           ;; write the column names for non-pivot tables
-          (when (or (not opts) (not (public-settings/enable-pivoted-exports)))
+          (when (or (not pivot?) (not (public-settings/enable-pivoted-exports)))
             (let [header (m/remove-nth (or pivot-grouping-key (inc (count col-names))) col-names)]
               (write-csv writer [header])
               (.flush writer)))))
 
       (write-row! [_ row _row-num _ {:keys [output-order]}]
-        (let [ordered-row              (if output-order
-                                         (let [row-v (into [] row)]
-                                           (into [] (for [i output-order] (row-v i))))
-                                         row)
-              {:keys [pivot-grouping]} (or (:config @pivot-data) @pivot-data)
-              group                    (get ordered-row pivot-grouping)]
-          (if (and (contains? @pivot-data :config) (public-settings/enable-pivoted-exports))
-            ;; if we're processing a pivot result, we don't write it out yet, just aggregate it
-            ;; so that we can post process the data in finish!
-            (when (= qp.pivot.postprocess/NON_PIVOT_ROW_GROUP (int group))
-              (swap! pivot-data (fn [pivot-data] (qp.pivot.postprocess/add-row pivot-data ordered-row))))
-
+        (let [ordered-row (if output-order
+                            (let [row-v (into [] row)]
+                              (into [] (for [i output-order] (row-v i))))
+                            row)
+              {:keys [pivot-grouping-key]} @pivot-data
+              group                    (get ordered-row pivot-grouping-key)]
+          (if (and (contains? @pivot-data :data) (public-settings/enable-pivoted-exports))
+            ;; TODO: try using a transient
+            (swap! pivot-data (fn [pivot-data] (update-in pivot-data [:data :rows] conj ordered-row)))
             (if group
               (when (= qp.pivot.postprocess/NON_PIVOT_ROW_GROUP (int group))
                 (let [formatted-row (->> (perf/mapv (fn [formatter r]
                                                       (formatter (streaming.common/format-value r)))
                                                     @ordered-formatters ordered-row)
-                                         (m/remove-nth pivot-grouping))]
+                                         (m/remove-nth pivot-grouping-key))]
                   (write-csv writer [formatted-row])
                   (.flush writer)))
               (let [formatted-row (perf/mapv (fn [formatter r]
@@ -148,9 +119,10 @@
 
       (finish! [_ _]
         ;; TODO -- not sure we need to flush both
-        (when (and (contains? @pivot-data :config) (public-settings/enable-pivoted-exports))
-          (doseq [xf-row (qp.pivot.postprocess/build-pivot-output @pivot-data @ordered-formatters)]
-            (write-csv writer [xf-row])))
+        (when (and (contains? @pivot-data :data) (public-settings/enable-pivoted-exports))
+          (let [output (qp.pivot.postprocess/build-pivot-output @pivot-data)]
+            (doseq [xf-row output]
+              (write-csv writer [xf-row]))))
         (.flush writer)
         (.flush os)
         (.close writer)))))

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -30,9 +30,10 @@
    (org.apache.poi.xssf.usermodel XSSFSheet)))
 
 (def ^:private cell-formatter (DataFormatter.))
+
 (defn- read-cell-with-formatting
   [c]
-  (.formatCellValue cell-formatter c))
+  (.formatCellValue ^DataFormatter cell-formatter c))
 
 (defn- read-xlsx
   [pivot result]
@@ -302,13 +303,17 @@
                     "2019-01-01T00:00:00Z"
                     "Row totals"]
                    ["Doohickey" "632.14" "854.19" "496.43" "203.13" "2185.89"]
-                   ["Gadget" "679.83" "1059.11" "844.51" "435.75" "3019.20"]
+                   ["Gadget" "679.83" "1059.11" "844.51" "435.75" "3019.2"]
                    ["Gizmo" "529.7" "1080.18" "997.94" "227.06" "2834.88"]
                    ["Widget" "987.39" "1014.68" "912.2" "195.04" "3109.31"]
                    ["Grand totals" "2829.06" "4008.16" "3251.08" "1060.98" "11149.28"]]
-                  #{:unsaved-card-download :card-download :dashcard-download
-                    :alert-attachment :subscription-attachment
-                    :public-question-download :public-dashcard-download}]
+                  #{:unsaved-card-download
+                    :card-download
+                    :dashcard-download
+                    :alert-attachment
+                    :subscription-attachment
+                    :public-question-download
+                    :public-dashcard-download}]
                  (->> (all-outputs! card {:export-format :csv :format-rows false :pivot true})
                       (group-by second)
                       ((fn [m] (update-vals m #(into #{} (mapv first %)))))
@@ -358,7 +363,7 @@
                                                  :breakout    [$category
                                                                !year.created_at]})}]
         (testing "formatted"
-          (is (= [[["Category" "2016" "2016" "2017" "2017" "2018" "2018" "2019" "2019" "Row totals" "Row totals"]
+          (is (= [[["" "2016" "2016" "2017" "2017" "2018" "2018" "2019" "2019" "Row totals" "Row totals"]
                    ["Category"
                     "Sum of Price"
                     "Average of Price"
@@ -368,23 +373,23 @@
                     "Average of Price"
                     "Sum of Price"
                     "Average of Price"
-                    ""
-                    ""]
-                   ["Doohickey" "$632.14" "48.63" "$854.19" "50.25" "$496.43" "62.05" "$203.13" "50.78" "$2,185.89" "52.93"]
-                   ["Gadget" "$679.83" "52.29" "$1,059.11" "55.74" "$844.51" "60.32" "$435.75" "62.25" "$3,019.20" "57.65"]
-                   ["Gizmo" "$529.70" "58.86" "$1,080.18" "51.44" "$997.94" "58.7" "$227.06" "56.77" "$2,834.88" "56.44"]
-                   ["Widget" "$987.39" "51.97" "$1,014.68" "56.37" "$912.20" "65.16" "$195.04" "65.01" "$3,109.31" "59.63"]
+                    "Sum of Price"
+                    "Average of Price"]
+                   ["Doohickey" "$632.14" "48.63" "$854.19" "50.25" "$496.43" "62.05" "$203.13" "50.78" "$2,185.89" "52.05"]
+                   ["Gadget" "$679.83" "52.29" "$1,059.11" "55.74" "$844.51" "60.32" "$435.75" "62.25" "$3,019.20" "56.97"]
+                   ["Gizmo" "$529.70" "58.86" "$1,080.18" "51.44" "$997.94" "58.7" "$227.06" "56.77" "$2,834.88" "55.59"]
+                   ["Widget" "$987.39" "51.97" "$1,014.68" "56.37" "$912.20" "65.16" "$195.04" "65.01" "$3,109.31" "57.58"]
                    ["Grand totals"
                     "$2,829.06"
-                    "52.94"
+                    "52.39"
                     "$4,008.16"
-                    "53.45"
+                    "53.44"
                     "$3,251.08"
-                    "61.56"
+                    "61.34"
                     "$1,060.98"
-                    "58.7"
+                    "58.94"
                     "$11,149.28"
-                    "56.66"]]
+                    "55.75"]]
                   #{:unsaved-card-download :card-download :dashcard-download
                     :alert-attachment :subscription-attachment
                     :public-question-download :public-dashcard-download}]
@@ -458,8 +463,8 @@
                        {:display                :pivot
                         :visualization_settings {:pivot_table.column_split
                                                  {:rows    ["C"]
-                                                  :columns ["A", "B"]
-                                                  :values  ["MEASURE"]}
+                                                  :columns ["A" "B"]
+                                                  :values  ["sum"]}
                                                  :pivot.show_row_totals    false
                                                  :pivot.show_column_totals false}
                         :dataset_query          (mt/mbql-query nil
@@ -471,7 +476,7 @@
                                                    :source-table (format "card__%s" pivot-data-card-id)})}]
           (let [result (card-download pivot-card {:export-format :csv :pivot true})]
             (is
-             (= [["C" "3" "4"]
+             (= [["" "3" "4"]
                  ["C" "BA" "BA"]
                  ["3" "1" "1"]
                  ["4" "1" "1"]]
@@ -522,7 +527,6 @@
                 (is (some? pivot))))))))))
 
 (deftest ^:parallel pivot-export-test
-  []
   (mt/dataset test-data
     (mt/with-temp [:model/Card {pivot-data-card-id :id}
                    {:dataset_query {:database (mt/id)
@@ -553,9 +557,10 @@
       (let [result (card-download pivot-card {:export-format :csv :pivot true})]
         (testing "Pivot CSV Exports look like a Pivoted Table"
           (testing "The Headers Properly indicate the pivot rows names."
-            ;; Pivot Rows Header are Simply the Column names from the rows specified in
+            ;; Pivot rows header are simply the column names from the rows specified in
             ;; [:visualization_settings :pivot_table.column_split :rows]
-            (is (= [["C" "D"]
+            ;; Because there are two pivot columns, the pivot row headers are only in the second row of the CSV.
+            (is (= [["" ""]
                     ["C" "D"]]
                    [(take 2 (first result))
                     (take 2 (second result))])))
@@ -578,15 +583,15 @@
                       (take 4 (drop 2 (second result)))]))
               ;; This combination logic would continue for each specified Pivot Column, but we'll just stick with testing 2
               ;; To keep things relatively easy to read and understand.
-              (testing "The first Header only contains possible values from the first specified pivot column"
+              (testing "The first header only contains possible values from the first specified pivot column"
                 (is (set/subset? possible-vals-of-a header1))
                 (is (not (set/subset? possible-vals-of-b header1))))
-              (testing "The second Header only contains possible values from the second specified pivot column"
+              (testing "The second header only contains possible values from the second specified pivot column"
                 (is (set/subset? possible-vals-of-b header2))
                 (is (not (set/subset? possible-vals-of-a header2))))
-              (testing "The Headers also show the Row Totals header"
-                (is (= ["Row totals" ""]
-                       (map last (take 2 result))))))))
+              (testing "The headers also show the Row Totals header"
+                (is (= "Row totals"
+                       (last (first result))))))))
 
         (testing "The Columns Properly indicate the pivot row names."
           (let [col1               (map first result)
@@ -637,7 +642,7 @@
                                                 {:format_rows   true
                                                  :pivot_results true})
                           csv/read-csv)]
-          (is (= [["Created At: Year"
+          (is (= [[""
                    "Doohickey" "Doohickey"
                    "Gadget" "Gadget"
                    "Gizmo" "Gizmo"
@@ -648,7 +653,7 @@
                    "Sum of Price" "Average of Rating"
                    "Sum of Price" "Average of Rating"
                    "Sum of Price" "Average of Rating"
-                   "" ""]]
+                   "Sum of Price" "Average of Rating"]]
                  (take 2 result))))))))
 
 (deftest ^:parallel pivot-export-aggregations-test
@@ -677,7 +682,7 @@
                           :visualization_settings {:pivot_table.column_split
                                                    {:rows    ["B" "C"]
                                                     :columns ["A"]
-                                                    :values  ["MEASURE"]}}
+                                                    :values  ["sum"]}}
                           :dataset_query          (mt/mbql-query nil
                                                     {:aggregation  [[:sum [:field "MEASURE" {:base-type :type/Integer}]]]
                                                      :breakout
@@ -690,8 +695,7 @@
                (= [["B" "C" "3" "4" "Row totals"]
                    ["BA" "3" "1" "1" "2"]
                    ["BA" "4" "1" "1" "2"]
-                   ["Totals for BA"  "" "2" "2" "4"]
-                   ["Grand totals" "" "2" "2" "4"]]
+                   ["Totals for BA"  "" "2" "2" "4"]]
                   result)))))))))
 
 (deftest ^:parallel zero-column-pivot-tables-test
@@ -736,8 +740,8 @@
                                                 {:format_rows   false
                                                  :pivot_results true})
                           csv/read-csv)]
-          (is (= [["Category" "Doohickey" "Gadget" "Gizmo" "Widget" "Row totals"]
-                  ["Grand totals" "2185.89" "3019.2" "2834.88" "3109.31" "11149.28"]]
+          (is (= [["Doohickey" "Gadget" "Gizmo" "Widget" "Row totals"]
+                  ["2185.89" "3019.2" "2834.88" "3109.31" "11149.28"]]
                  result)))))))
 
 (deftest ^:parallel zero-column-multiple-measures-pivot-tables-test
@@ -1330,7 +1334,7 @@
                    (update-vals formatted-results first)))))))))
 
 (deftest pivot-non-numeric-values-in-aggregations
-  (testing "A pivot table with an aggegation that results in non-numeric values (eg. Dates) will still worl (#49353)."
+  (testing "A pivot table with an aggegation that results in non-numeric values (eg. Dates) will still work (#49353)."
     (mt/dataset test-data
       (mt/with-temp [:model/Card card {:display                :pivot
                                        :dataset_query          (mt/mbql-query products

--- a/test/metabase/pivot/core_test.cljc
+++ b/test/metabase/pivot/core_test.cljc
@@ -1,0 +1,274 @@
+(ns metabase.pivot.core-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.pivot.core :as pivot]))
+
+(def ^:private pivot-test-data
+  "A minimal example of pivot data for testing."
+  {:rows [[1 "A" "Y" 0 1]
+          [1 "A" "Z" 0 1]
+          [1 "B" "Y" 0 1]
+          [1 "B" "Z" 0 1]
+          [1 "C" "Y" 0 1]
+          [1 "C" "Z" 0 1]
+          [2 "A" "Y" 0 1]
+          [2 "A" "Z" 0 1]
+          [2 "B" "Y" 0 1]
+          [2 "B" "Z" 0 1]
+          [2 "C" "Y" 0 1]
+          [2 "C" "Z" 0 1]
+          [nil "A" "Y" 1 2]
+          [nil "A" "Z" 1 2]
+          [nil "B" "Y" 1 2]
+          [nil "B" "Z" 1 2]
+          [nil "C" "Y" 1 2]
+          [nil "C" "Z" 1 2]
+          [nil nil "Y" 3 6]
+          [nil nil "Z" 3 6]
+          [1 "A" nil 4 2]
+          [1 "B" nil 4 2]
+          [1 "C" nil 4 2]
+          [2 "A" nil 4 2]
+          [2 "B" nil 4 2]
+          [2 "C" nil 4 2]
+          [nil "A" nil 5 4]
+          [nil "B" nil 5 4]
+          [nil "C" nil 5 4]
+          [nil nil nil 7 12]],
+   :pivot-export-options {:pivot-rows [1 0], :pivot-cols [2]},
+   :cols [{:database_type "INTEGER",
+           :semantic_type "type/PK",
+           :name "col0",
+           :source "breakout",
+           :field_ref ["field" "col0" {:base-type "type/Integer"}],
+           :effective_type "type/Integer",
+           :display_name "col0",
+           :remapping nil,
+           :remapped_from_index nil,
+           :base_type "type/Integer"}
+          {:database_type "CHARACTER VARYING",
+           :name "col1",
+           :source "breakout",
+           :field_ref ["field" "col1" {:base-type "type/Text"}],
+           :effective_type "type/Text",
+           :display_name "col1",
+           :remapping nil,
+           :remapped_from_index nil,
+           :fingerprint
+           {:global {:distinct-count 3, :nil% 0},
+            :type
+            {:type/Text
+             {:percent-json 0,
+              :percent-url 0,
+              :percent-email 0,
+              :percent-state 0,
+              :average-length 1}}},
+           :base_type "type/Text"}
+          {:database_type "CHARACTER VARYING",
+           :name "col2",
+           :source "breakout",
+           :field_ref ["field" "col2" {:base-type "type/Text"}],
+           :effective_type "type/Text",
+           :display_name "col2",
+           :remapping nil,
+           :remapped_from_index nil,
+           :fingerprint
+           {:global {:distinct-count 2, :nil% 0},
+            :type
+            {:type/Text
+             {:percent-json 0,
+              :percent-url 0,
+              :percent-email 0,
+              :percent-state 0,
+              :average-length 1}}},
+           :base_type "type/Text"}
+          {:database_type "INTEGER",
+           :name "pivot-grouping",
+           :expression_name "pivot-grouping",
+           :source "breakout",
+           :field_ref ["expression" "pivot-grouping"],
+           :effective_type "type/Integer",
+           :display_name "pivot-grouping",
+           :remapping nil,
+           :remapped_from_index nil,
+           :base_type "type/Integer"}
+          {:database_type "BIGINT",
+           :semantic_type "type/Quantity",
+           :name "count",
+           :source "aggregation",
+           :field_ref ["aggregation" 0],
+           :effective_type "type/BigInteger",
+           :aggregation_index 0,
+           :ident "S75TeXxnjAh0tJJDbzKg2",
+           :display_name "Count",
+           :remapping nil,
+           :remapped_from_index nil,
+           :base_type "type/BigInteger"}]})
+
+(deftest columns-without-pivot-group-test
+  (testing "Correctly filters out the pivot grouping column based on name"
+    (is (= ["col0" "col1" "col2" "count"]
+           (->> (pivot/columns-without-pivot-group (:cols pivot-test-data))
+                (map :name))))))
+
+(deftest split-pivot-data
+  (testing "split-pivot-table pulls apart the aggregations packed into a single
+    result set, keyed by the columns indexes that are aggregated"
+    (is (= {:pivot-data {[0 1 2] [[1 "A" "Y" 1]
+                                  [1 "A" "Z" 1]
+                                  [1 "B" "Y" 1]
+                                  [1 "B" "Z" 1]
+                                  [1 "C" "Y" 1]
+                                  [1 "C" "Z" 1]
+                                  [2 "A" "Y" 1]
+                                  [2 "A" "Z" 1]
+                                  [2 "B" "Y" 1]
+                                  [2 "B" "Z" 1]
+                                  [2 "C" "Y" 1]
+                                  [2 "C" "Z" 1]]
+                         [1 2]   [[nil "A" "Y" 2]
+                                  [nil "A" "Z" 2]
+                                  [nil "B" "Y" 2]
+                                  [nil "B" "Z" 2]
+                                  [nil "C" "Y" 2]
+                                  [nil "C" "Z" 2]]
+                         [2]     [[nil nil "Y" 6]
+                                  [nil nil "Z" 6]]
+                         [0 1]   [[1 "A" nil 2]
+                                  [1 "B" nil 2]
+                                  [1 "C" nil 2]
+                                  [2 "A" nil 2]
+                                  [2 "B" nil 2]
+                                  [2 "C" nil 2]]
+                         [1]     [[nil "A" nil 4]
+                                  [nil "B" nil 4]
+                                  [nil "C" nil 4]]
+                         []      [[nil nil nil 12]]}
+            :primary-rows-key [0 1 2]}
+           ;; Dissoc :columns beacuse this is the same as the result of `columns-without-pivot-group-test`, tested above
+           (dissoc (pivot/split-pivot-data pivot-test-data) :columns)))))
+
+(deftest get-subtotal-values-test
+  (testing "Extracts subtotal values from pivot data"
+    (let [pivot-data {[0 1 2] [[1 "A" "Y" 10]
+                               [1 "B" "Z" 20]]}
+          val-indexes [3]
+          result (#'pivot/get-subtotal-values pivot-data val-indexes nil)]
+      (is (= {[0 1 2] {[1 "A" "Y"] [10]
+                       [1 "B" "Z"] [20]}}
+             result)))))
+
+(deftest get-subtotal-values-primary-rows-key-test
+  (testing "Excludes the primary rows if passed a primary rows key"
+    (let [pivot-data {[0 1 2] [[1 "A" "Y" 10]
+                               [1 "B" "Z" 20]]}
+          val-indexes [3]
+          result (#'pivot/get-subtotal-values pivot-data val-indexes [0 1 2])]
+      (is (= {}
+             result)))))
+
+(deftest get-active-breakout-indexes-test
+  (testing "Correctly determines active breakout indexes from pivot group values"
+    (let [pivot-group   0  ;; All breakouts active (000 in binary)
+          num-breakouts 3]
+      (is (= [0 1 2]
+             (#'pivot/get-active-breakout-indexes pivot-group num-breakouts))))
+
+    (let [pivot-group   1  ;; One inactive breakout (001 in binary)
+          num-breakouts 3]
+      (is (= [1 2]
+             (#'pivot/get-active-breakout-indexes pivot-group num-breakouts))))
+
+    (let [pivot-group   6  ;; Two inactive breakouts (110 in binary)
+          num-breakouts 3]
+      (is (= [0]
+             (#'pivot/get-active-breakout-indexes pivot-group num-breakouts))))
+
+    (let [pivot-group   7  ;; No active breakouts (111 in binary)
+          num-breakouts 3]
+      (is (= []
+             (#'pivot/get-active-breakout-indexes pivot-group num-breakouts))))))
+
+(deftest get-subtotals-test
+  (testing "Returns correctly formatted subtotal values"
+    (let [subtotal-values {[0 1] {[1 "A"] [100 200]}}
+          breakout-indexes [0 1]
+          values [1 "A"]
+          other-attrs {:custom "attr"}
+          value-formatters [(fn [v] (str "$" v))
+                            (fn [v] (str v "%"))]
+          result (#'pivot/get-subtotals subtotal-values breakout-indexes values other-attrs value-formatters)]
+      (is (= [{:value "$100" :isSubtotal true :custom "attr"}
+              {:value "200%" :isSubtotal true :custom "attr"}]
+             result)))))
+
+(deftest create-row-section-getter-test
+  (testing "Returns a function that correctly retrieves cell values"
+    (let [values-by-key {["A" 1] {:values [10 20]
+                                  :valueColumns [{:name "count"} {:name "sum"}]
+                                  :data [{:value 1 :colIdx 0}
+                                         {:value "A" :colIdx 1}
+                                         {:value 10 :colIdx 2}
+                                         {:value 20 :colIdx 3}]
+                                  :dimensions [{:value 1 :colIdx 0}
+                                               {:value "A" :colIdx 1}]}}
+          subtotal-values {[1] {[1] [100 200]}}
+          value-formatters [#(str "$" %) #(str % "%")]
+          col-indexes [1]
+          row-indexes [0]
+          col-paths [["A"]]
+          row-paths [[1]]
+          color-getter (constantly "blue")
+          getter (#'pivot/create-row-section-getter values-by-key subtotal-values value-formatters
+                                                    col-indexes row-indexes col-paths row-paths color-getter)
+          result (getter 0 0)]
+      (is (= [{:value "$10"
+               :backgroundColor "blue"
+               :clicked {:data [{:value 1 :colIdx 0}
+                                {:value "A" :colIdx 1}
+                                {:value 10 :colIdx 2}
+                                {:value 20 :colIdx 3}]
+                         :dimensions [{:value 1 :colIdx 0}
+                                      {:value "A" :colIdx 1}]}}
+              {:value "20%"
+               :backgroundColor "blue"
+               :clicked {:data [{:value 1 :colIdx 0}
+                                {:value "A" :colIdx 1}
+                                {:value 10 :colIdx 2}
+                                {:value 20 :colIdx 3}]
+                         :dimensions [{:value 1 :colIdx 0}
+                                      {:value "A" :colIdx 1}]}}]
+             #?(:cljs (js->clj result :keywordize-keys true)
+                :clj result))))))
+
+(deftest tree-to-array-test
+  (testing "Correctly flattens a tree to array with position information"
+    (let [tree [{:value "A" :rawValue "A"
+                 :children [{:value "X" :rawValue "X" :children []}
+                            {:value "Y" :rawValue "Y" :children []}]}]
+          result (#'pivot/tree-to-array tree)]
+      (is (= [{:value "A"
+               :rawValue "A"
+               :depth 0
+               :offset 0
+               :hasChildren true
+               :path ["A"]
+               :span 2
+               :maxDepthBelow 1}
+              {:value "X"
+               :rawValue "X"
+               :depth 1
+               :offset 0
+               :hasChildren false
+               :path ["A" "X"]
+               :span 1
+               :maxDepthBelow 0}
+              {:value "Y"
+               :rawValue "Y"
+               :depth 1
+               :offset 1
+               :hasChildren false
+               :path ["A" "Y"]
+               :span 1
+               :maxDepthBelow 0}]
+             result)))))

--- a/test/metabase/query_processor/pivot/postprocess_test.clj
+++ b/test/metabase/query_processor/pivot/postprocess_test.clj
@@ -1,240 +1,119 @@
 (ns metabase.query-processor.pivot.postprocess-test
   (:require
    [clojure.test :refer :all]
-   [flatland.ordered.map :as ordered-map]
-   [flatland.ordered.set :as ordered-set]
-   [metabase.query-processor.pivot.postprocess :as process]))
+   [metabase.query-processor.pivot.postprocess :as pivot.postprocess]))
 
-(def ^:private column-titles
-  ["A" "B" "C" "D" "pivot-grouping" "MEASURE"])
+(deftest build-top-headers-test
+  (testing "builds top headers with single level hierarchy"
+    (let [top-left-header ["Row"]
+          top-header-items [{:depth 0 :value "A" :span 2}
+                            {:depth 0 :value "B" :span 1}]
+          result (#'pivot.postprocess/build-top-headers top-left-header top-header-items)]
+      (is (= [["Row" "A" "A" "B"]]
+             result))))
 
-(def ^:private pivot-spec
-  {:pivot-rows [2 3]
-   :pivot-cols [0 1]
-   :column-titles column-titles})
+  (testing "builds top headers with multi-level hierarchy"
+    (let [top-left-header ["Row1", "Row2"]
+          top-header-items [{:depth 0 :value "A" :span 2}
+                            {:depth 1 :value "X" :span 1}
+                            {:depth 1 :value "Y" :span 1}
+                            {:depth 0 :value "B" :span 1}
+                            {:depth 1 :value "Z" :span 1}]
+          result (#'pivot.postprocess/build-top-headers top-left-header top-header-items)]
+      (is (= [[nil nil "A" "A" "B"]
+              ["Row1" "Row2" "X" "Y" "Z"]]
+             result))))
 
-(deftest assoc-in-path-tree-test
-  (testing "Values are correctly assoc'ed into a path tree, maintaining insertion order at every level"
-    (let [base-tree (#'process/add-to-path-tree (ordered-map/ordered-map) [:a :b :c :d])]
-      ;; Assert on strings because direct map/set comparison doesn't preserve order, but strings do
-      (is (= "{:a {:b {:c #{:d}}}}" (str base-tree)))
-      (is (= "{:a {:b {:c #{:d :e}}}}"
-             (str (#'process/add-to-path-tree base-tree [:a :b :c :e]))))
-      (is (= "{:a {:b {:c #{:d :c}}}}"
-             (str (#'process/add-to-path-tree base-tree [:a :b :c :c]))))
-      (is (= "{:a {:b {:c #{:d}}, :e {:f #{:g}}}}"
-             (str (#'process/add-to-path-tree base-tree [:a :e :f :g]))))
-      (is (= "{:a {:b {:c #{:d}}, :a {:f #{:g}}}}"
-             (str (#'process/add-to-path-tree base-tree [:a :a :f :g]))))))
+  (testing "handles empty top header items withotu error"
+    (let [top-left-header ["Row"]
+          top-header-items []
+          result (#'pivot.postprocess/build-top-headers top-left-header top-header-items)]
+      (is (= [["Row"]]
+             result)))))
 
-  (testing "Assoc'ing a value with no key to an ordered map converts it to a top-level ordered set"
-    (let [new-tree (#'process/add-to-path-tree (ordered-map/ordered-map) [:a])]
-      (is (= [:a] (seq new-tree))))
+(deftest build-left-headers-test
+  (testing "builds left headers with single level hierarchy"
+    (let [left-header-items [{:depth 0 :value "A" :span 1 :offset 0}
+                             {:depth 0 :value "B" :span 1 :offset 1}]
+          result (#'pivot.postprocess/build-left-headers left-header-items)]
+      (is (= [["A"]
+              ["B"]]
+             result))))
 
-    (let [new-tree (#'process/add-to-path-tree (ordered-set/ordered-set :b) [:a])]
-      (is (= [:b :a] (seq new-tree))))))
+  (testing "builds left headers with multi-level hierarchy"
+    (let [left-header-items [{:depth 0 :value "A" :span 2 :offset 0}
+                             {:depth 1 :value "X" :span 1 :offset 0}
+                             {:depth 1 :value "Y" :span 1 :offset 1}
+                             {:depth 0 :value "B" :span 1 :offset 2}
+                             {:depth 1 :value "Z" :span 1 :offset 2}]
+          result (#'pivot.postprocess/build-left-headers left-header-items)]
+      (is (= [["A" "X"]
+              ["A" "Y"]
+              ["B" "Z"]]
+             result))))
 
-(deftest sort-path-tree-test
-  (testing "sort-path-tree with ascending and descending orders using integer indices in sort-orders"
-    (let [tree (ordered-map/ordered-map
-                :a (ordered-set/ordered-set 3 1 2)
-                :b (ordered-map/ordered-map
-                    :x (ordered-set/ordered-set 5 4 6)
-                    :y (ordered-set/ordered-set 8 7 9)))
-          sort-orders {0 :ascending
-                       1 :descending}
-          result (#'process/sort-path-tree tree [0 1] sort-orders)]
-      ;; Assert top-level keys are in ascending order
-      (is (= [:a :b] (keys result)))
-      ;; Assert second-level values in :a are in descending order
-      (is (= [3 2 1] (seq (get result :a))))
-      ;; Assert nested keys (:x, :y) in :b are in descending order
-      (is (= [:y :x] (keys (get result :b))))
-      ;; Assert :x and :y sets remain unsorted (no specific sort order provided for them)
-      (is (= [5 4 6] (seq (get-in result [:b :x]))))
-      (is (= [8 7 9] (seq (get-in result [:b :y]))))))
+  (testing "handles empty left header items without error"
+    (let [left-header-items []
+          result (#'pivot.postprocess/build-left-headers left-header-items)]
+      (is (= []
+             result)))))
 
-  (testing "sort-path-tree with no sort order provided"
-    (let [tree (ordered-map/ordered-map
-                :a (ordered-set/ordered-set 3 1 2)
-                :b (ordered-map/ordered-map
-                    :x (ordered-set/ordered-set 5 4 6)))
-          sort-orders {}
-          result (#'process/sort-path-tree tree [0 1] sort-orders)]
-      ;; Ensure the original tree structure remains intact
-      (is (= (str tree) (str result)))))
+(deftest build-full-pivot-test
+  (testing "builds full pivot table correctly"
+    (let [get-row-section (fn [col-idx row-idx]
+                            (case [col-idx row-idx]
+                              [0 0] [{:value "100"}]
+                              [0 1] [{:value "200"}]
+                              [1 0] [{:value "300"}]
+                              [1 1] [{:value "400"}]
+                              []))
+          left-headers [["Row A"]
+                        ["Row B"]]
+          top-headers [["" "Col X" "Col Y"]]
+          measure-count 1
+          result (#'pivot.postprocess/build-full-pivot get-row-section left-headers top-headers measure-count)]
+      (is (= [["" "Col X" "Col Y"]
+              ["Row A" "100" "300"]
+              ["Row B" "200" "400"]]
+             result))))
 
-  (testing "sort-path-tree with nil input"
-    (is (nil? (#'process/sort-path-tree nil [] {})))))
+  (testing "handles multiple measures per column"
+    (let [get-row-section (fn [col-idx row-idx]
+                            (case [col-idx row-idx]
+                              [0 0] [{:value "100"} {:value "101"}]
+                              [0 1] [{:value "200"} {:value "201"}]
+                              [1 0] [{:value "300"} {:value "301"}]
+                              [1 1] [{:value "400"} {:value "401"}]
+                              []))
+          left-headers [["Row A"]
+                        ["Row B"]]
+          top-headers [["" "Col X" "Col X" "Col Y" "Col Y"]]
+          measure-count 2
+          result (#'pivot.postprocess/build-full-pivot get-row-section left-headers top-headers measure-count)]
+      (is (= [["" "Col X" "Col X" "Col Y" "Col Y"]
+              ["Row A" "100" "101" "300" "301"]
+              ["Row B" "200" "201" "400" "401"]]
+             result))))
 
-(deftest enumerate-paths-test
-  (testing "enumerate-paths with nested maps and sets"
-    (let [tree (ordered-map/ordered-map
-                :a (ordered-map/ordered-map
-                    :w (ordered-set/ordered-set 1 2)
-                    :x (ordered-set/ordered-set 2 1)))]
-      (is (= [[:a :w 1]
-              [:a :w 2]
-              [:a :x 2]
-              [:a :x 1]]
-             (#'process/enumerate-paths tree)))))
+  (testing "handles empty left headers without error"
+    (let [get-row-section (fn [col-idx row-idx]
+                            (case [col-idx row-idx]
+                              [0 0] [{:value "100"}]
+                              []))
+          left-headers []
+          top-headers [["" "Col X"]]
+          measure-count 1
+          result (#'pivot.postprocess/build-full-pivot get-row-section left-headers top-headers measure-count)]
+      (is (= [["" "Col X"]
+              ["100"]]
+             result))))
 
-  (testing "enumerate-paths with a single-level set"
-    (let [tree (ordered-set/ordered-set 1 2 3)]
-      (is (= [[1] [2] [3]]
-             (#'process/enumerate-paths tree)))))
-
-  (testing "enumerate-paths with empty input"
-    (is (= [] (#'process/enumerate-paths {})))))
-
-(deftest add-pivot-measures-test
-  (testing "Given a `pivot-spec` without `:pivot-measures`, add them."
-    (is (= [5] (:pivot-measures (process/add-pivot-measures pivot-spec))))))
-
-(deftest pivot-aggregation-test
-  (testing "The pivot aggregation datastructure stores values as expected"
-    (let [pivot-config {:pivot-rows     [0]
-                        :pivot-cols     [1]
-                        :column-titles  ["A" "B" "pivot-grouping" "Count"]
-                        :row-totals?    true
-                        :col-totals?    true
-                        :pivot-measures [3]
-                        :pivot-grouping 2}
-          pivot        (process/init-pivot pivot-config)
-          pivot-data   (reduce process/add-row pivot [["aA" "bA" 0 1] ; add 4 rows in aA bA
-                                                      ["aA" "bA" 0 1]
-                                                      ["aA" "bA" 0 1]
-                                                      ["aA" "bA" 0 1]
-                                                      ["aA" "bB" 0 1]
-                                                      ["aA" "bC" 0 1]
-                                                      ["aA" "bD" 0 1]
-                                                      ["aB" "bA" 0 1]
-                                                      ["aB" "bB" 0 1]
-                                                      ["aB" "bC" 0 1]
-                                                      ["aB" "bD" 0 1]])]
-      (testing "data aggregation matches the input rows"
-        ;; Every row will contribute to the MEASURE somewhere, determined by
-        ;; the values in each pivot-row and pivot-col index. For example,
-        ;; given the pivot-config in this test, the row `["X" "Y" 0 1]` will end up adding
-        ;; {"X" {"Y" {3 {:result 1}}}}
-        ;; the operation is essentially an assoc-in done per measure:
-
-        ;;   assoc-in    path from rows cols and measures            value from measure idx
-        ;; `(assoc-in (concat pivot-rows pivot-cols pivot-measures) (get-in row measure-idx))`
-        (is (= {"aA" {"bA" {3 {:result 4}}
-                      "bB" {3 {:result 1}}
-                      "bC" {3 {:result 1}}
-                      "bD" {3 {:result 1}}}
-                "aB" {"bA" {3 {:result 1}}
-                      "bB" {3 {:result 1}}
-                      "bC" {3 {:result 1}}
-                      "bD" {3 {:result 1}}}}
-               (:data pivot-data)))
-
-        ;; Distinct values of rows and columns are built into a tree composed of ordered maps and sets. If there is only
-        ;; one row/col, it is stored as an ordered set at the top-level.
-        (is (= {:row-paths #{"aA" "aB"}
-                :col-paths #{"bA" "bB" "bC" "bD"}}
-               (select-keys pivot-data [:row-paths :col-paths])))
-        (is (= flatland.ordered.set.OrderedSet (type (:row-paths pivot-data))))
-        (is (= flatland.ordered.set.OrderedSet (type (:col-paths pivot-data))))
-
-        ;; since everything is aggregated as a row is added, we can store all of the
-        ;; relevant totals right away and use them to construct the pivot table totals
-        ;; if the user has specified them on (they're on by default and likely to be on most of the time)
-        (is (= {:grand-total {3 {:result 11}}
-                :section-totals {"aA" {3 {:result 7}} "aB" {3 {:result 4}}} ;; section refers to the 'row totals' interspersed between each row-wise group
-                :column-totals {:rows-part
-                                {"aA" {:cols-part {"bA" {3 {:result 4}}
-                                                   "bB" {3 {:result 1}}
-                                                   "bC" {3 {:result 1}}
-                                                   "bD" {3 {:result 1}}}}
-                                 "aB" {:cols-part {"bA" {3 {:result 1}}
-                                                   "bB" {3 {:result 1}}
-                                                   "bC" {3 {:result 1}}
-                                                   "bD" {3 {:result 1}}}}}}
-                "aA" {3 {:result 7}}
-                "aB" {3 {:result 4}}
-                "bC" {3 {:result 2}}
-                "bB" {3 {:result 2}}
-                "bD" {3 {:result 2}}
-                "bA" {3 {:result 5}}}
-               (:totals pivot-data)))))))
-
-(deftest pivot-aggregation-no-collisions-test
-  (testing "The pivot aggregation datastructure stores values as expected"
-    (let [pivot-config {:pivot-rows     [0 1]
-                        :pivot-cols     [2]
-                        :column-titles  ["A" "B" "pivot-grouping" "Count"]
-                        :row-totals?    true
-                        :col-totals?    true
-                        :pivot-measures [4]
-                        :pivot-grouping 3}
-          pivot        (process/init-pivot pivot-config)
-          pivot-data   (reduce process/add-row pivot [["aA" 11 1  0 1]
-                                                      ["aA" 10 2  0 1]
-                                                      ["aA"  9 3  0 1]
-                                                      ["aA"  8 4  0 1]
-                                                      ["aA"  7 5  0 1]
-                                                      ["aA"  6 6  0 1]
-                                                      ["aA"  5 7  0 1]
-                                                      ["aB"  4 8  0 1]
-                                                      ["aB"  3 9  0 1]
-                                                      ["aB"  2 10 0 1]
-                                                      ["aB"  1 11 0 1]])]
-      pivot-data)))
-
-(deftest add-rows-and-totals-test
-  (testing "Adding Rows produces the correct entries in :totals without 'collisions' on any indices. (#50207)"
-    (let [build-row           #'process/build-row
-          build-column-totals #'process/build-column-totals
-          pivot-config        {:pivot-rows     [0 1]
-                               :pivot-cols     [2]
-                               :column-titles  ["A" "B" "C" "pivot-grouping" "Sum of MEASURE"]
-                               :row-totals?    true
-                               :col-totals?    true
-                               :pivot-measures [4]
-                               :pivot-grouping 3}
-          pivot               (process/init-pivot pivot-config)
-          rows                [[3 "BA" 3 0 1]
-                               [3 "BA" 4 0 2]
-                               [4 "BA" 3 0 3]
-                               [4 "BA" 4 0 4]]
-          pivot-data          (reduce process/add-row pivot rows)]
-      (is (= {:data {3 {"BA" {3 {4 {:result 1}}}}},
-              :totals
-              {:grand-total    {4 {:result 1}},
-               3               {"BA" {4 {:result 1}}},
-               :section-totals {3 {4 {:result 1}}},
-               :column-totals  {:rows-part {3 {:cols-part {3 {4 {:result 1}}} "BA" {:cols-part {3 {4 {:result 1}}}}}}}}}
-             (select-keys (process/add-row pivot (first rows)) [:data :totals])))
-      (is (= {:data   {3 {"BA" {3 {4 {:result 1}}, 4 {4 {:result 2}}}}},
-              :totals {:grand-total    {4 {:result 3}},
-                       3               {"BA" {4 {:result 3}}},
-                       4               {4 {:result 2}},
-                       :section-totals {3 {4 {:result 3}}},
-                       :column-totals  {:rows-part
-                                        {3 {:cols-part {3 {4 {:result 1}},
-                                                        4 {4 {:result 2}}},
-                                            "BA"       {:cols-part {3 {4 {:result 1}},
-                                                                    4 {4 {:result 2}}}}}}}}}
-             (select-keys (reduce process/add-row pivot (take 2 rows)) [:data :totals])))
-      (is (= [4 "BA" 3 4 7]
-             (build-row [4 "BA"]
-                        [[3] [4]]
-                        [4]
-                        (:data pivot-data)
-                        (:totals pivot-data)
-                        true
-                        (repeat 5 identity)
-                        (repeat 2 identity)
-                        pivot-config)))
-      (is (= ["Totals for 4" nil 3 4 7]
-             (build-column-totals [4]
-                                  [[3] [4]]
-                                  [4]
-                                  (:totals pivot-data)
-                                  true
-                                  (repeat 5 identity)
-                                  [0 1]
-                                  [2]))))))
+  (testing "handles no values in row sections without error"
+    (let [get-row-section (constantly [])
+          left-headers [["Row A"]]
+          top-headers [["" "Col X"]]
+          measure-count 1
+          result (#'pivot.postprocess/build-full-pivot get-row-section left-headers top-headers measure-count)]
+      (is (= [["" "Col X"]
+              ["Row A"]]
+             result)))))


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/55423 to 53

This was originally backported in https://github.com/metabase/metabase/pull/55423 but reverted, but we've decided to backport again due to a customer need ([Slack thread](https://metaboat.slack.com/archives/C05NXACAG1G/p1744235530428769?thread_ts=1742397482.455879&cid=C05NXACAG1G))

Edit: original revert was because it's a larger change than we normally backport, so we decided not to backport in case there were unknown risks. now that it's baked in 54 a bit we feel safer about backporting.