### PR TITLE
fix: run cross-version-for-breaking-changes only on pull requests to make it pass on master

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -104,6 +104,7 @@ jobs:
     secrets: inherit
 
   cross-version-for-breaking-changes:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
     secrets: inherit
     with:


### PR DESCRIPTION
# Description

The workflow only makes sense on PRs, and it failed right away on the push on master for missing variables: https://github.com/metabase/metabase/actions/runs/14494823068/job/40659783145

This should make it only run on pull requests