### PR TITLE
Share pivot export code between XSLX/CSV instead of using native Excel pivots

### DIFF
--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -7,10 +7,8 @@
   (:refer-clojure :exclude [run!])
   (:require
    [clojure.set :as set]
-   [metabase.formatter :as formatter]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.pivot.core :as pivot]
-   [metabase.query-processor.streaming.common :as common]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.performance :as perf]))
@@ -93,29 +91,6 @@
         (get col-settings {::mb.viz/column-name (:name col)})))
      cols)))
 
-(defn- get-formatter
-  "Returns a memoized formatter for a column"
-  [timezone settings format-rows?]
-  (memoize
-   (fn [column]
-     (formatter/create-formatter timezone column settings format-rows?))))
-
-(defn- create-formatters
-  [columns indexes timezone settings format-rows?]
-  (let [formatter-fn (get-formatter timezone settings format-rows?)]
-    (mapv (fn [idx]
-            (let [column (nth columns idx)
-                  formatter (formatter-fn column)]
-              (fn [value]
-                (formatter (common/format-value value)))))
-          indexes)))
-
-(defn- make-formatters
-  [columns row-indexes col-indexes val-indexes settings timezone format-rows?]
-  {:row-formatters (create-formatters columns row-indexes timezone settings format-rows?)
-   :col-formatters (create-formatters columns col-indexes timezone settings format-rows?)
-   :val-formatters (create-formatters columns val-indexes timezone settings format-rows?)})
-
 (defn- build-top-headers
   [top-left-header top-header-items]
   (if (empty? top-header-items)
@@ -183,7 +158,7 @@
 (defn build-pivot-output
   "Processes pivot data into the final pivot structure for exports. Calls into metabase.pivot.core, which is the
   postprocessing code shared with the FE pivot table implementation."
-  [{:keys [data settings timezone format-rows? pivot-export-options]}]
+  [{:keys [data settings format-rows? pivot-export-options]} formatters]
   (let [columns                  (pivot/columns-without-pivot-group (:cols data))
         column-split             (:pivot_table.column_split settings)
         row-indexes              (:pivot-rows pivot-export-options)
@@ -192,7 +167,7 @@
         col-settings             (merge-column-settings columns settings)
         {:keys [row-formatters
                 col-formatters
-                val-formatters]} (make-formatters columns row-indexes col-indexes val-indexes settings timezone format-rows?)
+                val-formatters]} formatters
         {:keys [leftHeaderItems
                 topHeaderItems
                 getRowSection]}  (pivot/process-pivot-table data

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -44,7 +44,7 @@
   Rows whose pivot-grouping values are greater than 0 represent subtotals, and should not be included in non-pivot result outputs."
   0)
 
-(defn pivot-grouping-key
+(defn pivot-grouping-index
   "Get the index into the raw pivot rows for the 'pivot-grouping' column."
   [column-titles]
   ;; A vector is kinda sorta a map of indices->values, so we can use map-invert to create the map
@@ -58,14 +58,14 @@
        (set (range (count column-titles)))
        ;; we exclude indices already used in pivot rows and cols, and the pivot-grouping key
        ;; recall that a raw pivot row will always contain this 'pivot-grouping' column, which we don't actually need to use.
-       (set (concat pivot-rows pivot-cols [(pivot-grouping-key column-titles)])))
+       (set (concat pivot-rows pivot-cols [(pivot-grouping-index column-titles)])))
       sort
       vec))
 
 (mu/defn add-pivot-measures :- ::pivot-spec
   "Given a pivot-spec map without the `:pivot-measures` key, determine what key(s) the measures will be and assoc that value into `:pivot-measures`."
   [{measure-indices :pivot-measures :as pivot-spec} :- ::pivot-spec]
-  (let [pivot-grouping-key (pivot-grouping-key (:column-titles pivot-spec))]
+  (let [pivot-grouping-key (pivot-grouping-index (:column-titles pivot-spec))]
     (cond-> pivot-spec
       ;; if pivot-measures don't already exist (from the pivot qp), we add them ourselves, assuming lowest ID -> highest ID sort order
       (not (seq measure-indices)) (assoc :pivot-measures (pivot-measures pivot-spec))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -128,7 +128,7 @@
             ;; For pivot tables, accumulate rows in memory in a transient
             (vswap! pivot-data update-in [:data :rows] conj! ordered-row)
             (if pivot-group
-              ;; Non-pivoted pivot table: we have to remove the pivot-grouping column
+              ;; Non-pivoted pivot table: we have to remove the pivot-grouping column
               (when (= qp.pivot.postprocess/NON_PIVOT_ROW_GROUP (int pivot-group))
                 (let [formatted-row (->> (perf/mapv (fn [formatter r]
                                                       (formatter (streaming.common/format-value r)))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -84,11 +84,10 @@
 
 (defmethod qp.si/streaming-results-writer :csv
   [_ ^OutputStream os]
-  (let [writer             (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
-        ordered-formatters (volatile! nil)
-        pivot-data         (atom nil)
-        pivot-rows         (volatile! [])
-        pivoted-export?    (volatile! nil)]
+  (let [writer                  (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
+        ordered-formatters      (volatile! nil)
+        pivot-data              (volatile! nil)
+        enable-pivoted-exports? (public-settings/enable-pivoted-exports)]
     (reify qp.si/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols results_timezone format-rows? pivot-export-options pivot?]
                    :or   {format-rows? true
@@ -97,47 +96,47 @@
               pivot-grouping-key (qp.pivot.postprocess/pivot-grouping-index col-names)]
           (cond
             (and pivot? pivot-export-options)
-            (reset! pivot-data
-                    {:settings viz-settings
-                     :data {:cols (vec ordered-cols)
-                            :rows []}
-                     :timezone results_timezone
-                     :format-rows? format-rows?
-                     :pivot-grouping-key pivot-grouping-key
-                     :pivot-export-options pivot-export-options})
-            ;; Non-pivoted export of pivot table: sore the pivot-grouping-key so that the pivot group can be
+            (vreset! pivot-data
+                     {:settings viz-settings
+                      :data {:cols (vec ordered-cols)
+                             :rows (transient [])}
+                      :timezone results_timezone
+                      :format-rows? format-rows?
+                      :pivot-grouping-key pivot-grouping-key
+                      :pivot-export-options pivot-export-options})
+            ;; Non-pivoted export of pivot table: store the pivot-grouping-key so that the pivot group can be
             ;; removed from the exported data
             pivot-export-options
-            (reset! pivot-data {:pivot-grouping-key pivot-grouping-key}))
+            (vreset! pivot-data {:pivot-grouping-key pivot-grouping-key}))
 
           (vreset! ordered-formatters
                    (mapv #(formatter/create-formatter results_timezone % viz-settings format-rows?) ordered-cols))
 
-          (vreset! pivoted-export? (public-settings/enable-pivoted-exports))
-
-          ;; write the column names for non-pivot tables
-          (when (or (not pivot?) (not (public-settings/enable-pivoted-exports)))
+          ;; Write the column names for non-pivot tables
+          (when (or (not pivot?) (not enable-pivoted-exports?))
             (let [header (m/remove-nth (or pivot-grouping-key (inc (count col-names))) col-names)]
               (write-csv writer [header])
               (.flush writer)))))
 
       (write-row! [_ row _row-num _ {:keys [output-order]}]
-        (let [ordered-row (if output-order
-                            (mapv (vec row) output-order)
-                            row)
-              {:keys [pivot-grouping-key]} @pivot-data
-              group                    (get ordered-row pivot-grouping-key)]
-          (if (and (contains? @pivot-data :data) @pivoted-export?)
-            ;; TODO: try using a transient
-            (vswap! pivot-rows conj ordered-row)
-            (if group
-              (when (= qp.pivot.postprocess/NON_PIVOT_ROW_GROUP (int group))
+        (let [ordered-row                       (if output-order
+                                                  (mapv (vec row) output-order)
+                                                  row)
+              {:keys [pivot-grouping-key data]} @pivot-data
+              pivot-group                       (get ordered-row pivot-grouping-key)]
+          (if (and data enable-pivoted-exports?)
+            ;; For pivot tables, accumulate rows in memory in a transient
+            (vswap! pivot-data update-in [:data :rows] conj! ordered-row)
+            (if pivot-group
+              ;; Non-pivoted pivot table: we have to remove the pivot-grouping column
+              (when (= qp.pivot.postprocess/NON_PIVOT_ROW_GROUP (int pivot-group))
                 (let [formatted-row (->> (perf/mapv (fn [formatter r]
                                                       (formatter (streaming.common/format-value r)))
                                                     @ordered-formatters ordered-row)
                                          (m/remove-nth pivot-grouping-key))]
                   (write-csv writer [formatted-row])
                   (.flush writer)))
+              ;; All other results: write directly to the CSV
               (let [formatted-row (perf/mapv (fn [formatter r]
                                                (formatter (streaming.common/format-value r)))
                                              @ordered-formatters ordered-row)]
@@ -145,26 +144,14 @@
                 (.flush writer))))))
 
       (finish! [_ _]
-        ;; TODO -- not sure we need to flush both
-        (when (and (contains? @pivot-data :data) @pivoted-export?)
-          (let [pivot-export-options (:pivot-export-options @pivot-data)
-                row-indexes (:pivot-rows pivot-export-options)
-                col-indexes (:pivot-cols pivot-export-options)
-                val-indexes (:pivot-measures pivot-export-options)
-                columns    (pivot/columns-without-pivot-group (-> @pivot-data :data :cols))
-                formatters (make-formatters
-                            columns
-                            row-indexes
-                            col-indexes
-                            val-indexes
-                            (:settings @pivot-data)
-                            (:timezone @pivot-data)
-                            (:format-rows? @pivot-data))
-                output     (qp.pivot.postprocess/build-pivot-output
-                            (assoc-in @pivot-data [:data :rows] @pivot-rows)
-                            formatters)]
+        (when (and (contains? @pivot-data :data) enable-pivoted-exports?)
+          (let [{:keys [data settings timezone format-rows? pivot-export-options]} @pivot-data
+                {:keys [pivot-rows pivot-cols pivot-measures]} pivot-export-options
+                columns (pivot/columns-without-pivot-group (:cols data))
+                formatters (make-formatters columns pivot-rows pivot-cols pivot-measures settings timezone format-rows?)
+                output (qp.pivot.postprocess/build-pivot-output
+                        (update-in @pivot-data [:data :rows] persistent!)
+                        formatters)]
             (doseq [xf-row output]
               (write-csv writer [xf-row]))))
-        (.flush writer)
-        (.flush os)
         (.close writer)))))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -94,7 +94,7 @@
                    :or   {format-rows? true
                           pivot?       false}} :data} viz-settings]
         (let [col-names          (vec (streaming.common/column-titles ordered-cols (::mb.viz/column-settings viz-settings) format-rows?))
-              pivot-grouping-key (qp.pivot.postprocess/pivot-grouping-key col-names)]
+              pivot-grouping-key (qp.pivot.postprocess/pivot-grouping-index col-names)]
           (cond
             (and pivot? pivot-export-options)
             (reset! pivot-data

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -39,7 +39,7 @@
       (begin! [_ {{:keys [ordered-cols results_timezone format-rows?]
                    :or   {format-rows? true}} :data} viz-settings]
         (let [cols           (streaming.common/column-titles ordered-cols (::mb.viz/column-settings viz-settings) format-rows?)
-              pivot-grouping (qp.pivot.postprocess/pivot-grouping-key cols)]
+              pivot-grouping (qp.pivot.postprocess/pivot-grouping-index cols)]
           (when pivot-grouping (vreset! pivot-grouping-idx pivot-grouping))
           (let [names (cond->> cols
                         pivot-grouping (m/remove-nth pivot-grouping))]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -18,14 +18,22 @@
    [metabase.util.json :as json])
   (:import
    (java.io OutputStream)
-   (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)
-   (org.apache.poi.openxml4j.util ZipSecureFile)
-   (org.apache.poi.ss SpreadsheetVersion)
-   (org.apache.poi.ss.usermodel Cell DataConsolidateFunction DataFormat DateUtil Workbook)
-   (org.apache.poi.ss.util AreaReference CellRangeAddress CellReference)
+   (java.time
+    LocalDate
+    LocalDateTime
+    LocalTime
+    OffsetDateTime
+    OffsetTime
+    ZonedDateTime)
+   (org.apache.poi.ss.usermodel
+    Cell
+    DataConsolidateFunction
+    DataFormat
+    DateUtil
+    Workbook)
+   (org.apache.poi.ss.util CellRangeAddress)
    (org.apache.poi.xssf.streaming SXSSFRow SXSSFSheet SXSSFWorkbook)
-   (org.apache.poi.xssf.usermodel XSSFPivotTable XSSFRow XSSFSheet XSSFWorkbook)
-   (org.openxmlformats.schemas.spreadsheetml.x2006.main STFieldSortType)))
+   (org.apache.poi.xssf.usermodel XSSFRow XSSFSheet)))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -641,7 +641,7 @@
    :col-formatters (create-formatters cell-styles col-settings cols col-indexes)
    :val-formatters (create-formatters cell-styles col-settings cols val-indexes)})
 
-(defn* generate-styles
+(defn- generate-styles
   [workbook viz-settings non-pivot-cols format-rows?]
   (let [data-format (. ^SXSSFWorkbook workbook createDataFormat)]
     {:cell-styles (compute-column-cell-styles workbook data-format viz-settings non-pivot-cols format-rows?)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.streaming.xlsx
   (:require
    [clojure.string :as str]
-   [clojure.tools.logging :as log]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
    [java-time.api :as t]
    [medley.core :as m]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -521,17 +521,7 @@
                       ["Gizmo" "$529.70" "$1,080.18" "$997.94" "$227.06" "$2,834.88"]
                       ["Widget" "$987.39" "$1,014.68" "$912.20" "$195.04" "$3,109.31"]
                       ["Grand totals" "$2,829.06" "$4,008.16" "$3,251.08" "$1,060.98" "$11,149.28"]]
-                     (card-download card {:export-format :csv :format-rows true :pivot true}))))
-            (testing "the xlsx export has a pivot table"
-              (let [result (mt/user-http-request :crowberto :post 200
-                                                 (format "card/%d/query/xlsx" (:id card))
-                                                 {:format_rows   true
-                                                  :pivot_results true})
-                    pivot  (with-open [in (io/input-stream result)]
-                             (->> (spreadsheet/load-workbook in)
-                                  (spreadsheet/select-sheet "pivot")
-                                  ((fn [s] (.getPivotTables ^XSSFSheet s)))))]
-                (is (some? pivot))))))))))
+                     (card-download card {:export-format :csv :format-rows true :pivot true}))))))))))
 
 (deftest ^:parallel pivot-export-test
   (mt/dataset test-data

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -754,27 +754,6 @@
                           [[1]
                            [2]]))))))
 
