### PR TITLE
docs: mention supabase

### DIFF
--- a/docs/databases/connections/postgresql.md
+++ b/docs/databases/connections/postgresql.md
@@ -18,7 +18,7 @@ Metabase supports the oldest supported version of PostgreSQL through the latest 
 
 ## Connect to Supabase
 
-You can select PostgreSQL to connect to your Supabase database. Refer to [Supabase documentation](https://supabase.com/docs/guides/database/metabase) for more details.
+To connect to a Supabase database, select PostgreSQL. For more details, check out the [Supabase docs](https://supabase.com/docs/guides/database/metabase).
 
 ## Connection and sync
 

--- a/docs/databases/connections/postgresql.md
+++ b/docs/databases/connections/postgresql.md
@@ -16,6 +16,10 @@ Fill out the fields for that database, and click **Save changes** at the bottom.
 
 Metabase supports the oldest supported version of PostgreSQL through the latest stable version. See [PostgreSQL versions](https://www.postgresql.org/support/versioning/).
 
+## Connect to Supabase
+
+You can select PostgreSQL to connect to your Supabase database. Refer to [Supabase documentation](https://supabase.com/docs/guides/database/metabase) for more details.
+
 ## Connection and sync
 
 After connecting to a database, you'll see the "Connection and sync" section that displays the current connection status and options to manage your database connection.


### PR DESCRIPTION
Adding for search discoverability, because supabase is insanely popular. 
Just referring people to supabase's own docs on connecting to Metabase - although I could also walk people through the connection if we think that's better

[Slack thread for context](https://metaboat.slack.com/archives/C064EB1UE5P/p1744625648157679)