### PR TITLE
Disabled shortcuts when a modal is open on the page

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -1,5 +1,5 @@
 const { H } = cy;
-import { USERS } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_BY_YEAR_QUESTION_ID,
@@ -385,13 +385,14 @@ describe("command palette", () => {
   });
 });
 
-describe("shortcuts", () => {
+describe("shortcuts", { tags: ["@actions"] }, () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
   });
 
   it("should render a shortcuts modal, and global shortcuts should be available", () => {
+    H.setActionsEnabledForDB(SAMPLE_DB_ID);
     cy.visit("/");
     cy.findByTestId("home-page")
       .findByTestId("loading-indicator")
@@ -430,6 +431,38 @@ describe("shortcuts", () => {
 
     cy.realPress("t");
     cy.location("pathname").should("equal", "/trash");
+
+    cy.log("shortcuts should not be enabled when working in a modal (ADM 658)");
+
+    H.navigationSidebar().should("be.visible");
+    // Mantine Modals
+    H.newButton("Collection").click();
+
+    H.modal()
+      .findByLabelText(/collection it's saved in/i)
+      .click();
+
+    // Remove focus
+    H.entityPickerModal().findByRole("heading").click();
+
+    cy.realPress("[");
+    H.navigationSidebar().should("be.visible");
+    cy.realPress("Escape");
+    cy.realPress("[");
+    H.navigationSidebar().should("be.visible");
+    cy.realPress("Escape");
+    // Legacy Modals
+
+    H.newButton("Action").click();
+    // Remove focus
+    H.modal()
+      .findByText(/Build custom forms/)
+      .click();
+    cy.realPress("[");
+    H.navigationSidebar().should("be.visible");
+    cy.realPress("Escape");
+    cy.realPress("[");
+    H.navigationSidebar().should("not.visible");
   });
 
   it("should support dashboard shortcuts", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -371,18 +371,6 @@ describe("command palette", () => {
       cy.findByText("Report an issue").should("be.visible");
     });
   });
-
-  it("The data picker does not cover the command palette (metabase#45469)", () => {
-    cy.visit("/");
-    cy.log("Click on the New button in the navigation bar and select Question");
-    H.newButton("Question").click();
-    cy.findByRole("dialog", { name: "Pick your starting data" });
-    cy.log("Open the command palette with a shortcut key");
-    cy.get("body").type("{ctrl+k}{cmd+k}");
-    H.commandPalette().within(() => {
-      H.commandPaletteInput().should("be.visible");
-    });
-  });
 });
 
 describe("shortcuts", { tags: ["@actions"] }, () => {

--- a/frontend/src/metabase/components/Modal/Modal.tsx
+++ b/frontend/src/metabase/components/Modal/Modal.tsx
@@ -1,10 +1,12 @@
 import type { WindowModalProps } from "metabase/components/Modal/WindowModal";
 import { WindowModal } from "metabase/components/Modal/WindowModal";
+import { useDisableCommandPalette } from "metabase/palette/hooks/useDisableCommandPalette";
 
 export type ModalProps = WindowModalProps;
 
 /** @deprecated use Modal from metabase/ui */
 const Modal = ({ isOpen = true, ...props }: ModalProps) => {
+  useDisableCommandPalette({ disabled: isOpen });
   return <WindowModal isOpen={isOpen} {...props} />;
 };
 

--- a/frontend/src/metabase/palette/hooks/useDisableCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useDisableCommandPalette.tsx
@@ -10,7 +10,7 @@ export const useDisableCommandPalette = ({ disabled }: Props) => {
 
   useEffect(() => {
     // If there is no context, do nothing
-    if (!context) {
+    if (!context?.query) {
       return;
     }
 

--- a/frontend/src/metabase/palette/hooks/useDisableCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useDisableCommandPalette.tsx
@@ -1,0 +1,36 @@
+import { KBarContext } from "kbar";
+import { useContext, useEffect } from "react";
+
+interface Props {
+  disabled: boolean;
+}
+
+export const useDisableCommandPalette = ({ disabled }: Props) => {
+  const context = useContext(KBarContext);
+
+  useEffect(() => {
+    // If there is no context, do nothing
+    if (!context) {
+      return;
+    }
+
+    const { query, getState } = context;
+
+    // Check to see if the command palette is already disabled. this is important
+    // for nested modal scenarios where a child can re-enable the palette when
+    // it is unmounted
+    const alreadyDisabled = getState().disabled;
+    if (alreadyDisabled) {
+      return;
+    }
+
+    // Otherwise, disable the palette while the modal is open
+    if (disabled) {
+      query.disable(true);
+
+      return () => query.disable(false);
+    }
+  }, [context, disabled]);
+
+  return null;
+};

--- a/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/index.tsx
@@ -4,6 +4,7 @@ import {
   type ModalRootProps,
 } from "@mantine/core";
 
+import { useDisableCommandPalette } from "metabase/palette/hooks/useDisableCommandPalette";
 import { PreventEagerPortal } from "metabase/ui";
 
 export type { ModalProps } from "@mantine/core";
@@ -11,6 +12,10 @@ export type { ModalProps } from "@mantine/core";
 export * from "./Modal.config";
 
 export const Modal = (props: ModalProps) => {
+  useDisableCommandPalette({
+    disabled: props.opened,
+  });
+
   return (
     <PreventEagerPortal {...props}>
       <MantineModal {...props} />
@@ -18,12 +23,16 @@ export const Modal = (props: ModalProps) => {
   );
 };
 
-const ModalRoot = (props: ModalRootProps) => (
-  <PreventEagerPortal>
-    <MantineModal.Root {...props} />
-  </PreventEagerPortal>
-);
-
+const ModalRoot = (props: ModalRootProps) => {
+  useDisableCommandPalette({
+    disabled: props.opened,
+  });
+  return (
+    <PreventEagerPortal>
+      <MantineModal.Root {...props} />
+    </PreventEagerPortal>
+  );
+};
 Modal.Root = ModalRoot;
 Modal.Overlay = MantineModal.Overlay;
 Modal.Content = MantineModal.Content;


### PR DESCRIPTION
Closes ADM 658

### Description
Creates a hook that disabled `kbar` when mounted, and re-enables it when unmounted. Then applies this hook to modals sot that shortcuts cannot be used when a modal is opened on the page.

### How to verify
1. Open a modal (New -> collection), unfocus the text input and try any keyboard shortcuts. They should not trigger.
2. Next, open a legacy modal (New -> Action) and do the same. keyboard shortcuts should not be active. Close the modal, and they should be active again


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
