### PR TITLE
Use a deterministic identifier for chart downloads

### DIFF
--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -129,10 +129,19 @@ const downloadChart = async ({
   dashcardId,
 }: DownloadQueryResultsOpts) => {
   const fileName = getChartFileName(question);
+  const cardContainer = `[data-card-key='${getCardKey(question.id())}']`;
+  /**
+   * The same card can be added multiple times to the same dashboard
+   * so we need a unique identifier, which is the id of the dashcard.
+   *
+   * In order to keep downloads deterministic, we're using the one and
+   * the same selector as the node, which is the data-card-key.
+   */
   const chartSelector =
     dashcardId != null
-      ? `[data-dashcard-key='${dashcardId}']`
-      : `[data-card-key='${getCardKey(question.id())}']`;
+      ? `[data-dashcard-key='${dashcardId}'] ${cardContainer}`
+      : cardContainer;
+
   await saveChartImage(chartSelector, fileName);
 };
 


### PR DESCRIPTION
Resolves PRG-10.

This commit keeps the DOM node that we use for downloads deterministic, while ensuring that we always target the correct chart in the dashboard.

The same question can be added to the dashboard multiple times so the only unique identifier we can use is the dashcard id.

But this brings us to the weird situation that the node we're sending to the canvas to render before downloading is different when we're downloading the chart from a dashboard vs when we're downloading it directly from the question page.

This pseudo DOM code shows what we did before:

Dashboard:
```
dashcard-id <--- we were grabbing this
    visualization-root
        card-id
```

Question:
```
div
    visualization-root
        card-id <-- we were grabbing this
```

Compare that to what we're doing now

Dashboard:
```
dashcard-id
    visualization-root
        card-id <--- we are now grabbing this*
        
* but only when it is under the specific dashcard-id (selector A B)
```

Question:
```
div
    visualization-root
        card-id <-- we continue grabbing this like before
```

### How to verify

Since this particular piece of code was introduced in the past as part of #44941 (in order to fix the PNG downloads in dark more), we need to make sure things still work as expected.

1. Create a dashboard with at least one graph
2. Go to static embedding
3. Enable dark mode in the preview
4. Download a chart
5. Make sure it renders in a dark mode

### Demo

https://www.loom.com/share/afb9a4f39bd74fe48ad4b5841f195e58?sid=0812bdfc-bc65-4e45-bd5b-04a8487ec8d5

### Checklist

- N/A Tests have been added/updated to cover changes in this PR
