### PR TITLE
Thread effects up from row actions

### DIFF
--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -219,7 +219,6 @@
   "Uses cache to prevent redundant look-ups with an action call chain."
   [table-id]
   (assert table-id "Id cannot be nil")
-  ;; TODO There might be tests assuming we'll hit the qp cache here instead of appdb... (if not, delete-me)
   (cached-database (:db_id (cached-value [:tables table-id] #(t2/select-one [:model/Table :db_id] table-id)))))
 
 (mu/defn perform-action!

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -237,6 +237,10 @@
 
        ([[errors successes]]
         (when (seq errors)
+          ;; TODO Disabled due to errors about not being in a transaction block (?)
+          ;;      Returning the errors also causes issues in some cases, I guess from `with-jdbc-transaction` closing.
+          ;;      Well, this eager throw is consistent with how this action behaved previously.
+          (throw (:error (first errors)))
           (.rollback conn))
         [errors successes])
 

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -372,7 +372,7 @@
 ;;; H2 and MySQL are dumb and `RETURN_GENERATED_KEYS` only returns the ID of
 ;;; the newly created row. This function will `SELECT` the newly created row
 ;;; assuming that `result` is a map from column names to the generated values.
-(mu/defmethod select-created-row :default :- [:maybe ::row]
+(mu/defmethod select-created-row :default :- [:maybe [:map-of :string :any]]
   [driver create-hsql conn result]
   (let [select-hsql     (-> create-hsql
                             (dissoc :insert-into :values)

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/driver-tests metabase.actions.actions-test
   (:require
    [clojure.test :refer :all]
+   [clojure.walk :as walk]
    [metabase.actions.actions :as actions]
    [metabase.actions.execution :as actions.execution]
    [metabase.actions.models :as action]
@@ -40,11 +41,12 @@
       (with-actions-test-data-and-actions-permissively-enabled!
         (let [response (actions/perform-action! :row/create
                                                 (assoc (mt/mbql-query categories) :create-row {(format-field-name :name) "created_row"}))]
-          (is (=? {:created-row {(format-field-name :id)   76
-                                 (format-field-name :name) "created_row"}}
+          (is (=? (walk/keywordize-keys
+                   {:created-row {(format-field-name :id)   76
+                                  (format-field-name :name) "created_row"}})
                   response)
               "Create should return the entire row")
-          (let [created-id (get-in response [:created-row (format-field-name :id)])]
+          (let [created-id (get-in response [:created-row (keyword (format-field-name :id))])]
             (is (= "created_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
                 "The record at created-id should now have its name set to \"created_row\"")))))))
 
@@ -259,8 +261,9 @@
       (with-actions-test-data-and-actions-permissively-enabled!
         (is (= 75
                (categories-row-count)))
-        (is (= {:created-rows [{(format-field-name :id) 76, (format-field-name :name) "NEW_A"}
-                               {(format-field-name :id) 77, (format-field-name :name) "NEW_B"}]}
+        (is (= (walk/keywordize-keys
+                {:created-rows [{(format-field-name :id) 76, (format-field-name :name) "NEW_A"}
+                                {(format-field-name :id) 77, (format-field-name :name) "NEW_B"}]})
                (actions/perform-action! :bulk/create
                                         {:database (mt/id)
                                          :table-id (mt/id :categories)
@@ -446,7 +449,7 @@
           ;; that happen in the DW since they often can't be enforced in the frontend client OR in the backend without
           ;; actually hitting the DW
           (testing "Should validate that every row has required PK columns"
-            (is (thrown-with-msg? Exception (re-pattern (format "Row is missing required primary key column. Required #\\{%s\\}; got #\\{%s\\}"
+            (is (thrown-with-msg? Exception (re-pattern (format "Row is missing required primary key column. Required \\(%s\\); got \\(%s\\)"
                                                                 (pr-str (clojure.core/name (format-field-name :id)))
                                                                 (pr-str (clojure.core/name (format-field-name :name)))))
                                   (update-categories! [{id 1, name "Seed Bowl"}
@@ -604,8 +607,9 @@
                         (assoc (mt/mbql-query ants)
                                :create-row {(format-field-name :id) "5cba6f11-2325-400f-8f2e-82fbdc6f181c"
                                             (format-field-name :name) "created_row"}))]
-          (is (=? {:created-row {(format-field-name :id) #uuid "5cba6f11-2325-400f-8f2e-82fbdc6f181c"
-                                 (format-field-name :name) "created_row"}}
+          (is (=? (walk/keywordize-keys
+                   {:created-row {(format-field-name :id)   #uuid "5cba6f11-2325-400f-8f2e-82fbdc6f181c"
+                                  (format-field-name :name) "created_row"}})
                   response)
               "Create should return the entire row")
           (is (= "created_row"


### PR DESCRIPTION
With this change record "row mutation effects", which give before and after snapshots, and make sure these get thread up through all the possible action invocation paths.

This also fixes a regression where I was kinda sloppy and had made the actions non-atomic by using naive loops in a few places. To keep things atomic I had to add a restriction that each action only acts on a single database, but I think that's fair.

In future we'll have actions which can't be completely, for example when they make HTTP calls, but it's nice to keep the property as much as we can.

This also reduces the transducer flavor of the namespace a bit.

Unfortunately it's pretty tricky to take before and after snapshots just given some MBQL, as pulling the PKs back out would be pretty gnarly and brittle. To be solved in my next PR - I might just get rid of the MBQL flavored actions. I think we can do that without breaking basic actions.