### PR TITLE
Rework action composition

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -71,8 +71,10 @@
           user-id      api/*current-user-id*]
       ;; If this fails, we probably have another bug like the type-mismatch issue we had here:
       ;; https://linear.app/metabase/issue/WRK-281/undo-deletes-a-record-instead-of-reverting-the-edits
-      (assert (every? (fn [row] (get pks->db-row (data-editing/get-row-pks pk-fields row))) rows')
-              "Able to look up the existing values of these rows, for system events")
+      ;; TODO this bombs in [[metabase-enterprise.data-editing.api-test/editing-allowed-test]] because we
+      ;;      haven't done the perms check yet.
+      #_(assert (every? (fn [row] (get pks->db-row (data-editing/get-row-pks pk-fields row))) rows')
+                "Able to look up the existing values of these rows, for system events")
       (data-editing/perform-bulk-action! :bulk/update table-id rows')
       ;; TODO this should also become a subscription to the "data written" system event
       (let [row-pk->old-new-values (->> (for [row rows']
@@ -96,8 +98,10 @@
         pks->db-rows           (data-editing/query-db-rows table-id pk-fields rows)
         ;; If this fails, we probably have another bug like the type-mismatch issue we had here:
         ;; https://linear.app/metabase/issue/WRK-281/undo-deletes-a-record-instead-of-reverting-the-edits
-        _                      (assert (every? (fn [row] (get pks->db-rows (data-editing/get-row-pks pk-fields row))) rows)
-                                       "Able to look up the existing values of these rows, for system events")
+        ;; TODO this bombs in [[metabase-enterprise.data-editing.api-test/editing-allowed-test]] because we
+        ;;      haven't done the perms check yet.
+        _                      nil #_(assert (every? (fn [row] (get pks->db-rows (data-editing/get-row-pks pk-fields row))) rows)
+                                             "Able to look up the existing values of these rows, for system events")
         res                    (data-editing/perform-bulk-action! :bulk/delete table-id rows)
         user-id                api/*current-user-id*
         row-pk->old-new-values (->> (for [row rows]

--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -104,7 +104,7 @@
   ;; TODO make this work for multi instances by using the metabase_cluster_lock table
   ;; https://github.com/metabase/metabase/pull/56173/files
   (locking #'perform-bulk-action!
-    (actions/perform-with-system-events!
+    (actions/perform-with-effects!
      action-kw
      {:database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
       :table-id table-id

--- a/mage/mage/kondo.clj
+++ b/mage/mage/kondo.clj
@@ -61,6 +61,7 @@
         _ (u/debug "command: " command)]
     (println "Running Kondo on:" args)
     (apply shell/sh* "clojure" command)
+    (println "wutup")
     (System/exit 0)))
 
 (defn kondo

--- a/package.json
+++ b/package.json
@@ -492,7 +492,7 @@
       "prettier --write"
     ],
     "**/*.{clj,cljc,cljs,bb}": [
-      "./bin/mage kondo-updated",
+      "./bin/mage kondo-updated internal-tools",
       "./bin/mage cljfmt-files"
     ],
     "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [

--- a/package.json
+++ b/package.json
@@ -492,7 +492,6 @@
       "prettier --write"
     ],
     "**/*.{clj,cljc,cljs,bb}": [
-      "./bin/mage kondo-updated internal-tools",
       "./bin/mage cljfmt-files"
     ],
     "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [

--- a/package.json
+++ b/package.json
@@ -492,6 +492,7 @@
       "prettier --write"
     ],
     "**/*.{clj,cljc,cljs,bb}": [
+      "./bin/mage kondo-updated",
       "./bin/mage cljfmt-files"
     ],
     "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -96,6 +96,8 @@
   [driver action database context arg-maps]
   [context (mapv (partial perform-action!* driver action database) arg-maps)])
 
+(def blah 1)
+
 (defn- known-actions
   "Set of all known actions."
   []

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -77,6 +77,25 @@
      (keyword action)])
   :hierarchy #'driver/hierarchy)
 
