### PR TITLE
MultiAutocomplete + remapping

### DIFF
--- a/frontend/src/metabase-types/api/field.ts
+++ b/frontend/src/metabase-types/api/field.ts
@@ -159,6 +159,12 @@ export interface SearchFieldValuesRequest {
   limit: number;
 }
 
+export interface GetRemappedFieldValueRequest {
+  fieldId: FieldId;
+  remappedFieldId: FieldId;
+  value: string;
+}
+
 export interface CreateFieldDimensionRequest {
   id: FieldId;
   type: FieldDimensionType;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataFieldSettings/MetadataFieldSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataFieldSettings/MetadataFieldSettings.unit.spec.tsx
@@ -4,7 +4,7 @@ import { Route } from "react-router";
 
 import {
   setupDatabasesEndpoints,
-  setupFieldValuesEndpoints,
+  setupFieldValuesEndpoint,
   setupSearchEndpoints,
   setupUnauthorizedFieldEndpoint,
   setupUnauthorizedFieldValuesEndpoints,
@@ -134,7 +134,7 @@ const setup = async ({
     setupUnauthorizedFieldEndpoint(unauthorizedField);
   }
   if (hasFieldValuesAccess) {
-    setupFieldValuesEndpoints(fieldValues);
+    setupFieldValuesEndpoint(fieldValues);
   } else {
     setupUnauthorizedFieldValuesEndpoints(fieldValues);
   }

--- a/frontend/src/metabase/api/field.ts
+++ b/frontend/src/metabase/api/field.ts
@@ -5,6 +5,7 @@ import type {
   FieldValue,
   GetFieldRequest,
   GetFieldValuesResponse,
+  GetRemappedFieldValueRequest,
   SearchFieldValuesRequest,
   UpdateFieldRequest,
   UpdateFieldValuesRequest,
@@ -36,6 +37,17 @@ export const fieldApi = Api.injectEndpoints({
         url: `/api/field/${id}/values`,
       }),
       providesTags: (_, error, fieldId) => provideFieldValuesTags(fieldId),
+    }),
+    getRemappedFieldValue: builder.query<
+      FieldValue,
+      GetRemappedFieldValueRequest
+    >({
+      query: ({ fieldId, remappedFieldId, ...params }) => ({
+        method: "GET",
+        url: `/api/field/${fieldId}/remapping/${remappedFieldId}`,
+        params,
+      }),
+      providesTags: (_, error, { fieldId }) => provideFieldValuesTags(fieldId),
     }),
     searchFieldValues: builder.query<FieldValue[], SearchFieldValuesRequest>({
       query: ({ fieldId, searchFieldId, ...params }) => ({
@@ -107,6 +119,7 @@ export const fieldApi = Api.injectEndpoints({
 export const {
   useGetFieldQuery,
   useGetFieldValuesQuery,
+  useGetRemappedFieldValueQuery,
   useSearchFieldValuesQuery,
   useUpdateFieldMutation,
   useUpdateFieldValuesMutation,

--- a/frontend/src/metabase/api/field.ts
+++ b/frontend/src/metabase/api/field.ts
@@ -18,6 +18,7 @@ import {
   listTag,
   provideFieldTags,
   provideFieldValuesTags,
+  provideRemappedFieldValuesTags,
   tag,
 } from "./tags";
 
@@ -47,7 +48,8 @@ export const fieldApi = Api.injectEndpoints({
         url: `/api/field/${fieldId}/remapping/${remappedFieldId}`,
         params,
       }),
-      providesTags: (_, error, { fieldId }) => provideFieldValuesTags(fieldId),
+      providesTags: (_response, _error, { fieldId, remappedFieldId }) =>
+        provideRemappedFieldValuesTags(fieldId, remappedFieldId),
     }),
     searchFieldValues: builder.query<FieldValue[], SearchFieldValuesRequest>({
       query: ({ fieldId, searchFieldId, ...params }) => ({
@@ -55,7 +57,8 @@ export const fieldApi = Api.injectEndpoints({
         url: `/api/field/${fieldId}/search/${searchFieldId}`,
         params,
       }),
-      providesTags: (_, error, { fieldId }) => provideFieldValuesTags(fieldId),
+      providesTags: (_response, _error, { fieldId, searchFieldId }) =>
+        provideRemappedFieldValuesTags(fieldId, searchFieldId),
     }),
     updateField: builder.mutation<Field, UpdateFieldRequest>({
       query: ({ id, ...body }) => ({

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -381,6 +381,16 @@ export function provideFieldValuesTags(id: FieldId): TagDescription<TagType>[] {
   return [idTag("field-values", id)];
 }
 
+export function provideRemappedFieldValuesTags(
+  id: FieldId,
+  searchFieldId: FieldId,
+): TagDescription<TagType>[] {
+  return [
+    ...provideFieldValuesTags(id),
+    ...provideFieldValuesTags(searchFieldId),
+  ];
+}
+
 export function provideNotificationListTags(
   notifications: Notification[],
 ): TagDescription<TagType>[] {

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.unit.spec.js
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.unit.spec.js
@@ -1,4 +1,4 @@
-import { setupFieldValuesEndpoints } from "__support__/server-mocks";
+import { setupFieldValuesEndpoint } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -19,7 +19,7 @@ const state = createMockState({
 });
 
 function setup({ field }) {
-  setupFieldValuesEndpoints(PRODUCT_CATEGORY_VALUES);
+  setupFieldValuesEndpoint(PRODUCT_CATEGORY_VALUES);
 
   renderWithProviders(<CategoryFingerprint fieldId={field.id} />, {
     storeInitialState: state,

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -11,12 +11,7 @@ import {
   deserializeNumberParameterValue,
   serializeNumberParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
-import {
-  type ComboboxItem,
-  MultiAutocomplete,
-  MultiAutocompleteOption,
-  MultiAutocompleteValue,
-} from "metabase/ui";
+import { type ComboboxItem, MultiAutocomplete } from "metabase/ui";
 import type {
   Parameter,
   ParameterValue,
@@ -106,22 +101,7 @@ export function NumberInputWidget({
             autoFocus={autoFocus}
             comboboxProps={COMBOBOX_PROPS}
             parseValue={parseValue}
-            renderValue={({ value }) => (
-              <MultiAutocompleteValue
-                value={value}
-                label={
-                  labelByValue[value] !== value
-                    ? labelByValue[value]
-                    : undefined
-                }
-              />
-            )}
-            renderOption={({ option }) => (
-              <MultiAutocompleteOption
-                value={option.value}
-                label={option.label !== option.value ? option.label : undefined}
-              />
-            )}
+            renderValue={({ value }) => labelByValue[value] ?? value}
             onChange={handleChange}
           />
         </TokenFieldWrapper>

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -74,7 +74,7 @@ export function NumberInputWidget({
     values.map(getOption).filter((item): item is SelectItem => item !== null) ??
     [];
 
-  const handleCreate = (rawValue: string) => {
+  const parseValue = (rawValue: string) => {
     const number = parseNumber(rawValue);
     return number !== null ? String(number) : null;
   };
@@ -96,7 +96,7 @@ export function NumberInputWidget({
             placeholder={placeholder}
             autoFocus={autoFocus}
             comboboxProps={COMBOBOX_PROPS}
-            onCreate={handleCreate}
+            parseValue={parseValue}
             onChange={handleChange}
           />
         </TokenFieldWrapper>

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -11,7 +11,12 @@ import {
   deserializeNumberParameterValue,
   serializeNumberParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
-import { MultiAutocomplete } from "metabase/ui";
+import {
+  type ComboboxItem,
+  MultiAutocomplete,
+  MultiAutocompleteOption,
+  MultiAutocompleteValue,
+} from "metabase/ui";
 import type {
   Parameter,
   ParameterValue,
@@ -71,8 +76,12 @@ export function NumberInputWidget({
 
   const values = parameter?.values_source_config?.values ?? [];
   const options =
-    values.map(getOption).filter((item): item is SelectItem => item !== null) ??
-    [];
+    values
+      .map(getOption)
+      .filter((item): item is ComboboxItem => item !== null) ?? [];
+  const labelByValue = Object.fromEntries(
+    options.map((option) => [option.value, option.label]),
+  );
 
   const parseValue = (rawValue: string) => {
     const number = parseNumber(rawValue);
@@ -97,6 +106,22 @@ export function NumberInputWidget({
             autoFocus={autoFocus}
             comboboxProps={COMBOBOX_PROPS}
             parseValue={parseValue}
+            renderValue={({ value }) => (
+              <MultiAutocompleteValue
+                value={value}
+                label={
+                  labelByValue[value] !== value
+                    ? labelByValue[value]
+                    : undefined
+                }
+              />
+            )}
+            renderOption={({ option }) => (
+              <MultiAutocompleteOption
+                value={option.value}
+                label={option.label !== option.value ? option.label : undefined}
+              />
+            )}
             onChange={handleChange}
           />
         </TokenFieldWrapper>
@@ -137,12 +162,9 @@ export function NumberInputWidget({
   );
 }
 
-type SelectItem = {
-  value: string;
-  label: string;
-};
-
-function getOption(entry: string | number | ParameterValue): SelectItem | null {
+function getOption(
+  entry: string | number | ParameterValue,
+): ComboboxItem | null {
   const value = getValue(entry);
   const label = getLabel(entry);
 

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -14,7 +14,7 @@ import {
   setupCollectionByIdEndpoint,
   setupCollectionsEndpoints,
   setupDatabasesEndpoints,
-  setupFieldValuesEndpoints,
+  setupFieldValuesEndpoint,
   setupGetUserKeyValueEndpoint,
   setupModelIndexEndpoints,
   setupPropertiesEndpoints,
@@ -244,7 +244,7 @@ export const setup = async ({
   setupBookmarksEndpoints([]);
   setupTimelinesEndpoints([]);
   setupCollectionByIdEndpoint({ collections: [TEST_COLLECTION] });
-  setupFieldValuesEndpoints(
+  setupFieldValuesEndpoint(
     createMockFieldValues({ field_id: Number(ORDERS.QUANTITY) }),
   );
   setupRecentViewsEndpoints([]);

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
@@ -25,7 +25,7 @@ interface FilterValuePickerProps<T> {
   values: T[];
   autoFocus?: boolean;
   comboboxProps?: ComboboxProps;
-  onCreate?: (rawValue: string) => string | null;
+  parseValue?: (rawValue: string) => string | null;
   onChange: (newValues: T[]) => void;
 }
 
@@ -41,7 +41,7 @@ function FilterValuePicker({
   placeholder,
   autoFocus = false,
   comboboxProps,
-  onCreate,
+  parseValue,
   onChange,
 }: FilterValuePickerOwnProps) {
   const fieldInfo = useMemo(
@@ -86,7 +86,7 @@ function FilterValuePicker({
         columnDisplayName={columnInfo.displayName}
         autoFocus={autoFocus}
         comboboxProps={comboboxProps}
-        onCreate={onCreate}
+        parseValue={parseValue}
         onChange={onChange}
       />
     );
@@ -98,7 +98,7 @@ function FilterValuePicker({
       placeholder={placeholder}
       autoFocus={autoFocus}
       comboboxProps={comboboxProps}
-      onCreate={onCreate}
+      parseValue={parseValue}
       onChange={onChange}
     />
   );
@@ -125,7 +125,7 @@ export function NumberFilterValuePicker({
   onChange,
   ...props
 }: FilterValuePickerProps<Lib.NumberFilterValue>) {
-  const handleCreate = (rawValue: string) => {
+  const parseValue = (rawValue: string) => {
     const number = parseNumber(rawValue);
     return number != null ? String(number) : null;
   };
@@ -140,7 +140,7 @@ export function NumberFilterValuePicker({
       column={column}
       values={values.map((value) => String(value))}
       placeholder={isKeyColumn(column) ? t`Enter an ID` : t`Enter a number`}
-      onCreate={handleCreate}
+      parseValue={parseValue}
       onChange={handleChange}
     />
   );

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/utils.ts
@@ -1,9 +1,9 @@
-import type { SelectOption } from "metabase/ui";
+import type { ComboboxItem } from "metabase/ui";
 
 export function searchOptions(
-  options: SelectOption[],
+  options: ComboboxItem[],
   searchText: string,
-): SelectOption[] {
+): ComboboxItem[] {
   const searchValue = searchText.toLowerCase();
   return options.filter(
     ({ label }) => label != null && label.toLowerCase().includes(searchValue),

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -7,12 +7,12 @@ import {
   useSearchFieldValuesQuery,
 } from "metabase/api";
 import {
-  Box,
   type ComboboxItem,
   type ComboboxProps,
-  Flex,
   Loader,
   MultiAutocomplete,
+  MultiAutocompleteOption,
+  MultiAutocompleteValue,
 } from "metabase/ui";
 import type { FieldId, FieldValue } from "metabase-types/api";
 
@@ -147,12 +147,7 @@ function RemappedValue({
   }
 
   const option = getFieldOption(remappedValue);
-  return (
-    <Flex component="span" gap="sm">
-      <span>{option.label}</span>
-      <Box opacity={0.5}>{option.value}</Box>
-    </Flex>
-  );
+  return <MultiAutocompleteValue value={option.value} label={option.label} />;
 }
 
 type RemappedOptionProps = {
@@ -165,10 +160,5 @@ function RemappedOption({ option, isRemapped }: RemappedOptionProps) {
     return option.value;
   }
 
-  return (
-    <Flex flex={1} justify="space-between" gap="sm">
-      <span>{option.label}</span>
-      <Box opacity={0.5}>{option.value}</Box>
-    </Flex>
-  );
+  return <MultiAutocompleteOption value={option.value} label={option.label} />;
 }

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -101,7 +101,7 @@ export function SearchValuePicker({
       comboboxProps={comboboxProps}
       aria-label={t`Filter value`}
       parseValue={parseValue}
-      renderValue={(value) => (
+      renderValue={({ value }) => (
         <RemappedValue
           fieldId={fieldId}
           searchFieldId={searchFieldId}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -157,7 +157,7 @@ type RemappedOptionProps = {
 
 function RemappedOption({ option, isRemapped }: RemappedOptionProps) {
   if (!isRemapped) {
-    return option.value;
+    return option.label;
   }
 
   return <MultiAutocompleteOption value={option.value} label={option.label} />;

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -23,7 +23,7 @@ interface SearchValuePickerProps {
   columnDisplayName: string;
   autoFocus?: boolean;
   comboboxProps?: ComboboxProps;
-  onCreate?: (rawValue: string) => string | null;
+  parseValue?: (rawValue: string) => string | null;
   onChange: (newValues: string[]) => void;
 }
 
@@ -35,7 +35,7 @@ export function SearchValuePicker({
   columnDisplayName,
   autoFocus,
   comboboxProps,
-  onCreate,
+  parseValue,
   onChange,
 }: SearchValuePickerProps) {
   const [searchValue, setSearchValue] = useState("");
@@ -98,7 +98,7 @@ export function SearchValuePicker({
       nothingFoundMessage={nothingFoundMessage}
       comboboxProps={comboboxProps}
       aria-label={t`Filter value`}
-      onCreate={onCreate}
+      parseValue={parseValue}
       onChange={onChange}
       onSearchChange={handleSearchChange}
     />

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/utils.ts
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 
-import type { SelectOption } from "metabase/ui";
 import type { FieldValue } from "metabase-types/api";
 
 import { SEARCH_LIMIT } from "./constants";
@@ -15,17 +14,6 @@ export function shouldSearch(
   const hasMoreValues = fieldValues.length === SEARCH_LIMIT;
 
   return !isExtensionOfLastSearch || hasMoreValues;
-}
-
-export function getFilteredOptions(
-  options: SelectOption<string>[],
-  searchValue: string,
-  selectedValues: string[],
-) {
-  return options.filter(
-    (option) =>
-      option.value === searchValue || !selectedValues.includes(option.value),
-  );
 }
 
 export function getNothingFoundMessage(

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
@@ -7,7 +7,7 @@ interface StaticValuePickerProps {
   placeholder?: string;
   autoFocus?: boolean;
   comboboxProps?: ComboboxProps;
-  onCreate?: (rawValue: string) => string | null;
+  parseValue?: (rawValue: string) => string | null;
   onChange: (newValues: string[]) => void;
 }
 
@@ -16,7 +16,7 @@ export function StaticValuePicker({
   placeholder,
   autoFocus,
   comboboxProps,
-  onCreate,
+  parseValue,
   onChange,
 }: StaticValuePickerProps) {
   return (
@@ -26,7 +26,7 @@ export function StaticValuePicker({
       autoFocus={autoFocus}
       comboboxProps={comboboxProps}
       aria-label={t`Filter value`}
-      onCreate={onCreate}
+      parseValue={parseValue}
       onChange={onChange}
     />
   );

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
@@ -1,4 +1,4 @@
-import type { SelectOption } from "metabase/ui";
+import type { ComboboxItem } from "metabase/ui";
 import type { FieldValuesSearchInfo } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import type { FieldValue, GetFieldValuesResponse } from "metabase-types/api";
@@ -29,13 +29,15 @@ export function canSearchFieldValues(
   );
 }
 
-export function getFieldOptions(fieldValues: FieldValue[]): SelectOption[] {
-  return fieldValues
-    .filter(([value]) => value != null)
-    .map(([value, label = value]) => ({
-      value: String(value),
-      label: String(label),
-    }));
+export function getFieldOption([value, label]: FieldValue): ComboboxItem {
+  return {
+    value: String(value),
+    label: String(label ?? value),
+  };
+}
+
+export function getFieldOptions(fieldValues: FieldValue[]): ComboboxItem[] {
+  return fieldValues.filter(([value]) => value != null).map(getFieldOption);
 }
 
 function getSelectedOptions(selectedValues: string[]) {
@@ -48,7 +50,7 @@ export function getEffectiveOptions(
   fieldValues: FieldValue[],
   selectedValues: string[],
   elevatedValues: string[] = [],
-): SelectOption[] {
+): ComboboxItem[] {
   const options: { label?: string; value: string }[] = [
     ...getSelectedOptions(elevatedValues),
     ...getFieldOptions(fieldValues),

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -1,7 +1,9 @@
 import {
   type BoxProps,
   Combobox,
+  type ComboboxItem,
   type ComboboxLikeProps,
+  type ComboboxLikeRenderOptionInput,
   OptionsDropdown,
   Pill,
   PillsInput,
@@ -27,7 +29,11 @@ export type MultiAutocompleteProps = BoxProps &
     rightSection?: ReactNode;
     nothingFoundMessage?: ReactNode;
     "aria-label"?: string;
-    onCreate?: (rawValue: string) => string | null;
+    parseValue?: (rawValue: string) => string | null;
+    renderValue?: (value: string) => ReactNode;
+    renderOption?: (
+      input: ComboboxLikeRenderOptionInput<ComboboxItem>,
+    ) => ReactNode;
     onChange: (newValues: string[]) => void;
     onSearchChange?: (newValue: string) => void;
   };
@@ -58,7 +64,9 @@ export function MultiAutocomplete({
   withScrollArea,
   comboboxProps,
   "aria-label": ariaLabel,
-  onCreate,
+  parseValue = defaultParseValue,
+  renderValue = defaultRenderValue,
+  renderOption,
   onChange,
   onSearchChange,
   onDropdownOpen,
@@ -86,7 +94,7 @@ export function MultiAutocomplete({
   } = useMultiAutocomplete({
     values: value,
     data,
-    onCreate,
+    parseValue,
     onChange,
     onSearchChange,
   });
@@ -140,7 +148,7 @@ export function MultiAutocomplete({
                     onClick={(event) => handlePillClick(event, valueIndex)}
                     onRemove={() => handlePillRemoveClick(valueIndex)}
                   >
-                    {value}
+                    {renderValue(value)}
                   </Pill>
                 ) : (
                   <Combobox.EventsTarget key="field">
@@ -177,10 +185,20 @@ export function MultiAutocomplete({
           labelId={undefined}
           withScrollArea={withScrollArea}
           scrollAreaProps={undefined}
+          renderOption={renderOption}
           aria-label={undefined}
         />
       </Combobox>
       <Combobox.HiddenInput value={value} />
     </>
   );
+}
+
+function defaultParseValue(value: string) {
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function defaultRenderValue(value: string) {
+  return value;
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -20,6 +20,13 @@ import { Icon } from "../../icons";
 import S from "./MultiAutocomplete.module.css";
 import { useMultiAutocomplete } from "./use-multi-autocomplete";
 
+export type MultiAutocompleteRenderValueProps = {
+  value: string;
+};
+
+export type MultiAutocompleteRenderOptionProps =
+  ComboboxLikeRenderOptionInput<ComboboxItem>;
+
 export type MultiAutocompleteProps = BoxProps &
   __InputWrapperProps &
   ComboboxLikeProps & {
@@ -30,10 +37,8 @@ export type MultiAutocompleteProps = BoxProps &
     nothingFoundMessage?: ReactNode;
     "aria-label"?: string;
     parseValue?: (rawValue: string) => string | null;
-    renderValue?: (value: string) => ReactNode;
-    renderOption?: (
-      input: ComboboxLikeRenderOptionInput<ComboboxItem>,
-    ) => ReactNode;
+    renderValue?: (props: MultiAutocompleteRenderValueProps) => ReactNode;
+    renderOption?: (props: MultiAutocompleteRenderOptionProps) => ReactNode;
     onChange: (newValues: string[]) => void;
     onSearchChange?: (newValue: string) => void;
   };
@@ -148,7 +153,7 @@ export function MultiAutocomplete({
                     onClick={(event) => handlePillClick(event, valueIndex)}
                     onRemove={() => handlePillRemoveClick(valueIndex)}
                   >
-                    {renderValue(value)}
+                    {renderValue({ value })}
                   </Pill>
                 ) : (
                   <Combobox.EventsTarget key="field">
@@ -199,6 +204,6 @@ function defaultParseValue(value: string) {
   return trimmedValue.length > 0 ? trimmedValue : null;
 }
 
-function defaultRenderValue(value: string) {
+function defaultRenderValue({ value }: MultiAutocompleteRenderValueProps) {
   return value;
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
@@ -1,6 +1,6 @@
-import type { ComboboxData } from "@mantine/core";
+import type { ComboboxItem, ComboboxItemGroup } from "@mantine/core";
 import userEvent from "@testing-library/user-event";
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
@@ -21,44 +21,30 @@ function TestInput({ initialValue, onChange, ...props }: TestInputProps) {
   return <MultiAutocomplete {...props} value={value} onChange={handleChange} />;
 }
 
-const REMAPPED_DATA: ComboboxData = [
+const REMAPPED_DATA: ComboboxItem[] = [
   { value: "1", label: "One" },
   { value: "2", label: "Two" },
   { value: "3", label: "Three" },
   { value: "4", label: "Four" },
 ];
 
-const GROUPED_DATA: ComboboxData = [
+const GROUPED_DATA: ComboboxItemGroup[] = [
   { group: "A", items: ["A1", "A2"] },
   { group: "B", items: ["B1", "B2"] },
 ];
 
-type SetupOpts = {
+type SetupOpts = Omit<MultiAutocompleteProps, "value" | "onChange"> & {
   initialValue?: string[];
-  data?: ComboboxData;
-  placeholder?: string;
-  autoFocus?: boolean;
-  rightSection?: ReactNode;
-  nothingFoundMessage?: ReactNode;
-  "aria-label"?: string;
-  parseValue?: (rawValue: string) => string | null;
 };
 
-function setup({
-  initialValue = [],
-  data = [],
-  placeholder = "Enter some text",
-  parseValue,
-}: SetupOpts = {}) {
+function setup({ initialValue = [], ...props }: SetupOpts = {}) {
   const onChange = jest.fn<void, [string[]]>();
   const onSearchChange = jest.fn<void, [string]>();
 
   renderWithProviders(
     <TestInput
+      {...props}
       initialValue={initialValue}
-      data={data}
-      placeholder={placeholder}
-      parseValue={parseValue}
       onChange={onChange}
       onSearchChange={onSearchChange}
     />,
@@ -305,8 +291,13 @@ describe("MultiAutocomplete", () => {
     expect(onChange).toHaveBeenLastCalledWith(["3", "4", "2"]);
   });
 
-  it("should display the remapped value when there are matching data", () => {
-    setup({ initialValue: ["1", "2", "5"], data: REMAPPED_DATA });
+  it("should display the remapped value with renderValue", () => {
+    setup({
+      initialValue: ["1", "2", "5"],
+      data: REMAPPED_DATA,
+      renderValue: ({ value }) =>
+        REMAPPED_DATA.find((option) => option.value === value)?.label ?? value,
+    });
     expect(screen.getByText("One")).toBeInTheDocument();
     expect(screen.getByText("Two")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
@@ -316,11 +307,11 @@ describe("MultiAutocomplete", () => {
     const { input, onChange } = setup({
       initialValue: ["1", "3"],
       data: REMAPPED_DATA,
+      renderValue: ({ value }) =>
+        REMAPPED_DATA.find((option) => option.value === value)?.label ?? value,
     });
     await userEvent.click(screen.getByText("One"));
-    expect(input).toHaveValue("One");
-    expect(getOption("One")).toBeInTheDocument();
-    expect(queryOption("Two")).not.toBeInTheDocument();
+    expect(input).toHaveValue("1");
     expect(onChange).not.toHaveBeenCalled();
 
     await userEvent.clear(input);
@@ -360,34 +351,6 @@ describe("MultiAutocomplete", () => {
     expect(input).toHaveValue('"a\\"bc"');
     expect(onChange).toHaveBeenCalledWith(['a"bc']);
     expect(onSearchChange).toHaveBeenLastCalledWith('a"bc');
-  });
-
-  it("should quote the selected option label when editing", async () => {
-    const { input, onChange } = setup({
-      initialValue: ["1"],
-      data: [
-        { value: "1", label: "a,b" },
-        { value: "2", label: "a,b,c" },
-        { value: "3", label: "a,b,c,d" },
-      ],
-    });
-    await userEvent.click(screen.getByText("a,b"));
-    expect(input).toHaveValue('"a,b"');
-    expect(getOption("a,b")).toBeInTheDocument();
-    expect(getOption("a,b,c")).toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalled();
-
-    await userEvent.click(getOption("a,b,c"));
-    expect(input).toHaveValue("");
-    expect(onChange).toHaveBeenLastCalledWith(["2"]);
-
-    await userEvent.type(input, '"b\\,c"');
-    expect(queryOption("a,b")).not.toBeInTheDocument();
-    expect(queryOption("a,b,c")).not.toBeInTheDocument();
-    expect(getOption("a,b,c,d")).toBeInTheDocument();
-
-    await userEvent.click(getOption("a,b,c,d"));
-    expect(onChange).toHaveBeenLastCalledWith(["2", "3"]);
   });
 
   it("should open and close the dropdown correctly", async () => {

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
@@ -41,14 +41,14 @@ type SetupOpts = {
   rightSection?: ReactNode;
   nothingFoundMessage?: ReactNode;
   "aria-label"?: string;
-  onCreate?: (rawValue: string) => string | null;
+  parseValue?: (rawValue: string) => string | null;
 };
 
 function setup({
   initialValue = [],
   data = [],
   placeholder = "Enter some text",
-  onCreate,
+  parseValue,
 }: SetupOpts = {}) {
   const onChange = jest.fn<void, [string[]]>();
   const onSearchChange = jest.fn<void, [string]>();
@@ -58,7 +58,7 @@ function setup({
       initialValue={initialValue}
       data={data}
       placeholder={placeholder}
-      onCreate={onCreate}
+      parseValue={parseValue}
       onChange={onChange}
       onSearchChange={onSearchChange}
     />,
@@ -91,9 +91,9 @@ describe("MultiAutocomplete", () => {
     expect(input).toHaveValue("");
   });
 
-  it("should not accept values when blurring if they are not accepted by onCreate", async () => {
+  it("should not accept values when blurring if they are not accepted by parseValue", async () => {
     const { input, onChange } = setup({
-      onCreate: (value) => (value === "foo" ? value : null),
+      parseValue: (value) => (value === "foo" ? value : null),
     });
     await userEvent.type(input, "foo");
     await userEvent.click(document.body);
@@ -182,9 +182,9 @@ describe("MultiAutocomplete", () => {
     expect(input).toHaveValue("");
   });
 
-  it("should not accept values when entering a comma if they are not accepted by onCreate", async () => {
+  it("should not accept values when entering a comma if they are not accepted by parseValue", async () => {
     const { input, onChange } = setup({
-      onCreate: (value) => (value === "foo" ? value : null),
+      parseValue: (value) => (value === "foo" ? value : null),
     });
     await userEvent.type(input, "foo,");
     expect(onChange).toHaveBeenLastCalledWith(["foo"]);
@@ -220,9 +220,10 @@ describe("MultiAutocomplete", () => {
     expect(input).toHaveValue("");
   });
 
-  it("should accept comma-separated values, but omit values not accepted by onCreate", async () => {
+  it("should accept comma-separated values, but omit values not accepted by parseValue", async () => {
     const { input, onChange } = setup({
-      onCreate: (value) => (value === "foo" || value === "bar" ? value : null),
+      parseValue: (value) =>
+        value === "foo" || value === "bar" ? value : null,
     });
     await userEvent.click(input);
     await userEvent.paste("foo,bar,baz");
@@ -453,7 +454,7 @@ describe("MultiAutocomplete", () => {
 
   it("should ignore duplicates when there are different string representations of the underlying value", async () => {
     const { input, onChange } = setup({
-      onCreate: (value) => {
+      parseValue: (value) => {
         const number = parseFloat(value);
         return Number.isNaN(number) ? null : String(number);
       },
@@ -464,7 +465,7 @@ describe("MultiAutocomplete", () => {
 
   it("should ignore duplicates in the clipboard data", async () => {
     const { input, onChange } = setup({
-      onCreate: (value) => {
+      parseValue: (value) => {
         const number = parseFloat(value);
         return Number.isNaN(number) ? null : String(number);
       },

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
@@ -15,11 +15,13 @@ export function MultiAutocompleteOption({
 
   return (
     <span>
-      <span>{value}</span>
+      <span>{label}</span>
       <Box component="span" mx="xs" opacity={0.5}>
         -
       </Box>
-      <span>{label}</span>
+      <Box component="span" opacity={0.5}>
+        {value}
+      </Box>
     </span>
   );
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex } from "metabase/ui";
 
-type MultiAutocompleteOptionProps = {
+export type MultiAutocompleteOptionProps = {
   value: string;
   label?: string;
 };

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
@@ -1,0 +1,22 @@
+import { Box, Flex } from "metabase/ui";
+
+type MultiAutocompleteOptionProps = {
+  value: string;
+  label?: string;
+};
+
+export function MultiAutocompleteOption({
+  value,
+  label,
+}: MultiAutocompleteOptionProps) {
+  if (label == null) {
+    return value;
+  }
+
+  return (
+    <Flex flex={1} justify="space-between" gap="sm">
+      <span>{label}</span>
+      <Box opacity={0.5}>{value}</Box>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from "metabase/ui";
+import { Box } from "metabase/ui";
 
 export type MultiAutocompleteOptionProps = {
   value: string;
@@ -14,9 +14,12 @@ export function MultiAutocompleteOption({
   }
 
   return (
-    <Flex flex={1} justify="space-between" gap="sm">
+    <span>
+      <span>{value}</span>
+      <Box component="span" mx="xs" opacity={0.5}>
+        -
+      </Box>
       <span>{label}</span>
-      <Box opacity={0.5}>{value}</Box>
-    </Flex>
+    </span>
   );
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.unit.spec.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "__support__/ui";
+import {
+  MultiAutocompleteOption,
+  type MultiAutocompleteOptionProps,
+} from "metabase/ui";
+
+function setup(props: MultiAutocompleteOptionProps) {
+  render(<MultiAutocompleteOption {...props} />);
+}
+
+describe("MultiAutocompleteOption", () => {
+  it("should render the value only when the label is not provided", () => {
+    setup({ value: "value" });
+    expect(screen.getByText("value")).toBeInTheDocument();
+  });
+
+  it("should render both the label and the value when the label is provided", () => {
+    setup({ value: "value", label: "label" });
+    expect(screen.getByText("label")).toBeInTheDocument();
+    expect(screen.getByText("value")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/index.ts
@@ -1,0 +1,1 @@
+export * from "./MultiAutocompleteOption";

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
@@ -15,11 +15,13 @@ export function MultiAutocompleteValue({
 
   return (
     <span>
-      <span>{value}</span>
+      <span>{label}</span>
       <Box component="span" mx="xs" opacity={0.5}>
         -
       </Box>
-      <span>{label}</span>
+      <Box component="span" opacity={0.5}>
+        {value}
+      </Box>
     </span>
   );
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from "metabase/ui";
+import { Box } from "metabase/ui";
 
 export type MultiAutocompleteValueProps = {
   value: string;
@@ -14,9 +14,12 @@ export function MultiAutocompleteValue({
   }
 
   return (
-    <Flex component="span" gap="sm">
+    <span>
+      <span>{value}</span>
+      <Box component="span" mx="xs" opacity={0.5}>
+        -
+      </Box>
       <span>{label}</span>
-      <Box opacity={0.5}>{value}</Box>
-    </Flex>
+    </span>
   );
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex } from "metabase/ui";
 
-type MultiAutocompleteValueProps = {
+export type MultiAutocompleteValueProps = {
   value: string;
   label?: string;
 };

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
@@ -1,0 +1,22 @@
+import { Box, Flex } from "metabase/ui";
+
+type MultiAutocompleteValueProps = {
+  value: string;
+  label?: string;
+};
+
+export function MultiAutocompleteValue({
+  value,
+  label,
+}: MultiAutocompleteValueProps) {
+  if (label == null) {
+    return value;
+  }
+
+  return (
+    <Flex component="span" gap="sm">
+      <span>{label}</span>
+      <Box opacity={0.5}>{value}</Box>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.unit.spec.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "__support__/ui";
+import {
+  MultiAutocompleteValue,
+  type MultiAutocompleteValueProps,
+} from "metabase/ui";
+
+function setup(props: MultiAutocompleteValueProps) {
+  render(<MultiAutocompleteValue {...props} />);
+}
+
+describe("MultiAutocompleteValue", () => {
+  it("should render the value only when the label is not provided", () => {
+    setup({ value: "value" });
+    expect(screen.getByText("value")).toBeInTheDocument();
+  });
+
+  it("should render both the label and the value when the label is provided", () => {
+    setup({ value: "value", label: "label" });
+    expect(screen.getByText("label")).toBeInTheDocument();
+    expect(screen.getByText("value")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/index.ts
@@ -1,0 +1,1 @@
+export * from "./MultiAutocompleteValue";

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/index.ts
@@ -1,1 +1,3 @@
 export * from "./MultiAutocomplete";
+export * from "./MultiAutocompleteOption";
+export * from "./MultiAutocompleteValue";

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
@@ -2,7 +2,6 @@ import {
   type ComboboxData,
   type ComboboxItem,
   type ComboboxParsedItem,
-  getOptionsLockup,
   getParsedComboboxData,
   isOptionsGroup,
   useCombobox,
@@ -30,7 +29,7 @@ type UseMultiAutocompleteProps = {
   dropdownOpened?: boolean;
   defaultDropdownOpened?: boolean;
   selectFirstOptionOnChange?: boolean;
-  onCreate?: (rawValue: string) => string | null;
+  parseValue: (rawValue: string) => string | null;
   onChange: (newValues: string[]) => void;
   onSearchChange?: (newValue: string) => void;
   onDropdownOpen?: () => void;
@@ -54,7 +53,7 @@ export function useMultiAutocomplete({
   data,
   dropdownOpened,
   defaultDropdownOpened,
-  onCreate = defaultCreate,
+  parseValue,
   onChange,
   onSearchChange,
   onDropdownOpen,
@@ -76,7 +75,6 @@ export function useMultiAutocomplete({
   const fieldSelection = _fieldSelection ?? { index: values.length, length: 0 };
   const searchValue = useMemo(() => getSearchValue(fieldValue), [fieldValue]);
   const options = useMemo(() => getParsedComboboxData(data), [data]);
-  const optionByValue = useMemo(() => getOptionsLockup(options), [options]);
 
   const setFieldState = ({
     fieldValue,
@@ -101,7 +99,7 @@ export function useMultiAutocomplete({
   ) => {
     const newFieldValues = getFieldValuesWithoutDuplicates(
       values,
-      newParsedValues.map(onCreate).filter(isNotNullish),
+      newParsedValues.map(parseValue).filter(isNotNullish),
       fieldSelection,
     );
     const newValues = getValuesAfterChange(
@@ -188,11 +186,10 @@ export function useMultiAutocomplete({
     valueIndex: number,
   ) => {
     const selectedValue = values[valueIndex];
-    const selectedOption = optionByValue[selectedValue];
     const pillRect = event.currentTarget.getBoundingClientRect();
 
     setFieldState({
-      fieldValue: escapeCsv(selectedOption?.label ?? selectedValue),
+      fieldValue: escapeCsv(selectedValue),
       fieldSelection: { index: valueIndex, length: 1 },
       fieldMinWidth: pillRect.width,
     });
@@ -244,7 +241,7 @@ export function useMultiAutocomplete({
 
   return {
     combobox,
-    pillValues: getPillValues(values, optionByValue, fieldSelection),
+    pillValues: getPillValues(values, fieldSelection),
     filteredOptions: getOptionsWithoutDuplicates(
       values,
       options,
@@ -271,19 +268,8 @@ function getSearchValue(fieldValue: string) {
   return parsedValues.length === 1 ? parsedValues[0] : fieldValue;
 }
 
-function getPillValues(
-  values: string[],
-  optionByValue: Record<string, ComboboxItem>,
-  fieldSelection: FieldSelection,
-) {
-  const mappedValues = values.map(
-    (value) => optionByValue[value]?.label ?? value,
-  );
-  return getValuesAfterChange(
-    mappedValues,
-    [FIELD_PLACEHOLDER],
-    fieldSelection,
-  );
+function getPillValues(values: string[], fieldSelection: FieldSelection) {
+  return getValuesAfterChange(values, [FIELD_PLACEHOLDER], fieldSelection);
 }
 
 function getValuesNotInSelection(
@@ -434,10 +420,6 @@ function escapeCsv(value: string): string {
     return `${QUOTE_CHAR}${value.replaceAll(ESCAPED_CHARS, (s) => `${ESCAPE_CHAR}${s}`)}${QUOTE_CHAR}`;
   }
   return value;
-}
-
-function defaultCreate(value: string) {
-  return value.trim().length > 0 ? value : null;
 }
 
 function isNotNullish<T>(value: T | null): value is T {

--- a/frontend/test/__support__/server-mocks/field.ts
+++ b/frontend/test/__support__/server-mocks/field.ts
@@ -15,8 +15,24 @@ export function setupFieldEndpoints(field: Field) {
   fetchMock.post(`path:/api/field/${field.id}/discard_values`, {});
 }
 
-export function setupFieldValuesEndpoints(fieldValues: GetFieldValuesResponse) {
+export function setupFieldValuesEndpoint(fieldValues: GetFieldValuesResponse) {
   fetchMock.get(`path:/api/field/${fieldValues.field_id}/values`, fieldValues);
+}
+
+export function setupRemappedFieldValueEndpoint(
+  fieldId: FieldId,
+  remappedFieldId: FieldId,
+  value: string,
+  fieldValue: FieldValue,
+) {
+  fetchMock.get(
+    {
+      url: `path:/api/field/${fieldId}/remapping/${remappedFieldId}`,
+      query: { value },
+    },
+    fieldValue,
+    { overwriteRoutes: false },
+  );
 }
 
 export function setupUnauthorizedFieldEndpoint(field: Field) {
@@ -38,7 +54,7 @@ export function setupUnauthorizedFieldValuesEndpoints(
 export function setupFieldsValuesEndpoints(
   fieldsValues: GetFieldValuesResponse[],
 ) {
-  fieldsValues.forEach((fieldValues) => setupFieldValuesEndpoints(fieldValues));
+  fieldsValues.forEach((fieldValues) => setupFieldValuesEndpoint(fieldValues));
 }
 
 export function setupFieldSearchValuesEndpoint(


### PR DESCRIPTION
I used the same styles as in the legacy FieldValuesWidget for remapping.

Note that both the value and the label will only be displayed when the field is remapped to a different field, either via the direct FK remapping or via `Entity Name` remapping. 

How to verify QB:
- Admin -> Table metadata -> Orders -> User ID 
- Filtering on this field -> Search box
- Display value -> Foreign Key -> Name
- New -> Question -> Orders -> Filter -> User ID -> Type some letters -> See the remapped dropdown
- Pick the value -> See the pill is remapped
- Type some arbitrary number and Enter -> See it was remapped

QB:
<img width="655" alt="Screenshot 2025-04-11 at 15 32 05" src="https://github.com/user-attachments/assets/362eea92-16c5-4dcc-85fe-d77423e6ade2" />


