### PR TITLE
Add schema, table and field to missing database type to base type mapping

### DIFF
--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -334,10 +334,13 @@
 ;; keyword function converts database-type variable to a symbol, so we use symbols above to map the types
 (defn- database-type->base-type-or-warn
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."
-  [driver database-type]
+  [driver schema table-name column-name database-type]
   (or (sql-jdbc.sync/database-type->base-type driver (keyword database-type))
-      (do (log/warnf "Don't know how to map column type '%s' to a Field base_type, falling back to :type/*."
-                     database-type)
+      (do (log/warnf "Don't know how to map column type '%s' to a Field base_type for '%s' '%s' '%s', falling back to :type/*."
+                     database-type
+                     schema
+                     table-name
+                     column-name)
           :type/*)))
 
 (defn- run-query
@@ -385,7 +388,7 @@
               (map athena.schema-parser/parse-schema))
         (run-query database (format "DESCRIBE `%s`.`%s`;" schema table-name))))
 
-(defn- describe-table-fields-without-nested-fields [driver columns]
+(defn- describe-table-fields-without-nested-fields [driver schema table-name columns]
   (set
    (for [[idx {database-type :type_name
                column-name   :column_name
@@ -393,7 +396,7 @@
      (merge
       {:name              column-name
        :database-type     database-type
-       :base-type         (database-type->base-type-or-warn driver database-type)
+       :base-type         (database-type->base-type-or-warn driver schema table-name column-name database-type)
        :database-position idx}
       (when (not (str/blank? remarks))
         {:field-comment remarks})))))
@@ -426,7 +429,7 @@
                 ; but doesn't suffer from the bug in the JDBC driver as metabase#43980
               (empty? columns))
         (describe-table-fields-with-nested-fields database schema table-name)
-        (describe-table-fields-without-nested-fields driver columns)))
+        (describe-table-fields-without-nested-fields driver schema table-name columns)))
     (catch Throwable e
       (log/errorf e "Error retreiving fields for DB %s.%s" schema table-name)
       (throw e))))

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -47,7 +47,7 @@
   (testing "sync without nested fields"
     (is (= #{{:name "id", :base-type :type/Text, :database-type "string", :database-position 0}
              {:name "ts", :base-type :type/Text, :database-type "string", :database-position 1}}
-           (#'athena/describe-table-fields-without-nested-fields :athena flat-schema-columns)))))
+           (#'athena/describe-table-fields-without-nested-fields :athena "test" "test" flat-schema-columns)))))
 
 (deftest ^:parallel describe-table-fields-with-nested-fields-test
   (driver/with-driver :athena

--- a/src/metabase/driver/sql_jdbc/sync.clj
+++ b/src/metabase/driver/sql_jdbc/sync.clj
@@ -29,6 +29,7 @@
 
  [sql-jdbc.describe-table
   add-table-pks
+  database-type->base-type-or-warn
   describe-fields
   describe-fields-pre-process-xf
   describe-fields-sql

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -54,15 +54,19 @@
   (with-open [rs (.getCatalogs metadata)]
     (set (map :table_cat (jdbc/metadata-result rs)))))
 
-(defn- database-type->base-type-or-warn
+(defn database-type->base-type-or-warn
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."
-  [driver col]
-  (or (sql-jdbc.sync.interface/database-type->base-type driver (keyword (:database-type col)))
-      (do (log/warnf "Don't know how to map column type '%s' to a Field base_type for '%s' '%s' '%s', falling back to :type/*."
-                     (:database-type col)
-                     (:table-schema col)
-                     (:table-name col)
-                     (:name col))
+  [driver namespaced-col database-type]
+  (or (sql-jdbc.sync.interface/database-type->base-type driver (keyword database-type))
+      (do (let [pretty-column (str/join "."
+                                        (reverse
+                                         (into []
+                                               (comp (take-while some?)
+                                                     (map #(str "'" % "'")))
+                                               (reverse namespaced-col))))]
+            (log/warnf "Don't know how to map column type '%s' to a Field base_type for %s, falling back to :type/*."
+                       database-type
+                       pretty-column))
           :type/*)))
 
 (defn- calculated-semantic-type
@@ -173,12 +177,22 @@
          init
          [jdbc-metadata fallback-metadata])))))
 
+(def ^:private ^:dynamic *table-info*
+  "To be bound in [[describe-table-fields]] to convey table schema and name into [[describe-fields-xf]]. Reason
+  being, that describe-fields-xf is used in driver/describe-fields and driver/describe-table-fields, where transducer's
+  `col` arg is missing this information for the latter."
+  {})
+
 (defn describe-fields-xf
   "Returns a transducer for computing metadata about the fields in `db`."
   [driver db]
-  (def ddd db)
   (map (fn [col]
-         (let [base-type (or (:base-type col) (database-type->base-type-or-warn driver col))
+         (let [base-type (or (:base-type col) (database-type->base-type-or-warn
+                                               driver
+                                               [((some-fn :table-schema) col *table-info*)
+                                                ((some-fn :table-name)   col *table-info*)
+                                                (:name col)]
+                                               (:database-type col)))
                semantic-type (calculated-semantic-type driver (:name col) (:database-type col))
                json? (isa? base-type :type/JSON)
                database-position (some-> (:database-position col) int)]
@@ -217,10 +231,13 @@
 
 (defmethod describe-table-fields :sql-jdbc
   [driver conn table db-name-or-nil]
-  (into
-   #{}
-   (describe-table-fields-xf driver (table/database table))
-   (fields-metadata driver conn table db-name-or-nil)))
+  (binding [*table-info* (merge {:table-name (:name table)}
+                                (when (:schema table)
+                                  {:table-schema (:schema table)}))]
+    (into
+     #{}
+     (describe-table-fields-xf driver (table/database table))
+     (fields-metadata driver conn table db-name-or-nil))))
 
 ;;; TODO -- it seems like in practice we usually call this without passing in a DB name, so `db-name-or-nil` is almost
 ;;; always just `nil`. There's currently not a great driver-agnostic way to determine the actual physical Database name
@@ -327,6 +344,7 @@
           (and table-names (empty? table-names)))
     []
     (let [sql (describe-fields-sql driver (assoc args :details (:details db)))]
+      (def sss sql)
       (try
         (log/debugf "`describe-fields` sql query:\n```\n%s\n```\n`describe-fields` args:\n```\n%s\n```"
                     (driver/prettify-native-form driver (first sql))
@@ -339,6 +357,10 @@
         (m/mapply describe-fields-pre-process-xf driver db args)
         (describe-fields-xf driver db))
        (sql-jdbc.execute/reducible-query db sql)))))
+
+(comment
+
+  (filter (complement :table-schema) ahoj))
 
 (defmulti describe-indexes-sql
   "Returns a SQL query ([sql & params]) for use in the default JDBC implementation of [[metabase.driver/describe-indexes]],

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -344,7 +344,6 @@
           (and table-names (empty? table-names)))
     []
     (let [sql (describe-fields-sql driver (assoc args :details (:details db)))]
-      (def sss sql)
       (try
         (log/debugf "`describe-fields` sql query:\n```\n%s\n```\n`describe-fields` args:\n```\n%s\n```"
                     (driver/prettify-native-form driver (first sql))
@@ -357,10 +356,6 @@
         (m/mapply describe-fields-pre-process-xf driver db args)
         (describe-fields-xf driver db))
        (sql-jdbc.execute/reducible-query db sql)))))
-
-(comment
-
-  (filter (complement :table-schema) ahoj))
 
 (defmulti describe-indexes-sql
   "Returns a SQL query ([sql & params]) for use in the default JDBC implementation of [[metabase.driver/describe-indexes]],

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -58,12 +58,8 @@
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."
   [driver namespaced-col database-type]
   (or (sql-jdbc.sync.interface/database-type->base-type driver (keyword database-type))
-      (do (let [pretty-column (str/join "."
-                                        (reverse
-                                         (into []
-                                               (comp (take-while some?)
-                                                     (map #(str "'" % "'")))
-                                               (reverse namespaced-col))))]
+      (do (let [pretty-column (str/join "." (map #(str "'" % "'")
+                                                 (drop-while nil? namespaced-col)))]
             (log/warnf "Don't know how to map column type '%s' to a Field base_type for %s, falling back to :type/*."
                        database-type
                        pretty-column))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #56447
Closes https://linear.app/metabase/issue/SEM-230/improve-logging-when-base-type-cannot-be-mapped

### Description

Both codepaths, describe-fields and describe-table-fields, are handled.

### How to verify

I've tested the change manually. I've modified the `database-type->base-type-or-warn` to always call `database-type->base-type` with nonsensical database type to see the updated logs.