### PR TITLE
Fix the filter input placeholder for remapping cases

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1033,8 +1033,13 @@ describe("metabase#32985", () => {
 
     H.popover().within(() => {
       cy.findByText("Filter by this column").click();
-      cy.findByPlaceholderText("Search by Email").type("foo");
+      cy.findByPlaceholderText("Search by Email or enter an ID").type("foo");
     });
+    H.popover()
+      .should("have.length", 2)
+      .last()
+      .findByText("No matching Email found.")
+      .should("be.visible");
   });
 });
 

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -591,7 +591,7 @@ describe(
 
           cy.findByTestId("string-filter-picker").within(() => {
             cy.findByLabelText("Filter operator").should("have.text", "Is");
-            cy.findByPlaceholderText("Search by ID").type(id);
+            cy.findByLabelText("Filter value").type(id);
             cy.button("Add filter").click();
           });
 

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1817,14 +1817,13 @@ describe("issue 45063", { tags: "@flaky" }, () => {
 
   function verifySearchFilter({
     fieldDisplayName,
+    fieldPlaceholder,
     fieldValue,
     fieldValueLabel,
   }) {
     H.tableHeaderClick(fieldDisplayName);
     H.popover().findByText("Filter by this column").click();
-    H.popover()
-      .findByPlaceholderText(`Search by ${fieldDisplayName}`)
-      .type(fieldValueLabel);
+    H.popover().findByPlaceholderText(fieldPlaceholder).type(fieldValueLabel);
     H.selectDropdown().findByText(fieldValueLabel).click();
     cy.findByTestId("number-filter-picker")
       .click()
@@ -1839,6 +1838,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
     visitCard,
     fieldId,
     fieldDisplayName,
+    fieldPlaceholder,
     fieldValue,
     fieldValueLabel,
     expectedRowCount,
@@ -1856,7 +1856,12 @@ describe("issue 45063", { tags: "@flaky" }, () => {
     setSearchValues({ fieldId });
     cy.signInAsNormalUser();
     visitCard();
-    verifySearchFilter({ fieldDisplayName, fieldValue, fieldValueLabel });
+    verifySearchFilter({
+      fieldDisplayName,
+      fieldPlaceholder,
+      fieldValue,
+      fieldValueLabel,
+    });
     H.assertQueryBuilderRowCount(expectedRowCount);
   }
 
@@ -1872,6 +1877,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
         visitCard: () => H.visitQuestion("@questionId"),
         fieldId: PEOPLE.ID,
         fieldDisplayName: "ID",
+        fieldPlaceholder: "Search by Name or enter an ID",
         fieldValue: 1,
         fieldValueLabel: "Hudson Borer",
         expectedRowCount: 1,
@@ -1884,6 +1890,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
         visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: PEOPLE.ID,
         fieldDisplayName: "ID",
+        fieldPlaceholder: "Search by Name or enter an ID",
         fieldValue: 1,
         fieldValueLabel: "Hudson Borer",
         expectedRowCount: 1,
@@ -1901,6 +1908,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
         visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: PEOPLE.ID,
         fieldDisplayName: "ID",
+        fieldPlaceholder: "Search by Name or enter an ID",
         fieldValue: 1,
         fieldValueLabel: "Hudson Borer",
         expectedRowCount: 1,
@@ -1923,6 +1931,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
         visitCard: () => H.visitQuestion("@questionId"),
         fieldId: ORDERS.PRODUCT_ID,
         fieldDisplayName: "Product ID",
+        fieldPlaceholder: "Search by Title or enter an ID",
         fieldValue: 1,
         fieldValueLabel: "Rustic Paper Wallet",
         expectedRowCount: 93,
@@ -1935,6 +1944,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
         visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: ORDERS.PRODUCT_ID,
         fieldDisplayName: "Product ID",
+        fieldPlaceholder: "Search by Title or enter an ID",
         fieldValue: 1,
         fieldValueLabel: "Rustic Paper Wallet",
         expectedRowCount: 93,
@@ -1952,6 +1962,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
         visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: ORDERS.PRODUCT_ID,
         fieldDisplayName: "PRODUCT_ID",
+        fieldPlaceholder: "Search by Title or enter an ID",
         fieldValue: 1,
         fieldValueLabel: "Rustic Paper Wallet",
         expectedRowCount: 93,

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -658,6 +658,7 @@ export interface ClickObject {
 
 export interface FieldValuesSearchInfo {
   fieldId: FieldId | null;
+  searchField: ColumnMetadata | null;
   searchFieldId: FieldId | null;
   hasFieldValues: FieldValuesType;
 }

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
@@ -15,7 +15,9 @@ import {
   canListFieldValues,
   canLoadFieldValues,
   canSearchFieldValues,
-  isKeyColumn,
+  getNothingFoundMessage,
+  getSearchPlaceholder,
+  getStaticPlaceholder,
 } from "./utils";
 
 interface FilterValuePickerProps<T> {
@@ -29,21 +31,16 @@ interface FilterValuePickerProps<T> {
   onChange: (newValues: T[]) => void;
 }
 
-interface FilterValuePickerOwnProps extends FilterValuePickerProps<string> {
-  placeholder: string;
-}
-
 function FilterValuePicker({
   query,
   stageIndex,
   column,
   values: selectedValues,
-  placeholder,
   autoFocus = false,
   comboboxProps,
   parseValue,
   onChange,
-}: FilterValuePickerOwnProps) {
+}: FilterValuePickerProps<string>) {
   const fieldInfo = useMemo(
     () => Lib.fieldValuesSearchInfo(query, column),
     [query, column],
@@ -75,7 +72,9 @@ function FilterValuePicker({
   }
 
   if (canSearchFieldValues(fieldInfo, fieldData)) {
-    const columnInfo = Lib.displayInfo(query, stageIndex, column);
+    const placeholder = fieldInfo.searchField
+      ? getSearchPlaceholder(query, stageIndex, column, fieldInfo.searchField)
+      : getStaticPlaceholder(column);
 
     return (
       <SearchValuePicker
@@ -83,7 +82,8 @@ function FilterValuePicker({
         searchFieldId={checkNotNull(fieldInfo.searchFieldId)}
         fieldValues={fieldData?.values ?? []}
         selectedValues={selectedValues}
-        columnDisplayName={columnInfo.displayName}
+        placeholder={placeholder}
+        nothingFoundMessage={getNothingFoundMessage(query, stageIndex, column)}
         autoFocus={autoFocus}
         comboboxProps={comboboxProps}
         parseValue={parseValue}
@@ -95,7 +95,7 @@ function FilterValuePicker({
   return (
     <StaticValuePicker
       selectedValues={selectedValues}
-      placeholder={placeholder}
+      placeholder={getStaticPlaceholder(column)}
       autoFocus={autoFocus}
       comboboxProps={comboboxProps}
       parseValue={parseValue}
@@ -104,19 +104,8 @@ function FilterValuePicker({
   );
 }
 
-export function StringFilterValuePicker({
-  column,
-  values,
-  ...props
-}: FilterValuePickerProps<string>) {
-  return (
-    <FilterValuePicker
-      {...props}
-      column={column}
-      values={values}
-      placeholder={isKeyColumn(column) ? t`Enter an ID` : t`Enter some text`}
-    />
-  );
+export function StringFilterValuePicker(props: FilterValuePickerProps<string>) {
+  return <FilterValuePicker {...props} />;
 }
 
 export function NumberFilterValuePicker({
@@ -139,7 +128,6 @@ export function NumberFilterValuePicker({
       {...props}
       column={column}
       values={values.map((value) => String(value))}
-      placeholder={isKeyColumn(column) ? t`Enter an ID` : t`Enter a number`}
       parseValue={parseValue}
       onChange={handleChange}
     />

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
@@ -72,9 +72,18 @@ function FilterValuePicker({
   }
 
   if (canSearchFieldValues(fieldInfo, fieldData)) {
-    const placeholder = fieldInfo.searchField
-      ? getSearchPlaceholder(query, stageIndex, column, fieldInfo.searchField)
-      : getStaticPlaceholder(column);
+    const searchColumn = checkNotNull(fieldInfo.searchField);
+    const placeholder = getSearchPlaceholder(
+      query,
+      stageIndex,
+      column,
+      searchColumn,
+    );
+    const nothingFoundMessage = getNothingFoundMessage(
+      query,
+      stageIndex,
+      searchColumn,
+    );
 
     return (
       <SearchValuePicker
@@ -83,7 +92,7 @@ function FilterValuePicker({
         fieldValues={fieldData?.values ?? []}
         selectedValues={selectedValues}
         placeholder={placeholder}
-        nothingFoundMessage={getNothingFoundMessage(query, stageIndex, column)}
+        nothingFoundMessage={nothingFoundMessage}
         autoFocus={autoFocus}
         comboboxProps={comboboxProps}
         parseValue={parseValue}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
@@ -73,17 +73,8 @@ function FilterValuePicker({
 
   if (canSearchFieldValues(fieldInfo, fieldData)) {
     const searchColumn = checkNotNull(fieldInfo.searchField);
-    const placeholder = getSearchPlaceholder(
-      query,
-      stageIndex,
-      column,
-      searchColumn,
-    );
-    const nothingFoundMessage = getNothingFoundMessage(
-      query,
-      stageIndex,
-      searchColumn,
-    );
+    const searchColumInfo = Lib.displayInfo(query, stageIndex, searchColumn);
+    const searchColumName = searchColumInfo.displayName;
 
     return (
       <SearchValuePicker
@@ -91,8 +82,8 @@ function FilterValuePicker({
         searchFieldId={checkNotNull(fieldInfo.searchFieldId)}
         fieldValues={fieldData?.values ?? []}
         selectedValues={selectedValues}
-        placeholder={placeholder}
-        nothingFoundMessage={nothingFoundMessage}
+        placeholder={getSearchPlaceholder(column, searchColumName)}
+        nothingFoundMessage={getNothingFoundMessage(searchColumName)}
         autoFocus={autoFocus}
         comboboxProps={comboboxProps}
         parseValue={parseValue}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -625,7 +625,7 @@ describe("StringFilterValuePicker", () => {
       });
 
       await userEvent.type(
-        screen.getByRole("combobox", { name: "Filter value" }),
+        screen.getByPlaceholderText("Search by Name or enter an ID"),
         "a",
       );
       await userEvent.click(await screen.findByText("a@metabase.test"));
@@ -672,7 +672,7 @@ describe("StringFilterValuePicker", () => {
       });
 
       await userEvent.type(
-        screen.getByRole("combobox", { name: "Filter value" }),
+        screen.getByPlaceholderText("Search by Title or enter an ID"),
         "a",
       );
       await userEvent.click(await screen.findByText("a@metabase.test"));
@@ -1037,7 +1037,7 @@ describe("NumberFilterValuePicker", () => {
   });
 
   describe("no values", () => {
-    const column = findColumn("PEOPLE", "PASSWORD");
+    const column = findColumn("ORDERS", "TAX");
 
     it("should allow to add a value", async () => {
       const { onChange } = await setupNumberPicker({

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -1098,6 +1098,10 @@ describe("NumberFilterValuePicker", () => {
             field_id: ORDERS.PRODUCT_ID,
             values: [[1, "a@metabase.test"]],
           }),
+          c: createMockFieldValues({
+            field_id: ORDERS.PRODUCT_ID,
+            values: [],
+          }),
         },
         remappedValues: {
           2: [2, "b@metabase.test"],
@@ -1112,6 +1116,14 @@ describe("NumberFilterValuePicker", () => {
       await waitFor(() => {
         expect(onChange).toHaveBeenLastCalledWith([2, 1]);
       });
+
+      await userEvent.type(
+        screen.getByPlaceholderText("Search by Title or enter an ID"),
+        "c",
+      );
+      expect(
+        await screen.findByText("No matching Title found."),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -5,9 +5,7 @@ import { t } from "ttag";
 import { Checkbox, Icon, Stack, Text, TextInput } from "metabase/ui";
 import type { FieldValue } from "metabase-types/api";
 
-import { getEffectiveOptions } from "../utils";
-
-import { searchOptions } from "./utils";
+import { getEffectiveOptions, searchOptions } from "./utils";
 
 interface ListValuePickerProps {
   fieldValues: FieldValue[];

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/utils.ts
@@ -1,4 +1,7 @@
 import type { ComboboxItem } from "metabase/ui";
+import type { FieldValue } from "metabase-types/api";
+
+import { getFieldOptions } from "../utils";
 
 export function searchOptions(
   options: ComboboxItem[],
@@ -8,4 +11,33 @@ export function searchOptions(
   return options.filter(
     ({ label }) => label != null && label.toLowerCase().includes(searchValue),
   );
+}
+
+function getSelectedOptions(selectedValues: string[]) {
+  return selectedValues.map((value) => ({
+    value,
+  }));
+}
+
+export function getEffectiveOptions(
+  fieldValues: FieldValue[],
+  selectedValues: string[],
+  elevatedValues: string[] = [],
+): ComboboxItem[] {
+  const options: { label?: string; value: string }[] = [
+    ...getSelectedOptions(elevatedValues),
+    ...getFieldOptions(fieldValues),
+    ...getSelectedOptions(selectedValues),
+  ];
+
+  const mapping = options.reduce((map: Map<string, string>, option) => {
+    if (option.label) {
+      map.set(option.value, option.label);
+    } else if (!map.has(option.value)) {
+      map.set(option.value, option.value);
+    }
+    return map;
+  }, new Map<string, string>());
+
+  return [...mapping.entries()].map(([value, label]) => ({ value, label }));
 }

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -19,14 +19,15 @@ import type { FieldId, FieldValue } from "metabase-types/api";
 import { getFieldOption, getFieldOptions } from "../utils";
 
 import { SEARCH_DEBOUNCE, SEARCH_LIMIT } from "./constants";
-import { getNothingFoundMessage, shouldSearch } from "./utils";
+import { getEmptyResultsMessage, shouldSearch } from "./utils";
 
 type SearchValuePickerProps = {
   fieldId: FieldId;
   searchFieldId: FieldId;
   fieldValues: FieldValue[];
   selectedValues: string[];
-  columnDisplayName: string;
+  placeholder?: string;
+  nothingFoundMessage?: string;
   autoFocus?: boolean;
   comboboxProps?: ComboboxProps;
   parseValue?: (rawValue: string) => string | null;
@@ -38,7 +39,8 @@ export function SearchValuePicker({
   searchFieldId,
   fieldValues: initialFieldValues,
   selectedValues,
-  columnDisplayName,
+  placeholder,
+  nothingFoundMessage,
   autoFocus,
   comboboxProps,
   parseValue,
@@ -68,8 +70,8 @@ export function SearchValuePicker({
   const searchOptions = canSearch
     ? getFieldOptions(searchFieldValues)
     : getFieldOptions(initialFieldValues);
-  const nothingFoundMessage = getNothingFoundMessage(
-    columnDisplayName,
+  const emptyResultsMessage = getEmptyResultsMessage(
+    nothingFoundMessage,
     searchError,
     canSearch,
     isSearching,
@@ -94,10 +96,10 @@ export function SearchValuePicker({
     <MultiAutocomplete
       value={selectedValues}
       data={searchOptions}
-      placeholder={t`Search by ${columnDisplayName}`}
+      placeholder={placeholder}
       autoFocus={autoFocus}
       rightSection={isSearching ? <Loader size="xs" /> : undefined}
-      nothingFoundMessage={nothingFoundMessage}
+      nothingFoundMessage={emptyResultsMessage}
       comboboxProps={comboboxProps}
       aria-label={t`Filter value`}
       parseValue={parseValue}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/utils.ts
@@ -16,8 +16,8 @@ export function shouldSearch(
   return !isExtensionOfLastSearch || hasMoreValues;
 }
 
-export function getNothingFoundMessage(
-  columnDisplayName: string,
+export function getEmptyResultsMessage(
+  nothingFoundMessage: string | undefined,
   searchError: unknown,
   canSearch: boolean,
   isSearching: boolean,
@@ -27,6 +27,6 @@ export function getNothingFoundMessage(
   } else if (searchError) {
     return t`An error occurred.`;
   } else {
-    return t`No matching ${columnDisplayName} found.`;
+    return nothingFoundMessage;
   }
 }

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
@@ -56,27 +56,18 @@ export function getStaticPlaceholder(column: Lib.ColumnMetadata) {
 }
 
 export function getSearchPlaceholder(
-  query: Lib.Query,
-  stageIndex: number,
   column: Lib.ColumnMetadata,
-  searchColumn: Lib.ColumnMetadata,
+  searchColumName: string,
 ) {
   const isID = Lib.isPrimaryKey(column) || Lib.isForeignKey(column);
-  const searchColumnInfo = Lib.displayInfo(query, stageIndex, searchColumn);
-  const searchColumnName = searchColumnInfo.displayName;
 
   if (isID) {
-    return t`Search by ${searchColumnName} or enter an ID`;
+    return t`Search by ${searchColumName} or enter an ID`;
   } else {
-    return t`Search by ${searchColumnName}`;
+    return t`Search by ${searchColumName}`;
   }
 }
 
-export function getNothingFoundMessage(
-  query: Lib.Query,
-  stageIndex: number,
-  searchColumn: Lib.ColumnMetadata,
-) {
-  const columnInfo = Lib.displayInfo(query, stageIndex, searchColumn);
-  return t`No matching ${columnInfo.displayName} found.`;
+export function getNothingFoundMessage(searchColumName: string) {
+  return t`No matching ${searchColumName} found.`;
 }

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
@@ -47,7 +47,7 @@ export function getStaticPlaceholder(column: Lib.ColumnMetadata) {
   const isNumeric = Lib.isNumeric(column);
 
   if (isID) {
-    return t`Search by ID`;
+    return t`Enter an ID`;
   } else if (isNumeric) {
     return t`Enter a number`;
   } else {
@@ -62,14 +62,11 @@ export function getSearchPlaceholder(
   searchColumn: Lib.ColumnMetadata,
 ) {
   const isID = Lib.isPrimaryKey(column) || Lib.isForeignKey(column);
-  const isNumeric = Lib.isNumeric(column);
   const searchColumnInfo = Lib.displayInfo(query, stageIndex, searchColumn);
   const searchColumnName = searchColumnInfo.displayName;
 
   if (isID) {
     return t`Search by ${searchColumnName} or enter an ID`;
-  } else if (isNumeric) {
-    return t`Search by ${searchColumnName} or enter a number`;
   } else {
     return t`Search by ${searchColumnName}`;
   }
@@ -78,8 +75,8 @@ export function getSearchPlaceholder(
 export function getNothingFoundMessage(
   query: Lib.Query,
   stageIndex: number,
-  column: Lib.ColumnMetadata,
+  searchColumn: Lib.ColumnMetadata,
 ) {
-  const columnInfo = Lib.displayInfo(query, stageIndex, column);
+  const columnInfo = Lib.displayInfo(query, stageIndex, searchColumn);
   return t`No matching ${columnInfo.displayName} found.`;
 }

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
@@ -81,5 +81,5 @@ export function getNothingFoundMessage(
   column: Lib.ColumnMetadata,
 ) {
   const columnInfo = Lib.displayInfo(query, stageIndex, column);
-  return t`No matching ${columnInfo.displayName} found`;
+  return t`No matching ${columnInfo.displayName} found.`;
 }

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -815,8 +815,10 @@
    column                :- ::lib.schema.metadata/column]
   (when column
     (let [column-field-id (:id column)
-          search-field-id (:id (search-field metadata-providerable column))]
+          search-field    (search-field metadata-providerable column)
+          search-field-id (:id search-field)]
       {:field-id (when (int? column-field-id) column-field-id)
+       :search-field search-field
        :search-field-id (when (int? search-field-id) search-field-id)
        :has-field-values (if column
                            (infer-has-field-values column)

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -771,6 +771,7 @@
 (mr/def ::field-values-search-info
   [:map
    [:field-id         [:maybe [:ref ::lib.schema.id/field]]]
+   [:search-field     [:maybe [:ref ::lib.schema.metadata/column]]]
    [:search-field-id  [:maybe [:ref ::lib.schema.id/field]]]
    [:has-field-values [:ref ::field-values-search-info.has-field-values]]])
 

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -771,8 +771,8 @@
 (mr/def ::field-values-search-info
   [:map
    [:field-id         [:maybe [:ref ::lib.schema.id/field]]]
-   [:search-field     [:maybe [:ref ::lib.schema.metadata/column]]]
    [:search-field-id  [:maybe [:ref ::lib.schema.id/field]]]
+   [:search-field     [:maybe [:ref ::lib.schema.metadata/column]]]
    [:has-field-values [:ref ::field-values-search-info.has-field-values]]])
 
 (mu/defn infer-has-field-values :- ::field-values-search-info.has-field-values
@@ -819,8 +819,8 @@
           search-field    (search-field metadata-providerable column)
           search-field-id (:id search-field)]
       {:field-id (when (int? column-field-id) column-field-id)
-       :search-field search-field
        :search-field-id (when (int? search-field-id) search-field-id)
+       :search-field search-field
        :has-field-values (if column
                            (infer-has-field-values column)
                            :none)})))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -816,11 +816,11 @@
    column                :- ::lib.schema.metadata/column]
   (when column
     (let [column-field-id (:id column)
-          search-field    (search-field metadata-providerable column)
-          search-field-id (:id search-field)]
+          search-column   (search-field metadata-providerable column)
+          search-field-id (:id search-column)]
       {:field-id (when (int? column-field-id) column-field-id)
        :search-field-id (when (int? search-field-id) search-field-id)
-       :search-field search-field
+       :search-field search-column
        :has-field-values (if column
                            (infer-has-field-values column)
                            :none)})))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2400,11 +2400,11 @@
 
   > **Code health:** Single use. Only supports the search info."
   [metadata-providerable column]
-  (-> (lib.field/field-values-search-info metadata-providerable column)
-      (update :has-field-values name)
-      ;; TODO: This should probably reuse `display-info->js` for caching and uniformity.
-      (update-keys cljs-key->js-key)
-      clj->js))
+  (let [{:keys [field-id search-field search-field-id has-field-values]} (lib.field/field-values-search-info metadata-providerable column)]
+    #js {:fieldId        field-id
+         :searchField    search-field
+         :searchFieldId  search-field-id
+         :hasFieldValues (name has-field-values)}))
 
 ;; # Specialized Filtering
 ;; These specialized filter updates support the drag-and-drop "brush" filtering in the UI. Eg. dragging a box on a map

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1683,10 +1683,12 @@
         (is (=? {:id   (meta/id :venues :name)
                  :name "NAME"}
                 (#'lib.field/search-field metadata-provider venues-id))))
-      (is (= {:field-id         (meta/id :venues :id)
-              :search-field-id  (meta/id :venues :name)
-              :has-field-values :search}
-             (lib.field/field-values-search-info metadata-provider venues-id)))))
+      (is (=? {:field-id         (meta/id :venues :id)
+               :search-field-id  (meta/id :venues :name)
+               :search-field     {:id (meta/id :venues :name)
+                                  :display-name "Name"}
+               :has-field-values :search}
+              (lib.field/field-values-search-info metadata-provider venues-id)))))
   (testing "type/FK field remapped to a field in another table"
     (let [metadata-provider (-> meta/metadata-provider
                                 (lib.tu/merged-mock-metadata-provider {:fields [{:id               (meta/id :venues :name)
@@ -1706,10 +1708,12 @@
         (is (=? {:id   (meta/id :categories :name)
                  :name "NAME"}
                 (#'lib.field/search-field metadata-provider venues-name))))
-      (is (= {:field-id         (meta/id :venues :name)
-              :search-field-id  (meta/id :categories :name)
-              :has-field-values :search}
-             (lib.field/field-values-search-info metadata-provider venues-name))))))
+      (is (=? {:field-id         (meta/id :venues :name)
+               :search-field-id  (meta/id :categories :name)
+               :search-field     {:id (meta/id :categories :name)
+                                  :display-name "Name"}
+               :has-field-values :search}
+              (lib.field/field-values-search-info metadata-provider venues-name))))))
 
 (deftest ^:parallel field-values-search-info-pks-test
   (testing "Don't return anything for PKs"
@@ -1719,6 +1723,7 @@
                                 (lib.tu/remap-metadata-provider (meta/id :venues :id) (meta/id :categories :name)))]
       (is (= {:field-id         (meta/id :venues :id)
               :search-field-id  nil
+              :search-field     nil
               :has-field-values :list}
              (lib.field/field-values-search-info
               metadata-provider
@@ -1726,13 +1731,19 @@
 
 (deftest ^:parallel field-values-search-info-native-test
   (testing "No field-id without custom metadata (#37100)"
-    (is (= {:field-id nil :search-field-id nil :has-field-values :none}
+    (is (= {:field-id nil
+            :search-field-id nil
+            :search-field nil
+            :has-field-values :none}
            (lib.field/field-values-search-info
             meta/metadata-provider
             (-> (lib.tu/native-query)
                 lib/visible-columns
                 first))))
-    (is (= {:field-id nil :search-field-id nil :has-field-values :none}
+    (is (= {:field-id nil
+            :search-field-id nil
+            :search-field nil
+            :has-field-values :none}
            (lib.field/field-values-search-info
             meta/metadata-provider
             (-> (lib.tu/query-with-stage-metadata-from-card
@@ -1740,7 +1751,10 @@
                  (:venues/native (lib.tu/mock-cards)))
                 lib/visible-columns
                 first))))
-    (is (= {:field-id nil :search-field-id nil :has-field-values :none}
+    (is (= {:field-id nil
+            :search-field-id nil
+            :search-field nil
+            :has-field-values :none}
            (lib.field/field-values-search-info
             meta/metadata-provider
             (-> (lib.tu/query-with-stage-metadata-from-card
@@ -1750,19 +1764,26 @@
                 lib/visible-columns
                 first)))))
   (testing "field-id with custom metadata (#37100)"
-    (is (= {:field-id 1 :search-field-id 1 :has-field-values :search}
-           (lib.field/field-values-search-info
-            meta/metadata-provider
-            (-> (update-in (lib.tu/native-query) [:stages 0 :lib/stage-metadata :columns] conj
-                           {:lib/type :metadata/column
-                            :id 1
-                            :name "search"
-                            :ident "pu_Pfm-Oe2cnFTsRgmYM3"
-                            :display-name "Search"
-                            :base-type :type/Text})
-                lib/visible-columns
-                last))))
-    (is (= {:field-id 1 :search-field-id nil :has-field-values :none}
+    (is (=? {:field-id 1
+             :search-field-id 1
+             :search-field {:id 1
+                            :display-name "Search"}
+             :has-field-values :search}
+            (lib.field/field-values-search-info
+             meta/metadata-provider
+             (-> (update-in (lib.tu/native-query) [:stages 0 :lib/stage-metadata :columns] conj
+                            {:lib/type :metadata/column
+                             :id 1
+                             :name "search"
+                             :ident "pu_Pfm-Oe2cnFTsRgmYM3"
+                             :display-name "Search"
+                             :base-type :type/Text})
+                 lib/visible-columns
+                 last))))
+    (is (= {:field-id 1
+            :search-field-id nil
+            :search-field nil
+            :has-field-values :none}
            (lib.field/field-values-search-info
             meta/metadata-provider
             (-> (update-in (lib.tu/native-query) [:stages 0 :lib/stage-metadata :columns] conj


### PR DESCRIPTION
Handle placeholders how legacy dashboard code does, where there is a special `Search by {columnName} or enter an ID` placeholder for remapping.

How to verify:
- New -> Question -> People
- Filter -> ID -> Type text


<img width="460" alt="Screenshot 2025-04-14 at 15 08 57" src="https://github.com/user-attachments/assets/17b8057d-32f5-45f1-a9ad-d3571641e61a" />
<img width="466" alt="Screenshot 2025-04-14 at 15 08 45" src="https://github.com/user-attachments/assets/ccc08637-31bc-46e7-ae22-7856a0c140fc" />
<img width="506" alt="Screenshot 2025-04-14 at 15 08 51" src="https://github.com/user-attachments/assets/65ef5613-fbde-4925-9538-6f37cad0e537" />
