### PR TITLE
Rename regexextract to regexExtract 

### DIFF
--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -66,7 +66,7 @@ For an introduction to expressions, check out the [overview of custom expression
     - [lower](#lower)
     - [notEmpty](#notempty)
     - [path](#path)
-    - [regexextract](./expressions/regexextract.md)
+    - [regexExtract](./expressions/regexextract.md)
     - [replace](#replace)
     - [splitPart](#splitpart)
     - [rTrim](#rtrim)
@@ -413,7 +413,7 @@ Example: `contains([Status], "Class")`.
 
 If `Status` were "Classified", the expression would return `true`. If the `Status` were "**c**lassified", the expression would return `false`, because the case does not match.
 
-Related: [doesNotContain](#doesnotcontain), [regexextract](#regexextract).
+Related: [doesNotContain](#doesnotcontain), [regexExtract](#regexextract).
 
 ### date
 
@@ -455,7 +455,7 @@ Syntax: `doesNotContain(string1, string2)` for case-sensitive match.
 
 Example: `doesNotContain([Status], "Class")`. If `Status` were "Classified", the expression would return `false`.
 
-Related: [contains](#contains), [regexextract](#regexextract).
+Related: [contains](#contains), [regexExtract](#regexextract).
 
 ### domain
 
@@ -574,17 +574,17 @@ Example: `path([Page URL])`. For example, `path("https://www.example.com/path/to
 
 Related: [domain](#domain), [host](#host), [subdomain](#subdomain).
 
-### [regexextract](./expressions/regexextract.md)
+### [regexExtract](./expressions/regexextract.md)
 
-> ⚠️ `regexextract` is unavailable for MongoDB, SQLite, and SQL Server. For Druid, `regexextract` is only available for the Druid-JDBC driver.
+> ⚠️ `regexExtract` is unavailable for MongoDB, SQLite, and SQL Server. For Druid, `regexExtract` is only available for the Druid-JDBC driver.
 
 Extracts matching substrings according to a regular expression.
 
-Syntax: `regexextract(text, regular_expression)`
+Syntax: `regexExtract(text, regular_expression)`
 
-Example: `regexextract([Address], "[0-9]+")`
+Example: `regexExtract([Address], "[0-9]+")`
 
-Databases that don't support `regexextract`: H2, SQL Server, SQLite.
+Databases that don't support `regexExtract`: H2, SQL Server, SQLite.
 
 Related: [contains](#contains), [doesNotContain](#doesnotcontain), [substring](#substring).
 
@@ -659,7 +659,7 @@ Syntax: `substring(text, position, length)`
 
 Example: `substring([Title], 1, 10)` returns the first 10 letters of a string (the string index starts at position 1).
 
-Related: [regexextract](#regexextract), [replace](#replace).
+Related: [regexExtract](#regexextract), [replace](#replace).
 
 ### text
 
@@ -954,15 +954,15 @@ Example: `Offset(Sum([Total]), -1)` would get the `Sum([Total])` value from the 
 
 Limitations are noted for each aggregation and function above, and here there are in summary:
 
-**H2** (including Metabase Sample Database): `Median`, `Percentile`, `convertTimezone` and `regexextract`.
+**H2** (including Metabase Sample Database): `Median`, `Percentile`, `convertTimezone` and `regexExtract`.
 
 **Athena**: `convertTimezone`.
 
 **Databricks**: `convertTimezone`.
 
-**Druid**: `Median`, `Percentile`, `StandardDeviation`, `power`, `log`, `exp`, `sqrt`, `Offset`. Function `regexextract` is only available for the Druid-JDBC driver.
+**Druid**: `Median`, `Percentile`, `StandardDeviation`, `power`, `log`, `exp`, `sqrt`, `Offset`. Function `regexExtract` is only available for the Druid-JDBC driver.
 
-**MongoDB**: `Median`, `Percentile`, `power`, `log`, `exp`, `sqrt`, `Offset`, `regexextract`
+**MongoDB**: `Median`, `Percentile`, `power`, `log`, `exp`, `sqrt`, `Offset`, `regexExtract`
 
 **MariaDB**: `Median`, `Percentile`, `Offset`.
 
@@ -972,9 +972,9 @@ Limitations are noted for each aggregation and function above, and here there ar
 
 **SparkSQL**: `convertTimezone`.
 
-**SQL Server**: `Median`, `Percentile` and `regexextract`.
+**SQL Server**: `Median`, `Percentile` and `regexExtract`.
 
-**SQLite**: `exp`, `log`, `Median`, `Percentile`, `power`, `regexextract`, `StandardDeviation`, `sqrt` and `Variance`.
+**SQLite**: `exp`, `log`, `Median`, `Percentile`, `power`, `regexExtract`, `StandardDeviation`, `sqrt` and `Variance`.
 
 **Vertica**: `Median` and `Percentile`.
 

--- a/docs/questions/query-builder/expressions/regexextract.md
+++ b/docs/questions/query-builder/expressions/regexextract.md
@@ -1,16 +1,16 @@
 ---
-title: Regexextract
+title: RegexExtract
 ---
 
-# Regexextract
+# RegexExtract
 
-> ⚠️ `regexextract` is unavailable for MongoDB, SQLite, and SQL Server. For Druid, `regexextract` is only available for the Druid-JDBC driver.
+> ⚠️ `regexExtract` is unavailable for MongoDB, SQLite, and SQL Server. For Druid, `regexExtract` is only available for the Druid-JDBC driver.
 
-`regexextract` uses [regular expressions (regex)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) to get a specific part of your text.
+`regexExtract` uses [regular expressions (regex)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) to get a specific part of your text.
 
-`regexextract` is ideal for text that has little to no structure, like URLs or freeform survey responses. If you're working with strings in predictable formats like SKU numbers, IDs, or other types of codes, check out the simpler [substring](../expressions/substring.md) expression instead.
+`regexExtract` is ideal for text that has little to no structure, like URLs or freeform survey responses. If you're working with strings in predictable formats like SKU numbers, IDs, or other types of codes, check out the simpler [substring](../expressions/substring.md) expression instead.
 
-Use `regexextract` to create custom columns with shorter, more readable labels for things like:
+Use `regexExtract` to create custom columns with shorter, more readable labels for things like:
 
 - filter dropdown menus,
 - chart labels, or
@@ -18,7 +18,7 @@ Use `regexextract` to create custom columns with shorter, more readable labels f
 
 | Syntax                                                        | Example                                  |
 | ------------------------------------------------------------- | ---------------------------------------- |
-| `regexextract(text, regular_expression)`                      | `regexextract("regexextract", "ex(.*)")` |
+| `regexExtract(text, regular_expression)`                      | `regexExtract("regexExtract", "ex(.*)")` |
 | Gets a specific part of your text using a regular expression. | "extract"                                |
 
 ## Searching and cleaning text
@@ -34,7 +34,7 @@ Let's say that you have web data with a lot of different URLs, and you want to m
 You can create a custom column **Campaign Name** with the expression:
 
 ```
-regexextract([URL], "^[^?#]+\?utm_campaign=(.*)")
+regexExtract([URL], "^[^?#]+\?utm_campaign=(.*)")
 ```
 
 Here, the regex pattern [`^[^?#]+\?` matches all valid URL strings](https://www.oreilly.com/library/view/regular-expressions-cookbook/9780596802837/ch07s13.html). You can replace `utm_campaign=` with whatever query parameter you like. At the end of the regex pattern, the [capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Backreferences) `(.*)` gets all of the characters that appear after the query parameter `utm_campaign=`.
@@ -43,7 +43,7 @@ Now, you can use **Campaign Name** in places where you need clean labels, such a
 
 ## Accepted data types
 
-| [Data type](https://www.metabase.com/learn/grow-your-data-skills/data-fundamentals/data-types-overview#examples-of-data-types) | Works with `regexextract` |
+| [Data type](https://www.metabase.com/learn/grow-your-data-skills/data-fundamentals/data-types-overview#examples-of-data-types) | Works with `regexExtract` |
 | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
 | String                                                                                                                         | ✅                        |
 | Number                                                                                                                         | ❌                        |
@@ -53,13 +53,13 @@ Now, you can use **Campaign Name** in places where you need clean labels, such a
 
 ## Limitations
 
-`regexextract` is unavailable for MongoDB, SQLite, and SQL Server. For Druid, `regexextract` is only available for the Druid-JDBC driver.
+`regexExtract` is unavailable for MongoDB, SQLite, and SQL Server. For Druid, `regexExtract` is only available for the Druid-JDBC driver.
 
 Regex can be a dark art. You have been warned.
 
 ## Related functions
 
-This section covers functions and formulas that work the same way as the Metabase `regexextract` expression, with notes on how to choose the best option for your use case.
+This section covers functions and formulas that work the same way as the Metabase `regexExtract` expression, with notes on how to choose the best option for your use case.
 
 **[Metabase expressions](../expressions-list.md)**
 
@@ -86,7 +86,7 @@ substring([URL], 13, 8)
 or
 
 ```
-regexextract([URL], "^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/.\n]+)")
+regexExtract([URL], "^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/.\n]+)")
 ```
 
 ### SQL
@@ -102,10 +102,10 @@ SELECT
 FROM follow_the_white_rabbit
 ```
 
-is equivalent to the Metabase `regexextract` expression:
+is equivalent to the Metabase `regexExtract` expression:
 
 ```
-regexextract([URL], "^[^?#]+\?utm_campaign=(.*)")
+regexExtract([URL], "^[^?#]+\?utm_campaign=(.*)")
 ```
 
 ### Spreadsheets
@@ -113,13 +113,13 @@ regexextract([URL], "^[^?#]+\?utm_campaign=(.*)")
 If our [sample data](#searching-and-cleaning-text) is in a spreadsheet where "URL" is in column A, the spreadsheet function
 
 ```
-regexextract(A2, "^[^?#]+\?utm_campaign=(.*)")
+regexExtract(A2, "^[^?#]+\?utm_campaign=(.*)")
 ```
 
 uses pretty much the same syntax as the Metabase expression:
 
 ```
-regexextract([URL], "^[^?#]+\?utm_campaign=(.*)")
+regexExtract([URL], "^[^?#]+\?utm_campaign=(.*)")
 ```
 
 ### Python
@@ -130,10 +130,10 @@ Assuming the [sample data](#searching-and-cleaning-text) is in a dataframe colum
 df['Campaign Name'] = df['URL'].str.extract(r'^[^?#]+\?utm_campaign=(.*)')
 ```
 
-does the same thing as the Metabase `regexextract` expression:
+does the same thing as the Metabase `regexExtract` expression:
 
 ```
-regexextract([URL], "^[^?#]+\?utm_campaign=(.*)")
+regexExtract([URL], "^[^?#]+\?utm_campaign=(.*)")
 ```
 
 ## Further reading

--- a/docs/questions/query-builder/expressions/substring.md
+++ b/docs/questions/query-builder/expressions/substring.md
@@ -66,7 +66,7 @@ substring([Mission ID], (1 + length([Mission ID]) - 3), 3)
 
 ## Limitations
 
-`substring` extracts text by counting a fixed number of characters. If you need to extract text based on some more complicated logic, try [`regexextract`](../expressions-list.md#regexextract).
+`substring` extracts text by counting a fixed number of characters. If you need to extract text based on some more complicated logic, try [`regexExtract`](../expressions-list.md#regexextract).
 
 And if you only need to clean up extra whitespace around your text, you can use the [`trim`](../expressions-list.md#trim), [`lTrim`](../expressions-list.md#ltrim), or [`rTrim`](../expressions-list.md#rtrim) expressions instead.
 
@@ -76,7 +76,7 @@ This section covers functions and formulas that work the same way as the Metabas
 
 **[Metabase expressions](../expressions-list.md)**
 
-- [regexextract](#regexextract)
+- [regexExtract](#regexextract)
 
 **Other tools**
 
@@ -84,12 +84,12 @@ This section covers functions and formulas that work the same way as the Metabas
 - [Spreadsheets](#spreadsheets)
 - [Python](#python)
 
-### Regexextract
+### RegexExtract
 
-Use [regexextract](./regexextract.md) if you need to extract text based on more specific rules. For example, you could get the agent ID with a regex pattern that finds the last occurrence of "00" (and everything after it):
+Use [regexExtract](./regexextract.md) if you need to extract text based on more specific rules. For example, you could get the agent ID with a regex pattern that finds the last occurrence of "00" (and everything after it):
 
 ```
-regexextract([Mission ID], ".+(00.+)$")
+regexExtract([Mission ID], ".+(00.+)$")
 ```
 
 should return the same result as

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -119,7 +119,7 @@ describe("issue 13751", { tags: "@external" }, () => {
   it("should allow using strings in filter based on a custom column (metabase#13751)", () => {
     H.addCustomColumn();
     H.enterCustomColumnDetails({
-      formula: 'regexextract([State], "^C[A-Z]")',
+      formula: 'regexExtract([State], "^C[A-Z]")',
       name: CC_NAME,
     });
     cy.button("Done").should("not.be.disabled").click();
@@ -161,11 +161,11 @@ describe.skip(
     });
 
     it("should not remove regex escape characters (metabase#14517)", () => {
-      cy.log("Create custom column using `regexextract()`");
+      cy.log("Create custom column using `regexExtract()`");
       cy.findByLabelText("Custom Column").click();
       H.popover().within(() => {
         cy.get("[contenteditable='true']")
-          .type(`regexextract([State], "${ESCAPED_REGEX}")`)
+          .type(`regexExtract([State], "${ESCAPED_REGEX}")`)
           .blur();
 
         // It removes escaped characters already on blur
@@ -1633,7 +1633,7 @@ describe("issue 56596", () => {
   it("should not remove backslashes from escaped characters (metabase#56596)", () => {
     H.addCustomColumn();
     const expr = dedent`
-      regexextract([Vendor], "\\s.*")
+      regexExtract([Vendor], "\\s.*")
     `;
     H.enterCustomColumnDetails({
       formula: expr,

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -105,7 +105,7 @@ describe("postgres > user > query", { tags: "@external" }, () => {
     cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
   });
 
-  it("should handle the use of `regexextract` in a sandboxed table (metabase#14873)", () => {
+  it("should handle the use of `regexExtract` in a sandboxed table (metabase#14873)", () => {
     const CC_NAME = "Firstname";
     // We need ultra-wide screen to avoid scrolling (custom column is rendered at the last position)
     cy.viewport(2200, 1200);

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
@@ -209,7 +209,7 @@ describe("suggestFunctions", () => {
       });
       const results = await completer("rege|");
       expect(
-        results?.options.find((option) => option.label === "regexextract"),
+        results?.options.find((option) => option.label === "regexExtract"),
       ).toBe(undefined);
     });
 
@@ -220,10 +220,10 @@ describe("suggestFunctions", () => {
       });
       const results = await completer("rege|");
       expect(
-        results?.options.find((option) => option.label === "regexextract"),
+        results?.options.find((option) => option.label === "regexExtract"),
       ).toEqual({
-        label: "regexextract",
-        displayLabel: "regexextract",
+        label: "regexExtract",
+        displayLabel: "regexExtract",
         detail:
           "Extracts matching substrings according to a regular expression.",
         matches: [[0, 3]],

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -174,7 +174,7 @@ export const MBQL_CLAUSES = defineClauses({
     requiresFeature: "split-part",
   },
   "regex-match-first": {
-    displayName: `regexextract`,
+    displayName: `regexExtract`,
     type: "string",
     args: ["string", "string"],
     requiresFeature: "regex",

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -544,7 +544,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
   },
   {
     name: "regex-match-first",
-    structure: "regexextract",
+    structure: "regexExtract",
     category: "string",
     description: () =>
       t`Extracts matching substrings according to a regular expression.`,


### PR DESCRIPTION
This PR changes the last non-camelcased expression function; `regexextract`, to be camel-cased by default, ie. `regexExtract`.

[From Slack](https://metaboat.slack.com/archives/C01LQQ2UW03/p1745010321499819)

> Looks like all custom functions are camel case now except for regexextract. Any reason we decided not to do that one? It would be great if we can make that consistent with all the other ones. Thx!

### To verify 

1. New -> Question -> Sample database -> Orders
2. Custom column
3. Type: `regexextract([Products → Title], "foo")`
4. You should've seen `regexExtract` in the suggestions and helptext
5. Format the expression
6. It should now read `regexExtract([Products → Title], "foo")`
7. verify that the name for `regexExtract` is correctly cased in the function browser