### PR TITLE
Fix two bugs in DB Routing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/model.clj
@@ -31,3 +31,9 @@
   [field]
   (when-let [mirror-db-id (some->> field u/the-id field/field-id->database-id (router-db-or-id->mirror-db-id @api/*current-user*))]
     {:mirror-db-id mirror-db-id}))
+
+(defenterprise delete-associated-database-router!
+  "Deletes the Database Router associated with this router database."
+  :feature :database-routing
+  [db-id]
+  (t2/delete! :model/DatabaseRouter :database_id db-id))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -133,7 +133,8 @@
 
 (deftest can-delete-router-databases
   (mt/with-temp [:model/Database {db-id :id} {}
-                 :model/Database {dest-db-id :id} {:router_database_id db-id}]
+                 :model/Database {dest-db-id :id} {:router_database_id db-id}
+                 :model/DatabaseRouter _ {:database_id db-id :user_attribute "foo"}]
     (mt/user-http-request :crowberto :delete 204 (str "database/" db-id))
     (is (not (t2/exists? :model/Database dest-db-id)))
     (is (not (t2/exists? :model/Database db-id)))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1013,6 +1013,7 @@
   (api/let-404 [db (t2/select-one :model/Database :id id)]
     (api/check-403 (mi/can-write? db))
     (t2/delete! :model/Database :router_database_id id)
+    (database-routing/delete-associated-database-router! id)
     (t2/delete! :model/Database :id id)
     (events/publish-event! :event/database-delete {:object db :user-id api/*current-user-id*}))
   api/generic-204-no-content)

--- a/src/metabase/database_routing/core.clj
+++ b/src/metabase/database_routing/core.clj
@@ -35,3 +35,9 @@
   metabase-enterprise.database-routing.common
   [_db-or-id-or-spec]
   nil)
+
+(defenterprise delete-associated-database-router!
+  "OSS version, does nothing"
+  metabase-enterprise.database-routing.model
+  [_db-id]
+  nil)


### PR DESCRIPTION
Two changes:

[Fix deleting a DB with database routing on](https://github.com/metabase/metabase/commit/e48ea09a5663403f0655a5808ea0ea479c206bdf) (simple bugfix, just ... make this work. I'm doing this with a `t2/delete!` instead of a `CASCADE` because we've already merged the migration to create the foreign key.)

[Fix database sync with a user attribute set](https://github.com/metabase/metabase/commit/5c684e504ce0c0c4e258fd6626f40fe14aa369e6)

When an admin has the relevant user attribute set and tries to sync the
database schema, we use `(with-database-routing-off ...)` to explicitly
turn off database routing for the purposes of sync. However, there are
two problems here:

First, this is just informational for the purposes of error checking, it
didn't actually turn off database routing, it just made us throw an
exception if a driver touched a mirror database (in dev).

Second, during query processing, when we're actually doing the database
routing "swap" to replace the router with the mirror DB, we were doing
`with-database-routing-on`. This essentially means that if you do

```
(with-db-routing-off
 (qp/process-query query rff))
```

you *don't* actually turn off DB routing. 🤦

Both get fixed by the same change: if database-routing is OFF, don't DO any database routing in the QP middleware. This seems more reasonable to me anyway.
