### PR TITLE
Correct output for dashboard filter variables

### DIFF
--- a/bin/test-cljs.js
+++ b/bin/test-cljs.js
@@ -1,0 +1,19 @@
+#!node
+
+const namespace = process.argv[2];
+
+const fs = require("fs");
+const debounce = require("lodash.debounce");
+const { spawn } = require('child_process');
+
+const debouncedHandler = debounce((event, filename) => {
+  console.log(`Change detected: ${event} - ${filename}`);
+
+  const child = spawn('node', namespace?['target/node-tests.js', "--test="+ namespace]:['target/node-tests.js'], { stdio: 'inherit' });
+}, 300);
+
+console.log("Watching target/node-tests.js");
+
+fs.watch("target/node-tests.js", { recursive: true }, debouncedHandler);
+
+debouncedHandler();

--- a/src/metabase/models/params/shared.cljc
+++ b/src/metabase/models/params/shared.cljc
@@ -346,4 +346,3 @@
             (add-values-to-variables tag->normalized-param locale escape-markdown)
             join-consecutive-strings
             strip-optional-blocks)))))
-

--- a/src/metabase/util/time.cljc
+++ b/src/metabase/util/time.cljc
@@ -92,6 +92,13 @@
   ([temporal-value unit locale]
    (internal/format-unit temporal-value unit locale)))
 
+(defn parse-unit
+  "Parses a string given the unit of time to parse by."
+  ([str unit]
+   (internal/parse-unit str unit))
+  ([str unit locale]
+   (internal/parse-unit str unit locale)))
+
 (defn format-diff
   "Formats a time difference between two temporal values.
    Drops redundant information."

--- a/src/metabase/util/time/impl.clj
+++ b/src/metabase/util/time/impl.clj
@@ -2,6 +2,7 @@
   (:require
    [java-time.api :as t]
    [metabase.util.date-2 :as u.date]
+   [metabase.util.i18n :as i18n]
    [metabase.util.time.impl-common :as common])
   (:import
    (java.time.format DateTimeFormatter)
@@ -327,15 +328,18 @@
     :always (localize)))
 
 (def ^:private unit-formats
-  {:day-of-week     "EEEE"
-   :day-of-week-iso "EEEE"
-   :month-of-year   "MMM"
-   :minute-of-hour  "m"
-   :hour-of-day     "h a"
-   :day-of-month    "d"
-   :day-of-year     "D"
-   :week-of-year    "w"
-   :quarter-of-year "'Q'Q"})
+  {:day-of-week        "EEEE"
+   :day-of-week-abbrev "EEE"
+   :day-of-week-iso    "EEEE"
+   :month-of-year      "MMM"
+   :month-of-year-full "MMMM"
+   :minute-of-hour     "m"
+   :hour-of-day        "h a"
+   :hour-of-day-24     "H"
+   :day-of-month       "d"
+   :day-of-year        "D"
+   :week-of-year       "w"
+   :quarter-of-year    "'Q'Q"})
 
 (defn ^:private format-extraction-unit
   "Formats a date-time value given the temporal extraction unit.
@@ -344,7 +348,7 @@
   (when-let [^DateTimeFormatter formatter (some-> unit
                                                   unit-formats
                                                   t/formatter
-                                                  (cond-> #_formatter locale (.withLocale locale)))]
+                                                  (cond-> #_formatter locale (.withLocale (i18n/locale locale))))]
     (.format formatter t)))
 
 (defn format-unit
@@ -352,7 +356,8 @@
    If unit is nil, formats the full date/time"
   ([input unit] (format-unit input unit nil))
   ([input unit locale]
-   (if (string? input)
+   (cond
+     (string? input)
      (let [time? (common/matches-time? input)
            date? (common/matches-date? input)
            date-time? (common/matches-date-time? input)
@@ -368,11 +373,41 @@
             date? (t/format "MMM d, yyyy" t)
             :else (t/format "MMM d, yyyy, h:mm a" t)))
          input))
+
+     (number? input)
      (if (= unit :hour-of-day)
        (str (cond (zero? input) "12" (<= input 12) input :else (- input 12)) " " (if (<= input 11) "AM" "PM"))
        (or
         (format-extraction-unit (common/number->timestamp input {:unit unit}) unit locale)
-        (str input))))))
+        (str input)))
+
+     (instance? java.time.temporal.TemporalAccessor input)
+     (let [input ^java.time.temporal.TemporalAccessor input]
+       (or (format-extraction-unit input unit locale)
+           (cond
+             ;; no hour, must be date
+             (not (.isSupported input (t/field :hour-of-day)))
+             (t/format "MMM d, yyyy" input)
+
+             ;; no day, must be time
+             (not (.isSupported input (t/field :day-of-month)))
+             (t/format "h:mm a" input)
+
+             :else ;; otherwise both date and time
+             (t/format "MMM d, yyyy, h:mm a" input))
+           (str input))))))
+
+(defn parse-unit
+  "Parse a unit of time/date, e.g., 'Wed' or 'August' or '14'."
+  ([str unit]
+   (parse-unit str unit nil))
+  ([str unit locale]
+   (some-> unit
+           unit-formats
+           t/formatter
+           (cond-> #_formatter
+            locale (.withLocale (i18n/locale locale)))
+           (.parse str))))
 
 (defn format-diff
   "Formats a time difference between two temporal values.

--- a/src/metabase/util/time/impl.cljs
+++ b/src/metabase/util/time/impl.cljs
@@ -228,30 +228,64 @@
       common/drop-trailing-time-zone
       (moment/utc moment/ISO_8601)))
 
