### PR TITLE
Make edit db form tab-able

### DIFF
--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -72,7 +72,7 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
           </Route>
         </Route>
         <Route path=":databaseId" component={DatabaseEditApp}>
-          <ModalRoute path="edit" modal={DatabaseConnectionModal} />
+          <ModalRoute path="edit" modal={DatabaseConnectionModal} noWrap />
           {PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes(IsAdmin)}
         </Route>
       </Route>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #56499
Closes ADM-641

### Description

Fix issue where a modal was in a modal causing the focus to get trapped in the wrong modal, prevent users from being able to tab through the edit database form.

### How to verify

- Go to admin settings database database page
- Edit db connection
- You should be able to tab through the form now

### Demo

https://github.com/user-attachments/assets/50c27c26-f177-4fb2-9732-930b8aa8737c

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
If someone feels the juice is worth the squeeze I'll add tests, but personally I don't think it's worth it.