### PR TITLE
test: move flaky mongo test to jail

### DIFF
--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -330,63 +330,76 @@ describe(
       cy.signInAsAdmin();
     });
 
-    it("should work for both simple and nested questions based on previously converted GUI query", () => {
-      H.startNewQuestion();
-      H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Tables").click();
-        cy.findByText(MONGO_DB_NAME).click();
-        cy.findByText("Products").click();
-      });
+    it(
+      "should work for both simple and nested questions based on previously converted GUI query",
+      { tags: "@flaky" },
+      () => {
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
+          cy.findByText(MONGO_DB_NAME).click();
+          cy.findByText("Products").click();
+        });
 
-      cy.log("Simple question");
-      cy.findByLabelText("View native query").click();
-      cy.findByTestId("native-query-preview-sidebar").within(() => {
-        cy.findByText("Native query for this question").should("exist");
-        H.NativeEditor.get()
-          .should("be.visible")
-          .and("contain", "$project")
-          .and("contain", "$limit");
+        cy.log("Simple question");
+        cy.findByLabelText("View native query").click();
+        cy.findByTestId("native-query-preview-sidebar").within(() => {
+          cy.findByText("Native query for this question").should("exist");
+          H.NativeEditor.get()
+            .should("be.visible")
+            .and("contain", "$project")
+            .and("contain", "$limit");
 
-        cy.button("Convert this question to a native query").click();
-      });
+          cy.button("Convert this question to a native query").click();
+        });
 
-      cy.log("Database and table should be pre-selected (metabase#15946)");
-      cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
-      cy.findByTestId("selected-table").should("have.text", "Products");
-      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
+        cy.log("Database and table should be pre-selected (metabase#15946)");
+        cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
+        cy.findByTestId("selected-table").should("have.text", "Products");
+        cy.get("[data-testid=cell-data]").should(
+          "contain",
+          "Small Marble Shoes",
+        );
 
-      cy.log("Nested question");
-      cy.log(
-        "should be possible to save a question and `Explore results` (metabase#32121)",
-      );
-      H.saveQuestion("foo", undefined, {
-        tab: "Browse",
-        path: ["Our analytics"],
-      });
-      cy.findByTestId("qb-header").findByText("Explore results").click();
-      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
+        cy.log("Nested question");
+        cy.log(
+          "should be possible to save a question and `Explore results` (metabase#32121)",
+        );
+        H.saveQuestion("foo", undefined, {
+          tab: "Browse",
+          path: ["Our analytics"],
+        });
+        cy.findByTestId("qb-header").findByText("Explore results").click();
+        cy.get("[data-testid=cell-data]").should(
+          "contain",
+          "Small Marble Shoes",
+        );
 
-      cy.log("The generated query should be valid (metabase#38181)");
-      H.openNotebook(); // SQL sidebar state was persisted so it's already open now
-      cy.findByTestId("native-query-preview-sidebar").within(() => {
-        cy.findByText("Native query for this question").should("exist");
-        H.NativeEditor.get()
-          .should("be.visible")
-          .and("contain", "$project")
-          .and("contain", "$limit")
-          .and("not.contain", "BsonString")
-          .and("not.contain", "BsonInt32");
+        cy.log("The generated query should be valid (metabase#38181)");
+        H.openNotebook(); // SQL sidebar state was persisted so it's already open now
+        cy.findByTestId("native-query-preview-sidebar").within(() => {
+          cy.findByText("Native query for this question").should("exist");
+          H.NativeEditor.get()
+            .should("be.visible")
+            .and("contain", "$project")
+            .and("contain", "$limit")
+            .and("not.contain", "BsonString")
+            .and("not.contain", "BsonInt32");
 
-        cy.button("Convert this question to a native query").click();
-      });
+          cy.button("Convert this question to a native query").click();
+        });
 
-      cy.log(
-        "Database and table should be pre-selected (metabase#15946 and/or metabase#40557)",
-      );
-      cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
-      cy.findByTestId("selected-table").should("have.text", "Products");
-      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
-    });
+        cy.log(
+          "Database and table should be pre-selected (metabase#15946 and/or metabase#40557)",
+        );
+        cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
+        cy.findByTestId("selected-table").should("have.text", "Products");
+        cy.get("[data-testid=cell-data]").should(
+          "contain",
+          "Small Marble Shoes",
+        );
+      },
+    );
 
     it.skip("should work for a nested GUI question (metabase#40557)", () => {
       H.withDatabase(


### PR DESCRIPTION
<img width="1896" alt="4e89d530a733cdc7d0c4923612d634a8a65ab89cd54769c1db777a6c1f2c43a2" src="https://github.com/user-attachments/assets/83f92ca0-b61e-4f44-b107-332b2ece9618" />
<img width="491" alt="Screenshot 2025-04-16 at 00 49 22" src="https://github.com/user-attachments/assets/a5da4af7-27b1-4739-9446-ef89c502091e" />

I couldn't find the reason of flakiness locally, so let's put it to a jail