### PR TITLE
Do not throw if metric metadata lookup fails in lib.metadata.calculation/metadata-method :metric

### DIFF
--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -138,17 +138,20 @@
 
 (defmethod lib.metadata.calculation/metadata-method :metric
   [query _stage-number [_ opts metric-id]]
-  (let [metric-meta       (lib.metadata/metric query metric-id)
-        metric-query      (lib.query/query query (normalize-legacy-query (:dataset-query metric-meta)))
-        inner-aggregation (first (lib.aggregation/aggregations metric-query))
-        inner-meta        (lib.metadata.calculation/metadata metric-query -1 inner-aggregation)]
-    (-> inner-meta
-        (assoc :display-name           (:name metric-meta) ; Metric card's name
-               :lib/hack-original-name (:name metric-meta) ; Metric card's name
-               :name                   (:name inner-meta)) ; Name of the inner aggregation column
-        ;; We emphatically DO NOT want to use the `:ident` of the inner aggregation from the metric's definition.
-        ;; If the `[:metric ...]` ref is a top-level aggregation, it will have its own ident, which we should use.
-        ;; If there is no ident in the `[:metric ...]` ref then *drop* the ident from column.
-        (u/assoc-dissoc :ident (:ident opts))
-        ;; If the :metric ref has a :name option, that overrides the metric card's name.
-        (cond-> (:name opts) (assoc :name (:name opts))))))
+  (if-let [metric-meta (lib.metadata/metric query metric-id)]
+    (let [metric-query      (lib.query/query query (normalize-legacy-query (:dataset-query metric-meta)))
+          inner-aggregation (first (lib.aggregation/aggregations metric-query))
+          inner-meta        (lib.metadata.calculation/metadata metric-query -1 inner-aggregation)]
+      (-> inner-meta
+          (assoc :display-name           (:name metric-meta) ; Metric card's name
+                 :lib/hack-original-name (:name metric-meta) ; Metric card's name
+                 :name                   (:name inner-meta)) ; Name of the inner aggregation column
+          ;; We emphatically DO NOT want to use the `:ident` of the inner aggregation from the metric's definition.
+          ;; If the `[:metric ...]` ref is a top-level aggregation, it will have its own ident, which we should use.
+          ;; If there is no ident in the `[:metric ...]` ref then *drop* the ident from column.
+          (u/assoc-dissoc :ident (:ident opts))
+          ;; If the :metric ref has a :name option, that overrides the metric card's name.
+          (cond-> (:name opts) (assoc :name (:name opts)))))
+    {:lib/type :metadata/metric
+     :id metric-id
+     :display-name (i18n/tru "Unknown Metric")}))


### PR DESCRIPTION
### Description

This is a partial backport of 7425651fecdda77cec2944b782f92f6ca797e5cc from https://github.com/metabase/metabase/pull/55468 to fix pivot dashcards that reference metrics (https://github.com/metabase/metabase/issues/56348).

This was failing due to `metric-meta` being `nil` because no metadata was provided to `maybeUsePivotEndpoint` [in `fetchCardDataAction`](https://github.com/metabase/metabase/blob/5322cebfc0a5324a12c96d9ec417c5af8d2951cb/frontend/src/metabase/dashboard/actions/data-fetching.ts#L371).

This commit allows the dashcard to be displayed in the dashboard, but there are corresponding FE changes coming as well.

### How to verify

See repro steps in #56348

### Demo

![Screenshot 2025-04-14 at 12 18 15 PM](https://github.com/user-attachments/assets/03c8fe5b-1b9e-41ca-85b3-dac188a02e34)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
