### PR TITLE
remove embedding as  codeowners from the release branch of 54

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Before changing this file, make sure you have read how we use it:
 # https://www.notion.so/metabase/Pull-Request-Code-Review-Guide-374f05df889748b69d67af753f9bc9b8?pvs=4#36550c04ceab40b5a8b8bee6264b090c
 
-enterprise/frontend/src/embedding-sdk @metabase/embedding
-frontend/src/metabase/embedding-sdk @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
+# enterprise/frontend/src/embedding-sdk @metabase/embedding
+# frontend/src/metabase/embedding-sdk @metabase/embedding
+# frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
+# frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 # snowplow/* @metabase/data
 


### PR DESCRIPTION
Same thing we did for the previous release branches, this is to prevent the automations to ask our team for a review on a automatically approved pr, example of where it just happened: https://github.com/metabase/metabase/pull/56911
<img width="384" alt="image" src="https://github.com/user-attachments/assets/f24885bf-ed7e-4d43-84fb-40045a6256fc" />
