### PR TITLE
Add data-editing/action endpoint to list query actions for a dashcard

### DIFF
--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -38,4 +38,5 @@
   apply-json-query]
  [metabase.actions.models
   dashcard->action
-  select-action])
+  select-action
+  select-actions])


### PR DESCRIPTION
Adds a new endpoint for listing dashcard actions.

- `GET ee/data-editing/action?dashcard-id=42` will return accessible actions from that editable dashcard.
- An action will be accessible if your user has permissions to access the model collection (same as normal action policy).
- Only actions created for models that directly reference the editables table will be returned.
- Returned action schema will be the same as that returned by the OSS action listing endpoint `GET api/action?model-id=42` so existing FE types should work.