### PR TITLE
Swapped out the custom <StepTitle/> for default <Title/> 

### DIFF
--- a/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.tsx
+++ b/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.tsx
@@ -6,16 +6,11 @@ import ButtonsS from "metabase/css/components/buttons.module.css";
 import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useSelector } from "metabase/lib/redux";
 import { subscribeToNewsletter } from "metabase/setup/utils";
-import { Switch } from "metabase/ui";
+import { Switch, Title } from "metabase/ui";
 
 import { getIsStepActive, getUserEmail } from "../../selectors";
 
-import {
-  StepBody,
-  StepFooter,
-  StepRoot,
-  StepTitle,
-} from "./CompletedStep.styled";
+import { StepBody, StepFooter, StepRoot } from "./CompletedStep.styled";
 
 export const CompletedStep = (): JSX.Element | null => {
   const [checkboxValue, setCheckboxValue] = useState(false);
@@ -47,7 +42,7 @@ export const CompletedStep = (): JSX.Element | null => {
 
   return (
     <StepRoot>
-      <StepTitle>{t`You're all set up!`}</StepTitle>
+      <Title order={2}>{t`You're all set up!`}</Title>
       <StepBody>
         <Switch
           checked={checkboxValue}


### PR DESCRIPTION
### Description

The existing title in the last setup step is inconsistent with the rest of the UI. It has the wrong color and size.

![image](https://github.com/user-attachments/assets/c171deaa-4bd8-49c3-8865-689b76049274)

To solve this, we changed the title to use the actual `Title` component.

![CleanShot 2025-04-22 at 16 09 39@2x](https://github.com/user-attachments/assets/8cbbc715-79db-45f6-adcd-bac8913f2899)

### How to verify

In the setup, click all the way to the last step.
