### PR TITLE
Improve Table Static Viz Text Wrapping Column Widths

### DIFF
--- a/src/metabase/channel/render/table.clj
+++ b/src/metabase/channel/render/table.clj
@@ -249,8 +249,6 @@
   "Takes a vector of column definitions and visualization settings
   Returns a map of column identifier keys to style maps based on the visualization settings"
   [columns viz-settings]
-  (def columns columns)
-  (def viz-settings viz-settings)
   (let [column-settings (get viz-settings ::mb.viz/column-settings)
         column-widths   (get viz-settings :table.column_widths)]
     (reduce
@@ -267,7 +265,7 @@
                                        {:min-width (format "%spx" (get-min-width column-widths column-index))}
                                        ;; Text wrapping enabled but conditions not met, fall back to 780px
                                        ;; Email clients respond to `min-width`, but slack responds to `width`
-                                       {:min-width "780px"
+                                       {:max-width "780px !important"
                                         :width "780px"})))
 
            ;; text alignment
@@ -301,7 +299,6 @@
   - minibar-cols: Columns that should display mini-bar visualizations"
   ([color-selector {:keys [col-names cols-for-color-lookup]} [header & rows] columns viz-settings minibar-cols]
    (let [col->styles        (column->viz-setting-styles columns viz-settings)
-         _                  (def col->styles col->styles)
          row-index?         (:table.row_index viz-settings)
          pivot-grouping-idx (u/index-of #{"pivot-grouping"} col-names)
          col-names          (cond->> col-names
@@ -316,8 +313,6 @@
          color-getter       (partial js.color/get-background-color color-selector)
          thead              (render-table-head (vec col-names) header columns col->styles row-index?)
          tbody              (render-table-body color-getter cols-for-color-lookup rows columns viz-settings minibar-cols col->styles row-index?)]
-     (def thead thead)
-     (def tbody tbody)
      [:table {:style       (style/style {:max-width     "100%"
                                          :white-space   "nowrap"
                                          :border        (str "1px solid " style/color-border)


### PR DESCRIPTION
Changes include:
  - #56898 reverted column width viz setting behavior such that now only columns with user defined widths will have values in the viz setting array.
    - Table static viz assumes that if the column widths setting is present then it will contain values for all columns
    - So, this change gracefully handles when column widths are in viz settings but no value present for text wrapped column
  - Tweaks the fallback values to better support slack

Slack context [here](https://metaboat.slack.com/archives/C64DB8QH2/p1745218810344149)
