### PR TITLE
Less ambiguous notification logs

### DIFF
--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -342,6 +342,7 @@
                             (.awaitTermination ^ExecutorService executor 30 java.util.concurrent.TimeUnit/SECONDS)
                             (catch InterruptedException _
                               (log/warn "Interrupted while waiting for notification executor to terminate"))))))
+    (log/infof "Starting notification thread pool with %d threads" pool-size)
     (dotimes [_ pool-size]
       (.submit ^ExecutorService executor
                ^Callable (fn []
@@ -385,7 +386,7 @@
                      :payload_type    (:payload_type notification)}
     (let [options      (merge *default-options* options)
           notification (with-meta notification {:notification/triggered-at-ns (u/start-timer)})]
-      (log/debugf "Sending %s" (if (:notification/sync? options) "synchronously" "asynchronously"))
+      (log/debugf "Will be send %s" (if (:notification/sync? options) "synchronously" "asynchronously"))
       (if (:notification/sync? options)
         (send-notification-sync! notification)
         (send-notification-async! notification)))))

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -117,7 +117,7 @@
             (notification.send/send-notification! (assoc notification :triggering_subscription subscription)))
           (log/info "Submitted to the notification queue")
           (catch Exception e
-            (log/errorf e "Failed to submit to the notification queue: %s")
+            (log/error e "Failed to submit to the notification queue")
             (throw e)))
 
         (nil? notification)

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -102,29 +102,32 @@
   (let [subscription    (t2/select-one :model/NotificationSubscription subscription-id)
         notification-id (:notification_id subscription)
         notification    (t2/select-one :model/Notification notification-id)]
-    (cond
-      (:active notification)
-      (try
-        (log/infof "Sending notification %d for subscription %d" notification-id subscription-id)
-        (task-history/with-task-history {:task         "notification-trigger"
-                                         :task_details {:trigger_type                 :notification-subscription/cron
-                                                        :notification_subscription_id subscription-id
-                                                        :cron_schedule                (:cron_schedule subscription)
-                                                        :notification_ids             [notification-id]}}
-          (notification.send/send-notification! (assoc notification :triggering_subscription subscription)))
-        (log/infof "Sent notification %d for subscription %d" notification-id subscription-id)
-        (catch Exception e
-          (log/errorf e "Failed to send notification %d for subscription %d" notification-id subscription-id)
-          (throw e)))
+    (log/with-context {:subscription-id subscription-id
+                       :notification-id notification-id}
 
-      (nil? notification)
-      (do
-        (log/warnf "Skipping and deleting trigger for subscription %d because it does not exist." subscription-id)
-        (delete-trigger-for-subscription! subscription-id))
-      (not (:active notification))
-      (do
-        (log/warnf "Skipping and deleting trigger for subscription %d because the notification is deactivated" subscription-id)
-        (delete-trigger-for-subscription! subscription-id)))))
+      (cond
+        (:active notification)
+        (try
+          (log/info "Submitting to the notification queue")
+          (task-history/with-task-history {:task         "notification-trigger"
+                                           :task_details {:trigger_type                 :notification-subscription/cron
+                                                          :notification_subscription_id subscription-id
+                                                          :cron_schedule                (:cron_schedule subscription)
+                                                          :notification_ids             [notification-id]}}
+            (notification.send/send-notification! (assoc notification :triggering_subscription subscription)))
+          (log/info "Submitted to the notification queue")
+          (catch Exception e
+            (log/errorf "Failed to submit to the notification queue: %s" e)
+            (throw e)))
+
+        (nil? notification)
+        (do
+          (log/warnf "Skipping and deleting trigger for subscription %d because it does not exist." subscription-id)
+          (delete-trigger-for-subscription! subscription-id))
+        (not (:active notification))
+        (do
+          (log/warnf "Skipping and deleting trigger for subscription %d because the notification is deactivated" subscription-id)
+          (delete-trigger-for-subscription! subscription-id))))))
 
 (defn- active-cron-subscription-id->subscription
   []

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -117,13 +117,14 @@
             (notification.send/send-notification! (assoc notification :triggering_subscription subscription)))
           (log/info "Submitted to the notification queue")
           (catch Exception e
-            (log/errorf "Failed to submit to the notification queue: %s" e)
+            (log/errorf e "Failed to submit to the notification queue: %s")
             (throw e)))
 
         (nil? notification)
         (do
           (log/warnf "Skipping and deleting trigger for subscription %d because it does not exist." subscription-id)
           (delete-trigger-for-subscription! subscription-id))
+
         (not (:active notification))
         (do
           (log/warnf "Skipping and deleting trigger for subscription %d because the notification is deactivated" subscription-id)


### PR DESCRIPTION
Some log messages were misleading where it's say sending but it's actually submitting to the queue. This makes it clearer.



```
2025-04-15 04:35:00,010 INFO task.send :: {notification-id=4, quartz-job-type=SendNotification, subscription-id=4} Submitting to the notification queue
2025-04-15 04:35:00,013 DEBUG notification.send :: {notification-id=4, notification_id=4, payload_type=:notification/card, quartz-job-type=SendNotification, subscription-id=4} Will be send asynchronously
2025-04-15 04:35:00,013 INFO notification.send :: {notification_id=4, payload_type=:notification/card} Sending
2025-04-15 04:35:00,014 INFO task.send :: {notification-id=4, quartz-job-type=SendNotification, subscription-id=4} Submitted to the notification queue
2025-04-15 04:35:00,051 DEBUG payload.execute :: {card_id=113, notification_id=4, payload_type=:notification/card} Result has 13856 rows
2025-04-15 04:35:00,053 DEBUG payload.execute :: {card_id=113, notification_id=4, payload_type=:notification/card} Storing 13856 rows to disk
2025-04-15 04:35:00,058 DEBUG payload.temp-storage :: {card_id=113, notification_id=4, payload_type=:notification/card} stored data in temp file {:length 137433}
2025-04-15 04:35:00,060 DEBUG notification.send :: {notification_id=4, payload_type=:notification/card} Found 1 handlers
2025-04-15 04:35:00,065 DEBUG render.card :: {card_id=113, channel_type=:channel/email, handler_id=4, notification_id=4, payload_type=:notification/card} Rendering pulse card with chart-type :table and render-type :attachment
2025-04-15 04:35:00,075 DEBUG email.result-attachment :: {channel_type=:channel/email, handler_id=4, notification_id=4, payload_type=:notification/card} Streaming results to :csv with 13856 rows
2025-04-15 04:35:00,148 DEBUG notification.send :: {channel_type=:channel/email, handler_id=4, notification_id=4, payload_type=:notification/card} Got 1 messages for channel channel/email with template null
2025-04-15 04:35:00,148 DEBUG notification.send :: {channel_type=:channel/email, handler_id=4, notification_id=4, payload_type=:notification/card} Started sending
2025-04-15 04:35:00,273 DEBUG notification.send :: {channel_type=:channel/email, handler_id=4, notification_id=4, payload_type=:notification/card} Sent with 0 retries
2025-04-15 04:35:00,273 INFO notification.send :: {channel_type=:channel/email, handler_id=4, notification_id=4, payload_type=:notification/card} Sent successfully
2025-04-15 04:35:00,276 INFO notification.send :: {notification_id=4, payload_type=:notification/card} Sent successfully
```