### PR TITLE
fix: use a shared lock for report_card updates

### DIFF
--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -36,8 +36,10 @@
                              items)]
       (doseq [[model ids] model->ids]
         (let [cnt->ids (group-by-frequency ids)
-              lock-name (keyword "metabase.events.view_log"
-                                 (str (name (t2/table-name model)) "-view-count"))]
+              lock-name (if (= model :model/Card)
+                          cluster-lock/card-statistics-lock ;; need to use a shared lock for all updates to the card table
+                          (keyword "metabase.events.view_log"
+                                   (str (name (t2/table-name model)) "-view-count")))]
           (cluster-lock/with-cluster-lock lock-name
             (t2/query {:update (t2/table-name model)
                        :set    {:view_count [:+ :view_count (into [:case]

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -21,7 +21,8 @@
                                         (fn [xs] (apply t/max (map :timestamp xs))))]
     (log/debugf "Update last_used_at of %d cards" (count card-id->timestamp))
     (try
-      (cluster-lock/with-cluster-lock ::used-at-update
+      ;; need to use a shared lock for all updates to the card table
+      (cluster-lock/with-cluster-lock cluster-lock/card-statistics-lock
         (t2/update! :model/Card :id [:in (keys card-id->timestamp)]
                     {:last_used_at (into [:case]
                                          (mapcat (fn [[id timestamp]]

--- a/src/metabase/util/cluster_lock.clj
+++ b/src/metabase/util/cluster_lock.clj
@@ -87,3 +87,7 @@
   the specified name to coordinate concurrency with other metabase instances sharing the appdb."
   ([lock-options & body]
    `(do-with-cluster-lock ~lock-options (fn [] ~@body))))
+
+(def card-statistics-lock
+  "A shared keyword that any method doing a batch update of card statistics can use for the cluster lock"
+  ::statistics-lock)


### PR DESCRIPTION
### Description

the view_count and last_view_at updates of report cards can deadlock against each other, so introduce a shared keyword they can use to each take a cluster lock when updating these values to prevent the deadlocks.

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
