### PR TITLE
Hide `Schemas` for dest DBs

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -157,7 +157,8 @@
     driver.common/cloud-ip-address-info
     {:name "schema-filters"
      :type :schema-filters
-     :display-name "Schemas"}
+     :display-name "Schemas"
+     :visible-if {"destination-database" false}}
     driver.common/default-ssl-details
     {:name         "ssl-mode"
      :display-name (trs "SSL Mode")


### PR DESCRIPTION
Is this the only schema filter? Kind of confused that it's postgres-specific...

[ADM-659: Pre-fill the add destination db modal and remove the schema selector](https://linear.app/metabase/issue/ADM-659/pre-fill-the-add-destination-db-modal-and-remove-the-schema-selector)