### PR TITLE
docs: mongodb version

### DIFF
--- a/docs/databases/connecting.md
+++ b/docs/databases/connecting.md
@@ -28,7 +28,7 @@ The databases listed below have official drivers maintained by the Metabase team
 - [ClickHouse](./connections/clickhouse.md)
 - [Databricks](./connections/databricks.md)
 - [Druid](./connections/druid.md)
-- [MongoDB (recommend version 4.2 or higher)](./connections/mongodb.md)
+- [MongoDB](./connections/mongodb.md)
 - [MariaDB](./connections/mariadb.md)
 - [MySQL](./connections/mysql.md)
 - [Oracle](./connections/oracle.md)


### PR DESCRIPTION
We now have a section about version in the article itself so there's no need to say this in the link (especially if we forget to update it)