### PR TITLE
Fix metric tests

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/complete/metrics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/metrics.unit.spec.ts
@@ -19,6 +19,7 @@ describe("suggestMetrics", () => {
     const METRIC_FOO = createMockCard({
       name: "FOO",
       type: "metric",
+      table_id: TABLE_ID,
       dataset_query: createMockStructuredDatasetQuery({
         database: DATABASE_ID,
         query: {
@@ -123,14 +124,21 @@ describe("suggestMetrics", () => {
   describe("expressionMode = aggregations", () => {
     const expressionMode = "aggregation";
 
-    // TODO: I cannot get metrics to work
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should suggest metrics", () => {
+    it("should suggest metrics", () => {
       const complete = setup({ expressionMode });
-      const results = complete("Fo|");
-      expect(results).toBe({
+      const results = complete("FO|");
+      expect(results).toEqual({
         from: 0,
-        options: [],
+        to: 2,
+        options: [
+          {
+            displayLabel: "FOO",
+            icon: "metric",
+            label: "[FOO]",
+            matches: [[0, 1]],
+            type: "metric",
+          },
+        ],
       });
     });
   });

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
@@ -239,9 +239,7 @@ describe("format", () => {
     it.each([
       { result: "[Unknown Field]", parts: fields.orders.TOTAL },
       { result: "[Unknown Segment]", parts: segments.EXPENSIVE_THINGS },
-
-      // TODO: fix metrics in tests
-      // { result: "[Unknown Metric]", parts: metrics.FOO },
+      { result: "[Unknown Metric]", parts: metrics.FOO },
     ])("should format an unknown %s as %s", async ({ result, parts }) => {
       const clause = Lib.expressionClause(parts);
 
@@ -599,11 +597,9 @@ describe("if printWidth = Infinity, it should return the same results as the sin
     // ],
   });
 
-  // TODO: cannot find available metrics in tests
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should format metrics", async () => {
+  it("should format metrics", async () => {
     await all({
-      "[Metric]": metrics.FOO,
+      "[Foo Metric]": metrics.FOO,
     });
   });
 

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -70,6 +70,7 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
 
   creator?: CreatorInfo;
   "last-edit-info"?: LastEditInfo;
+  table_id?: TableId;
 }
 
 export interface PublicCard {


### PR DESCRIPTION
This PR unskips some skipped tests which didn't work due to `Lib.availableMetrics` being finicky and not returning metrics.

Turns out we [need to set `table_id` on the metric's card for it to show up](https://github.com/metabase/metabase/blob/master/src/metabase/lib/js/metadata.cljs#L531).