+(def ^:private unit-formats
+  {:day-of-week        "dddd"
+   :day-of-week-abbrev "ddd"
+   :day-of-week-iso    "dddd"
+   :month-of-year      "MMM"
+   :month-of-year-full "MMMM"
+   :minute-of-hour     "m"
+   :hour-of-day        "h A"
+   :hour-of-day-24     "h"
+   :day-of-month       "D"
+   :day-of-year        "DDD"
+   :week-of-year       "w"
+   :quarter-of-year    "[Q]Q"})
+
 (defn ^:private format-extraction-unit
   "Formats a date-time value given the temporal extraction unit.
   If unit is not supported, returns nil."
-  [t unit]
-  (case unit
-    :day-of-week     (.format t "dddd")
-    :day-of-week-iso (.format t "dddd")
-    :month-of-year   (.format t "MMM")
-    :minute-of-hour  (.format t "m")
-    :hour-of-day     (.format t "h A")
-    :day-of-month    (.format t "D")
-    :day-of-year     (.format t "DDD")
-    :week-of-year    (.format t "w")
-    :quarter-of-year (.format t "[Q]Q")
-    nil))
+  [t unit locale]
+  (when-some [format (get unit-formats unit)]
+    (if locale
+      (-> t
+          (.locale locale)
+          (.format format))
+      (.format t format))))
+
+(defn- has-explicit-time?
+  "Does this moment value have explicit time parts (i.e., what it parsed with time components?"
+  [m]
+  ;; type hints to quell warnings from compiler
+  (let [^js/Object flags (.parsingFlags ^moment/Moment m)
+        ^js/Array parts (.-parsedDateParts flags)]
+    (when parts
+      (some (fn [i] (aget parts i)) [3 ;; hours
+                                     4 ;; minutes
+                                     5 ;; seconds
+                                     ]))))
+
+(defn- has-explicit-date?
+  "Does this moment value have explicit date parts (i.e., what it parsed with date components?"
+  [m]
+  ;; type hints to quell warnings from compiler
+  (let [^js/Object flags (.parsingFlags ^moment/Moment m)
+        ^js/Array parts (.-parsedDateParts flags)]
+    (when parts
+      (some (fn [i] (aget parts i)) [0 ;; year
+                                     1 ;; month
+                                     2 ;; day
+                                     ]))))
 
 (defn format-unit
   "Formats a temporal-value (iso date/time string, int for extraction units) given the temporal-bucketing unit.
    If unit is nil, formats the full date/time.
    Time input formatting is only defined with time units."
   ;; This third argument is needed for the JVM side; it can be ignored here.
-  ([input unit _locale] (format-unit input unit))
-  ([input unit]
-   (if (string? input)
+  ([input unit] (format-unit input unit nil))
+  ([input unit locale]
+   (cond
+     (string? input)
      (let [time? (common/matches-time? input)
            date? (common/matches-date? input)
            date-time? (common/matches-date-time? input)
@@ -262,17 +296,48 @@
                (or date? date-time?) (coerce-local-date-time input))]
        (if (and t (.isValid t))
          (or
-          (format-extraction-unit t unit)
+          (format-extraction-unit t unit locale)
+          ;; no locale for default formats
           (cond
             time? (.format t "h:mm A")
             date? (.format t "MMM D, YYYY")
             date-time? (.format t "MMM D, YYYY, h:mm A")))
          input))
+
+     (number? input)
      (if (= unit :hour-of-day)
        (str (cond (zero? input) "12" (<= input 12) input :else (- input 12)) " " (if (<= input 11) "AM" "PM"))
        (or
-        (format-extraction-unit (common/number->timestamp input {:unit unit}) unit)
-        (str input))))))
+        (format-extraction-unit (common/number->timestamp input {:unit unit}) unit locale)
+        (str input)))
+
+     (moment/isMoment input)
+     (or (format-extraction-unit input unit locale)
+         ;; no locale for default formats
+         (cond
+           ;; no hour, minute, or seconds, must be date
+           (not (has-explicit-time? input))
+           (.format input "MMM D, YYYY")
+
+           ;; no year, month, or day, must be a time
+           (not (has-explicit-date? input))
+           (.format input "h:mm A")
+
+           :else ;; otherwise both date and time
+           (.format input "MMM D, YYYY, h:mm A"))))))
+
+(defn parse-unit
+  "Parse a unit of time/date, e.g., 'Wed' or 'August' or '14'."
+  ([input unit]
+   (when-some [format (get unit-formats unit)]
+     (moment input format)))
+  ([input unit locale]
+   (let [temp (.locale moment)]     ;; 1. save current locale
+     (try
+       (.locale moment locale)      ;; 2. set new locale for subsequent parse
+       (parse-unit input unit)
+       (finally
+         (.locale moment temp)))))) ;; 3. set locale to original
 
 (defn format-diff
   "Formats a time difference between two temporal values.

--- a/test/metabase/models/params/shared_test.cljc
+++ b/test/metabase/models/params/shared_test.cljc
@@ -191,11 +191,73 @@
 
       "{{foo}}"
       {"foo" {:type :date/all-options :value "~2022-07-09"}}
-      "July 9\\, 2022"
+      "Before July 9\\, 2022"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "2022-07-09~"}}
+      "After July 9\\, 2022"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "2022-07-09"}}
+      "On July 9\\, 2022"
 
       "{{foo}}"
       {"foo" {:type :date/all-options :value "2022-07-06~2022-07-09"}}
       "July 6\\, 2022 \\- July 9\\, 2022"))