-(deftest pivot-table-resource-usage-test
-  (testing "pivot table initialization should complete in reasonable time and memory"
-    ;; We test XLSX export of an empty table (0 rows) with pivoting enabled. This should test the initialization of
-    ;; pivot machinery that used to allocate and retain a lot of memory (and hence was slow on smaller heaps).
-    (let [do-export #(xlsx-export [{:display_name "A"}
-                                   {:display_name "B"}
-                                   {:display_name "C"}
-                                   {:display_name "D"}
-                                   {:display_name "pivot-grouping"}
-                                   {:display_name "E"}
-                                   {:display_name "F"}]
-                                  {}
-                                  []
-                                  :pivot-export-options {:pivot-rows [0 1], :pivot-cols [2 3], :pivot-measures [5 4]})
-          ;; Run once before measuring to warm-up and thus reduce flakiness.
-          _ (do-export)
-          start-bytes (get-allocated-bytes)]
-      (do-export)
-      ;; Should always allocate less than 100Mb.
-      (is (< (- (get-allocated-bytes) start-bytes) (* 100 1024 1024))))))
-
 (deftest number-of-characters-cell-test
   (testing "When the number of characters exceeds *number-of-characters-cell*, the excess part will be truncated."
     (binding [qp.xlsx/*number-of-characters-cell* 5]

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -12,9 +12,11 @@
    [metabase.util.json :as json])
   (:import
    (com.fasterxml.jackson.core JsonGenerator)
-   (com.sun.management ThreadMXBean)
-   (java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream)
-   (java.lang.management ManagementFactory)))
+   (java.io
+    BufferedInputStream
+    BufferedOutputStream
+    ByteArrayInputStream
+    ByteArrayOutputStream)))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -428,9 +428,6 @@
            (.. cell getCellStyle getDataFormatString))
          row)))
 
-(defn- get-allocated-bytes []
-  (.getCurrentThreadAllocatedBytes ^ThreadMXBean (ManagementFactory/getThreadMXBean)))
-
 (deftest export-format-test
   (mt/with-temporary-setting-values [custom-formatting {}]
     (testing "Different format strings are used for ints and numbers that round to ints (with 2 decimal places)"


### PR DESCRIPTION
Removes our prior approach for pivoted XLSX exports, which was trying to generate native Excel PivotTables but had many correctness issues due to Excel limitations. Switches instead to generating the pivoted shape in-memory as we do for CSVs and then writing it to the XLSX workbook directly.

We're still leveraging Excel's native formatting using format codes. The XLSX export code generates custom formatters (in `make-formatters`) which annotate the raw values with their format codes, and these are passed into the pivot namespace instead of the normal value formatters.

Fixes https://github.com/metabase/metabase/issues/54498
Fixes https://github.com/metabase/metabase/issues/54497