### PR TITLE
Enable :expression-literals for sqlserver

### DIFF
--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -525,6 +525,106 @@
                           :columns
                           (map :base_type)))))))))))
 
+(deftest ^:parallel top-level-boolean-expressions-test
+  (mt/test-driver :sqlserver
+    (testing "BIT values like 0 and 1 get converted to equivalent boolean expressions"
+      (let [true-value  [:value true {:base_type :type/Boolean}]
+            false-value [:value false {:base_type :type/Boolean}]]
+        (letfn [(orders-query [args]
+                  (-> (mt/mbql-query orders
+                        {:expressions {"MyTrue"  true-value
+                                       "MyFalse" false-value}
+                         :fields      [[:expression "MyTrue"]]
+                         :limit       1})
+                      (update :query merge args)))]
+          (doseq [{:keys [desc query expected-sql expected-rows]}
+                  [{:desc "true filter"
+                    :query
+                    (orders-query {:filter true-value})
+                    :expected-sql
+                    {:query ["SELECT"
+                             "  TOP(1) ? AS MyTrue"
+                             "FROM"
+                             "  dbo.orders"
+                             "WHERE"
+                             "  ? = ?"]
+                     :params [1 1 1]}
+                    :expected-rows
+                    [[1]]}
+                   {:desc "false filter"
+                    :query
+                    (orders-query {:filter false-value})
+                    :expected-sql
+                    {:query ["SELECT"
+                             "  TOP(1) ? AS MyTrue"
+                             "FROM"
+                             "  dbo.orders"
+                             "WHERE"
+                             "  ? = ?"]
+                     :params [1 0 1]}
+                    :expected-rows
+                    []}
+                   {:desc "not filter"
+                    :query
+                    (orders-query {:filter [:not false-value]})
+                    :expected-sql
+                    {:query ["SELECT"
+                             "  TOP(1) ? AS MyTrue"
+                             "FROM"
+                             "  dbo.orders"
+                             "WHERE"
+                             "  NOT (? = ?)"]
+                     :params [1 0 1]}
+                    :expected-rows
+                    [[1]]}
+                   {:desc "nested logical operators"
+                    :query
+                    (orders-query {:filter [:and
+                                            [:not false-value]
+                                            [:or
+                                             [:expression "MyFalse"]
+                                             [:expression "MyTrue"]]]})
+                    :expected-sql
+                    {:query ["SELECT"
+                             "  TOP(1) ? AS MyTrue"
+                             "FROM"
+                             "  dbo.orders"
+                             "WHERE"
+                             "  NOT (? = ?)"
+                             "  AND ("
+                             "    (? = ?)"
+                             "    OR (? = ?)"
+                             "  )"]
+                     :params [1 0 1 0 1 1 1]}
+                    :expected-rows
+                    [[1]]}
+                   ;; only top-level booleans should be transformed; otherwise an expression like 1 = 1 gets compiled
+                   ;; to (1 = 1) = (1 = 1)
+                   {:desc "non-top-level booleans"
+                    :query
+                    (orders-query {:filter [:= true-value true-value]})
+                    :expected-sql
+                    {:query ["SELECT"
+                             "  TOP(1) ? AS MyTrue"
+                             "FROM"
+                             "  dbo.orders"
+                             "WHERE"
+                             "  ? = ?"]
+                     :params [1 1 1]}
+                    :expected-rows
+                    [[1]]}]]
+            (testing (format "\n%s\nMBQL query = %s\n" desc query)
+              (testing "Should generate the correct SQL query"
+                (is (= expected-sql
+                       (-> query
+                           qp.compile/compile
+                           (update :query pretty-sql)))))
+              (testing "Should return correct results"
+                (is (= expected-rows
+                       (->> query
+                            qp/process-query
+                            mt/rows)))))))))))
+
 (deftest filter-by-datetime-fields-test
   (mt/test-driver :sqlserver
     (testing "Should match datetime fields even in non-default timezone (#30454)"

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -404,7 +404,7 @@
                                                [:aggregation-options [:sum [:expression "Two"]] {:name "SumTwo"}]
                                                [:aggregation-options [:min [:expression "Bob"]] {:name "MinBob"}]]
                                 :breakout     [$category_id]
-                                :filters      [[:= 2.0 [:* [:expression "Two"] [:expression "AvgOne"]]]]}
+                                :filters      [[:= 2.0 [:* [:expression "Two"] [:expression "One"]]]]}
                  :filters      [[:!= *MinBob/Text [:expression "Name"]]
                                 [:= true [:expression "True"]]
                                 [:= [:expression "True"] true]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -690,23 +690,22 @@
 (deftest ^:parallel joined-literal-expression-test
   (testing "joined literal expression"
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :expression-literals :left-join :nested-queries)
-      (is (= [[2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "25°"]
-              [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "In-N-Out Burger"]
-              [2 "Stout Burgers & Beers" 2 0.5 true 1 "Stout Burgers & Beers" "The Apple Pan"]]
+      (is (= [[2 "Stout Burgers & Beers" 2 0.5 1 "Stout Burgers & Beers" "25°"]
+              [2 "Stout Burgers & Beers" 2 0.5 1 "Stout Burgers & Beers" "In-N-Out Burger"]
+              [2 "Stout Burgers & Beers" 2 0.5 1 "Stout Burgers & Beers" "The Apple Pan"]]
              (mt/formatted-rows
-              [int str int 1.0 mt/boolish->bool int str str]
+              [int str int 1.0 int str str]
               (mt/run-mbql-query venues
                 {:fields      [$id
                                $name
                                $price
                                [:expression "InversePrice"]
-                               [:expression "NameEquals"]
                                &JoinedCategories.*LiteralInt/Integer
                                &JoinedCategories.*LiteralString/Text
                                &JoinedCategories.venues.name]
                  :expressions {"InversePrice"  [:/ &JoinedCategories.*LiteralInt/Integer $price]
                                "NameEquals"    [:= &JoinedCategories.*LiteralString/Text $name]}
-                 :filters     [[:= true [:expression "NameEquals"]]]
+                 :filters     [[:expression "NameEquals"]]
                  :joins       [{:strategy     :left-join
                                 :condition    [:= $category_id &JoinedCategories.venues.category_id]
                                 :source-query {:source-table $$venues


### PR DESCRIPTION
Closes QUE-859

### Description

Enable the `:expression-literals` feature on `:sqlserver`.

Convert 0 and 1 boolean constants to an equivalent boolean expression in the top-level of filter clauses and `:and` and `:or` expressions.

### How to verify

sqlserver now passes existing `:expression-literal` tests

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