+
+  (t/testing "Exclude options are formatted correctly"
+    (t/are [text tag->param expected] (= expected (params/substitute-tags text tag->param))
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-months-Jul"}}
+      "Exclude July"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-months-Dec"}}
+      "Exclude December"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-months-Dec-Sep"}}
+      "Exclude December\\, September"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-months-Dec-Sep-Jul"}}
+      "Exclude 3 selections"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-hours-0"}}
+      "Exclude 12 AM"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-hours-0-14"}}
+      "Exclude 12 AM\\, 2 PM"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-hours-0-14-16"}}
+      "Exclude 3 selections"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-days-Mon"}}
+      "Exclude Monday"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-days-Wed-Fri"}}
+      "Exclude Wednesday\\, Friday"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-days-Tue-Sat-Sun"}}
+      "Exclude 3 selections"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-quarters-1"}}
+      "Exclude Q1"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-quarters-2-3"}}
+      "Exclude Q2\\, Q3"
+
+      "{{foo}}"
+      {"foo" {:type :date/all-options :value "exclude-quarters-2-1-4"}}
+      "Exclude 3 selections"))
 
   (t/testing "Relative date values are formatted correctly"
     (t/are [text tag->param expected] (= expected (params/substitute-tags text tag->param))

--- a/test/metabase/util/time_test.cljc
+++ b/test/metabase/util/time_test.cljc
@@ -232,13 +232,57 @@
     "Q1" :quarter-of-year
     "Feb 8, 2023" nil)
 
+  (are [exp u] (= exp (shared.ut/format-unit "2023-02-08" u "fr"))
+    "mercredi" :day-of-week
+    "févr." :month-of-year
+    "8" :day-of-month
+    "39" :day-of-year
+    "6" :week-of-year
+    "Q1" :quarter-of-year
+    "Feb 8, 2023" nil) ;; no locale for default formats
+
+  (are [exp u] (= exp (shared.ut/format-unit (from-local-date "2023-02-08") u))
+    "Wednesday" :day-of-week
+    "Feb" :month-of-year
+    "8" :day-of-month
+    "39" :day-of-year
+    "6" :week-of-year
+    "Q1" :quarter-of-year
+    "Feb 8, 2023" nil)
+
+  (are [exp u] (= exp (shared.ut/format-unit (from-local-date "2023-02-08") u "fr"))
+    "mercredi" :day-of-week
+    "févr." :month-of-year
+    "8" :day-of-month
+    "39" :day-of-year
+    "6" :week-of-year
+    "Q1" :quarter-of-year
+    "Feb 8, 2023" nil)
+
   (is (= "12:00 PM" (shared.ut/format-unit "12:00:00.000" nil)))
+  (is (= "12:00 PM" (shared.ut/format-unit (from-local-time "12:00:00.000") nil)))
+
   (is (= "Oct 3, 2023, 1:30 PM" (shared.ut/format-unit "2023-10-03T13:30:00" nil)))
+  (is (= "Oct 3, 2023, 1:30 PM" (shared.ut/format-unit (from-local "2023-10-03T13:30:00") nil)))
+
   (is (= "30" (shared.ut/format-unit "2023-10-03T13:30:00" :minute-of-hour)))
   (is (= "1 PM" (shared.ut/format-unit "2023-10-03T13:30:00" :hour-of-day)))
   (is (= "30" (shared.ut/format-unit 30 :minute-of-hour)))
   (is (= "1 PM" (shared.ut/format-unit 13 :hour-of-day)))
   (is (= "12 AM" (shared.ut/format-unit 0 :hour-of-day))))
