### PR TITLE
fix: make enhance table stats a single query

### DIFF
--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -1018,11 +1018,10 @@
                  :model/Field    _ {:table_id table-id}]
     (mt/with-test-user :rasta
       (automagic-dashboards.test/with-dashboard-cleanup!
-        (is (= {:list-like?  true
-                :num-fields 2}
-               (-> (#'magic/load-tables-with-enhanced-table-stats [[:= :id table-id]])
-                   first
-                   :stats)))))))
+        (is (partial= {:list-like?  true
+                       :num-fields 2}
+                      (-> (#'magic/load-tables-with-enhanced-table-stats [[:= :id table-id]])
+                          first)))))))
 
 (deftest enhance-table-stats-fk-test
   (mt/with-temp [:model/Database {db-id :id}    {}
@@ -1033,10 +1032,8 @@
     (mt/with-test-user :rasta
       (automagic-dashboards.test/with-dashboard-cleanup!
         (testing "filters out link-tables"
-          (is (nil?
-               (-> (#'magic/load-tables-with-enhanced-table-stats [[:= :id table-id]])
-                   first
-                   :stats))))))))
+          (is (empty?
+               (#'magic/load-tables-with-enhanced-table-stats [[:= :id table-id]]))))))))
 
 ;;; ------------------- Definition overloading -------------------
 


### PR DESCRIPTION
closes #56693 

### Description

Avoids hitting the postgresql query parameter limit when there are more than MAX_UINT16 tables in a database, also should be more efficient to fetch this in a single query.

This combines the three extant queries into a single query that uses `count case when ...` in it's select clause to get the count needed to determine `list-like?` and `link-table?` whose predicates are then applied in our for loop. 

### How to verify

1. Create a database with more than 65535 tables
2. Ask for automagic candidates!

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
