### PR TITLE
fix: increase flex basis to avoid wrapping in bigger screens

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.module.css
@@ -1,5 +1,5 @@
 .Root {
-  flex-basis: 20%;
+  flex-basis: 40%;
   flex-grow: 0;
 
   .FooterButtonGroup {

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/RightViewFooterButtonGroup.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/RightViewFooterButtonGroup.module.css
@@ -1,3 +1,3 @@
 .Root {
-  flex-basis: 20%;
+  flex-basis: 40%;
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55518

### Description

Increases the flex basis to avoid wrapping. Now it starts wrapping after `718px` which looks good

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Just open visualization table and check the footer

### Screenshot
<img width="718" alt="Screenshot 2025-04-15 at 7 14 23 PM" src="https://github.com/user-attachments/assets/6b2e4501-c4f9-4637-bff6-45c21af7041d" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR (not applicable)
