### PR TITLE
Fix - Filtering the foreign key dropdown randomly works

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -93,6 +93,34 @@ describe("scenarios > admin > datamodel > field > field type", () => {
     cy.findByTestId("fk-target-select").should("have.value", "Products → ID");
   });
 
+  it("should correctly filter out options in Foreign Key picker (metabase#56839)", () => {
+    H.visitAlias("@ORDERS_PRODUCT_ID_URL");
+    cy.wait("@metadata");
+
+    cy.findByPlaceholderText("Select a target").clear();
+    H.popover()
+      .should("contain.text", "Orders → ID")
+      .and("contain.text", "People → ID")
+      .and("contain.text", "Products → ID")
+      .and("contain.text", "Reviews → ID");
+
+    cy.log("should case-insensitive match field name");
+    cy.findByPlaceholderText("Select a target").type("id");
+    H.popover()
+      .should("contain.text", "Orders → ID")
+      .and("contain.text", "People → ID")
+      .and("contain.text", "Products → ID")
+      .and("contain.text", "Reviews → ID");
+
+    cy.log("should case-insensitive match field description");
+    cy.findByPlaceholderText("Select a target").clear().type("EXT");
+    H.popover()
+      .should("not.contain.text", "Orders → ID")
+      .and("not.contain.text", "People → ID")
+      .and("contain.text", "Products → ID")
+      .and("contain.text", "Reviews → ID");
+  });
+
   it("should not let you change the type to 'Number' (metabase#16781)", () => {
     H.visitAlias("@ORDERS_PRODUCT_ID_URL");
     cy.wait(["@metadata", "@metadata"]);

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -104,7 +104,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
       .and("contain.text", "Products → ID")
       .and("contain.text", "Reviews → ID");
 
-    cy.log("should case-insensitive match field name");
+    cy.log("should case-insensitive match field display name");
     cy.findByPlaceholderText("Select a target").type("id");
     H.popover()
       .should("contain.text", "Orders → ID")

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -76,9 +76,8 @@ export const FkTargetPicker = ({
           }
 
           return (
-            field.display_name.includes(query) ||
-            field.table?.display_name.includes(query) ||
-            field.table?.schema_name?.includes(query)
+            option.label.toLowerCase().includes(query) ||
+            field.description?.toLowerCase().includes(query)
           );
         });
       }}


### PR DESCRIPTION
Fixes #56839 ([SEM-252](https://linear.app/metabase/issue/SEM-252/filtering-the-foreign-key-dropdown-randomly-works))

### How to verify

1. Admin > Table Metadata > Sample Database > Orders
2. Focus target FK picker for User ID column
3. Clear search value and then type `id`

You should see all 8 ID columns

4. Clear search value and then type `INV`

You should see "Invoice -> ID" column and "Orders -> ID" column (because its description matches search query)
