### PR TITLE
Closes VIZ-659 cards flashing no results instead of loading state

### DIFF
--- a/frontend/src/metabase/components/EditBar/EditBar.styled.tsx
+++ b/frontend/src/metabase/components/EditBar/EditBar.styled.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
 import isPropValid from "@emotion/is-prop-valid";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -1,4 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
+import isPropValid from "@emotion/is-prop-valid";
+// eslint-disable-next-line no-restricted-imports
 import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
@@ -145,7 +147,10 @@ type InputResetButtonProps = {
   hasRightIcon: boolean;
 };
 
-export const InputResetButton = styled(InputButton)<InputResetButtonProps>`
+// shouldForwardProp: isPropValid is used to prevent passing the `hasRightIcon` prop to the DOM element
+export const InputResetButton = styled(InputButton, {
+  shouldForwardProp: isPropValid,
+})<InputResetButtonProps>`
   right: ${(props) => (props.hasRightIcon ? "1.25rem" : 0)};
 `;
 

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
 import isPropValid from "@emotion/is-prop-valid";
 // eslint-disable-next-line no-restricted-imports
 import { css } from "@emotion/react";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -316,7 +316,10 @@ function DashCardInner({
     );
 
   const onEditVisualizationClick = useMemo(() => {
-    if (!isVisualizerSupportedVisualization(dashcard.card.display)) {
+    if (
+      !isVisualizerDashboardCard(dashcard) &&
+      !isVisualizerSupportedVisualization(dashcard.card.display)
+    ) {
       return;
     }
 

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -58,7 +58,13 @@ export function Header({
   const saveButtonEnabled = isRenderable && (isDirty || allowSaveWhenPristine);
 
   return (
-    <Flex p="md" gap="md" align="center" className={className} data-testid="visualizer-header">
+    <Flex
+      p="md"
+      gap="md"
+      align="center"
+      className={className}
+      data-testid="visualizer-header"
+    >
       <ActionIcon onClick={() => dispatch(toggleDataSideBar())}>
         <Icon name="sidebar_open" />
       </ActionIcon>

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/HorizontalWell/FunnelHorizontalWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/HorizontalWell/FunnelHorizontalWell.tsx
@@ -146,7 +146,6 @@ function FunnelWellItem({
       bg={isDraggable ? "var(--mb-color-bg-white)" : "transparent"}
       style={{
         cursor: isDraggable ? "grab" : "default",
-        border: `1px solid hsla(204,66,8,51%)`,
       }}
     />
   );

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -50,12 +50,19 @@ describe("getInitialStateForCardDataSource", () => {
       dataset,
     );
 
-    expect(initialState.columns).toHaveLength(1);
+    expect(initialState.columns).toHaveLength(2);
     expect(initialState.columnValuesMapping).toEqual({
       COLUMN_1: [
         {
           name: "COLUMN_1",
           originalName: "Foo",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "Bar",
           sourceId: "card:1",
         },
       ],

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -65,7 +65,7 @@ describe("updateSettingsForDisplay", () => {
     expect(result).toBeUndefined();
   });
 
-  it("should return undefined if sourceDisplay and targetDisplay are cartesian", () => {
+  it("should work if sourceDisplay and targetDisplay are cartesian", () => {
     const settings = {};
     const sourceDisplay = "bar";
     const targetDisplay = "bar";
@@ -76,7 +76,11 @@ describe("updateSettingsForDisplay", () => {
       sourceDisplay,
       targetDisplay,
     );
-    expect(result).toBeUndefined();
+    expect(result).toStrictEqual({
+      columnValuesMapping,
+      columns,
+      settings: { "graph.dimensions": [], "graph.metrics": [] },
+    });
   });
 
   describe("cartesian -> pie", () => {

--- a/frontend/src/metabase/visualizer/utils/merge-data.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.ts
@@ -1,6 +1,11 @@
 import _ from "underscore";
 
-import type { Dataset, DatasetColumn, RowValues } from "metabase-types/api";
+import type {
+  Dataset,
+  DatasetColumn,
+  RowValue,
+  RowValues,
+} from "metabase-types/api";
 import type {
   VisualizerColumnValueSource,
   VisualizerDataSource,
@@ -28,6 +33,17 @@ type MergeVisualizerSeries = {
    */
   dataSources: VisualizerDataSource[];
 };
+
+/**
+ * Checks if the given array of values is empty, i.e. if it contains
+ * any undefined values or is itself undefined.
+ *
+ * @param value - The value to check
+ * @returns Whether the value is empty
+ */
+function isEmpty(value: (RowValue | undefined)[]): boolean {
+  return value === undefined || value.some((v) => v === undefined);
+}
 
 /**
  * Merges data from multiple datasets into a single dataset.
@@ -75,7 +91,7 @@ export function mergeVisualizerData({
       .flat(),
   );
 
-  return unzippedRows.some((v) => !v || v.some((_v) => _v === undefined))
+  return unzippedRows.some(isEmpty)
     ? undefined
     : {
         cols: columns,

--- a/frontend/src/metabase/visualizer/utils/merge-data.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.ts
@@ -11,12 +11,30 @@ import { extractReferencedColumns } from "./column";
 import { getDataSourceIdFromNameRef, isDataSourceNameRef } from "./data-source";
 
 type MergeVisualizerSeries = {
+  /**
+   * The columns to merge
+   */
   columns: DatasetColumn[];
+  /**
+   * The mapping of column values to their sources
+   */
   columnValuesMapping: Record<string, VisualizerColumnValueSource[]>;
+  /**
+   * The datasets to merge
+   */
   datasets: Record<VisualizerDataSourceId, Dataset | null | undefined>;
+  /**
+   * The data sources to merge
+   */
   dataSources: VisualizerDataSource[];
 };
 
+/**
+ * Merges data from multiple datasets into a single dataset.
+ *
+ * @param param0 - The data to merge
+ * @returns the merged data or undefined if the data is loading
+ */
 export function mergeVisualizerData({
   columns,
   columnValuesMapping,
@@ -50,16 +68,18 @@ export function mergeVisualizerData({
         }
         const values = referencedColumnValuesMap[valueSource.name];
         if (!values) {
-          return [];
+          return undefined;
         }
         return values;
       })
       .flat(),
   );
 
-  return {
-    cols: columns,
-    rows: _.zip(...unzippedRows),
-    results_metadata: { columns },
-  };
+  return unzippedRows.some((v) => !v || v.some((_v) => _v === undefined))
+    ? undefined
+    : {
+        cols: columns,
+        rows: _.zip(...unzippedRows),
+        results_metadata: { columns },
+      };
 }

--- a/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
@@ -1,0 +1,44 @@
+import { NumberColumn, StringColumn } from "__support__/visualizations";
+import { createMockColumn } from "metabase-types/api/mocks";
+
+import { mergeVisualizerData } from "./merge-data";
+
+describe("mergeData", () => {
+  // [VIZ-659: Visualizer dashcards flash "no results" > one chart > different chart]
+  // (https://linear.app/metabase/issue/VIZ-659
+  it("should return undefined when data is loading (VIZ-659)", () => {
+    const result = mergeVisualizerData({
+      columns: [
+        createMockColumn(StringColumn({ name: "COLUMN_1" })),
+        createMockColumn(NumberColumn({ name: "COLUMN_2" })),
+      ],
+      columnValuesMapping: {
+        COLUMN_1: [
+          {
+            sourceId: "card:73",
+            originalName: "RATING",
+            name: "COLUMN_1",
+          },
+        ],
+        COLUMN_2: [
+          {
+            sourceId: "card:73",
+            originalName: "count",
+            name: "COLUMN_2",
+          },
+        ],
+      },
+      datasets: {},
+      dataSources: [
+        {
+          id: "card:73",
+          sourceId: 73,
+          type: "card",
+          name: "bar chart yo",
+        },
+      ],
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/frontend/src/metabase/visualizer/utils/split-series.ts
+++ b/frontend/src/metabase/visualizer/utils/split-series.ts
@@ -30,7 +30,7 @@ export function splitVisualizerSeries(
   series: RawSeries,
   columnValuesMapping: Record<string, VisualizerColumnValueSource[]>,
 ): RawSeries {
-  if (!series || series.length === 0) {
+  if (!series || series.length === 0 || series.some((s) => !s.data)) {
     return series;
   }
 

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -310,6 +310,7 @@ describe("cartesian", () => {
       });
       expect(state.settings).toEqual({
         "scatter.bubble": "COLUMN_1",
+        "graph.metrics": [],
       });
     });
 


### PR DESCRIPTION
Closes [VIZ-659: Visualizer dashcards flash "no results" > one chart > different chart](https://linear.app/metabase/issue/VIZ-659/visualizer-dashcards-flash-no-results-one-chart-different-chart)

### Description

`Visualization.tsx` relies on the rawSeries' shape to know whether it's loading or has loaded an empty dataset. This PR makes the `mergeData` function return what's needed.

### How to verify

1. New visualizer card in a dashboard
2. Add a filter to the dashboard, connect the card to it
3. Filter, the card should briefly flash a "loading" state
4. Filter so no result is returned, the card should show a "No results" placeholder

### Demo

https://www.loom.com/share/64115e20cc174fd0bdd0b4000065a095

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
