### PR TITLE
Use action-agnostic events to trigger table notifications

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/events.clj
@@ -1,5 +1,16 @@
-(ns metabase-enterprise.data-editing.events)
+(ns metabase-enterprise.data-editing.events
+  (:require
+   [metabase.events.notification :as events.notification]))
 
 (derive ::event :metabase/event)
 
-;; there will probably come a day
+(derive :event/rows.created ::event)
+(derive :event/rows.updated ::event)
+(derive :event/rows.deleted ::event)
+
+(doseq [event [:event/rows.created
+               :event/rows.updated
+               :event/rows.deleted]]
+  (defmethod events.notification/notification-filter-for-topic event
+    [_topic event-info]
+    [:= :table_id (-> event-info :args :table_id)]))

--- a/frontend/src/metabase-types/api/mocks/notification.ts
+++ b/frontend/src/metabase-types/api/mocks/notification.ts
@@ -112,9 +112,8 @@ export const createMockTableNotification = (
   payload_id: null,
   payload_type: "notification/system-event",
   payload: {
-    event_name: "event/action.success",
+    event_name: "event/rows.created",
     table_id: 42,
-    action: "bulk/create",
   },
   creator: createMockUserInfo(),
   creator_id: 3,

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -11,9 +11,11 @@ export type NotificationCardSendCondition =
   | "goal_below"
   | "has_result";
 
-export type SystemEvent = "event/action.success";
-
-export type ActionType = "bulk/create" | "bulk/update" | "bulk/delete";
+// The SystemEvent values that can trigger notifications.
+export type NotificationTriggerEvent =
+  | "event/rows.created"
+  | "event/rows.updated"
+  | "event/rows.deleted";
 
 type NotificationPayloadType =
   | "notification/card"
@@ -38,9 +40,8 @@ type NotificationCardPayload = {
 type NotificationSystemEventPayload = {
   payload_type: "notification/system-event";
   payload: {
-    event_name: SystemEvent;
+    event_name: NotificationTriggerEvent;
     table_id: TableId;
-    action: ActionType;
     table?: Table; // hydrated on the BE
   };
   payload_id: null;
@@ -195,8 +196,7 @@ export type UpdateNotificationRequest =
 export type GetNotificationPayloadExampleRequest = {
   payload_type: NotificationPayloadType;
   payload: {
-    event_name: SystemEvent;
-    action: ActionType;
+    event_name: NotificationTriggerEvent;
   };
   creator_id: UserId;
 };

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react";
 
 import { renderWithTheme } from "__support__/ui";
-import { action } from "metabase/lib/urls";
 import type {
   AlertNotification,
   NotificationTriggerEvent,
@@ -50,8 +49,7 @@ const getTableNotificationItem = (
       updated_at: "2025-01-07T12:00:00Z",
       payload_type: "notification/system-event",
       payload: {
-        event_name: "event/action.success",
-        action: action,
+        event_name: event,
         table_id: mockTable.id,
         table: mockTable,
       },
@@ -213,8 +211,8 @@ describe("NotificationCard", () => {
     expect(onArchive).not.toHaveBeenCalled();
   });
 
-  it("should render a table notification with 'bulk created' event", () => {
-    const tableNotification = getTableNotificationItem("bulk/create");
+  it("should render a table notification with 'rows created' event", () => {
+    const tableNotification = getTableNotificationItem("event/rows.created");
     const user = createMockUser();
 
     renderWithTheme(
@@ -237,8 +235,8 @@ describe("NotificationCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render a table notification with 'bulk updated' event", () => {
-    const tableNotification = getTableNotificationItem("bulk/update");
+  it("should render a table notification with 'rows updated' event", () => {
+    const tableNotification = getTableNotificationItem("event/rows.updated");
     const user = createMockUser();
 
     renderWithTheme(
@@ -257,8 +255,8 @@ describe("NotificationCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render a table notification with 'bulk deleted' event", () => {
-    const tableNotification = getTableNotificationItem("bulk/delete");
+  it("should render a table notification with 'rows deleted' event", () => {
+    const tableNotification = getTableNotificationItem("event/rows.updated");
     const user = createMockUser();
 
     renderWithTheme(
@@ -278,7 +276,10 @@ describe("NotificationCard", () => {
   });
 
   it("should render a table notification with custom table name", () => {
-    const tableNotification = getTableNotificationItem("bulk/create", "Orders");
+    const tableNotification = getTableNotificationItem(
+      "event/rows.created",
+      "Orders",
+    );
     const user = createMockUser();
 
     renderWithTheme(

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
@@ -227,7 +227,7 @@ describe("NotificationCard", () => {
     );
 
     expect(
-      screen.getByText("Sample Table table - Row created"),
+      screen.getByText("Sample Table table - Rows created"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("mail icon")).toBeInTheDocument();
     expect(
@@ -251,7 +251,7 @@ describe("NotificationCard", () => {
     );
 
     expect(
-      screen.getByText("Sample Table table - Row updated"),
+      screen.getByText("Sample Table table - Rows updated"),
     ).toBeInTheDocument();
   });
 
@@ -271,7 +271,7 @@ describe("NotificationCard", () => {
     );
 
     expect(
-      screen.getByText("Sample Table table - Row deleted"),
+      screen.getByText("Sample Table table - Rows deleted"),
     ).toBeInTheDocument();
   });
 
@@ -293,7 +293,7 @@ describe("NotificationCard", () => {
       />,
     );
 
-    expect(screen.getByText("Orders table - Row created")).toBeInTheDocument();
+    expect(screen.getByText("Orders table - Rows created")).toBeInTheDocument();
   });
 
   it("should unsubscribe when user is the creator and subscribed with another user", () => {

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, screen } from "@testing-library/react";
 
 import { renderWithTheme } from "__support__/ui";
-import type { ActionType, AlertNotification } from "metabase-types/api";
+import { action } from "metabase/lib/urls";
+import type {
+  AlertNotification,
+  NotificationTriggerEvent,
+} from "metabase-types/api";
 import {
   createMockAlertNotification,
   createMockNotificationCronSubscription,
@@ -27,7 +31,7 @@ const getQuestionAlertItem = (
 });
 
 const getTableNotificationItem = (
-  action: ActionType,
+  event: NotificationTriggerEvent,
   tableName = "Sample Table",
 ): TableNotificationListItem => {
   const mockTable = createMockTable({

--- a/frontend/src/metabase/lib/notifications.ts
+++ b/frontend/src/metabase/lib/notifications.ts
@@ -14,7 +14,6 @@ import {
 } from "metabase-lib/v1/Alert";
 import type Question from "metabase-lib/v1/Question";
 import type {
-  ActionType,
   ChannelApiResponse,
   ChannelType,
   Notification,
@@ -27,8 +26,8 @@ import type {
   NotificationHandlerSlack,
   NotificationRecipient,
   NotificationRecipientRawValue,
+  NotificationTriggerEvent,
   ScheduleSettings,
-  SystemEvent,
   User,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -44,26 +43,21 @@ export const formatTitle = ({ item, type }: NotificationListItem) => {
     case "table-notification": {
       const payload = item.payload;
       return (
-        t`${payload.table!.display_name} table - ${formatEventName(payload.event_name, payload.action)}` ||
+        t`${payload.table!.display_name} table - ${formatEventName(payload.event_name)}` ||
         t`Table Notification`
       );
     }
   }
 };
 
-function formatEventName(event_name: SystemEvent, action: ActionType) {
+function formatEventName(event_name: NotificationTriggerEvent) {
   switch (event_name) {
-    case "event/action.success":
-      switch (action) {
-        case "bulk/create":
-          return t`Rows created`;
-        case "bulk/update":
-          return t`Rows updated`;
-        case "bulk/delete":
-          return t`Rows deleted`;
-        default:
-          return event_name;
-      }
+    case "event/rows.created":
+      return t`Rows created`;
+    case "event/rows.updated":
+      return t`Rows updated`;
+    case "event/rows.deleted":
+      return t`Rows deleted`;
     default:
       return event_name;
   }

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.unit.spec.tsx
@@ -13,10 +13,9 @@ import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { CreateOrEditTableNotificationModal } from "metabase/notifications/modals";
 import type { UserWithApplicationPermissions } from "metabase/plugins";
 import type {
-  ActionType,
   ChannelApiResponse,
   NotificationChannel,
-  SystemEvent,
+  NotificationTriggerEvent,
   TableNotification,
 } from "metabase-types/api";
 import {
@@ -351,8 +350,7 @@ function createMockTableNotification({
   user_id = 1,
 }: {
   id?: number;
-  event_name?: SystemEvent;
-  action?: ActionType;
+  event_name?: NotificationTriggerEvent;
   table_id?: number;
   user_id?: number;
 }): TableNotification {

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.unit.spec.tsx
@@ -179,7 +179,7 @@ describe("CreateOrEditTableNotificationModal", () => {
   it("should show notification data when in edit mode", async () => {
     // Create a custom notification with 'row updated' event
     const mockNotification = createMockTableNotification({
-      action: "bulk/update",
+      event_name: "event/rows.updated",
     });
 
     setup({
@@ -225,11 +225,7 @@ describe("CreateOrEditTableNotificationModal", () => {
     const parsedBody = JSON.parse(requestBody as string);
 
     await waitFor(() => {
-      expect(parsedBody.payload.event_name).toBe("event/action.success");
-    });
-
-    await waitFor(() => {
-      expect(parsedBody.payload.action).toBe("bulk/create");
+      expect(parsedBody.payload.event_name).toBe("event/rows.created");
     });
 
     // Verify it has the default table_id
@@ -275,11 +271,7 @@ describe("CreateOrEditTableNotificationModal", () => {
     const parsedBody = JSON.parse(requestBody as string);
 
     await waitFor(() => {
-      expect(parsedBody.payload.event_name).toBe("event/action.success");
-    });
-
-    await waitFor(() => {
-      expect(parsedBody.payload.action).toBe("bulk/update");
+      expect(parsedBody.payload.event_name).toBe("event/rows.updated");
     });
 
     // Additional assertions...
@@ -297,7 +289,7 @@ describe("CreateOrEditTableNotificationModal", () => {
     // Create a notification with 'row created' event
     const mockNotification = createMockTableNotification({
       id: notificationId,
-      event_name: "event/action.success",
+      event_name: "event/rows.created",
     });
 
     setup({
@@ -334,7 +326,7 @@ describe("CreateOrEditTableNotificationModal", () => {
       return parsedBody; // Return the parsed body for later assertions
     }).then((parsedBody) => {
       // Verify the event has been changed to 'row updated'
-      expect(parsedBody.payload.action).toBe("bulk/update");
+      expect(parsedBody.payload.event).toBe("event/row.updated");
     });
 
     expect(onNotificationUpdatedMock).toHaveBeenCalledTimes(1);
@@ -344,8 +336,7 @@ describe("CreateOrEditTableNotificationModal", () => {
 // Helper function to create a mock table notification
 function createMockTableNotification({
   id = 123,
-  event_name = "event/action.success",
-  action = "bulk/create",
+  event_name = "event/rows.created",
   table_id = 42,
   user_id = 1,
 }: {
@@ -376,7 +367,6 @@ function createMockTableNotification({
     payload: {
       event_name,
       table_id,
-      action,
     },
     payload_id: null,
     condition: ["=", ["field", "id"], 1],

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/types.ts
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/types.ts
@@ -1,6 +1,6 @@
-import type { SystemEvent } from "metabase-types/api";
+import type { NotificationTriggerEvent } from "metabase-types/api";
 
 export type TableNotificationTriggerOption = {
-  value: SystemEvent;
+  value: NotificationTriggerEvent;
   label: string;
 };

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListItem.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListItem.tsx
@@ -12,9 +12,8 @@ import {
 import { getUser } from "metabase/selectors/user";
 import { Box, Group, Text } from "metabase/ui";
 import type {
-  ActionType,
   NotificationChannel,
-  SystemEvent,
+  NotificationTriggerEvent,
   TableNotification,
   User,
 } from "metabase-types/api";
@@ -85,10 +84,7 @@ export const TableNotificationsListItem = ({
       onMouseLeave={handleMouseLeave}
     >
       <Text className={S.itemTitle} size="md" lineClamp={1} fw="bold">
-        {formatTitle(
-          notification.payload.event_name,
-          notification.payload.action,
-        )}
+        {formatTitle(notification.payload.event_name)}
       </Text>
       <Group gap="xs" align="center" c="text-secondary">
         {user && (
@@ -133,19 +129,14 @@ export const TableNotificationsListItem = ({
   );
 };
 
-const formatTitle = (eventName: SystemEvent, action: ActionType): string => {
+const formatTitle = (eventName: NotificationTriggerEvent): string => {
   switch (eventName) {
-    case "event/action.success":
-      switch (action) {
-        case "bulk/create":
-          return t`Notify when new records are created`;
-        case "bulk/update":
-          return t`Notify when records are updated`;
-        case "bulk/delete":
-          return t`Notify when records are deleted`;
-        default:
-          return eventName;
-      }
+    case "event/rows.created":
+      return t`Notify when new records are created`;
+    case "event/rows.updated":
+      return t`Notify when records are updated`;
+    case "event/rows.deleted":
+      return t`Notify when records are deleted`;
     default:
       return t`Notification`;
   }

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/test-utils.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/test-utils.tsx
@@ -96,9 +96,8 @@ export const createNotificationForUser = (
     creator_id: userId,
     // Use payload to make each notification unique for testing
     payload: {
-      event_name: "event/action.success",
+      event_name: "event/rows.created",
       table_id: index + 1,
-      action: "bulk/create",
     },
     payload_id: null,
   };

--- a/frontend/src/metabase/notifications/utils.ts
+++ b/frontend/src/metabase/notifications/utils.ts
@@ -1,13 +1,12 @@
 import type {
-  ActionType,
   CardId,
   ChannelApiResponse,
   CreateAlertNotificationRequest,
   CreateTableNotificationRequest,
   NotificationChannel,
   NotificationHandler,
+  NotificationTriggerEvent,
   ScheduleSettings,
-  SystemEvent,
   TableId,
   UserId,
 } from "metabase-types/api";
@@ -132,8 +131,7 @@ export const getDefaultTableNotificationRequest = ({
   userCanAccessSettings,
 }: {
   tableId: TableId;
-  eventName: SystemEvent;
-  action: ActionType;
+  eventName: NotificationTriggerEvent;
   currentUserId: UserId;
   channelSpec: ChannelApiResponse;
   hookChannels: NotificationChannel[];

--- a/frontend/src/metabase/notifications/utils.ts
+++ b/frontend/src/metabase/notifications/utils.ts
@@ -124,7 +124,6 @@ export const getDefaultQuestionAlertRequest = ({
 export const getDefaultTableNotificationRequest = ({
   tableId,
   eventName,
-  action,
   currentUserId,
   channelSpec,
   hookChannels,
@@ -142,7 +141,6 @@ export const getDefaultTableNotificationRequest = ({
     payload: {
       event_name: eventName,
       table_id: tableId,
-      action,
     },
     payload_id: null,
     handlers: getDefaultChannelConfig({

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -262,7 +262,7 @@
       (catch Exception e
         (let [msg  (ex-message e)
               info (ex-data e)
-              info (with-meta info (merge (meta info) {:exception #p e}))]
+              info (with-meta info (merge (meta info) {:exception e}))]
           (publish-action-failure! invocation-id user-id action-kw msg info)
           (throw e))))))
 

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -208,12 +208,11 @@
 
 (defn publish-action-success!
   "Publish an action success event. This is a success event for the action that was invoked."
-  [invocation-id user-id action-kw args-map result]
+  [invocation-id user-id action-kw result]
   (->> {:action        action-kw
         :invocation_id invocation-id
         :actor_id      user-id
-        :result        result
-        :args          (u/snake-keys args-map)}
+        :result        result}
        (events/publish-event! :event/action.success)))
 
 (defn- publish-action-failure! [invocation-id user-id action-kw msg info]
@@ -231,28 +230,39 @@
   "Eventually, all calls to perform-action! should go through this... Proceeding with caution."
   [action-kw args-map & {:as opts}]
   (let [qry-context       ((requiring-resolve 'metabase-enterprise.data-editing.data-editing/qry-context) args-map)
+        ;; TODO this is totally broken if you create more than 1 row, because we don't know the pk yet (it's just {})
         pk->db-row-before ((requiring-resolve 'metabase-enterprise.data-editing.data-editing/query-previous-rows) action-kw qry-context)
         invocation-id     (nano-id/nano-id)
         user-id           api/*current-user-id*]
     (publish-action-invocation! invocation-id user-id action-kw args-map)
     (try
-      (let [result           (perform-action! action-kw args-map opts)
-            pk->db-row-after ((requiring-resolve 'metabase-enterprise.data-editing.data-editing/query-latest-rows) action-kw qry-context result)
-            all-pks          (set/union (set (keys pk->db-row-before))
-                                        (set (keys pk->db-row-after)))
-            row-changes      (for [pk all-pks
-                                   :let [before (get pk->db-row-before pk)
-                                         after (get pk->db-row-after pk)]
-                                   :when (not= before after)]
-                               {:pk     pk
-                                :before before
-                                :after  after})]
-        (publish-action-success! invocation-id user-id action-kw args-map row-changes)
-        result)
+      (u/prog1 (perform-action! action-kw args-map opts)
+        (publish-action-success! invocation-id user-id action-kw <>)
+
+        ;; process the "data has changed" side effects
+        (let [pk->db-row-after ((requiring-resolve 'metabase-enterprise.data-editing.data-editing/query-latest-rows) action-kw qry-context <>)
+              all-pks          (set/union (set (keys pk->db-row-before))
+                                          (set (keys pk->db-row-after)))
+              row-changes      (for [pk all-pks
+                                     :let [before (get pk->db-row-before pk)
+                                           after  (get pk->db-row-after pk)]
+                                     :when (not= before after)]
+                                 {:pk     pk
+                                  :before before
+                                  :after  after})]
+          (->> {:actor_id      user-id
+                :row-changes   row-changes
+                :args          (u/snake-keys args-map)}
+               (events/publish-event!
+                (case action-kw
+                  :bulk/create :event/rows.created
+                  :bulk/update :event/rows.updated
+                  :bulk/delete :event/rows.deleted)))))
+
       (catch Exception e
         (let [msg  (ex-message e)
               info (ex-data e)
-              info (with-meta info (merge (meta info) {:exception e}))]
+              info (with-meta info (merge (meta info) {:exception #p e}))]
           (publish-action-failure! invocation-id user-id action-kw msg info)
           (throw e))))))
 

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -194,47 +194,48 @@
 ;;                                           System Event                                          ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(def ^:private action->template
-  {:bulk/create {:channel_type :channel/slack
-                 :details      {:type :slack/handlebars-text
-                                :body (str "# {{editor.first_name}} {{editor.last_name}} has created a row for {{table.name}}"
-                                           "\n\n"
-                                           "## Created row:"
-                                           "\n\n"
-                                           "{{#each records}}\n"
-                                           "{{#each this.row}}\n"
-                                           "- {{@key}} : {{@value}}\n"
-                                           "{{/each}}\n"
-                                           "{{/each}}")}}
-   :bulk/update {:channel_type :channel/slack
-                 :details      {:type :slack/handlebars-text
-                                :body (str "# {{editor.first_name}} {{editor.last_name}} has updated a row from {{table.name}}\n\n"
-                                           "\n\n"
-                                           "## Update:"
-                                           "\n\n"
-                                           "{{#each records}}\n"
-                                           "{{#each this.changes}}\n"
-                                           "- {{@key}} : {{@value.after}}\n"
-                                           "{{/each}}\n"
-                                           "{{/each}}")}}
-   :bulk/delete {:channel_type :channel/slack
-                 :details      {:type :slack/handlebars-text
-                                :body (str "# {{editor.first_name}} {{editor.last_name}} has deleted a row from {{table.name}}"
-                                           "\n\n"
-                                           "## Deleted row:"
-                                           "\n\n"
-                                           "{{#each records}}\n"
-                                           "{{#each this.row}}\n"
-                                           "- {{@key}} : {{@value}}\n"
-                                           "{{/each}}\n"
-                                           "{{/each}}")}}})
+(def ^:private event->template
+  {:event/rows.created
+   {:channel_type :channel/slack
+    :details      {:type :slack/handlebars-text
+                   :body (str "# {{editor.first_name}} {{editor.last_name}} has created a row for {{table.name}}"
+                              "\n\n"
+                              "## Created row:"
+                              "\n\n"
+                              "{{#each records}}\n"
+                              "{{#each this.row}}\n"
+                              "- {{@key}} : {{@value}}\n"
+                              "{{/each}}\n"
+                              "{{/each}}")}}
+   :event/rows.updated
+   {:channel_type :channel/slack
+    :details      {:type :slack/handlebars-text
+                   :body (str "# {{editor.first_name}} {{editor.last_name}} has updated a row from {{table.name}}\n\n"
+                              "\n\n"
+                              "## Update:"
+                              "\n\n"
+                              "{{#each records}}\n"
+                              "{{#each this.changes}}\n"
+                              "- {{@key}} : {{@value.after}}\n"
+                              "{{/each}}\n"
+                              "{{/each}}")}}
+   :event/rows.deleted
+   {:channel_type :channel/slack
+    :details      {:type :slack/handlebars-text
+                   :body (str "# {{editor.first_name}} {{editor.last_name}} has deleted a row from {{table.name}}"
+                              "\n\n"
+                              "## Deleted row:"
+                              "\n\n"
+                              "{{#each records}}\n"
+                              "{{#each this.row}}\n"
+                              "- {{@key}} : {{@value}}\n"
+                              "{{/each}}\n"
+                              "{{/each}}")}}})
 
 (mu/defmethod channel/render-notification [:channel/slack :notification/system-event] :- [:sequential SlackMessage]
   [_channel-type {:keys [context] :as notification-payload} template recipients]
   (let [event-name (:event_name context)
-        template    (or template
-                        (when (= :event/action.success event-name)
-                          (get action->template (:action context))))]
+        template    (or template (get event->template event-name))]
     (assert template (str "No template found for event " event-name))
     (if-not template
       []

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -15,7 +15,8 @@
    [metabase.task :as task]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import (org.quartz TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -265,7 +266,7 @@
   ([subscription-id cron-schedule]
    (subscription->trigger-info subscription-id cron-schedule "UTC"))
   ([subscription-id cron-schedule timezone]
-   {:key      (.getName (#'task.notification/send-notification-trigger-key subscription-id))
+   {:key      (.getName ^TriggerKey (#'task.notification/send-notification-trigger-key subscription-id))
     :schedule cron-schedule
     :data     {"subscription-id" subscription-id}
     :timezone timezone}))


### PR DESCRIPTION
Decouple table notifications from the batch events, since single row updates will need to trigger the notifications as well.

This was also important because the current implemented *lied* about the result of the action, returning completely different data in the event.

Moves back to using a custom event. For now this is still only being published when we perform bulk actions, and even then only when they're called from the table APIs, but that's getting fixed next.

To simplify the FE changes I simply dropped the ability to subscribe to actions directly for now, I suspect we're a far way off from needing that again.

I think it makes sense to take this further, and publish a single event with all relevant creates, updates, and deletes combined, for the case of compound events. The current notifications would then need to filter to only the diffs they care about, and suppress themselves if there are no records. This is somewhat similar to our idea of filtering on which columns were changed, and to which values.