### PR TITLE
Address remarks for status and task filtering in GET /task endpoint

### DIFF
--- a/src/metabase/api/task.clj
+++ b/src/metabase/api/task.clj
@@ -15,7 +15,7 @@
    {:keys [_status _task]
     :as filter} :- task-history/Filter]
   (validation/check-has-application-permission :monitoring)
-  {:total  (task-history/tasks-count filter)
+  {:total  (task-history/total filter)
    :limit  (request/limit)
    :offset (request/offset)
    :data   (task-history/all (request/limit) (request/offset) filter)})

--- a/src/metabase/api/task.clj
+++ b/src/metabase/api/task.clj
@@ -7,8 +7,7 @@
    [metabase.models.task-history :as task-history]
    [metabase.request.core :as request]
    [metabase.task :as task]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
+   [metabase.util.malli.schema :as ms]))
 
 (api.macros/defendpoint :get "/"
   "Fetch a list of recent tasks stored as Task History"
@@ -16,7 +15,7 @@
    {:keys [_status _task]
     :as filter} :- task-history/Filter]
   (validation/check-has-application-permission :monitoring)
-  {:total  (t2/count :model/TaskHistory)
+  {:total  (task-history/tasks-count filter)
    :limit  (request/limit)
    :offset (request/offset)
    :data   (task-history/all (request/limit) (request/offset) filter)})

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -44,7 +44,7 @@
                                                                                :order-by [[:ended_at :desc]]})]
     (t2/delete! (t2/table-name :model/TaskHistory) :ended_at [:<= clean-before-date])))
 
-(def ^:private task-history-status #{:started :success :failed})
+(def ^:private task-history-status #{:started :success :failed :unknown})
 
 (defn- assert-task-history-status
   [status]

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -89,8 +89,8 @@
                                          {:offset offset}))))
 
 (mu/defn total
-  [filter :- Filter]
   "Return count of all, or filtered if `filter` is provided, task history entries."
+  [filter :- Filter]
   (t2/count :model/TaskHistory ((fnil identity {}) (filter->where filter))))
 
 (defn unique-tasks

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -88,7 +88,7 @@
                                        (when offset
                                          {:offset offset}))))
 
-(mu/defn tasks-count
+(mu/defn total
   [filter :- Filter]
   "Return count of all, or filtered if `filter` is provided, task history entries."
   (t2/count :model/TaskHistory ((fnil identity {}) (filter->where filter))))

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -77,7 +77,7 @@
                  :task   {:optional true} [:string {:min 1}]]]])
 
 (mu/defn all
-  "Return all TaskHistory entries, applying `limit` and `offset` if not nil"
+  "Return all TaskHistory entries, filtered if `filter` is provided, applying `limit` and `offset` if not nil."
   [limit  :- [:maybe ms/PositiveInt]
    offset :- [:maybe ms/IntGreaterThanOrEqualToZero]
    filter :- Filter]

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -88,6 +88,11 @@
                                        (when offset
                                          {:offset offset}))))
 
+(mu/defn tasks-count
+  [filter :- Filter]
+  "Return count of all, or filtered if `filter` is provided, task history entries."
+  (t2/count :model/TaskHistory ((fnil identity {}) (filter->where filter))))
+
 (defn unique-tasks
   "Return _vector_ of all unique tasks' names in alphabetical order."
   []


### PR DESCRIPTION
Follow-up for https://linear.app/metabase/issue/SEM-226/support-filtering-and-sorting-of-the-task-list-in-the-backend to address remarks in https://github.com/metabase/metabase/pull/56451

### Description

- Updated count to use filter.
- Docstring.
- Added `:unknown` status.
- Tests.

### How to verify

Run new tests.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
