### PR TITLE
Add missing docsPage links to custom expression HELPER_TEXT_STRINGS

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -52,6 +52,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     structure: "CumulativeCount",
     category: "aggregation",
     description: () => t`The additive total of rows across a breakout.`,
+    docsPage: "cumulative",
   },
   {
     name: "sum",
@@ -78,6 +79,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: ["dimension", t`Subtotal`],
       },
     ],
+    docsPage: "cumulative",
   },
   {
     name: "distinct",
@@ -142,6 +144,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: -1,
       },
     ],
+    docsPage: "offset",
   },
   {
     name: "avg",
@@ -221,6 +224,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: [">", ["dimension", t`Subtotal`], 100],
       },
     ],
+    docsPage: "countif",
   },
   {
     name: "sum-where",
@@ -240,6 +244,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: ["=", ["dimension", t`Order Status`], "Valid"],
       },
     ],
+    docsPage: "sumif",
   },
   {
     name: "var",
@@ -1150,6 +1155,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: "Gadget",
       },
     ],
+    docsPage: "in",
   },
   {
     name: "not-in",
@@ -1240,6 +1246,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
         example: "iso",
       },
     ],
+    docsPage: "week",
   },
   {
     name: "get-day",
@@ -1365,6 +1372,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     structure: "now",
     category: "date",
     description: getDescriptionForNow,
+    docsPage: "now",
   },
   {
     name: "convert-timezone",


### PR DESCRIPTION
### Description

Add missing `docsPage` links to custom expression editor `HELPER_TEXT_STRINGS`.

Slack thread: https://metaboat.slack.com/archives/C0645JP1W81/p1744834449423139

Adds links to the following function-specific help doc pages

CountIf: https://www.metabase.com/docs/latest/questions/query-builder/expressions/countif
CumulativeSum: https://www.metabase.com/docs/latest/questions/query-builder/expressions/cumulative
CumulativeCount: https://www.metabase.com/docs/latest/questions/query-builder/expressions/cumulative
In: https://www.metabase.com/docs/latest/questions/query-builder/expressions/in
now: https://www.metabase.com/docs/latest/questions/query-builder/expressions/now
Offset: https://www.metabase.com/docs/latest/questions/query-builder/expressions/offset
SumIf: https://www.metabase.com/docs/latest/questions/query-builder/expressions/sumif
week: https://www.metabase.com/docs/latest/questions/query-builder/expressions/week

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> People
2. Summarize > Custom Expression
3. Type one of the functions above, e.g. `CountIf`
4. Click the "Learn more" link
5. It should take you to the function-specific docs, not the general expression docs.

### Demo

![Screenshot 2025-04-16 at 2 03 07 PM](https://github.com/user-attachments/assets/ebc6ff17-f07c-44da-a915-c8f49b8c881e)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
