### PR TITLE
Fix native model perms

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1434,3 +1434,30 @@ describe("issue 51925", () => {
     });
   });
 });
+
+describe("issue 56698", () => {
+  beforeEach(() => {
+    H.restore();
+  });
+
+  it("should create an editable ad-hoc query based on a read-only native model (metabase#56698)", () => {
+    cy.log("create a native model");
+    cy.signInAsNormalUser();
+    H.createNativeQuestion(
+      {
+        name: "Native model",
+        native: { query: "select 1 union all select 2" },
+        type: "model",
+      },
+      { wrapId: true, idAlias: "modelId" },
+    );
+
+    cy.log("verify that we create an editable ad-hoc query");
+    cy.signIn("readonlynosql");
+    cy.get("@modelId").then((modelId) => H.visitModel(Number(modelId)));
+    H.assertQueryBuilderRowCount(2);
+    H.summarize();
+    H.rightSidebar().button("Done").click();
+    H.assertQueryBuilderRowCount(1);
+  });
+});

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -305,10 +305,10 @@ export const getQuestion = createSelector(
     // with a clean, ad-hoc, query.
     // This has to be skipped for users without data permissions.
     // See https://github.com/metabase/metabase/issues/20042
-    const { isEditable } = Lib.queryDisplayInfo(question.query());
-    return (isModel || isMetric) && isEditable
-      ? question.composeQuestion()
-      : question;
+    const composedQuestion =
+      isModel || isMetric ? question.composeQuestion() : question;
+    const { isEditable } = Lib.queryDisplayInfo(composedQuestion.query());
+    return isEditable ? composedQuestion : question;
   },
 );
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/56698

If the user has readonly collection access to the model, and only `query-builder` without native access, they should see an ad-hoc query when opening a native model and not the readonly native model.

Before:
<img width="1672" alt="Screenshot 2025-04-14 at 21 24 58" src="https://github.com/user-attachments/assets/0b5a06d5-beeb-4962-b2b4-04516b8ff420" />

After:
<img width="1682" alt="Screenshot 2025-04-14 at 21 25 16" src="https://github.com/user-attachments/assets/50935567-4daf-4910-9b97-a418bb452779" />

