### PR TITLE
WRK-258: Expose default template for notifications

### DIFF
--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -103,6 +103,32 @@ export const notificationApi = Api.injectEndpoints({
         body,
       }),
     }),
+    getDefaultNotificationTemplate: builder.query<
+      Record<
+        string,
+        {
+          channel_type: string;
+          details: {
+            type: string;
+            subject?: string;
+            body: string;
+          };
+        }
+      >,
+      {
+        notification: {
+          payload_type: string;
+          payload: Record<string, unknown>;
+        };
+        channel_types: string[];
+      }
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/notification/default_template",
+        body,
+      }),
+    }),
   }),
 });
 
@@ -118,6 +144,7 @@ export const {
   useUnsubscribeFromNotificationMutation,
   useSendUnsavedNotificationMutation,
   useGetNotificationPayloadExampleMutation,
+  useGetDefaultNotificationTemplateQuery,
 } = notificationApi;
 
 export const useTableNotificationsQuery = (

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
@@ -11,6 +11,7 @@ import {
   useListChannelsQuery,
   useUpdateNotificationMutation,
 } from "metabase/api";
+import { useEscapeToCloseModal } from "metabase/common/hooks/use-escape-to-close-modal";
 import ButtonWithStatus from "metabase/components/ButtonWithStatus";
 import { AutoWidthSelect } from "metabase/components/Schedule/AutoWidthSelect";
 import CS from "metabase/css/core/index.css";
@@ -44,7 +45,6 @@ type TableNotificationTriggerOption = {
   label: string;
 };
 
-// Format JSON for tooltip display
 const formatJsonForTooltip = (json: any) => {
   return json ? JSON.stringify(json, null, 2) : "";
 };
@@ -229,7 +229,7 @@ export const CreateOrEditTableNotificationModal = ({
           addUndo({
             icon: "warning",
             toastColor: "error",
-            message: t`An error occurred`,
+            message: t`Failed to save alert.`,
           }),
         );
 
@@ -262,6 +262,8 @@ export const CreateOrEditTableNotificationModal = ({
     [requestBody, notification],
   );
 
+  useEscapeToCloseModal(onClose, { capture: false });
+
   if (!isLoadingChannelInfo && channelSpec && !channelRequirementsMet) {
     return (
       <ChannelSetupModal
@@ -284,6 +286,7 @@ export const CreateOrEditTableNotificationModal = ({
       size="lg"
       onClose={onClose}
       padding="2.5rem"
+      closeOnEscape={false}
       title={isEditMode ? t`Edit alert` : t`New alert`}
       styles={{
         body: {

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.module.css
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.module.css
@@ -1,11 +1,11 @@
 .customTemplateRoot {
-  --mb-color-border: transparent;
+  border: none;
 
   color: var(--mb-color-text-primary);
 }
 
 .customTemplateControl {
-  --mb-color-border: transparent;
+  border: none;
 
   padding: 0;
 }
@@ -21,4 +21,9 @@
   path {
     stroke-width: 0.75;
   }
+}
+
+.customTemplateItem,
+.customTemplateChevron {
+  border: none !important;
 }

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -131,6 +131,17 @@ interface NotificationChannelsPickerProps {
   getInvalidRecipientText?: (domains: string) => string;
   enableTemplates?: boolean;
   formattedJsonTemplate?: string;
+  defaultTemplates?: Record<
+    string,
+    {
+      channel_type: string;
+      details: {
+        type: string;
+        subject?: string;
+        body: string;
+      };
+    }
+  > | null;
 }
 
 interface TemplateHelperTooltipProps {
@@ -207,6 +218,7 @@ export const NotificationChannelsPicker = ({
   getInvalidRecipientText = defaultGetInvalidRecipientText,
   enableTemplates = false,
   formattedJsonTemplate = "",
+  defaultTemplates,
 }: NotificationChannelsPickerProps) => {
   const { data: httpChannelsConfig = [] } = useListChannelsQuery();
   const { data: users } = useListUserRecipientsQuery();
@@ -237,38 +249,55 @@ export const NotificationChannelsPicker = ({
     };
 
     notificationHandlers.forEach((handler) => {
-      if (!handler.template?.details) {
-        return;
-      }
-
-      const { channel_type, details } = handler.template;
-      const handlerChannelType = channel_type as keyof typeof templateTypeMap;
-      const stateKey = templateTypeMap[handlerChannelType]?.stateKey;
-
-      if (!stateKey) {
-        return;
-      }
-
-      // For simplicity, both channels use the same structure,
-      // but in future we'll need to introduce proper interface for each channel.
-      const hasContent = details.subject?.trim() || details.body?.trim();
-      if (hasContent) {
-        if (stateKey === "email") {
-          templates.email = {
-            subject: details.subject || "",
-            body: details.body || "",
-          };
-        } else if (stateKey === "slack") {
-          templates.slack = {
-            subject: "",
-            body: details.body || "",
-          };
+      if (handler.template?.details) {
+        const { channel_type, details } = handler.template;
+        const handlerChannelType = channel_type as keyof typeof templateTypeMap;
+        const stateKey = templateTypeMap[handlerChannelType]?.stateKey;
+        if (!stateKey) {
+          return;
+        }
+        const hasContent = details.subject?.trim() || details.body?.trim();
+        if (hasContent) {
+          if (stateKey === "email") {
+            templates.email = {
+              subject: details.subject || "",
+              body: details.body || "",
+            };
+          } else if (stateKey === "slack") {
+            templates.slack = {
+              subject: "",
+              body: details.body || "",
+            };
+          }
+        }
+      } else if (
+        handler.channel_type &&
+        defaultTemplates &&
+        defaultTemplates[handler.channel_type]
+      ) {
+        // Use default template if available and no template is set
+        const stateKey =
+          templateTypeMap[handler.channel_type as keyof typeof templateTypeMap]
+            ?.stateKey;
+        const details = defaultTemplates[handler.channel_type]?.details;
+        if (stateKey && details) {
+          if (stateKey === "email") {
+            templates.email = {
+              subject: details.subject || "",
+              body: details.body || "",
+            };
+          } else if (stateKey === "slack") {
+            templates.slack = {
+              subject: "",
+              body: details.body || "",
+            };
+          }
         }
       }
     });
 
     return { templates };
-  }, [notificationHandlers]);
+  }, [notificationHandlers, defaultTemplates]);
 
   const [templateState, dispatch] = useReducer(
     templateReducer,
@@ -277,6 +306,10 @@ export const NotificationChannelsPicker = ({
   // Re-initialize template state if handlers change externally
   useEffect(() => {
     dispatch({ type: "INITIALIZE_TEMPLATE", payload: initialTemplateState });
+    setValidationErrors({
+      email: { subject: false, body: false },
+      slack: { subject: false, body: false },
+    });
   }, [initialTemplateState]);
 
   const addChannel = useCallback(

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -566,10 +566,10 @@ export const NotificationChannelsPicker = ({
                 control: S.customTemplateControl,
                 label: S.customTemplateLabel,
                 icon: S.customTemplateIcon,
+                item: S.customTemplateItem,
+                chevron: S.customTemplateChevron,
               }}
-              defaultValue={
-                templateState.templates.email ? "email-template" : null
-              }
+              defaultValue={"email-template"}
             >
               <Accordion.Item value="email-template">
                 <Accordion.Control>
@@ -580,7 +580,9 @@ export const NotificationChannelsPicker = ({
                     />
                   </Flex>
                 </Accordion.Control>
-                <Accordion.Panel styles={{ content: { padding: 0 } }}>
+                <Accordion.Panel
+                  styles={{ content: { padding: 0, border: "none" } }}
+                >
                   <Stack>
                     <Stack gap="xs">
                       <Text size="sm" fw={700}>{t`Subject`}</Text>
@@ -646,10 +648,10 @@ export const NotificationChannelsPicker = ({
                 control: S.customTemplateControl,
                 label: S.customTemplateLabel,
                 icon: S.customTemplateIcon,
+                item: S.customTemplateItem,
+                chevron: S.customTemplateChevron,
               }}
-              defaultValue={
-                templateState.templates.slack ? "slack-template" : null
-              }
+              defaultValue={"slack-template"}
             >
               <Accordion.Item value="slack-template">
                 <Accordion.Control>
@@ -660,7 +662,9 @@ export const NotificationChannelsPicker = ({
                     />
                   </Flex>
                 </Accordion.Control>
-                <Accordion.Panel styles={{ content: { padding: 0 } }}>
+                <Accordion.Panel
+                  styles={{ content: { padding: 0, border: "none" } }}
+                >
                   <Stack gap="xs">
                     <Text size="sm" fw={700}>{t`Content`}</Text>
                     <TemplateEditor

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/test-utils.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/test-utils.tsx
@@ -27,6 +27,18 @@ export interface SetupOpts {
   webhooksResult?: NotificationChannel[];
   notificationHandlers?: NotificationHandler[];
   onChange?: jest.Mock;
+  defaultTemplates?: Record<
+    string,
+    {
+      channel_type: string;
+      details: {
+        type: string;
+        subject?: string;
+        body: string;
+      };
+    }
+  > | null;
+  enableTemplates?: boolean;
 }
 
 export const setup = ({
@@ -38,6 +50,8 @@ export const setup = ({
   webhooksResult = [],
   notificationHandlers = [],
   onChange = jest.fn(),
+  defaultTemplates = null,
+  enableTemplates = false,
 }: SetupOpts = {}) => {
   const settings = mockSettings({
     "token-features": createMockTokenFeatures({
@@ -101,6 +115,8 @@ export const setup = ({
       getInvalidRecipientText={(domains) =>
         `You're only allowed to email notifications to addresses ending in ${domains}`
       }
+      defaultTemplates={defaultTemplates}
+      enableTemplates={enableTemplates}
     />,
     {
       storeInitialState: {

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -166,6 +166,12 @@ export const TemplateEditor = ({
             ref.current.view?.focus();
           }
         }}
+        onKeyDown={(e) => {
+          // Prevent Escape key from propagating to the modal
+          if (e.key === "Escape") {
+            e.stopPropagation();
+          }
+        }}
         ref={ref}
         value={internalValue}
         onChange={handleChange}
@@ -182,6 +188,7 @@ export const TemplateEditor = ({
           [S.hasError]: error && typeof error === "string",
           [S.textInputVariant]: isTextInput,
         })}
+        indentWithTab={isTextArea}
         {...rest}
       />
       {typeof error === "string" && error && (

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -10,7 +10,7 @@ import CodeMirror, {
   type ReactCodeMirrorRef,
 } from "@uiw/react-codemirror";
 import cx from "classnames";
-import React, { Fragment, useMemo, useRef, useState } from "react";
+import React, { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import { useSetting } from "metabase/common/hooks";
 import type { CodeLanguage } from "metabase/components/CodeBlock/types";
@@ -87,7 +87,7 @@ export const TemplateEditor = ({
   onChange,
   minHeight = "5rem",
   language = "html",
-  placeholder: propsPlaceholder,
+  placeholder,
   className,
   variant = "textarea",
   error,
@@ -98,6 +98,10 @@ export const TemplateEditor = ({
   const helpers = useSetting("default-handlebars-helpers");
   const ref = useRef<ReactCodeMirrorRef>(null);
   const [internalValue, setInternalValue] = useState(defaultValue);
+
+  useEffect(() => {
+    setInternalValue(defaultValue);
+  }, [defaultValue]);
 
   const handleChange = React.useCallback(
     (val: string) => {
@@ -167,6 +171,7 @@ export const TemplateEditor = ({
         onChange={handleChange}
         extensions={combinedExtensions}
         minHeight={isTextArea && minHeight ? minHeight : undefined}
+        placeholder={placeholder}
         basicSetup={{
           lineNumbers: false,
           foldGutter: false,

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/autocomplete.ts
@@ -7,12 +7,12 @@ import type {
 
 import type { Settings } from "metabase-types/api";
 
-// Type helper for consistent completion options
 export type MustacheCompletionOption = Completion & {
   type: "keyword" | "variable" | "function";
 };
 
 // Helper function to recursively find all leaf paths in an object
+// to provide all possible autocomplete options at once
 function getAllPaths(obj: any, currentPath = ""): string[] {
   let paths: string[] = [];
   if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {


### PR DESCRIPTION
Closes [WRK-258: Expose default template for notifications](https://linear.app/metabase/issue/WRK-258/expose-default-template-for-notifications)

### Summary

This PR exposes default notification templates to the Metabase frontend UI, enabling users to see to actual code behind predefined templates when configuring notification channels and creating custom templates.

### Changes

  - Updated `frontend/src/metabase/api/notification.ts` to support fetching default templates from the backend. Configured it as a query, even though using POST request, to leverage caching.
  - Modified `CreateOrEditTableNotificationModal.tsx` to fetch and populate default templates during notification creation and editing.
  - Added ConfirmModal to display confirmation before closing if there were any changes to the handlers
  - Updated related test files to cover new behaviors.

### Verification Steps

1. Open the notification creation modal.
2. Confirm that the custom template form is populated with Handlebars code.
3. Change the event type, observe that form content is replaced with related template code.
4. Save the notification. Trigger notification. Observe that the actual content corresponds to existing template.
5. Open Edit notification modal, try to change to event type. Observe the form content is not changed, since it's already has a bound template saved.
6. Clear form fields. Blur the form. Observe that it's populated with the code of default template.

### Demo

<img width="502" alt="image" src="https://github.com/user-attachments/assets/57d8b6ee-9090-4c83-8fa4-67ea8a53f0cf" />

<img width="497" alt="image" src="https://github.com/user-attachments/assets/6f2bbb9c-59a0-4aab-82e1-98bb110ea6d0" />

<img width="576" alt="image" src="https://github.com/user-attachments/assets/1a93f2fb-dea5-48b7-8f2e-b68845f9848e" />

