### PR TITLE
feat(sdk): Use public types for Dashboard/Collection/User and other entities

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/utils/xray-models.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/xray-models.ts
@@ -1,5 +1,8 @@
+import type {
+  MetabaseDashboard,
+  SdkDashboardId,
+} from "embedding-sdk/types/dashboard";
 import { uuid } from "metabase/lib/uuid";
-import type { Dashboard, DashboardId } from "metabase-types/api";
 
 import { propagateErrorResponse } from "./propagate-error-response";
 
@@ -12,7 +15,7 @@ interface Options {
 
 export async function createXrayDashboardFromModel(
   options: Options,
-): Promise<DashboardId> {
+): Promise<SdkDashboardId> {
   const { modelId, instanceUrl, cookie = "" } = options;
 
   // Queries an auto-generated dashboard layout for the model
@@ -37,7 +40,7 @@ export async function createXrayDashboardFromModel(
 
   await propagateErrorResponse(res);
 
-  const dashboard: Dashboard = await res.json();
+  const dashboard: MetabaseDashboard = await res.json();
 
   return dashboard.id;
 }

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -6,10 +6,10 @@ import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
 import type {
   EntityTypeFilterKeys,
   LoadSdkQuestionParams,
+  MetabaseQuestion,
   SdkQuestionId,
   SqlParameterValues,
 } from "embedding-sdk/types/question";
-import type { MetabaseQuestion } from "metabase/embedding-sdk/types/question";
 import type { NotebookProps as QBNotebookProps } from "metabase/querying/notebook/components/Notebook";
 import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import type Question from "metabase-lib/v1/Question";

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/PublicComponentWrapper.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/PublicComponentWrapper.unit.spec.tsx
@@ -1,10 +1,10 @@
 import { renderWithProviders, screen } from "__support__/ui";
 import { sdkReducers } from "embedding-sdk/store";
-import type { LoginStatus } from "embedding-sdk/store/types";
 import {
   createMockLoginStatusState,
   createMockSdkState,
 } from "embedding-sdk/test/mocks/state";
+import type { LoginStatus } from "embedding-sdk/types/user";
 import { createMockState } from "metabase-types/store/mocks";
 
 import { SdkContextProvider } from "../SdkContext";

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -8,7 +8,10 @@ import {
 import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
 import { useSdkSelector } from "embedding-sdk/store/use-sdk-selector";
-import type { SdkCollectionId } from "embedding-sdk/types/collection";
+import type {
+  MetabaseCollectionItem,
+  SdkCollectionId,
+} from "embedding-sdk/types/collection";
 import type { CommonStylingProps } from "embedding-sdk/types/props";
 import { COLLECTION_PAGE_SIZE } from "metabase/collections/components/CollectionContent";
 import { CollectionItemsTable } from "metabase/collections/components/CollectionContent/CollectionItemsTable";
@@ -18,7 +21,6 @@ import { Stack } from "metabase/ui";
 import type {
   CollectionEssentials,
   CollectionId,
-  CollectionItem,
   CollectionItemModel,
 } from "metabase-types/api";
 
@@ -87,7 +89,7 @@ export type CollectionBrowserProps = {
   /**
    * A function to call when an item is clicked.
    */
-  onClick?: (item: CollectionItem) => void;
+  onClick?: (item: MetabaseCollectionItem) => void;
 } & CommonStylingProps;
 
 export const CollectionBrowserInner = ({
@@ -113,13 +115,13 @@ export const CollectionBrowserInner = ({
     setCurrentCollectionId(baseCollectionId);
   }, [baseCollectionId]);
 
-  const onClickItem = (item: CollectionItem) => {
+  const onClickItem = (item: MetabaseCollectionItem) => {
     if (onClick) {
       onClick(item);
     }
 
     if (item.model === "collection") {
-      setCurrentCollectionId(item.id);
+      setCurrentCollectionId(item.id as CollectionId);
     }
   };
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.stories.tsx
@@ -8,8 +8,8 @@ import {
 
 import { EditableDashboard } from "embedding-sdk/components/public";
 import { CommonSdkStoryWrapper } from "embedding-sdk/test/CommonSdkStoryWrapper";
+import type { MetabaseDashboard } from "embedding-sdk/types/dashboard";
 import { Box, Button } from "metabase/ui";
-import type { Dashboard } from "metabase-types/api";
 
 import { CreateDashboardModal } from "./CreateDashboardModal";
 import {
@@ -38,7 +38,7 @@ export const Default = {
 const HookTemplate: StoryFn<
   JSXElementConstructor<Record<string, never>>
 > = () => {
-  const [dashboard, setDashboard] = useState<Dashboard | null>(null);
+  const [dashboard, setDashboard] = useState<MetabaseDashboard | null>(null);
   const { createDashboard } = useCreateDashboardApi();
 
   const props: CreateDashboardValues = {
@@ -71,7 +71,7 @@ export const UseCreateDashboardApiHook = {
 const FullWorkflowExampleTemplate: StoryFn<
   JSXElementConstructor<Record<string, never>>
 > = () => {
-  const [dashboard, setDashboard] = useState<Dashboard | null>(null);
+  const [dashboard, setDashboard] = useState<MetabaseDashboard | null>(null);
 
   if (dashboard) {
     return <EditableDashboard dashboardId={dashboard.id} />;

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -1,9 +1,9 @@
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import type { SdkCollectionId } from "embedding-sdk/types/collection";
+import type { MetabaseDashboard } from "embedding-sdk/types/dashboard";
 import { useCollectionQuery } from "metabase/common/hooks";
 import { CreateDashboardModal as CreateDashboardModalCore } from "metabase/dashboard/containers/CreateDashboardModal";
-import type { Dashboard } from "metabase-types/api";
 
 /**
  * @expand
@@ -23,7 +23,7 @@ export interface CreateDashboardModalProps {
   /**
    * Handler to react on dashboard creation.
    */
-  onCreate: (dashboard: Dashboard) => void;
+  onCreate: (dashboard: MetabaseDashboard) => void;
 
   /**
    * Handler to close modal component

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useSdkStore } from "embedding-sdk/store";
 import { getCollectionNumericIdFromReference } from "embedding-sdk/store/collections";
 import type { SdkCollectionId } from "embedding-sdk/types/collection";
+import type { MetabaseDashboard } from "embedding-sdk/types/dashboard";
 import { useCreateDashboardMutation } from "metabase/api";
 import type { CreateDashboardProperties } from "metabase/dashboard/containers/CreateDashboardForm";
 
@@ -35,7 +36,10 @@ export const useCreateDashboardApi = () => {
    * @function
    */
   const handleCreateDashboard = useCallback(
-    async ({ collectionId = "personal", ...rest }: CreateDashboardValues) => {
+    async ({
+      collectionId = "personal",
+      ...rest
+    }: CreateDashboardValues): Promise<MetabaseDashboard> => {
       const realCollectionId = getCollectionNumericIdFromReference(
         store.getState(),
         collectionId,

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/use-create-dashboard-api.unit.spec.tsx
@@ -6,7 +6,7 @@ import { screen } from "__support__/ui";
 import { renderWithSDKProviders } from "embedding-sdk/test/__support__/ui";
 import { createMockAuthProviderUriConfig } from "embedding-sdk/test/mocks/config";
 import { setupSdkState } from "embedding-sdk/test/server-mocks/sdk-init";
-import type { Dashboard } from "metabase-types/api";
+import type { MetabaseDashboard } from "embedding-sdk/types/dashboard";
 import { createMockUser } from "metabase-types/api/mocks";
 
 import type { CreateDashboardValues } from "./use-create-dashboard-api";
@@ -61,7 +61,7 @@ describe("useCreateDashboardApi", () => {
 
 const TestComponent = (
   props: CreateDashboardValues & {
-    onDashboardCreate: (dashboard: Dashboard) => void;
+    onDashboardCreate: (dashboard: MetabaseDashboard) => void;
   },
 ) => {
   const { onDashboardCreate, ...restProps } = props;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
@@ -3,6 +3,7 @@ import type { ComponentType, FC } from "react";
 import type { ConnectedProps } from "react-redux";
 import _ from "underscore";
 
+import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
 import type { CommonStylingProps } from "embedding-sdk/types/props";
 import * as dashboardActions from "metabase/dashboard/actions";
@@ -36,7 +37,6 @@ import type {
   DashboardRefreshPeriodControls,
 } from "metabase/dashboard/types";
 import { connect } from "metabase/lib/redux";
-import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
 import { useDashboardLoadHandlers } from "metabase/public/containers/PublicOrEmbeddedDashboard/use-dashboard-load-handlers";
 import { closeNavbar, setErrorPage } from "metabase/redux/app";
 import { getIsNavbarOpen } from "metabase/selectors/app";
@@ -99,7 +99,7 @@ type ConnectedDashboardProps = {
   DashboardFullscreenControls &
   DashboardRefreshPeriodControls &
   DashboardLoaderWrapperProps &
-  PublicOrEmbeddedDashboardEventHandlersProps;
+  DashboardEventHandlersProps;
 
 const ConnectedDashboardInner = ({
   dashboard,

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
@@ -11,13 +11,13 @@ import {
   useSdkDashboardParams,
 } from "embedding-sdk/hooks/private/use-sdk-dashboard-params";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
+import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
 import {
   DASHBOARD_EDITING_ACTIONS,
   SDK_DASHBOARD_VIEW_ACTIONS,
 } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/constants";
 import { getIsEditing } from "metabase/dashboard/selectors";
-import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
 import { setErrorPage } from "metabase/redux/app";
 import { getErrorPage } from "metabase/selectors/app";
 
@@ -48,7 +48,7 @@ export type EditableDashboardProps = {
    */
   drillThroughQuestionProps?: DrillThroughQuestionProps;
 } & Omit<SdkDashboardDisplayProps, "withTitle" | "hiddenParameters"> &
-  PublicOrEmbeddedDashboardEventHandlersProps;
+  DashboardEventHandlersProps;
 
 /**
  * A dashboard component with the features available in the `InteractiveDashboard` component, as well as the ability to add and update questions, layout, and content within your dashboard.

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -14,12 +14,12 @@ import {
   useSdkDashboardParams,
 } from "embedding-sdk/hooks/private/use-sdk-dashboard-params";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
+import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
 import { DASHBOARD_DISPLAY_ACTIONS } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/constants";
 import { useEmbedTheme } from "metabase/dashboard/hooks";
 import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import { PublicOrEmbeddedDashboard } from "metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard";
-import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
 import { setErrorPage } from "metabase/redux/app";
 import { getErrorPage } from "metabase/selectors/app";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
@@ -58,7 +58,7 @@ export type InteractiveDashboardProps = {
    */
   drillThroughQuestionProps?: DrillThroughQuestionProps;
 } & SdkDashboardDisplayProps &
-  PublicOrEmbeddedDashboardEventHandlersProps;
+  DashboardEventHandlersProps;
 
 const InteractiveDashboardInner = ({
   dashboardId: initialDashboardId,

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -12,12 +12,12 @@ import {
   useSdkDashboardParams,
 } from "embedding-sdk/hooks/private/use-sdk-dashboard-params";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
+import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
 import CS from "metabase/css/core/index.css";
 import { useEmbedTheme } from "metabase/dashboard/hooks";
 import type { EmbedDisplayParams } from "metabase/dashboard/types";
 import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { PublicOrEmbeddedDashboard } from "metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard";
-import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
 import { setErrorPage } from "metabase/redux/app";
 import { getErrorPage } from "metabase/selectors/app";
 import { Box } from "metabase/ui";
@@ -28,7 +28,7 @@ import { Box } from "metabase/ui";
  * @category StaticDashboard
  */
 export type StaticDashboardProps = SdkDashboardDisplayProps &
-  PublicOrEmbeddedDashboardEventHandlersProps;
+  DashboardEventHandlersProps;
 
 export const StaticDashboardInner = ({
   dashboardId,

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.unit.spec.tsx
@@ -18,7 +18,6 @@ import {
 } from "embedding-sdk/store";
 import { refreshTokenAsync } from "embedding-sdk/store/auth";
 import { getIsLoggedIn, getLoginStatus } from "embedding-sdk/store/selectors";
-import type { LoginStatusError } from "embedding-sdk/store/types";
 import { createMockAuthProviderUriConfig } from "embedding-sdk/test/mocks/config";
 import {
   createMockLoginStatusState,
@@ -28,6 +27,7 @@ import type {
   MetabaseAuthConfig,
   MetabaseAuthConfigWithProvider,
 } from "embedding-sdk/types";
+import type { LoginStatusError } from "embedding-sdk/types/user";
 import { GET } from "metabase/lib/api";
 import {
   createMockSettings,

--- a/enterprise/frontend/src/embedding-sdk/hooks/public/use-current-user.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/public/use-current-user.ts
@@ -1,4 +1,6 @@
+import type { MetabaseUser } from "embedding-sdk/types/user";
 import { useSelector } from "metabase/lib/redux";
 import { getUser } from "metabase/selectors/user";
 
-export const useCurrentUser = () => useSelector(getUser);
+export const useCurrentUser: () => MetabaseUser | null = () =>
+  useSelector(getUser);

--- a/enterprise/frontend/src/embedding-sdk/hooks/public/use-question-search.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/public/use-question-search.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import { useSdkSelector } from "embedding-sdk/store";
 import { getIsLoggedIn } from "embedding-sdk/store/selectors";
+import type { MetabaseCollectionItem } from "embedding-sdk/types/collection";
 import { useSearchListQuery } from "metabase/common/hooks";
 
 export const useQuestionSearch = (searchQuery?: string) => {
@@ -18,7 +19,7 @@ export const useQuestionSearch = (searchQuery?: string) => {
         };
   }, [searchQuery]);
 
-  return useSearchListQuery({
+  return useSearchListQuery<MetabaseCollectionItem, null>({
     query,
     enabled: isLoggedIn,
   });

--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -19,26 +19,32 @@ export * from "./hooks/public";
 export * from "./components/public";
 
 export type {
-  CollectionItem,
   CustomDashboardCardMenuItem,
   DashCardMenuItem,
   DashboardCardCustomMenuItem,
   DashboardCardMenuCustomElement,
   EntityTypeFilterKeys,
   IconName,
+  LoginStatus,
   MetabaseAuthConfig,
   MetabaseClickActionPluginsConfig,
   MetabaseClickAction,
+  MetabaseCollection,
+  MetabaseCollectionItem,
   MetabaseDataPointObject,
+  MetabaseDashboard,
   MetabaseDashboardPluginsConfig,
   MetabasePluginsConfig,
   MetabaseQuestion,
+  MetabaseUser,
   SdkCollectionId,
   SdkDashboardId,
   SdkDashboardLoadEvent,
+  SdkEntityId,
   SdkEventHandlersConfig,
   SdkQuestionId,
   SdkQuestionTitleProps,
+  SdkUserId,
   SqlParameterValues,
 } from "./types";
 
@@ -52,5 +58,3 @@ export type {
   MetabaseColors,
   MetabaseComponentTheme,
 } from "metabase/embedding-sdk/theme";
-
-export type { Dashboard as MetabaseDashboard } from "metabase-types/api";

--- a/enterprise/frontend/src/embedding-sdk/store/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/types.ts
@@ -13,6 +13,7 @@ import type {
   MetabaseFetchRequestTokenFn,
 } from "embedding-sdk/types/refresh-token";
 import type { SdkUsageProblem } from "embedding-sdk/types/usage-problem";
+import type { LoginStatus } from "embedding-sdk/types/user";
 import type { State } from "metabase-types/store";
 
 export type EmbeddingSessionTokenState = {
@@ -20,26 +21,6 @@ export type EmbeddingSessionTokenState = {
   loading: boolean;
   error: SerializedError | null;
 };
-
-type LoginStatusUninitialized = {
-  status: "uninitialized";
-};
-type LoginStatusSuccess = {
-  status: "success";
-};
-type LoginStatusLoading = {
-  status: "loading";
-};
-export type LoginStatusError = {
-  status: "error";
-  error: Error;
-};
-
-export type LoginStatus =
-  | LoginStatusUninitialized
-  | LoginStatusSuccess
-  | LoginStatusLoading
-  | LoginStatusError;
 
 export type SdkDispatch = ThunkDispatch<SdkStoreState, void, AnyAction>;
 

--- a/enterprise/frontend/src/embedding-sdk/test/mocks/state.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/mocks/state.ts
@@ -1,8 +1,8 @@
 import type {
   EmbeddingSessionTokenState,
-  LoginStatus,
   SdkState,
 } from "embedding-sdk/store/types";
+import type { LoginStatus } from "embedding-sdk/types/user";
 
 export const createMockTokenState = ({
   ...opts

--- a/enterprise/frontend/src/embedding-sdk/types/auth-config.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/auth-config.ts
@@ -1,5 +1,8 @@
 import type { MetabaseFetchRequestTokenFn } from "embedding-sdk";
 
+/**
+ * @inline
+ */
 type BaseMetabaseAuthConfig = {
   metabaseInstanceUrl: string;
 

--- a/enterprise/frontend/src/embedding-sdk/types/collection.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/collection.ts
@@ -1,4 +1,4 @@
-import type { CollectionItem as InternalCollectionItem } from "metabase-types/api";
+import type { SdkUserId } from "embedding-sdk/types/user";
 
 import type { SdkEntityId } from "./entity-id";
 
@@ -8,6 +8,54 @@ import type { SdkEntityId } from "./entity-id";
 export type SdkCollectionId = number | "personal" | "root" | SdkEntityId;
 
 /**
- * TODO: replace the internal type with a proper one
+ * The Collection entity
  */
-export type CollectionItem = InternalCollectionItem;
+export type MetabaseCollection = {
+  id: SdkCollectionId;
+  name: string;
+  slug?: string;
+  entity_id?: SdkEntityId;
+  description: string | null;
+  children?: MetabaseCollection[];
+  type?: "instance-analytics" | "trash" | null;
+
+  parent_id?: SdkCollectionId | null;
+  personal_owner_id?: SdkUserId;
+  location: string | null;
+};
+
+/**
+ * The CollectionItem entity
+ */
+export type MetabaseCollectionItem = {
+  id: SdkCollectionId;
+  entity_id?: SdkEntityId;
+  model: string;
+  name: string;
+  description: string | null;
+  archived: boolean;
+  copy?: boolean;
+  collection_position?: number | null;
+  collection_preview?: boolean | null;
+  fully_parameterized?: boolean | null;
+  collection?: MetabaseCollection | null;
+  collection_id: SdkCollectionId | null; // parent collection id
+  display?: string;
+  type?:
+    | "instance-analytics"
+    | "trash"
+    | "model"
+    | "question"
+    | "metric"
+    | null;
+  "last-edit-info"?: {
+    email: string;
+    first_name: string;
+    last_name: string;
+    id: SdkUserId;
+    timestamp: string;
+  };
+  location?: string;
+  effective_location?: string;
+  dashboard_count?: number | null;
+};

--- a/enterprise/frontend/src/embedding-sdk/types/collection.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/collection.ts
@@ -16,12 +16,6 @@ export type MetabaseCollection = {
   slug?: string;
   entity_id?: SdkEntityId;
   description: string | null;
-  children?: MetabaseCollection[];
-  type?: "instance-analytics" | "trash" | null;
-
-  parent_id?: SdkCollectionId | null;
-  personal_owner_id?: SdkUserId;
-  location: string | null;
 };
 
 /**
@@ -33,14 +27,6 @@ export type MetabaseCollectionItem = {
   model: string;
   name: string;
   description: string | null;
-  archived: boolean;
-  copy?: boolean;
-  collection_position?: number | null;
-  collection_preview?: boolean | null;
-  fully_parameterized?: boolean | null;
-  collection?: MetabaseCollection | null;
-  collection_id: SdkCollectionId | null; // parent collection id
-  display?: string;
   type?:
     | "instance-analytics"
     | "trash"
@@ -55,7 +41,4 @@ export type MetabaseCollectionItem = {
     id: SdkUserId;
     timestamp: string;
   };
-  location?: string;
-  effective_location?: string;
-  dashboard_count?: number | null;
 };

--- a/enterprise/frontend/src/embedding-sdk/types/dashboard.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/dashboard.ts
@@ -1,12 +1,44 @@
 import type { MantineColor } from "@mantine/core/lib/core";
 import type { ReactNode } from "react";
 
-import type { DashboardId } from "metabase-types/api";
+import type { MetabaseCollection } from "embedding-sdk/types/collection";
 
 import type { SdkEntityId } from "./entity-id";
 import type { IconName } from "./ui";
 
-export type SdkDashboardId = DashboardId | SdkEntityId;
+export type SdkDashboardId = number | string | SdkEntityId;
+
+/**
+ * The Dashboard entity
+ */
+export type MetabaseDashboard = {
+  id: SdkDashboardId;
+  entity_id: SdkEntityId;
+  created_at: string;
+  updated_at: string;
+  collection?: MetabaseCollection | null;
+  name: string;
+  description: string | null;
+  "last-edit-info": {
+    id: number;
+    email: string;
+    first_name: string;
+    last_name: string;
+    timestamp: string;
+  };
+};
+
+export type DashboardEventHandlersProps = {
+  /**
+   * Callback that is called when the dashboard is loaded.
+   */
+  onLoad?: (dashboard: MetabaseDashboard | null) => void;
+
+  /**
+   * Callback that is called when the dashboard is loaded without cards.
+   */
+  onLoadWithoutCards?: (dashboard: MetabaseDashboard | null) => void;
+};
 
 export type DashCardMenuItem = {
   /**

--- a/enterprise/frontend/src/embedding-sdk/types/events.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/events.ts
@@ -1,6 +1,8 @@
-import type { Dashboard } from "metabase-types/api";
+import type { MetabaseDashboard } from "embedding-sdk/types/dashboard";
 
-export type SdkDashboardLoadEvent = (dashboard: Dashboard | null) => void;
+export type SdkDashboardLoadEvent = (
+  dashboard: MetabaseDashboard | null,
+) => void;
 
 export type SdkEventHandlersConfig = {
   /**

--- a/enterprise/frontend/src/embedding-sdk/types/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/index.ts
@@ -1,7 +1,9 @@
 export type * from "./auth-config";
 export type * from "./collection";
 export type * from "./dashboard";
+export type * from "./entity-id";
 export type * from "./events";
 export type * from "./plugins";
 export type * from "./question";
 export type * from "./ui";
+export type * from "./user";

--- a/enterprise/frontend/src/embedding-sdk/types/props.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/props.ts
@@ -1,5 +1,8 @@
 import type { CSSProperties } from "react";
 
+/**
+ * @inline
+ */
 export type CommonStylingProps = {
   /**
    * A custom class name to be added to the root element.

--- a/enterprise/frontend/src/embedding-sdk/types/question.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/question.ts
@@ -15,8 +15,9 @@ export type SdkQuestionId = number | "new" | SdkEntityId;
  * Inline wrapper to properly display the `MetabaseQuestion` type without referencing the `internal` type
  *
  * @inline
+ * @interface
  */
-type _MetabaseQuestion = InternalMetabaseQuestion;
+interface _MetabaseQuestion extends InternalMetabaseQuestion {}
 
 /**
  * The Question entity

--- a/enterprise/frontend/src/embedding-sdk/types/ui.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/ui.ts
@@ -3,6 +3,7 @@ import type { IconName as InternalIconName } from "metabase/ui";
 /**
  * Inline wrapper to properly display the `IconName` type without referencing the `internal` type
  *
+ * @hidden
  * @inline
  */
 type _IconName = InternalIconName;

--- a/enterprise/frontend/src/embedding-sdk/types/ui.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/ui.ts
@@ -1,10 +1,10 @@
-import type { Icons } from "metabase/ui";
+import type { IconName as InternalIconName } from "metabase/ui";
 
 /**
  * Inline wrapper to properly display the `IconName` type without referencing the `internal` type
  *
  * @inline
  */
-type _IconName = keyof typeof Icons;
+type _IconName = InternalIconName;
 
 export type IconName = _IconName;

--- a/enterprise/frontend/src/embedding-sdk/types/user.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/user.ts
@@ -10,11 +10,6 @@ export type MetabaseUser = {
   common_name: string;
   email: string;
   locale: string | null;
-  google_auth: boolean;
-  is_active: boolean;
-  is_qbnewb: boolean;
-  is_superuser: boolean;
-
   date_joined: string;
   last_login: string;
   first_login: string;

--- a/enterprise/frontend/src/embedding-sdk/types/user.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/user.ts
@@ -1,0 +1,44 @@
+export type SdkUserId = number;
+
+/**
+ * The User entity
+ */
+export type MetabaseUser = {
+  id: SdkUserId;
+  first_name: string | null;
+  last_name: string | null;
+  common_name: string;
+  email: string;
+  locale: string | null;
+  google_auth: boolean;
+  is_active: boolean;
+  is_qbnewb: boolean;
+  is_superuser: boolean;
+
+  date_joined: string;
+  last_login: string;
+  first_login: string;
+};
+
+type LoginStatusUninitialized = {
+  status: "uninitialized";
+};
+
+type LoginStatusSuccess = {
+  status: "success";
+};
+
+type LoginStatusLoading = {
+  status: "loading";
+};
+
+export type LoginStatusError = {
+  status: "error";
+  error: Error;
+};
+
+export type LoginStatus =
+  | LoginStatusUninitialized
+  | LoginStatusSuccess
+  | LoginStatusLoading
+  | LoginStatusError;

--- a/enterprise/frontend/src/embedding-sdk/types/user.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/user.ts
@@ -15,18 +15,30 @@ export type MetabaseUser = {
   first_login: string;
 };
 
+/**
+ * @inline
+ */
 type LoginStatusUninitialized = {
   status: "uninitialized";
 };
 
+/**
+ * @inline
+ */
 type LoginStatusSuccess = {
   status: "success";
 };
 
+/**
+ * @inline
+ */
 type LoginStatusLoading = {
   status: "loading";
 };
 
+/**
+ * @inline
+ */
 export type LoginStatusError = {
   status: "error";
   error: Error;

--- a/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
+++ b/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
@@ -420,865 +420,1086 @@ import zoom_in_source from "./zoom_in.svg?source";
 import zoom_out_component from "./zoom_out.svg?component";
 import zoom_out_source from "./zoom_out.svg?source";
 
-export const Icons = {
-  add: {
-    component: add_component,
-    source: add_source,
-  },
-  add_column: {
-    component: add_column_component,
-    source: add_column_source,
-  },
-  add_data: {
-    component: add_data_component,
-    source: add_data_source,
-  },
-  add_row: {
-    component: add_row_component,
-    source: add_row_source,
-  },
-  add_to_dash: {
-    component: add_to_dash_component,
-    source: add_to_dash_source,
-  },
-  ai: {
-    component: ai_component,
-    source: ai_source,
-  },
-  alert: {
-    component: alert_component,
-    source: alert_source,
-  },
-  alert_filled: {
-    component: alert_filled_component,
-    source: alert_filled_source,
-  },
-  alert_confirm: {
-    component: alert_confirm_component,
-    source: alert_confirm_source,
-  },
-  archive: {
-    component: archive_component,
-    source: archive_source,
-  },
-  area: {
-    component: area_component,
-    source: area_source,
-  },
-  attachment: {
-    component: attachment_component,
-    source: attachment_source,
-  },
-  arrow_up: {
-    component: arrow_up_component,
-    source: arrow_up_source,
-  },
-  arrow_down: {
-    component: arrow_down_component,
-    source: arrow_down_source,
-  },
-  arrow_left: {
-    component: arrow_left_component,
-    source: arrow_left_source,
-  },
-  arrow_left_to_line: {
-    component: arrow_left_to_line_component,
-    source: arrow_left_to_line_source,
-  },
-  arrow_right: {
-    component: arrow_right_component,
-    source: arrow_right_source,
-  },
-  arrow_split: {
-    component: arrow_split_component,
-    source: arrow_split_source,
-  },
-  audit: {
-    component: audit_component,
-    source: audit_source,
-  },
-  badge: {
-    component: badge_component,
-    source: badge_source,
-  },
-  bar: {
-    component: bar_component,
-    source: bar_source,
-  },
-  bell: {
-    component: bell_component,
-    source: bell_source,
-  },
-  birthday: {
-    component: birthday_component,
-    source: birthday_source,
-  },
-  bookmark: {
-    component: bookmark_component,
-    source: bookmark_source,
-  },
-  bookmark_filled: {
-    component: bookmark_filled_component,
-    source: bookmark_filled_source,
-  },
-  bolt: {
-    component: bolt_component,
-    source: bolt_source,
-  },
-  bolt_filled: {
-    component: bolt_filled_component,
-    source: bolt_filled_source,
-  },
-  breakout: {
-    component: breakout_component,
-    source: breakout_source,
-  },
-  bubble: {
-    component: bubble_component,
-    source: bubble_source,
-  },
-  burger: {
-    component: burger_component,
-    source: burger_source,
-  },
-  calendar: {
-    component: calendar_component,
-    source: calendar_source,
-  },
-  check: {
-    component: check_component,
-    source: check_source,
-  },
-  chevrondown: {
-    component: chevrondown_component,
-    source: chevrondown_source,
-  },
-  chevronleft: {
-    component: chevronleft_component,
-    source: chevronleft_source,
-  },
-  chevronright: {
-    component: chevronright_component,
-    source: chevronright_source,
-  },
-  chevronup: {
-    component: chevronup_component,
-    source: chevronup_source,
-  },
-  click: {
-    component: click_component,
-    source: click_source,
-  },
-  clipboard: {
-    component: clipboard_component,
-    source: clipboard_source,
-  },
-  clock: {
-    component: clock_component,
-    source: clock_source,
-  },
-  clone: {
-    component: clone_component,
-    source: clone_source,
-  },
-  close: {
-    component: close_component,
-    source: close_source,
-  },
-  cloud: {
-    component: cloud_component,
-    source: cloud_source,
-  },
-  cloud_filled: {
-    component: cloud_filled_component,
-    source: cloud_filled_source,
-  },
-  compare: {
-    component: compare_component,
-    source: compare_source,
-  },
-  combine: {
-    component: combine_component,
-    source: combine_source,
-  },
-  connections: {
-    component: connections_component,
-    source: connections_source,
-  },
-  contract: {
-    component: contract_component,
-    source: contract_source,
-  },
-  copy: {
-    component: copy_component,
-    source: copy_source,
-  },
-  curved: {
-    component: curved_component,
-    source: curved_source,
-  },
-  database: {
-    component: database_component,
-    source: database_source,
-  },
-  dash: {
-    component: dash_component,
-    source: dash_source,
-  },
-  dashboard: {
-    component: dashboard_component,
-    source: dashboard_source,
-  },
-  curve: {
-    component: curve_component,
-    source: curve_source,
-  },
-  document: {
-    component: document_component,
-    source: document_source,
-  },
-  download: {
-    component: download_component,
-    source: download_source,
-  },
-  dyno: {
-    component: dyno_component,
-    source: dyno_source,
-  },
-  edit_document: {
-    component: edit_document_component,
-    source: edit_document_source,
-  },
-  ellipsis: {
-    component: ellipsis_component,
-    source: ellipsis_source,
-  },
-  embed: {
-    component: embed_component,
-    source: embed_source,
-  },
-  empty: {
-    component: empty_component,
-    source: empty_source,
-  },
-  enter_or_return: {
-    component: enter_or_return_component,
-    source: enter_or_return_source,
-  },
-  expand: {
-    component: expand_component,
-    source: expand_source,
-  },
-  expand_arrow: {
-    component: expand_arrow_component,
-    source: expand_arrow_source,
-  },
-  extract: {
-    component: extract_component,
-    source: extract_source,
-  },
-  eye: {
-    component: eye_component,
-    source: eye_source,
-  },
-  eye_crossed_out: {
-    component: eye_crossed_out_component,
-    source: eye_crossed_out_source,
-  },
-  eye_outline: {
-    component: eye_outline_component,
-    source: eye_outline_source,
-  },
-  field: {
-    component: field_component,
-    source: field_source,
-  },
-  fields: {
-    component: fields_component,
-    source: fields_source,
-  },
-  filter: {
-    component: filter_component,
-    source: filter_source,
-  },
-  filter_plus: {
-    component: filter_plus_component,
-    source: filter_plus_source,
-  },
-  bug: {
-    component: bug_component,
-    source: bug_source,
-  },
-  format_code: {
-    component: format_code_component,
-    source: format_code_source,
-  },
-  formula: {
-    component: formula_component,
-    source: formula_source,
-  },
-  function: {
-    component: function_component,
-    source: function_source,
-  },
-  funnel: {
-    component: funnel_component,
-    source: funnel_source,
-  },
-  funnel_outline: {
-    component: funnel_outline_component,
-    source: funnel_outline_source,
-  },
-  folder: {
-    component: folder_component,
-    source: folder_source,
-  },
-  folder_filled: {
-    component: folder_filled_component,
-    source: folder_filled_source,
-  },
-  gauge: {
-    component: gauge_component,
-    source: gauge_source,
-  },
-  gear: {
-    component: gear_component,
-    source: gear_source,
-  },
-  gem: {
-    component: gem_component,
-    source: gem_source,
-  },
-  globe: {
-    component: globe_component,
-    source: globe_source,
-  },
-  grabber: {
-    component: grabber_component,
-    source: grabber_source,
-  },
-  grid: {
-    component: grid_component,
-    source: grid_source,
-  },
-  group: {
-    component: group_component,
-    source: group_source,
-  },
-  google: {
-    component: google_component,
-    source: google_source,
-  },
-  google_drive: {
-    component: google_drive_component,
-    source: google_drive_source,
-  },
-  google_sheet: {
-    component: google_sheet_component,
-    source: google_sheet_source,
-  },
-  history: {
-    component: history_component,
-    source: history_source,
-  },
-  home: {
-    component: home_component,
-    source: home_source,
-  },
-  horizontal_bar: {
-    component: horizontal_bar_component,
-    source: horizontal_bar_source,
-  },
-  hourglass: {
-    component: hourglass_component,
-    source: hourglass_source,
-  },
-  info: {
-    component: info_component,
-    source: info_source,
-  },
-  info_filled: {
-    component: info_filled_component,
-    source: info_filled_source,
-  },
-  info_outline: {
-    component: info_outline_component,
-    source: info_outline_source,
-  },
-  insight: {
-    component: insight_component,
-    source: insight_source,
-  },
-  int: {
-    component: int_component,
-    source: int_source,
-  },
-  io: {
-    component: io_component,
-    source: io_source,
-  },
-  join_full_outer: {
-    component: join_full_outer_component,
-    source: join_full_outer_source,
-  },
-  join_inner: {
-    component: join_inner_component,
-    source: join_inner_source,
-  },
-  join_left_outer: {
-    component: join_left_outer_component,
-    source: join_left_outer_source,
-  },
-  join_right_outer: {
-    component: join_right_outer_component,
-    source: join_right_outer_source,
-  },
-  index: {
-    component: index_component,
-    source: index_source,
-  },
-  key: {
-    component: key_component,
-    source: key_source,
-  },
-  label: {
-    component: label_component,
-    source: label_source,
-  },
-  ldap: {
-    component: ldap_component,
-    source: ldap_source,
-  },
-  learn: {
-    component: learn_component,
-    source: learn_source,
-  },
-  lightbulb: {
-    component: lightbulb_component,
-    source: lightbulb_source,
-  },
-  link: {
-    component: link_component,
-    source: link_source,
-  },
-  line: {
-    component: line_component,
-    source: line_source,
-  },
-  lines: {
-    component: lines_component,
-    source: lines_source,
-  },
-  lineandbar: {
-    component: lineandbar_component,
-    source: lineandbar_source,
-  },
-  line_style_dashed: {
-    component: line_style_dashed_component,
-    source: line_style_dashed_source,
-  },
-  line_style_dotted: {
-    component: line_style_dotted_component,
-    source: line_style_dotted_source,
-  },
-  line_style_solid: {
-    component: line_style_solid_component,
-    source: line_style_solid_source,
-  },
-  list: {
-    component: list_component,
-    source: list_source,
-  },
-  location: {
-    component: location_component,
-    source: location_source,
-  },
-  lock: {
-    component: lock_component,
-    source: lock_source,
-  },
-  lock_filled: {
-    component: lock_filled_component,
-    source: lock_filled_source,
-  },
-  mail: {
-    component: mail_component,
-    source: mail_source,
-  },
-  mail_filled: {
-    component: mail_filled_component,
-    source: mail_filled_source,
-  },
-  metric: {
-    component: metric_component,
-    source: metric_source,
-  },
-  model: {
-    component: model_component,
-    source: model_source,
-  },
-  model_with_badge: {
-    component: model_with_badge_component,
-    source: model_with_badge_source,
-  },
-  moon: {
-    component: moon_component,
-    source: moon_source,
-  },
-  move: {
-    component: move_component,
-    source: move_source,
-  },
-  move_card: {
-    component: move_card_component,
-    source: move_card_source,
-  },
-  new_folder: {
-    component: new_folder_component,
-    source: new_folder_source,
-  },
-  notebook: {
-    component: notebook_component,
-    source: notebook_source,
-  },
-  number: {
-    component: number_component,
-    source: number_source,
-  },
-  palette: {
-    component: palette_component,
-    source: palette_source,
-  },
-  pause: {
-    component: pause_component,
-    source: pause_source,
-  },
-  pencil: {
-    component: pencil_component,
-    source: pencil_source,
-  },
-  pencil_lines: {
-    component: pencil_lines_component,
-    source: pencil_lines_source,
-  },
-  permissions_limited: {
-    component: permissions_limited_component,
-    source: permissions_limited_source,
-  },
-  person: {
-    component: person_component,
-    source: person_source,
-  },
-  pie: {
-    component: pie_component,
-    source: pie_source,
-  },
-  pin: {
-    component: pin_component,
-    source: pin_source,
-  },
-  pinmap: {
-    component: pinmap_component,
-    source: pinmap_source,
-  },
-  pivot_table: {
-    component: pivot_table_component,
-    source: pivot_table_source,
-  },
-  play: {
-    component: play_component,
-    source: play_source,
-  },
-  play_outlined: {
-    component: play_outlined_component,
-    source: play_outlined_source,
-  },
-  popover: {
-    component: popover_component,
-    source: popover_source,
-  },
-  popular: {
-    component: popular_component,
-    source: popular_source,
-  },
-  progress: {
-    component: progress_component,
-    source: progress_source,
-  },
-  pulse: {
-    component: pulse_component,
-    source: pulse_source,
-  },
-  recents: {
-    component: recents_component,
-    source: recents_source,
-  },
-  revert: {
-    component: revert_component,
-    source: revert_source,
-  },
-  sankey: {
-    component: sankey_component,
-    source: sankey_source,
-  },
-  share: {
-    component: share_component,
-    source: share_source,
-  },
-  split: {
-    component: split_component,
-    source: split_source,
-  },
-  sql: {
-    component: sql_component,
-    source: sql_source,
-  },
-  subscription: {
-    component: subscription_component,
-    source: subscription_source,
-  },
-  straight: {
-    component: straight_component,
-    source: straight_source,
-  },
-  stepped: {
-    component: stepped_component,
-    source: stepped_source,
-  },
-  sort: {
-    component: sort_component,
-    source: sort_source,
-  },
-  sort_arrows: {
-    component: sort_arrows_component,
-    source: sort_arrows_source,
-  },
-  sum: {
-    component: sum_component,
-    source: sum_source,
-  },
-  sync: {
-    component: sync_component,
-    source: sync_source,
-  },
-  question: {
-    component: question_component,
-    source: question_source,
-  },
-  return: {
-    component: return_component,
-    source: return_source,
-  },
-  reference: {
-    component: reference_component,
-    source: reference_source,
-  },
-  refresh: {
-    component: refresh_component,
-    source: refresh_source,
-  },
-  refresh_downstream: {
-    component: refresh_downstream_component,
-    source: refresh_downstream_source,
-  },
-  rocket: {
-    component: rocket_component,
-    source: rocket_source,
-  },
-  ruler: {
-    component: ruler_component,
-    source: ruler_source,
-  },
-  search: {
-    component: search_component,
-    source: search_source,
-  },
-  section: {
-    component: section_component,
-    source: section_source,
-  },
-  segment: {
-    component: segment_component,
-    source: segment_source,
-  },
-  shield: {
-    component: shield_component,
-    source: shield_source,
-  },
-  sidebar_closed: {
-    component: sidebar_closed_component,
-    source: sidebar_closed_source,
-  },
-  sidebar_open: {
-    component: sidebar_open_component,
-    source: sidebar_open_source,
-  },
-  slack: {
-    component: slack_component,
-    source: slack_source,
-  },
-  slack_colorized: {
-    component: slack_colorized_component,
-    source: slack_colorized_source,
-  },
-  smartscalar: {
-    component: smartscalar_component,
-    source: smartscalar_source,
-  },
-  snippet: {
-    component: snippet_component,
-    source: snippet_source,
-  },
-  sparkles: {
-    component: sparkles_component,
-    source: sparkles_source,
-  },
-  star_filled: {
-    component: star_filled_component,
-    source: star_filled_source,
-  },
-  star: {
-    component: star_component,
-    source: star_source,
-  },
-  store: {
-    component: store_component,
-    source: store_source,
-  },
-  string: {
-    component: string_component,
-    source: string_source,
-  },
-  sun: {
-    component: sun_component,
-    source: sun_source,
-  },
-  "t-shirt": {
-    component: t_shirt_component,
-    source: t_shirt_source,
-  },
-  tab: {
-    component: tab_component,
-    source: tab_source,
-  },
-  table: {
-    // for database tables
-    component: table_component,
-    source: table_source,
-  },
-  table2: {
-    // for questions with table visualizations
-    component: table2_component,
-    source: table2_source,
-  },
-  time_history: {
-    component: time_history_component,
-    source: time_history_source,
-  },
-  trash: {
-    component: trash_component,
-    source: trash_source,
-  },
-  trash_filled: {
-    component: trash_filled_component,
-    source: trash_filled_source,
-  },
-  triangle_left: {
-    component: triangle_left_component,
-    source: triangle_left_source,
-  },
-  triangle_right: {
-    component: triangle_right_component,
-    source: triangle_right_source,
-  },
-  unarchive: {
-    component: unarchive_component,
-    source: unarchive_source,
-  },
-  unknown: {
-    component: unknown_component,
-    source: unknown_source,
-  },
-  unpin: {
-    component: unpin_component,
-    source: unpin_source,
-  },
-  unsubscribe: {
-    component: unsubscribe_component,
-    source: unsubscribe_source,
-  },
-  upload: {
-    component: upload_component,
-    source: upload_source,
-  },
-  variable: {
-    component: variable_component,
-    source: variable_source,
-  },
-  verified: {
-    component: verified_component,
-    source: verified_source,
-  },
-  official_collection: {
-    component: official_collection_component,
-    source: official_collection_source,
-  },
-  verified_filled: {
-    component: verified_filled_component,
-    source: verified_filled_source,
-  },
-  view_archive: {
-    component: view_archive_component,
-    source: view_archive_source,
-  },
-  warning: {
-    component: warning_component,
-    source: warning_source,
-  },
-  warning_round_filled: {
-    component: warning_round_filled_component,
-    source: warning_round_filled_source,
-  },
-  waterfall: {
-    component: waterfall_component,
-    source: waterfall_source,
-  },
-  webhook: {
-    component: webhook_component,
-    source: webhook_source,
-  },
-  "10k": {
-    component: ten_thousand_component,
-    source: ten_thousand_source,
-  },
-  "1m": {
-    component: one_million_component,
-    source: one_million_source,
-  },
-  zoom_in: {
-    component: zoom_in_component,
-    source: zoom_in_source,
-  },
-  zoom_out: {
-    component: zoom_out_component,
-    source: zoom_out_source,
-  },
-  scalar: {
-    component: number_component,
-    source: number_source,
-  },
-  cake: {
-    component: birthday_component,
-    source: birthday_source,
-  },
-  external: { component: share_component, source: share_source },
-  table_spaced: { component: table_component, source: table_source },
-  collection: { component: folder_component, source: folder_source },
-  beaker: { component: formula_component, source: formula_source },
-  eye_filled: { component: eye_component, source: eye_source },
-} as const;
+export const Icons: Record<IconName, { component: React.VFC; source: string }> =
+  {
+    add: {
+      component: add_component,
+      source: add_source,
+    },
+    add_column: {
+      component: add_column_component,
+      source: add_column_source,
+    },
+    add_data: {
+      component: add_data_component,
+      source: add_data_source,
+    },
+    add_row: {
+      component: add_row_component,
+      source: add_row_source,
+    },
+    add_to_dash: {
+      component: add_to_dash_component,
+      source: add_to_dash_source,
+    },
+    ai: {
+      component: ai_component,
+      source: ai_source,
+    },
+    alert: {
+      component: alert_component,
+      source: alert_source,
+    },
+    alert_filled: {
+      component: alert_filled_component,
+      source: alert_filled_source,
+    },
+    alert_confirm: {
+      component: alert_confirm_component,
+      source: alert_confirm_source,
+    },
+    archive: {
+      component: archive_component,
+      source: archive_source,
+    },
+    area: {
+      component: area_component,
+      source: area_source,
+    },
+    attachment: {
+      component: attachment_component,
+      source: attachment_source,
+    },
+    arrow_up: {
+      component: arrow_up_component,
+      source: arrow_up_source,
+    },
+    arrow_down: {
+      component: arrow_down_component,
+      source: arrow_down_source,
+    },
+    arrow_left: {
+      component: arrow_left_component,
+      source: arrow_left_source,
+    },
+    arrow_left_to_line: {
+      component: arrow_left_to_line_component,
+      source: arrow_left_to_line_source,
+    },
+    arrow_right: {
+      component: arrow_right_component,
+      source: arrow_right_source,
+    },
+    arrow_split: {
+      component: arrow_split_component,
+      source: arrow_split_source,
+    },
+    audit: {
+      component: audit_component,
+      source: audit_source,
+    },
+    badge: {
+      component: badge_component,
+      source: badge_source,
+    },
+    bar: {
+      component: bar_component,
+      source: bar_source,
+    },
+    bell: {
+      component: bell_component,
+      source: bell_source,
+    },
+    birthday: {
+      component: birthday_component,
+      source: birthday_source,
+    },
+    bookmark: {
+      component: bookmark_component,
+      source: bookmark_source,
+    },
+    bookmark_filled: {
+      component: bookmark_filled_component,
+      source: bookmark_filled_source,
+    },
+    bolt: {
+      component: bolt_component,
+      source: bolt_source,
+    },
+    bolt_filled: {
+      component: bolt_filled_component,
+      source: bolt_filled_source,
+    },
+    breakout: {
+      component: breakout_component,
+      source: breakout_source,
+    },
+    bubble: {
+      component: bubble_component,
+      source: bubble_source,
+    },
+    burger: {
+      component: burger_component,
+      source: burger_source,
+    },
+    calendar: {
+      component: calendar_component,
+      source: calendar_source,
+    },
+    check: {
+      component: check_component,
+      source: check_source,
+    },
+    chevrondown: {
+      component: chevrondown_component,
+      source: chevrondown_source,
+    },
+    chevronleft: {
+      component: chevronleft_component,
+      source: chevronleft_source,
+    },
+    chevronright: {
+      component: chevronright_component,
+      source: chevronright_source,
+    },
+    chevronup: {
+      component: chevronup_component,
+      source: chevronup_source,
+    },
+    click: {
+      component: click_component,
+      source: click_source,
+    },
+    clipboard: {
+      component: clipboard_component,
+      source: clipboard_source,
+    },
+    clock: {
+      component: clock_component,
+      source: clock_source,
+    },
+    clone: {
+      component: clone_component,
+      source: clone_source,
+    },
+    close: {
+      component: close_component,
+      source: close_source,
+    },
+    cloud: {
+      component: cloud_component,
+      source: cloud_source,
+    },
+    cloud_filled: {
+      component: cloud_filled_component,
+      source: cloud_filled_source,
+    },
+    compare: {
+      component: compare_component,
+      source: compare_source,
+    },
+    combine: {
+      component: combine_component,
+      source: combine_source,
+    },
+    connections: {
+      component: connections_component,
+      source: connections_source,
+    },
+    contract: {
+      component: contract_component,
+      source: contract_source,
+    },
+    copy: {
+      component: copy_component,
+      source: copy_source,
+    },
+    curved: {
+      component: curved_component,
+      source: curved_source,
+    },
+    database: {
+      component: database_component,
+      source: database_source,
+    },
+    dash: {
+      component: dash_component,
+      source: dash_source,
+    },
+    dashboard: {
+      component: dashboard_component,
+      source: dashboard_source,
+    },
+    curve: {
+      component: curve_component,
+      source: curve_source,
+    },
+    document: {
+      component: document_component,
+      source: document_source,
+    },
+    download: {
+      component: download_component,
+      source: download_source,
+    },
+    dyno: {
+      component: dyno_component,
+      source: dyno_source,
+    },
+    edit_document: {
+      component: edit_document_component,
+      source: edit_document_source,
+    },
+    ellipsis: {
+      component: ellipsis_component,
+      source: ellipsis_source,
+    },
+    embed: {
+      component: embed_component,
+      source: embed_source,
+    },
+    empty: {
+      component: empty_component,
+      source: empty_source,
+    },
+    enter_or_return: {
+      component: enter_or_return_component,
+      source: enter_or_return_source,
+    },
+    expand: {
+      component: expand_component,
+      source: expand_source,
+    },
+    expand_arrow: {
+      component: expand_arrow_component,
+      source: expand_arrow_source,
+    },
+    extract: {
+      component: extract_component,
+      source: extract_source,
+    },
+    eye: {
+      component: eye_component,
+      source: eye_source,
+    },
+    eye_crossed_out: {
+      component: eye_crossed_out_component,
+      source: eye_crossed_out_source,
+    },
+    eye_outline: {
+      component: eye_outline_component,
+      source: eye_outline_source,
+    },
+    field: {
+      component: field_component,
+      source: field_source,
+    },
+    fields: {
+      component: fields_component,
+      source: fields_source,
+    },
+    filter: {
+      component: filter_component,
+      source: filter_source,
+    },
+    filter_plus: {
+      component: filter_plus_component,
+      source: filter_plus_source,
+    },
+    bug: {
+      component: bug_component,
+      source: bug_source,
+    },
+    format_code: {
+      component: format_code_component,
+      source: format_code_source,
+    },
+    formula: {
+      component: formula_component,
+      source: formula_source,
+    },
+    function: {
+      component: function_component,
+      source: function_source,
+    },
+    funnel: {
+      component: funnel_component,
+      source: funnel_source,
+    },
+    funnel_outline: {
+      component: funnel_outline_component,
+      source: funnel_outline_source,
+    },
+    folder: {
+      component: folder_component,
+      source: folder_source,
+    },
+    folder_filled: {
+      component: folder_filled_component,
+      source: folder_filled_source,
+    },
+    gauge: {
+      component: gauge_component,
+      source: gauge_source,
+    },
+    gear: {
+      component: gear_component,
+      source: gear_source,
+    },
+    gem: {
+      component: gem_component,
+      source: gem_source,
+    },
+    globe: {
+      component: globe_component,
+      source: globe_source,
+    },
+    grabber: {
+      component: grabber_component,
+      source: grabber_source,
+    },
+    grid: {
+      component: grid_component,
+      source: grid_source,
+    },
+    group: {
+      component: group_component,
+      source: group_source,
+    },
+    google: {
+      component: google_component,
+      source: google_source,
+    },
+    google_drive: {
+      component: google_drive_component,
+      source: google_drive_source,
+    },
+    google_sheet: {
+      component: google_sheet_component,
+      source: google_sheet_source,
+    },
+    history: {
+      component: history_component,
+      source: history_source,
+    },
+    home: {
+      component: home_component,
+      source: home_source,
+    },
+    horizontal_bar: {
+      component: horizontal_bar_component,
+      source: horizontal_bar_source,
+    },
+    hourglass: {
+      component: hourglass_component,
+      source: hourglass_source,
+    },
+    info: {
+      component: info_component,
+      source: info_source,
+    },
+    info_filled: {
+      component: info_filled_component,
+      source: info_filled_source,
+    },
+    info_outline: {
+      component: info_outline_component,
+      source: info_outline_source,
+    },
+    insight: {
+      component: insight_component,
+      source: insight_source,
+    },
+    int: {
+      component: int_component,
+      source: int_source,
+    },
+    io: {
+      component: io_component,
+      source: io_source,
+    },
+    join_full_outer: {
+      component: join_full_outer_component,
+      source: join_full_outer_source,
+    },
+    join_inner: {
+      component: join_inner_component,
+      source: join_inner_source,
+    },
+    join_left_outer: {
+      component: join_left_outer_component,
+      source: join_left_outer_source,
+    },
+    join_right_outer: {
+      component: join_right_outer_component,
+      source: join_right_outer_source,
+    },
+    index: {
+      component: index_component,
+      source: index_source,
+    },
+    key: {
+      component: key_component,
+      source: key_source,
+    },
+    label: {
+      component: label_component,
+      source: label_source,
+    },
+    ldap: {
+      component: ldap_component,
+      source: ldap_source,
+    },
+    learn: {
+      component: learn_component,
+      source: learn_source,
+    },
+    lightbulb: {
+      component: lightbulb_component,
+      source: lightbulb_source,
+    },
+    link: {
+      component: link_component,
+      source: link_source,
+    },
+    line: {
+      component: line_component,
+      source: line_source,
+    },
+    lines: {
+      component: lines_component,
+      source: lines_source,
+    },
+    lineandbar: {
+      component: lineandbar_component,
+      source: lineandbar_source,
+    },
+    line_style_dashed: {
+      component: line_style_dashed_component,
+      source: line_style_dashed_source,
+    },
+    line_style_dotted: {
+      component: line_style_dotted_component,
+      source: line_style_dotted_source,
+    },
+    line_style_solid: {
+      component: line_style_solid_component,
+      source: line_style_solid_source,
+    },
+    list: {
+      component: list_component,
+      source: list_source,
+    },
+    location: {
+      component: location_component,
+      source: location_source,
+    },
+    lock: {
+      component: lock_component,
+      source: lock_source,
+    },
+    lock_filled: {
+      component: lock_filled_component,
+      source: lock_filled_source,
+    },
+    mail: {
+      component: mail_component,
+      source: mail_source,
+    },
+    mail_filled: {
+      component: mail_filled_component,
+      source: mail_filled_source,
+    },
+    metric: {
+      component: metric_component,
+      source: metric_source,
+    },
+    model: {
+      component: model_component,
+      source: model_source,
+    },
+    model_with_badge: {
+      component: model_with_badge_component,
+      source: model_with_badge_source,
+    },
+    moon: {
+      component: moon_component,
+      source: moon_source,
+    },
+    move: {
+      component: move_component,
+      source: move_source,
+    },
+    move_card: {
+      component: move_card_component,
+      source: move_card_source,
+    },
+    new_folder: {
+      component: new_folder_component,
+      source: new_folder_source,
+    },
+    notebook: {
+      component: notebook_component,
+      source: notebook_source,
+    },
+    number: {
+      component: number_component,
+      source: number_source,
+    },
+    palette: {
+      component: palette_component,
+      source: palette_source,
+    },
+    pause: {
+      component: pause_component,
+      source: pause_source,
+    },
+    pencil: {
+      component: pencil_component,
+      source: pencil_source,
+    },
+    pencil_lines: {
+      component: pencil_lines_component,
+      source: pencil_lines_source,
+    },
+    permissions_limited: {
+      component: permissions_limited_component,
+      source: permissions_limited_source,
+    },
+    person: {
+      component: person_component,
+      source: person_source,
+    },
+    pie: {
+      component: pie_component,
+      source: pie_source,
+    },
+    pin: {
+      component: pin_component,
+      source: pin_source,
+    },
+    pinmap: {
+      component: pinmap_component,
+      source: pinmap_source,
+    },
+    pivot_table: {
+      component: pivot_table_component,
+      source: pivot_table_source,
+    },
+    play: {
+      component: play_component,
+      source: play_source,
+    },
+    play_outlined: {
+      component: play_outlined_component,
+      source: play_outlined_source,
+    },
+    popover: {
+      component: popover_component,
+      source: popover_source,
+    },
+    popular: {
+      component: popular_component,
+      source: popular_source,
+    },
+    progress: {
+      component: progress_component,
+      source: progress_source,
+    },
+    pulse: {
+      component: pulse_component,
+      source: pulse_source,
+    },
+    recents: {
+      component: recents_component,
+      source: recents_source,
+    },
+    revert: {
+      component: revert_component,
+      source: revert_source,
+    },
+    sankey: {
+      component: sankey_component,
+      source: sankey_source,
+    },
+    share: {
+      component: share_component,
+      source: share_source,
+    },
+    split: {
+      component: split_component,
+      source: split_source,
+    },
+    sql: {
+      component: sql_component,
+      source: sql_source,
+    },
+    subscription: {
+      component: subscription_component,
+      source: subscription_source,
+    },
+    straight: {
+      component: straight_component,
+      source: straight_source,
+    },
+    stepped: {
+      component: stepped_component,
+      source: stepped_source,
+    },
+    sort: {
+      component: sort_component,
+      source: sort_source,
+    },
+    sort_arrows: {
+      component: sort_arrows_component,
+      source: sort_arrows_source,
+    },
+    sum: {
+      component: sum_component,
+      source: sum_source,
+    },
+    sync: {
+      component: sync_component,
+      source: sync_source,
+    },
+    question: {
+      component: question_component,
+      source: question_source,
+    },
+    return: {
+      component: return_component,
+      source: return_source,
+    },
+    reference: {
+      component: reference_component,
+      source: reference_source,
+    },
+    refresh: {
+      component: refresh_component,
+      source: refresh_source,
+    },
+    refresh_downstream: {
+      component: refresh_downstream_component,
+      source: refresh_downstream_source,
+    },
+    rocket: {
+      component: rocket_component,
+      source: rocket_source,
+    },
+    ruler: {
+      component: ruler_component,
+      source: ruler_source,
+    },
+    search: {
+      component: search_component,
+      source: search_source,
+    },
+    section: {
+      component: section_component,
+      source: section_source,
+    },
+    segment: {
+      component: segment_component,
+      source: segment_source,
+    },
+    shield: {
+      component: shield_component,
+      source: shield_source,
+    },
+    sidebar_closed: {
+      component: sidebar_closed_component,
+      source: sidebar_closed_source,
+    },
+    sidebar_open: {
+      component: sidebar_open_component,
+      source: sidebar_open_source,
+    },
+    slack: {
+      component: slack_component,
+      source: slack_source,
+    },
+    slack_colorized: {
+      component: slack_colorized_component,
+      source: slack_colorized_source,
+    },
+    smartscalar: {
+      component: smartscalar_component,
+      source: smartscalar_source,
+    },
+    snippet: {
+      component: snippet_component,
+      source: snippet_source,
+    },
+    sparkles: {
+      component: sparkles_component,
+      source: sparkles_source,
+    },
+    star_filled: {
+      component: star_filled_component,
+      source: star_filled_source,
+    },
+    star: {
+      component: star_component,
+      source: star_source,
+    },
+    store: {
+      component: store_component,
+      source: store_source,
+    },
+    string: {
+      component: string_component,
+      source: string_source,
+    },
+    sun: {
+      component: sun_component,
+      source: sun_source,
+    },
+    "t-shirt": {
+      component: t_shirt_component,
+      source: t_shirt_source,
+    },
+    tab: {
+      component: tab_component,
+      source: tab_source,
+    },
+    table: {
+      // for database tables
+      component: table_component,
+      source: table_source,
+    },
+    table2: {
+      // for questions with table visualizations
+      component: table2_component,
+      source: table2_source,
+    },
+    time_history: {
+      component: time_history_component,
+      source: time_history_source,
+    },
+    trash: {
+      component: trash_component,
+      source: trash_source,
+    },
+    trash_filled: {
+      component: trash_filled_component,
+      source: trash_filled_source,
+    },
+    triangle_left: {
+      component: triangle_left_component,
+      source: triangle_left_source,
+    },
+    triangle_right: {
+      component: triangle_right_component,
+      source: triangle_right_source,
+    },
+    unarchive: {
+      component: unarchive_component,
+      source: unarchive_source,
+    },
+    unknown: {
+      component: unknown_component,
+      source: unknown_source,
+    },
+    unpin: {
+      component: unpin_component,
+      source: unpin_source,
+    },
+    unsubscribe: {
+      component: unsubscribe_component,
+      source: unsubscribe_source,
+    },
+    upload: {
+      component: upload_component,
+      source: upload_source,
+    },
+    variable: {
+      component: variable_component,
+      source: variable_source,
+    },
+    verified: {
+      component: verified_component,
+      source: verified_source,
+    },
+    official_collection: {
+      component: official_collection_component,
+      source: official_collection_source,
+    },
+    verified_filled: {
+      component: verified_filled_component,
+      source: verified_filled_source,
+    },
+    view_archive: {
+      component: view_archive_component,
+      source: view_archive_source,
+    },
+    warning: {
+      component: warning_component,
+      source: warning_source,
+    },
+    warning_round_filled: {
+      component: warning_round_filled_component,
+      source: warning_round_filled_source,
+    },
+    waterfall: {
+      component: waterfall_component,
+      source: waterfall_source,
+    },
+    webhook: {
+      component: webhook_component,
+      source: webhook_source,
+    },
+    "10k": {
+      component: ten_thousand_component,
+      source: ten_thousand_source,
+    },
+    "1m": {
+      component: one_million_component,
+      source: one_million_source,
+    },
+    zoom_in: {
+      component: zoom_in_component,
+      source: zoom_in_source,
+    },
+    zoom_out: {
+      component: zoom_out_component,
+      source: zoom_out_source,
+    },
+    scalar: {
+      component: number_component,
+      source: number_source,
+    },
+    cake: {
+      component: birthday_component,
+      source: birthday_source,
+    },
+    external: { component: share_component, source: share_source },
+    table_spaced: { component: table_component, source: table_source },
+    collection: { component: folder_component, source: folder_source },
+    beaker: { component: formula_component, source: formula_source },
+    eye_filled: { component: eye_component, source: eye_source },
+  };
 
-export type IconName = keyof typeof Icons;
+/**
+ * We need a standalone type to prevent adding the `Icons` object (as a type) into `index.d.ts` of Embedding SDK dist
+ */
+export type IconName =
+  | "add"
+  | "add_column"
+  | "add_data"
+  | "add_row"
+  | "add_to_dash"
+  | "ai"
+  | "alert"
+  | "alert_filled"
+  | "alert_confirm"
+  | "archive"
+  | "area"
+  | "attachment"
+  | "arrow_up"
+  | "arrow_down"
+  | "arrow_left"
+  | "arrow_left_to_line"
+  | "arrow_right"
+  | "arrow_split"
+  | "audit"
+  | "badge"
+  | "bar"
+  | "bell"
+  | "birthday"
+  | "bookmark"
+  | "bookmark_filled"
+  | "bolt"
+  | "bolt_filled"
+  | "breakout"
+  | "bubble"
+  | "burger"
+  | "calendar"
+  | "check"
+  | "chevrondown"
+  | "chevronleft"
+  | "chevronright"
+  | "chevronup"
+  | "click"
+  | "clipboard"
+  | "clock"
+  | "clone"
+  | "close"
+  | "cloud"
+  | "cloud_filled"
+  | "compare"
+  | "combine"
+  | "connections"
+  | "contract"
+  | "copy"
+  | "curved"
+  | "database"
+  | "dash"
+  | "dashboard"
+  | "curve"
+  | "document"
+  | "download"
+  | "dyno"
+  | "edit_document"
+  | "ellipsis"
+  | "embed"
+  | "empty"
+  | "enter_or_return"
+  | "expand"
+  | "expand_arrow"
+  | "extract"
+  | "eye"
+  | "eye_crossed_out"
+  | "eye_outline"
+  | "field"
+  | "fields"
+  | "filter"
+  | "filter_plus"
+  | "bug"
+  | "format_code"
+  | "formula"
+  | "function"
+  | "funnel"
+  | "funnel_outline"
+  | "folder"
+  | "folder_filled"
+  | "gauge"
+  | "gear"
+  | "gem"
+  | "globe"
+  | "grabber"
+  | "grid"
+  | "group"
+  | "google"
+  | "google_drive"
+  | "google_sheet"
+  | "history"
+  | "home"
+  | "horizontal_bar"
+  | "hourglass"
+  | "info"
+  | "info_filled"
+  | "info_outline"
+  | "insight"
+  | "int"
+  | "io"
+  | "join_full_outer"
+  | "join_inner"
+  | "join_left_outer"
+  | "join_right_outer"
+  | "index"
+  | "key"
+  | "label"
+  | "ldap"
+  | "learn"
+  | "lightbulb"
+  | "link"
+  | "line"
+  | "lines"
+  | "lineandbar"
+  | "line_style_dashed"
+  | "line_style_dotted"
+  | "line_style_solid"
+  | "list"
+  | "location"
+  | "lock"
+  | "lock_filled"
+  | "mail"
+  | "mail_filled"
+  | "metric"
+  | "model"
+  | "model_with_badge"
+  | "moon"
+  | "move"
+  | "move_card"
+  | "new_folder"
+  | "notebook"
+  | "number"
+  | "palette"
+  | "pause"
+  | "pencil"
+  | "pencil_lines"
+  | "permissions_limited"
+  | "person"
+  | "pie"
+  | "pin"
+  | "pinmap"
+  | "pivot_table"
+  | "play"
+  | "play_outlined"
+  | "popover"
+  | "popular"
+  | "progress"
+  | "pulse"
+  | "recents"
+  | "revert"
+  | "sankey"
+  | "share"
+  | "split"
+  | "sql"
+  | "subscription"
+  | "straight"
+  | "stepped"
+  | "sort"
+  | "sort_arrows"
+  | "sum"
+  | "sync"
+  | "question"
+  | "return"
+  | "reference"
+  | "refresh"
+  | "refresh_downstream"
+  | "rocket"
+  | "ruler"
+  | "search"
+  | "section"
+  | "segment"
+  | "shield"
+  | "sidebar_closed"
+  | "sidebar_open"
+  | "slack"
+  | "slack_colorized"
+  | "smartscalar"
+  | "snippet"
+  | "sparkles"
+  | "star_filled"
+  | "star"
+  | "store"
+  | "string"
+  | "sun"
+  | "t-shirt"
+  | "tab"
+  | "table"
+  | "table2"
+  | "time_history"
+  | "trash"
+  | "trash_filled"
+  | "triangle_left"
+  | "triangle_right"
+  | "unarchive"
+  | "unknown"
+  | "unpin"
+  | "unsubscribe"
+  | "upload"
+  | "variable"
+  | "verified"
+  | "official_collection"
+  | "verified_filled"
+  | "view_archive"
+  | "warning"
+  | "warning_round_filled"
+  | "waterfall"
+  | "webhook"
+  | "10k"
+  | "1m"
+  | "zoom_in"
+  | "zoom_out"
+  | "scalar"
+  | "cake"
+  | "external"
+  | "table_spaced"
+  | "collection"
+  | "beaker"
+  | "eye_filled";
 
 export const iconNames = Object.keys(Icons) as unknown as IconName[];
 


### PR DESCRIPTION
Use public types for Dashboard/Collection/User and other entities.

The PR keeps only ~20 internal generated docs types and reduces the `index.d.ts` file size to `~1400 LOC`

![image](https://github.com/user-attachments/assets/0470bd54-da39-4b29-9b17-8f3deae62341)


How to verify:
- ci should pass