### PR TITLE
Fix undo and notifications for tables with an UUID pk

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -20,7 +20,12 @@
 (defn get-row-pks
   "Given a row, strip it down to just its primary keys."
   [pk-fields row]
-  (select-keys row (map (comp keyword :name) pk-fields)))
+  (->> (map (comp keyword :name) pk-fields)
+       (select-keys row)
+       ;; Hack for now, pending discussion of the ideal fix
+       ;; https://linear.app/metabase/issue/WRK-281/undo-deletes-a-record-instead-of-reverting-the-edits
+       ;; See https://metaboat.slack.com/archives/C0641E4PB9B/p1744978660610899
+       (m/map-vals #(if (uuid? %) (str %) %))))
 
 (defn- valid-pks [pks]
   (every? some? (vals pks)))


### PR DESCRIPTION
References WRK-281

This is a workaround for type mismatch between coerced and queried values.

I would expect that we coerce values from the FE to have the same structure as db values, but I found two surprising details:

1. We don't coerce PKs. The reason in the [comment](https://github.com/metabase/metabase/blob/7a7045f541dd5441473202def523d3111ca32fb1/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj#L81) is not clear to me.
2. We don't consider the `base_type` of the column, e.g. turning a string into a UUID. Maybe there's no need for this in general, but it did surprise me.

Because of these difference, we fail to look up the "before" row values for notifications and undo snapshots:

```clojure
(get {{:id #uuid "123"} {:id #uuid "123", :name "bart"}} {:id "123"}) ;; => nil
```

Update: I realize that things are even weirder - the queried values will have gone through QP and had the semantic types applies, so there's even less reason for values to have equality, and we can't just fix this by tweaking the coerce logic.