### PR TITLE
Setup app cleanup for sample-app runner

### DIFF
--- a/e2e/runner/sample-apps-shared/helpers/setup-app-cleanup.ts
+++ b/e2e/runner/sample-apps-shared/helpers/setup-app-cleanup.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+
+import { shell } from "../../cypress-runner-utils";
+
+export function setupAppCleanup({
+  rootPath,
+  env,
+  dockerDownCommand,
+}: {
+  rootPath: string;
+  env: Record<string, string | number>;
+  dockerDownCommand: string;
+}) {
+  if (!process.env.CI) {
+    ["exit", "SIGINT", "SIGTERM", "uncaughtException"].forEach((signal) => {
+      process.on(signal, () => {
+        console.log(`Parent received ${signal}, stopping app...`);
+
+        shell(dockerDownCommand, { cwd: rootPath, env });
+        fs.rmSync(rootPath, { recursive: true, force: true });
+      });
+    });
+  }
+}

--- a/e2e/runner/sample-apps-shared/helpers/start-containers.ts
+++ b/e2e/runner/sample-apps-shared/helpers/start-containers.ts
@@ -40,14 +40,4 @@ export async function startContainers({
   } catch {
     shell(dockerDownCommand, { cwd, env });
   }
-
-  if (!process.env.CI) {
-    ["exit", "SIGINT", "SIGTERM", "uncaughtException"].forEach((signal) => {
-      process.on(signal, () => {
-        console.log(`Parent received ${signal}, killing stopping app...`);
-
-        shell(dockerDownCommand, { cwd, env });
-      });
-    });
-  }
 }

--- a/e2e/runner/start-sample-app-containers/startSampleAppContainers.ts
+++ b/e2e/runner/start-sample-app-containers/startSampleAppContainers.ts
@@ -7,6 +7,7 @@ import {
   copyLocalEmbeddingSdkPackage,
   copyLocalMetabaseJar,
 } from "../sample-apps-shared/helpers/prepare-app";
+import { setupAppCleanup } from "../sample-apps-shared/helpers/setup-app-cleanup";
 import { startContainers } from "../sample-apps-shared/helpers/start-containers";
 import type {
   EmbeddingSdkVersion,
@@ -47,6 +48,8 @@ export async function startSampleAppContainers(
       appName,
       branch,
     });
+
+    setupAppCleanup({ rootPath, env, dockerDownCommand });
 
     copyExampleEnvFile({ rootPath, dockerEnvExamplePath, dockerEnvPath });
 


### PR DESCRIPTION
Setup app cleanup for sample-app runner:
- to avoid undeleted `tmp` folders