### PR TITLE
fix: do not render gauge if grouping col is date

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
@@ -16,7 +16,7 @@ import {
   getDefaultSize,
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
-import { isNumeric } from "metabase-lib/v1/types/utils/isa";
+import { isDate, isNumeric } from "metabase-lib/v1/types/utils/isa";
 
 import { GaugeArcPath } from "./Gauge.styled";
 import { getValue } from "./utils";
@@ -75,7 +75,7 @@ export default class Gauge extends Component {
       data: { cols, rows },
     },
   ]) {
-    if (!isNumeric(cols[0])) {
+    if (!isNumeric(cols[0]) || isDate(cols[0])) {
       throw new Error(t`Gauge visualization requires a number.`);
     }
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55728

### Description

Groupings like `Day of Week`, `Month of Year` have `base_type` as `type/Integer` which is correct since it lies in `1-7` or `1-12` (respective examples) so I added a check to see if the column is a Date and if it is, we show the same `Gauge visualization requires a number` error

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question
2. Select Orders as Data
3. Summarize `Count of rows` and group them by `created_at` by `Day of Week`, `Month of Year` etc.
4. Now click on Visualize and click Visualization to bring the sidebar
5. Select Gauge from Other Charts
6. Check that you see the screenshot below

### Screenshot

<img width="1470" alt="Screenshot 2025-04-15 at 3 56 24 PM" src="https://github.com/user-attachments/assets/ad1c7bff-9356-470e-87b2-02d1955740c8" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (not applicable)
