### PR TITLE
closes viz-670 allow clearing a card's title

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -331,6 +331,12 @@ export function openDashboardMenu(option?: string) {
   }
 }
 
+export function assertDashboardCardTitle(index: number, title: string) {
+  getDashboardCard(index)
+    .findByTestId("legend-caption-title")
+    .should("have.text", title);
+}
+
 export const dashboardHeader = () => {
   return cy.findByTestId("dashboard-header");
 };

--- a/e2e/test/scenarios/dashboard/visualizer/dashboard-visualizer.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/dashboard-visualizer.cy.spec.ts
@@ -176,39 +176,49 @@ describe("scenarios > dashboard > visualizer", () => {
     createDashboardWithVisualizerDashcards();
     H.editDashboard();
 
-    H.findDashCardAction(H.getDashboardCard(0), "Edit visualization").click();
+    // Rename the first card and check
+    // My chart -> "Renamed chart"
+    H.showDashcardVisualizerModal(0);
     H.modal().within(() => {
-      cy.findByDisplayValue("My chart")
-        .type("{selectall}{del}Renamed chart")
-        .blur();
-      cy.button("Save").click();
+      cy.findByDisplayValue("My chart").clear().type("Renamed chart").blur();
     });
-    H.getDashboardCard(0).within(() => {
-      cy.findByText("Renamed chart").should("exist");
-      cy.findByText("My chart").should("not.exist");
-    });
+    H.saveDashcardVisualizerModal();
+    H.assertDashboardCardTitle(0, "Renamed chart");
 
-    H.showDashcardVisualizerModalSettings(3);
+    // Rename the third card and check
+    // PRODUCTS_COUNT_BY_CREATED_AT.name -> "Another chart"
+    H.showDashcardVisualizerModal(3);
     H.modal().within(() => {
       cy.findByDisplayValue(PRODUCTS_COUNT_BY_CREATED_AT.name)
-        .type("{selectall}{del}Another chart")
+        .clear()
+        .type("Another chart")
         .blur();
-      cy.button("Save").click();
     });
-    H.getDashboardCard(3).within(() => {
-      cy.findByText("Another chart").should("exist");
-      cy.findByText(PRODUCTS_COUNT_BY_CREATED_AT.name).should("not.exist");
-    });
+    H.saveDashcardVisualizerModal();
+    H.assertDashboardCardTitle(3, "Another chart");
 
+    // Clear the second card title
+    // My category chart -> ""
+    H.showDashcardVisualizerModal(1);
+    H.modal().within(() => {
+      cy.findByTestId("visualizer-title").clear().blur();
+    });
+    H.saveDashcardVisualizerModal();
+    H.assertDashboardCardTitle(1, "");
+
+    // Save the dashboard
     H.saveDashboard();
 
-    H.getDashboardCard(0).within(() => {
-      cy.findByText("Renamed chart").should("exist");
-      cy.findByText("My chart").should("not.exist");
-    });
-    H.getDashboardCard(3).within(() => {
-      cy.findByText("Another chart").should("exist");
-      cy.findByText(PRODUCTS_COUNT_BY_CREATED_AT.name).should("not.exist");
+    // Check that the card titles are still good
+    H.assertDashboardCardTitle(0, "Renamed chart");
+    H.assertDashboardCardTitle(1, "");
+    H.assertDashboardCardTitle(3, "Another chart");
+
+    // Making sure the title is empty (not "My new visualization")
+    H.editDashboard();
+    H.showDashcardVisualizerModal(1);
+    H.modal().within(() => {
+      cy.findByTestId("visualizer-title").should("have.text", "");
     });
   });
 

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -54,7 +54,7 @@ const EditableText = forwardRef(function EditableText(
   ref: Ref<HTMLDivElement>,
 ) {
   const [inputValue, setInputValue] = useState(initialValue ?? "");
-  const [submitValue, setSubmitValue] = useState(initialValue ?? "");
+  const [submitValue, setSubmitValue] = useState(initialValue);
   const [isInFocus, setIsInFocus] = useState(isEditing);
   const displayValue = inputValue ? inputValue : placeholder;
   const submitOnBlur = useRef(true);

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -70,6 +70,7 @@ export function Header({
       </ActionIcon>
       <EditableText
         initialValue={title}
+        isOptional
         onChange={handleChangeTitle}
         className={S.title}
       />

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -73,6 +73,8 @@ export function Header({
         isOptional
         onChange={handleChangeTitle}
         className={S.title}
+        data-testid="visualizer-title"
+        placeholder={t`Add a title`}
       />
 
       {/* Spacer */}

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -24,7 +24,6 @@ import type {
 import {
   createDataSource,
   extractReferencedColumns,
-  getDefaultVisualizationName,
   mergeVisualizerData,
   shouldSplitVisualizerSeries,
   splitVisualizerSeries,
@@ -51,7 +50,7 @@ export const getCards = (state: State) => state.visualizer.cards;
 
 export function getVisualizationTitle(state: State) {
   const settings = getVisualizerRawSettings(state);
-  return settings["card.title"] ?? getDefaultVisualizationName();
+  return settings["card.title"];
 }
 
 export function getVisualizationType(state: State) {

--- a/frontend/src/metabase/visualizer/utils/index.ts
+++ b/frontend/src/metabase/visualizer/utils/index.ts
@@ -7,5 +7,4 @@ export * from "./drag-and-drop";
 export * from "./get-initial-state-for-card-data-source";
 export * from "./is-visualizer-dashboard-card";
 export * from "./merge-data";
-export * from "./misc";
 export * from "./split-series";

--- a/frontend/src/metabase/visualizer/utils/misc.ts
+++ b/frontend/src/metabase/visualizer/utils/misc.ts
@@ -1,5 +1,0 @@
-import { t } from "ttag";
-
-export function getDefaultVisualizationName() {
-  return t`My new visualization`;
-}

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -40,7 +40,6 @@ import {
   extractReferencedColumns,
   getColumnVizSettings,
   getDataSourceIdFromNameRef,
-  getDefaultVisualizationName,
   getInitialStateForCardDataSource,
   parseDataSourceId,
 } from "./utils";
@@ -84,9 +83,7 @@ function getInitialVisualizerHistoryItem(): VisualizerHistoryItem {
     display: null,
     columns: [],
     columnValuesMapping: {},
-    settings: {
-      "card.title": getDefaultVisualizationName(),
-    },
+    settings: {},
   };
 }
 
@@ -410,9 +407,6 @@ const visualizerHistoryItemSlice = createSlice({
         const initialState = action.payload;
         if (initialState) {
           Object.assign(state, initialState);
-        }
-        if (!state.settings?.["card.title"]) {
-          state.settings["card.title"] = getDefaultVisualizationName();
         }
       })
       .addCase(addDataSource.fulfilled, (state, action) => {


### PR DESCRIPTION
Closes [VIZ-670: Clearing the title of a visualizer card doesn't work as expected](https://linear.app/metabase/issue/VIZ-670/clearing-the-title-of-a-visualizer-card-doesnt-work-as-expected)

### Description

Made a visualizer's card title optional