### PR TITLE
Parse BigQuery timestamp values with microsecond precision

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1237,3 +1237,15 @@
           (is (= "bigquery.example.com"
                  (.getHost (.getOptions client)))
               "BigQuery client should be configured with alternate host"))))))
+
+(deftest timestamp-precision-test
+  (mt/test-driver :bigquery-cloud-sdk
+    (let [sql (str "select"
+                   " timestamp '2024-12-11 16:23:55.123456 UTC' col_timestamp,"
+                   " datetime  '2024-12-11T16:23:55.123456' col_datetime")
+          query {:database (mt/id)
+                 :type :native
+                 :native {:query sql}}]
+      (is (=? [["2024-12-11T16:23:55.123456Z" #"2024-12-11T16:23:55.123456.*"]]
+              (-> (qp/process-query query)
+                  mt/rows))))))


### PR DESCRIPTION
Fixes #51175
Fixes QUE-529

### Description

BigQuery sometimes returns timestamp values as floating point values (as strings, of course). We used to pass the parsed double value to java-time.api/instant, but that seems to have microsecond precision. In this change we use Java's built-in Instant construction function to keep the full precision.

### How to verify

Try the repro steps from #51175. Now the row should be returned. Also check out the new test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
