### PR TITLE
WRK-251,WRK-259,WRK-260,WRK-263: Add autocomplete for custom templates form

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataHeader.tsx
@@ -67,15 +67,17 @@ export const EditTableDataHeader = ({
             variant="filled"
             onClick={onCreate}
           >{t`New record`}</Button>
-          <RunButtonWithTooltip
-            iconSize={16}
-            onlyIcon
-            medium
-            compact
-            isRunning={isLoading}
-            onRun={refetchTableDataQuery}
-          />
-          <TableNotificationsTrigger tableId={table.id} />
+          <Flex gap="xs">
+            <RunButtonWithTooltip
+              iconSize={16}
+              onlyIcon
+              medium
+              compact
+              isRunning={isLoading}
+              onRun={refetchTableDataQuery}
+            />
+            <TableNotificationsTrigger tableId={table.id} />
+          </Flex>
         </Group>
       </Flex>
       <QuestionFiltersHeader

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/view/BrowseTableData.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/view/BrowseTableData.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { useGetTableDataQuery, useGetTableQuery } from "metabase/api";
 import Link from "metabase/core/components/Link";
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { TableNotificationsTrigger } from "metabase/notifications/modals/TableNotificationsModals/TableNotificationsTrigger";
+import { TableNotificationsTrigger } from "metabase/notifications/modals";
 import { closeNavbar } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getUserIsAdmin } from "metabase/selectors/user";

--- a/frontend/src/metabase/components/CodeBlock/types.ts
+++ b/frontend/src/metabase/components/CodeBlock/types.ts
@@ -1,6 +1,7 @@
 export type CodeLanguage =
   | "clojure"
   | "html"
+  | "markdown"
   | "json"
   | "mustache"
   | "pug"

--- a/frontend/src/metabase/components/CodeBlock/utils.ts
+++ b/frontend/src/metabase/components/CodeBlock/utils.ts
@@ -1,6 +1,7 @@
 import { html } from "@codemirror/lang-html";
 import { javascript } from "@codemirror/lang-javascript";
 import { json } from "@codemirror/lang-json";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { python } from "@codemirror/lang-python";
 import { StreamLanguage } from "@codemirror/language";
 import { clojure } from "@codemirror/legacy-modes/mode/clojure";
@@ -30,10 +31,12 @@ export function getLanguageExtension(language: CodeLanguage): Extension {
       return html();
     case "json":
       return json();
+    case "markdown":
+      return markdown({ base: markdownLanguage });
     case "python":
       return python();
     case "mustache":
-      return handlebars;
+      return [handlebars, html()];
     case "pug":
       return StreamLanguage.define(pug);
     case "ruby":

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsTrigger/TableNotificationsTrigger.module.css
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsTrigger/TableNotificationsTrigger.module.css
@@ -1,0 +1,6 @@
+/* Specificity to override already overridden custom styling without !important */
+.alertIcon[data-variant="subtle"] {
+  &:hover {
+    color: var(--mb-color-brand);
+  }
+}

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsTrigger/TableNotificationsTrigger.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsTrigger/TableNotificationsTrigger.tsx
@@ -14,8 +14,10 @@ import { addUndo } from "metabase/redux/undo";
 import { ActionIcon, Icon, Tooltip } from "metabase/ui";
 import type { TableId, TableNotification } from "metabase-types/api";
 
-import { CreateOrEditTableNotificationModal } from "./CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal";
-import { TableNotificationsListModal } from "./TableNotificationsListModal/TableNotificationsListModal";
+import { CreateOrEditTableNotificationModal } from "../CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal";
+import { TableNotificationsListModal } from "../TableNotificationsListModal/TableNotificationsListModal";
+
+import S from "./TableNotificationsTrigger.module.css";
 
 interface TableNotificationsModalProps {
   tableId: TableId;
@@ -121,7 +123,13 @@ export const TableNotificationsTrigger = ({
   return (
     <>
       <Tooltip label={hasNotifications ? t`Edit alerts` : t`Create alert`}>
-        <ActionIcon size="lg" variant="subtle" onClick={handleOpen} {...props}>
+        <ActionIcon
+          className={S.alertIcon}
+          variant="subtle"
+          size="lg"
+          onClick={handleOpen}
+          {...props}
+        >
           <Icon name="alert" />
         </ActionIcon>
       </Tooltip>

--- a/frontend/src/metabase/notifications/modals/index.ts
+++ b/frontend/src/metabase/notifications/modals/index.ts
@@ -1,5 +1,5 @@
 export { CreateOrEditQuestionAlertModal } from "./AlertsModals/CreateOrEditQuestionAlertModal";
 export { QuestionAlertListModal } from "./AlertsModals/QuestionAlertListModal";
-export { TableNotificationsTrigger } from "./TableNotificationsModals/TableNotificationsTrigger";
+export { TableNotificationsTrigger } from "./TableNotificationsModals/TableNotificationsTrigger/TableNotificationsTrigger";
 export { TableNotificationsListModal } from "./TableNotificationsModals/TableNotificationsListModal";
 export { CreateOrEditTableNotificationModal } from "./TableNotificationsModals/CreateOrEditTableNotificationModal";

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.module.css
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.module.css
@@ -1,0 +1,65 @@
+/* Styling CodeMirror to look like Mantine inputs */
+.templateEditor {
+  :global(.cm-editor) {
+    border: 1px solid var(--mb-color-border);
+    border-radius: var(--mantine-radius-sm);
+    background-color: var(--mb-color-bg-white);
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    transition:
+      border-color 100ms ease,
+      box-shadow 100ms ease;
+    font-family: var(--mantine-font-family);
+    color: var(--mb-color-text-dark);
+    font-size: var(--mantine-font-size-md);
+  }
+
+  :global(.cm-editor.cm-focused) {
+    border-color: var(--mb-color-brand);
+    outline: none;
+  }
+
+  :global(.cm-content) {
+    padding: 0;
+    caret-color: var(--mb-color-text-dark);
+    cursor: text;
+  }
+
+  :global(.cm-line) {
+    padding: 0;
+  }
+
+  :global(.cm-placeholder) {
+    color: var(--mb-color-text-light);
+  }
+
+  &.textInputVariant {
+    :global(.cm-editor) {
+      padding: 0 var(--mantine-spacing-sm);
+      min-height: 2.5rem;
+      height: auto;
+      line-height: calc(2.5rem - 2px);
+    }
+    :global(.cm-content) {
+      line-height: calc(2.5rem - 2px);
+    }
+    :global(.cm-scroller) {
+      overflow-x: hidden;
+      overflow-y: hidden;
+      display: flex;
+      align-items: center;
+    }
+    :global(.cm-gutters) {
+      display: none;
+    }
+  }
+
+  &.hasError {
+    :global(.cm-editor) {
+      border-color: var(--mb-color-error);
+    }
+
+    :global(.cm-editor.cm-focused) {
+      border-color: var(--mb-color-error);
+    }
+  }
+}

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -1,0 +1,257 @@
+import {
+  type CompletionContext,
+  type CompletionResult,
+  type CompletionSource,
+  autocompletion,
+  completionKeymap,
+} from "@codemirror/autocomplete";
+import {
+  defaultHighlightStyle,
+  syntaxHighlighting,
+} from "@codemirror/language";
+import { ChangeSet, type ChangeSpec, EditorState } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
+import CodeMirror, {
+  type ReactCodeMirrorProps,
+  type ReactCodeMirrorRef,
+} from "@uiw/react-codemirror";
+import cx from "classnames";
+import React, { Fragment, useMemo, useRef, useState } from "react";
+
+import type { CodeLanguage } from "metabase/components/CodeBlock/types";
+import {
+  getLanguageExtension,
+  nonce,
+} from "metabase/components/CodeBlock/utils";
+import { isNotNull } from "metabase/lib/types";
+import { Text } from "metabase/ui";
+
+import S from "./TemplateEditor.module.css";
+
+// Helper function to recursively find all leaf paths in an object
+function getAllPaths(obj: any, currentPath = ""): string[] {
+  let paths: string[] = [];
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return [];
+  }
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const newPath = currentPath ? `${currentPath}.${key}` : key;
+      const value = obj[key];
+
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        !Array.isArray(value) &&
+        value.constructor === Object
+      ) {
+        paths = paths.concat(getAllPaths(value, newPath));
+      } else {
+        paths.push(newPath);
+      }
+    }
+  }
+  return paths;
+}
+
+// Build a set of all possible paths for autocomplete from provided payload object.
+const createTemplateAutocompleteSource = (
+  context: Record<string, any>,
+): CompletionSource => {
+  const allSortedPaths = getAllPaths(context).sort();
+
+  return (completionContext: CompletionContext): CompletionResult | null => {
+    const word = completionContext.matchBefore(/{{\s*(?:[\w#-]+\s+)*([\w.]*)$/);
+
+    if (!word || word.text.startsWith("{{/")) {
+      return null;
+    }
+
+    const matchResult = word.text.match(/{{\s*(?:[\w#-]+\s+)*([\w.]*)$/);
+    const pathPrefix = matchResult ? matchResult[1] : "";
+
+    if (!matchResult) {
+      return null;
+    }
+
+    const from = word.to - pathPrefix.length;
+
+    const matchingPaths = allSortedPaths.filter((p) =>
+      p.startsWith(pathPrefix),
+    );
+
+    if (matchingPaths.length === 0) {
+      return null;
+    }
+
+    const options = matchingPaths.map((fullPath) => ({
+      label: fullPath,
+      apply: fullPath,
+      type: "variable",
+    }));
+
+    return {
+      from: from,
+      to: word.to,
+      options: options,
+      filter: false,
+    };
+  };
+};
+
+export interface TemplateEditorProps
+  extends Omit<
+    ReactCodeMirrorProps,
+    | "defaultValue"
+    | "onChange"
+    | "extensions"
+    | "basicSetup"
+    | "value"
+    | "onBlur"
+    | "minHeight"
+  > {
+  variant?: "textarea" | "textinput";
+  language?: CodeLanguage;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  onBlur?: (value: string) => void;
+  minHeight?: string;
+  placeholder?: string;
+  templateContext?: Record<string, any>;
+  error?: string | boolean;
+}
+
+// Transaction filter to prevent newlines entering in textinput variant.
+// This imitates behavior of a regular single-line text input.
+const preventNewlinesFilter = EditorState.transactionFilter.of((tr) => {
+  if (!tr.docChanged) {
+    return tr;
+  }
+
+  const specs: ChangeSpec[] = [];
+  let hasNewline = false;
+
+  tr.changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
+    const text = inserted.toString();
+    if (text.includes("\n")) {
+      hasNewline = true;
+      specs.push({ from: fromA, to: toA, insert: text.replace(/\n/g, "") });
+    } else {
+      specs.push({ from: fromA, to: toA, insert: text });
+    }
+  }, true);
+
+  if (hasNewline) {
+    const newChanges = ChangeSet.of(specs, tr.startState.doc.length);
+
+    return {
+      changes: newChanges,
+      selection: tr.selection,
+      filter: false,
+    };
+  }
+
+  return tr;
+});
+
+export const TemplateEditor = ({
+  defaultValue = "",
+  onChange,
+  minHeight = "5rem",
+  language = "html",
+  placeholder: propsPlaceholder,
+  className,
+  variant = "textarea",
+  error,
+  templateContext,
+  onBlur,
+  ...rest
+}: TemplateEditorProps) => {
+  const ref = useRef<ReactCodeMirrorRef>(null);
+  const [internalValue, setInternalValue] = useState(defaultValue);
+
+  const handleChange = React.useCallback(
+    (val: string) => {
+      setInternalValue(val);
+      if (onChange) {
+        onChange(val);
+      }
+    },
+    [onChange],
+  );
+
+  const blurEventHandlerExtension = useMemo(() => {
+    return EditorView.updateListener.of((update) => {
+      if (update.focusChanged && !update.view.hasFocus && onBlur) {
+        const currentValue = update.state.doc.toString();
+        onBlur(currentValue);
+      }
+    });
+  }, [onBlur]);
+
+  const templateAutocompleteExtension = useMemo(() => {
+    return templateContext
+      ? autocompletion({
+          override: [createTemplateAutocompleteSource(templateContext)],
+        })
+      : [];
+  }, [templateContext]);
+
+  const combinedExtensions = useMemo(() => {
+    return [
+      blurEventHandlerExtension,
+      nonce(),
+      syntaxHighlighting(defaultHighlightStyle),
+      variant === "textarea" ? EditorView.lineWrapping : null,
+      getLanguageExtension(language),
+      templateAutocompleteExtension,
+      variant === "textinput" ? preventNewlinesFilter : null,
+    ]
+      .filter(isNotNull)
+      .concat(keymap.of(completionKeymap))
+      .flat();
+  }, [
+    language,
+    blurEventHandlerExtension,
+    templateAutocompleteExtension,
+    variant,
+  ]);
+
+  const isTextArea = variant === "textarea";
+  const isTextInput = variant === "textinput";
+
+  return (
+    <Fragment>
+      <CodeMirror
+        onClick={() => {
+          if (ref.current && !ref.current.view?.hasFocus) {
+            ref.current.view?.focus();
+          }
+        }}
+        ref={ref}
+        value={internalValue}
+        onChange={handleChange}
+        extensions={combinedExtensions}
+        minHeight={isTextArea && minHeight ? minHeight : undefined}
+        basicSetup={{
+          lineNumbers: false,
+          foldGutter: false,
+          highlightActiveLine: false,
+          indentOnInput: false,
+        }}
+        className={cx(S.templateEditor, className, {
+          [S.hasError]: error && typeof error === "string",
+          [S.textInputVariant]: isTextInput,
+        })}
+        {...rest}
+      />
+      {typeof error === "string" && error && (
+        <Text c="error" size="sm" mt="xs">
+          {error}
+        </Text>
+      )}
+    </Fragment>
+  );
+};
+TemplateEditor.displayName = "TemplateEditor";

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-markdown": "6.0.0",
     "@codemirror/lang-python": "^6.1.7",
     "@codemirror/lang-sql": "^6.8.0",
     "@codemirror/legacy-modes": "^6.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,7 +1188,7 @@
     "@lezer/common" "^1.0.2"
     "@lezer/css" "^1.1.7"
 
-"@codemirror/lang-html@^6.4.7", "@codemirror/lang-html@^6.4.9":
+"@codemirror/lang-html@^6.0.0", "@codemirror/lang-html@^6.4.7", "@codemirror/lang-html@^6.4.9":
   version "6.4.9"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.9.tgz#d586f2cc9c341391ae07d1d7c545990dfa069727"
   integrity sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==
@@ -1223,6 +1223,18 @@
   dependencies:
     "@codemirror/language" "^6.0.0"
     "@lezer/json" "^1.0.0"
+
+"@codemirror/lang-markdown@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.0.0.tgz#cfbbb4ae2c56c4d176ceab4c553b5132003737e0"
+  integrity sha512-ozJaO1W4WgGlwWOoYCSYzbVhhM0YM/4lAWLrNsBbmhh5Ztpl0qm4CgEQRl3t8/YcylTZYBIXiskui8sHNGd4dg==
+  dependencies:
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/markdown" "^1.0.0"
 
 "@codemirror/lang-python@^6.1.7":
   version "6.1.7"
@@ -2553,6 +2565,14 @@
   integrity sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==
   dependencies:
     "@lezer/common" "^1.0.0"
+
+"@lezer/markdown@^1.0.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@lezer/markdown/-/markdown-1.4.2.tgz#39abb22dc3289a52dc313e235d80929df0ee075a"
+  integrity sha512-iYewCigG/517D0xJPQd7RGaCjZAFwROiH8T9h7OTtz0bRVtkxzFhGBFJ9JGKgBBs4uuo1cvxzyQ5iKhDLMcLUQ==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
 
 "@lezer/python@^1.1.4":
   version "1.1.15"
@@ -19648,7 +19668,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19665,6 +19685,15 @@ string-width@^4.0.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0:
   version "5.1.0"
@@ -19765,7 +19794,14 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21856,7 +21892,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21869,6 +21905,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Closes [WRK-251](https://linear.app/metabase/issue/WRK-251), [WRK-259](https://linear.app/metabase/issue/WRK-259), [WRK-260](https://linear.app/metabase/issue/WRK-260), [WRK-263
](https://linear.app/metabase/issue/WRK-263)

### Description

This PR introduces autocomplete support for Handlebars syntax within the custom template subject and message fields in table alerts form.

- Replaced the standard `TextInput` and `TextArea` components with styled `CodeMirror` instances configured for HTML/Markup Handlebars.
- Added a "textinput" variant to the `CodeMirror` component to visually mimic a single-line input for the subject field.
- Includes various minor styling adjustments and fixes related to the implementation.

This creates a better user experience when building complex notification templates by providing syntax highlighting and autocompletion.

### How to verify

1.  Navigate to the table view.
2.  Click the bell icon to set up an alert.
3.  Choose a notification type (e.g., Slack, Email) that allows custom templates.
4.  Observe the "Subject" and "Message" fields. They should now be rendered using `CodeMirror`, but look like regular Mantine components.
5.  Try typing Handlebars expressions like `{{` or using HTML tags within the fields. Verify that syntax highlighting works.
6.  Check that the autocomplete suggestions appear, check their correctness referencing provided JSON payload example.

### Demo

<img width="517" alt="image" src="https://github.com/user-attachments/assets/05769569-80c7-42eb-b4e0-88a29b0d23d1" />

<img width="508" alt="image" src="https://github.com/user-attachments/assets/5de0a8f7-4d0a-4252-b7f1-f268c845ab98" />
