### PR TITLE
introduce the no-auto-issue-links label

### DIFF
--- a/.github/scripts/update-pr-with-issues.js
+++ b/.github/scripts/update-pr-with-issues.js
@@ -78,8 +78,8 @@ async function link_issues(github) {
     if (prInfo &&
         prInfo.data &&
         prInfo.data.labels &&
-        prInfo.data.labels.some(label => label.name === "no-issue-links")) {
-      console.log('PR has "no-issue-links" label, skipping...');
+        prInfo.data.labels.some(label => label.name === "no-auto-issue-links")) {
+      console.log('PR has "no-auto-issue-links" label, skipping...');
       return;
     }
 
@@ -161,7 +161,7 @@ async function link_issues(github) {
       // Generate closing references
       const closingRefs = issueNumbersToAdd.map(num => `closes #${num}`).join(' ');
 
-      const messagePreamble = "<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-issue-links' label to your PR. -->"
+      const messagePreamble = "<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. -->"
 
       newBody = `${messagePreamble} ${closingRefs}\n` + newBody;
 

--- a/.github/scripts/update-pr-with-issues.js
+++ b/.github/scripts/update-pr-with-issues.js
@@ -75,6 +75,14 @@ async function link_issues(github) {
 
     console.log('PR Info:\n' + JSON.stringify(prInfo, null, 2) + "\n");
 
+    if (prInfo &&
+        prInfo.data &&
+        prInfo.data.labels &&
+        prInfo.data.labels.some(label => label.name === "no-issue-links")) {
+      console.log('PR has "no-issue-links" label, skipping...');
+      return;
+    }
+
     const prUrl = prInfo.data.html_url;
     console.log(`Processing PR: ${prUrl}`);
 
@@ -153,7 +161,9 @@ async function link_issues(github) {
       // Generate closing references
       const closingRefs = issueNumbersToAdd.map(num => `closes #${num}`).join(' ');
 
-      newBody = `<!-- Added by 'Add Issue References to PR' GitHub Action -->${closingRefs}\n` + newBody;
+      const messagePreamble = "<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-issue-links' label to your PR. -->"
+
+      newBody = `${messagePreamble} ${closingRefs}\n` + newBody;
 
       // Update PR body with new closing references
       await github.rest.issues.update({


### PR DESCRIPTION
## Situation

Whenever there's a PR opened, pushed, or edited, `Add Issue References to PR` is run. It searches linear for issues that are attached to BOTH the current PR, and _any issues in github_. If it finds some, it will add a `closes #_123456` magic closing tag to the PR. 

## Problem

People say `The "Add Issue References to PR" github action is lovely`, however on this PR: https://github.com/metabase/metabase/pull/56793 there is an attachment to a github issue on the linear issue, but we don't want to link them together. Removing one gets linked from the other, so doing it manually is extremely tricky if not impossible.

## Fix

So we now check for the new `no-auto-issue-links` label, and if it's there, never link linear issues. 🎉

