### PR TITLE
make the sdk docs check not required so we can merge things

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -150,7 +150,7 @@ jobs:
     needs:
       - embedding-sdk-cli-snippets-type-check
       - embedding-sdk-docs-snippets-type-check
-      - embedding-sdk-docs-update-check
+      # - embedding-sdk-docs-update-check
       - sdk-e2e-tests
       - e2e-component-tests-embedding-sdk-cross-version
     if: always() && !cancelled()


### PR DESCRIPTION
I think we should make this not required so we can merge things until we decide what to do

https://metaboat.slack.com/archives/C063Q3F1HPF/p1744648861164279

**Note: this is set to auto merge**