### PR TITLE
Wait a bit longer in util.queue tests to let them pass in CI

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -300,6 +300,7 @@
   metabase.util.malli/with                                                             [[:default]]
   metabase.util.malli/with-api-error-message                                           [[:default]]
   metabase.util.namespaces/import-fns                                                  [[:default]]
+  metabase.util.queue-test/await-test                                                  [[:block 1]]
   metabuild-common.core/exit-when-finished-nonzero-on-exception                        [[:block 0]]
   metabuild-common.core/step                                                           [[:block 1]]
   metabuild-common.entrypoint/exit-when-finished-nonzero-on-exception                  [[:block 0]]

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -300,7 +300,7 @@
   metabase.util.malli/with                                                             [[:default]]
   metabase.util.malli/with-api-error-message                                           [[:default]]
   metabase.util.namespaces/import-fns                                                  [[:default]]
-  metabase.util.queue-test/await-test                                                  [[:block 1]]
+  metabase.util.queue-test/await-test-while                                            [[:block 1]]
   metabuild-common.core/exit-when-finished-nonzero-on-exception                        [[:block 0]]
   metabuild-common.core/step                                                           [[:block 1]]
   metabuild-common.entrypoint/exit-when-finished-nonzero-on-exception                  [[:block 0]]

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -127,6 +127,19 @@
 (defn- thread-name-running? [name]
   (some #(= name (.getName ^Thread %)) (keys (Thread/getAllStackTraces))))
 
+(defmacro ^:private await-test
+  "Wait 100 times 10 milliseconds or until `delay-condition` becomes false and evaluate `assertions`.
+  Reaching 100 tries results in the test failing."
+  {:style/indent 1}
+  [delay-condition & assertions]
+  ;; make tries and the sleep time macro parameters if needed
+  `(loop [tries# 100]
+     (Thread/sleep 10)
+     (cond
+       (zero? tries#)   (is false "Max waiting time exceeded")
+       ~delay-condition (recur (dec tries#))
+       :else            (do ~@assertions))))
+
 (deftest listener-handler-test
   (testing "Standard behavior with a handler"
     (let [listener-name "test-listener"
@@ -146,20 +159,22 @@
       (is (nil? (queue/listen! listener-name queue
                                (fn [batch] (throw (ex-info "Second listener with the same name cannot be created" {:batch batch})))
                                {:max-next-ms 5})))
+      (try
+        (queue/put-with-delay! queue 0 "a")
+        (await-test (zero? @items-handled)
+                    (is (= 1 @items-handled))
+                    (is (= ["a"] @last-batch)))
 
-      (queue/put-with-delay! queue 0 "a")
-      (Thread/sleep 10)
-      (is (= 1 @items-handled))
-      (is (= ["a"] @last-batch))
+        (queue/put-with-delay! queue 0 "b")
+        (queue/put-with-delay! queue 0 "c")
+        (queue/put-with-delay! queue 0 "d")
+        (await-test (< @items-handled 4)
+                    (is (= 4 @items-handled))
+                    (is (some #{"d"} @last-batch)))
 
-      (queue/put-with-delay! queue 0 "b")
-      (queue/put-with-delay! queue 0 "c")
-      (queue/put-with-delay! queue 0 "d")
-      (Thread/sleep 10)
-      (is (= 4 @items-handled))
-      (is (some #{"d"} @last-batch))
+        (finally
+          (queue/stop-listening! listener-name)))
 
-      (queue/stop-listening! listener-name)
       (is (not (thread-name-running? thread-name)))
       (is (not (queue/listener-exists? listener-name)))
 
@@ -174,27 +189,30 @@
           error-count (atom 0)
           last-error (atom nil)]
       (queue/listen! listener-name queue
-                     (fn [batch] (if (some #{"err"} batch)
-                                   (throw (ex-info "Test Error" {:batch batch}))
-                                   (count batch)))
+                     (fn [batch]
+                       (if (some #{"err"} batch)
+                         (throw (ex-info "Test Error" {:batch batch}))
+                         (count batch)))
                      {:success-handler (fn [result duration name]
                                          (is (= listener-name name))
                                          (is (< 0 duration))
                                          (swap! result-count + result))
                       :err-handler     (fn [e _] (swap! error-count inc) (reset! last-error e))
                       :max-next-ms    5})
-      (queue/put-with-delay! queue 0 "a")
-      (Thread/sleep 10)
-      (is (= 0 @error-count))
-      (is (= 1 @result-count))
+      (try
+        (queue/put-with-delay! queue 0 "a")
+        (await-test (zero? @result-count)
+                    (is (= 0 @error-count))
+                    (is (= 1 @result-count)))
 
-      (queue/put-with-delay! queue 0 "err")
-      (Thread/sleep 10)
-      (is (= 1 @error-count))
-      (is (= 1 @result-count))
-      (is (= "Test Error" (.getMessage ^Exception @last-error)))
+        (queue/put-with-delay! queue 0 "err")
+        (await-test (zero? @error-count)
+                    (is (= 1 @error-count))
+                    (is (= 1 @result-count))
+                    (is (= "Test Error" (.getMessage ^Exception @last-error))))
 
-      (queue/stop-listening! listener-name))))
+        (finally
+          (queue/stop-listening! listener-name))))))
 
 (deftest multithreaded-listener-test
   (testing "Test behavior with a multithreaded listener"
@@ -213,18 +231,20 @@
                       :pool-size          3
                       :max-batch-messages 10
                       :max-next-ms        5})
-      (is (thread-name-running? (str "queue-" listener-name "-0")))
-      (is (thread-name-running? (str "queue-" listener-name "-1")))
-      (is (thread-name-running? (str "queue-" listener-name "-2")))
+      (try
+        (is (thread-name-running? (str "queue-" listener-name "-0")))
+        (is (thread-name-running? (str "queue-" listener-name "-1")))
+        (is (thread-name-running? (str "queue-" listener-name "-2")))
 
-      (dotimes [i 100]
-        (queue/put-with-delay! queue 0 i))
+        (dotimes [i 100]
+          (queue/put-with-delay! queue 0 i))
 
-      (Thread/sleep 100)
-      (is (= 100 @batches-handled))
-      (is (contains? @handlers-used listener-name))
+        (await-test (< @batches-handled 100)
+                    (is (= 100 @batches-handled))
+                    (is (contains? @handlers-used listener-name)))
 
-      (queue/stop-listening! listener-name)
+        (finally
+          (queue/stop-listening! listener-name)))
       (is (not (thread-name-running? (str "queue-" listener-name "-0"))))
       (is (not (thread-name-running? (str "queue-" listener-name "-1"))))
       (is (not (thread-name-running? (str "queue-" listener-name "-2ˇ")))))))

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -162,15 +162,15 @@
       (try
         (queue/put-with-delay! queue 0 "a")
         (await-test (zero? @items-handled)
-                    (is (= 1 @items-handled))
-                    (is (= ["a"] @last-batch)))
+          (is (= 1 @items-handled))
+          (is (= ["a"] @last-batch)))
 
         (queue/put-with-delay! queue 0 "b")
         (queue/put-with-delay! queue 0 "c")
         (queue/put-with-delay! queue 0 "d")
         (await-test (< @items-handled 4)
-                    (is (= 4 @items-handled))
-                    (is (some #{"d"} @last-batch)))
+          (is (= 4 @items-handled))
+          (is (some #{"d"} @last-batch)))
 
         (finally
           (queue/stop-listening! listener-name)))
@@ -202,14 +202,14 @@
       (try
         (queue/put-with-delay! queue 0 "a")
         (await-test (zero? @result-count)
-                    (is (= 0 @error-count))
-                    (is (= 1 @result-count)))
+          (is (= 0 @error-count))
+          (is (= 1 @result-count)))
 
         (queue/put-with-delay! queue 0 "err")
         (await-test (zero? @error-count)
-                    (is (= 1 @error-count))
-                    (is (= 1 @result-count))
-                    (is (= "Test Error" (.getMessage ^Exception @last-error))))
+          (is (= 1 @error-count))
+          (is (= 1 @result-count))
+          (is (= "Test Error" (.getMessage ^Exception @last-error))))
 
         (finally
           (queue/stop-listening! listener-name))))))
@@ -240,8 +240,8 @@
           (queue/put-with-delay! queue 0 i))
 
         (await-test (< @batches-handled 100)
-                    (is (= 100 @batches-handled))
-                    (is (contains? @handlers-used listener-name)))
+          (is (= 100 @batches-handled))
+          (is (contains? @handlers-used listener-name)))
 
         (finally
           (queue/stop-listening! listener-name)))


### PR DESCRIPTION
### Description

The 10 ms waiting time in the `metabase.util.queue` tests is not always enough in CI. Wait a bit longer.
The implementation is somewhat crude, but I think it would make my branch pass the CI tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
