### PR TITLE
Fix bug in events for multi-row creation

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -167,10 +167,7 @@
     (query-db-rows table-id pk-fields rows)
 
     :bulk/create
-    (->> (for [row (:created-rows result)]
-           [(query-db-rows table-id pk-fields [row])
-            (update-keys row keyword)])
-         (into {}))
+    (query-db-rows table-id pk-fields (map #(update-keys % keyword) (:created-rows result)))
 
     ;; action does not relate to row updates
     (throw (ex-info "See, this doesn't make sense" {:dumb :hack}))))

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -264,7 +264,6 @@
   "Fire the expected events used to send notifications if the underlying actions modified table data."
   [action-kw args-map & {:as opts}]
   (let [qry-context       ((requiring-resolve 'metabase-enterprise.data-editing.data-editing/qry-context) args-map)
-        ;; TODO this is totally broken if you create more than 1 row, because we don't know the pk yet (it's just {})
         pk->db-row-before ((requiring-resolve 'metabase-enterprise.data-editing.data-editing/query-previous-rows) action-kw qry-context)]
     (u/prog1 (perform-action! action-kw args-map opts)
       ;; process the "data has changed" side effects


### PR DESCRIPTION
Before this change, we calculated the PK of all created rows as `{}` and lost all but 1 of them when indexing the collection.

Verified using `#p` since we're not "officially" supporting batch events yet, and when we do they should have e2e tests.