### PR TITLE
Replace all references of StartRule with Lib.ExpressionMode

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/compiler.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.ts
@@ -4,7 +4,6 @@ import type { Expression } from "metabase-types/api";
 import { type ExpressionError, renderError } from "./errors";
 import { compile, lexify, parse } from "./pratt";
 import { type Resolver, resolver as defaultResolver } from "./resolver";
-import type { StartRule } from "./types";
 
 export type CompileResult =
   | {
@@ -22,17 +21,17 @@ export type CompileResult =
 
 export function compileExpression({
   source,
-  startRule,
+  expressionMode,
   query,
   stageIndex,
   resolver = defaultResolver({
     query,
     stageIndex,
-    startRule,
+    expressionMode,
   }),
 }: {
   source: string;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   stageIndex: number;
   resolver?: Resolver | null;
@@ -41,7 +40,7 @@ export function compileExpression({
     const { tokens } = lexify(source);
     const { root } = parse(tokens, { throwOnError: true });
     const expressionParts = compile(root, {
-      startRule,
+      expressionMode,
       resolver,
     });
     const expressionClause = Lib.expressionClause(expressionParts);

--- a/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
@@ -1,3 +1,5 @@
+import type * as Lib from "metabase-lib";
+
 import {
   bool,
   created,
@@ -9,19 +11,18 @@ import {
   total,
 } from "./__support__/shared";
 import { compileExpression } from "./compiler";
-import type { StartRule } from "./types";
 
 function expr(
   source: string,
   {
-    startRule = "expression",
+    expressionMode = "expression",
   }: {
-    startRule?: StartRule;
+    expressionMode?: Lib.ExpressionMode;
   } = {},
 ) {
   const { expression, error } = compileExpression({
     source,
-    startRule,
+    expressionMode,
     query,
     stageIndex: -1,
   });
@@ -34,11 +35,11 @@ function expr(
 }
 
 function filter(source: string) {
-  return expr(source, { startRule: "boolean" });
+  return expr(source, { expressionMode: "filter" });
 }
 
 function aggregation(source: string) {
-  return expr(source, { startRule: "aggregation" });
+  return expr(source, { expressionMode: "aggregation" });
 }
 
 describe("old recursive-parser tests", () => {

--- a/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
@@ -19,18 +19,18 @@ import {
 
 export type Options = {
   query: Lib.Query;
-  startRule: string;
+  expressionMode: Lib.ExpressionMode;
   metadata: Metadata;
   reportTimezone?: string;
 };
 
 export function suggestAggregations({
-  startRule,
+  expressionMode,
   query,
   metadata,
   reportTimezone,
 }: Options) {
-  if (startRule !== "aggregation") {
+  if (expressionMode !== "aggregation") {
     return null;
   }
 

--- a/frontend/src/metabase-lib/v1/expressions/complete/aggregations.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/aggregations.unit.spec.ts
@@ -8,7 +8,7 @@ import { type Options, suggestAggregations } from "./aggregations";
 
 describe("suggestAggregations", () => {
   function setup({
-    startRule = "aggregation",
+    expressionMode = "aggregation",
     features = [],
   }: Partial<Options> & {
     features?: DatabaseFeature[];
@@ -22,7 +22,7 @@ describe("suggestAggregations", () => {
     });
     const query = createQuery({ metadata });
     const source = suggestAggregations({
-      startRule,
+      expressionMode,
       query,
       metadata,
       reportTimezone: "America/New_York",
@@ -33,28 +33,28 @@ describe("suggestAggregations", () => {
     };
   }
 
-  describe("startRule = expression", () => {
-    const startRule = "expression";
+  describe("expressionMode = expression", () => {
+    const expressionMode = "expression";
 
     it("should not suggest aggregations", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("Coun|");
       expect(results).toEqual(null);
     });
   });
 
-  describe("startRule = boolean", () => {
-    const startRule = "boolean";
+  describe("expressionMode = boolean", () => {
+    const expressionMode = "filter";
 
     it("should not suggest aggregations", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("Coun|");
       expect(results).toEqual(null);
     });
   });
 
-  describe("startRule = aggregation", () => {
-    const startRule = "aggregation";
+  describe("expressionMode = aggregation", () => {
+    const expressionMode = "aggregation";
 
     const RESULTS = {
       from: 0,
@@ -116,13 +116,13 @@ describe("suggestAggregations", () => {
     };
 
     it("should suggest aggregations", () => {
-      const completer = setup({ startRule, features: [] });
+      const completer = setup({ expressionMode, features: [] });
       const results = completer("Coun|");
       expect(results).toEqual(RESULTS);
     });
 
     it("should not suggest unsupported aggregations", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("StandardDev|");
       expect(results).toEqual({
         from: 0,
@@ -133,7 +133,7 @@ describe("suggestAggregations", () => {
 
     it("should suggest supported aggregations", () => {
       const completer = setup({
-        startRule,
+        expressionMode,
         features: ["standard-deviation-aggregations"],
       });
       const results = completer("StandardDev|");
@@ -155,7 +155,7 @@ describe("suggestAggregations", () => {
     });
 
     it("should suggest aggregations, inside a word", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("Cou|n");
       expect(results).toEqual(RESULTS);
     });
@@ -180,7 +180,7 @@ describe("suggestAggregations", () => {
         "Cou|n ([Foo])",
       ];
       for (const doc of cases) {
-        const completer = setup({ startRule });
+        const completer = setup({ expressionMode });
         const results = completer(doc);
         expect(results).toEqual(RESULTS_NO_TEMPLATE);
       }

--- a/frontend/src/metabase-lib/v1/expressions/complete/complete.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/complete.ts
@@ -4,14 +4,12 @@ import { isNotNull } from "metabase/lib/types";
 import type * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
-import type { StartRule } from "../types";
-
 export type SuggestOptions = {
   query: Lib.Query;
   stageIndex: number;
   metadata: Metadata;
   reportTimezone?: string;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   expressionIndex: number | undefined;
 };
 

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
@@ -19,19 +19,19 @@ import {
 } from "./util";
 
 export type Options = {
-  startRule: string;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   metadata: Metadata;
   reportTimezone?: string;
 };
 
 export function suggestFunctions({
-  startRule,
+  expressionMode,
   query,
   metadata,
   reportTimezone,
 }: Options) {
-  if (startRule !== "expression" && startRule !== "boolean") {
+  if (expressionMode !== "expression" && expressionMode !== "filter") {
     return null;
   }
 
@@ -42,7 +42,7 @@ export function suggestFunctions({
     .filter((clause) => clause && database?.hasFeature(clause.requiresFeature))
     .filter(function disableOffsetInFilterExpressions(clause) {
       const isOffset = clause.name === "offset";
-      const isFilterExpression = startRule === "boolean";
+      const isFilterExpression = expressionMode === "filter";
       const isOffsetInFilterExpression = isOffset && isFilterExpression;
       return !isOffsetInFilterExpression;
     })

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
@@ -8,7 +8,7 @@ import { type Options, suggestFunctions } from "./functions";
 
 describe("suggestFunctions", () => {
   function setup({
-    startRule = "expression",
+    expressionMode = "expression",
     reportTimezone = "America/New_York",
     features = undefined,
   }: Partial<Options> & {
@@ -23,7 +23,7 @@ describe("suggestFunctions", () => {
     });
     const query = createQuery({ metadata });
     const source = suggestFunctions({
-      startRule,
+      expressionMode,
       query,
       metadata,
       reportTimezone,
@@ -132,17 +132,17 @@ describe("suggestFunctions", () => {
     })),
   };
 
-  describe("startRule = expression", () => {
-    const startRule = "expression";
+  describe("expressionMode = expression", () => {
+    const expressionMode = "expression";
 
     it("should suggest functions", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("conc|");
       expect(results).toEqual(RESULTS);
     });
 
     it("should suggest functions, inside a word", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("con|c");
       expect(results).toEqual(RESULTS);
     });
@@ -167,14 +167,14 @@ describe("suggestFunctions", () => {
         "con|c ([Foo])",
       ];
       for (const doc of cases) {
-        const completer = setup({ startRule });
+        const completer = setup({ expressionMode });
         const results = completer(doc);
         expect(results).toEqual(RESULTS_NO_TEMPLATE);
       }
     });
 
     it("should not suggest offset", async () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = await completer("offse|");
       const options = results?.options.filter(
         (option) => option.label === "offset",
@@ -183,7 +183,7 @@ describe("suggestFunctions", () => {
     });
 
     it("should suggest case", async () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = await completer("cas|");
       const options = results?.options.filter(
         (option) => option.label === "case",
@@ -204,7 +204,7 @@ describe("suggestFunctions", () => {
 
     it("should not suggest unsupported functions", async () => {
       const completer = setup({
-        startRule,
+        expressionMode,
         features: [],
       });
       const results = await completer("rege|");
@@ -215,7 +215,7 @@ describe("suggestFunctions", () => {
 
     it("should suggest supported functions", async () => {
       const completer = setup({
-        startRule,
+        expressionMode,
         features: ["regex"],
       });
       const results = await completer("rege|");
@@ -234,40 +234,40 @@ describe("suggestFunctions", () => {
     });
   });
 
-  describe("startRule = aggregation", () => {
-    const startRule = "aggregation";
+  describe("expressionMode = aggregation", () => {
+    const expressionMode = "aggregation";
 
     it("should not suggest functions", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("con|");
       expect(results).toEqual(null);
     });
   });
 
-  describe("startRule = boolean", () => {
-    const startRule = "boolean";
+  describe("expressionMode = boolean", () => {
+    const expressionMode = "filter";
 
     it("should suggest functions", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("conc|");
       expect(results).toEqual(RESULTS);
     });
 
     it("should suggest functions, inside a word", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("con|c");
       expect(results).toEqual(RESULTS);
     });
 
     it("should suggest functions, before parenthesis, inside a word", () => {
-      const completer = setup({ startRule });
+      const completer = setup({ expressionMode });
       const results = completer("con|c()");
       expect(results).toEqual(RESULTS_NO_TEMPLATE);
     });
   });
 
   it("should complete functions whose name starts with the an operator name as a prefix (metabase#55686)", async () => {
-    const completer = setup({ startRule: "expression" });
+    const completer = setup({ expressionMode: "expression" });
     const results = await completer("not|");
     expect(results?.options.map((result) => result.displayLabel)).toEqual([
       "notIn",

--- a/frontend/src/metabase-lib/v1/expressions/complete/metrics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/metrics.ts
@@ -7,12 +7,12 @@ import { formatIdentifier } from "../identifier";
 import { content, fuzzyMatcher, tokenAtPos } from "./util";
 
 export type Options = {
-  startRule: string;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   stageIndex: number;
 };
 
-export function suggestMetrics({ startRule, query, stageIndex }: Options) {
+export function suggestMetrics({ expressionMode, query, stageIndex }: Options) {
   const metrics = Lib.availableMetrics(query, stageIndex)?.map((metric) => {
     const displayInfo = Lib.displayInfo(query, stageIndex, metric);
     return {
@@ -23,7 +23,7 @@ export function suggestMetrics({ startRule, query, stageIndex }: Options) {
     };
   });
 
-  if (startRule !== "aggregation" || metrics.length === 0) {
+  if (expressionMode !== "aggregation" || metrics.length === 0) {
     return null;
   }
 

--- a/frontend/src/metabase-lib/v1/expressions/complete/metrics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/metrics.unit.spec.ts
@@ -12,7 +12,7 @@ import { complete } from "./__support__";
 import { type Options, suggestMetrics } from "./metrics";
 
 describe("suggestMetrics", () => {
-  function setup({ startRule = "expression" }: Partial<Options>) {
+  function setup({ expressionMode = "expression" }: Partial<Options>) {
     const DATABASE_ID = SAMPLE_DATABASE.id;
     const TABLE_ID = 1;
 
@@ -90,7 +90,7 @@ describe("suggestMetrics", () => {
     });
 
     const source = suggestMetrics({
-      startRule,
+      expressionMode,
       query,
       stageIndex: -1,
     });
@@ -100,33 +100,33 @@ describe("suggestMetrics", () => {
     };
   }
 
-  describe("startRule = expression", () => {
-    const startRule = "expression";
+  describe("expressionMode = expression", () => {
+    const expressionMode = "expression";
 
     it("should not suggest metrics", () => {
-      const complete = setup({ startRule });
+      const complete = setup({ expressionMode });
       const results = complete("Fo|");
       expect(results).toBe(null);
     });
   });
 
-  describe("startRule = boolean", () => {
-    const startRule = "boolean";
+  describe("expressionMode = boolean", () => {
+    const expressionMode = "filter";
 
     it("should not suggest metrics", () => {
-      const complete = setup({ startRule });
+      const complete = setup({ expressionMode });
       const results = complete("Fo|");
       expect(results).toBe(null);
     });
   });
 
-  describe("startRule = aggregations", () => {
-    const startRule = "aggregations";
+  describe("expressionMode = aggregations", () => {
+    const expressionMode = "aggregation";
 
     // TODO: I cannot get metrics to work
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip("should suggest metrics", () => {
-      const complete = setup({ startRule });
+      const complete = setup({ expressionMode });
       const results = complete("Fo|");
       expect(results).toBe({
         from: 0,

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/check-lib-diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/check-lib-diagnostics.ts
@@ -1,26 +1,24 @@
 import * as Lib from "metabase-lib";
 
 import { DiagnosticError } from "../errors";
-import type { StartRule } from "../types";
-import { getExpressionMode } from "../utils";
 
 export function checkLibDiagnostics({
   query,
   stageIndex,
-  startRule,
+  expressionMode,
   expressionClause,
   expressionIndex,
 }: {
   query: Lib.Query;
   stageIndex: number;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   expressionClause: Lib.ExpressionClause;
   expressionIndex?: number;
 }) {
   const error = Lib.diagnoseExpression(
     query,
     stageIndex,
-    getExpressionMode(startRule),
+    expressionMode,
     expressionClause,
     expressionIndex,
   );

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.ts
@@ -6,7 +6,6 @@ import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { type CompileResult, compileExpression } from "../compiler";
 import { DiagnosticError, type ExpressionError, renderError } from "../errors";
 import { lexify } from "../pratt";
-import type { StartRule } from "../types";
 
 import { checkArgCount } from "./check-arg-count";
 import { checkArgValidators } from "./check-arg-validators";
@@ -21,7 +20,7 @@ import { checkSupportedFunctions } from "./check-supported-functions";
 
 export function diagnose(options: {
   source: string;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   stageIndex: number;
   expressionIndex?: number;
@@ -36,14 +35,14 @@ export function diagnose(options: {
 
 export function diagnoseAndCompile({
   source,
-  startRule,
+  expressionMode,
   query,
   stageIndex,
   metadata,
   expressionIndex,
 }: {
   source: string;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   stageIndex: number;
   metadata?: Metadata;
@@ -55,7 +54,7 @@ export function diagnoseAndCompile({
     // make a simple check on expression syntax correctness
     const result = compileExpression({
       source,
-      startRule,
+      expressionMode,
       query,
       stageIndex,
     });
@@ -68,7 +67,7 @@ export function diagnoseAndCompile({
     diagnoseExpression({
       query,
       stageIndex,
-      startRule,
+      expressionMode,
       expressionClause: result.expressionClause,
       expressionParts: result.expressionParts,
       expressionIndex,
@@ -118,7 +117,7 @@ const expressionChecks = [
 export function diagnoseExpression(options: {
   query: Lib.Query;
   stageIndex: number;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   expressionClause: Lib.ExpressionClause;
   expressionParts: Lib.ExpressionParts | Lib.ExpressionArg;
   expressionIndex?: number;

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -1,9 +1,8 @@
 import { createMockMetadata } from "__support__/metadata";
+import type * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-
-import type { StartRule } from "../types";
 
 import { diagnose, diagnoseAndCompile } from "./diagnostics";
 
@@ -11,18 +10,18 @@ describe("diagnostics", () => {
   describe("diagnose", () => {
     function setup({
       expression,
-      startRule = "expression",
+      expressionMode = "expression",
       metadata,
     }: {
       expression: string;
-      startRule?: StartRule;
+      expressionMode?: Lib.ExpressionMode;
       metadata?: Metadata;
     }) {
       const query = createQuery();
       const stageIndex = -1;
       return diagnose({
         source: expression,
-        startRule,
+        expressionMode,
         query,
         stageIndex,
         metadata,
@@ -31,10 +30,10 @@ describe("diagnostics", () => {
 
     function err(
       expression: string,
-      startRule: StartRule = "expression",
+      expressionMode: Lib.ExpressionMode = "expression",
       metadata?: Metadata,
     ) {
-      return setup({ expression, startRule, metadata })?.message;
+      return setup({ expression, expressionMode, metadata })?.message;
     }
 
     it("should catch mismatched parentheses", () => {
@@ -66,7 +65,7 @@ describe("diagnostics", () => {
     });
 
     it("should show the correct number of function arguments in a custom expression", () => {
-      expect(err("between([Tax])", "boolean")).toBe(
+      expect(err("between([Tax])", "filter")).toBe(
         "Function between expects 3 arguments",
       );
     });
@@ -293,7 +292,7 @@ describe("diagnostics", () => {
         source: expression,
         query,
         stageIndex,
-        startRule: "expression",
+        expressionMode: "expression",
       });
     }
 

--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.unit.spec.ts
@@ -5,11 +5,13 @@ import type { Expression } from "metabase-types/api";
 
 import { dataForFormatting, query } from "../__support__/shared";
 import { compileExpression } from "../compiler";
-import type { StartRule } from "../types";
 
 import { format } from "./formatter";
 
-function setup(printWidth: number, startRule: StartRule = "expression") {
+function setup(
+  printWidth: number,
+  expressionMode: Lib.ExpressionMode = "expression",
+) {
   async function assertFormatted(
     expressions: string | string[],
   ): Promise<void> {
@@ -19,7 +21,7 @@ function setup(printWidth: number, startRule: StartRule = "expression") {
     for (const source of expressions) {
       const options = {
         query,
-        startRule,
+        expressionMode,
         stageIndex: -1,
       };
 
@@ -172,7 +174,7 @@ describe("format", () => {
     });
 
     it("formats unary operators", async () => {
-      const { assertFormatted } = setup(25, "boolean");
+      const { assertFormatted } = setup(25, "filter");
       await assertFormatted([
         expression`
           NOT [Total] < 10

--- a/frontend/src/metabase-lib/v1/expressions/fuzz.compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/fuzz.compiler.unit.spec.ts
@@ -4,7 +4,6 @@ import { query } from "./__support__/shared";
 import { compileExpression } from "./compiler";
 import { fuzz } from "./test/fuzz";
 import { generateExpression } from "./test/generator";
-import type { StartRule } from "./types";
 
 jest.mock("metabase-lib", () => {
   const mod = jest.requireActual("metabase-lib");
@@ -18,7 +17,10 @@ jest.mock("metabase-lib", () => {
 
 const MAX_SEED = 10_000;
 
-function compile(expression: string, startRule: StartRule = "expression") {
+function compile(
+  expression: string,
+  expressionMode: Lib.ExpressionMode = "expression",
+) {
   const stageIndex = -1;
 
   const columns = Lib.expressionableColumns(query, stageIndex);
@@ -27,7 +29,7 @@ function compile(expression: string, startRule: StartRule = "expression") {
     source: expression,
     query,
     stageIndex,
-    startRule,
+    expressionMode,
     resolver() {
       return columns[0];
     },
@@ -62,7 +64,7 @@ fuzz("FUZZING metabase-lib/v1/expressions/compiler", () => {
 
     it("should parse generated boolean expression from seed " + seed, () => {
       const { expression } = generateExpression(seed, "boolean");
-      expect(() => compile(expression, "boolean")).not.toThrow();
+      expect(() => compile(expression, "filter")).not.toThrow();
     });
   }
 });

--- a/frontend/src/metabase-lib/v1/expressions/pratt/compiler.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/compiler.ts
@@ -12,7 +12,7 @@ import {
   isStringLiteral,
 } from "../matchers";
 import type { Kind } from "../resolver";
-import type { ExpressionType, StartRule } from "../types";
+import type { ExpressionType } from "../types";
 
 import {
   ADD,
@@ -49,7 +49,7 @@ type CompileFn = (
 
 type Options = {
   resolver?: Resolver | null;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
 };
 
 type Context = {
@@ -59,9 +59,18 @@ type Context = {
 
 export function compile(node: Node, options: Options) {
   return compileRoot(node, {
-    type: options.startRule,
+    type: getTypeForExpressionMode(options.expressionMode),
     resolver: options.resolver ?? fallbackResolver,
   });
+}
+
+function getTypeForExpressionMode(
+  expressionMode: Lib.ExpressionMode,
+): ExpressionType {
+  if (expressionMode === "filter") {
+    return "boolean";
+  }
+  return expressionMode;
 }
 
 function fallbackResolver(_kind: Kind, name: string, _node?: Node) {

--- a/frontend/src/metabase-lib/v1/expressions/pratt/compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/compiler.unit.spec.ts
@@ -28,7 +28,7 @@ describe("pratt/compiler", () => {
     });
 
     return compile(ast.root, {
-      startRule: "expression",
+      expressionMode: "expression",
     });
   }
 

--- a/frontend/src/metabase-lib/v1/expressions/resolver.ts
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.ts
@@ -18,7 +18,7 @@ export type Resolver = (
 export function resolver(options: {
   query: Lib.Query;
   stageIndex: number;
-  startRule: string;
+  expressionMode: Lib.ExpressionMode;
 }): Resolver {
   return function (kind, name, node) {
     if (kind === "metric") {
@@ -114,7 +114,7 @@ export function parseDimension(
     query: Lib.Query;
     stageIndex: number;
     expressionIndex?: number | undefined;
-    startRule: string;
+    expressionMode: Lib.ExpressionMode;
   },
 ) {
   return getAvailableDimensions(options).find(({ info }) => {
@@ -133,12 +133,12 @@ function getAvailableDimensions({
   query,
   stageIndex,
   expressionIndex,
-  startRule,
+  expressionMode,
 }: {
   query: Lib.Query;
   stageIndex: number;
   expressionIndex?: number | undefined;
-  startRule: string;
+  expressionMode: Lib.ExpressionMode;
 }) {
   const results = Lib.expressionableColumns(
     query,
@@ -151,7 +151,7 @@ function getAvailableDimensions({
     };
   });
 
-  if (startRule === "aggregation") {
+  if (expressionMode === "aggregation") {
     return [
       ...results,
       ...Lib.availableMetrics(query, stageIndex).map((dimension) => {

--- a/frontend/src/metabase-lib/v1/expressions/resolver.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.unit.spec.ts
@@ -1,9 +1,13 @@
+import type * as Lib from "metabase-lib";
+
 import { query } from "./__support__/shared";
 import { compileExpression } from "./compiler";
-import type { StartRule } from "./types";
 
 describe("resolve", () => {
-  function collect(source: string, startRule: StartRule = "expression") {
+  function collect(
+    source: string,
+    expressionMode: Lib.ExpressionMode = "expression",
+  ) {
     const fields: string[] = [];
     const segments: string[] = [];
     const metrics: string[] = [];
@@ -12,7 +16,7 @@ describe("resolve", () => {
 
     const res = compileExpression({
       source,
-      startRule,
+      expressionMode,
       query,
       stageIndex,
       resolver(kind: string, name: string) {
@@ -48,7 +52,7 @@ describe("resolve", () => {
   }
 
   const expression = (expr: string) => collect(expr, "expression");
-  const filter = (expr: string) => collect(expr, "boolean");
+  const filter = (expr: string) => collect(expr, "filter");
   const aggregation = (expr: string) => collect(expr, "aggregation");
 
   describe("for filters", () => {

--- a/frontend/src/metabase-lib/v1/expressions/types.ts
+++ b/frontend/src/metabase-lib/v1/expressions/types.ts
@@ -39,8 +39,6 @@ interface HelpTextArg {
   template?: string;
 }
 
-export type StartRule = "expression" | "boolean" | "aggregation";
-
 type MBQLClauseFunctionReturnType =
   | "aggregation"
   | "any"

--- a/frontend/src/metabase-lib/v1/expressions/utils.ts
+++ b/frontend/src/metabase-lib/v1/expressions/utils.ts
@@ -12,18 +12,6 @@ export function getDatabase(
   return metadata?.database(databaseId) ?? null;
 }
 
-export function getExpressionMode(startRule: string): Lib.ExpressionMode {
-  switch (startRule) {
-    case "expression":
-      return "expression";
-    case "aggregation":
-      return "aggregation";
-    case "boolean":
-      return "filter";
-  }
-  throw new Error(`Unknown start rule: ${startRule}`);
-}
-
 type Nodable =
   | unknown[]
   | Lib.ExpressionParts

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -249,7 +249,7 @@ export function AggregationPicker({
         name={displayInfo?.displayName}
         clause={clause}
         withName
-        startRule="aggregation"
+        expressionMode="aggregation"
         header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
         onChangeClause={handleClauseChange}
         onClose={closeExpressionEditor}

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -16,7 +16,6 @@ import { Button, Tooltip as ButtonTooltip, Flex, Icon } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 import {
   type ExpressionError,
-  type StartRule,
   diagnoseAndCompile,
   format,
   getClauseDefinition,
@@ -43,7 +42,7 @@ type EditorProps = {
   clause?: Lib.Expressionable | null;
   query: Lib.Query;
   stageIndex: number;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   expressionIndex?: number;
   reportTimezone?: string;
   readOnly?: boolean;
@@ -65,7 +64,7 @@ const FB_HEIGHT_WITH_HEADER = FB_HEIGHT + 48;
 export function Editor(props: EditorProps) {
   const {
     id,
-    startRule = "expression",
+    expressionMode = "expression",
     stageIndex,
     query,
     expressionIndex,
@@ -114,7 +113,7 @@ export function Editor(props: EditorProps) {
   });
 
   const extensions = useExtensions({
-    startRule,
+    expressionMode,
     query,
     stageIndex,
     expressionIndex,
@@ -208,7 +207,7 @@ export function Editor(props: EditorProps) {
       {isFunctionBrowserOpen && (
         <LayoutSidebar h={hasHeader ? FB_HEIGHT_WITH_HEADER : FB_HEIGHT}>
           <FunctionBrowser
-            startRule={startRule}
+            expressionMode={expressionMode}
             reportTimezone={reportTimezone}
             query={query}
             onClauseClick={handleFunctionBrowserClauseClick}
@@ -228,7 +227,7 @@ export function Editor(props: EditorProps) {
 
 function useExpression({
   clause,
-  startRule,
+  expressionMode,
   stageIndex,
   query,
   expressionIndex,
@@ -297,7 +296,7 @@ function useExpression({
 
       const { error, expressionClause: clause } = diagnoseAndCompile({
         source,
-        startRule,
+        expressionMode,
         query,
         stageIndex,
         metadata,
@@ -313,7 +312,7 @@ function useExpression({
     [
       query,
       stageIndex,
-      startRule,
+      expressionMode,
       metadata,
       handleChange,
       debouncedOnChange,

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/extensions.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/extensions.ts
@@ -9,7 +9,6 @@ import { useMemo } from "react";
 import { isNotNull } from "metabase/lib/types";
 import { metabaseSyntaxHighlighting } from "metabase/ui/syntax";
 import type * as Lib from "metabase-lib";
-import type { StartRule } from "metabase-lib/v1/expressions";
 import { suggestions } from "metabase-lib/v1/expressions/complete";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
@@ -19,7 +18,7 @@ import S from "./Editor.module.css";
 import { customExpression } from "./language";
 
 type Options = {
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   stageIndex: number;
   expressionIndex: number | undefined;
@@ -43,7 +42,7 @@ function getTooltipParent() {
 
 export function useExtensions(options: Options): Extension[] {
   const {
-    startRule,
+    expressionMode,
     query,
     stageIndex,
     expressionIndex,
@@ -73,7 +72,7 @@ export function useExtensions(options: Options): Extension[] {
       highlighting(),
       EditorView.lineWrapping,
       customExpression({
-        startRule,
+        expressionMode,
         query,
         stageIndex,
         expressionIndex,
@@ -97,7 +96,7 @@ export function useExtensions(options: Options): Extension[] {
         query,
         stageIndex,
         reportTimezone,
-        startRule,
+        expressionMode,
         expressionIndex,
         metadata,
       }),
@@ -111,7 +110,7 @@ export function useExtensions(options: Options): Extension[] {
       .filter(isNotNull);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    startRule,
+    expressionMode,
     query,
     stageIndex,
     expressionIndex,

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/language.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/language.ts
@@ -3,7 +3,7 @@ import { type Diagnostic, linter } from "@codemirror/lint";
 import type { EditorView } from "@codemirror/view";
 
 import type * as Lib from "metabase-lib";
-import type { ExpressionError, StartRule } from "metabase-lib/v1/expressions";
+import type { ExpressionError } from "metabase-lib/v1/expressions";
 import { diagnoseAndCompile } from "metabase-lib/v1/expressions";
 import { parser } from "metabase-lib/v1/expressions/tokenizer/parser";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
@@ -16,7 +16,7 @@ const expressionLanguage = LRLanguage.define({
 });
 
 type LintOptions = {
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   stageIndex: number;
   expressionIndex?: number | undefined;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { isNotNull } from "metabase/lib/types";
 import { Box, Button, Flex } from "metabase/ui";
 import type * as Lib from "metabase-lib";
-import type { ExpressionError, StartRule } from "metabase-lib/v1/expressions";
+import type { ExpressionError } from "metabase-lib/v1/expressions";
 
 import {
   trackColumnCombineViaShortcut,
@@ -22,7 +22,7 @@ import { NameInput } from "./NameInput";
 const WIDGET_WIDTH = 472;
 
 export type ExpressionWidgetProps = {
-  startRule?: StartRule;
+  expressionMode?: Lib.ExpressionMode;
 
   query: Lib.Query;
   stageIndex: number;
@@ -44,7 +44,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
     name: initialName,
     clause: initialClause,
     withName = false,
-    startRule = "expression",
+    expressionMode = "expression",
     reportTimezone,
     header,
     expressionIndex,
@@ -103,20 +103,20 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
   const shortcuts = useMemo(
     () =>
       [
-        startRule === "expression" &&
+        expressionMode === "expression" &&
           hasCombinations(query, stageIndex) && {
             name: t`Combine columns`,
             icon: "combine",
             action: () => setIsCombiningColumns(true),
           },
-        startRule === "expression" &&
+        expressionMode === "expression" &&
           hasExtractions(query, stageIndex) && {
             name: t`Extract columns`,
             icon: "arrow_split",
             action: () => setIsExtractingColumn(true),
           },
       ].filter((x): x is Shortcut => Boolean(x)),
-    [startRule, query, stageIndex],
+    [expressionMode, query, stageIndex],
   );
 
   const handleCombineColumnsSubmit = useCallback(
@@ -148,7 +148,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
     setIsExtractingColumn(false);
   }, []);
 
-  if (startRule === "expression" && isCombiningColumns) {
+  if (expressionMode === "expression" && isCombiningColumns) {
     return (
       <Box w={WIDGET_WIDTH} data-testid="expression-editor">
         <CombineColumns
@@ -181,7 +181,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
 
       <Editor
         id="expression-content"
-        startRule={startRule}
+        expressionMode={expressionMode}
         clause={clause}
         onChange={handleExpressionChange}
         query={query}
@@ -201,7 +201,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
               value={name}
               onChange={setName}
               onSubmit={handleSubmit}
-              startRule={startRule}
+              expressionMode={expressionMode}
             />
           )}
           <Flex py="sm" pr="sm" gap="sm">

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -118,9 +118,9 @@ describe("ExpressionWidget", () => {
     });
   });
 
-  describe("startRule = 'aggregation'", () => {
+  describe("expressionMode = 'aggregation'", () => {
     it("should show 'unknown metric' error if the identifier is not recognized as a dimension (metabase#50753)", async () => {
-      await setup({ startRule: "aggregation" });
+      await setup({ expressionMode: "aggregation" });
 
       await userEvent.paste("[Imaginary]");
       await userEvent.tab();
@@ -132,7 +132,7 @@ describe("ExpressionWidget", () => {
     });
 
     it("should show 'no aggregation found' error if the identifier is recognized as a dimension (metabase#50753)", async () => {
-      await setup({ startRule: "aggregation" });
+      await setup({ expressionMode: "aggregation" });
 
       await userEvent.paste("[Total] / [Subtotal]");
       await userEvent.tab();
@@ -146,9 +146,9 @@ describe("ExpressionWidget", () => {
     });
   });
 
-  describe("startRule = 'expression'", () => {
+  describe("expressionMode = 'expression'", () => {
     it("should show a detailed error when comma is missing (metabase#15892)", async () => {
-      await setup({ startRule: "expression" });
+      await setup({ expressionMode: "expression" });
 
       await userEvent.paste('concat([Tax] "test")');
       await userEvent.tab();

--- a/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/FunctionBrowser.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/FunctionBrowser.tsx
@@ -15,7 +15,7 @@ import { useSelector } from "metabase/lib/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Flex, Icon, Input, Text } from "metabase/ui";
 import type * as Lib from "metabase-lib";
-import type { HelpText, StartRule } from "metabase-lib/v1/expressions";
+import type { HelpText } from "metabase-lib/v1/expressions";
 
 import { HighlightExpressionSource } from "../HighlightExpression";
 
@@ -36,12 +36,12 @@ const components = {
 };
 
 export function FunctionBrowser({
-  startRule,
+  expressionMode,
   reportTimezone,
   query,
   onClauseClick,
 }: {
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   reportTimezone?: string;
   onClauseClick?: (name: string) => void;
@@ -56,8 +56,9 @@ export function FunctionBrowser({
   );
 
   const filteredClauses = useMemo(
-    () => getFilteredClauses({ startRule, filter, database, reportTimezone }),
-    [filter, startRule, database, reportTimezone],
+    () =>
+      getFilteredClauses({ expressionMode, filter, database, reportTimezone }),
+    [filter, expressionMode, database, reportTimezone],
   );
 
   const isEmpty = filteredClauses.length === 0;
@@ -73,7 +74,7 @@ export function FunctionBrowser({
         size="sm"
         mb="sm"
         mx="md"
-        placeholder={getSearchPlaceholder(startRule)}
+        placeholder={getSearchPlaceholder(expressionMode)}
         value={filter}
         onChange={handleFilterChange}
         leftSection={<Icon name="search" />}

--- a/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/utils.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/utils.ts
@@ -7,7 +7,6 @@ import {
   EXPRESSION_FUNCTIONS,
   type HelpText,
   type MBQLClauseFunctionConfig,
-  type StartRule,
   getClauseDefinition,
 } from "metabase-lib/v1/expressions";
 import { getHelpText } from "metabase-lib/v1/expressions/helper-text-strings";
@@ -21,20 +20,22 @@ const AGGREGATION_CLAUSES = Array.from(AGGREGATION_FUNCTIONS)
   .map(getClauseDefinition)
   .filter(isNotNull);
 
-export function getSearchPlaceholder(startRule: StartRule) {
-  if (startRule === "expression" || startRule === "boolean") {
+export function getSearchPlaceholder(expressionMode: Lib.ExpressionMode) {
+  if (expressionMode === "expression" || expressionMode === "filter") {
     return t`Search functions…`;
   }
-  if (startRule === "aggregation") {
+  if (expressionMode === "aggregation") {
     return t`Search aggregations…`;
   }
 }
 
-function getClauses(startRule: StartRule): MBQLClauseFunctionConfig[] {
-  if (startRule === "expression" || startRule === "boolean") {
+function getClauses(
+  expressionMode: Lib.ExpressionMode,
+): MBQLClauseFunctionConfig[] {
+  if (expressionMode === "expression" || expressionMode === "filter") {
     return EXPRESSION_CLAUSES;
   }
-  if (startRule === "aggregation") {
+  if (expressionMode === "aggregation") {
     return AGGREGATION_CLAUSES;
   }
   return [];
@@ -60,17 +61,17 @@ function getCategoryName(category: string) {
 }
 
 export function getFilteredClauses({
-  startRule,
+  expressionMode,
   filter,
   database,
   reportTimezone,
 }: {
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
   filter: string;
   database: Database | null;
   reportTimezone?: string;
 }) {
-  const clauses = getClauses(startRule);
+  const clauses = getClauses(expressionMode);
   const filteredClauses = clauses
     .filter(
       (clause) =>

--- a/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/utils.unit.spec.ts
@@ -1,15 +1,15 @@
 import { createMockMetadata } from "__support__/metadata";
-import type { StartRule } from "metabase-lib/v1/expressions";
+import type * as Lib from "metabase-lib";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { getFilteredClauses } from "./utils";
 
 function setup({
   filter = "",
-  startRule = "expression",
+  expressionMode = "expression",
 }: {
   filter?: string;
-  startRule?: StartRule;
+  expressionMode?: Lib.ExpressionMode;
 } = {}) {
   const sampleDatabase = createSampleDatabase();
   const metadata = createMockMetadata({ databases: [sampleDatabase] });
@@ -21,7 +21,7 @@ function setup({
 
   return getFilteredClauses({
     filter,
-    startRule,
+    expressionMode,
     database,
   });
 }

--- a/frontend/src/metabase/query_builder/components/expressions/NameInput/NameInput.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/NameInput/NameInput.tsx
@@ -1,7 +1,7 @@
 import { type ChangeEvent, type KeyboardEvent, useCallback } from "react";
 
 import { TextInput } from "metabase/ui";
-import type { StartRule } from "metabase-lib/v1/expressions";
+import type * as Lib from "metabase-lib";
 
 import S from "./NameInput.module.css";
 import { getPlaceholder } from "./utils";
@@ -10,12 +10,12 @@ export function NameInput({
   value,
   onChange,
   onSubmit,
-  startRule,
+  expressionMode,
 }: {
   value: string;
   onChange: (value: string) => void;
   onSubmit: () => void;
-  startRule: StartRule;
+  expressionMode: Lib.ExpressionMode;
 }) {
   const handleChange = useCallback(
     (evt: ChangeEvent<HTMLInputElement>) => {
@@ -39,7 +39,7 @@ export function NameInput({
       data-testid="expression-name"
       type="text"
       value={value}
-      placeholder={getPlaceholder(startRule)}
+      placeholder={getPlaceholder(expressionMode)}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       classNames={{

--- a/frontend/src/metabase/query_builder/components/expressions/NameInput/utils.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/NameInput/utils.ts
@@ -1,13 +1,13 @@
 import { t } from "ttag";
 
-import type { StartRule } from "metabase-lib/v1/expressions";
+import type * as Lib from "metabase-lib";
 
-export function getPlaceholder(startRule: StartRule) {
-  if (startRule === "expression") {
+export function getPlaceholder(expressionMode: Lib.ExpressionMode) {
+  if (expressionMode === "expression") {
     return t`Give your column a name…`;
-  } else if (startRule === "aggregation") {
+  } else if (expressionMode === "aggregation") {
     return t`Give your aggregation a name…`;
-  } else if (startRule === "boolean") {
+  } else if (expressionMode === "filter") {
     return t`Give your filter a name…`;
   }
   return t`Give your expression a name…`;

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
@@ -99,7 +99,7 @@ export function FilterPicker({
         query={query}
         stageIndex={stageIndex}
         clause={filter}
-        startRule="boolean"
+        expressionMode="filter"
         header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
         onChangeClause={handleClauseChange}
         onClose={closeExpressionEditor}


### PR DESCRIPTION
Replaces the `StartRule` type and fixes all the instances where it was used in favor of `Lib.ExpressionMode`.