### PR TITLE
fix: prevent info popover when header is clicked

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -469,7 +469,9 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
               className={cx({
                 [S.pivotedFirstColumn]: columnIndex === 0 && isPivoted,
               })}
-              infoPopoversDisabled={!hasMetadataPopovers || isDashboard}
+              infoPopoversDisabled={
+                !!clicked || !hasMetadataPopovers || isDashboard
+              }
               timezone={data.results_timezone}
               question={question}
               column={col}
@@ -534,6 +536,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     settings,
     tableTheme,
     isDashboard,
+    clicked,
   ]);
 
   const handleColumnResize = useCallback(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55637

### Description

`clicked` carries the settings popover, so when it is present, we should set `infoPopoversDisabled` to `true`

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Click on a header column
2. Now hover on any header column
3. You can observe that the info popover doesn't appear

### Demo

<img width="285" alt="Screenshot 2025-04-15 at 6 22 26 PM" src="https://github.com/user-attachments/assets/d4e4038b-3920-4d3e-833e-0bd34c25eee7" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (not applicable)
