### PR TITLE
Add GET action endpoint to know which params can be inferred from a row

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -347,9 +347,9 @@
   (let [action             (-> (actions/select-action :id (parse-long action-id) :archived false)
                                (t2/hydrate :creator)
                                api/read-check)
-        {:keys [card_id]}  (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
-        {:keys [table_id]} (api/check-404 (t2/select-one :model/Card card_id))
-        fields             (t2/select [:model/Field :name] :table_id table_id)
+        card-id            (api/check-404 (t2/select-one-fn :card_id [:model/DashboardCard :card_id] dashcard-id))
+        table-id           (api/check-404 (t2/select-one-fn :table_id [:model/Card :table_id] card-id))
+        fields             (t2/select [:model/Field :name] :table_id table-id)
         field-names        (set (map :name fields))
         include?           #(not (contains? field-names (:slug %)))]
     (update action :parameters #(some->> % (filterv include?)))))


### PR DESCRIPTION
Adds a new endpoint `GET /ee/data-editing/row-action/{action-id}?dashcard_id=?` that returns the action (same schema as normal API) but customises the `parameters`. Any parameters who share field names with the table referenced by the model will be omitted.

The goal with this PR is for things to work for model dashcards, but it accepts any action-id, not just those associated with the model. 