### PR TITLE
Support auto list field values

### DIFF
--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-source.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-source.ts
@@ -127,11 +127,9 @@ export const canSearchFieldValues = (
   const canSearch = fields.every((field) =>
     field.searchField(disablePKRemapping),
   );
-  const hasFieldValues = fields.some(
-    (field) =>
-      field.has_field_values === "search" ||
-      (field.has_field_values === "list" && field.has_more_values === true),
+  const hasNoPlainInputField = fields.some(
+    (field) => field.has_field_values === "none",
   );
 
-  return hasFields && canSearch && hasFieldValues;
+  return hasFields && canSearch && hasNoPlainInputField;
 };

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-source.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-source.ts
@@ -128,7 +128,7 @@ export const canSearchFieldValues = (
     field.searchField(disablePKRemapping),
   );
   const hasNoPlainInputField = fields.some(
-    (field) => field.has_field_values === "none",
+    (field) => field.has_field_values !== "none",
   );
 
   return hasFields && canSearch && hasNoPlainInputField;

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.ts
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.ts
@@ -263,6 +263,10 @@ export function getValuesMode({
   disableSearch: boolean;
   disablePKRemappingForSearch?: boolean;
 }): ValuesMode {
+  if (shouldList({ parameter, fields, disableSearch })) {
+    return "list";
+  }
+
   if (
     isSearchable({
       parameter,
@@ -273,10 +277,6 @@ export function getValuesMode({
     })
   ) {
     return "search";
-  }
-
-  if (shouldList({ parameter, fields, disableSearch })) {
-    return "list";
   }
 
   return "none";

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.unit.spec.js
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.unit.spec.js
@@ -37,6 +37,11 @@ describe("Components > FieldValuesWidget > utils", () => {
         expect(isSearchable({ fields })).toBe(true);
       });
 
+      it("should be false for fields that cannot be searched", () => {
+        const nonSearchableField = metadata.field(PRODUCTS.ID);
+        expect(isSearchable({ fields: [nonSearchableField] })).toBe(false);
+      });
+
       it("should be true if there is at least one field that requires search", () => {
         const fields = [searchField, listField];
         expect(isSearchable({ fields })).toBe(true);

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.unit.spec.js
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.unit.spec.js
@@ -32,9 +32,9 @@ describe("Components > FieldValuesWidget > utils", () => {
     });
 
     describe("when all fields are searchable", () => {
-      it("should be false if there are no fields that require search", () => {
+      it("should be true for list fields that can be searched", () => {
         const fields = [listField];
-        expect(isSearchable({ fields })).toBe(false);
+        expect(isSearchable({ fields })).toBe(true);
       });
 
       it("should be true if there is at least one field that requires search", () => {

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/FilterValuePicker.tsx
@@ -71,7 +71,7 @@ function FilterValuePicker({
     );
   }
 
-  if (canSearchFieldValues(fieldInfo, fieldData)) {
+  if (canSearchFieldValues(fieldInfo)) {
     const searchColumn = checkNotNull(fieldInfo.searchField);
     const searchColumInfo = Lib.displayInfo(query, stageIndex, searchColumn);
     const searchColumName = searchColumInfo.displayName;

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/utils.ts
@@ -19,16 +19,12 @@ export function canListFieldValues({
   return values.length > 0 && !has_more_values;
 }
 
-export function canSearchFieldValues(
-  { fieldId, searchFieldId, hasFieldValues }: FieldValuesSearchInfo,
-  fieldData: GetFieldValuesResponse | undefined,
-): boolean {
-  return (
-    fieldId != null &&
-    searchFieldId != null &&
-    ((hasFieldValues === "list" && fieldData?.has_more_values) ||
-      hasFieldValues === "search")
-  );
+export function canSearchFieldValues({
+  fieldId,
+  searchFieldId,
+  hasFieldValues,
+}: FieldValuesSearchInfo): boolean {
+  return fieldId != null && searchFieldId != null && hasFieldValues !== "none";
 }
 
 export function getFieldOption([value, label]: FieldValue): ComboboxItem {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/56598

When there is a **text** field with `has_field_values: "list"` that doesn't have field values, we will default to the search box and not the plain input. I have no idea how to reproduce this in a E2E test, so this is currently a unit test-only fix.