### PR TITLE
fix: add cluster lock around view count update

### DIFF
--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -8,6 +8,7 @@
    [metabase.models.query.permissions :as query-perms]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
+   [metabase.util.cluster-lock :as cluster-lock]
    [metabase.util.grouper :as grouper]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -34,13 +35,16 @@
                              {}
                              items)]
       (doseq [[model ids] model->ids]
-        (let [cnt->ids (group-by-frequency ids)]
-          (t2/query {:update (t2/table-name model)
-                     :set    {:view_count [:+ :view_count (into [:case]
-                                                                (mapcat (fn [[cnt ids]]
-                                                                          [[:in :id ids] cnt])
-                                                                        cnt->ids))]}
-                     :where  [:in :id (apply concat (vals cnt->ids))]}))))
+        (let [cnt->ids (group-by-frequency ids)
+              lock-name (keyword "metabase.events.view_log"
+                                 (str (name (t2/table-name model)) "-view-count"))]
+          (cluster-lock/with-cluster-lock lock-name
+            (t2/query {:update (t2/table-name model)
+                       :set    {:view_count [:+ :view_count (into [:case]
+                                                                  (mapcat (fn [[cnt ids]]
+                                                                            [[:in :id ids] cnt])
+                                                                          cnt->ids))]}
+                       :where  [:in :id (apply concat (vals cnt->ids))]})))))
     (catch Exception e
       (log/error e "Failed to increment view counts"))))
 

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -183,16 +183,18 @@
   (mt/with-temp [:model/Card  {card-1-id :id} {}
                  :model/Card  {card-2-id :id} {:view_count 2}
                  :model/Table {table-id :id}  {}]
-    (t2/with-call-count [call-count]
+    (let [call-count (atom 0)
+          t2-query-orig t2/query]
       (testing "increment-view-counts!* update the view_count correctly"
-        (#'events.view-log/increment-view-counts!* [;; table-id : 1 views, card-id-1: 2 views, card-id 2: 2 views
-                                                    {:model :model/Table :id table-id}
-                                                    {:model :model/Card  :id card-1-id}
-                                                    {:model :model/Card  :id card-1-id}
-                                                    {:model :model/Card  :id card-2-id}
-                                                    {:model :model/Card  :id card-2-id}])
+        (with-redefs [t2/query (fn [& args] (swap! call-count inc) (apply t2-query-orig args))]
+          (#'events.view-log/increment-view-counts!* [;; table-id : 1 views, card-id-1: 2 views, card-id 2: 2 views
+                                                      {:model :model/Table :id table-id}
+                                                      {:model :model/Card  :id card-1-id}
+                                                      {:model :model/Card  :id card-1-id}
+                                                      {:model :model/Card  :id card-2-id}
+                                                      {:model :model/Card  :id card-2-id}]))
         (is (= 2 ;; one for update card, one for table
-               (call-count))
+               @call-count)
             "and groups db calls by frequency")
         (is (= 1 (t2/select-one-fn :view_count :model/Table table-id))
             "view_count for table-id should be 1")


### PR DESCRIPTION
### Description

To avoid deadlocks on postgresql appdbs caused by overlapping ids in the in clause of these updates.

I also had to change the `call-count` implementation for one of the tests to spy on t2/query instead. The call-count pipeline middleware will register either 2 or 4 depending on if we need to insert rows into the lock table or not.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
