### PR TITLE
Add sorting capabilities to GET /task/ endpoint

### DIFF
--- a/src/metabase/api/task.clj
+++ b/src/metabase/api/task.clj
@@ -12,7 +12,7 @@
 (api.macros/defendpoint :get "/"
   "Fetch a list of recent tasks stored as Task History"
   [_
-   params :- [:maybe [:union task-history/FilterParams task-history/SortParams]]]
+   params :- [:maybe [:merge task-history/FilterParams task-history/SortParams]]]
   (validation/check-has-application-permission :monitoring)
   {:total  (task-history/total params)
    :limit  (request/limit)

--- a/src/metabase/api/task.clj
+++ b/src/metabase/api/task.clj
@@ -12,13 +12,12 @@
 (api.macros/defendpoint :get "/"
   "Fetch a list of recent tasks stored as Task History"
   [_
-   {:keys [_status _task]
-    :as filter} :- task-history/Filter]
+   params :- [:maybe [:union task-history/FilterParams task-history/SortParams]]]
   (validation/check-has-application-permission :monitoring)
-  {:total  (task-history/total filter)
+  {:total  (task-history/total params)
    :limit  (request/limit)
    :offset (request/offset)
-   :data   (task-history/all (request/limit) (request/offset) filter)})
+   :data   (task-history/all (request/limit) (request/offset) params)})
 
 (api.macros/defendpoint :get "/:id"
   "Get `TaskHistory` entry with ID."

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -95,7 +95,7 @@
   "Return all TaskHistory entries, filtered if `filter` is provided, applying `limit` and `offset` if not nil."
   [limit  :- [:maybe ms/PositiveInt]
    offset :- [:maybe ms/IntGreaterThanOrEqualToZero]
-   params :- [:maybe [:union FilterParams SortParams]]]
+   params :- [:maybe [:merge FilterParams SortParams]]]
   (t2/select :model/TaskHistory (merge (params->where params)
                                        (params->order-by params)
                                        (when limit

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -64,25 +64,40 @@
   {:task_details mi/transform-json-eliding
    :status       mi/transform-keyword})
 
-(defn- filter->where
-  [{:keys [status task] :as filter}]
-  (when (not-empty filter)
+(defn- params->where
+  [{:keys [status task]}]
+  (when (or status task)
     {:where (cond-> [:and]
               task   (conj [:= :task task])
               status (conj [:= :status (name status)]))}))
 
-(def Filter
+(def FilterParams
   "Schema for filter for task history."
-  [:maybe [:map [:status {:optional true} (into [:enum] task-history-status)
-                 :task   {:optional true} [:string {:min 1}]]]])
+  [:map
+   [:status {:optional true} (into [:enum] task-history-status)]
+   [:task {:optional true} [:string {:min 1}]]])
+
+(defn params->order-by
+  [{col :sort_column
+    dir :sort_direction}]
+  {:order-by [[col dir]]})
+
+(def ^:private avaialble-sort-columns
+  #{:duration :ended_at :started_at})
+
+(def SortParams
+  "Sorting map schema."
+  [:map
+   [:sort_column    {:default :started_at} (into [:enum] avaialble-sort-columns)]
+   [:sort_direction {:default :desc}       [:enum :asc :desc]]])
 
 (mu/defn all
   "Return all TaskHistory entries, filtered if `filter` is provided, applying `limit` and `offset` if not nil."
   [limit  :- [:maybe ms/PositiveInt]
    offset :- [:maybe ms/IntGreaterThanOrEqualToZero]
-   filter :- Filter]
-  (t2/select :model/TaskHistory (merge {:order-by [[:started_at :desc]]}
-                                       (filter->where filter)
+   params :- [:maybe [:union FilterParams SortParams]]]
+  (t2/select :model/TaskHistory (merge (params->where params)
+                                       (params->order-by params)
                                        (when limit
                                          {:limit limit})
                                        (when offset
@@ -90,8 +105,8 @@
 
 (mu/defn total
   "Return count of all, or filtered if `filter` is provided, task history entries."
-  [filter :- Filter]
-  (t2/count :model/TaskHistory ((fnil identity {}) (filter->where filter))))
+  [params :- FilterParams]
+  (t2/count :model/TaskHistory ((fnil identity {}) (params->where params))))
 
 (defn unique-tasks
   "Return _vector_ of all unique tasks' names in alphabetical order."

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -77,7 +77,7 @@
    [:status {:optional true} (into [:enum] task-history-status)]
    [:task {:optional true} [:string {:min 1}]]])
 
-(defn params->order-by
+(defn- params->order-by
   [{col :sort_column
     dir :sort_direction}]
   {:order-by [[col dir]]})

--- a/test/metabase/api/task_test.clj
+++ b/test/metabase/api/task_test.clj
@@ -402,3 +402,105 @@
           (is (= 2 (-> response :total)))
           (is (= 1 (-> response :data count)))
           (is (= "success" (-> response :data first :status))))))))
+
+(deftest sort-tasks-test
+  (t2/delete! :model/TaskHistory)
+  (let [now (t/zoned-date-time)]
+    (mt/with-temp
+      [;; task a
+       :model/TaskHistory
+       _
+       (let [start (t/minus now (t/days 8))
+             duration 10000
+             end (t/plus start (t/millis duration))]
+         {:status "success"
+          :task "a"
+          :duration duration
+          :started_at start
+          :ended_at end})
+       :model/TaskHistory
+       _
+       (let [start (t/minus now (t/days 5))
+             duration 5000
+             end (t/plus start (t/millis duration))]
+         {:status "failed"
+          :task "a"
+          :duration duration
+          :started_at start
+          :ended_at end})
+
+       ;; task b
+       :model/TaskHistory
+       _
+       (let [start (t/minus now (t/days 4))
+             duration 3000
+             end (t/plus start (t/millis duration))]
+         {:status :failed
+          :task "b"
+          :duration duration
+          :started_at start
+          :ended_at end})
+       :model/TaskHistory
+       _
+       (let [start (t/minus now (t/days 3))
+             duration 300
+             end (t/plus start (t/millis duration))]
+         {:status :success
+          :task "b"
+          :duration duration
+          :started_at start
+          :ended_at  end})
+
+       ;; task c
+       :model/TaskHistory
+       _
+       (let [start (t/minus now (t/days 2))]
+         {:status :started
+          :task "c"
+          :duration nil
+          :started_at start
+          :ended_at nil})
+       :model/TaskHistory
+       _
+       (let [start (t/minus now (t/days 1))]
+         {:status :started
+          :task "c"
+          :duration nil
+          :started_at start
+          :ended_at nil})]
+      (doseq [sort-column [:started_at :ended_at :duration]
+              sort-direction [:asc :desc]
+              :let [expected-data (cond (and (#{:started_at :ended_at} sort-column)
+                                             (= :desc sort-direction))
+                                        (mapv #(hash-map :task  %)
+                                              ["c" "c" "b" "b" "a" "a"])
+
+                                        (and (#{:started_at :ended_at} sort-column)
+                                             (= :asc sort-direction))
+                                        (mapv #(hash-map :task  %)
+                                              ["a" "a" "b" "b" "c" "c"])
+
+                                        (and (= :duration sort-column)
+                                             (= :asc sort-direction))
+                                        (mapv #(hash-map :duration %)
+                                              [300 3000 5000 10000 nil nil])
+
+                                        (and (= :duration sort-column)
+                                             (= :desc sort-direction))
+                                        (mapv #(hash-map :duration %)
+                                              [nil nil 10000 5000 3000 300]))]]
+        (testing (format "Sorting works correctly for %s %s" sort-column sort-direction)
+          (let [response (mt/user-http-request :crowberto :get 200 "task/"
+                                               :sort_column sort-column :sort_direction sort-direction)]
+            (is (= 6 (-> response :total)))
+            (is (=? expected-data
+                    (-> response :data vec))))))
+      (testing "Sorting works with filtering and pagination"
+        (let [response (mt/user-http-request :crowberto :get 200 "task/"
+                                             :sort_column :duration :sort_direction :desc
+                                             :offset 0 :limit 1
+                                             :status :success)]
+          (is (= 2 (-> response :total)))
+          (is (= 1 (-> response :data count)))
+          (is [{:duration 10000}]
+              (-> response :data vec)))))))

--- a/test/metabase/api/task_test.clj
+++ b/test/metabase/api/task_test.clj
@@ -449,60 +449,42 @@
           :task "b"
           :duration duration
           :started_at start
-          :ended_at  end})
-
-       ;; task c
-       :model/TaskHistory
-       _
-       (let [start (t/minus now (t/days 2))]
-         {:status :started
-          :task "c"
-          :duration nil
-          :started_at start
-          :ended_at nil})
-       :model/TaskHistory
-       _
-       (let [start (t/minus now (t/days 1))]
-         {:status :started
-          :task "c"
-          :duration nil
-          :started_at start
-          :ended_at nil})]
+          :ended_at  end})]
       (doseq [sort-column [:started_at :ended_at :duration]
               sort-direction [:asc :desc]
               :let [expected-data (cond (and (= :ended_at sort-column)
                                              (= :desc sort-direction))
                                         (mapv #(hash-map :task  %)
-                                              ["b" "b" "a" "a" "c" "c"])
+                                              ["b" "b" "a" "a"])
 
                                         (and (= :started_at sort-column)
                                              (= :desc sort-direction))
                                         (mapv #(hash-map :task  %)
-                                              ["c" "c" "b" "b" "a" "a"])
+                                              ["b" "b" "a" "a"])
 
                                         (and (= :ended_at sort-column)
                                              (= :asc sort-direction))
                                         (mapv #(hash-map :task  %)
-                                              ["c" "c" "a" "a" "b" "b"])
+                                              ["a" "a" "b" "b"])
 
                                         (and (= :started_at sort-column)
                                              (= :asc sort-direction))
                                         (mapv #(hash-map :task  %)
-                                              ["a" "a" "b" "b" "c" "c"])
+                                              ["a" "a" "b" "b"])
 
                                         (and (= :duration sort-column)
                                              (= :asc sort-direction))
                                         (mapv #(hash-map :duration %)
-                                              [nil nil 300 3000 5000 10000])
+                                              [300 3000 5000 10000])
 
                                         (and (= :duration sort-column)
                                              (= :desc sort-direction))
                                         (mapv #(hash-map :duration %)
-                                              [10000 5000 3000 300 nil nil]))]]
+                                              [10000 5000 3000 300]))]]
         (testing (format "Sorting works correctly for %s %s" sort-column sort-direction)
           (let [response (mt/user-http-request :crowberto :get 200 "task/"
                                                :sort_column sort-column :sort_direction sort-direction)]
-            (is (= 6 (-> response :total)))
+            (is (= 4 (-> response :total)))
             (is (=? expected-data
                     (-> response :data vec))))))
       (testing "Sorting works with filtering and pagination"

--- a/test/metabase/api/task_test.clj
+++ b/test/metabase/api/task_test.clj
@@ -470,12 +470,22 @@
           :ended_at nil})]
       (doseq [sort-column [:started_at :ended_at :duration]
               sort-direction [:asc :desc]
-              :let [expected-data (cond (and (#{:started_at :ended_at} sort-column)
+              :let [expected-data (cond (and (= :ended_at sort-column)
+                                             (= :desc sort-direction))
+                                        (mapv #(hash-map :task  %)
+                                              ["b" "b" "a" "a" "c" "c"])
+
+                                        (and (= :started_at sort-column)
                                              (= :desc sort-direction))
                                         (mapv #(hash-map :task  %)
                                               ["c" "c" "b" "b" "a" "a"])
 
-                                        (and (#{:started_at :ended_at} sort-column)
+                                        (and (= :ended_at sort-column)
+                                             (= :asc sort-direction))
+                                        (mapv #(hash-map :task  %)
+                                              ["c" "c" "a" "a" "b" "b"])
+
+                                        (and (= :started_at sort-column)
                                              (= :asc sort-direction))
                                         (mapv #(hash-map :task  %)
                                               ["a" "a" "b" "b" "c" "c"])
@@ -483,12 +493,12 @@
                                         (and (= :duration sort-column)
                                              (= :asc sort-direction))
                                         (mapv #(hash-map :duration %)
-                                              [300 3000 5000 10000 nil nil])
+                                              [nil nil 300 3000 5000 10000])
 
                                         (and (= :duration sort-column)
                                              (= :desc sort-direction))
                                         (mapv #(hash-map :duration %)
-                                              [nil nil 10000 5000 3000 300]))]]
+                                              [10000 5000 3000 300 nil nil]))]]
         (testing (format "Sorting works correctly for %s %s" sort-column sort-direction)
           (let [response (mt/user-http-request :crowberto :get 200 "task/"
                                                :sort_column sort-column :sort_direction sort-direction)]


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-235/sorting-by-start-end-date-and-duration

### Description

This PR adds sorting capabilities to GET /task/endpoint. Sorting is available for started_at, ended_at and duration columns.

### How to verify

Run new tests

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
