### PR TITLE
Closes viz-650 same id and same type are now required for compatibility

### DIFF
--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.ts
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.ts
@@ -27,6 +27,14 @@ function compareTypeAndName(
   return column.semantic_type === field.semantic_type;
 }
 
+function comparedId(column: DatasetColumn | undefined, field: Field): boolean {
+  if (!column) {
+    return false;
+  }
+
+  return column.id === field.id;
+}
+
 interface CompatibilityParameters {
   currentDataset: {
     display?: VisualizationDisplay;
@@ -56,11 +64,9 @@ export function getIsCompatible(parameters: CompatibilityParameters) {
     return false;
   }
 
-  const idAndNameMatcher = (field: Field) =>
-    compareIdAndName(primaryColumn, field);
-
-  const typeMatcher = (field: Field) =>
-    compareTypeAndName(primaryColumn, field);
+  const idAndNameMatcher = (f: Field) => compareIdAndName(primaryColumn, f);
+  const idMatcher = (f: Field) => comparedId(primaryColumn, f);
+  const typeMatcher = (f: Field) => compareTypeAndName(primaryColumn, f);
 
   if (currentDisplay === "scalar") {
     return (
@@ -73,7 +79,7 @@ export function getIsCompatible(parameters: CompatibilityParameters) {
   }
 
   if (isNumber(primaryColumn) || isString(primaryColumn)) {
-    return fields.some(idAndNameMatcher) || fields.some(typeMatcher);
+    return fields.some(idMatcher) || fields.some(typeMatcher);
   }
 
   if (isDate(primaryColumn)) {

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.unit.spec.ts
@@ -3,6 +3,7 @@ import {
   NumberColumn,
   StringColumn,
 } from "__support__/visualizations";
+import type { Field } from "metabase-types/api";
 import { createMockColumn, createMockField } from "metabase-types/api/mocks";
 
 import { getIsCompatible } from "./getIsCompatible";
@@ -258,5 +259,55 @@ describe("getIsCompatible", () => {
         },
       }),
     ).toBe(true);
+  });
+
+  it("should only accept columns with same id and same type", () => {
+    const primaryColumn = createMockColumn(
+      NumberColumn({
+        id: 1,
+      }),
+    );
+
+    const dateField = createMockField(
+      DateTimeColumn({
+        id: 42,
+        name: "create at",
+      }),
+    );
+
+    const sameIdAndType = createMockField(
+      NumberColumn({
+        id: 1,
+      }),
+    );
+
+    const differentIdAndType = createMockField(
+      StringColumn({
+        id: 2,
+      }),
+    );
+
+    const differentIdSameType = createMockField(
+      StringColumn({
+        id: 3,
+      }),
+    );
+
+    const allDifferent = createMockField(
+      StringColumn({
+        id: 4,
+      }),
+    );
+
+    const isCompatible = (fields: Field[]) =>
+      getIsCompatible({
+        currentDataset: { display: "line", primaryColumn },
+        targetDataset: { display: "line", fields },
+      });
+
+    expect(isCompatible([dateField, sameIdAndType])).toBe(true);
+    expect(isCompatible([dateField, differentIdAndType])).toBe(false);
+    expect(isCompatible([dateField, differentIdSameType])).toBe(false);
+    expect(isCompatible([dateField, allDifferent])).toBe(false);
   });
 });


### PR DESCRIPTION
Closes [VIZ-650: Different categorical fields showing up as compatible for some reason](https://linear.app/metabase/issue/VIZ-650/different-categorical-fields-showing-up-as-compatible-for-some-reason)

### Description

This makes the compatibility check stricter for datasets in the visualizer.