### PR TITLE
Add memory usage logging to sync steps

### DIFF
--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -20,6 +20,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.memory :as u.mem]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize])
   (:import
@@ -129,11 +130,12 @@
   {:style/indent [:form]}
   [log-fn message f]
   (let [start-time (System/nanoTime)
-        _          (log-fn (u/format-color 'magenta "STARTING: %s" message))
+        _          (log-fn (u/format-color 'magenta "STARTING: %s (%s)" message (u.mem/pretty-usage-str)))
         result     (f)]
-    (log-fn (u/format-color 'magenta "FINISHED: %s (%s)"
+    (log-fn (u/format-color 'magenta "FINISHED: %s (%s) (%s)"
                             message
-                            (u/format-nanoseconds (- (System/nanoTime) start-time))))
+                            (u/format-nanoseconds (- (System/nanoTime) start-time))
+                            (u.mem/pretty-usage-str)))
     result))
 
 (defn- with-start-and-finish-logging

--- a/src/metabase/util/memory.clj
+++ b/src/metabase/util/memory.clj
@@ -1,0 +1,23 @@
+(ns metabase.util.memory)
+
+(set! *warn-on-reflection* true)
+
+(defn total-memory
+  "Get total memory in bytes"
+  []
+  (.totalMemory (Runtime/getRuntime)))
+
+(defn free-memory
+  "Get free memory in bytes."
+  []
+  (.freeMemory (Runtime/getRuntime)))
+
+(defn pretty-usage-str
+  "Return pretty string with memory usage."
+  []
+  (let [free (free-memory)
+        total (total-memory)]
+    (format "free: %.2fG, total: %.2fG, ratio: %.2f"
+            (/ free 1e9)
+            (/ total 1e9)
+            (double (/ free total)))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-203/add-memory-related-logging-to-the-sync-scan-and-fingerprinting

### Description

This PR adds memory usage logging to the beginning and end of every sync step. If it turns out we need more fine grained logging, it will be addressed in follow-up.

### How to verify

N/A

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
