### PR TITLE
[Permissions] Skip fetching of table fields when updating db permissions

### DIFF
--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -143,6 +143,7 @@ export const updateDataPermission = createThunkAction(
             dbId: entityId.databaseId,
             include_hidden: true,
             remove_inactive: true,
+            skip_fields: true,
           }),
         );
       }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56796

### Description

When permissions are updated at the database level, all the tables for that database were getting refetched without the `skip_fields` flag being enabled. On initial page load we fetch a database and it's tables without fields due to how much data is fetched, but this specific code path it wouldn't skip. For customers with lots of large tables this was consuming a lot of memory.

### How to verify

- Go to permissions page
- Change the "View data" permissions for a database from "Can view" to "Blocked"
- Open browser network inspector
- Save edits to permissions
- Validate that the network request for refetching the database does include table fields anymore