### PR TITLE
Show All Pivot Queries in View SQL Sidebar

### DIFF
--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -179,7 +179,7 @@
    query
    (lib/order-bys query)))
 
-(mu/defn- generate-queries :- [:sequential ::lib.schema/query]
+(mu/defn generate-queries :- [:sequential ::lib.schema/query]
   "Generate the additional queries to perform a generic pivot table"
   [query                                               :- ::lib.schema/query
    {:keys [pivot-rows pivot-cols], :as _pivot-options} :- ::pivot-opts]
@@ -440,7 +440,7 @@
     (when (some some? (vals pivot-opts))
       pivot-opts)))
 
-(mu/defn- pivot-options :- ::pivot-opts
+(mu/defn pivot-options :- ::pivot-opts
   "Looks at the `pivot_table.column_split` key in the card's visualization settings and generates `pivot-rows` and
   `pivot-cols` to use for generating subqueries. Supports both column name and field ref-based settings.
 


### PR DESCRIPTION
WIP

Closes #25037

Changes include:
  - Pass viz settings to dataset `/native` endpoint
    - If this is a pivot query, populate and return all queries with labels in response
  - Update `NotebookNativePreview` to show tabs for each query if this question is a pivot table viz

<details>
<summary>Screenshots</summary>
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/7c16bd4b-822b-4fb5-9e7b-3fa10396f5c8" />
<img width="504" alt="image" src="https://github.com/user-attachments/assets/a6671ae6-c93f-4d49-9e1f-b9cbf727c345" />
</details>

TODO:
  - [ ] Get product feedback on if this is what we want in order to close 25037
  - [ ] Update tests