### PR TITLE
Fix inaccurate row collapsing for pivot exports

### DIFF
--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -90,7 +90,7 @@
               (persistent!
                (reduce
                 (fn [acc row]
-                  (let [grouping-key (mapv #(nth row %) column-indexes)
+                  (let [grouping-key (json-roundtrip (mapv #(nth row %) column-indexes))
                         values (mapv #(nth row %) val-indexes)]
                     (assoc! acc grouping-key values)))
                 (transient {})
@@ -160,7 +160,7 @@
   (let [col-and-row-indexes (into (vec col-indexes) row-indexes)]
     (reduce
      (fn [acc row]
-       (let [value-key  (select-indexes row col-and-row-indexes)
+       (let [value-key  (map json-roundtrip (select-indexes row col-and-row-indexes))
              values     (select-indexes row val-indexes)
              data       (into []
                               (map-indexed
@@ -502,7 +502,8 @@
 (defn- get-normal-cell-values
   "Processes and formats values for normal data cells (non-subtotal)."
   [values-by-key index-values value-formatters color-getter]
-  (let [{:keys [values valueColNames data dimensions]} (get values-by-key index-values) formatted-values (format-values values value-formatters)]
+  (let [{:keys [values valueColNames data dimensions]} (get values-by-key index-values)
+        formatted-values (format-values values value-formatters)]
     (if-not data
       formatted-values
       (map-indexed

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -18,6 +18,12 @@
   #?(:cljs (js->clj (js/JSON.parse x))
      :clj (json/decode x)))
 
+(defn- json-roundtrip
+  "Round-trips a value to JSON and back"
+  [x]
+  #?(:cljs (js->clj (js/JSON.parse (js/JSON.stringify x)))
+     :clj (json/decode (json/encode x))))
+
 (defn- pivot-group-column?
   "Is the given column the pivot-grouping column?"
   [col]
@@ -130,7 +136,10 @@
   {:children (ordered-map/ordered-map)}."
   [path tree]
   (if (seq path)
-    (let [v (first path)]
+    ;; In `add-is-collapsed` we parse JSON from the viz settings to determine
+    ;; the path of values to collapse. So we have to roundtrip values from the QP
+    ;; to JSON and back to make sure their types match.
+    (let [v (json-roundtrip (first path))]
       (update tree v
               (fn [node]
                 (let [subtree (or (:children node) (ordered-map/ordered-map))]

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -161,7 +161,7 @@
   (let [col-and-row-indexes (into (vec col-indexes) row-indexes)]
     (reduce
      (fn [acc row]
-       (let [value-key  (map json-roundtrip (select-indexes row col-and-row-indexes))
+       (let [value-key  (json-roundtrip (select-indexes row col-and-row-indexes))
              values     (select-indexes row val-indexes)
              data       (into []
                               (map-indexed

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -19,9 +19,10 @@
      :clj (json/decode x)))
 
 (defn- json-roundtrip
-  "Round-trips a value to JSON and back"
+  "Round-trips a value to JSON and back in Clojure to ensure it can be used as a key with consistent type.
+  Does nothing in CLJS."
   [x]
-  #?(:cljs (js->clj (js/JSON.parse (js/JSON.stringify x)))
+  #?(:cljs x
      :clj (json/decode (json/encode x))))
 
 (defn- pivot-group-column?

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -315,12 +315,9 @@
                    ["Gizmo" "529.7" "1080.18" "997.94" "227.06" "2834.88"]
                    ["Widget" "987.39" "1014.68" "912.2" "195.04" "3109.31"]
                    ["Grand totals" "2829.06" "4008.16" "3251.08" "1060.98" "11149.28"]]
-                  #{:unsaved-card-download
-                    :card-download
-                    :dashcard-download
+                  #{:unsaved-card-download :card-download :dashcard-download
                     :subscription-attachment
-                    :public-question-download
-                    :public-dashcard-download}]
+                    :public-question-download :public-dashcard-download}]
                  (->> (all-outputs! card {:export-format :csv :format-rows false :pivot true})
                       (group-by second)
                       ((fn [m] (update-vals m #(into #{} (mapv first %)))))

--- a/test/metabase/pivot/core_test.cljc
+++ b/test/metabase/pivot/core_test.cljc
@@ -354,18 +354,18 @@
           row-indexes [0 1]
           col-indexes [2]
           val-indexes [4]
-          col-settings [{} {} {} {} {}]]
-      (let [settings {:pivot_table.collapsed_rows {:value ["[1]"]}}
-            result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-        (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                            {:children [] :isCollapsed false :value "B"}]
-                 :isCollapsed true  ;; Only the node with value 1 should be collapsed
-                 :value 1}
-                {:children [{:children [] :isCollapsed false :value "A"}
-                            {:children [] :isCollapsed false :value "B"}]
-                 :isCollapsed false ;; Node with value 2 should not be collapsed
-                 :value 2.5}]
-               (:row-tree result)))))))
+          col-settings [{} {} {} {} {}]
+          settings {:pivot_table.collapsed_rows {:value ["[1]"]}}
+          result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+      (is (= [{:children [{:children [] :isCollapsed false :value "A"}
+                          {:children [] :isCollapsed false :value "B"}]
+               :isCollapsed true  ;; Only the node with value 1 should be collapsed
+               :value 1}
+              {:children [{:children [] :isCollapsed false :value "A"}
+                          {:children [] :isCollapsed false :value "B"}]
+               :isCollapsed false ;; Node with value 2 should not be collapsed
+               :value 2.5}]
+             (:row-tree result))))))
 
 (deftest create-row-section-getter-test
   (testing "Returns a function that correctly retrieves cell values"

--- a/test/metabase/pivot/core_test.cljc
+++ b/test/metabase/pivot/core_test.cljc
@@ -202,6 +202,171 @@
               {:value "200%" :isSubtotal true :custom "attr"}]
              result)))))
 
+(deftest build-pivot-trees-test
+  (testing "build-pivot-trees correctly builds basic row and column tree structures"
+    (let [rows [[1 "A" "Y" 0 10]
+                [2 "B" "Z" 0 20]]
+          cols [{:name "col0" :source "breakout"}
+                {:name "col1" :source "breakout"}
+                {:name "col2" :source "breakout"}
+                {:name "pivot-grouping" :source "breakout"}
+                {:name "count" :source "aggregation"}]
+          row-indexes [0 1]
+          col-indexes [2]
+          val-indexes [4]
+          settings {}
+          col-settings [{} {} {} {} {}]
+          result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+      (is (= [{:children [{:children [] :isCollapsed false :value "A"}]
+               :isCollapsed false
+               :value 1}
+              {:children [{:children [] :isCollapsed false :value "B"}]
+               :isCollapsed false
+               :value 2}]
+             (:row-tree result)))
+
+      (is (= [{:children [] :isCollapsed false :value "Y"}
+              {:children [] :isCollapsed false :value "Z"}]
+             (:col-tree result)))
+
+      (is (= [[["Y" 1 "A"] [10]]
+              [["Z" 2 "B"] [20]]]
+             (map
+              (fn [[k v]] [k (:values v)])
+              (:values-by-key result)))
+          "values-by-key should identify each value by its concatenated column and row paths"))))
+
+(deftest build-pivot-trees-with-collapsed-levels-test
+  (testing "build-pivot-trees correctly handles collapsed subtotals"
+    (let [rows [[1 "A" "Y" 0 10]
+                [1 "B" "Z" 0 20]
+                [2 "A" "Y" 0 30]
+                [2 "B" "Z" 0 40]]
+          cols [{:name "col0" :source "breakout"}
+                {:name "col1" :source "breakout"}
+                {:name "col2" :source "breakout"}
+                {:name "pivot-grouping" :source "breakout"}
+                {:name "count" :source "aggregation"}]
+          row-indexes [0 1]
+          col-indexes [2]
+          val-indexes [4]
+          col-settings [{} {} {} {} {}]]
+      ;; Set up collapsed subtotals for level 1 (the root level)
+      (let [settings {:pivot_table.collapsed_rows {:value ["1"]}}
+            result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+        (is (= [{:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed true
+                 :value 1}
+                {:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed true
+                 :value 2}]
+               (:row-tree result))
+            "Row tree should have correct collapsed state for the root level"))
+
+      ;; Set up collapsed subtotals for level 2 (children of the root)
+      (let [settings {:pivot_table.collapsed_rows {:value ["1"]}}
+            result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+        (is (= [{:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed true
+                 :value 1}
+                {:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed true
+                 :value 2}]
+               (:row-tree result))
+            "Row tree should have correct collapsed state for the chlidren of the root")))))
+
+(deftest build-pivot-trees-with-collapsed-paths-test
+  (testing "build-pivot-trees correctly handles collapsed specific paths"
+    (let [rows [[1 "A" "Y" 0 10]
+                [1 "B" "Z" 0 20]
+                [2 "A" "Y" 0 30]
+                [2 "B" "Z" 0 40]]
+          cols [{:name "col0" :source "breakout"}
+                {:name "col1" :source "breakout"}
+                {:name "col2" :source "breakout"}
+                {:name "pivot-grouping" :source "breakout"}
+                {:name "count" :source "aggregation"}]
+          row-indexes [0 1]
+          col-indexes [2]
+          val-indexes [4]
+          col-settings [{} {} {} {} {}]]
+      ;; Test collapsing a specific node at the root level
+      (let [settings {:pivot_table.collapsed_rows {:value ["[1]"]}}
+            result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+
+        (is (= [{:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed true  ;; Only the node with value 1 should be collapsed
+                 :value 1}
+                {:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed false ;; Node with value 2 should not be collapsed
+                 :value 2}]
+               (:row-tree result))
+            "Row tree should have correct collapsed state for node with value 1 only"))
+
+      ;; Test collapsing a specific nested path
+      (let [settings {:pivot_table.collapsed_rows {:value ["[1,\"A\"]"]}}
+            result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+
+        (is (= [{:children [{:children [] :isCollapsed true :value "A"}  ;; Only [1,"A"] should be collapsed
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed false
+                 :value 1}
+                {:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed false
+                 :value 2}]
+               (:row-tree result))
+            "Row tree should have correct collapsed state for nested path [1,\"A\"]"))
+
+      ;; Test collapsing multiple specific paths
+      (let [settings {:pivot_table.collapsed_rows {:value ["[1,\"A\"]", "[2,\"B\"]"]}}
+            result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+
+        (is (= [{:children [{:children [] :isCollapsed true :value "A"}  ;; [1,"A"] should be collapsed
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed false
+                 :value 1}
+                {:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed true :value "B"}]  ;; [2,"B"] should be collapsed
+                 :isCollapsed false
+                 :value 2}]
+               (:row-tree result))
+            "Row tree should have correct collapsed state for multiple specific paths")))))
+
+(deftest build-pivot-trees-collapsed-rows-type-coherence-test
+  (testing "build-pivot-trees correctly associates values in the viz settings with values from the QP"
+    ;; Use BigInts and BigDecimals in the raw rows and ensure the collapsed_rows setting still applies
+    (let [rows [[1N "A" "Y" 0 10]
+                [1N "B" "Z" 0 20]
+                [2.5M "A" "Y" 0 30]
+                [2.5M "B" "Z" 0 40]]
+          cols [{:name "col0" :source "breakout"}
+                {:name "col1" :source "breakout"}
+                {:name "col2" :source "breakout"}
+                {:name "pivot-grouping" :source "breakout"}
+                {:name "count" :source "aggregation"}]
+          row-indexes [0 1]
+          col-indexes [2]
+          val-indexes [4]
+          col-settings [{} {} {} {} {}]]
+      (let [settings {:pivot_table.collapsed_rows {:value ["[1]"]}}
+            result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
+        (is (= [{:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed true  ;; Only the node with value 1 should be collapsed
+                 :value 1}
+                {:children [{:children [] :isCollapsed false :value "A"}
+                            {:children [] :isCollapsed false :value "B"}]
+                 :isCollapsed false ;; Node with value 2 should not be collapsed
+                 :value 2.5}]
+               (:row-tree result)))))))
+
 (deftest create-row-section-getter-test
   (testing "Returns a function that correctly retrieves cell values"
     (let [values-by-key {["A" 1] {:values [10 20]

--- a/test/metabase/pivot/core_test.cljc
+++ b/test/metabase/pivot/core_test.cljc
@@ -105,6 +105,20 @@
            :remapped_from_index nil,
            :base_type "type/BigInteger"}]})
 
+(deftest json-roundtrip-test
+  #?(:clj
+     (testing "Normalizes types (like BigInt/BigDecimal) by passing them through JSON encoding/decoding"
+       (is (= java.lang.Integer (type (@#'pivot/json-roundtrip 3))))
+       (is (= java.lang.Integer (type (@#'pivot/json-roundtrip 3N))))
+       (is (= java.lang.Double (type (@#'pivot/json-roundtrip 3.0))))
+       (is (= java.lang.Double (type (@#'pivot/json-roundtrip 3.0M)))))
+     :cljs
+     (testing "Does nothing on CLJS (intentional! values are already normalized)"
+       (is (= js/Number (type (@#'pivot/json-roundtrip 3))))
+       (is (= js/Number (type (@#'pivot/json-roundtrip 3N))))
+       (is (= js/Number (type (@#'pivot/json-roundtrip 3.0))))
+       (is (= js/Number (type (@#'pivot/json-roundtrip 3.0M)))))))
+
 (deftest columns-without-pivot-group-test
   (testing "Correctly filters out the pivot grouping column based on name"
     (is (= ["col0" "col1" "col2" "count"]


### PR DESCRIPTION
The config for collapsed pivot sections is stored in the viz settings as an array of values, indicating a "path" through the row tree that should be collapsed. We parse this list from JSON into native data structures and use it to index into a data structure built from the raw rows returned from the QP. 

However, on the backend, the rows from the QP might have different data types from the values parsed from the viz settings JSON. I noticed this in particular with ints vs BigIntegers and decimals vs BigDecimals. This discrepancy results in us not correctly annotating the tree with `:isCollapsed` metadata, and exports not respecting collapsing in some cases.

I've fixed this by adding a `json-roundtrip` function and ensuring we call it on any values that will be used as keys in maps so that they get their type normalized. This is only needed on the backend since this already happens implicitly on the FE. I've also added a few new unit tests but `build-pivot-trees-collapsed-rows-type-coherence-test` is the relevant one for this fix.

Fixes https://github.com/metabase/metabase/issues/57077