### PR TITLE
Add `permissions_group.magic_group_type`

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11118,6 +11118,35 @@ databaseChangeLog:
             constraintName: fk_metabase_database_metabase_database_id
             onDelete: RESTRICT
 
+
+  - changeSet:
+      id: v55.2025-04-17T08:44:39
+      author: johnswanson
+      comment: Add permissions_group.magic_group_type
+      preConditions: # Not required
+      changes:
+        - addColumn:
+            tableName: permissions_group
+            columns:
+              - column:
+                  name: magic_group_type
+                  type: varchar(254)
+                  remarks: The magic_group_type of the permissions_group
+                  constraints:
+                    unique: true
+                    nullable: true
+
+  - changeSet:
+      id: v55.2025-04-17T08:47:19
+      author: johnswanson
+      comment: Set type on existing permissions groups
+      rollback: #
+      changes:
+        - sql:
+            sql: |
+              UPDATE permissions_group SET magic_group_type='all-internal-users' WHERE name='All Users';
+              UPDATE permissions_group SET magic_group_type='admin' WHERE name='Administrators';
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -670,8 +670,8 @@
                                                              :db_id      db-id
                                                              :created_at #t "2020"
                                                              :updated_at #t "2020"})
-          group-id (t2/insert-returning-pk! :model/PermissionsGroup {:name "Test Group"})]
-      (t2/insert! :model/PermissionsGroupMembership {:user_id user-id :group_id group-id})
+          group-id (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "Test Group"})]
+      (t2/insert! (t2/table-name :model/PermissionsGroupMembership) {:user_id user-id :group_id group-id})
       (migrate!)
       (data-perms/set-table-permission! group-id table-id :perms/view-data :blocked)
       (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id)))
@@ -702,8 +702,8 @@
                                                                  :db_id      db-id
                                                                  :created_at #t "2020"
                                                                  :updated_at #t "2020"})
-          group-id     (t2/insert-returning-pk! :model/PermissionsGroup {:name "Test Group"})]
-      (t2/insert! :model/PermissionsGroupMembership {:user_id user-id :group_id group-id})
+          group-id     (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "Test Group"})]
+      (t2/insert! (t2/table-name :model/PermissionsGroupMembership) {:user_id user-id :group_id group-id})
       (migrate!)
       (data-perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
       (data-perms/set-table-permission! group-id table-id :perms/view-data :blocked)

--- a/test/metabase/permissions/models/permissions_group_test.clj
+++ b/test/metabase/permissions/models/permissions_group_test.clj
@@ -22,12 +22,15 @@
 
 (deftest magic-groups-test
   (testing "check that we can get the magic permissions groups through the helper functions\n"
-    (doseq [[group-name group] {"All Users"      (perms-group/all-users)
-                                "Administrators" (perms-group/admin)}]
+    (doseq [[group-name group magic-group-type]
+            [["All Users"      (perms-group/all-users) perms-group/all-users-magic-group-type]
+             ["Administrators" (perms-group/admin)     perms-group/admin-magic-group-type]]]
       (testing group-name
         (is (mi/instance-of? :model/PermissionsGroup group))
         (is (= group-name
                (:name group)))
+        (is (= magic-group-type
+               (:magic_group_type group)))
         (testing "make sure we're not allowed to delete the magic groups"
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -283,8 +283,8 @@
   (delay
     (schema-migrations-test.impl/with-temp-empty-app-db [conn :h2]
       ;; since the actual group defs are not dynamic, we need with-redefs to change them here
-      (with-redefs [perms-group/all-users (#'perms-group/magic-group perms-group/all-users-group-name)
-                    perms-group/admin     (#'perms-group/magic-group perms-group/admin-group-name)]
+      (with-redefs [perms-group/all-users (#'perms-group/magic-group perms-group/all-users-magic-group-type)
+                    perms-group/admin     (#'perms-group/magic-group perms-group/admin-magic-group-type)]
         (mdb/setup-db! :create-sample-content? false)
         (let [f (java.io.File/createTempFile "db-export" ".sql")]
           (next.jdbc/execute! conn ["SCRIPT TO ?" (str f)])


### PR DESCRIPTION
closes adm-650

and use it as the source of truth for whether a group is the "All Users" or "Administrators" group, instead of just the name.

This is a unique field, but it's nullable. H2, MariaDB, MySQL, and Postgres all treat `null` values as unequal, so it's fine to have many permissions groups without a `magic_group_type`, but any row *with* a `magic_group_type` must be distinct from the others. In other words, we can have lots of non-magic groups and exactly one magic group of each type.

For now, we'll just have the same Administrators and All Users groups and the names won't change. At some point, when tenants are enabled, we'll want to rename "All Users" to "All Internal Users" and create a separate "All External Users" group.
