### PR TITLE
use big number mode for apache compress

### DIFF
--- a/src/metabase/util/compress.clj
+++ b/src/metabase/util/compress.clj
@@ -28,6 +28,7 @@
                                                        (.setModificationTime (System/currentTimeMillis))))
                         (TarArchiveOutputStream. 512 "UTF-8"))]
       (.setLongFileMode tar TarArchiveOutputStream/LONGFILE_POSIX)
+      (.setBigNumberMode tar TarArchiveOutputStream/BIGNUMBER_POSIX)
 
       (doseq [^File f (file-seq src)
               :let    [path-in-tar (subs (.getPath f) (count prefix))


### PR DESCRIPTION
possibly fixes a problem we're seeing in #53354

I have no ideas how to test this.

<img width="467" alt="image" src="https://github.com/user-attachments/assets/1b7a44ac-d91e-4268-ab0a-235a10928b3e" />

