### PR TITLE
Setting to get handlebars helpers list

### DIFF
--- a/src/metabase/channel/email/_notification_card_condition.hbs
+++ b/src/metabase/channel/email/_notification_card_condition.hbs
@@ -1,11 +1,11 @@
-{{#if (equals send_condition "has_result")}}
+{{#if (eq send_condition "has_result")}}
   whenever this question has any results
 {{else}}
-  {{#if (equals send_condition "goal_above")}}
+  {{#if (eq send_condition "goal_above")}}
     when this question meets its goal
   {{else}}
-    {{#if (equals send_condition "goal_below")}}
+    {{#if (eq send_condition "goal_below")}}
       when this question goes below its goal
     {{/if}}
   {{/if}}
-{{/if}} 
+{{/if}}

--- a/src/metabase/channel/email/notification_card.hbs
+++ b/src/metabase/channel/email/notification_card.hbs
@@ -35,7 +35,7 @@
             {{{computed.content}}}
             {{#if computed.goal_value}}
               <p style="color: {{payload.style.color_text_medium}}; font-size: 12px; font-weight: 400">
-                {{#if (equals payload.notification_card.send_condition "goal_above")}}
+                {{#if (eq payload.notification_card.send_condition "goal_above")}}
                   This question has reached its goal of {{computed.goal_value}}.
                 {{else}}
                   This question has gone below its goal of {{computed.goal_value}}.

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -182,7 +182,7 @@
    "card-url"      #'card-url
    "dashboard-url" #'dashboard-url})
 
-(defn helpers-info
+(defn- helpers-info
   "Get a list of helpers with their names and docstrings."
   [helper-name->helper]
   (for [[helper-name helper] helper-name->helper]

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -2,11 +2,12 @@
   (:refer-clojure :exclude [count])
   (:require
    [java-time.api :as t]
+   [metabase.models.setting :as setting]
    [metabase.util.date-2 :as u.date]
    [metabase.util.urls :as urls])
   (:import
    (com.github.jknack.handlebars
-    Options Handlebars Helper Handlebars$SafeString)))
+    Options Handlebars Helper)))
 
 (set! *warn-on-reflection* true)
 
@@ -19,11 +20,6 @@
   "Get the else block."
   [^Options option]
   (.inverse option))
-
-(defn safe-str
-  "A wrapper of Handlebars.SafeString"
-  [& text]
-  (Handlebars$SafeString. (apply str text)))
 
 (defmacro defhelper
   "Define a helper function.
@@ -61,7 +57,7 @@
 (defn register-helpers
   "Register a list of helpers."
   [^Handlebars hbs helpers]
-  (doseq [[name helper] helpers]
+  (doseq [[name helper] (update-vals helpers var-get)]
     (register-helper hbs name helper)))
 
 ;;---------------- Predefined helpers ----------------;;
@@ -69,28 +65,48 @@
 ;; Generics
 
 (defhelper count
-  "Return the number of items in a collection."
+  "Counts the number of items in a collection.
+
+   Example:
+   ```
+   {{count items}}
+   ```
+
+   Arguments:
+   - collection: The collection to count items in"
   [collection _params _kparams _options]
   (clojure.core/count collection))
 
-(defhelper equals
-  "Return true if two values are equal.
+(defhelper eq
+  "Checks if two values are equal.
 
-  {{if (equals product.name \"Hot Dog\")}}
-    Hot Dog
-  {{else}}
-    Not Hot Dog
-  {{/if}}"
+   Example:
+   ```
+   {{#if (eq product.name \"Hot Dog\")}}
+     Hot Dog
+   {{else}}
+     Not Hot Dog
+   {{/if}}
+   ```
+
+   Arguments:
+   - x: First value to compare
+   - y: Second value to compare"
   [x [y] _kparams _options]
   (= x y))
 
 (defhelper format-date
-  "Format date helper.
+  "Formats a date according to specified pattern.
 
-  {{format-date '2000-30-01''dd-MM-YY'}}
-  ;; => 30-01-00
+   Example:
+   ```
+   {{format-date '2000-01-30' 'dd-MM-YY'}}
+   ;; => 30-01-00
+   ```
 
-  date can be either a string or a date time object."
+   Arguments:
+   - date: Date string or date object to format
+   - fmt: String format pattern"
   [date [fmt] _kparams _options]
   (assert (string? fmt) "Format must be a string")
   (u.date/format fmt
@@ -99,37 +115,88 @@
                    date)))
 
 (defhelper now
-  "Get the current date and time. Returned object is a java.time.Instant"
+  "Returns the current date and time as java.time.Instant.
+
+   Example:
+   ```
+   {{format-date (now) 'yyyy-MM-dd'}}
+   ;; => 2025-04-17
+   ```
+
+   Arguments:
+   - None"
   [_context _params _kparams _options]
   (t/instant))
 
 ;; Metabase specifics
 
 (defhelper card-url
-  "Return an appropriate URL for a `Card` with ID.
+  "Generates a URL for a Card with the given ID.
 
-  {{card-url 10}}
-  ;; => \"http://localhost:3000/question/10\""
+   Example:
+   ```
+   {{card-url 10}}
+   ;; => \"https://metabase.com/question/10\"
+   ```
+
+   Arguments:
+   - id: The ID of the card"
   [id _params _kparams _options]
   (urls/card-url id))
 
 (defhelper trash-url
-  "Return the URL to trash page."
+  "Generates the URL for the trash page.
+
+   Example:
+   ```
+   {{trash-url}}
+   ;; => \"https://metabase.com/admin/trash\"
+   ```
+
+   Arguments:
+   - None"
   [_ _params _kparams _options]
   (urls/trash-url))
 
 (defhelper dashboard-url
-  "Return an appropriate URL for a `Dashboard` with ID.
+  "Generates a URL for a Dashboard with the given ID.
 
-     {{dashboard-url 10}} -> \"http://localhost:3000/dashboard/10\""
+   Example:
+   ```
+   {{dashboard-url 10}}
+   ;; => \"https://metabase.com/dashboard/10\"
+   ```
+
+   Arguments:
+   - id: The ID of the dashboard
+   - parameters: Optional parameters to include in the URL"
   [id [parameters] _kparams _options]
   (urls/dashboard-url id (map #(update-keys % keyword) parameters)))
 
 (def default-helpers
   "A list of default helpers."
-  {"count"         count
-   "equals"        equals
-   "format-date"   format-date
-   "now"           now
-   "card-url"      card-url
-   "dashboard-url" dashboard-url})
+  {"count"         #'count
+   "eq"            #'eq
+   "format-date"   #'format-date
+   "now"           #'now
+   "card-url"      #'card-url
+   "dashboard-url" #'dashboard-url})
+
+(defn helpers-info
+  "Get a list of helpers with their names and docstrings."
+  [helper-name->helper]
+  (for [[helper-name helper] helper-name->helper]
+    {:name helper-name
+     :doc  (-> helper meta :doc)}))
+
+;; Exposing this via settings so FE can find it
+;; TODO: the better way is to follow metabase.lib's steps by writing this as cljc so FE can access it directly.
+(setting/defsetting default-handlebars-helpers
+  "A list of default handlebars helpers."
+  :type        :json
+  :encryption  :no
+  :export?     false
+  :getter      (fn [] (helpers-info default-helpers))
+  :setter      :none
+  :visibility  :public
+  :description "A list of default handlebars helpers.")

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -182,12 +182,100 @@
    "card-url"      #'card-url
    "dashboard-url" #'dashboard-url})
 
+(def ^:private built-in-helpers-info
+  (map
+   #(assoc % :type :built-in)
+   [{:name "if"
+     :doc  "Conditionally renders a block based on the truthiness of a value.
+
+   Example:
+   ```
+   {{#if author}}
+     <h1>{{firstName}} {{lastName}}</h1>
+   {{else}}
+     <h1>Unknown Author</h1>
+   {{/if}}
+   ```
+
+   Arguments:
+   - value: The value to test for truthiness
+   - options: Hash options including 'includeZero' to treat 0 as truthy"}
+    {:name "unless"
+     :doc  "Conditionally renders a block if the value is falsy.
+
+   Example:
+   ```
+   {{#unless license}}
+     <p>WARNING: This entry has no license!</p>
+   {{/unless}}
+   ```
+
+   Arguments:
+   - value: The value to test for falsiness"}
+    {:name "each"
+     :doc  "Iterates over a collection and renders a block for each item.
+
+   Example:
+   ```
+   {{#each people}}
+     <li>{{this}}</li>
+   {{else}}
+     <li>No people to display</li>
+   {{/each}}
+   ```
+
+   Special variables:
+   - @index: Current loop index for arrays
+   - @key: Current key name for objects
+   - @first: True on first iteration
+   - @last: True on last iteration"}
+    {:name "with"
+     :doc  "Changes the evaluation context for a block.
+
+   Example:
+   ```
+   {{#with person}}
+     {{firstName}} {{lastName}}
+   {{else}}
+     No person found
+   {{/with}}
+   ```
+
+   Arguments:
+   - context: The new context to use
+   - blockParam: Optional block parameter name to define reference"}
+    {:name "lookup"
+     :doc  "Looks up a value in an object or array using dynamic parameter resolution.
+
+   Example:
+   ```
+   {{lookup person age}}
+   ```
+
+   Arguments:
+   - object: The object or array to perform lookup on
+   - key: The property or index to look up"}
+    {:name "log"
+     :doc  "Logs a value to the console for debugging.
+
+   Example:
+   ```
+   {{log \"Current value:\" this}}
+   ```
+
+   Arguments:
+   - values: Any number of values to log
+   - level: Optional hash param for log level (debug, info, warn, error)"}]))
+
 (defn- helpers-info
   "Get a list of helpers with their names and docstrings."
   [helper-name->helper]
-  (for [[helper-name helper] helper-name->helper]
-    {:name helper-name
-     :doc  (-> helper meta :doc)}))
+  (concat
+   built-in-helpers-info
+   (for [[helper-name helper] helper-name->helper]
+     {:name helper-name
+      :doc  (-> helper meta :doc)
+      :type :custom})))
 
 ;; Exposing this via settings so FE can find it
 ;; TODO: the better way is to follow metabase.lib's steps by writing this as cljc so FE can access it directly.

--- a/test/metabase/channel/template/handlebars_helper_test.clj
+++ b/test/metabase/channel/template/handlebars_helper_test.clj
@@ -40,8 +40,8 @@
     (is (= "Not Hot Dog" (hot-dog-not-hot-dog "Pho")))))
 
 ;; predefined helper tests
-(deftest equals-test
-  (let [hot-dog-not-hot-dog #(handlebars/render-string "{{#if (equals product.name \"Hot Dog\")}}Hot Dog{{else}}Not Hot Dog{{/if}}" {:product %})]
+(deftest eq-test
+  (let [hot-dog-not-hot-dog #(handlebars/render-string "{{#if (eq product.name \"Hot Dog\")}}Hot Dog{{else}}Not Hot Dog{{/if}}" {:product %})]
     (is (= "Hot Dog" (hot-dog-not-hot-dog {:name "Hot Dog"})))
     (is (= "Not Hot Dog" (hot-dog-not-hot-dog {:name "Pho"})))))
 


### PR DESCRIPTION
Add a `default-handlebars-helpers` setting that contains handlebars available helpers.

Used for FE to get the available helpers.

Not the best way to expose it right now, in the future we'll probably want to rewrite helpers to cljc so it can be shared with FE directly.