### PR TITLE
[svg] Pool static-viz-context objects

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -137,6 +137,7 @@
   org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.80"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.80"}
   org.clj-commons/claypoole                 {:mvn/version "1.2.2"}              ; Threadpool tools for Clojure
+  org.clj-commons/dirigiste                 {:mvn/version "1.0.4"}              ; Instrumented object pooling
   org.clj-commons/hickory                   {:mvn/version "0.7.7"               ; Parse HTML into Clojure data structures
                                              :exclusions [org.jsoup/jsoup]}
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -12,6 +12,7 @@
    [metabase.util.delay :as delay]
    [metabase.util.json :as json])
   (:import
+   (io.aleph.dirigiste Pool IPool$Generator IPool$Controller Pools Stats)
    (java.io ByteArrayInputStream ByteArrayOutputStream)
    (java.nio.charset StandardCharsets)
    (java.util.concurrent TimeUnit)
@@ -43,22 +44,56 @@
     (js.engine/load-resource bundle-path)
     (js.engine/load-resource interface-path)))
 
-(def ^:private static-viz-context-delay
-  "Delay containing a graal js context. It has the chart bundle and the above `src-api` in its environment suitable for
-  creating charts. However, under some circumstances, the Truffle JS engine tends to leak memory, so we don't want to
-  keep the reference to the engine forever. Ideally, we would like to make the engine lifetime bound to a single
-  request or something like that, but that would introduce a lot of changes and noise to the system. Hence, with this
-  bandaid, we keep the JS engine for some reasonable time (10 minutes) before recreating it."
-  (delay/delay-with-ttl (.toMillis TimeUnit/MINUTES 10)
-                        #(load-viz-bundle (js.engine/context))))
+(def ^:private ^Pool static-viz-context-pool
+  "Pool of Truffle JS engine objects. They are not thread-safe, so the access to them has to be carefully managed
+  between threads. Each engine with loaded static viz code takes ~130 MB in memory, so we don't want too many of them.
+  However, one takes ~3 seconds to initialize, so we don't want to load them anew each time in prod. Under some
+  circumstances, the Truffle JS engine tends to leak memory, so we don't want to keep the reference to the engine
+  forever. Considering all that, this pool targets 100% utilization (so, if the utilization is lower, the pool will
+  start dropping objects) and the maximum of 3 objects (to prevent OOMs), but at least 1 object will always be in the
+  pool to pick up. However, together with each engine object keep its creation timestamp so that we can throwaway
+  instances that are too old to avoid leaks."
+  ;; We build upon plain utilization controller that keeps up to 3 instances, but can go down to zero.
+  (let [base-controller (Pools/utilizationController 1.0 3 3)]
+    (Pool. (reify IPool$Generator
+             (generate [_ _]
+               ;; Generate a tuple of the engine and the expiry timestamp.
+               [(load-viz-bundle (js.engine/context))
+                (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES 10))])
+             (destroy [_ _ v]))
+           ;; Wrap the utilization controller with a modification that doesn't allow the pool to go below 1 instance.
+           (reify IPool$Controller
+             (shouldIncrement [_ k a b] (.shouldIncrement base-controller k a b))
+             (adjustment [_ stats]
+               (let [adj (.adjustment base-controller stats)
+                     ;; :engines is arbitrary key, it just has to be consistent everywhere when working with the pool.
+                     n (some-> ^Stats (:engines stats) .getNumWorkers)
+                     engines-adj (:engines adj)]
+                 (if (and n engines-adj (<= (+ n engines-adj) 0))
+                   ;; If the adjustment is going to bring the pool to 0 engines, return empty adjustment instead.
+                   {}
+                   adj))))
+           65000 ;; Queue size - doesn't matter much.
+           25 ;; Sampling interval - doesn't matter much.
+           10000 ;; Recheck every 10 seconds
+           TimeUnit/MILLISECONDS)))
 
-(defn- context
-  "Returns a static viz context. In dev mode, this will be a new context each time. In prod or test modes, it will
-  return the derefed contents of `static-viz-context-delay`."
-  ^Context []
+(defn do-with-static-viz-context [f]
   (if config/is-dev?
-    (load-viz-bundle (js.engine/context))
-    @static-viz-context-delay))
+    (f (load-viz-bundle (js.engine/context)))
+    (loop []
+      (let [[context expiry-ts :as tuple] (.acquire static-viz-context-pool :engines)]
+        (if (>= (System/nanoTime) expiry-ts)
+          (do (.dispose static-viz-context-pool :engines tuple)
+              (recur))
+          (try (f context)
+               (finally (.release static-viz-context-pool :engines tuple))))))))
+
+(defmacro with-static-viz-context
+  "Execute `body` where `binding-name` is bound to a static viz context. In dev mode, this will be a new context each
+  time. In prod or test modes, it will return an instance from `static-viz-context-pool`."
+  [binding-name & body]
+  `(do-with-static-viz-context (fn [~binding-name] ~@body)))
 
 (defn- post-process
   "Mutate in place the elements of the svg document. Remove the fill=transparent attribute in favor of
@@ -153,21 +188,23 @@
   "Clojure entrypoint to render a funnel chart. Data should be vec of [[Step Measure]] where Step is {:name name :format format-options} and Measure is {:format format-options} and you go and look to frontend/src/metabase/static-viz/components/FunnelChart/types.ts for the actual format options.
   Returns a byte array of a png file."
   [data settings]
-  (let [svg-string (.asString (js.engine/execute-fn-name (context) "funnel" (json/encode data)
-                                                         (json/encode settings)))]
+  (let [svg-string (with-static-viz-context context
+                     (.asString (js.engine/execute-fn-name context "funnel" (json/encode data)
+                                                           (json/encode settings))))]
     (svg-string->bytes svg-string)))
 
 (defn ^:dynamic *javascript-visualization*
   "Clojure entrypoint to render javascript visualizations.
 This functions is dynanic only for testing purposes."
   [cards-with-data dashcard-viz-settings]
-  (let [response (.asString (js.engine/execute-fn-name (context) "javascript_visualization"
-                                                       (json/encode cards-with-data)
-                                                       (json/encode dashcard-viz-settings)
-                                                       (json/encode {:applicationColors (public-settings/application-colors)
-                                                                     :startOfWeek (public-settings/start-of-week)
-                                                                     :customFormatting (public-settings/custom-formatting)
-                                                                     :tokenFeatures (public-settings/token-features)})))]
+  (let [response (with-static-viz-context context
+                   (.asString (js.engine/execute-fn-name context "javascript_visualization"
+                                                         (json/encode cards-with-data)
+                                                         (json/encode dashcard-viz-settings)
+                                                         (json/encode {:applicationColors (public-settings/application-colors)
+                                                                       :startOfWeek (public-settings/start-of-week)
+                                                                       :customFormatting (public-settings/custom-formatting)
+                                                                       :tokenFeatures (public-settings/token-features)}))))]
     (-> response
         json/decode+kw
         (update :type (fnil keyword "unknown")))))
@@ -175,30 +212,33 @@ This functions is dynanic only for testing purposes."
 (defn row-chart
   "Clojure entrypoint to render a row chart."
   [settings data]
-  (let [svg-string (.asString (js.engine/execute-fn-name (context) "row_chart"
-                                                         (json/encode settings)
-                                                         (json/encode data)
-                                                         (json/encode (public-settings/application-colors))))]
+  (let [svg-string (with-static-viz-context context
+                     (.asString (js.engine/execute-fn-name context "row_chart"
+                                                           (json/encode settings)
+                                                           (json/encode data)
+                                                           (json/encode (public-settings/application-colors)))))]
     (svg-string->bytes svg-string)))
 
 (defn gauge
   "Clojure entrypoint to render a gauge chart. Returns a byte array of a png file"
   [card data]
-  (let [js-res (js.engine/execute-fn-name (context) "gauge"
-                                          (json/encode card)
-                                          (json/encode data))
-        svg-string (.asString js-res)]
-    (svg-string->bytes svg-string)))
+  (with-static-viz-context context
+    (let [js-res (js.engine/execute-fn-name context "gauge"
+                                            (json/encode card)
+                                            (json/encode data))
+          svg-string (.asString js-res)]
+      (svg-string->bytes svg-string))))
 
 (defn progress
   "Clojure entrypoint to render a progress bar. Returns a byte array of a png file"
   [value goal settings]
-  (let [js-res (js.engine/execute-fn-name (context) "progress"
-                                          (json/encode {:value value :goal goal})
-                                          (json/encode settings)
-                                          (json/encode (public-settings/application-colors)))
-        svg-string (.asString js-res)]
-    (svg-string->bytes svg-string)))
+  (with-static-viz-context context
+    (let [js-res (js.engine/execute-fn-name context "progress"
+                                            (json/encode {:value value :goal goal})
+                                            (json/encode settings)
+                                            (json/encode (public-settings/application-colors)))
+          svg-string (.asString js-res)]
+      (svg-string->bytes svg-string))))
 
 (def ^:private icon-paths
   {:dashboard "M32 28a4 4 0 0 1-4 4H4a4.002 4.002 0 0 1-3.874-3H0V4a4 4 0 0 1 4-4h25a3 3 0 0 1 3 3v25zm-4 0V8H4v20h24zM7.273 18.91h10.182v4.363H7.273v-4.364zm0-6.82h17.454v4.365H7.273V12.09zm13.09 6.82h4.364v4.363h-4.363v-4.364z"

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -78,9 +78,6 @@
       (is (no-html-elements tag-set) (str "Contained html elements: "
                                           (set/intersection #{"div" "span" "p"}))))))
 
-(defn- context ^Context []
-  (#'js.svg/context))
-
 (deftest ^:parallel progress-test
   (let [value    1234
         goal     1337
@@ -88,14 +85,14 @@
     (testing "It returns bytes"
       (let [svg-bytes (js.svg/progress value goal settings)]
         (is (bytes? svg-bytes))))
-    (let [svg-string (.asString ^Value
-                      (js.engine/execute-fn-name
-                       (context)
-                       "progress"
-                       (json/encode {:value value :goal goal})
-                       (json/encode settings)
-                       (json/encode {})))]
-      (validate-svg-string :progress svg-string))))
+    (js.svg/with-static-viz-context context
+      (let [svg-string (.asString ^Value (js.engine/execute-fn-name
+                                          context
+                                          "progress"
+                                          (json/encode {:value value :goal goal})
+                                          (json/encode settings)
+                                          (json/encode {})))]
+        (validate-svg-string :progress svg-string)))))
 
 (deftest ^:parallel parse-svg-sanitizes-characters-test
   (testing "Characters discouraged or not permitted by the xml 1.0 specification are removed. (#"


### PR DESCRIPTION
This is an attempt to address #42496. Instead of a time-limited delay of one JS context object, keep a pool of up to 3 objects to be shareable across multiple threads.

- The pool has 100% target utilization, which means that it will strive towards not keeping objects when they are not used. This means somewhat longer waiting on the first request after a while, but at the same time, the pool will be empty when unused, thus not even 1 context object will occupy the heap needlessly.
- Since pool will drop unused contexts, this solves the memory leak issue same as the current time-bound delay does.
- Three object limit is just guesswork. Having more risks going into OOM in certain scenarios. Having just 2 doesn't justify going with the whole pool approach; might as well stay with the current delay-based one.