### PR TITLE
Snowplow tracking for shortcuts

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -527,7 +527,8 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     // Sidesheet
     cy.realPress("]");
     cy.findByRole("dialog", { name: "Info" }).should("exist");
-    cy.realPress("]");
+    // Should be able to toggle again in ], but modals disable shortcuts
+    cy.realPress("Escape");
     cy.findByRole("dialog", { name: "Info" }).should("not.exist");
 
     // Viz Settings

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -373,10 +373,12 @@ describe("command palette", () => {
   });
 });
 
-describe("shortcuts", { tags: ["@actions"] }, () => {
+H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
   beforeEach(() => {
+    H.resetSnowplow();
     H.restore();
     cy.signInAsAdmin();
+    H.enableTracking();
   });
 
   it("should render a shortcuts modal, and global shortcuts should be available", () => {
@@ -398,9 +400,17 @@ describe("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("c").realPress("f");
     cy.findByRole("dialog", { name: /collection/i }).should("exist");
     cy.realPress("Escape");
+    H.expectGoodSnowplowEvent({
+      event: "keyboard_shortcut_performed",
+      event_detail: "create-collection",
+    });
     cy.realPress("c").realPress("d");
     cy.findByRole("dialog", { name: /dashboard/i }).should("exist");
     cy.realPress("Escape");
+    H.expectGoodSnowplowEvent({
+      event: "keyboard_shortcut_performed",
+      event_detail: "create-dashboard",
+    });
 
     cy.realPress("g").realPress("d");
     cy.location("pathname").should("contain", "browse/databases");
@@ -410,15 +420,31 @@ describe("shortcuts", { tags: ["@actions"] }, () => {
     H.navigationSidebar().should("not.be.visible");
     cy.realPress("[");
     H.navigationSidebar().should("be.visible");
+    H.expectGoodSnowplowEvent(
+      {
+        event: "keyboard_shortcut_performed",
+        event_detail: "toggle-navbar",
+      },
+      2,
+    );
 
     cy.realPress("g").realPress("p");
     cy.location("pathname").should(
       "equal",
       `/collection/${ADMIN_PERSONAL_COLLECTION_ID}`,
     );
+    H.expectGoodSnowplowEvent({
+      event: "keyboard_shortcut_performed",
+      event_detail: "navigate-personal-collection",
+    });
 
     cy.realPress("g").realPress("t");
     cy.location("pathname").should("equal", "/trash");
+
+    H.expectGoodSnowplowEvent({
+      event: "keyboard_shortcut_performed",
+      event_detail: "navigate-trash",
+    });
 
     cy.log("shortcuts should not be enabled when working in a modal (ADM 658)");
 

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -402,14 +402,14 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("Escape");
     H.expectGoodSnowplowEvent({
       event: "keyboard_shortcut_performed",
-      event_detail: "create-collection",
+      event_detail: "create-new-collection",
     });
     cy.realPress("c").realPress("d");
     cy.findByRole("dialog", { name: /dashboard/i }).should("exist");
     cy.realPress("Escape");
     H.expectGoodSnowplowEvent({
       event: "keyboard_shortcut_performed",
-      event_detail: "create-dashboard",
+      event_detail: "create-new-dashboard",
     });
 
     cy.realPress("g").realPress("d");

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -2,6 +2,7 @@ import type {
   ChecklistItemCTA,
   ChecklistItemValue,
 } from "metabase/home/components/Onboarding/types";
+import type { KeyboardShortcutId } from "metabase/palette/shortcuts";
 
 type SimpleEventSchema = {
   event: string;
@@ -91,6 +92,11 @@ export type GsheetsImportClickedEvent = ValidateEvent<{
   triggered_from: "sheets-url-popup";
 }>;
 
+export type KeyboardShortcutPerformEvent = ValidateEvent<{
+  event: "keyboard_shortcut_performed";
+  event_detail: KeyboardShortcutId;
+}>;
+
 export type SimpleEvent =
   | CSVUploadClickedEvent
   | DatabaseAddClickedEvent
@@ -103,4 +109,5 @@ export type SimpleEvent =
   | ErrorDiagnosticModalOpenedEvent
   | ErrorDiagnosticModalSubmittedEvent
   | GsheetsConnectionClickedEvent
-  | GsheetsImportClickedEvent;
+  | GsheetsImportClickedEvent
+  | KeyboardShortcutPerformEvent;

--- a/frontend/src/metabase/palette/hooks/useRegisterShortcut.tsx
+++ b/frontend/src/metabase/palette/hooks/useRegisterShortcut.tsx
@@ -1,5 +1,6 @@
 import { KBarContext, useRegisterActions } from "kbar";
 import { type DependencyList, useContext } from "react";
+import _ from "underscore";
 
 import { trackSimpleEvent } from "metabase/lib/analytics";
 
@@ -31,18 +32,17 @@ export const useRegisterShortcut = (
           throw Error(`Unrecgonized shortcut id ${id}`);
         }
 
-        const wrappedPerform = () => {
-          perform();
-          trackSimpleEvent({
-            event: "keyboard_shortcut_performed",
-            event_detail: id,
-          });
-        };
-
         return {
           ...shortcutDef,
           id,
-          perform: wrappedPerform,
+          perform: _.compose(
+            () =>
+              trackSimpleEvent({
+                event: "keyboard_shortcut_performed",
+                event_detail: id,
+              }),
+            perform,
+          ),
           ...rest,
         };
       })

--- a/frontend/src/metabase/palette/shortcuts/index.ts
+++ b/frontend/src/metabase/palette/shortcuts/index.ts
@@ -10,4 +10,4 @@ export const shortcuts = {
   ...questionShortcuts,
 };
 
-export type ShortcutId = keyof typeof shortcuts;
+export type KeyboardShortcutId = keyof typeof shortcuts;

--- a/frontend/src/metabase/palette/shortcuts/shortcuts.unit.spec.ts
+++ b/frontend/src/metabase/palette/shortcuts/shortcuts.unit.spec.ts
@@ -1,7 +1,7 @@
-import { type ShortcutId, shortcuts } from ".";
+import { type KeyboardShortcutId, shortcuts } from ".";
 
 const getShortcutsWithPrefix = (prefix: string) => {
-  const allIds = Object.keys(shortcuts) as ShortcutId[];
+  const allIds = Object.keys(shortcuts) as KeyboardShortcutId[];
   return allIds
     .filter((id) => id.startsWith(prefix))
     .map((id) => ({ ...shortcuts[id], id }));


### PR DESCRIPTION
Closes ADM 661

### Description
PR that wraps the `perform` function for shortcuts with snowplow tracking, as well as adding a test to ensure events are being sent correctly

### How to verify
1. Do some shortcuts
2. Check that snowplow events are generated. Likely easiest to set `MB_LOG_ANALYTICS=true` as an env var and look at the console

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
