### PR TITLE
Collection operators

### DIFF
--- a/src/metabase/notification/condition.clj
+++ b/src/metabase/notification/condition.clj
@@ -1,4 +1,20 @@
 (ns metabase.notification.condition
+  "Expression language for evaluating conditions in notifications.
+
+  Grammar:
+
+    <expr> ::= <literal> | <func_eval>
+
+    <literal> ::= <number> | <string> | <boolean>
+    <number> ::= integer or decimal
+    <string> ::= quoted text
+    <boolean> ::= true | false
+
+    <func_eval> ::= [<func>, <expr>*]
+
+    <func> ::= 'and' | 'or' | 'not' | '=' | '!=' | '>' | '<' | '>=' | '<=' 
+               | 'max' | 'min' | 'count' | 'context' | 'this' | 'every' | 'some' | 'none'
+    <expr>* ::= zero or more expressions or paths"
   (:require
    [clojure.walk :as walk]
    [metabase.util :as u]))
@@ -51,6 +67,10 @@
         :this    (if (seq operands)
                    (get-in *local-context* operands)
                    *local-context*)
+
+        ;; Collection predicates, [:every predicate collection]
+        ;; Predicate is an expression that returns a boolean. It'll bind *local-context*
+        ;; when it's evaluated. Use [:this] to refer to the current context.
         :every   (collection-predicate-op every? operands context)
         :some    (collection-predicate-op some operands context)
         :none    (collection-predicate-op not-any? operands context)

--- a/src/metabase/notification/condition.clj
+++ b/src/metabase/notification/condition.clj
@@ -30,7 +30,8 @@
   [expr context]
   (if (sequential? expr)
     (let [operator (first expr)
-          operands (rest expr)]
+          operands (rest expr)
+          context  (stringify-map context)]
       (case (keyword operator)
         ;; Logical operators
         :and (boolean (every? #(evaluate-expression % context) operands))
@@ -46,7 +47,7 @@
         :<= (apply <= (map #(evaluate-expression % context) operands))
 
         ;; Data access
-        :context (get-in context (map keyword operands))
+        :context (get-in context operands)
         :this    (if (seq operands)
                    (get-in *local-context* operands)
                    *local-context*)

--- a/test/metabase/notification/condition_test.clj
+++ b/test/metabase/notification/condition_test.clj
@@ -133,3 +133,47 @@
              ["=" ["context" "status"] "active"]
              [">" ["context" "score"] 90]]
       {:status "inactive", :score 85})))
+
+(deftest evaluate-collection-predicate-operators-test
+  (testing "collection predicate operators"
+    (testing "with each item is an atom"
+      (let [numbers-context {:numbers [1 2 3 4 5]}]
+
+        (testing ":every operator"
+          (is (true? (evaluate-expression ["every" [">" ["this"] 0] ["context" "numbers"]] numbers-context))
+              "every number is greater than 0")
+          (is (false? (evaluate-expression ["every" [">" ["this"] 3] ["context" "numbers"]] numbers-context))
+              "not every number is greater than 3"))
+
+        (testing ":some operator"
+          (is (true? (evaluate-expression ["some" ["=" ["this"] 3] ["context" "numbers"]] numbers-context))
+              "some number equals 3")
+          (is (not (evaluate-expression ["some" ["=" ["this"] 10] ["context" "numbers"]] numbers-context))
+              "no number equals 10"))
+
+        (testing ":none operator"
+          (is (true? (evaluate-expression ["none" ["<" ["this"] 0] ["context" "numbers"]] numbers-context))
+              "none of the numbers is less than 0")
+          (is (false? (evaluate-expression ["none" [">" ["this"] 2] ["context" "numbers"]] numbers-context))
+              "some numbers are greater than 2"))))
+    (testing "with each item is a map"
+      (let [objects-context {:items [{:value 10} {:value 20} {:value 30}]}]
+
+        (testing ":every operator"
+
+          (is (true? (evaluate-expression ["every" [">" ["this" "value"] 5] ["context" "items"]] objects-context))
+              "every object has value greater than 5")
+          (is (false? (evaluate-expression ["every" [">" ["this" "value"] 15] ["context" "items"]] objects-context))
+              "not every object has value greater than 15"))
+
+        (testing ":some operator"
+          (is (true? (evaluate-expression ["some" ["=" ["this" "value"] 20] ["context" "items"]] objects-context))
+              "some object has value equal to 20")
+          (is (not (evaluate-expression ["some" ["=" ["this" "value"] 50] ["context" "items"]] objects-context))
+              "no object has value equal to 50"))
+
+        (testing ":none operator"
+          (is (true? (evaluate-expression ["none" [">" ["this" "value"] 50] ["context" "items"]] objects-context))
+              "none of the objects has value greater than 50")
+          (is (false? (evaluate-expression ["none" ["<" ["this" "value"] 20] ["context" "items"]] objects-context))
+              "some objects have value less than 20"))))))


### PR DESCRIPTION
This adds 3 collection operators, every, some, none.

It has the syntax of  [operator predicate collection]. Where
- predicate is an expression that returns a boolean. This expression is evaluated with a magic binding of the current item that can be accessed using the `[:this]` operator. 

```clojure
;; Check if all numbers in a collection are positive
[:every [:> [:this] 0] [1, 2, 3, 4]]  ;; true

;; Check if any value in a collection exceeds a threshold
[:some [:> [:this] 10] [5, 8, 12, 3]]  ;; true

;; Check if no user in a list is admin
[:none [:= [:this :role] "admin"] [{:role "user"} {:role "manager"}]  ;; true
```