### PR TITLE
Updating entity-id cards in sidesheets

### DIFF
--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -1345,6 +1345,11 @@ describe("scenarios > embedding > full app", () => {
 
       cy.findByTestId("dashboard-name-heading").should("be.visible");
       cy.button(/Edited.*by/).should("be.visible");
+
+      H.dashboardHeader().findByRole("img", { name: /info/i }).click();
+      H.modal()
+        .findByRole("heading", { name: /entity id/i })
+        .should("not.exist");
     });
 
     it("should hide the dashboard header by a param", () => {

--- a/frontend/src/metabase/common/components/Sidesheet/SidesheetCard.tsx
+++ b/frontend/src/metabase/common/components/Sidesheet/SidesheetCard.tsx
@@ -41,5 +41,5 @@ export const SidesheetCard = ({
 };
 
 export const SidesheetCardTitle = (props: TitleProps) => (
-  <Title lh={1} mb=".75rem" c="text-light" order={4} {...props} />
+  <Title lh={1} mb=".75rem" c="text-medium" order={4} {...props} />
 );

--- a/frontend/src/metabase/components/CopyButton/CopyButton.tsx
+++ b/frontend/src/metabase/components/CopyButton/CopyButton.tsx
@@ -10,12 +10,17 @@ import { Icon, Text, Tooltip } from "metabase/ui";
 
 import CopyButtonStyles from "./CopyButton.module.css";
 
+export const COPY_BUTTON_ICON = (
+  <Icon className={CopyButtonStyles.CopyButton} tabIndex={0} name="copy" />
+);
+
 type CopyButtonProps = {
   value: CopyToClipboard.Props["text"];
   onCopy?: () => void;
   className?: string;
   style?: object;
   "aria-label"?: string;
+  target?: React.ReactNode;
 };
 
 export const CopyButton = ({
@@ -23,6 +28,7 @@ export const CopyButton = ({
   onCopy,
   className = cx(Styles.textBrandHover, Styles.cursorPointer),
   style,
+  target = COPY_BUTTON_ICON,
 }: CopyButtonProps) => {
   const [copied, setCopied] = useState(false);
   const timeoutIdRef = useRef<number>();
@@ -40,7 +46,7 @@ export const CopyButton = ({
   }, [onCopy]);
 
   const copyOnEnter = useCallback(
-    (e: React.KeyboardEvent<SVGElement>) => {
+    (e: React.KeyboardEvent<HTMLElement>) => {
       if (isPlainKey(e, "Enter")) {
         onCopyValue();
       }
@@ -55,12 +61,7 @@ export const CopyButton = ({
           label={<Text fw={700} c="white">{t`Copied!`}</Text>}
           opened={copied}
         >
-          <Icon
-            className={CopyButtonStyles.CopyButton}
-            tabIndex={0}
-            onKeyDown={copyOnEnter}
-            name="copy"
-          />
+          <span onKeyDown={copyOnEnter}>{target}</span>
         </Tooltip>
       </div>
     </CopyToClipboard>

--- a/frontend/src/metabase/components/EntityIdCard/EntityIdCard.module.css
+++ b/frontend/src/metabase/components/EntityIdCard/EntityIdCard.module.css
@@ -1,9 +1,7 @@
 .CopyButton {
   cursor: pointer;
   position: relative;
-  top: -1px;
   color: var(--mb-color-text-light);
-  line-height: 1rem;
 
   &:hover {
     color: var(--mb-color-brand);

--- a/frontend/src/metabase/components/EntityIdCard/EntityIdCard.tsx
+++ b/frontend/src/metabase/components/EntityIdCard/EntityIdCard.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import {
@@ -6,16 +7,16 @@ import {
   SidesheetCardTitle,
 } from "metabase/common/components/Sidesheet";
 import { useDocsUrl, useHasTokenFeature } from "metabase/common/hooks";
-import { CopyButton } from "metabase/components/CopyButton";
+import { COPY_BUTTON_ICON, CopyButton } from "metabase/components/CopyButton";
 import Link from "metabase/core/components/Link";
+import CS from "metabase/css/core/index.css";
 import {
   Flex,
   Group,
+  type GroupProps,
   Icon,
   Paper,
   Popover,
-  Stack,
-  type StackProps,
   Text,
   type TitleProps,
 } from "metabase/ui";
@@ -23,54 +24,73 @@ import {
 import Styles from "./EntityIdCard.module.css";
 
 const EntityIdTitle = (props?: TitleProps) => {
-  const { url: docsLink, showMetabaseLinks } = useDocsUrl(
-    "installation-and-operation/serialization",
-  );
-
   return (
     <SidesheetCardTitle mb={0} {...props}>
       <Group gap="sm">
         {t`Entity ID`}
-        <Popover position="top-start">
-          <Popover.Target>
-            <Icon tabIndex={0} name="info" className={Styles.InfoIcon} />
-          </Popover.Target>
-          <Popover.Dropdown>
-            <Paper p="md" maw="13rem">
-              <Text fz="sm">
-                {t`When using serialization, replace the sequential ID with this global entity ID to have stable URLs across environments. Also useful when troubleshooting serialization.`}{" "}
-                {showMetabaseLinks && (
-                  <>
-                    <Link
-                      target="_new"
-                      to={docsLink}
-                      style={{ color: "var(--mb-color-brand)" }}
-                    >
-                      {t`Learn more`}
-                    </Link>
-                  </>
-                )}
-              </Text>
-            </Paper>
-          </Popover.Dropdown>
-        </Popover>
+        <EntityInfoIcon />
       </Group>
     </SidesheetCardTitle>
   );
 };
 
+export const EntityInfoIcon = () => {
+  const { url: docsLink, showMetabaseLinks } = useDocsUrl(
+    "installation-and-operation/serialization",
+  );
+
+  return (
+    <Popover position="top-start">
+      <Popover.Target>
+        <Icon tabIndex={0} name="info" className={Styles.InfoIcon} />
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Paper p="md" maw="13rem">
+          <Text fz="sm">
+            {t`When using serialization, replace the sequential ID with this global entity ID to have stable URLs across environments. Also useful when troubleshooting serialization.`}{" "}
+            {showMetabaseLinks && (
+              <>
+                <Link
+                  target="_new"
+                  to={docsLink}
+                  style={{ color: "var(--mb-color-brand)" }}
+                >
+                  {t`Learn more`}
+                </Link>
+              </>
+            )}
+          </Text>
+        </Paper>
+      </Popover.Dropdown>
+    </Popover>
+  );
+};
+
+export const EntityCopyButton = ({ entityId }: { entityId: string }) => (
+  <CopyButton
+    className={cx(Styles.CopyButton, CS.hoverParent, CS.hoverVisibility)}
+    value={entityId}
+    style={{
+      height: "1rem",
+    }}
+    target={
+      <Flex gap="sm" wrap="nowrap" align="center">
+        <div className={cx(CS.hoverChild)}>{COPY_BUTTON_ICON}</div>
+        <Text lh="1rem">{entityId}</Text>
+      </Flex>
+    }
+  />
+);
+
 export const EntityIdDisplay = ({
   entityId,
   ...props
-}: { entityId: string } & StackProps) => {
+}: { entityId: string } & GroupProps) => {
   return (
-    <Stack gap="md" {...props}>
+    <Group justify="space-between" {...props}>
       <EntityIdTitle />
-      <Flex gap="sm">
-        <Text lh="1rem">{entityId}</Text>
-        <CopyButton className={Styles.CopyButton} value={entityId} />
-      </Flex>
-    </Stack>
+      <EntityCopyButton entityId={entityId} />
+    </Group>
   );
 };
 

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.module.css
@@ -1,0 +1,15 @@
+.EntityId {
+  margin-bottom: 0.5rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.CollapseButton {
+  cursor: pointer;
+
+  &:hover {
+    color: var(--mb-color-brand);
+  }
+}

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.module.css
@@ -1,11 +1,3 @@
-.EntityId {
-  margin-bottom: 0.5rem;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
 .CollapseButton {
   cursor: pointer;
 

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.tsx
@@ -49,9 +49,14 @@ export const DashboardEntityIdCard = ({
         <Icon name={opened ? "chevronup" : "chevrondown"} />
       </Group>
 
-      <Collapse in={opened}>
+      <Collapse in={opened} role="list">
         <Divider mb="0.75rem" />
-        <Group justify="space-between" className={Styles.EntityId}>
+        <Group
+          justify="space-between"
+          className={Styles.EntityId}
+          role="listitem"
+          aria-label="This dashboard"
+        >
           <Text>{t`This dashboard`}</Text>
           <EntityCopyButton entityId={dashboard.entity_id} />
         </Group>
@@ -61,6 +66,8 @@ export const DashboardEntityIdCard = ({
               justify="space-between"
               key={tab.id}
               className={Styles.EntityId}
+              role="listitem"
+              aria-label={tab.name}
             >
               <Text>{tab.name}</Text>
               <EntityCopyButton entityId={tab.entity_id} />

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.tsx
@@ -51,29 +51,29 @@ export const DashboardEntityIdCard = ({
 
       <Collapse in={opened} role="list">
         <Divider mb="0.75rem" />
-        <Group
-          justify="space-between"
-          className={Styles.EntityId}
-          role="listitem"
-          aria-label="This dashboard"
-        >
-          <Text>{t`This dashboard`}</Text>
-          <EntityCopyButton entityId={dashboard.entity_id} />
-        </Group>
-        {tabs?.map((tab) =>
-          tab.entity_id ? (
-            <Group
-              justify="space-between"
-              key={tab.id}
-              className={Styles.EntityId}
-              role="listitem"
-              aria-label={tab.name}
-            >
-              <Text>{tab.name}</Text>
-              <EntityCopyButton entityId={tab.entity_id} />
-            </Group>
-          ) : null,
-        )}
+        <Stack gap="0.5rem">
+          <Group
+            justify="space-between"
+            role="listitem"
+            aria-label={t`This dashboard`}
+          >
+            <Text>{t`This dashboard`}</Text>
+            <EntityCopyButton entityId={dashboard.entity_id} />
+          </Group>
+          {tabs?.map((tab) =>
+            tab.entity_id ? (
+              <Group
+                justify="space-between"
+                key={tab.id}
+                role="listitem"
+                aria-label={tab.name}
+              >
+                <Text>{tab.name}</Text>
+                <EntityCopyButton entityId={tab.entity_id} />
+              </Group>
+            ) : null,
+          )}
+        </Stack>
       </Collapse>
     </SidesheetCard>
   );

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/DashboardEntityIdCard.tsx
@@ -6,11 +6,15 @@ import {
   SidesheetCardTitle,
 } from "metabase/common/components/Sidesheet";
 import { useHasTokenFeature } from "metabase/common/hooks";
-import { CopyButton } from "metabase/components/CopyButton";
-import { EntityIdDisplay } from "metabase/components/EntityIdCard";
-import S from "metabase/components/EntityIdCard/EntityIdCard.module.css";
-import { Divider, Flex, Select, Stack } from "metabase/ui";
+import {
+  EntityCopyButton,
+  EntityInfoIcon,
+} from "metabase/components/EntityIdCard";
+import { isWithinIframe } from "metabase/lib/dom";
+import { Collapse, Divider, Group, Icon, Stack, Text } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
+
+import Styles from "./DashboardEntityIdCard.module.css";
 
 export const DashboardEntityIdCard = ({
   dashboard,
@@ -19,44 +23,51 @@ export const DashboardEntityIdCard = ({
 }) => {
   const { tabs } = dashboard;
   // The id of the tab currently selected in the dropdown
-  const [tabId, setTabId] = useState<string | null>(
-    tabs?.length ? tabs[0].id.toString() : null,
-  );
+  const [opened, setOpened] = useState<boolean>(false);
 
-  if (!useHasTokenFeature("serialization")) {
+  if (!useHasTokenFeature("serialization") || isWithinIframe()) {
     return null;
   }
 
-  const tabEntityId = tabs?.find(
-    (tab) => tab.id.toString() === tabId,
-  )?.entity_id;
-
   return (
     <SidesheetCard>
-      <EntityIdDisplay entityId={dashboard.entity_id} />
-      {tabEntityId && (
-        <>
-          <Divider w="100%" />
-          <Stack gap="xs">
-            <SidesheetCardTitle>{t`Specific tab IDs`}</SidesheetCardTitle>
-            <Flex gap="md" align="center">
-              <Select
-                value={tabId}
-                onChange={(value) => setTabId(value)}
-                data={tabs?.map((tab) => ({
-                  value: tab.id.toString(),
-                  label: tab.name,
-                }))}
-                w="15rem"
-              />
-              <Flex gap="sm" wrap="nowrap">
-                {tabEntityId}
-                <CopyButton className={S.CopyButton} value={tabEntityId} />
-              </Flex>
-            </Flex>
-          </Stack>
-        </>
-      )}
+      <Group
+        justify="space-between"
+        onClick={() => setOpened((x) => !x)}
+        className={Styles.CollapseButton}
+      >
+        <Stack gap="0.25rem">
+          <SidesheetCardTitle
+            mb={0}
+            c="inherit"
+          >{t`Entity ID`}</SidesheetCardTitle>
+          <Group>
+            <Text c="inherit">{t`Useful when using serialization or embedding`}</Text>
+            <EntityInfoIcon />
+          </Group>
+        </Stack>
+        <Icon name={opened ? "chevronup" : "chevrondown"} />
+      </Group>
+
+      <Collapse in={opened}>
+        <Divider mb="0.75rem" />
+        <Group justify="space-between" className={Styles.EntityId}>
+          <Text>{t`This dashboard`}</Text>
+          <EntityCopyButton entityId={dashboard.entity_id} />
+        </Group>
+        {tabs?.map((tab) =>
+          tab.entity_id ? (
+            <Group
+              justify="space-between"
+              key={tab.id}
+              className={Styles.EntityId}
+            >
+              <Text>{tab.name}</Text>
+              <EntityCopyButton entityId={tab.entity_id} />
+            </Group>
+          ) : null,
+        )}
+      </Collapse>
     </SidesheetCard>
   );
 };

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardEntityIdCard/tests/premium.unit.spec.tsx
@@ -1,6 +1,5 @@
 import userEvent from "@testing-library/user-event";
 
-import { viewMantineSelectOptions } from "__support__/components/mantineSelect";
 import { type RenderWithProvidersOptions, screen } from "__support__/ui";
 import type { BaseEntityId, Dashboard } from "metabase-types/api";
 import {
@@ -24,47 +23,42 @@ const setup = ({
 };
 
 describe("DashboardEntityIdCard (EE with token)", () => {
-  it("should display all tabs from the dashboard as options in the Select", async () => {
+  it("should display all tabs from the dashboard when expanded", async () => {
+    const tabs = [
+      createMockDashboardTab({
+        id: 1,
+        name: "Tab 1",
+        entity_id: "tab-1-entity-id" as BaseEntityId,
+      }),
+      createMockDashboardTab({
+        id: 2,
+        name: "Tab 2",
+        entity_id: "tab-2-entity-id" as BaseEntityId,
+      }),
+      createMockDashboardTab({
+        id: 3,
+        name: "Tab 3",
+        entity_id: "tab-3-entity-id" as BaseEntityId,
+      }),
+    ];
     const dashboard = createMockDashboard({
-      tabs: [
-        createMockDashboardTab({
-          id: 1,
-          name: "Tab 1",
-          entity_id: "tab-1-entity-id" as BaseEntityId,
-        }),
-        createMockDashboardTab({
-          id: 2,
-          name: "Tab 2",
-          entity_id: "tab-2-entity-id" as BaseEntityId,
-        }),
-        createMockDashboardTab({
-          id: 3,
-          name: "Tab 3",
-          entity_id: "tab-3-entity-id" as BaseEntityId,
-        }),
-      ],
+      tabs,
     });
     setup({ dashboard });
-    expect(
+
+    await userEvent.click(
       await screen.findByRole("heading", { name: /Entity ID/ }),
+    );
+
+    expect(
+      await screen.findByRole("listitem", { name: "This dashboard" }),
     ).toBeInTheDocument();
 
-    const firstClickOnSelect = await viewMantineSelectOptions();
-    expect(firstClickOnSelect.displayedOption.value).toBe("Tab 1");
-    expect(firstClickOnSelect.optionTextContents).toEqual([
-      "Tab 1",
-      "Tab 2",
-      "Tab 3",
-    ]);
-    expect(await screen.findByText("tab-1-entity-id")).toBeInTheDocument();
-
-    await userEvent.click(firstClickOnSelect.optionElements[1]);
-    expect(await screen.findByText("tab-2-entity-id")).toBeInTheDocument();
-
-    const secondClickOnSelect = await viewMantineSelectOptions();
-    expect(secondClickOnSelect.displayedOption.value).toBe("Tab 2");
-    await userEvent.click(secondClickOnSelect.optionElements[2]);
-    expect(await screen.findByText("tab-3-entity-id")).toBeInTheDocument();
+    tabs.forEach(async (tab) => {
+      expect(
+        await screen.findByRole("listitem", { name: tab.name }),
+      ).toHaveTextContent(tab.entity_id as string);
+    });
   });
 
   it("does not display a select, if there are no tabs", () => {


### PR DESCRIPTION
Closes ADM-209

### Description
Changes the UI for the Entity ID cards in dashboards and questions, as well as hides the cards when metabase detects that it is within an iframe for public dashboard embeds

### How to verify

1. Setup public embedding of a dashboard, and to the embedded site
2. The entity ID cards should not be visible in the info bar embedded dashboards 
3. back in metabase, go to any questions / dashboards
4. the entity id cards should have a new UI (but same functionality)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