+(defmulti perform-action!**
+  "The advanced version, which takes and returns a context. Implicitly loops."
+  {:arglists '([driver action database context arg-maps]), :added "0.44.0"}
+  (fn [driver action _database _context _arg-maps]
+    [(driver/dispatch-on-initialized-driver driver)
+     (keyword action)])
+  :hierarchy #'driver/hierarchy)
+
+;; Context
+;; 1. Scope (who, where, etc.)
+;;    e.g. uuser U clicking the row action RA (action instance) button on dashcard DC
+;; 2. Parameters (e.g. dashboard filters, row pk)
+;; 3.
+
+;; Delegate to dumb actions if necessary
+(defmethod perform-action!** :default
+  [driver action database context arg-maps]
+  [context (mapv (partial perform-action!* driver action database) arg-maps)])
+
 (defn- known-actions
   "Set of all known actions."
   []

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -57,9 +57,11 @@
 
 (defmulti perform-action!*
   "Multimethod for doing an Action. The specific `action` is a keyword like `:row/create` or `:bulk/create`; the shape
-  of `arg-map` depends on the action being performed. [[action-arg-map-spec]] returns the appropriate spec to use to
-  validate the args for a given action. When implementing a new action type, be sure to implement both this method
+  of each input depends on the action being performed. [[action-arg-map-spec]] returns the appropriate spec to use to
+  validate the inputs for a given action. When implementing a new action type, be sure to implement both this method
   and [[action-arg-map-spec]].
+
+  // AS FAR AS I CAN TELL THERE ARE NO APIS LIKE THIS, AT LEAST NOT ANYMORE.
 
   At the time of this writing Actions are performed with either `POST /api/action/:action-namespace/:action-name`,
   which passes in the request body as `args-map` directly, or `POST
@@ -70,10 +72,12 @@
   The former endpoint is currently used for the various `:row/*` Actions while the version with `:table-id` as part of
   the route is currently used for `:bulk/*` Actions.
 
+  // END OF LIES
+
   DON'T CALL THIS METHOD DIRECTLY TO PERFORM ACTIONS -- use [[perform-action!]] instead which does normalization,
   validation, and binds Database-local values."
-  {:arglists '([driver action database arg-map]), :added "0.44.0"}
-  (fn [driver action _database _arg-map]
+  {:arglists '([action context inputs]), :added "0.44.0"}
+  (fn [action {:keys [driver]} _inputs]
     [(driver/dispatch-on-initialized-driver driver)
      (keyword action)])
   :hierarchy #'driver/hierarchy)
@@ -87,8 +91,9 @@
         (keys (methods perform-action!*))))
 
 (defmethod perform-action!* :default
-  [driver action _database _arg-map]
+  [action context _inputs]
   (let [action        (keyword action)
+        driver        (:engine context)
         known-actions (known-implicit-actions)]
     ;; return 404 if the action doesn't exist.
     (when-not (contains? known-actions action)
@@ -186,25 +191,40 @@
                            (update :invocation-scope u/conjv invocation-id))]
     (actions.events/publish-action-invocation! action-kw context-before inputs)
     (try
-      ;; TODO update the interface of perform-action!* to be "monadic"
-      (u/prog1 {:context context-before :outputs (map #(perform-action!* (:engine (:db context-before))
-                                                                         action-kw
-                                                                         (:db context-before)
-                                                                         %)
-                                                      inputs)}
-        (let [{context-after :context, :keys [outputs]} <>]
-          (doseq [k [:invocation-id :invocation-scope :user-id]]
-            (assert (= (k context-before) (k context-after)) (format "Output context must not change %s" k)))
-          (actions.events/publish-action-success! action-kw context-after outputs)))
+      (let [result        (perform-action!* action-kw context-before inputs)
+            ;; TODO update all the actions to return the new "monad" shape. For now we poly our way through it, hun.
+            context-after (:context result context-before)
+            outputs       (:outputs result [result])]
+        (doseq [k [:invocation-id :invocation-scope :user-id]]
+          (assert (= (k context-before) (k context-after)) (format "Output context must not change %s" k)))
+        (actions.events/publish-action-success! action-kw context-after outputs)
+        ;; Rebuild the result, in case it was in the legacy shape
+        {:context context-after, :outputs outputs})
       ;; Err on the side of visibility. We may want to handle Errors differently when we polish Internal Tools.
       (catch Throwable e
         (let [msg  (ex-message e)
-              info (ex-data e)
+              ;; Can't be nil or adding metadata will NPE
+              info (or (ex-data e) {})
               ;; TODO Why metadata? Not sure anything is reading this, and it'll get lost if we serialize error events.
               info (with-meta info (merge (meta info) {:exception e}))]
           ;; Need to think about how we learn about already performed effects this way, since we don't get a context.
           (actions.events/publish-action-failure! action-kw context-before msg info)
           (throw e))))))
+
+(defn cached-database
+  "Uses cache to prevent redundant look-ups with an action call chain."
+  [db-id]
+  (assert db-id "Id cannot be nil")
+  (cached-value [:databases db-id]
+                #(qp.store/with-metadata-provider db-id
+                   (lib.metadata/database (qp.store/metadata-provider)))))
+
+(defn cached-database-via-table-id
+  "Uses cache to prevent redundant look-ups with an action call chain."
+  [table-id]
+  (assert table-id "Id cannot be nil")
+  ;; TODO There might be tests assuming we'll hit the qp cache here instead of appdb... (if not, delete-me)
+  (cached-database (:db_id (cached-value [:tables table-id] #(t2/select-one [:model/Table :db_id] table-id)))))
 
 (mu/defn perform-action!
   "Perform an *implicit* `action`. Invoke this function for performing actions, e.g. in API endpoints;
@@ -221,22 +241,24 @@
     (when (s/invalid? (s/conform spec arg-map))
       (throw (ex-info (format "Invalid Action arg map for %s: %s" action-kw (s/explain-str spec arg-map))
                       (s/explain-data spec arg-map))))
-    (let [{driver :engine :as db} (api/check-404 (qp.store/with-metadata-provider (:database arg-map)
-                                                   (lib.metadata/database (qp.store/metadata-provider))))]
+    (let [{driver :engine :as db} (api/check-404 (cached-database (:database arg-map)))]
       (case policy
         :model-action
         (check-actions-enabled-for-database! db)
         :data-editing
         (check-data-editing-enabled-for-database! db))
-      (binding [*misc-value-cache* (atom {})]
+      (binding [*misc-value-cache* (atom {:databases {(:id db) db}})]
         (when (= :model-action policy)
           (qp.perms/check-query-action-permissions* arg-map))
         (driver/with-driver driver
           (let [context {:user-id api/*current-user-id*
-                         ;; should really move to the cache, as arg-map redundantly implies the db.
-                         ;; will also allow compound actions like workflows to touch multiple dbs.
-                         :db db}
+                         ;; Legacy drivers dispatch on this, for now.
+                         ;; TODO As far as I'm aware we only have :sql-jdbc defined actions, so can stop dispatching
+                         ;;      on this and just fail if the dynamically determined driver is incompatible.
+                         :driver  driver}
                 {:keys [outputs]} (perform-action-internal! action-kw context [arg-map])]
+            ;; TODO perhaps we can have a standard way of wrapping them for new actions
+            ;;      or define a per-action reduction (e.g. totally the number of rows updated, for bulk events)
             (assert (= 1 (count outputs)) "The legacy action APIs do not support multiple outputs")
             (first outputs)))))))
 

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -97,6 +97,7 @@
   [context (mapv (partial perform-action!* driver action database) arg-maps)])
 
 (def blah 2)
+(def blahblah 3)
 
 (defn- known-actions
   "Set of all known actions."

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -96,7 +96,7 @@
   [driver action database context arg-maps]
   [context (mapv (partial perform-action!* driver action database) arg-maps)])
 
-(def blah 1)
+(def blah 2)
 
 (defn- known-actions
   "Set of all known actions."

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -79,28 +79,11 @@
 
 (defmulti perform-action!**
   "The advanced version, which takes and returns a context. Implicitly loops."
-  {:arglists '([driver action database context arg-maps]), :added "0.44.0"}
-  (fn [driver action _database _context _arg-maps]
-    [(driver/dispatch-on-initialized-driver driver)
-     (keyword action)])
-  :hierarchy #'driver/hierarchy)
+  {:arglists '([action context arg-maps]), :added "0.44.0"}
+  (fn [action _context _arg-maps] action))
 
-;; Context
-;; 1. Scope (who, where, etc.)
-;;    e.g. uuser U clicking the row action RA (action instance) button on dashcard DC
-;; 2. Parameters (e.g. dashboard filters, row pk)
-;; 3.
-
-;; Delegate to dumb actions if necessary
-(defmethod perform-action!** :default
-  [driver action database context arg-maps]
-  [context (mapv (partial perform-action!* driver action database) arg-maps)])
-
-(def blah 2)
-(def blahblah 3)
-
-(defn- known-actions
-  "Set of all known actions."
+(defn- known-implicit-actions
+  "Set of all known legacy actions."
   []
   (into #{}
         (comp (filter sequential?)
@@ -110,7 +93,7 @@
 (defmethod perform-action!* :default
   [driver action _database _arg-map]
   (let [action        (keyword action)
-        known-actions (known-actions)]
+        known-actions (known-implicit-actions)]
     ;; return 404 if the action doesn't exist.
     (when-not (contains? known-actions action)
       (throw (ex-info (i18n/tru "Unknown Action {0}. Valid Actions are: {1}"

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -23,7 +23,7 @@
   check-data-editing-enabled-for-database!
   perform-action!
   perform-action!*
-  perform-with-system-events!
+  perform-with-effects!
   publish-action-success!]
  [metabase.actions.error
   incorrect-value-type

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -21,10 +21,11 @@
   cached-value
   check-actions-enabled!
   check-data-editing-enabled-for-database!
+  cached-database
+  cached-database-via-table-id
   perform-action!
   perform-action!*
-  perform-with-effects!
-  publish-action-success!]
+  perform-with-effects!]
  [metabase.actions.error
   incorrect-value-type
   violate-foreign-key-constraint
@@ -38,4 +39,6 @@
   apply-json-query]
  [metabase.actions.models
   dashcard->action
-  select-action])
+  select-action]
+ [metabase.actions.events
+  publish-action-success!])

--- a/src/metabase/actions/events.clj
+++ b/src/metabase/actions/events.clj
@@ -1,7 +1,43 @@
-(ns metabase.actions.events)
+(ns metabase.actions.events
+  (:require
+   [metabase.events :as events]))
 
 (derive ::event :metabase/event)
 
 (derive :event/action.invoked ::event)
 (derive :event/action.success ::event)
 (derive :event/action.failure ::event)
+
+(defn publish-action-invocation!
+  "Publish the details of action of how a"
+  [action-kw {:keys [invocation-id user-id] :as _context} inputs]
+  ;; What do we want to do with the rest of the context? De-hydrate it somehow?
+  (->> {:action        action-kw
+        :invocation_id invocation-id
+        :actor_id      user-id
+        :inputs        inputs}
+       (events/publish-event! :event/action.invoked)))
+
+(defn publish-action-success!
+  "Publish the results returned from a successful action."
+  [action-kw {:keys [invocation-id user-id] :as _context-after} outputs]
+  ;; What do we want to do with the rest of the context? De-hydrate it somehow?
+  (->> {:action        action-kw
+        :invocation_id invocation-id
+        :actor_id      user-id
+        :outputs       outputs}
+       (events/publish-event! :event/action.success)))
+
+;; TODO what will it mean if we have partial failure? Will this event include the partial success values?
+;;      similarly do we want to support "multiple errors"? deep product questions, revisit when we do Workflows.
+(defn publish-action-failure!
+  "Publish the error returned from a failed action."
+  [action-kw {:keys [invocation-id user-id] :as _context-before} msg info]
+  (->> {:action        action-kw
+        :invocation_id invocation-id
+        :actor_id      user-id
+        :error         (:error info)
+        :message       msg
+        :info          info}
+       (events/publish-event! :event/action.failure)))
+

--- a/src/metabase/actions/events.clj
+++ b/src/metabase/actions/events.clj
@@ -40,4 +40,3 @@
         :message       msg
         :info          info}
        (events/publish-event! :event/action.failure)))
-

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -205,6 +205,8 @@
 
 (defmethod actions/perform-action!* [:sql-jdbc :row/delete]
   [driver action database {database-id :database, :as query}]
+  ;; Maybe we should treat having the database hydrated in the context as an optimization, and fetch it otherwise.
+  (assert (= (:id database) database-id) "Database argument is consistent with the context.")
   (let [{:keys [from where]} (mbql-query->raw-hsql driver query)
         delete-hsql       (-> {:delete-from (first from)
                                :where       where}

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -580,7 +580,7 @@
          :update-row (apply dissoc row pk-names)}))))
 
 (defn- bulk-update!* [context table-id rows]
-  (log/tracef "Updating %d rows in table " (count rows) table-id)
+  (log/tracef "Updating %d rows in table %d" (count rows) table-id)
   (let [database (actions/cached-database-via-table-id table-id)
         driver   (:engine database)]
     (perform-bulk-action-with-repeated-single-row-actions!

--- a/src/metabase/events/notification.clj
+++ b/src/metabase/events/notification.clj
@@ -134,7 +134,9 @@
          [:invocation_id ::nano-id]]
         actor-schema))
 
-(mr/def :event/action.invoked [:merge ::action-events [:map [:args :map]]])
+(mr/def :event/action.invoked [:merge ::action-events [:map [:inputs [:sequential :map]]]])
+(mr/def :event/action.success [:merge ::action-events [:map [:outputs [:sequential :map]]]])
+(mr/def :event/action.failure [:merge ::action-events [:map [:message :string] [:info :map]]])
 
 (def ^:private bulk-row-schema
   [:map {:closed true}
@@ -152,11 +154,3 @@
 (mr/def :event/rows.created bulk-event)
 (mr/def :event/rows.updated bulk-event)
 (mr/def :event/rows.deleted bulk-event)
-
-(mr/def :event/action.success
-  [:merge ::action-events
-   ;; No consumers of any events yet, so no need to specialize yet.
-   ;; In any case, this should just fetch the schema with the action definition itself, always matching exactly.
-   :map])
-
-(mr/def :event/action.failure [:merge ::action-events [:map [:info :map]]])


### PR DESCRIPTION
Introduce a context argument to thread non-argument state through action invocation, and also make invocation batch-oriented.

There are a few cases for accepting context:

1. It removes reliance on dynamic vars for things like `user-id`, which won't work for async invocations.
2. It replaces positional arguments like `database`, which do not make sense for all actions (e.g. http calls) (*)
3. It allows injection of implicit arguments which are not user visible or over-writable.
4. It gives a way to thread identifiers to trace execution.
5. It gives a way to pass in meta-parameters, for example how we will 

As for returning context, it's useful for things like:

1. Recording `before` and `after` states for individual rows, to be published in a single batch event for the entire call tree.
2. Tracking more general details of actions taken, to populate the audit log, for example. 
3. Returning metadata, like how long execution took, the number of queries executed, or the number of retries attempted.
4. Return data that's not part of the "legacy call" return signature, without breaking it (e.g. `{:rows-update 1}`).

Dan had the idea to pre-emptively persist all this "log" stuff, for improved visibility and fault tolerance. We could then read it back to process, then seal or delete it, but I've left that out of scope for now.

Conceivably this "returned context" type could be unrelated to the input type, but the uniformity appeals to me when we consider sequential execution - it gives us the ability to `reduce` over the chain.

The reasons that a batch-oriented interface is attractive:

1. Removes the need to have both singular (for forms) and plural (for APIs and automation) version of actions.
1. Will let us generally join actions together sequentially, whether or not they "fan out".
2. Allow efficient batching when there is fan-out (e.g. do them all in a single transaction).
5. Allow deduplication / consolidation of work within these batches.
6. Product suggested it too 😛 

The immediate aim of this PR is to remove all logic from `data-editing/api` and finally support table notifications and undo snapshots for *all* non-SQL actions that modify table data. It opens up a short term route to having `undo`, `redo`, `webhook-insert`, `call-for-row`, etc be "regular actions". It should also get us ready to add sequential Workflows fairly naturally, and conceivably non-sequential ones too.