### PR TITLE
Downgrade clickhouse jdbc driver to v1

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -25,7 +25,7 @@
 
 (set! *warn-on-reflection* true)
 
-(System/setProperty "clickhouse.jdbc.v2" "true")
+(System/setProperty "clickhouse.jdbc.v1" "true")
 (driver/register! :clickhouse :parent #{:sql-jdbc})
 
 (defmethod driver/display-name :clickhouse [_] "ClickHouse")


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56690

### Description

Downgrade clickhouse jdbc driver to v1 to solve ? problem.

When you have a ? in a literal string or in a comment, it confuses the jdbc params recognition system.
