### PR TITLE
pivot table: show subtotals for a single item

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1350,3 +1350,107 @@ describe("issue 57132", () => {
       .should("be.visible");
   });
 });
+
+describe("issue 52333", () => {
+  const baseQuery = `
+SELECT *
+FROM (
+  SELECT
+    category,
+    source,
+    state,
+    SUM(orders.discount) AS discount,
+    SUM(orders.total) AS total,
+    SUM(orders.quantity) AS quantity
+  FROM
+    orders
+    LEFT JOIN products ON orders.product_id = products.id
+    LEFT JOIN people ON orders.user_id = people.id
+  GROUP BY category, source, state
+) AS filtered_orders
+WHERE NOT (
+  category = 'Gizmo'
+  AND (
+    source IN ('Facebook', 'Google', 'Organic', 'Twitter')
+    OR state NOT IN ('AK')
+  )
+);`;
+
+  const baseQuestionDetails = {
+    name: "52333",
+    display: "table",
+    native: {
+      query: baseQuery,
+    },
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("pivot table should show subtotals for a group of a single value (metabase#52333)", () => {
+    H.createNativeQuestion(baseQuestionDetails, {
+      visitQuestion: true,
+      wrapId: true,
+    });
+
+    cy.get("@questionId").then((id) => {
+      const questionDetails = {
+        query: {
+          "source-table": `card__${id}`,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              "CATEGORY",
+              {
+                "base-type": "type/Text",
+              },
+            ],
+            [
+              "field",
+              "SOURCE",
+              {
+                "base-type": "type/Text",
+              },
+            ],
+            [
+              "field",
+              "STATE",
+              {
+                "base-type": "type/Text",
+              },
+            ],
+          ],
+        },
+        display: "pivot",
+        visualization_settings: {
+          "pivot_table.column_split": {
+            rows: ["CATEGORY", "SOURCE", "STATE"],
+            columns: [],
+            values: ["count", "avg"],
+          },
+          "pivot_table.column_widths": {
+            leftHeaderWidths: [104, 92, 80],
+            totalLeftHeaderWidths: 276,
+            valueHeaderWidths: {},
+          },
+          "pivot_table.collapsed_rows": {
+            value: ['["Doohickey"]', '["Gadget"]', '["Widget"]'],
+            rows: ["CATEGORY", "SOURCE", "STATE"],
+          },
+        },
+      };
+
+      H.createQuestion(questionDetails, { visitQuestion: true });
+    });
+
+    H.queryBuilderMain().within(() => {
+      cy.findByText("Affiliate");
+      cy.findByText("AK");
+      // Ensure it shows subtotals for the single value
+      cy.findByText("Totals for Affiliate");
+    });
+  });
+});

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1449,8 +1449,18 @@ WHERE NOT (
     H.queryBuilderMain().within(() => {
       cy.findByText("Affiliate");
       cy.findByText("AK");
-      // Ensure it shows subtotals for the single value
-      cy.findByText("Totals for Affiliate");
+
+      // Ensure it does not show subtotals for the single value by default
+      cy.findByText("Totals for Affiliate").should("not.exist");
+
+      H.openVizSettingsSidebar();
     });
+
+    H.sidebar().findByText("Condense duplicate totals").click();
+
+    // Ensure it shows subtotals for the single value
+    H.queryBuilderMain()
+      .findByText("Totals for Affiliate")
+      .should("be.visible");
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/pivot-table-test-mocks.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/pivot-table-test-mocks.tsx
@@ -53,6 +53,7 @@ const rows = [
 const pivotSettings = {
   "pivot.show_column_totals": true,
   "pivot.show_row_totals": true,
+  "pivot.condense_duplicate_totals": true,
   "pivot_table.collapsed_rows": {
     rows: [cols[0].name, cols[1].name, cols[2].name],
     value: [],

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -166,9 +166,15 @@ export const settings = {
     inline: true,
   },
   "pivot.condense_duplicate_totals": {
-    section: t`Columns`,
-    title: t`Condense duplicate totals`,
-    hint: t`Hide additional total elements if the totals are the same`,
+    get section() {
+      return t`Columns`;
+    },
+    get title() {
+      return t`Condense duplicate totals`;
+    },
+    get hint() {
+      return t`Hide additional total elements if the totals are the same`;
+    },
     widget: "toggle",
     default: true,
     inline: true,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -16,6 +16,7 @@ import { displayNameForColumn } from "metabase/lib/formatting";
 import { ChartSettingIconRadio } from "metabase/visualizations/components/settings/ChartSettingIconRadio";
 import { ChartSettingsTableFormatting } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import { migratePivotColumnSplitSetting } from "metabase-lib/v1/queries/utils/pivot";
 import { isDimension } from "metabase-lib/v1/types/utils/isa";
 import type {
@@ -23,6 +24,7 @@ import type {
   DatasetColumn,
   DatasetData,
   PivotTableColumnSplitSetting,
+  RawSeries,
   Series,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -162,6 +164,23 @@ export const settings = {
     widget: "toggle",
     default: true,
     inline: true,
+  },
+  "pivot.condense_duplicate_totals": {
+    section: t`Columns`,
+    title: t`Condense duplicate totals`,
+    widget: "toggle",
+    default: true,
+    inline: true,
+    getHidden: (
+      _series: RawSeries,
+      settings: ComputedVisualizationSettings,
+    ) => {
+      return (
+        !settings["pivot.show_row_totals"] &&
+        !settings["pivot.show_column_totals"]
+      );
+    },
+    readDependencies: ["pivot.show_row_totals", "pivot.show_column_totals"],
   },
   "pivot_table.column_widths": {},
   [COLUMN_FORMATTING_SETTING]: {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -168,6 +168,7 @@ export const settings = {
   "pivot.condense_duplicate_totals": {
     section: t`Columns`,
     title: t`Condense duplicate totals`,
+    hint: t`Hide additional total elements if the totals are the same`,
     widget: "toggle",
     default: true,
     inline: true,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/stories-data.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/stories-data.ts
@@ -71,6 +71,7 @@ const rows = [
 const pivotSettings = {
   "pivot.show_column_totals": true,
   "pivot.show_row_totals": true,
+  "pivot.condense_duplicate_totals": true,
   "pivot_table.collapsed_rows": {
     rows: [cols[0].name, cols[1].name, cols[2].name],
     value: [],

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -645,7 +645,7 @@ describe("data_grid", () => {
           ]);
         });
 
-        it("not condense duplcate totals", () => {
+        it("does not condense duplicate totals", () => {
           const data = makePivotData([
             ["a", "x", 1],
             ["a", "y", 2],

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -176,6 +176,7 @@ describe("data_grid", () => {
         columnShowTotals = [],
         showColumnTotals = true,
         showRowTotals = true,
+        condenseDuplicateTotals = true,
       } = {},
     ) => {
       const settings = {
@@ -194,6 +195,7 @@ describe("data_grid", () => {
         [COLLAPSED_ROWS_SETTING]: { value: collapsedRows },
         "pivot.show_row_totals": showRowTotals,
         "pivot.show_column_totals": showColumnTotals,
+        "pivot.condense_duplicate_totals": condenseDuplicateTotals,
       };
       data = {
         ...data,
@@ -641,6 +643,31 @@ describe("data_grid", () => {
           expect(getRowSection(0, 1)).toEqual([
             { isSubtotal: true, value: "7" },
           ]);
+        });
+
+        it("not condense duplcate totals", () => {
+          const data = makePivotData([
+            ["a", "x", 1],
+            ["a", "y", 2],
+            ["b", "x", 3],
+          ]);
+          const { topHeaderItems, leftHeaderItems } = multiLevelPivotForIndexes(
+            data,
+            [0],
+            [1],
+            [2],
+            {
+              condenseDuplicateTotals: false,
+            },
+          );
+          expect(getValues(leftHeaderItems)).toEqual([
+            "x",
+            "Totals for x",
+            "y",
+            "Totals for y",
+            "Grand totals",
+          ]);
+          expect(getValues(topHeaderItems)).toEqual(["a", "b", "Row totals"]);
         });
       });
 

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -343,72 +343,72 @@
    :isSubtotal true
    :children []})
 
-(defn- should-create-subtotal?
-  "Determines if a subtotal should be created based on settings and row structure."
-  [is-subtotal-enabled should-show-subtotal]
-  (and is-subtotal-enabled should-show-subtotal))
+(defn- subtotal-permitted?
+  "Returns true if subtotals are enabled for this column and visible for this row."
+  [subtotal-enabled-for-col? visible?]
+  (and subtotal-enabled-for-col? visible?))
+
+(defn- subtotal-visible?
+  "Determines whether a subtotal should be shown for a given row."
+  [row-item settings]
+  (let [condense? (true? (:pivot.condense_duplicate_totals settings))
+        child-count (count (:children row-item))]
+    (or (not condense?) (> child-count 1) (:isCollapsed row-item))))
 
 (declare add-subtotal)
 
 (defn- process-children
   "Recursively processes children nodes to add subtotals."
-  [children rest-subtotal-settings should-show-fn]
+  [children remaining-col-settings settings]
   (persistent!
    (reduce (fn [acc child]
              (if (seq (:children child))
                (add-subtotal child
-                             rest-subtotal-settings
-                             (should-show-fn child)
-                             acc)
+                             remaining-col-settings
+                             (subtotal-visible? child settings)
+                             acc
+                             settings)
                (conj! acc child)))
            (transient []) children)))
 
 (defn- add-subtotal
   "Adds subtotal nodes to a row item based on subtotal settings.
-   Returns a sequence of nodes (the original node and possibly a subtotal node).
-  `transient-row` is the accumulator where results are added."
-  [row-item subtotal-settings-by-col should-show-subtotal transient-row]
-  (let [current-col-setting    (first subtotal-settings-by-col)
-        remaining-col-settings (rest subtotal-settings-by-col)
-        subtotal-enabled?      (should-create-subtotal? current-col-setting should-show-subtotal)
-        subtotal-node          (when subtotal-enabled?
-                                 (create-subtotal-node row-item))]
-    (if (:isCollapsed row-item)
+   Returns a sequence of nodes (the original node and possibly a subtotal node)."
+  [row-item subtotal-settings-by-col visible? transient-row settings]
+  (let [subtotal-enabled-for-col? (first subtotal-settings-by-col)
+        remaining-col-settings    (rest subtotal-settings-by-col)
+        subtotal-node             (when (subtotal-permitted? subtotal-enabled-for-col? visible?)
+                                    (create-subtotal-node row-item))
+        is-collapsed?             (:isCollapsed row-item)]
+    (if is-collapsed?
       ;; For collapsed items, just add subtotals if applicable
       (conj! transient-row subtotal-node)
-      ;; For expanded items, process children recursively
-      (let [should-show-fn     (fn [child]
-                                 (or (> (count (:children child)) 1)
-                                     (:isCollapsed child)))
-            processed-children (process-children (:children row-item)
+      ;; For expanded items, recurse.
+      (let [processed-children (process-children (:children row-item)
                                                  remaining-col-settings
-                                                 should-show-fn)
+                                                 settings)
             updated-node       (-> row-item
                                    (assoc :children processed-children)
-                                   (assoc :hasSubtotal subtotal-enabled?))]
+                                   (assoc :hasSubtotal (boolean subtotal-node)))]
         (cond-> (conj! transient-row updated-node)
           subtotal-node (conj! subtotal-node))))))
 
 (defn- add-subtotals
-  "Adds subtotal rows to the pivot table based on settings.
-   Returns the tree with subtotals added where appropriate."
+  "Adds subtotal rows to the pivot table based on settings."
   [row-tree row-indexes settings col-settings]
   (if-not (should-show-column-totals? settings)
     (vec row-tree)
     (let [subtotal-settings-by-col (map (fn [idx]
                                           (not= ((nth col-settings idx) :pivot_table.column_show_totals)
                                                 false))
-                                        row-indexes)
-          has-multiple-children    (some #(> (count (:children %)) 1) row-tree)
-          should-show-root-total   (fn [row-item]
-                                     (or has-multiple-children
-                                         (> (count (:children row-item)) 1)))]
+                                        row-indexes)]
       (persistent!
        (reduce (fn [acc row-item]
                  (add-subtotal row-item
                                subtotal-settings-by-col
-                               (should-show-root-total row-item)
-                               acc))
+                               (subtotal-visible? row-item settings)
+                               acc
+                               settings))
                (transient []) row-tree)))))
 
 (defn display-name-for-col

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -789,9 +789,10 @@
       (mt/with-temp [:model/Card {pivot-card-id :id}
                      {:display                :pivot
                       :visualization_settings {:pivot_table.column_split
-                                               {:rows    ["CREATED_AT"],
-                                                :columns ["CATEGORY"],
-                                                :values  ["sum"]}}
+                                               {:rows    ["CREATED_AT"]
+                                                :columns ["CATEGORY"]
+                                                :values  ["sum"]}
+                                               :pivot.condense_duplicate_totals true}
                       :dataset_query          (mt/mbql-query products
                                                 {:aggregation [[:sum $price]
                                                                [:avg $rating]]
@@ -1181,6 +1182,7 @@
                                                {:rows    ["CATEGORY"]
                                                 :columns ["CREATED_AT"]
                                                 :values  ["sum"]}
+                                               :pivot.condense_duplicate_totals true
                                                :column_settings
                                                {"[\"name\",\"sum\"]" {:number_style       "currency"
                                                                       :currency_in_header false}}}
@@ -1347,6 +1349,7 @@
                             {:rows    ["CATEGORY"]
                              :columns ["CREATED_AT"]
                              :values  ["sum"]}
+                            :pivot.condense_duplicate_totals true
                             :column_settings
                             {"[\"name\",\"sum\"]" (merge {:number_style       "currency"
                                                           :currency_in_header false}

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -359,7 +359,8 @@
                                                 :values  ["sum" "avg"]}
                                                :column_settings
                                                {"[\"name\",\"sum\"]" {:number_style       "currency"
-                                                                      :currency_in_header false}}}
+                                                                      :currency_in_header false}}
+                                               :pivot.condense_duplicate_totals true}
                       :dataset_query          (mt/mbql-query products
                                                 {:aggregation [[:sum $price]
                                                                [:avg $price]]
@@ -505,7 +506,8 @@
                                                     :values  ["sum"]}
                                                    :column_settings
                                                    {"[\"name\",\"sum\"]" {:number_style       "currency"
-                                                                          :currency_in_header false}}}
+                                                                          :currency_in_header false}}
+                                                   :pivot.condense_duplicate_totals true}
                           :dataset_query          (mt/mbql-query products
                                                     {:aggregation [[:sum $price]]
                                                      :breakout    [$category
@@ -538,7 +540,8 @@
                     :visualization_settings {:pivot_table.column_split
                                              {:rows    ["C" "D"]
                                               :columns ["A" "B"]
-                                              :values  ["sum"]}}
+                                              :values  ["sum"]}
+                                             :pivot.condense_duplicate_totals true}
                     :dataset_query          (mt/mbql-query nil
                                               {:aggregation  [[:sum [:field "MEASURE" {:base-type :type/Integer}]]]
                                                :breakout
@@ -1404,7 +1407,8 @@
                         :visualization_settings {:pivot_table.column_split
                                                  {:rows    ["MEASURE"]
                                                   :columns []
-                                                  :values  ["count" "sum"]}}
+                                                  :values  ["count" "sum"]}
+                                                 :pivot.condense_duplicate_totals true}
                         :dataset_query          (mt/mbql-query nil
                                                   {:breakout     [[:field "MEASURE" {:base-type :type/Integer}]],
                                                    :aggregation
@@ -1447,7 +1451,8 @@
                         :visualization_settings {:pivot_table.column_split
                                                  {:rows    ["MEASURE"]
                                                   :columns []
-                                                  :values  ["count" "sum" "sum_2"]}}
+                                                  :values  ["count" "sum" "sum_2"]}
+                                                 :pivot.condense_duplicate_totals true}
                         :dataset_query          (mt/mbql-query nil
                                                   {:breakout [[:field "MEASURE" {:base-type :type/Integer}]],
                                                    :aggregation
@@ -1460,7 +1465,8 @@
                         :visualization_settings {:pivot_table.column_split
                                                  {:rows    ["MEASURE"]
                                                   :columns []
-                                                  :values  ["sum_2" "count" "sum"]}}
+                                                  :values  ["sum_2" "count" "sum"]}
+                                                 :pivot.condense_duplicate_totals true}
                         :dataset_query          (mt/mbql-query nil
                                                   {:breakout     [[:field "MEASURE" {:base-type :type/Integer}]],
                                                    :aggregation
@@ -1537,7 +1543,8 @@
                         :visualization_settings {:pivot_table.column_split
                                                  {:rows    ["A"]
                                                   :columns []
-                                                  :values  ["count" "sum" "avg" "min" "max"]}}
+                                                  :values  ["count" "sum" "avg" "min" "max"]}
+                                                 :pivot.condense_duplicate_totals true}
                         :dataset_query          (mt/mbql-query nil
                                                   {:breakout     [[:field "A" {:base-type :type/Integer}]],
                                                    :aggregation

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -283,7 +283,8 @@
                                                 :values  ["sum"]}
                                                :column_settings
                                                {"[\"name\",\"sum\"]" {:number_style       "currency"
-                                                                      :currency_in_header false}}}
+                                                                      :currency_in_header false}}
+                                               :pivot.condense_duplicate_totals true}
                       :dataset_query          (mt/mbql-query products
                                                 {:aggregation [[:sum $price]]
                                                  :breakout    [$category


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52333

### Description

Describe the overall approach and the problem being solved.

### How to verify

Test query:
```
SELECT *
FROM (
  SELECT
    category,
    source,
    state,
    SUM(orders.discount) AS discount,
    SUM(orders.total) AS total,
    SUM(orders.quantity) AS quantity
  FROM
    orders
    LEFT JOIN products ON orders.product_id = products.id
    LEFT JOIN people ON orders.user_id = people.id
  GROUP BY category, source, state
) AS filtered_orders
WHERE NOT (
  category = 'Gizmo'
  AND (
    source IN ('Facebook', 'Google', 'Organic', 'Twitter')
    OR state NOT IN ('AK')
  )
);
```

- Create a question from the query above and save it
- Click "Explore results" to create a nested question
- Group by Category, Source, State
- Make it a pivot table with the following settings
<img width="334" alt="Screenshot 2025-01-23 at 10 07 26 PM" src="https://github.com/user-attachments/assets/df94aa75-1d1b-4870-a655-38ec13a100f3" />

- Ensure it does not initially show subtotals for Affiliate
- Disable "Condense duplicate totals" setting
- Ensure it shows subtotals for Affiliate even though it has a single state value:

<img width="428" alt="Screenshot 2025-01-23 at 10 07 16 PM" src="https://github.com/user-attachments/assets/c4dd3ed3-95b8-4b6c-a436-28eb15912d99" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
