### PR TITLE
Closes VIZ-332 no more dupes in y-axis ticks

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -555,6 +555,10 @@ export function getYAxisModel(
     label,
     formatter,
     isNormalized: stackType === "normalized",
+    splitNumber:
+      settings["graph.y_axis.split_number"] > 0
+        ? settings["graph.y_axis.split_number"]
+        : undefined,
   };
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -178,6 +178,7 @@ export type YAxisModel = {
   column: DatasetColumn;
   label?: string;
   formatter: AxisFormatter;
+  splitNumber?: number;
   isNormalized?: boolean;
 };
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -389,6 +389,7 @@ export const buildMetricAxis = (
     show: true,
     scale: !!settings["graph.y_axis.unpin_from_zero"],
     type: "value",
+    splitNumber: axisModel.splitNumber,
     ...range,
     ...getAxisNameDefaultOption(
       renderingContext,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -845,6 +845,14 @@ export const GRAPH_AXIS_SETTINGS = {
     getHidden: (series, vizSettings) =>
       vizSettings["graph.y_axis.auto_range"] !== false,
   },
+  "graph.y_axis.split_number": {
+    section: t`Axes`,
+    group: t`Y-axis`,
+    index: 7,
+    title: t`Number of intervals`,
+    widget: "number",
+    placeholder: "auto",
+  },
   "graph.y_axis.auto_split": {
     get section() {
       return t`Axes`;

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -849,7 +849,7 @@ export const GRAPH_AXIS_SETTINGS = {
     section: t`Axes`,
     group: t`Y-axis`,
     index: 7,
-    title: t`Number of intervals`,
+    title: t`Approximate number of intervals`,
     widget: "number",
     placeholder: "auto",
   },

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -846,10 +846,16 @@ export const GRAPH_AXIS_SETTINGS = {
       vizSettings["graph.y_axis.auto_range"] !== false,
   },
   "graph.y_axis.split_number": {
-    section: t`Axes`,
-    group: t`Y-axis`,
+    get section() {
+      return t`Axes`;
+    },
+    get group() {
+      return t`Y-axis`;
+    },
     index: 7,
-    title: t`Approximate number of intervals`,
+    get title() {
+      return t`Approximate number of intervals`;
+    },
     widget: "number",
     placeholder: "auto",
   },


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action -->closes #35046
Closes [VIZ-332: Changing decimal values of a measure directly impacts the y-axis scale values](https://linear.app/metabase/issue/VIZ-332/changing-decimal-values-of-a-measure-directly-impacts-the-y-axis-scale)

### Description

The ticks are computed before formatting is applied, hence potential duplicates in the ticks. This PR exposes the `splitNumber` option to solve that.

### How to verify

See original ticket for instructions

### Demo

[_Upload a demo video or before/after screenshots if sensible or remove the section_](https://www.loom.com/share/5a4a271beab84cb7930f810e6ab494f2)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
