### PR TITLE
WRK-250: Add autocomplete for handlebars fns and helpers

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -370,7 +370,7 @@ interface PublicSettings {
   "default-handlebars-helpers"?: Array<{
     name: string;
     doc: string;
-    type: "built-in" | "custom-block" | "custom-inline";
+    type: "built-in" | "custom";
   }>;
   "email-configured?": boolean;
   "embedding-app-origin": string | null;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -367,6 +367,11 @@ interface PublicSettings {
   "custom-homepage": boolean;
   "custom-homepage-dashboard": DashboardId | null;
   "ee-ai-features-enabled"?: boolean;
+  "default-handlebars-helpers"?: Array<{
+    name: string;
+    doc: string;
+    type: "built-in" | "custom-block" | "custom-inline";
+  }>;
   "email-configured?": boolean;
   "embedding-app-origin": string | null;
   "embedding-app-origins-sdk": string | null;

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.tsx
@@ -256,7 +256,7 @@ describe("NotificationCard", () => {
   });
 
   it("should render a table notification with 'rows deleted' event", () => {
-    const tableNotification = getTableNotificationItem("event/rows.updated");
+    const tableNotification = getTableNotificationItem("event/rows.deleted");
     const user = createMockUser();
 
     renderWithTheme(

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
@@ -295,6 +295,7 @@ export const CreateOrEditTableNotificationModal = ({
         </AlertModalSettingsBlock>
         <AlertModalSettingsBlock
           title={t`Where do you want to send the alerts?`}
+          contentProps={{ style: { overflow: "visible" } }}
         >
           <NotificationChannelsPicker
             enableTemplates

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.unit.spec.tsx
@@ -33,6 +33,7 @@ import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 describe("CreateOrEditTableNotificationModal", () => {
   beforeEach(() => {
     fetchMock.reset();
+    fetchMock.post("path:/api/notification/payload", { body: { id: 123 } });
   });
 
   afterEach(() => {
@@ -172,7 +173,7 @@ describe("CreateOrEditTableNotificationModal", () => {
       screen.getByRole("option", { name: /When any cell changes it's value/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: /When a records are deleted/i }),
+      screen.getByRole("option", { name: /When records are deleted/i }),
     ).toBeInTheDocument();
   });
 
@@ -326,7 +327,7 @@ describe("CreateOrEditTableNotificationModal", () => {
       return parsedBody; // Return the parsed body for later assertions
     }).then((parsedBody) => {
       // Verify the event has been changed to 'row updated'
-      expect(parsedBody.payload.event).toBe("event/row.updated");
+      expect(parsedBody.payload.event_name).toBe("event/rows.updated");
     });
 
     expect(onNotificationUpdatedMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
@@ -140,9 +140,8 @@ describe("TableNotificationsListModal", () => {
     const currentUserId = 1;
     const notification = createNotificationForUser(currentUserId, 0, {
       payload: {
-        event_name: "event/action.success",
+        event_name: "event/rows.updated",
         table_id: 1,
-        action: "bulk/update",
       },
     });
     const onEdit = jest.fn();
@@ -168,9 +167,8 @@ describe("TableNotificationsListModal", () => {
     const currentUserId = 1;
     const notification = createNotificationForUser(currentUserId, 0, {
       payload: {
-        event_name: "event/action.success",
+        event_name: "event/rows.deleted",
         table_id: 1,
-        action: "bulk/delete",
       },
     });
     const onDelete = jest.fn();

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
@@ -215,7 +215,7 @@ describe("TableNotificationsListModal", () => {
 
     // Verify the notification is rendered
     const notificationTitle = screen.getByText(
-      "Notify when records are created",
+      "Notify when new records are created",
     );
     expect(notificationTitle).toBeInTheDocument();
 

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/TableNotificationsListModal.unit.spec.tsx
@@ -138,7 +138,13 @@ describe("TableNotificationsListModal", () => {
 
   it("should call onEdit when edit button is clicked", async () => {
     const currentUserId = 1;
-    const notification = createNotificationForUser(currentUserId);
+    const notification = createNotificationForUser(currentUserId, 0, {
+      payload: {
+        event_name: "event/action.success",
+        table_id: 1,
+        action: "bulk/update",
+      },
+    });
     const onEdit = jest.fn();
 
     setup({
@@ -151,7 +157,7 @@ describe("TableNotificationsListModal", () => {
     // Clicking on the notification item itself triggers edit
     // We'll click directly on the title which is part of the notification item
     const notificationTitle = screen.getByText(
-      "Notify when new records are created",
+      "Notify when records are updated",
     );
     await userEvent.click(notificationTitle);
 
@@ -160,7 +166,13 @@ describe("TableNotificationsListModal", () => {
 
   it("should call onDelete when delete button is clicked", async () => {
     const currentUserId = 1;
-    const notification = createNotificationForUser(currentUserId);
+    const notification = createNotificationForUser(currentUserId, 0, {
+      payload: {
+        event_name: "event/action.success",
+        table_id: 1,
+        action: "bulk/delete",
+      },
+    });
     const onDelete = jest.fn();
 
     setup({
@@ -172,7 +184,7 @@ describe("TableNotificationsListModal", () => {
 
     // Get the notification title and test that it's rendered
     const notificationTitle = screen.getByText(
-      "Notify when new records are created",
+      "Notify when records are deleted",
     );
     expect(notificationTitle).toBeInTheDocument();
 
@@ -205,7 +217,7 @@ describe("TableNotificationsListModal", () => {
 
     // Verify the notification is rendered
     const notificationTitle = screen.getByText(
-      "Notify when new records are created",
+      "Notify when records are created",
     );
     expect(notificationTitle).toBeInTheDocument();
 

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/test-utils.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/TableNotificationsListModal/test-utils.tsx
@@ -88,6 +88,7 @@ export const setup = ({
 export const createNotificationForUser = (
   userId: number,
   index = 0,
+  extra?: Partial<TableNotification>,
 ): TableNotification => {
   return {
     ...createMockTableNotification(),
@@ -100,5 +101,6 @@ export const createNotificationForUser = (
       table_id: index + 1,
     },
     payload_id: null,
+    ...extra,
   };
 };

--- a/frontend/src/metabase/notifications/modals/shared/components/AlertModalSettingsBlock/AlertModalSettingsBlock.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/AlertModalSettingsBlock/AlertModalSettingsBlock.tsx
@@ -1,18 +1,20 @@
 import type { ReactNode } from "react";
 
-import { Box, Stack, type StackProps, Text } from "metabase/ui";
+import { Box, type BoxProps, Stack, type StackProps, Text } from "metabase/ui";
 
 import styles from "./AlertModalSettingsBlock.module.css";
 
 type AlertModalSettingsBlockProps = {
   title: string;
   children: ReactNode;
+  contentProps?: BoxProps;
 } & StackProps;
 
 export const AlertModalSettingsBlock = ({
   title,
   children,
   className,
+  contentProps,
   ...stackProps
 }: AlertModalSettingsBlockProps) => {
   return (
@@ -20,7 +22,9 @@ export const AlertModalSettingsBlock = ({
       <Text size="lg" lineClamp={1}>
         {title}
       </Text>
-      <Box className={styles.contentContainer}>{children}</Box>
+      <Box className={styles.contentContainer} {...contentProps}>
+        {children}
+      </Box>
     </Stack>
   );
 };

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -555,7 +555,6 @@ export const NotificationChannelsPicker = ({
                         variant="textinput"
                         placeholder={t`Alert from {{payload.result.table.name}} table`}
                         templateContext={parsedTemplateContext} // Pass parsed context
-                        minHeight="auto"
                         defaultValue={getTemplateValue("email", "subject")}
                         onBlur={(newValue) => {
                           handleTemplateBlur("email", "subject", newValue);

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.module.css
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.module.css
@@ -32,6 +32,10 @@
     color: var(--mb-color-text-light);
   }
 
+  :global(.cm-tooltip .cm-completionInfo) {
+    line-height: 1.2;
+  }
+
   &.textInputVariant {
     :global(.cm-editor) {
       padding: 0 var(--mantine-spacing-sm);

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -1,10 +1,4 @@
-import {
-  type CompletionContext,
-  type CompletionResult,
-  type CompletionSource,
-  autocompletion,
-  completionKeymap,
-} from "@codemirror/autocomplete";
+import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
 import {
   defaultHighlightStyle,
   syntaxHighlighting,
@@ -27,78 +21,10 @@ import { isNotNull } from "metabase/lib/types";
 import { Text } from "metabase/ui";
 
 import S from "./TemplateEditor.module.css";
-
-// Helper function to recursively find all leaf paths in an object
-function getAllPaths(obj: any, currentPath = ""): string[] {
-  let paths: string[] = [];
-  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
-    return [];
-  }
-
-  for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      const newPath = currentPath ? `${currentPath}.${key}` : key;
-      const value = obj[key];
-
-      if (
-        typeof value === "object" &&
-        value !== null &&
-        !Array.isArray(value) &&
-        value.constructor === Object
-      ) {
-        paths = paths.concat(getAllPaths(value, newPath));
-      } else {
-        paths.push(newPath);
-      }
-    }
-  }
-  return paths;
-}
-
-// Build a set of all possible paths for autocomplete from provided payload object.
-const createTemplateAutocompleteSource = (
-  context: Record<string, any>,
-): CompletionSource => {
-  const allSortedPaths = getAllPaths(context).sort();
-
-  return (completionContext: CompletionContext): CompletionResult | null => {
-    const word = completionContext.matchBefore(/{{\s*(?:[\w#-]+\s+)*([\w.]*)$/);
-
-    if (!word || word.text.startsWith("{{/")) {
-      return null;
-    }
-
-    const matchResult = word.text.match(/{{\s*(?:[\w#-]+\s+)*([\w.]*)$/);
-    const pathPrefix = matchResult ? matchResult[1] : "";
-
-    if (!matchResult) {
-      return null;
-    }
-
-    const from = word.to - pathPrefix.length;
-
-    const matchingPaths = allSortedPaths.filter((p) =>
-      p.startsWith(pathPrefix),
-    );
-
-    if (matchingPaths.length === 0) {
-      return null;
-    }
-
-    const options = matchingPaths.map((fullPath) => ({
-      label: fullPath,
-      apply: fullPath,
-      type: "variable",
-    }));
-
-    return {
-      from: from,
-      to: word.to,
-      options: options,
-      filter: false,
-    };
-  };
-};
+import {
+  createTemplateAutocompleteSource,
+  mustacheHelpersCompletionSource,
+} from "./autocomplete";
 
 export interface TemplateEditorProps
   extends Omit<
@@ -191,11 +117,16 @@ export const TemplateEditor = ({
   }, [onBlur]);
 
   const templateAutocompleteExtension = useMemo(() => {
-    return templateContext
-      ? autocompletion({
-          override: [createTemplateAutocompleteSource(templateContext)],
-        })
-      : [];
+    if (!templateContext) {
+      return [];
+    }
+    // Combine both Mustache helpers and context path completions
+    return autocompletion({
+      override: [
+        mustacheHelpersCompletionSource,
+        createTemplateAutocompleteSource(templateContext),
+      ],
+    });
   }, [templateContext]);
 
   const combinedExtensions = useMemo(() => {

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -25,6 +25,7 @@ import {
   createTemplateAutocompleteSource,
   mustacheHelpersCompletionSource,
 } from "./autocomplete";
+import { useSetting } from "metabase/common/hooks";
 
 export interface TemplateEditorProps
   extends Omit<
@@ -94,6 +95,8 @@ export const TemplateEditor = ({
   onBlur,
   ...rest
 }: TemplateEditorProps) => {
+  const helpers = useSetting("default-handlebars-helpers");
+  console.log({ helpers });
   const ref = useRef<ReactCodeMirrorRef>(null);
   const [internalValue, setInternalValue] = useState(defaultValue);
 
@@ -123,11 +126,11 @@ export const TemplateEditor = ({
     // Combine both Mustache helpers and context path completions
     return autocompletion({
       override: [
-        mustacheHelpersCompletionSource,
-        createTemplateAutocompleteSource(templateContext),
+        mustacheHelpersCompletionSource(helpers),
+        createTemplateAutocompleteSource(templateContext, helpers),
       ],
     });
-  }, [templateContext]);
+  }, [templateContext, helpers]);
 
   const combinedExtensions = useMemo(() => {
     return [

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -12,6 +12,7 @@ import CodeMirror, {
 import cx from "classnames";
 import React, { Fragment, useMemo, useRef, useState } from "react";
 
+import { useSetting } from "metabase/common/hooks";
 import type { CodeLanguage } from "metabase/components/CodeBlock/types";
 import {
   getLanguageExtension,
@@ -25,7 +26,6 @@ import {
   createTemplateAutocompleteSource,
   mustacheHelpersCompletionSource,
 } from "./autocomplete";
-import { useSetting } from "metabase/common/hooks";
 
 export interface TemplateEditorProps
   extends Omit<
@@ -96,7 +96,6 @@ export const TemplateEditor = ({
   ...rest
 }: TemplateEditorProps) => {
   const helpers = useSetting("default-handlebars-helpers");
-  console.log({ helpers });
   const ref = useRef<ReactCodeMirrorRef>(null);
   const [internalValue, setInternalValue] = useState(defaultValue);
 

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
@@ -5,6 +5,8 @@ import type {
   CompletionSource,
 } from "@codemirror/autocomplete";
 
+import type { Settings } from "metabase-types/api";
+
 // Type helper for consistent completion options
 export type MustacheCompletionOption = Completion & {
   type: "keyword" | "variable" | "function";
@@ -37,31 +39,6 @@ function getAllPaths(obj: any, currentPath = ""): string[] {
   return paths;
 }
 
-// Define helper categories clearly
-const BLOCK_HELPERS = ["each", "if", "unless", "with"];
-const METABASE_HELPERS = [
-  "count",
-  "format-date",
-  "now",
-  "card-url",
-  "trash-url",
-  "dashboard-url",
-];
-const INLINE_CONDITIONAL_HELPERS = [
-  "and",
-  "empty",
-  "else",
-  "eq",
-  "gt",
-  "gte",
-  "lookup",
-  "lt",
-  "lte",
-  "ne",
-  "or",
-  "not",
-];
-
 // Helper to compute the currently open block helper (for closing tag suggestions)
 function getOpenBlockHelper(text: string): string | undefined {
   const openBlockPattern = /{{\s*#(\w+)\b.*?}}/gs;
@@ -86,42 +63,86 @@ function getOpenBlockHelper(text: string): string | undefined {
   return blockStack.pop();
 }
 
-// Suggest block helpers, Metabase helpers, and closing tags based on context
-export const mustacheHelpersCompletionSource: CompletionSource = (
-  completionContext: CompletionContext,
-): CompletionResult | null => {
-  const textBefore = completionContext.state.doc.sliceString(
-    0,
-    completionContext.pos,
-  );
-  const lastOpenMustache = textBefore.lastIndexOf("{{");
-  const lastCloseMustache = textBefore.lastIndexOf("}}");
+// --- Utility functions for shared logic ---
+function isInsideOpenMustache(textBefore: string): boolean {
+  const lastOpen = textBefore.lastIndexOf("{{");
+  const lastClose = textBefore.lastIndexOf("}}");
+  return lastOpen > lastClose;
+}
 
-  // Only provide suggestions if inside an unclosed {{ }} block
-  if (lastOpenMustache > lastCloseMustache) {
-    // Context 1: Typing opening helper or variable (NOT inside parentheses)
-    const blockContent = textBefore.substring(lastOpenMustache);
-    let parenLevel = 0;
-    for (const char of blockContent) {
-      if (char === "(") {
-        parenLevel++;
-      } else if (char === ")") {
-        parenLevel--;
-      }
+function getParenLevel(text: string): number {
+  let level = 0;
+  for (const char of text) {
+    if (char === "(") {
+      level++;
+    } else if (char === ")") {
+      level--;
     }
+  }
+  return level;
+}
+
+function extractPrefix(
+  textBefore: string,
+  pos: number,
+): { prefix: string; start: number } | null {
+  const match = textBefore.match(/[\w\.]*$/);
+  if (!match) {
+    return null;
+  }
+  return { prefix: match[0], start: match.index ?? pos };
+}
+
+function createCompletionOptions(
+  labels: string[],
+  type: "keyword" | "variable" | "function",
+  boost = 1,
+): MustacheCompletionOption[] {
+  return labels.map((label) => ({ label, type, boost }));
+}
+
+// Suggest block helpers, Metabase helpers, and closing tags based on context
+export const mustacheHelpersCompletionSource =
+  (helpers: Settings["default-handlebars-helpers"] = []) =>
+  (completionContext: CompletionContext): CompletionResult | null => {
+    const builtinBlockHelpers = helpers
+      .filter((helper) => helper.type === "built-in")
+      .map((helper) => helper.name);
+    const mbBlockHelpers = helpers
+      .filter((helper) => helper.type === "custom-block")
+      .map((helper) => helper.name);
+
+    const textBefore = completionContext.state.doc.sliceString(
+      0,
+      completionContext.pos,
+    );
+    if (!isInsideOpenMustache(textBefore)) {
+      return null;
+    }
+
+    // Context 1: Typing opening helper or variable (NOT inside parentheses)
+    const blockContent = textBefore.substring(textBefore.lastIndexOf("{{"));
+    const parenLevel = getParenLevel(blockContent);
 
     // Context 2: Typing a closing helper {{/
     const closeMatch = completionContext.matchBefore(/{{\/\w*$/); // Allow space after /
     if (closeMatch) {
       const currentlyOpenHelper = getOpenBlockHelper(textBefore);
-      if (!currentlyOpenHelper) return null;
+      if (!currentlyOpenHelper) {
+        return null;
+      }
       const prefixMatch = closeMatch.text.match(/\w*$/);
-      const options: MustacheCompletionOption[] = BLOCK_HELPERS.filter(
-        (helperName) =>
-          helperName === currentlyOpenHelper &&
-          helperName.startsWith(prefixMatch ? prefixMatch[0] : ""),
-      ).map((helperName) => ({ label: helperName, type: "keyword" }));
-      if (options.length === 0) return null;
+      const options = createCompletionOptions(
+        builtinBlockHelpers.filter(
+          (helperName) =>
+            helperName === currentlyOpenHelper &&
+            helperName.startsWith(prefixMatch ? prefixMatch[0] : ""),
+        ),
+        "keyword",
+      );
+      if (options.length === 0) {
+        return null;
+      }
       return {
         from: prefixMatch
           ? closeMatch.from + (prefixMatch.index ?? 0)
@@ -139,36 +160,32 @@ export const mustacheHelpersCompletionSource: CompletionSource = (
         let options: MustacheCompletionOption[];
         if (startsWithHash) {
           const typedAfterHash = openMatch.text.match(/\s*#(\w*)$/)?.[1] || "";
-          options = BLOCK_HELPERS.filter((helper) =>
-            helper.startsWith(typedAfterHash),
-          ).map((helperName) => ({
-            label: helperName,
-            type: "keyword",
-            boost: 99,
-          }));
-        } else {
-          const blockOptions: MustacheCompletionOption[] = BLOCK_HELPERS.map(
-            (helperName) => ({
-              label: `#${helperName}`,
-              type: "keyword",
-              boost: 1,
-            }),
+          options = createCompletionOptions(
+            builtinBlockHelpers.filter((helper) =>
+              helper.startsWith(typedAfterHash),
+            ),
+            "keyword",
+            99,
           );
-          const metabaseOptions: MustacheCompletionOption[] =
-            METABASE_HELPERS.map((label) => ({
-              label,
-              type: "function",
-              boost: 1,
-            }));
+        } else {
+          const blockOptions = createCompletionOptions(
+            builtinBlockHelpers.map((helperName) => `#${helperName}`),
+            "keyword",
+            1,
+          );
+          const metabaseOptions = createCompletionOptions(
+            mbBlockHelpers,
+            "function",
+            1,
+          );
           options = blockOptions.concat(metabaseOptions);
         }
         // Add proactive closing tag suggestion
         const currentlyOpenHelper = getOpenBlockHelper(textBefore);
         if (currentlyOpenHelper) {
           const closingTag = `/${currentlyOpenHelper}`;
-          const closingLabel = `/${currentlyOpenHelper}`;
           const closingOption: MustacheCompletionOption = {
-            label: closingLabel,
+            label: closingTag,
             type: "keyword",
             apply: closingTag,
             boost: 5,
@@ -198,158 +215,113 @@ export const mustacheHelpersCompletionSource: CompletionSource = (
         }
       }
     }
-  }
-  return null; // No context matched
-};
+    return null; // No context matched
+  };
 
 // Build suggestions for template variables AND helpers inside parentheses
 export const createTemplateAutocompleteSource = (
   context: Record<string, any>,
+  helpers: Settings["default-handlebars-helpers"],
 ): CompletionSource => {
+  const mbInlineHelpers = helpers
+    .filter((helper) => helper.type === "custom-inline")
+    .map((helper) => helper.name);
   // Precompute all possible paths once
   const allVarPaths = getAllPaths(context);
-  // Generate base options with full paths as labels
-  const baseVarOptions: MustacheCompletionOption[] = allVarPaths.map(
-    (path) => ({
-      label: path,
-      type: "variable",
-      boost: -1, // Lower boost than helpers
-    }),
+  const baseVarOptions = createCompletionOptions(allVarPaths, "variable", -1);
+  const inlineHelperOptions = createCompletionOptions(
+    mbInlineHelpers,
+    "keyword",
+    1,
   );
-
-  const inlineHelperOptions: MustacheCompletionOption[] =
-    INLINE_CONDITIONAL_HELPERS.map((label) => ({
-      label,
-      type: "keyword",
-      boost: 1, // Higher boost than variables
-    }));
 
   return (completionContext: CompletionContext): CompletionResult | null => {
     const { state, pos } = completionContext;
     const textBefore = state.doc.sliceString(0, pos);
-
-    // Ensure we are inside an active {{ block
-    const lastOpenMustache = textBefore.lastIndexOf("{{");
-    const lastCloseMustache = textBefore.lastIndexOf("}}");
-    if (lastOpenMustache <= lastCloseMustache) {
-      return null; // Not inside an active {{ block
-    }
-
-    // Get prefix and its start position
-    const prefixMatch = textBefore.match(/[\w\.]*$/);
-    // We need prefixMatch to proceed
-    if (prefixMatch === null) {
+    if (!isInsideOpenMustache(textBefore)) {
       return null;
     }
-    const prefixStartPos = prefixMatch.index ?? pos;
+
+    const prefixObj = extractPrefix(textBefore, pos);
+    if (!prefixObj) {
+      return null;
+    }
+    const { prefix, start: prefixStartPos } = prefixObj;
 
     // Check if likely inside parentheses
-    // A simple check: is there an unclosed '(' between the last {{ and the prefix start?
-    const contentSinceMustache = textBefore.substring(lastOpenMustache);
+    const contentSinceMustache = textBefore.substring(
+      textBefore.lastIndexOf("{{"),
+    );
     const parensCheckText = contentSinceMustache.slice(
       0,
-      prefixStartPos - lastOpenMustache,
+      prefixStartPos - textBefore.lastIndexOf("{{"),
     );
-    let parenLevel = 0;
-    for (const char of parensCheckText) {
-      if (char === "(") {
-        parenLevel++;
-      } else if (char === ")") {
-        parenLevel--;
-      }
-    }
+    const parenLevel = getParenLevel(parensCheckText);
     const isInsideParens = parenLevel > 0;
 
     let optionsToSuggest: MustacheCompletionOption[] = [];
     let resultFrom = prefixStartPos;
 
     if (isInsideParens) {
-      const input = prefixMatch[0];
-      // *** Inside Parentheses Logic ***
-      if (input.includes(".")) {
-        // Object path completion (e.g., user.)
-        const lastDotIndex = input.lastIndexOf(".");
-        const basePath = input.substring(0, lastDotIndex + 1);
-        // The filter should be applied only to the part after the last dot
+      if (prefix.includes(".")) {
+        const lastDotIndex = prefix.lastIndexOf(".");
+        const basePath = prefix.substring(0, lastDotIndex + 1);
         optionsToSuggest = baseVarOptions
           .filter(
-            (opt) => opt.label.startsWith(input) && opt.label !== basePath,
+            (opt) => opt.label.startsWith(prefix) && opt.label !== basePath,
           )
           .map((opt) => {
             const applyPart = opt.label.substring(basePath.length);
-            // Only suggest if there's something to apply after the dot
             return applyPart ? { ...opt, apply: applyPart } : null;
           })
           .filter((opt) => opt !== null) as MustacheCompletionOption[];
-        // Set 'from' so that filtering is only on the segment after the last dot
-        resultFrom = pos - (prefixMatch[0].length - lastDotIndex - 1);
+        resultFrom = pos - (prefix.length - lastDotIndex - 1);
       } else {
-        // Not an object path (e.g., (, eq, user)
-        // Check the last non-whitespace character before the prefix start was '('
         const textRightBeforePrefix = textBefore.substring(0, prefixStartPos);
-        const trimmedTextBefore = textRightBeforePrefix.trimEnd(); // Remove trailing whitespace
+        const trimmedTextBefore = textRightBeforePrefix.trimEnd();
         const effectiveCharBefore = trimmedTextBefore.charAt(
           trimmedTextBefore.length - 1,
-        ); // Get last non-whitespace char
-
-        // If the last significant character before the prefix was '(', suggest helpers
+        );
         if (effectiveCharBefore === "(") {
-          // Suggest only inline helpers right after '(' or '( '
           optionsToSuggest = inlineHelperOptions;
-          // Adjust 'from' position based on whether the prefix itself is empty or not
-          resultFrom = prefixMatch[0] === "" ? pos : prefixStartPos;
+          resultFrom = prefix === "" ? pos : prefixStartPos;
         } else {
-          // Suggest only variables otherwise (after helper/variable name inside parens)
-          // (or if typing the first helper/variable name)
           optionsToSuggest = baseVarOptions;
-          resultFrom = prefixStartPos; // From start of variable/helper prefix
+          resultFrom = prefixStartPos;
         }
       }
     } else {
-      // *** Outside Parentheses Logic (but inside {{ }}) ***
-      const contentBetweenBraces = textBefore.substring(lastOpenMustache + 2);
+      const contentBetweenBraces = textBefore.substring(
+        textBefore.lastIndexOf("{{") + 2,
+      );
       const trimmedContent = contentBetweenBraces.trimStart();
-      // If the user is typing a block helper (e.g., '{{ #ea'), do NOT suggest variables
-      // But if they've typed a space after the helper (e.g., '{{ #each '), allow variables
       if (/^#\w*$/.test(trimmedContent)) {
         return null;
       }
-      // Return null ONLY if the user has typed exactly '/' after {{ (allowing for whitespace)
       if (trimmedContent === "/") {
         return null;
       }
-      // --- Require whitespace after closing parenthesis to show suggestions ---
-      // If the character immediately before the cursor is a ')', require whitespace (or end of input) after it
       const charBefore = textBefore[prefixStartPos - 1];
       if (charBefore === ")") {
         const charAfter = state.doc.sliceString(
           prefixStartPos,
           prefixStartPos + 1,
         );
-        // Block suggestions if at end of input with ')' as last char
         if (charAfter.length === 0) {
           return null;
         }
-        // Block suggestions if next char is not whitespace
         if (!/\s/.test(charAfter)) {
           return null;
         }
       }
-      // Otherwise, suggest variables outside parentheses
       optionsToSuggest = baseVarOptions;
-      resultFrom = prefixStartPos; // From start of variable prefix
+      resultFrom = prefixStartPos;
     }
 
-    // Filter out the exact prefix if it matches a label exactly
-    // Needed because filter:true only checks startsWith
-    const finalOptions = optionsToSuggest.filter(
-      (opt) => opt.label !== prefixMatch[0],
-    );
-
+    const finalOptions = optionsToSuggest.filter((opt) => opt.label !== prefix);
     if (finalOptions.length === 0) {
       return null;
     }
-
     return {
       from: resultFrom,
       options: finalOptions,

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
@@ -1,0 +1,359 @@
+import type {
+  Completion,
+  CompletionContext,
+  CompletionResult,
+  CompletionSource,
+} from "@codemirror/autocomplete";
+
+// Type helper for consistent completion options
+export type MustacheCompletionOption = Completion & {
+  type: "keyword" | "variable" | "function";
+};
+
+// Helper function to recursively find all leaf paths in an object
+function getAllPaths(obj: any, currentPath = ""): string[] {
+  let paths: string[] = [];
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return [];
+  }
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const newPath = currentPath ? `${currentPath}.${key}` : key;
+      const value = obj[key];
+
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        !Array.isArray(value) &&
+        value.constructor === Object
+      ) {
+        paths = paths.concat(getAllPaths(value, newPath));
+      } else {
+        paths.push(newPath);
+      }
+    }
+  }
+  return paths;
+}
+
+// Define helper categories clearly
+const BLOCK_HELPERS = ["each", "if", "unless", "with"];
+const METABASE_HELPERS = [
+  "count",
+  "format-date",
+  "now",
+  "card-url",
+  "trash-url",
+  "dashboard-url",
+];
+const INLINE_CONDITIONAL_HELPERS = [
+  "and",
+  "empty",
+  "else",
+  "eq",
+  "gt",
+  "gte",
+  "lookup",
+  "lt",
+  "lte",
+  "ne",
+  "or",
+  "not",
+];
+
+// Helper to compute the currently open block helper (for closing tag suggestions)
+function getOpenBlockHelper(text: string): string | undefined {
+  const openBlockPattern = /{{\s*#(\w+)\b.*?}}/gs;
+  const closeBlockPattern = /{{\s*\/(\w+)\b.*?}}/gs;
+  const openMatches = Array.from(text.matchAll(openBlockPattern));
+  const closeMatches = Array.from(text.matchAll(closeBlockPattern));
+  const blockStack: string[] = [];
+  const closedCounts: Record<string, number> = {};
+  const openCounts: Record<string, number> = {};
+
+  for (const match of closeMatches) {
+    const helper = match[1];
+    closedCounts[helper] = (closedCounts[helper] || 0) + 1;
+  }
+  for (const match of openMatches) {
+    const helper = match[1];
+    openCounts[helper] = (openCounts[helper] || 0) + 1;
+    if (openCounts[helper] > (closedCounts[helper] || 0)) {
+      blockStack.push(helper);
+    }
+  }
+  return blockStack.pop();
+}
+
+// Suggest block helpers, Metabase helpers, and closing tags based on context
+export const mustacheHelpersCompletionSource: CompletionSource = (
+  completionContext: CompletionContext,
+): CompletionResult | null => {
+  const textBefore = completionContext.state.doc.sliceString(
+    0,
+    completionContext.pos,
+  );
+  const lastOpenMustache = textBefore.lastIndexOf("{{");
+  const lastCloseMustache = textBefore.lastIndexOf("}}");
+
+  // Only provide suggestions if inside an unclosed {{ }} block
+  if (lastOpenMustache > lastCloseMustache) {
+    // Context 1: Typing opening helper or variable (NOT inside parentheses)
+    const blockContent = textBefore.substring(lastOpenMustache);
+    let parenLevel = 0;
+    for (const char of blockContent) {
+      if (char === "(") {
+        parenLevel++;
+      } else if (char === ")") {
+        parenLevel--;
+      }
+    }
+
+    // Context 2: Typing a closing helper {{/
+    const closeMatch = completionContext.matchBefore(/{{\/\w*$/); // Allow space after /
+    if (closeMatch) {
+      const currentlyOpenHelper = getOpenBlockHelper(textBefore);
+      if (!currentlyOpenHelper) return null;
+      const prefixMatch = closeMatch.text.match(/\w*$/);
+      const options: MustacheCompletionOption[] = BLOCK_HELPERS.filter(
+        (helperName) =>
+          helperName === currentlyOpenHelper &&
+          helperName.startsWith(prefixMatch ? prefixMatch[0] : ""),
+      ).map((helperName) => ({ label: helperName, type: "keyword" }));
+      if (options.length === 0) return null;
+      return {
+        from: prefixMatch
+          ? closeMatch.from + (prefixMatch.index ?? 0)
+          : completionContext.pos,
+        options,
+        filter: true,
+      };
+    }
+
+    // Only proceed if we are NOT inside parentheses (parenLevel <= 0)
+    if (parenLevel <= 0) {
+      const openMatch = completionContext.matchBefore(/(?<!\(){{\s*[#]?\w*$/);
+      if (openMatch) {
+        const startsWithHash = openMatch.text.includes("#");
+        let options: MustacheCompletionOption[];
+        if (startsWithHash) {
+          const typedAfterHash = openMatch.text.match(/\s*#(\w*)$/)?.[1] || "";
+          options = BLOCK_HELPERS.filter((helper) =>
+            helper.startsWith(typedAfterHash),
+          ).map((helperName) => ({
+            label: helperName,
+            type: "keyword",
+            boost: 99,
+          }));
+        } else {
+          const blockOptions: MustacheCompletionOption[] = BLOCK_HELPERS.map(
+            (helperName) => ({
+              label: `#${helperName}`,
+              type: "keyword",
+              boost: 1,
+            }),
+          );
+          const metabaseOptions: MustacheCompletionOption[] =
+            METABASE_HELPERS.map((label) => ({
+              label,
+              type: "function",
+              boost: 1,
+            }));
+          options = blockOptions.concat(metabaseOptions);
+        }
+        // Add proactive closing tag suggestion
+        const currentlyOpenHelper = getOpenBlockHelper(textBefore);
+        if (currentlyOpenHelper) {
+          const closingTag = `/${currentlyOpenHelper}`;
+          const closingLabel = `/${currentlyOpenHelper}`;
+          const closingOption: MustacheCompletionOption = {
+            label: closingLabel,
+            type: "keyword",
+            apply: closingTag,
+            boost: 5,
+            info: `Close the open #${currentlyOpenHelper} block`,
+          };
+          options.unshift(closingOption);
+        }
+        if (startsWithHash) {
+          const hashIndex = openMatch.text.indexOf("#");
+          let afterHash = hashIndex + 1;
+          while (openMatch.text[afterHash] === " ") {
+            afterHash++;
+          }
+          return {
+            from: openMatch.from + afterHash,
+            options: options,
+            filter: false,
+          };
+        } else {
+          // Otherwise, use the old logic (after {{ and whitespace)
+          const afterBraces = openMatch.text.match(/{{\s*/)?.[0].length || 2;
+          return {
+            from: openMatch.from + afterBraces,
+            options: options,
+            filter: false,
+          };
+        }
+      }
+    }
+  }
+  return null; // No context matched
+};
+
+// Build suggestions for template variables AND helpers inside parentheses
+export const createTemplateAutocompleteSource = (
+  context: Record<string, any>,
+): CompletionSource => {
+  // Precompute all possible paths once
+  const allVarPaths = getAllPaths(context);
+  // Generate base options with full paths as labels
+  const baseVarOptions: MustacheCompletionOption[] = allVarPaths.map(
+    (path) => ({
+      label: path,
+      type: "variable",
+      boost: -1, // Lower boost than helpers
+    }),
+  );
+
+  const inlineHelperOptions: MustacheCompletionOption[] =
+    INLINE_CONDITIONAL_HELPERS.map((label) => ({
+      label,
+      type: "keyword",
+      boost: 1, // Higher boost than variables
+    }));
+
+  return (completionContext: CompletionContext): CompletionResult | null => {
+    const { state, pos } = completionContext;
+    const textBefore = state.doc.sliceString(0, pos);
+
+    // Ensure we are inside an active {{ block
+    const lastOpenMustache = textBefore.lastIndexOf("{{");
+    const lastCloseMustache = textBefore.lastIndexOf("}}");
+    if (lastOpenMustache <= lastCloseMustache) {
+      return null; // Not inside an active {{ block
+    }
+
+    // Get prefix and its start position
+    const prefixMatch = textBefore.match(/[\w\.]*$/);
+    // We need prefixMatch to proceed
+    if (prefixMatch === null) {
+      return null;
+    }
+    const prefixStartPos = prefixMatch.index ?? pos;
+
+    // Check if likely inside parentheses
+    // A simple check: is there an unclosed '(' between the last {{ and the prefix start?
+    const contentSinceMustache = textBefore.substring(lastOpenMustache);
+    const parensCheckText = contentSinceMustache.slice(
+      0,
+      prefixStartPos - lastOpenMustache,
+    );
+    let parenLevel = 0;
+    for (const char of parensCheckText) {
+      if (char === "(") {
+        parenLevel++;
+      } else if (char === ")") {
+        parenLevel--;
+      }
+    }
+    const isInsideParens = parenLevel > 0;
+
+    let optionsToSuggest: MustacheCompletionOption[] = [];
+    let resultFrom = prefixStartPos;
+
+    if (isInsideParens) {
+      const input = prefixMatch[0];
+      // *** Inside Parentheses Logic ***
+      if (input.includes(".")) {
+        // Object path completion (e.g., user.)
+        const lastDotIndex = input.lastIndexOf(".");
+        const basePath = input.substring(0, lastDotIndex + 1);
+        // The filter should be applied only to the part after the last dot
+        optionsToSuggest = baseVarOptions
+          .filter(
+            (opt) => opt.label.startsWith(input) && opt.label !== basePath,
+          )
+          .map((opt) => {
+            const applyPart = opt.label.substring(basePath.length);
+            // Only suggest if there's something to apply after the dot
+            return applyPart ? { ...opt, apply: applyPart } : null;
+          })
+          .filter((opt) => opt !== null) as MustacheCompletionOption[];
+        // Set 'from' so that filtering is only on the segment after the last dot
+        resultFrom = pos - (prefixMatch[0].length - lastDotIndex - 1);
+      } else {
+        // Not an object path (e.g., (, eq, user)
+        // Check the last non-whitespace character before the prefix start was '('
+        const textRightBeforePrefix = textBefore.substring(0, prefixStartPos);
+        const trimmedTextBefore = textRightBeforePrefix.trimEnd(); // Remove trailing whitespace
+        const effectiveCharBefore = trimmedTextBefore.charAt(
+          trimmedTextBefore.length - 1,
+        ); // Get last non-whitespace char
+
+        // If the last significant character before the prefix was '(', suggest helpers
+        if (effectiveCharBefore === "(") {
+          // Suggest only inline helpers right after '(' or '( '
+          optionsToSuggest = inlineHelperOptions;
+          // Adjust 'from' position based on whether the prefix itself is empty or not
+          resultFrom = prefixMatch[0] === "" ? pos : prefixStartPos;
+        } else {
+          // Suggest only variables otherwise (after helper/variable name inside parens)
+          // (or if typing the first helper/variable name)
+          optionsToSuggest = baseVarOptions;
+          resultFrom = prefixStartPos; // From start of variable/helper prefix
+        }
+      }
+    } else {
+      // *** Outside Parentheses Logic (but inside {{ }}) ***
+      const contentBetweenBraces = textBefore.substring(lastOpenMustache + 2);
+      const trimmedContent = contentBetweenBraces.trimStart();
+      // If the user is typing a block helper (e.g., '{{ #ea'), do NOT suggest variables
+      // But if they've typed a space after the helper (e.g., '{{ #each '), allow variables
+      if (/^#\w*$/.test(trimmedContent)) {
+        return null;
+      }
+      // Return null ONLY if the user has typed exactly '/' after {{ (allowing for whitespace)
+      if (trimmedContent === "/") {
+        return null;
+      }
+      // --- Require whitespace after closing parenthesis to show suggestions ---
+      // If the character immediately before the cursor is a ')', require whitespace (or end of input) after it
+      const charBefore = textBefore[prefixStartPos - 1];
+      if (charBefore === ")") {
+        const charAfter = state.doc.sliceString(
+          prefixStartPos,
+          prefixStartPos + 1,
+        );
+        // Block suggestions if at end of input with ')' as last char
+        if (charAfter.length === 0) {
+          return null;
+        }
+        // Block suggestions if next char is not whitespace
+        if (!/\s/.test(charAfter)) {
+          return null;
+        }
+      }
+      // Otherwise, suggest variables outside parentheses
+      optionsToSuggest = baseVarOptions;
+      resultFrom = prefixStartPos; // From start of variable prefix
+    }
+
+    // Filter out the exact prefix if it matches a label exactly
+    // Needed because filter:true only checks startsWith
+    const finalOptions = optionsToSuggest.filter(
+      (opt) => opt.label !== prefixMatch[0],
+    );
+
+    if (finalOptions.length === 0) {
+      return null;
+    }
+
+    return {
+      from: resultFrom,
+      options: finalOptions,
+      filter: true,
+    };
+  };
+};

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
@@ -122,9 +122,7 @@ export const mustacheHelpersCompletionSource =
     const builtinBlockHelpersArr = helpers.filter(
       (helper) => helper.type === "built-in",
     );
-    const mbBlockHelpersArr = helpers.filter(
-      (helper) => helper.type === "custom-block",
-    );
+    const mbHelpersArr = helpers.filter((helper) => helper.type === "custom");
     const builtinBlockHelpers = builtinBlockHelpersArr.map(
       (helper) => helper.name,
     );
@@ -194,7 +192,7 @@ export const mustacheHelpersCompletionSource =
             1,
           );
           const metabaseOptions = createCompletionOptionsFromHelpers(
-            mbBlockHelpersArr,
+            mbHelpersArr,
             "function",
             1,
           );
@@ -242,14 +240,12 @@ export const createTemplateAutocompleteSource = (
   context: Record<string, any>,
   helpers: Settings["default-handlebars-helpers"] = [],
 ): CompletionSource => {
-  const mbInlineHelpersArr = helpers.filter(
-    (helper) => helper.type === "custom-inline",
-  );
+  const mbHelpersArr = helpers.filter((helper) => helper.type === "custom");
   // Precompute all possible paths once
   const allVarPaths = getAllPaths(context);
   const baseVarOptions = createCompletionOptions(allVarPaths, "variable", -1);
   const inlineHelperOptions = createCompletionOptionsFromHelpers(
-    mbInlineHelpersArr,
+    mbHelpersArr,
     "keyword",
     1,
   );

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
@@ -1,0 +1,395 @@
+import type { Completion, CompletionResult } from "@codemirror/autocomplete";
+import { CompletionContext, autocompletion } from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+
+import {
+  createTemplateAutocompleteSource,
+  mustacheHelpersCompletionSource,
+} from "./autocomplete";
+
+// Mock context data for testing variable suggestions
+const MOCK_CONTEXT = {
+  user: {
+    id: 1,
+    name: "Test User",
+    address: {
+      street: "123 Main St",
+      city: "Testville",
+    },
+  },
+  card: {
+    id: 10,
+    name: "Test Card",
+  },
+  topLevelVar: "value",
+};
+
+// Define the default sources
+const defaultSources = [
+  mustacheHelpersCompletionSource,
+  createTemplateAutocompleteSource(MOCK_CONTEXT),
+];
+
+// Updated helper to get completions, handling single or multiple sources
+async function getCompletionsHelper(
+  doc: string,
+): Promise<CompletionResult | null> {
+  const pos = doc.length;
+
+  // Setup EditorState and CompletionContext once
+  const templateAutocompleteExtension = autocompletion({
+    override: defaultSources,
+  });
+  const state = EditorState.create({
+    doc,
+    extensions: [templateAutocompleteExtension],
+  });
+  const context = new CompletionContext(state, pos, true);
+
+  // Mock context methods
+  // We might need to clear mocks if this runs multiple times in one test run
+  jest.spyOn(context, "tokenBefore").mockReturnValue(null);
+  jest.spyOn(context, "matchBefore").mockImplementation((expr) => {
+    const textBefore = state.doc.sliceString(0, pos);
+    const match = textBefore.match(expr);
+    if (!match || match.index === undefined) {
+      return null;
+    }
+    const from = match.index;
+    const to = from + match[0].length;
+    // Ensure matchBefore respects the 'to' position if it's different from 'pos'
+    if (to !== pos) {
+      // This scenario might happen if matching something not directly ending at pos.
+      // Adjust behavior if needed, but for current tests, we assume match ends at pos.
+      // console.warn(`matchBefore found match not ending at pos: ${match[0]} at ${from}-${to} (pos=${pos})`);
+    }
+    return { from, to, text: match[0] };
+  });
+
+  let combinedOptions: Completion[] = [];
+
+  // 1. Determine the prefix and its start position (used for filtering and final 'from')
+  const textBefore = doc.slice(0, pos);
+  const prefixMatch = textBefore.match(/[\w\.]*$/);
+  const prefix = prefixMatch ? prefixMatch[0] : "";
+  const matchFrom = prefixMatch ? (prefixMatch.index ?? pos) : pos;
+
+  let overallResultStructure: Omit<CompletionResult, "options"> | null = null;
+
+  // 2. Collect Raw Options & Structure from specified sources
+  for (const func of defaultSources) {
+    // Call source function directly with the created context
+    const result = await func(context);
+    if (result) {
+      // Capture the structure (like span, validFor) from the first source that provides it
+      if (overallResultStructure === null) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { options, ...structure } = result;
+        overallResultStructure = structure;
+      }
+      combinedOptions = combinedOptions.concat(result.options);
+    }
+  }
+
+  // If no source provided any result structure, we can't proceed
+  if (overallResultStructure === null) {
+    return null;
+  }
+
+  // 3. Filter combined options based on the determined prefix
+  const filteredOptions = combinedOptions.filter((option) =>
+    option.label.toLowerCase().startsWith(prefix.toLowerCase()),
+  );
+
+  // 4. Handle No Matches after filtering
+  // If there's a prefix but no options match, return null
+  // If prefix is empty, allow empty results (e.g., for closing tags potentially, though handled later)
+  if (filteredOptions.length === 0 && prefix.length > 0) {
+    return null;
+  }
+
+  // 5. Sort the filtered options
+  const mutableOptions = [...filteredOptions];
+  mutableOptions.sort((a: Completion, b: Completion) => {
+    const boostA = a.boost ?? 0;
+    const boostB = b.boost ?? 0;
+    if (boostB !== boostA) {
+      return boostB - boostA;
+    }
+    if (a.label.length !== b.label.length) {
+      return a.label.length - b.label.length;
+    }
+    return a.label.localeCompare(b.label);
+  });
+
+  // 6. Construct the final result
+  const finalResult: CompletionResult = {
+    ...overallResultStructure,
+    // Use the 'from' calculated from the prefix match for the final result,
+    // unless the original source provided a specific span, in which case respect that.
+    from:
+      typeof (overallResultStructure as any).from === "number"
+        ? (overallResultStructure as any).from
+        : matchFrom,
+    options: mutableOptions,
+  };
+
+  // Handle specific case for closing tag suggestions where 'from' needs adjustment by the source
+  // The mustacheHelpersCompletionSource should return the correct 'from' after {{/
+  // Let's ensure the final 'from' respects that if it comes from the source structure.
+  if (
+    finalResult.options.length === 1 &&
+    finalResult.options[0].label.startsWith("/") &&
+    typeof overallResultStructure.from === "number"
+  ) {
+    // If source gave a 'from' (like mustacheHelpers for /if), use its 'from'
+    finalResult.from = overallResultStructure.from;
+  } else if (
+    // Fallback for edge cases or if 'from' wasn't provided, but looks like a close tag
+    finalResult.options.length === 1 &&
+    finalResult.options[0].label.startsWith("/")
+  ) {
+    // This logic might be redundant if source always provides span, but acts as safety
+    const closeTagMatch = textBefore.match(/\{\{\/\s*$/);
+    if (closeTagMatch && closeTagMatch.index !== undefined) {
+      finalResult.from = closeTagMatch.index + closeTagMatch[0].length;
+    }
+  }
+
+  // If after all filtering and sorting, we have no options, return null
+  if (finalResult.options.length === 0) {
+    return null;
+  }
+
+  return finalResult;
+}
+
+describe("Mustache Autocomplete Sources", () => {
+  describe("mustacheHelpersCompletionSource", () => {
+    it("should suggest nothing outside mustaches", async () => {
+      const result = await getCompletionsHelper("Hello world");
+      expect(result).toBeNull();
+    });
+
+    it("should suggest block/metabase helpers and variables on {{ opening", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{ ");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      // Check for boosted helpers first (order might vary slightly based on sorting details)
+      expect(labels).toContain("#each"); // Block helper
+      expect(labels).toContain("count"); // Metabase helper
+      // Check for variables
+      expect(labels).toContain("user.name");
+      expect(labels).toContain("card.id");
+      expect(labels).toContain("topLevelVar");
+    });
+
+    it("should suggest ONLY block helpers on {{# opening", async () => {
+      // Uses default sources (but createTemplateAutocompleteSource should return null here)
+      const result = await getCompletionsHelper("{{#");
+      expect(result).not.toBeNull();
+      expect(result?.options).toHaveLength(4); // only #each, #if, #unless, #with
+      const labels = result?.options.map((o) => o.label);
+      expect(labels?.sort()).toEqual(["each", "if", "unless", "with"].sort());
+    });
+
+    it("should filter block helpers on {{# prefix", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{#if");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels?.sort()).toEqual(["if"].sort());
+    });
+
+    it("should suggest closing tag for open block on {{/ opening", async () => {
+      const doc = "{{#if user.name}} Hello {{/";
+      // Test only the helper source for this specific logic
+      const result = await getCompletionsHelper(doc);
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).toEqual(["if"]);
+    });
+
+    it("should suggest correct closing tag for nested blocks", async () => {
+      const doc = "{{#each users}}{{#if active}} User: {{name}} {{/";
+      // Test only the helper source
+      const result = await getCompletionsHelper(doc);
+      expect(result).not.toBeNull();
+      expect(result?.options.map((o) => o.label)).toEqual(["if"]);
+      expect(result?.from).toBe(doc.length); // From after {{/
+
+      const docOuter = doc + "if}} {{/";
+      // Test only the helper source
+      const resultOuter = await getCompletionsHelper(docOuter);
+      expect(resultOuter).not.toBeNull();
+      expect(resultOuter?.options.map((o) => o.label)).toEqual(["each"]);
+      expect(resultOuter?.from).toBe(docOuter.length); // From after {{/
+    });
+
+    it("should NOT suggest closing tag if no block is open", async () => {
+      const doc = "{{/";
+      // Test only the helper source
+      const result = await getCompletionsHelper(doc);
+      expect(result).toBeNull();
+    });
+
+    it("should suggest closing tag proactively on {{ if block open", async () => {
+      const doc = "{{#if condition}} Some text {{ ";
+      // Uses default sources
+      const result = await getCompletionsHelper(doc);
+      expect(result).not.toBeNull();
+      const firstSuggestion = result?.options[0];
+      expect(firstSuggestion?.label).toBe("/if"); // Closing tag is boosted
+      expect(firstSuggestion?.boost).toBeGreaterThan(1);
+    });
+
+    it("should NOT suggest block helpers after {{# space", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{# ");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).not.toContain("if");
+    });
+
+    it("should NOT suggest closing tag after {{/ space", async () => {
+      const doc = "{{#if condition}} {{/ ";
+      // Uses default sources, but specifically testing helper source behavior
+      const result = await getCompletionsHelper(doc);
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).not.toContain("if");
+    });
+  });
+
+  describe("createTemplateAutocompleteSource", () => {
+    it("should suggest variables after {{ opening (if no helper prefix)", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{ us");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).toContain("user.id");
+      expect(labels).toContain("user.name");
+      expect(labels).toContain("user.address.street");
+      expect(labels).not.toContain("card.id"); // Filtered by prefix 'us'
+      expect(labels).not.toContain("#if"); // No helpers from this source
+    });
+
+    it("should suggest variables after helper and space", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{#if user.");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).toContain("user.id");
+      expect(labels).toContain("user.name");
+      expect(labels).toContain("user.address.city");
+    });
+
+    it("should NOT suggest variables when typing helper name {{#if", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{#if");
+      // createTemplateAutocompleteSource should return null,
+      // mustacheHelpersCompletionSource provides the 'if' completion.
+      expect(result).not.toBeNull(); // Helpers are suggested
+      const variableLabels = result?.options
+        .filter((o) => o.type === "variable")
+        .map((o) => o.label);
+      expect(variableLabels).toEqual([]); // No variable suggestions
+    });
+
+    it("should suggest inline helpers immediately inside parentheses", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{ (e");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).toContain("eq");
+      expect(labels).toContain("empty");
+      expect(labels).toContain("else");
+      expect(labels).not.toContain("user.name"); // No variables here
+      expect(labels).not.toContain("count"); // No Metabase helpers
+      expect(labels).not.toContain("#if"); // No block helpers
+    });
+
+    it("should suggest variables after inline helper and space inside parentheses", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{ (eq user.");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).toContain("user.id");
+      expect(labels).toContain("user.name");
+      expect(labels).not.toContain("eq"); // No helpers here
+    });
+
+    it("should suggest variable inside parentheses", async () => {
+      // Uses default sources
+      const result = await getCompletionsHelper("{{ (eq user.name user.");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).toContain("user.id");
+      expect(labels).toContain("user.name");
+      expect(labels).not.toContain("card.id");
+      expect(labels).not.toContain("eq"); // No helpers here
+    });
+
+    it("should require whitespace after closing parenthesis to show suggestions", async () => {
+      // No suggestions immediately after closing parenthesis
+      let result = await getCompletionsHelper("{{ (eq user.name)");
+      expect(result).toBeNull();
+      // Suggestions appear after closing parenthesis and a space
+      result = await getCompletionsHelper("{{ (eq user.name) ");
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label);
+      expect(labels).toContain("user.id");
+      expect(labels).toContain("user.name");
+    });
+
+    it("should handle nested parentheses correctly", async () => {
+      // Uses default sources
+      // Inside inner parens, right after '(': suggest inline helpers
+      let result = await getCompletionsHelper("{{ (eq user.name ( ");
+      const parensLabels = result?.options.map((o) => o.label);
+      expect(parensLabels).toContain("and"); // Suggest inline helpers
+      expect(parensLabels).not.toContain("user.id");
+
+      // Inside inner parens, after helper + space + prefix: suggest variables
+      result = await getCompletionsHelper("{{ (eq user.name (gt user.");
+      const innerParensLabels = result?.options.map((o) => o.label);
+      expect(innerParensLabels).not.toContain("gt");
+      expect(innerParensLabels).toContain("user.id"); // Suggest variables
+
+      // Back in outer parens, after ')) ' + space: suggest variables
+      result = await getCompletionsHelper("{{ (eq user.name (gt user.id)) ");
+      expect(result).not.toBeNull();
+      const outerParensLabels = result?.options.map((o) => o.label);
+      expect(outerParensLabels).toContain("user.id"); // Suggest variables
+      expect(outerParensLabels).toContain("user.address.city");
+      expect(outerParensLabels).toContain("card.name");
+      expect(outerParensLabels).not.toContain("eq"); // Suggest inline helpers again
+      expect(outerParensLabels).not.toContain("#if"); // Suggest inline helpers again
+    });
+
+    it("should filter object path variables correctly inside parentheses", async () => {
+      // Uses default sources
+      const text = "{{ (eq user.name user.";
+      const result = await getCompletionsHelper(text);
+
+      expect(result).not.toBeNull();
+      const labels = result?.options.map((o) => o.label).sort();
+      const expectedLabels = [
+        "user.address.city",
+        "user.address.street",
+        "user.id",
+        "user.name",
+      ].sort();
+      expect(labels).toEqual(expectedLabels);
+
+      const idOption = result?.options.find((o) => o.label === "user.id");
+      expect(idOption?.apply).toBe("id"); // Check apply logic works
+
+      // Ensure other root variables/helpers are NOT suggested
+      expect(labels).not.toContain("card.id");
+      expect(labels).not.toContain("topLevelVar");
+      expect(labels).not.toContain("eq");
+    });
+  });
+});

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
@@ -34,7 +34,7 @@ const METABASE_BLOCK_HELPERS = [
   "card-url",
   "trash-url",
   "dashboard-url",
-].map((name) => ({ name, doc: "", type: "custom-block" as const }));
+].map((name) => ({ name, doc: "", type: "custom" as const }));
 const METABASE_INLINE_HELPERS = [
   "and",
   "empty",
@@ -47,13 +47,17 @@ const METABASE_INLINE_HELPERS = [
   "ne",
   "or",
   "not",
-].map((name) => ({ name, doc: "", type: "custom-inline" as const }));
+].map((name) => ({ name, doc: "", type: "custom" as const }));
 
-const helpers = [...BLOCK_HELPERS, ...METABASE_BLOCK_HELPERS];
+// We'll use these for now, but we might need to split custom helpers
+// to provide more sophisticated autocompletion.
+const ALL_MB_HELPERS = [...METABASE_BLOCK_HELPERS, ...METABASE_INLINE_HELPERS];
+
+const helpers = [...BLOCK_HELPERS, ...ALL_MB_HELPERS];
 // Define the default sources
 const defaultSources = [
   mustacheHelpersCompletionSource(helpers),
-  createTemplateAutocompleteSource(MOCK_CONTEXT, METABASE_INLINE_HELPERS),
+  createTemplateAutocompleteSource(MOCK_CONTEXT, helpers),
 ];
 
 // Updated helper to get completions, handling single or multiple sources

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
@@ -83,12 +83,6 @@ async function getCompletionsHelper(
     }
     const from = match.index;
     const to = from + match[0].length;
-    // Ensure matchBefore respects the 'to' position if it's different from 'pos'
-    if (to !== pos) {
-      // This scenario might happen if matching something not directly ending at pos.
-      // Adjust behavior if needed, but for current tests, we assume match ends at pos.
-      // console.warn(`matchBefore found match not ending at pos: ${match[0]} at ${from}-${to} (pos=${pos})`);
-    }
     return { from, to, text: match[0] };
   });
 
@@ -109,7 +103,6 @@ async function getCompletionsHelper(
     if (result) {
       // Capture the structure (like span, validFor) from the first source that provides it
       if (overallResultStructure === null) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { options, ...structure } = result;
         overallResultStructure = structure;
       }

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.unit.spec.ts
@@ -24,10 +24,36 @@ const MOCK_CONTEXT = {
   topLevelVar: "value",
 };
 
+const BLOCK_HELPERS = ["each", "if", "unless", "with", "lookup"].map(
+  (name) => ({ name, doc: "", type: "built-in" as const }),
+);
+const METABASE_BLOCK_HELPERS = [
+  "count",
+  "format-date",
+  "now",
+  "card-url",
+  "trash-url",
+  "dashboard-url",
+].map((name) => ({ name, doc: "", type: "custom-block" as const }));
+const METABASE_INLINE_HELPERS = [
+  "and",
+  "empty",
+  "else",
+  "eq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "ne",
+  "or",
+  "not",
+].map((name) => ({ name, doc: "", type: "custom-inline" as const }));
+
+const helpers = [...BLOCK_HELPERS, ...METABASE_BLOCK_HELPERS];
 // Define the default sources
 const defaultSources = [
-  mustacheHelpersCompletionSource,
-  createTemplateAutocompleteSource(MOCK_CONTEXT),
+  mustacheHelpersCompletionSource(helpers),
+  createTemplateAutocompleteSource(MOCK_CONTEXT, METABASE_INLINE_HELPERS),
 ];
 
 // Updated helper to get completions, handling single or multiple sources
@@ -189,9 +215,10 @@ describe("Mustache Autocomplete Sources", () => {
       // Uses default sources (but createTemplateAutocompleteSource should return null here)
       const result = await getCompletionsHelper("{{#");
       expect(result).not.toBeNull();
-      expect(result?.options).toHaveLength(4); // only #each, #if, #unless, #with
       const labels = result?.options.map((o) => o.label);
-      expect(labels?.sort()).toEqual(["each", "if", "unless", "with"].sort());
+      expect(labels?.sort()).toEqual(
+        ["each", "if", "unless", "with", "lookup"].sort(),
+      );
     });
 
     it("should filter block helpers on {{# prefix", async () => {

--- a/frontend/test/__support__/mocks.js
+++ b/frontend/test/__support__/mocks.js
@@ -31,7 +31,7 @@ jest.mock("@uiw/react-codemirror", () => {
   const { forwardRef } = jest.requireActual("react");
 
   const MockEditor = forwardRef((props, ref) => {
-    const { indentWithTab, extensions, ...rest } = props;
+    const { indentWithTab, extensions, minHeight, basicSetup, ...rest } = props;
     return (
       // @ts-expect-error: some props types are different on CodeMirror
       <textarea

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -261,7 +261,7 @@
 
 ;; Split helpers into block and inline helpers
 (def block-helpers
-  "A map of custom block helpers, used inside {{ }}"
+  "A list of custom block helpers, used inside {{ }}"
   {"count"         #'count
    "format-date"   #'format-date
    "now"           #'now
@@ -269,7 +269,7 @@
    "dashboard-url" #'dashboard-url})
 
 (def inline-helpers
-  "A map of custom inline helpers, used inside ( )."
+  "A list of custom inline helpers, used inside ( )."
   {"eq"            #'eq
    "ne"            #'ne
    "gt"            #'gt
@@ -278,7 +278,7 @@
    "le"            #'le})
 
 (def default-helpers
-  "A map of all custom helpers (block + inline), for backward compatibility."
+  "A list of all custom helpers combined."
   (merge block-helpers inline-helpers))
 
 (def ^:private built-in-helpers-info

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -259,27 +259,19 @@
   [id [parameters] _kparams _options]
   (urls/dashboard-url id (map #(update-keys % keyword) parameters)))
 
-;; Split helpers into block and inline helpers
-(def block-helpers
-  "A list of custom block helpers, used inside {{ }}"
+(def default-helpers
+  "A list of default helpers."
   {"count"         #'count
-   "format-date"   #'format-date
-   "now"           #'now
-   "card-url"      #'card-url
-   "dashboard-url" #'dashboard-url})
-
-(def inline-helpers
-  "A list of custom inline helpers, used inside ( )."
-  {"eq"            #'eq
+   "eq"            #'eq
    "ne"            #'ne
    "gt"            #'gt
    "ge"            #'ge
    "lt"            #'lt
-   "le"            #'le})
-
-(def default-helpers
-  "A list of all custom helpers combined."
-  (merge block-helpers inline-helpers))
+   "le"            #'le
+   "format-date"   #'format-date
+   "now"           #'now
+   "card-url"      #'card-url
+   "dashboard-url" #'dashboard-url})
 
 (def ^:private built-in-helpers-info
   (map
@@ -367,18 +359,14 @@
    - level: Optional hash param for log level (debug, info, warn, error)"}]))
 
 (defn- helpers-info
-  "Get a list of helpers with their names, docstrings, and types."
-  [block-helpers inline-helpers]
+  "Get a list of helpers with their names and docstrings."
+  [helper-name->helper]
   (concat
    built-in-helpers-info
-   (for [[helper-name helper] block-helpers]
+   (for [[helper-name helper] helper-name->helper]
      {:name helper-name
       :doc  (-> helper meta :doc)
-      :type :custom-block})
-   (for [[helper-name helper] inline-helpers]
-     {:name helper-name
-      :doc  (-> helper meta :doc)
-      :type :custom-inline})))
+      :type :custom})))
 
 ;; Exposing this via settings so FE can find it
 ;; TODO: the better way is to follow metabase.lib's steps by writing this as cljc so FE can access it directly.
@@ -387,7 +375,7 @@
   :type        :json
   :encryption  :no
   :export?     false
-  :getter      (fn [] (helpers-info block-helpers inline-helpers))
+  :getter      (fn [] (helpers-info default-helpers))
   :setter      :none
   :visibility  :public
   :description "A list of default handlebars helpers.")

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -259,19 +259,27 @@
   [id [parameters] _kparams _options]
   (urls/dashboard-url id (map #(update-keys % keyword) parameters)))
 
-(def default-helpers
-  "A list of default helpers."
+;; Split helpers into block and inline helpers
+(def block-helpers
+  "A map of custom block helpers, used inside {{ }}"
   {"count"         #'count
-   "eq"            #'eq
-   "ne"            #'ne
-   "gt"            #'gt
-   "ge"            #'ge
-   "lt"            #'lt
-   "le"            #'le
    "format-date"   #'format-date
    "now"           #'now
    "card-url"      #'card-url
    "dashboard-url" #'dashboard-url})
+
+(def inline-helpers
+  "A map of custom inline helpers, used inside ( )."
+  {"eq"            #'eq
+   "ne"            #'ne
+   "gt"            #'gt
+   "ge"            #'ge
+   "lt"            #'lt
+   "le"            #'le})
+
+(def default-helpers
+  "A map of all custom helpers (block + inline), for backward compatibility."
+  (merge block-helpers inline-helpers))
 
 (def ^:private built-in-helpers-info
   (map
@@ -359,14 +367,18 @@
    - level: Optional hash param for log level (debug, info, warn, error)"}]))
 
 (defn- helpers-info
-  "Get a list of helpers with their names and docstrings."
-  [helper-name->helper]
+  "Get a list of helpers with their names, docstrings, and types."
+  [block-helpers inline-helpers]
   (concat
    built-in-helpers-info
-   (for [[helper-name helper] helper-name->helper]
+   (for [[helper-name helper] block-helpers]
      {:name helper-name
       :doc  (-> helper meta :doc)
-      :type :custom})))
+      :type :custom-block})
+   (for [[helper-name helper] inline-helpers]
+     {:name helper-name
+      :doc  (-> helper meta :doc)
+      :type :custom-inline})))
 
 ;; Exposing this via settings so FE can find it
 ;; TODO: the better way is to follow metabase.lib's steps by writing this as cljc so FE can access it directly.
@@ -375,7 +387,7 @@
   :type        :json
   :encryption  :no
   :export?     false
-  :getter      (fn [] (helpers-info default-helpers))
+  :getter      (fn [] (helpers-info block-helpers inline-helpers))
   :setter      :none
   :visibility  :public
   :description "A list of default handlebars helpers.")


### PR DESCRIPTION
Closes [WRK-250](https://linear.app/metabase/issue/WRK-250/auto-complete-for-handlebars-fns-and-helpers)

### Description

This PR integrates information on available handlebars helpers provided through settings and implements proper autocompletion logic for available block-level and inline helpers (see attached screenshots).
The logic for autocompletion isn't 100% bug-proof, but it should be good enough for a starting point. A set of unit-tests is provided to partially cover autocompletion functionality, but since it only simulates internal CodeMirror's autocompletion, e2e tests should also be added in the future.

I've had to update BE code handling the provision of information on helpers to be able to distinguish between block-level and inline, so default helpers list was split to `custom-block` and `custom-inline`.

Also fixed unit-tests for TableNotificationsList which broke due to recently introduced changes in wording.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open the template editor in a notification modal.
2. Type `{{` and observe that autocomplete suggestions include both the helper name and its documentation.
3. Ensure that suggestions reflect the current backend-provided helpers (see `/api/session/properties` request -> `default-handlebars-helpers`).

### Demo

<img width="560" alt="image" src="https://github.com/user-attachments/assets/70acc4f1-66b2-4e91-9ac4-10034680150c" />

<img width="560" alt="image" src="https://github.com/user-attachments/assets/963482dc-25f0-431d-a362-49a7de3a4693" />

<img width="560" alt="image" src="https://github.com/user-attachments/assets/a359d0d0-a4f9-47a4-9775-4422e58eee51" />

 
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
