### PR TITLE
Add unit tests for visualizer column mapping

### DIFF
--- a/frontend/src/metabase-types/api/mocks/dataset.ts
+++ b/frontend/src/metabase-types/api/mocks/dataset.ts
@@ -26,6 +26,31 @@ export const createMockColumn = (
   };
 };
 
+export const createMockDatetimeColumn = (data: Partial<DatasetColumn> = {}) =>
+  createMockColumn({
+    base_type: "type/DateTime",
+    effective_type: "type/DateTime",
+    semantic_type: null,
+    unit: "month",
+    ...data,
+  });
+
+export const createMockCategoryColumn = (data: Partial<DatasetColumn> = {}) =>
+  createMockColumn({
+    base_type: "type/Text",
+    effective_type: "type/Text",
+    semantic_type: "type/Category",
+    ...data,
+  });
+
+export const createMockNumericColumn = (data: Partial<DatasetColumn> = {}) =>
+  createMockColumn({
+    base_type: "type/Integer",
+    effective_type: "type/Integer",
+    semantic_type: null,
+    ...data,
+  });
+
 export const createMockDatasetData = ({
   cols = [
     createMockColumn({

--- a/frontend/src/metabase-types/store/mocks/index.ts
+++ b/frontend/src/metabase-types/store/mocks/index.ts
@@ -12,3 +12,4 @@ export * from "./setup";
 export * from "./state";
 export * from "./upload";
 export * from "./downloads";
+export * from "./visualizer";

--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -16,6 +16,7 @@ import { createMockRoutingState } from "./routing";
 import { createMockSettingsState } from "./settings";
 import { createMockSetupState } from "./setup";
 import { createMockUploadState } from "./upload";
+import { createMockVisualizerState } from "./visualizer";
 
 export function createMockState<S extends Pick<SdkStoreState, "sdk">>(
   opts?: S,
@@ -39,6 +40,7 @@ export function createMockState(opts: any) {
     settings: createMockSettingsState(),
     setup: createMockSetupState(),
     upload: createMockUploadState(),
+    visualizer: createMockVisualizerState(),
     modal: null,
     ...opts,
   };

--- a/frontend/src/metabase-types/store/mocks/visualizer.ts
+++ b/frontend/src/metabase-types/store/mocks/visualizer.ts
@@ -1,0 +1,32 @@
+import type { VisualizerHistoryItem, VisualizerState } from "../visualizer";
+
+export const createMockVisualizerHistoryItem = (
+  opts?: Partial<VisualizerHistoryItem>,
+): VisualizerHistoryItem => ({
+  display: null,
+  columns: [],
+  columnValuesMapping: {},
+  settings: {
+    "card.title": "Card Title",
+  },
+  ...opts,
+});
+
+export const createMockVisualizerState = (
+  opts?: Partial<VisualizerState>,
+): VisualizerState => ({
+  initialState: createMockVisualizerHistoryItem(),
+  past: [],
+  present: createMockVisualizerHistoryItem(),
+  future: [],
+  cards: [],
+  datasets: {},
+  expandedDataSources: {},
+  loadingDataSources: {},
+  loadingDatasets: {},
+  isDataSidebarOpen: true,
+  isVizSettingsSidebarOpen: false,
+  error: null,
+  draggedItem: null,
+  ...opts,
+});

--- a/frontend/src/metabase/visualizer/utils/column.ts
+++ b/frontend/src/metabase/visualizer/utils/column.ts
@@ -1,5 +1,4 @@
-import { isDate } from "metabase-lib/v1/types/utils/isa";
-import type { DatasetColumn, FieldLiteral } from "metabase-types/api";
+import type { DatasetColumn } from "metabase-types/api";
 import type {
   VisualizerColumnReference,
   VisualizerColumnValueSource,
@@ -73,30 +72,10 @@ export function copyColumn(
   dataSourceName: string,
   existingColumns: DatasetColumn[],
 ): DatasetColumn {
-  const copy: DatasetColumn = {
-    ...column,
-    name,
-    field_ref: [
-      "field",
-      name,
-      { "base-type": column.base_type },
-    ] as FieldLiteral,
-  };
+  const copy: DatasetColumn = { ...column, name };
 
   if (existingColumns.some((col) => col.display_name === copy.display_name)) {
     copy.display_name = `${copy.display_name} (${dataSourceName})`;
-  }
-
-  // TODO Remove manual MBQL manipulation
-  if (isDate(column)) {
-    const opts = copy.field_ref?.[2];
-    const temporalUnit = maybeGetTemporalUnit(column);
-    if (temporalUnit && opts) {
-      // TODO fix type
-      (opts as any)["temporal-unit"] = temporalUnit;
-    }
-    // TODO fix type
-    copy.field_ref = ["field", name, opts as any];
   }
 
   return copy;
@@ -121,11 +100,4 @@ export function extractReferencedColumns(
     (valueSource): valueSource is VisualizerColumnReference =>
       typeof valueSource !== "string",
   );
-}
-
-function maybeGetTemporalUnit(col: DatasetColumn) {
-  const maybeOpts = col.field_ref?.[2];
-  if (maybeOpts && "temporal-unit" in maybeOpts) {
-    return maybeOpts["temporal-unit"];
-  }
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -44,36 +44,6 @@ describe("getInitialStateForCardDataSource", () => {
     }),
   });
 
-  it("should not try to replace unknown columns in the settings", () => {
-    const initialState = getInitialStateForCardDataSource(
-      dashCard.card,
-      dataset,
-    );
-
-    expect(initialState.columns).toHaveLength(2);
-    expect(initialState.columnValuesMapping).toEqual({
-      COLUMN_1: [
-        {
-          name: "COLUMN_1",
-          originalName: "Foo",
-          sourceId: "card:1",
-        },
-      ],
-      COLUMN_2: [
-        {
-          name: "COLUMN_2",
-          originalName: "Bar",
-          sourceId: "card:1",
-        },
-      ],
-    });
-
-    expect(initialState.settings).toEqual({
-      "card.title": "ScalarMcSmartface",
-      "scalar.compact_primary_number": true,
-    });
-  });
-
   it("should pick the proper display if it is not supported by the visualizer", () => {
     const initialState = getInitialStateForCardDataSource(
       dashCard.card,

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -227,7 +227,7 @@ const funnelToPie = (
     settings: {
       ...otherSettings,
       "pie.metric": metric,
-      "pie.dimensions": dimension,
+      "pie.dimension": dimension,
     },
   };
 };

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -30,7 +30,7 @@ export function getUpdatedSettingsForDisplay(
       settings: VisualizationSettings;
     }
   | undefined {
-  if (!sourceDisplay || !targetDisplay) {
+  if (!sourceDisplay || !targetDisplay || sourceDisplay === targetDisplay) {
     return undefined;
   }
 

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -63,7 +63,7 @@ describe("updateSettingsForDisplay", () => {
       "bar",
       "bar",
     );
-    expect(result).toBeUndefined()
+    expect(result).toBeUndefined();
   });
 
   it("should work if sourceDisplay and targetDisplay are cartesian", () => {

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -1,7 +1,12 @@
 import registerVisualizations from "metabase/visualizations/register";
-import { createMockColumn } from "metabase-types/api/mocks";
+import {
+  createMockCategoryColumn,
+  createMockDatetimeColumn,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks";
 import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
 
+import { createDataSourceNameRef } from "./data-source";
 import { getUpdatedSettingsForDisplay } from "./get-updated-settings-for-display";
 
 registerVisualizations();
@@ -20,61 +25,55 @@ describe("updateSettingsForDisplay", () => {
   } as Record<string, VisualizerColumnValueSource[]>;
 
   const columns = [
-    createMockColumn({
-      semantic_type: "type/CreationTimestamp",
+    createMockDatetimeColumn({
+      id: 1,
       name: "COLUMN_1",
-      field_ref: [
-        "field",
-        "COLUMN_1",
-        { "base-type": "type/DateTime", "temporal-unit": "month" },
-      ],
-      effective_type: "type/DateTime",
-      id: 13,
       display_name: "Created At: Month",
-      base_type: "type/DateTime",
     }),
-    createMockColumn({
-      display_name: "Category",
-      semantic_type: "type/Category",
-      field_ref: ["field", "COLUMN_2", { "base-type": "type/Text" }],
-      base_type: "type/Text",
-      effective_type: "type/Text",
+    createMockCategoryColumn({
+      id: 2,
       name: "COLUMN_2",
+      display_name: "Category",
     }),
-    createMockColumn({
-      display_name: "Count",
-      semantic_type: "type/Quantity",
-      field_ref: ["field", "COLUMN_2", { "base-type": "type/BigInteger" }],
-      base_type: "type/BigInteger",
-      effective_type: "type/BigInteger",
+    createMockNumericColumn({
+      id: 3,
       name: "COLUMN_3",
+      display_name: "Count",
     }),
   ];
 
-  it("should return undefined if sourceDisplay or targetDisplay is null", () => {
+  it("should return undefined if sourceDisplay or targetDisplay are null", () => {
     const settings = {};
-    const sourceDisplay = null;
-    const targetDisplay = null;
     const result = getUpdatedSettingsForDisplay(
       columnValuesMapping,
       columns,
       settings,
-      sourceDisplay,
-      targetDisplay,
+      null,
+      null,
     );
     expect(result).toBeUndefined();
   });
 
-  it("should work if sourceDisplay and targetDisplay are cartesian", () => {
+  it("should return undefined if sourceDisplay and targetDisplay are the same", () => {
     const settings = {};
-    const sourceDisplay = "bar";
-    const targetDisplay = "bar";
     const result = getUpdatedSettingsForDisplay(
       columnValuesMapping,
       columns,
       settings,
-      sourceDisplay,
-      targetDisplay,
+      "bar",
+      "bar",
+    );
+    expect(result).toBeUndefined()
+  });
+
+  it("should work if sourceDisplay and targetDisplay are cartesian", () => {
+    const settings = {};
+    const result = getUpdatedSettingsForDisplay(
+      columnValuesMapping,
+      columns,
+      settings,
+      "bar",
+      "line",
     );
     expect(result).toStrictEqual({
       columnValuesMapping,
@@ -83,20 +82,40 @@ describe("updateSettingsForDisplay", () => {
     });
   });
 
-  describe("cartesian -> pie", () => {
-    it("should work with a single dimension (and remove extraneous columns)", () => {
-      const settings = {
-        "graph.metrics": ["COLUMN_3"],
-        "graph.dimensions": ["COLUMN_1"],
-      };
-      const sourceDisplay = "line";
-      const targetDisplay = "pie";
+  describe("cartesian → cartesian", () => {
+    it("should keep current state", () => {
       const result = getUpdatedSettingsForDisplay(
         columnValuesMapping,
         columns,
-        settings,
-        sourceDisplay,
-        targetDisplay,
+        {
+          "graph.metrics": ["COLUMN_1", "COLUMN_3"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+        "line",
+        "bar",
+      );
+      expect(result).toEqual({
+        columnValuesMapping,
+        columns,
+        settings: {
+          "graph.metrics": ["COLUMN_1", "COLUMN_3"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+      });
+    });
+  });
+
+  describe("cartesian -> pie", () => {
+    it("should work with a single dimension (and remove extraneous columns)", () => {
+      const result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        {
+          "graph.metrics": ["COLUMN_3"],
+          "graph.dimensions": ["COLUMN_1"],
+        },
+        "line",
+        "pie",
       );
       expect(result).toEqual({
         columnValuesMapping: {
@@ -112,18 +131,15 @@ describe("updateSettingsForDisplay", () => {
     });
 
     it("should work with multiple dimensions", () => {
-      const settings = {
-        "graph.metrics": ["COLUMN_3"],
-        "graph.dimensions": ["COLUMN_1", "COLUMN_2"],
-      };
-      const sourceDisplay = "line";
-      const targetDisplay = "pie";
       const result = getUpdatedSettingsForDisplay(
         columnValuesMapping,
         columns,
-        settings,
-        sourceDisplay,
-        targetDisplay,
+        {
+          "graph.metrics": ["COLUMN_3"],
+          "graph.dimensions": ["COLUMN_1", "COLUMN_2"],
+        },
+        "line",
+        "pie",
       );
       expect(result).toEqual({
         columnValuesMapping,
@@ -136,27 +152,149 @@ describe("updateSettingsForDisplay", () => {
     });
   });
 
-  it("should work if sourceDisplay is pie and targetDisplay is cartesian", () => {
-    const settings = {
-      "pie.metric": "COLUMN_3",
-      "pie.dimension": "COLUMN_1",
-    };
-    const sourceDisplay = "pie";
-    const targetDisplay = "line";
-    const result = getUpdatedSettingsForDisplay(
-      columnValuesMapping,
-      columns,
-      settings,
-      sourceDisplay,
-      targetDisplay,
-    );
-    expect(result).toEqual({
-      columnValuesMapping,
-      columns,
-      settings: {
-        "graph.metrics": ["COLUMN_3"],
-        "graph.dimensions": ["COLUMN_1"],
-      },
+  describe("pie → cartesian", () => {
+    it("should turn pie metric and dimensions settings into cartesian ones", () => {
+      const result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        {
+          "pie.metric": "COLUMN_3",
+          "pie.dimension": ["COLUMN_1", "COLUMN_2"],
+        },
+        "pie",
+        "line",
+      );
+      expect(result).toEqual({
+        columnValuesMapping,
+        columns,
+        settings: {
+          "graph.metrics": ["COLUMN_3"],
+          "graph.dimensions": ["COLUMN_1", "COLUMN_2"],
+        },
+      });
+    });
+
+    it("should work with a single pie dimension", () => {
+      const result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        {
+          "pie.metric": "COLUMN_3",
+          "pie.dimension": "COLUMN_1",
+        },
+        "pie",
+        "line",
+      );
+      expect(result).toEqual({
+        columnValuesMapping,
+        columns,
+        settings: {
+          "graph.metrics": ["COLUMN_3"],
+          "graph.dimensions": ["COLUMN_1"],
+        },
+      });
+    });
+  });
+
+  describe("funnel → cartesian", () => {
+    it("should turn funnel metric and dimension settings into cartesian ones", () => {
+      const result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        {
+          "funnel.metric": "COLUMN_3",
+          "funnel.dimension": "COLUMN_2",
+        },
+        "funnel",
+        "line",
+      );
+      expect(result).toEqual({
+        columnValuesMapping,
+        columns,
+        settings: {
+          "graph.metrics": ["COLUMN_3"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+      });
+    });
+  });
+
+  describe("funnel → pie", () => {
+    it("should turn funnel metric and dimensions settings into pie ones", () => {
+      const result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        {
+          "funnel.metric": "COLUMN_3",
+          "funnel.dimension": "COLUMN_2",
+        },
+        "funnel",
+        "pie",
+      );
+      expect(result).toEqual({
+        columnValuesMapping,
+        columns,
+        settings: {
+          "pie.metric": "COLUMN_3",
+          "pie.dimension": "COLUMN_2",
+        },
+      });
+    });
+  });
+
+  describe("funnel made of scalars", () => {
+    it("should reset state when changing to any other display type", () => {
+      const cleanState = {
+        settings: { "card.title": "My viz" },
+        columns: [],
+        columnValuesMapping: {},
+      };
+
+      const columns = [
+        createMockNumericColumn({ name: "METRIC", display_name: "METRIC" }),
+        createMockCategoryColumn({
+          name: "DIMENSION",
+          display_name: "DIMENSION",
+        }),
+      ];
+      const columnValuesMapping: Record<string, VisualizerColumnValueSource[]> =
+        {
+          METRIC: [
+            { sourceId: "card:1", originalName: "views", name: "COLUMN_1" },
+            { sourceId: "card:2", originalName: "checkout", name: "COLUMN_2" },
+            { sourceId: "card:3", originalName: "done", name: "COLUMN_3" },
+          ],
+          DIMENSION: [
+            createDataSourceNameRef("card:1"),
+            createDataSourceNameRef("card:2"),
+            createDataSourceNameRef("card:3"),
+          ],
+        };
+      const settings = {
+        "card.title": "My viz",
+        "funnel.metric": "METRIC",
+        "funnel.dimension": "DIMENSION",
+      };
+
+      let result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        settings,
+        "funnel",
+        "bar",
+      );
+
+      expect(result).toEqual(cleanState);
+
+      result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        settings,
+        "funnel",
+        "pie",
+      );
+
+      expect(result).toEqual(cleanState);
     });
   });
 });

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -221,17 +221,21 @@ export function addColumnToCartesianChart(
       );
     }
   } else {
-    const ownMetrics = state.settings["graph.metrics"] ?? [];
     const ownDimensions = state.settings["graph.dimensions"] ?? [];
 
     if (
       ownDimensions.length === 0 ||
       isCompatibleWithCartesianChart(state, dataset)
     ) {
-      if (isDimension(column)) {
-        state.settings["graph.dimensions"] = [...ownDimensions, column.name];
+      if (isDimension(column) && !isMetric(column)) {
+        addDimensionColumnToCartesianChart(
+          state,
+          column,
+          columnRef,
+          dataSource,
+        );
       } else if (isMetric(column)) {
-        state.settings["graph.metrics"] = [...ownMetrics, column.name];
+        addMetricColumnToCartesianChart(state, column, columnRef, dataSource);
       }
     }
   }

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -220,19 +220,19 @@ export function addColumnToCartesianChart(
         dataSource,
       );
     }
-  }
+  } else {
+    const ownMetrics = state.settings["graph.metrics"] ?? [];
+    const ownDimensions = state.settings["graph.dimensions"] ?? [];
 
-  const ownMetrics = state.settings["graph.metrics"] ?? [];
-  const ownDimensions = state.settings["graph.dimensions"] ?? [];
-
-  if (
-    ownDimensions.length === 0 ||
-    isCompatibleWithCartesianChart(state, dataset)
-  ) {
-    if (isDimension(column)) {
-      state.settings["graph.dimensions"] = [...ownDimensions, column.name];
-    } else if (isMetric(column)) {
-      state.settings["graph.metrics"] = [...ownMetrics, column.name];
+    if (
+      ownDimensions.length === 0 ||
+      isCompatibleWithCartesianChart(state, dataset)
+    ) {
+      if (isDimension(column)) {
+        state.settings["graph.dimensions"] = [...ownDimensions, column.name];
+      } else if (isMetric(column)) {
+        state.settings["graph.metrics"] = [...ownMetrics, column.name];
+      }
     }
   }
 }

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1,4 +1,8 @@
+import _ from "underscore";
+
 import {
+  createMockCategoryColumn,
+  createMockColumn,
   createMockDataset,
   createMockDatetimeColumn,
   createMockNumericColumn,
@@ -15,6 +19,7 @@ import {
   addColumnToCartesianChart,
   addDimensionColumnToCartesianChart,
   addMetricColumnToCartesianChart,
+  combineWithCartesianChart,
   removeBubbleSizeFromCartesianChart,
   removeColumnFromCartesianChart,
   replaceMetricColumnAsScatterBubbleSize,
@@ -38,10 +43,142 @@ describe("cartesian", () => {
       column2Ref,
     ]);
 
+    const column4 = createMockColumn({
+      id: 4,
+      name: "BOOL",
+      base_type: "type/Boolean",
+      effective_type: "type/Boolean",
+      semantic_type: null,
+    });
+    const column4Ref = createVisualizerColumnReference(dataSource, column4, [
+      column1Ref,
+      column2Ref,
+    ]);
+
     const dataset = createMockDataset({
       data: {
         cols: [column1, column2, column3],
       },
+    });
+
+    it("should add a metric column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+      };
+
+      addColumnToCartesianChart(
+        state,
+        column2,
+        column2Ref,
+        dataset,
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_2"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_2: [
+          {
+            name: "COLUMN_2",
+            originalName: column2.name,
+            sourceId: dataSource.id,
+          },
+        ],
+      });
+      expect(state.settings).toEqual({ "graph.metrics": ["COLUMN_2"] });
+    });
+
+    it("should add a dimenion column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+      };
+
+      addColumnToCartesianChart(
+        state,
+        column1,
+        column1Ref,
+        dataset,
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          {
+            name: "COLUMN_1",
+            originalName: column1.name,
+            sourceId: dataSource.id,
+          },
+        ],
+      });
+      expect(state.settings).toEqual({ "graph.dimensions": ["COLUMN_1"] });
+    });
+
+    it("should do nothing if the column is already in the state", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [{ ...column1, name: "COLUMN_1" }],
+        settings: {
+          "graph.dimensions": ["COLUMN_1"],
+        },
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              name: "COLUMN_1",
+              originalName: column1.name,
+              sourceId: dataSource.id,
+            },
+          ],
+        },
+      };
+
+      addColumnToCartesianChart(
+        state,
+        column1,
+        column1Ref,
+        dataset,
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          {
+            name: "COLUMN_1",
+            originalName: column1.name,
+            sourceId: dataSource.id,
+          },
+        ],
+      });
+      expect(state.settings).toEqual({ "graph.dimensions": ["COLUMN_1"] });
+    });
+
+    // TODO Enable when VIZ-652 is closed
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip("should do nothing if the column can't be used in a chart", () => {
+      const state: VisualizerHistoryItem = {
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+        display: "bar",
+      };
+
+      addColumnToCartesianChart(
+        state,
+        column4,
+        column4Ref,
+        dataset,
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual([]);
+      expect(state.columnValuesMapping).toEqual({});
+      expect(state.settings).toEqual({});
     });
 
     describe("for scatter", () => {
@@ -109,6 +246,413 @@ describe("cartesian", () => {
           "graph.metrics": ["COLUMN_2"],
           "scatter.bubble": "COLUMN_3", // <-- this is the only change
         });
+      });
+    });
+  });
+
+  describe("removeColumnFromCartesianChart", () => {
+    const dataSource1 = createDataSource("card", 1, "Card 1");
+    const metric1 = createMockNumericColumn({ id: 1, name: "count" });
+    const dimension1 = createMockDatetimeColumn({ id: 2, name: "created_at" });
+
+    const dataSource2 = createDataSource("card", 2, "Card 2");
+    const metric2 = createMockNumericColumn({ id: 3, name: "avg" });
+    const dimension2 = createMockDatetimeColumn({ id: 4, name: "date" });
+
+    it("should remove a metric from a single series chart", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [
+          { ...metric1, name: "COLUMN_1" },
+          { ...dimension1, name: "COLUMN_2" },
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+          COLUMN_2: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_2",
+              originalName: "created_at",
+            },
+          ],
+        },
+        settings: {
+          "graph.metrics": ["COLUMN_1"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+      };
+
+      removeColumnFromCartesianChart(state, "COLUMN_1");
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_2"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_2: [
+          { sourceId: "card:1", name: "COLUMN_2", originalName: "created_at" },
+        ],
+      });
+      expect(state.settings).toEqual({
+        "graph.metrics": [],
+        "graph.dimensions": ["COLUMN_2"],
+      });
+    });
+
+    it("should remove a metric from a multi series chart", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [
+          { ...metric1, name: "COLUMN_1" },
+          { ...dimension1, name: "COLUMN_2" },
+          { ...metric2, name: "COLUMN_3" },
+          { ...dimension2, name: "COLUMN_4" },
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+          COLUMN_2: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_2",
+              originalName: "created_at",
+            },
+          ],
+          COLUMN_3: [
+            {
+              sourceId: dataSource2.id,
+              name: "COLUMN_3",
+              originalName: "avg",
+            },
+          ],
+          COLUMN_4: [
+            {
+              sourceId: dataSource2.id,
+              name: "COLUMN_4",
+              originalName: "date",
+            },
+          ],
+        },
+        settings: {
+          "graph.metrics": ["COLUMN_1", "COLUMN_3"],
+          "graph.dimensions": ["COLUMN_2", "COLUMN_4"],
+        },
+      };
+
+      removeColumnFromCartesianChart(state, "COLUMN_1");
+
+      expect(state.columns.map((c) => c.name)).toEqual([
+        "COLUMN_2",
+        "COLUMN_3",
+        "COLUMN_4",
+      ]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_2: [
+          { sourceId: "card:1", name: "COLUMN_2", originalName: "created_at" },
+        ],
+        COLUMN_3: [
+          { sourceId: "card:2", name: "COLUMN_3", originalName: "avg" },
+        ],
+        COLUMN_4: [
+          { sourceId: "card:2", name: "COLUMN_4", originalName: "date" },
+        ],
+      });
+      expect(state.settings).toEqual({
+        "graph.metrics": ["COLUMN_3"],
+        "graph.dimensions": ["COLUMN_2", "COLUMN_4"],
+      });
+    });
+
+    it("should remove a dimension from a single series chart", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [
+          { ...metric1, name: "COLUMN_1" },
+          { ...dimension1, name: "COLUMN_2" },
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+          COLUMN_2: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_2",
+              originalName: "created_at",
+            },
+          ],
+        },
+        settings: {
+          "graph.metrics": ["COLUMN_1"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+      };
+
+      removeColumnFromCartesianChart(state, "COLUMN_2");
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+        ],
+      });
+      expect(state.settings).toEqual({
+        "graph.metrics": ["COLUMN_1"],
+        "graph.dimensions": [],
+      });
+    });
+
+    it("should remove a dimension from a multi series chart", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [
+          { ...metric1, name: "COLUMN_1" },
+          { ...dimension1, name: "COLUMN_2" },
+          { ...metric2, name: "COLUMN_3" },
+          { ...dimension2, name: "COLUMN_4" },
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+          COLUMN_2: [
+            {
+              sourceId: dataSource1.id,
+              name: "COLUMN_2",
+              originalName: "created_at",
+            },
+          ],
+          COLUMN_3: [
+            {
+              sourceId: dataSource2.id,
+              name: "COLUMN_3",
+              originalName: "avg",
+            },
+          ],
+          COLUMN_4: [
+            {
+              sourceId: dataSource2.id,
+              name: "COLUMN_4",
+              originalName: "date",
+            },
+          ],
+        },
+        settings: {
+          "graph.metrics": ["COLUMN_1", "COLUMN_3"],
+          "graph.dimensions": ["COLUMN_2", "COLUMN_4"],
+        },
+      };
+
+      removeColumnFromCartesianChart(state, "COLUMN_2");
+
+      expect(state.columns.map((c) => c.name)).toEqual([
+        "COLUMN_1",
+        "COLUMN_3",
+        "COLUMN_4",
+      ]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+        ],
+        COLUMN_3: [
+          { sourceId: "card:2", name: "COLUMN_3", originalName: "avg" },
+        ],
+        COLUMN_4: [
+          { sourceId: "card:2", name: "COLUMN_4", originalName: "date" },
+        ],
+      });
+      expect(state.settings).toEqual({
+        "graph.metrics": ["COLUMN_1", "COLUMN_3"],
+        "graph.dimensions": ["COLUMN_4"],
+      });
+    });
+  });
+
+  describe("combineWithCartesianChart", () => {
+    it("should add metric and dimension columns", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [
+          createMockNumericColumn({ name: "COLUMN_1", display_name: "Count" }),
+          createMockDatetimeColumn({
+            name: "COLUMN_2",
+            display_name: "Created At",
+          }),
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "Count" },
+          ],
+          COLUMN_2: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_2",
+              originalName: "Created At",
+            },
+          ],
+        },
+        settings: {
+          "graph.metrics": ["COLUMN_1"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+      };
+
+      const newMetricColumn = createMockNumericColumn({
+        name: "AVG",
+        display_name: "Average",
+      });
+      const newDimensionColumn = createMockDatetimeColumn({
+        name: "DATE",
+        display_name: "Date",
+      });
+
+      const nextState = _.clone(state);
+      combineWithCartesianChart(
+        nextState,
+        createMockDataset({
+          data: { cols: [newMetricColumn, newDimensionColumn] },
+        }),
+        createDataSource("card", 2, "Card 2"),
+      );
+
+      expect(nextState.columns.map((col) => col.name)).toEqual([
+        "COLUMN_1",
+        "COLUMN_2",
+        "COLUMN_3",
+        "COLUMN_4",
+      ]);
+      expect(nextState.columnValuesMapping).toEqual({
+        ...state.columnValuesMapping,
+        COLUMN_3: [
+          { sourceId: "card:2", name: "COLUMN_3", originalName: "AVG" },
+        ],
+        COLUMN_4: [
+          { sourceId: "card:2", name: "COLUMN_4", originalName: "DATE" },
+        ],
+      });
+      expect(nextState.settings).toStrictEqual({
+        ...state.settings,
+        "graph.metrics": ["COLUMN_1", "COLUMN_3"],
+        "graph.dimensions": ["COLUMN_2", "COLUMN_4"],
+      });
+    });
+
+    it("should add multiple metrics and dimensions", () => {
+      const state: VisualizerHistoryItem = {
+        display: "bar",
+        columns: [
+          createMockNumericColumn({ name: "COLUMN_1", display_name: "Count" }),
+          createMockDatetimeColumn({
+            name: "COLUMN_2",
+            display_name: "Created At",
+          }),
+          createMockCategoryColumn({
+            name: "COLUMN_3",
+            display_name: "Category",
+          }),
+        ],
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "Count" },
+          ],
+          COLUMN_2: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_2",
+              originalName: "Created At",
+            },
+          ],
+          COLUMN_3: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_3",
+              originalName: "Category",
+            },
+          ],
+        },
+        settings: {
+          "graph.metrics": ["COLUMN_1"],
+          "graph.dimensions": ["COLUMN_2", "COLUMN_3"],
+        },
+      };
+
+      const newMetric1Column = createMockNumericColumn({
+        name: "AVG",
+        display_name: "Average",
+      });
+      const newMetric2Column = createMockNumericColumn({
+        name: "MAX",
+        display_name: "Max",
+      });
+      const newTimeDimensionColumn = createMockDatetimeColumn({
+        name: "DATE",
+        display_name: "Date",
+      });
+      const newCategoryDimensionColumn = createMockCategoryColumn({
+        name: "CATEGORY",
+        display_name: "Category",
+      });
+
+      const nextState = _.clone(state);
+      combineWithCartesianChart(
+        nextState,
+        createMockDataset({
+          data: {
+            cols: [
+              newMetric1Column,
+              newMetric2Column,
+              newTimeDimensionColumn,
+              newCategoryDimensionColumn,
+            ],
+          },
+        }),
+        createDataSource("card", 2, "Card 2"),
+      );
+
+      expect(nextState.columns.map((col) => col.name)).toEqual([
+        "COLUMN_1",
+        "COLUMN_2",
+        "COLUMN_3",
+        "COLUMN_4",
+        "COLUMN_5",
+        "COLUMN_6",
+        "COLUMN_7",
+      ]);
+      expect(nextState.columnValuesMapping).toEqual({
+        ...state.columnValuesMapping,
+        COLUMN_4: [
+          { sourceId: "card:2", name: "COLUMN_4", originalName: "AVG" },
+        ],
+        COLUMN_5: [
+          { sourceId: "card:2", name: "COLUMN_5", originalName: "MAX" },
+        ],
+        COLUMN_6: [
+          { sourceId: "card:2", name: "COLUMN_6", originalName: "DATE" },
+        ],
+        COLUMN_7: [
+          { sourceId: "card:2", name: "COLUMN_7", originalName: "CATEGORY" },
+        ],
+      });
+      expect(nextState.settings).toStrictEqual({
+        ...state.settings,
+        "graph.metrics": ["COLUMN_1", "COLUMN_4", "COLUMN_5"],
+        "graph.dimensions": ["COLUMN_2", "COLUMN_3", "COLUMN_6", "COLUMN_7"],
       });
     });
   });

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1,7 +1,15 @@
-import { createMockColumn, createMockDataset } from "metabase-types/api/mocks";
+import {
+  createMockDataset,
+  createMockDatetimeColumn,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks";
 import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
 
-import { createDataSource, createVisualizerColumnReference } from "../utils";
+import {
+  copyColumn,
+  createDataSource,
+  createVisualizerColumnReference,
+} from "../utils";
 
 import {
   addColumnToCartesianChart,
@@ -16,30 +24,25 @@ describe("cartesian", () => {
   describe("addColumnToCartesianChart", () => {
     const dataSource = createDataSource("card", 1, "Card 1");
 
-    const column1 = createMockColumn({
-      name: "CREATED_AT",
-      effective_type: "type/DateTime",
-    });
+    const column1 = createMockDatetimeColumn({ id: 1, name: "CREATED_AT" });
     const column1Ref = createVisualizerColumnReference(dataSource, column1, []);
 
-    const column2 = createMockColumn({
-      effective_type: "type/BigInteger",
-      name: "count",
-    });
+    const column2 = createMockNumericColumn({ id: 2, name: "count" });
     const column2Ref = createVisualizerColumnReference(dataSource, column2, [
       column1Ref,
     ]);
 
-    const column3 = createMockColumn({
-      effective_type: "type/BigInteger",
-      name: "avg",
-    });
+    const column3 = createMockNumericColumn({ id: 3, name: "avg" });
     const column3Ref = createVisualizerColumnReference(dataSource, column3, [
       column1Ref,
       column2Ref,
     ]);
 
-    const dataset = createMockDataset({});
+    const dataset = createMockDataset({
+      data: {
+        cols: [column1, column2, column3],
+      },
+    });
 
     describe("for scatter", () => {
       it("should add columns in the right order", () => {
@@ -53,7 +56,7 @@ describe("cartesian", () => {
         // First column is automatically added as a dimension
         addColumnToCartesianChart(
           state,
-          column1,
+          copyColumn(column1Ref.name, column1, dataSource.name, []),
           column1Ref,
           dataset,
           dataSource,
@@ -65,7 +68,7 @@ describe("cartesian", () => {
         // Second column is automatically added as a metric
         addColumnToCartesianChart(
           state,
-          column2,
+          copyColumn(column2Ref.name, column2, dataSource.name, []),
           column2Ref,
           dataset,
           dataSource,
@@ -86,7 +89,7 @@ describe("cartesian", () => {
         // Third column is automatically added as a the bubble size
         addColumnToCartesianChart(
           state,
-          column3,
+          copyColumn(column3Ref.name, column3, dataSource.name, []),
           column3Ref,
           dataset,
           dataSource,
@@ -113,10 +116,10 @@ describe("cartesian", () => {
   describe("scatter bubble size", () => {
     const dataSource = createDataSource("card", 1, "Card 1");
 
-    const column1 = createMockColumn({ name: "count" });
+    const column1 = createMockNumericColumn({ id: 1, name: "count" });
     const column1Ref = createVisualizerColumnReference(dataSource, column1, []);
 
-    const column2 = createMockColumn({ name: "sum" });
+    const column2 = createMockNumericColumn({ id: 2, name: "sum" });
     const column2Ref = createVisualizerColumnReference(dataSource, column2, [
       column1Ref,
     ]);
@@ -156,6 +159,7 @@ describe("cartesian", () => {
         columnValuesMapping: {},
         display: "scatter",
       };
+
       // Add the first column
       replaceMetricColumnAsScatterBubbleSize(
         state,
@@ -193,8 +197,14 @@ describe("cartesian", () => {
         columnValuesMapping: {},
         display: "scatter",
       };
+
       // Add the first column as the Y axis
-      addMetricColumnToCartesianChart(state, column1, column1Ref, dataSource);
+      addMetricColumnToCartesianChart(
+        state,
+        copyColumn(column1Ref.name, column1, dataSource.name, []),
+        column1Ref,
+        dataSource,
+      );
 
       // Add it as the bubble size too
       replaceMetricColumnAsScatterBubbleSize(
@@ -246,8 +256,14 @@ describe("cartesian", () => {
         columnValuesMapping: {},
         display: "scatter",
       };
+
       // Add the first column as the Y axis
-      addMetricColumnToCartesianChart(state, column1, column1Ref, dataSource);
+      addMetricColumnToCartesianChart(
+        state,
+        copyColumn(column1Ref.name, column1, dataSource.name, []),
+        column1Ref,
+        dataSource,
+      );
 
       // Add it as the bubble size too
       replaceMetricColumnAsScatterBubbleSize(
@@ -283,13 +299,26 @@ describe("cartesian", () => {
         columnValuesMapping: {},
         display: "scatter",
       };
+
+      const copiedColumn1 = copyColumn(
+        column1Ref.name,
+        column1,
+        dataSource.name,
+        [],
+      );
+
       // Add the first column as the Y axis
-      addMetricColumnToCartesianChart(state, column1, column1Ref, dataSource);
+      addMetricColumnToCartesianChart(
+        state,
+        copiedColumn1,
+        column1Ref,
+        dataSource,
+      );
 
       // Add it as the bubble size too
       replaceMetricColumnAsScatterBubbleSize(
         state,
-        column1,
+        copiedColumn1,
         column1Ref,
         dataSource,
       );
@@ -321,10 +350,11 @@ describe("cartesian", () => {
         columnValuesMapping: {},
         display: "scatter",
       };
+
       // Add the first column as the X axis
       addDimensionColumnToCartesianChart(
         state,
-        column1,
+        copyColumn(column1Ref.name, column1, dataSource.name, []),
         column1Ref,
         dataSource,
       );

--- a/frontend/src/metabase/visualizer/visualizations/funnel.ts
+++ b/frontend/src/metabase/visualizer/visualizations/funnel.ts
@@ -1,4 +1,5 @@
 import type { DragEndEvent } from "@dnd-kit/core";
+import _ from "underscore";
 
 import { DROPPABLE_ID } from "metabase/visualizer/constants";
 import {
@@ -181,7 +182,7 @@ export function removeColumnFromFunnel(
     if (columnName === "METRIC" || columnName === "DIMENSION") {
       state.columns = [];
       state.columnValuesMapping = {};
-      state.settings = {};
+      state.settings = _.pick(state.settings, "card.title");
     } else {
       const index = state.columnValuesMapping.METRIC.findIndex(
         (mapping) => typeof mapping !== "string" && mapping.name === columnName,

--- a/frontend/src/metabase/visualizer/visualizations/funnel.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/funnel.unit.spec.ts
@@ -1,0 +1,707 @@
+import _ from "underscore";
+
+import {
+  createMockCategoryColumn,
+  createMockDataset,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks";
+import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
+
+import {
+  createDataSource,
+  createDataSourceNameRef,
+  createVisualizerColumnReference,
+} from "../utils";
+
+import {
+  addColumnToFunnel,
+  combineWithFunnel,
+  removeColumnFromFunnel,
+} from "./funnel";
+
+describe("funnel", () => {
+  const dataSource = createDataSource("card", 1, "Q1");
+
+  const metricColumn = createMockNumericColumn({ id: 1, name: "count" });
+  const metricColumnRef = createVisualizerColumnReference(
+    dataSource,
+    metricColumn,
+    [],
+  );
+
+  const metricColumn2 = createMockNumericColumn({ id: 2, name: "sum" });
+
+  const dimensionColumn = createMockCategoryColumn({
+    id: 3,
+    name: "category",
+  });
+  const dimensionColumnRef = createVisualizerColumnReference(
+    dataSource,
+    dimensionColumn,
+    [metricColumnRef],
+  );
+
+  const dimensionColumn2 = createMockCategoryColumn({
+    id: 4,
+    name: "category2",
+  });
+
+  const dataset = createMockDataset({
+    data: {
+      cols: [metricColumn, metricColumn2, dimensionColumn, dimensionColumn2],
+    },
+  });
+
+  const scalarDataset1 = createMockDataset({
+    data: {
+      cols: [metricColumn],
+      rows: [[500]],
+    },
+  });
+
+  const dataSource2 = createDataSource("card", 2, "Q2");
+  const scalarDataset2 = createMockDataset({
+    data: {
+      cols: [metricColumn2],
+      rows: [[1000]],
+    },
+  });
+
+  describe("addColumnToFunnel", () => {
+    describe("regular funnel", () => {
+      it("should add a metric column", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [],
+          settings: {},
+          columnValuesMapping: {},
+        };
+
+        addColumnToFunnel(
+          state,
+          { ...metricColumn, name: "COLUMN_1" },
+          metricColumnRef,
+          dataset,
+          dataSource,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        expect(state.columnValuesMapping).toEqual({
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+        });
+        expect(state.settings).toEqual({ "funnel.metric": "COLUMN_1" });
+      });
+
+      it("should not change the metric column if it's already set", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...metricColumn, name: "COLUMN_1" }],
+          settings: { "funnel.metric": "COLUMN_1" },
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: "card:1",
+                name: "COLUMN_1",
+                originalName: "count",
+              },
+            ],
+          },
+        };
+
+        addColumnToFunnel(
+          state,
+          { ...metricColumn2, name: "COLUMN_2" },
+          createVisualizerColumnReference(dataSource, metricColumn2, [
+            metricColumnRef,
+          ]),
+          dataset,
+          dataSource,
+        );
+
+        // TODO Enable when VIZ-652 is closed
+        // expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        // expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+        expect(state.settings).toEqual({ "funnel.metric": "COLUMN_1" });
+      });
+
+      it("should add a dimension column", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...metricColumn, name: "COLUMN_1" }],
+          settings: { "funnel.metric": "COLUMN_1" },
+          columnValuesMapping: {
+            COLUMN_1: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+          },
+        };
+
+        addColumnToFunnel(
+          state,
+          { ...dimensionColumn, name: "COLUMN_2" },
+          dimensionColumnRef,
+          dataset,
+          dataSource,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "COLUMN_1",
+          "COLUMN_2",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+          COLUMN_2: [
+            { sourceId: "card:1", name: "COLUMN_2", originalName: "category" },
+          ],
+        });
+        expect(state.settings).toEqual({
+          "funnel.metric": "COLUMN_1",
+          "funnel.dimension": "COLUMN_2",
+        });
+      });
+
+      it("should not change the dimension column if it's already set", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+          settings: { "funnel.dimension": "COLUMN_1" },
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: "card:1",
+                name: "COLUMN_1",
+                originalName: "count",
+              },
+            ],
+          },
+        };
+
+        addColumnToFunnel(
+          state,
+          { ...dimensionColumn2, name: "COLUMN_2" },
+          createVisualizerColumnReference(dataSource, dimensionColumn2, [
+            dimensionColumnRef,
+          ]),
+          dataset,
+          dataSource,
+        );
+
+        // TODO Enable when VIZ-652 is closed
+        // expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        // expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+        expect(state.settings).toEqual({ "funnel.dimension": "COLUMN_1" });
+      });
+    });
+
+    describe("scalar funnel", () => {
+      it("should start a scalar funnel from clean state", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [],
+          settings: {},
+          columnValuesMapping: {},
+        };
+
+        addColumnToFunnel(
+          state,
+          { ...metricColumn, name: "COLUMN_1" },
+          metricColumnRef,
+          scalarDataset1,
+          dataSource,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "METRIC",
+          "DIMENSION",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          METRIC: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+          DIMENSION: [createDataSourceNameRef(dataSource.id)],
+        });
+      });
+
+      it("should add a new column to an existing scalar funnel", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [
+            createMockNumericColumn({ name: "METRIC" }),
+            createMockCategoryColumn({ name: "DIMENSION" }),
+          ],
+          settings: {
+            "funnel.metric": "METRIC",
+            "funnel.dimension": "DIMENSION",
+          },
+          columnValuesMapping: {
+            METRIC: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+            DIMENSION: [createDataSourceNameRef(dataSource.id)],
+          },
+        };
+
+        addColumnToFunnel(
+          state,
+          { ...metricColumn2, name: "COLUMN_2" },
+          createVisualizerColumnReference(dataSource, metricColumn2, [
+            metricColumnRef,
+            dimensionColumnRef,
+          ]),
+          scalarDataset2,
+          dataSource2,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "METRIC",
+          "DIMENSION",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          METRIC: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            { sourceId: "card:2", name: "COLUMN_2", originalName: "sum" },
+          ],
+          DIMENSION: [
+            createDataSourceNameRef(dataSource.id),
+            createDataSourceNameRef(dataSource2.id),
+          ],
+        });
+        expect(state.settings).toEqual({
+          "funnel.metric": "METRIC",
+          "funnel.dimension": "DIMENSION",
+        });
+      });
+    });
+  });
+
+  describe("removeColumnFromFunnel", () => {
+    describe("regular funnel", () => {
+      it("should remove a metric column", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...metricColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.metric": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+          },
+        };
+
+        removeColumnFromFunnel(state, "COLUMN_1");
+
+        expect(state.columns.map((c) => c.name)).toEqual([]);
+        expect(state.columnValuesMapping).toEqual({});
+        expect(state.settings).toEqual({});
+      });
+
+      it("should remove a dimension column", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.dimension": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+          },
+        };
+
+        removeColumnFromFunnel(state, "COLUMN_1");
+
+        expect(state.columns.map((c) => c.name)).toEqual([]);
+        expect(state.columnValuesMapping).toEqual({});
+        expect(state.settings).toEqual({});
+      });
+
+      it("should do nothing if a column isn't used", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...metricColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.metric": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+          },
+        };
+
+        removeColumnFromFunnel(state, "COLUMN_2");
+
+        expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        expect(state.columnValuesMapping).toEqual({
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+        });
+        expect(state.settings).toEqual({ "funnel.metric": "COLUMN_1" });
+      });
+    });
+
+    describe("scalar funnel", () => {
+      const initialState: VisualizerHistoryItem = {
+        display: "funnel",
+        columns: [
+          createMockNumericColumn({ name: "METRIC" }),
+          createMockCategoryColumn({ name: "DIMENSION" }),
+        ],
+        settings: {
+          "card.title": "My funnel",
+          "funnel.metric": "METRIC",
+          "funnel.dimension": "DIMENSION",
+        },
+        columnValuesMapping: {
+          METRIC: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            { sourceId: "card:2", name: "COLUMN_2", originalName: "sum" },
+          ],
+          DIMENSION: [
+            createDataSourceNameRef(dataSource.id),
+            createDataSourceNameRef(dataSource2.id),
+          ],
+        },
+      };
+
+      it("should reset state when removing a metric column", () => {
+        const state = _.clone(initialState);
+
+        removeColumnFromFunnel(state, "METRIC");
+
+        expect(state.columns.map((c) => c.name)).toEqual([]);
+        expect(state.columnValuesMapping).toEqual({});
+        expect(state.settings).toEqual({ "card.title": "My funnel" });
+      });
+
+      it("should reset state when removing a dimension column", () => {
+        const state = _.clone(initialState);
+
+        removeColumnFromFunnel(state, "DIMENSION");
+
+        expect(state.columns.map((c) => c.name)).toEqual([]);
+        expect(state.columnValuesMapping).toEqual({});
+        expect(state.settings).toEqual({ "card.title": "My funnel" });
+      });
+
+      it("should remove a funnel step", () => {
+        const state = _.clone(initialState);
+
+        removeColumnFromFunnel(state, "COLUMN_2");
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "METRIC",
+          "DIMENSION",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          METRIC: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+          DIMENSION: [createDataSourceNameRef(dataSource.id)],
+        });
+        expect(state.settings).toEqual({
+          "card.title": "My funnel",
+          "funnel.metric": "METRIC",
+          "funnel.dimension": "DIMENSION",
+        });
+      });
+    });
+  });
+
+  describe("combineWithFunnel", () => {
+    describe("regular funnel", () => {
+      it("should set funnel.metric if it's undefined and there's one metric column", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.dimension": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: "card:1",
+                name: "COLUMN_1",
+                originalName: "category",
+              },
+            ],
+          },
+        };
+
+        combineWithFunnel(
+          state,
+          createMockDataset({
+            data: {
+              cols: [metricColumn2, dimensionColumn2],
+            },
+          }),
+          dataSource2,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "COLUMN_1",
+          "COLUMN_2",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "category" },
+          ],
+          COLUMN_2: [
+            { sourceId: "card:2", name: "COLUMN_2", originalName: "sum" },
+          ],
+        });
+        expect(state.settings).toEqual({
+          "funnel.metric": "COLUMN_2",
+          "funnel.dimension": "COLUMN_1",
+        });
+      });
+
+      it("should not change funnel.metric if it's already set", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...metricColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.metric": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+          },
+        };
+
+        combineWithFunnel(
+          state,
+          createMockDataset({
+            data: { cols: [metricColumn2] },
+          }),
+          dataSource2,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+        expect(state.settings).toEqual({ "funnel.metric": "COLUMN_1" });
+      });
+
+      it("shouldn't set funnel.metric if it's undefined and there are multiple metric columns", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.dimension": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+          },
+        };
+
+        combineWithFunnel(
+          state,
+          createMockDataset({
+            data: { cols: [metricColumn, metricColumn2] },
+          }),
+          dataSource2,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+        expect(state.settings).toEqual({ "funnel.dimension": "COLUMN_1" });
+      });
+
+      it("should set funnel.dimension if it's undefined and there's one dimension column", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...metricColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.metric": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: "card:1",
+                name: "COLUMN_1",
+                originalName: "count",
+              },
+            ],
+          },
+        };
+
+        combineWithFunnel(
+          state,
+          createMockDataset({
+            data: { cols: [dimensionColumn2] },
+          }),
+          dataSource2,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "COLUMN_1",
+          "COLUMN_2",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+          COLUMN_2: [
+            { sourceId: "card:2", name: "COLUMN_2", originalName: "category2" },
+          ],
+        });
+        expect(state.settings).toEqual({
+          "funnel.metric": "COLUMN_1",
+          "funnel.dimension": "COLUMN_2",
+        });
+      });
+
+      it("should not set funnel.dimension if it's undefined and there are multiple dimension columns", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...metricColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.metric": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            ],
+          },
+        };
+
+        combineWithFunnel(
+          state,
+          createMockDataset({
+            data: { cols: [dimensionColumn, dimensionColumn2] },
+          }),
+          dataSource2,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+        expect(state.settings).toEqual({
+          "funnel.metric": "COLUMN_1",
+        });
+      });
+
+      it("should not change funnel.dimension if it's already set", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+          settings: {
+            "funnel.dimension": "COLUMN_1",
+          },
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: "card:1",
+                name: "COLUMN_1",
+                originalName: "category",
+              },
+            ],
+          },
+        };
+
+        combineWithFunnel(
+          state,
+          createMockDataset({
+            data: { cols: [dimensionColumn2] },
+          }),
+          dataSource2,
+        );
+
+        expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+        expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+        expect(state.settings).toEqual({ "funnel.dimension": "COLUMN_1" });
+      });
+    });
+
+    describe("scalar funnel", () => {
+      const initialState: VisualizerHistoryItem = {
+        display: "funnel",
+        columns: [
+          createMockNumericColumn({ name: "METRIC" }),
+          createMockCategoryColumn({ name: "DIMENSION" }),
+        ],
+        settings: {
+          "card.title": "My funnel",
+          "funnel.metric": "METRIC",
+          "funnel.dimension": "DIMENSION",
+        },
+        columnValuesMapping: {
+          METRIC: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            { sourceId: "card:2", name: "COLUMN_2", originalName: "sum" },
+          ],
+          DIMENSION: [
+            createDataSourceNameRef(dataSource.id),
+            createDataSourceNameRef(dataSource2.id),
+          ],
+        },
+      };
+
+      it("should start a scalar funnel from clean state", () => {
+        const state: VisualizerHistoryItem = {
+          display: "funnel",
+          columns: [],
+          settings: {},
+          columnValuesMapping: {},
+        };
+
+        combineWithFunnel(state, scalarDataset1, dataSource);
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "METRIC",
+          "DIMENSION",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          METRIC: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+          DIMENSION: [createDataSourceNameRef(dataSource.id)],
+        });
+      });
+
+      it("should add a scalar dataset to an existing scalar funnel", () => {
+        const state = _.clone(initialState);
+
+        combineWithFunnel(state, scalarDataset2, dataSource2);
+
+        expect(state.columns.map((c) => c.name)).toEqual([
+          "METRIC",
+          "DIMENSION",
+        ]);
+        expect(state.columnValuesMapping).toEqual({
+          METRIC: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+            { sourceId: "card:2", name: "COLUMN_2", originalName: "sum" },
+          ],
+          DIMENSION: [
+            createDataSourceNameRef(dataSource.id),
+            createDataSourceNameRef(dataSource2.id),
+          ],
+        });
+        expect(state.settings).toEqual({
+          "card.title": "My funnel",
+          "funnel.metric": "METRIC",
+          "funnel.dimension": "DIMENSION",
+        });
+      });
+
+      it("should do nothing if the dataset isn't compatible", () => {
+        const state = _.clone(initialState);
+
+        combineWithFunnel(state, createMockDataset(), dataSource);
+
+        expect(state).toStrictEqual(initialState);
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizer/visualizations/pie.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.ts
@@ -1,4 +1,5 @@
 import type { DragEndEvent } from "@dnd-kit/core";
+import _ from "underscore";
 
 import { isNotNull } from "metabase/lib/types";
 import { DROPPABLE_ID } from "metabase/visualizer/constants";
@@ -150,7 +151,7 @@ export function combineWithPieChart(
     addColumnToPieChart(state, column);
   }
 
-  if (!state.settings["pie.dimension"] && dimensions.length === 1) {
+  if (_.isEmpty(state.settings["pie.dimension"]) && dimensions.length === 1) {
     const [dimension] = dimensions;
     const columnRef = createVisualizerColumnReference(
       dataSource,

--- a/frontend/src/metabase/visualizer/visualizations/pie.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.unit.spec.ts
@@ -1,0 +1,396 @@
+import {
+  createMockCategoryColumn,
+  createMockDataset,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks";
+import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
+
+import { createDataSource } from "../utils";
+
+import {
+  addColumnToPieChart,
+  combineWithPieChart,
+  removeColumnFromPieChart,
+} from "./pie";
+
+describe("pie", () => {
+  const metricColumn = createMockNumericColumn({ id: 1, name: "count" });
+  const metricColumn2 = createMockNumericColumn({ id: 2, name: "sum" });
+
+  const dimensionColumn = createMockCategoryColumn({
+    id: 3,
+    name: "category",
+  });
+  const dimensionColumn2 = createMockCategoryColumn({
+    id: 4,
+    name: "category2",
+  });
+
+  describe("addColumnToPieChart", () => {
+    it("should add a metric column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+      };
+
+      addColumnToPieChart(state, { ...metricColumn, name: "COLUMN_1" });
+
+      // TODO Enable when VIZ-652 is closed
+      // expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      // expect(state.columnValuesMapping).toEqual({
+      //   COLUMN_1: [
+      //     { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+      //   ],
+      // });
+      expect(state.settings).toEqual({ "pie.metric": "COLUMN_1" });
+    });
+
+    it("should not change the metric column if it's already set", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...metricColumn, name: "COLUMN_1" }],
+        settings: { "pie.metric": "COLUMN_1" },
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+        },
+      };
+
+      addColumnToPieChart(state, { ...metricColumn2, name: "COLUMN_2" });
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+      expect(state.settings).toEqual({ "pie.metric": "COLUMN_1" });
+    });
+
+    it("should add a dimension column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [],
+        settings: {},
+        columnValuesMapping: {},
+      };
+
+      addColumnToPieChart(state, { ...dimensionColumn, name: "COLUMN_1" });
+
+      // TODO Enable when VIZ-652 is closed
+      // expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      // expect(state.columnValuesMapping).toEqual({
+      //   COLUMN_1: [
+      //     { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+      //   ],
+      // });
+      expect(state.settings).toEqual({ "pie.dimension": ["COLUMN_1"] });
+    });
+
+    it("should add a second dimension column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+        settings: { "pie.dimension": ["COLUMN_1"] },
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+        },
+      };
+
+      addColumnToPieChart(state, { ...dimensionColumn2, name: "COLUMN_2" });
+
+      // TODO Enable when VIZ-652 is closed
+      // expect(state.columns.map((c) => c.name)).toEqual([
+      //   "COLUMN_1",
+      //   "COLUMN_2",
+      // ]);
+      // expect(state.columnValuesMapping).toEqual({
+      //   COLUMN_1: [
+      //     {
+      //       sourceId: "card:1",
+      //       name: "COLUMN_1",
+      //       originalName: "count",
+      //     },
+      //   ],
+      //   COLUMN_2: [
+      //     {
+      //       sourceId: "card:1",
+      //       name: "COLUMN_2",
+      //       originalName: "category2",
+      //     },
+      //   ],
+      // });
+      expect(state.settings).toEqual({
+        "pie.dimension": ["COLUMN_1", "COLUMN_2"],
+      });
+    });
+  });
+
+  describe("removeColumnFromPieChart", () => {
+    it("should remove a metric column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...metricColumn, name: "COLUMN_1" }],
+        settings: { "pie.metric": "COLUMN_1" },
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+        },
+      };
+
+      removeColumnFromPieChart(state, "COLUMN_1");
+
+      expect(state.columns.map((c) => c.name)).toEqual([]);
+      expect(state.columnValuesMapping).toEqual({});
+      expect(state.settings).toEqual({});
+    });
+
+    it("should remove a dimension column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+        settings: { "pie.dimension": ["COLUMN_1"] },
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+        },
+      };
+
+      removeColumnFromPieChart(state, "COLUMN_1");
+
+      expect(state.columns.map((c) => c.name)).toEqual([]);
+      expect(state.columnValuesMapping).toEqual({});
+      expect(state.settings).toEqual({ "pie.dimension": [] });
+    });
+
+    it("should do nothing if a column isn't used", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+        settings: { "pie.dimension": ["COLUMN_1"] },
+        columnValuesMapping: {
+          COLUMN_1: [
+            {
+              sourceId: "card:1",
+              name: "COLUMN_1",
+              originalName: "count",
+            },
+          ],
+        },
+      };
+
+      removeColumnFromPieChart(state, "COLUMN_2");
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+      expect(state.settings).toEqual({ "pie.dimension": ["COLUMN_1"] });
+    });
+  });
+
+  describe("combineWithPieChart", () => {
+    const dataSource = createDataSource("card", 2, "Q2");
+
+    const metricColumn3 = createMockNumericColumn({ id: 5, name: "avg" });
+    const dimensionColumn3 = createMockCategoryColumn({
+      id: 6,
+      name: "category3",
+    });
+
+    it("should set pie.metric if it's undefined and there's one metric column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+        settings: {
+          "pie.dimension": ["COLUMN_1"],
+        },
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "category" },
+          ],
+        },
+      };
+
+      combineWithPieChart(
+        state,
+        createMockDataset({
+          data: { cols: [metricColumn2] },
+        }),
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual([
+        "COLUMN_1",
+        "COLUMN_2",
+      ]);
+      expect(state.columnValuesMapping).toEqual({
+        COLUMN_1: [
+          { sourceId: "card:1", name: "COLUMN_1", originalName: "category" },
+        ],
+        COLUMN_2: [
+          { sourceId: "card:2", name: "COLUMN_2", originalName: "sum" },
+        ],
+      });
+      expect(state.settings).toEqual({
+        "pie.metric": "COLUMN_2",
+        "pie.dimension": ["COLUMN_1"],
+      });
+    });
+
+    it("should not change pie.metric if it's already set", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...metricColumn, name: "COLUMN_1" }],
+        settings: {
+          "pie.metric": "COLUMN_1",
+        },
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+        },
+      };
+
+      combineWithPieChart(
+        state,
+        createMockDataset({
+          data: { cols: [metricColumn2] },
+        }),
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+      expect(state.settings).toEqual({ "pie.metric": "COLUMN_1" });
+    });
+
+    it("shouldn't set pie.metric if it's undefined and there are multiple metric columns", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...metricColumn, name: "COLUMN_1" }],
+        settings: {
+          "pie.metric": "COLUMN_1",
+        },
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+        },
+      };
+
+      combineWithPieChart(
+        state,
+        createMockDataset({
+          data: { cols: [metricColumn2, metricColumn3] },
+        }),
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+      expect(state.settings).toEqual({ "pie.metric": "COLUMN_1" });
+    });
+
+    it("should set pie.dimension if it's undefined and there's one dimension column", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...metricColumn, name: "COLUMN_1" }],
+        settings: { "pie.metric": "COLUMN_1" },
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+        },
+      };
+
+      combineWithPieChart(
+        state,
+        createMockDataset({
+          data: { cols: [dimensionColumn] },
+        }),
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual([
+        "COLUMN_1",
+        "COLUMN_2",
+      ]);
+      expect(Object.keys(state.columnValuesMapping)).toEqual([
+        "COLUMN_1",
+        "COLUMN_2",
+      ]);
+      expect(state.settings).toEqual({
+        "pie.metric": "COLUMN_1",
+        "pie.dimension": ["COLUMN_2"],
+      });
+    });
+
+    it("should not set pie.dimension if it's undefined and there are multiple dimension columns", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...metricColumn, name: "COLUMN_1" }],
+        settings: { "pie.metric": "COLUMN_1" },
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+        },
+      };
+
+      combineWithPieChart(
+        state,
+        createMockDataset({
+          data: { cols: [dimensionColumn2, dimensionColumn3] },
+        }),
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+      expect(state.settings).toEqual({ "pie.metric": "COLUMN_1" });
+    });
+
+    it("should not change pie.dimension if it's already set", () => {
+      const state: VisualizerHistoryItem = {
+        display: "pie",
+        columns: [{ ...dimensionColumn, name: "COLUMN_1" }],
+        settings: { "pie.dimension": ["COLUMN_1"] },
+        columnValuesMapping: {
+          COLUMN_1: [
+            { sourceId: "card:1", name: "COLUMN_1", originalName: "count" },
+          ],
+        },
+      };
+
+      combineWithPieChart(
+        state,
+        createMockDataset({
+          data: { cols: [dimensionColumn2] },
+        }),
+        dataSource,
+      );
+
+      expect(state.columns.map((c) => c.name)).toEqual(["COLUMN_1"]);
+      expect(Object.keys(state.columnValuesMapping)).toEqual(["COLUMN_1"]);
+      expect(state.settings).toEqual({ "pie.dimension": ["COLUMN_1"] });
+    });
+  });
+});


### PR DESCRIPTION
Fixes failing unit tests on `feature-visualizer` and adds additional coverage to key functions used in column mapping:

- `getUpdatedSettingsForDisplay`
- `addColumnToCartesianChart`
- `removeColumnFromCartesianChart`
- `combineWithCartesianChart`
- `addColumnToFunnel`
- `removeColumnFromFunnel`
- `combineWithFunnel`
- `addColumnToPieChart`
- `combineWithPieChart`
- `removeColumnFromPieChart`