### PR TITLE
backport to 0.53.x: [metrics] Add hiccup and allocation rate metrics (#56345)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,6 +36,8 @@
   com.clearspring.analytics/stream          {:mvn/version "2.9.8"               ; Various sketching algorithms
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
+  com.clojure-goes-fast/jvm-alloc-rate-meter{:mvn/version "0.1.4"}              ; Monitor heap allocation rate.
+  com.clojure-goes-fast/jvm-hiccup-meter    {:mvn/version "0.1.1"}              ; Monitor GC pauses and other system-induced pauses.
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.0"}              ; trans dep of commons-codec
   ; Detect the charset in uploaded CSV files

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -11,6 +11,8 @@
    [iapetos.collector :as collector]
    [iapetos.collector.ring :as collector.ring]
    [iapetos.core :as prometheus]
+   [jvm-alloc-rate-meter.core :as alloc-rate-meter]
+   [jvm-hiccup-meter.core :as hiccup-meter]
    [metabase.analytics.settings :refer [prometheus-server-port]]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.server.core :as server]
@@ -179,7 +181,11 @@
                     (MemoryPoolsExports.))
    (collector/named {:namespace "metabase_application"
                      :name      "jvm_threads"}
-                    (ThreadExports.))])
+                    (ThreadExports.))
+   (prometheus/histogram :metabase_application/jvm_hiccups
+                         {:description "Duration in milliseconds of system-induced pauses."})
+   (prometheus/gauge :metabase_application/jvm_allocation_rate
+                     {:description "Heap allocation rate in bytes/sec."})])
 
 (defn- jetty-collectors
   []
@@ -313,6 +319,9 @@
                            (keyword? v) (u/qualified-name v)
                            :else v))))
 
+(def ^:private jvm-hiccup-thread (atom nil))
+(def ^:private jvm-alloc-rate-thread (atom nil))
+
 (defn- setup-metrics!
   "Instrument the application. Conditionally done when some setting is set. If [[prometheus-server-port]] is not set it
   will throw."
@@ -327,6 +336,14 @@
                                 (product-collectors)))]
     (doseq [{:keys [metric labels value]} (initial-labelled-metric-values)]
       (prometheus/inc registry metric (qualified-vals labels) value))
+    (when @jvm-hiccup-thread (@jvm-hiccup-thread))
+    (reset! jvm-hiccup-thread
+            (hiccup-meter/start-hiccup-meter
+             #(some-> (:registry system) (prometheus/observe :metabase_application/jvm_hiccups (/ % 1e6)))))
+    (when @jvm-alloc-rate-thread (@jvm-alloc-rate-thread))
+    (reset! jvm-alloc-rate-thread
+            (alloc-rate-meter/start-alloc-rate-meter
+             #(some-> (:registry system) (prometheus/observe :metabase_application/jvm_allocation_rate %))))
     registry))
 
 (defn- start-web-server!
@@ -363,6 +380,8 @@
   (when system
     (locking #'system
       (when system
+        (when @jvm-hiccup-thread (@jvm-hiccup-thread))
+        (when @jvm-alloc-rate-thread (@jvm-alloc-rate-thread))
         (try (stop-web-server system)
              (prometheus/clear (.-registry system))
              (alter-var-root #'system (constantly nil))


### PR DESCRIPTION
Manual backport of #56345