### PR TITLE
Allow passing strings to isEmpty and notEmpty

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1654,3 +1654,51 @@ describe("issue 56596", () => {
     });
   });
 });
+
+describe("issue 55687", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+
+    const questionDetails = {
+      query: {
+        "source-table": PRODUCTS_ID,
+        limit: 1,
+      },
+    };
+
+    H.createQuestion(questionDetails, { visitQuestion: true });
+
+    H.openNotebook();
+  });
+
+  function addExpression(name, expression) {
+    H.getNotebookStep("expression").icon("add").click();
+    H.enterCustomColumnDetails({
+      formula: expression,
+      name,
+    });
+    H.popover().button("Done").click();
+  }
+
+  it("should allow passing stringly-typed expressions to is-empty and not-empty (metabase#55687)", () => {
+    H.addCustomColumn();
+    H.popover().button("Cancel").click();
+
+    addExpression("isEmpty - title", "isEmpty([Title])");
+    addExpression("isEmpty - ltrim - title", "isEmpty(lTrim([Title]))");
+    addExpression("isEmpty - literal", "isEmpty('AAA')");
+    addExpression("isEmpty - ltrim - literal", "isEmpty(lTrim('AAA'))");
+
+    addExpression("notEmpty - title", "notEmpty([Title])");
+    addExpression("notEmpty - ltrim - title", "notEmpty(lTrim([Title]))");
+    addExpression("notEmpty - literal", "notEmpty('AAA')");
+    addExpression("notEmpty - ltrim - literal", "notEmpty(lTrim('AAA'))");
+
+    H.visualize();
+
+    cy.findByTestId("query-visualization-root")
+      .findByText("There was a problem with your question")
+      .should("not.exist");
+  });
+});

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -824,8 +824,8 @@
 
 ;; These are rewritten as `[:or [:= <field> nil] [:= <field> ""]]` and
 ;; `[:and [:not= <field> nil] [:not= <field> ""]]`
-(defclause ^:sugar is-empty  field [:or StringExpressionArg Field])
-(defclause ^:sugar not-empty field [:or StringExpressionArg Field])
+(defclause ^:sugar is-empty  field Emptyable)
+(defclause ^:sugar not-empty field Emptyable)
 
 (def ^:private StringFilterOptions
   [:map

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -819,10 +819,13 @@
 (defclause ^:sugar is-null,  field Field)
 (defclause ^:sugar not-null, field Field)
 
+(def ^:private Emptyable
+  [:or StringExpressionArg Field])
+
 ;; These are rewritten as `[:or [:= <field> nil] [:= <field> ""]]` and
 ;; `[:and [:not= <field> nil] [:not= <field> ""]]`
-(defclause ^:sugar is-empty,  field Field)
-(defclause ^:sugar not-empty, field Field)
+(defclause ^:sugar is-empty  field [:or StringExpressionArg Field])
+(defclause ^:sugar not-empty field [:or StringExpressionArg Field])
 
 (def ^:private StringFilterOptions
   [:map

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -226,3 +226,16 @@
     [:segment 1]
     [:and [:expression "bool1"] [:expression "bool2"]]
     [:or  [:expression "bool1"] [:expression "bool2"]]))
+
+(deftest ^:parallel emptyable-filter-test
+  (are [x] (not (me/humanize (mr/explain ::mbql.s/Filter x)))
+    [:is-empty ""]
+    [:is-empty "A"]
+    [:is-empty [:field 1 nil]]
+    [:is-empty [:ltrim "A"]]
+    [:is-empty [:ltrim [:field 1 nil]]]
+    [:not-empty ""]
+    [:not-empty "A"]
+    [:not-empty [:field 1 nil]]
+    [:not-empty [:ltrim "A"]]
+    [:not-empty [:ltrim [:field 1 nil]]]))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55687

Allows `isEmpty` and `notEmpty` to accept strings and stringly-typed expressions instead of just fields. 

This only changes the type definition in legacy mbql since pMBQL already allowed expressions.

## To verify

1. New -> Question -> Sample database -> Products
2. Custom Column
3. Type:
   ```
   isEmpty(lTrim([Title]))
   ```
4. Add a name for the column and save it
5. Visualize

There should be no error shown.