+
+(deftest parse-unit-test
+  (are [exp input unit-in unit-out locale-in locale-out]
+       (= exp (-> (shared.ut/parse-unit input unit-in  locale-in)
+                  (shared.ut/format-unit      unit-out locale-out)))
+    "Wednesday" "Wed" :day-of-week-abbrev :day-of-week   "en" "en"
+    "lundi"     "Mon" :day-of-week-abbrev :day-of-week   "en" "fr"
+
+    "January"   "Jan" :month-of-year :month-of-year-full "en" "en"
+    "janvier"   "Jan" :month-of-year :month-of-year-full "en" "fr"
+
+    "1 PM"      "13"  :hour-of-day-24 :hour-of-day       "en" "en"
+    "12 AM"     "0"   :hour-of-day-24 :hour-of-day       "en" "en"))
 
 (deftest format-diff-test
   (are [exp a b] (= exp (shared.ut/format-diff a b))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39385

### Description

The dashboard text previews were incomplete. I've completed them for various cases:

`Before DATE`
`After DATE`
`On DATE`
`Exclude {hours|days|quarters|months}`

### How to verify

1. Create a dashboad.
2. Add a filter type Date Picker called Date
3. Add a text box. Add the text {{Date}}
4. Save it.
5. Click edit. Click the date picker filter.
6. In the text box, select Date as the variable to map to.
7. Click save.
8. Select a date: Specific Date-> Before-> Pick a date
9. Observe the text "Before ..." in the text box.
