### PR TITLE
add comment to explain why we pass `isDashboard` to Visualization in PublicOrEmbeddedQuestionView

### DIFF
--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
@@ -115,8 +115,11 @@ export function PublicOrEmbeddedQuestionView({
             }}
             gridUnit={12}
             showTitle={false}
-            isDashboard
             mode={PublicMode}
+            // Why do we need `isDashboard` when this is a standalone question?
+            // `isDashboard` is used by Visualization to change some visual behaviors
+            // including the "No results" message
+            isDashboard
             metadata={metadata}
             onChangeCardAndRun={() => {}}
             token={token}


### PR DESCRIPTION
Looking into https://metaboat.slack.com/archives/C063Q3F1HPF/p1744706997938009 I didn't feel right in keeping that prop there, but I tried to remove it and some tests failed.
As a compromise, I added a comment so the next time someone is confused by the prop they won't spend time doing the same thing