### PR TITLE
Add Trino mention on Starburst driver name

### DIFF
--- a/modules/drivers/starburst/resources/metabase-plugin.yaml
+++ b/modules/drivers/starburst/resources/metabase-plugin.yaml
@@ -4,7 +4,7 @@ info:
   description: Allows Metabase to connect to Starburst Enterprise, Starburst Galaxy, and Trino query engines.
 driver:
   name: starburst
-  display-name: Starburst
+  display-name: Starburst (Trino)
   lazy-load: true
   parent: sql-jdbc
   connection-properties:


### PR DESCRIPTION
Rename `Starburst` to `Starburst (Trino)` to help customers understand that it is Trino compatible.