### PR TITLE
Add diagnostics for expressions with illegal nested aggregations

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -39,6 +39,7 @@ const getNowAtTimezone = (
     ? moment().tz(reportTimezone).format("LT")
     : moment().format("LT");
 
+// some of the structure names below are duplicated in src/metabase/lib/expression.cljc
 const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
   {
     name: "count",


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #55720
Fixes QUE-822

### Description

We prevent aggregation expressions to be nested, with the exception of an aggregation exception nested in a window expression.

### How to verify

The steps in #55720 should now lead to an error in the expression editor.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
