### PR TITLE
fix: focus search field in category editing dropdown

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { useSearchFieldValuesQuery } from "metabase/api";
@@ -41,12 +41,18 @@ export const EditingBodyCellCategorySelect = ({
   onChangeValue,
   onCancel,
 }: EditingBodyCellCategorySelectProps) => {
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(initialValue?.toString() ?? "");
   const [search, setSearch] = useState("");
+
+  const focusSearchInput = useCallback(() => {
+    setTimeout(() => searchInputRef.current?.focus(), 0);
+  }, []);
 
   const combobox = useCombobox({
     defaultOpened: autoFocus,
     onDropdownClose: onCancel,
+    onDropdownOpen: focusSearchInput,
   });
 
   const { options, isLoading, isFetching } = useCategorySelectSearchOptions({
@@ -156,7 +162,10 @@ export const EditingBodyCellCategorySelect = ({
             placeholder={t`Search the list`}
             leftSection={<Icon name="search" />}
             rightSection={isFetching ? <Loader size="xs" /> : undefined}
+            // Auto focus works when dropdown is initially rendered as opened (e.g. inline editing)
+            // whereas `onDropdownOpen` is called only when dropdown is opened by clicking the button (e.g. modal editing)
             autoFocus
+            ref={searchInputRef}
           />
         </Box>
 


### PR DESCRIPTION
Resolves [WRK-197](https://linear.app/metabase/issue/WRK-197/editing-fks-or-categories-place-pointer-into-the-search-field-when)