### PR TITLE
Compute current chart's setting when adding a new data source

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -65,6 +65,13 @@ export function ensureDisplayIsSelected(display: VisualizationDisplay) {
   cy.findByDisplayValue(display).should("be.checked");
 }
 
+export function selectColumnFromColumnsList(
+  datasetName: string,
+  columnName: string,
+) {
+  dataSourceColumn(datasetName, columnName).click();
+}
+
 export function deselectColumnFromColumnsList(
   datasetName: string,
   columnName: string,

--- a/e2e/support/test-visualizer-data.ts
+++ b/e2e/support/test-visualizer-data.ts
@@ -147,6 +147,19 @@ export const SCALAR_CARD: Record<string, NativeQuestionDetailsWithName> = {
   },
 };
 
+export const PIVOT_TABLE_CARD: StructuredQuestionDetailsWithName = {
+  name: "Pivot table",
+  display: "pivot",
+  query: {
+    aggregation: [["count"], ["avg", ["field", ORDERS.QUANTITY, null]]],
+    breakout: [
+      ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+      ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+    ],
+    "source-table": ORDERS_ID,
+  },
+};
+
 export const STEP_COLUMN_CARD: NativeQuestionDetailsWithName = {
   name: "Step Column",
   display: "table",

--- a/e2e/test/scenarios/dashboard/visualizer/dashboard-visualizer.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/dashboard-visualizer.cy.spec.ts
@@ -4,6 +4,7 @@ import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   ORDERS_COUNT_BY_CREATED_AT,
   ORDERS_COUNT_BY_PRODUCT_CATEGORY,
+  PIVOT_TABLE_CARD,
   PRODUCTS_COUNT_BY_CATEGORY,
   PRODUCTS_COUNT_BY_CATEGORY_PIE,
   PRODUCTS_COUNT_BY_CREATED_AT,
@@ -952,6 +953,47 @@ describe("scenarios > dashboard > visualizer", () => {
           .findAllByTestId("well-item")
           .should("have.length", 0);
       });
+    });
+  });
+
+  it("should work correctly when built from a non-cartesian chart", () => {
+    H.createQuestion(PIVOT_TABLE_CARD);
+
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(PIVOT_TABLE_CARD.name);
+
+    H.modal().within(() => {
+      H.deselectColumnFromColumnsList(
+        PIVOT_TABLE_CARD.name,
+        "Product → Category",
+      );
+      H.deselectColumnFromColumnsList(
+        PIVOT_TABLE_CARD.name,
+        "Average of Quantity",
+      );
+      H.deselectColumnFromColumnsList(PIVOT_TABLE_CARD.name, "pivot-grouping");
+
+      H.switchToAddMoreData();
+      H.addDataset(ORDERS_COUNT_BY_CREATED_AT.name);
+      H.switchToColumnsList();
+      // Shouldn't this be automatic though?
+      H.selectColumnFromColumnsList(ORDERS_COUNT_BY_CREATED_AT.name, "Count");
+
+      H.verticalWell().within(() => {
+        cy.findByText("Count").should("exist");
+        cy.findByText(`Count (${ORDERS_COUNT_BY_CREATED_AT.name})`).should(
+          "exist",
+        );
+        cy.findAllByTestId("well-item").should("have.length", 2);
+      });
+      H.horizontalWell().within(() => {
+        cy.findByText("Created At: Year").should("exist");
+        cy.findAllByTestId("well-item").should("have.length", 1);
+      });
+
+      H.chartLegendItems().should("have.length", 2);
     });
   });
 });


### PR DESCRIPTION
Fixes an issue when columns auto-mapping wasn't working for cartesian charts made of pivot tables. The root cause was that we weren't using the current chart's computed settings when adding a new data source. With pivot tables, if we remove columns until we have a dimension and a measure (or several measures), visualizer wouldn't set them explicitly in viz settings, so the code combing the datasets won't "see them". Fixed by passing computed viz settings to `maybeCombineDataset`. Had to move more code inside `addDataSource` thunk, so we can use a selector to get visualizer chart's raw series to compute viz settings properly

### To verify

1. Create a pivot table (e.g. count + avg discount + avg total by category and created at)
2. Open the pivot table in visualizer, and remove columns, so you only have Count + Created At (visualizer should automatically switch to a bar chart in that case)
3. Add another data source with a time dimension
4. Ensure new data source's column are automatically imported so you have two series