### PR TITLE
Clean up unused code in the expression parser

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/errors.ts
+++ b/frontend/src/metabase-lib/v1/expressions/errors.ts
@@ -16,7 +16,7 @@ export abstract class ExpressionError extends Error {
 export class CompileError extends ExpressionError {
   constructor(
     message: string,
-    private node: Node,
+    private node?: Node,
   ) {
     super(message);
   }

--- a/frontend/src/metabase-lib/v1/expressions/pratt/types.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/types.ts
@@ -96,23 +96,6 @@ export interface NodeType {
   expectedTypes: Type[] | null;
 }
 
-type HookFn = (token: Token, node: Node) => void;
-type HookErrFn = (token: Token, node: Node, err: CompileError) => void;
-type NodeErrFn = (node: Node, err: CompileError) => void;
-export interface Hooks {
-  onIteration?: HookFn;
-  onCreateNode?: HookFn;
-  onPlaceNode?: (node: Node, parent: Node) => void;
-  onSkipToken?: HookFn;
-  onReparentNode?: HookFn;
-  onCompleteNode?: HookFn;
-  onTerminatorToken?: HookFn;
-  onBadToken?: HookErrFn;
-  onUnexpectedTerminator?: HookErrFn;
-  onMissinChildren?: HookErrFn;
-  onChildConstraintViolation?: NodeErrFn;
-}
-
 class AssertionError extends Error {
   data?: any;
 


### PR DESCRIPTION
Removes unused code from the expression parser.

No functionality changes, all tests should still pass.