### PR TITLE
ci: centralize uberjar build in run-tests.yml

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,6 +28,14 @@ on:
       split_index: # index of the chunk
         required: false
         type: number
+      artifact_name_ee:
+        type: string
+        description: "Name of the EE uberjar artifact"
+        required: false
+      artifact_name_oss:
+        type: string
+        description: "Name of the OSS uberjar artifact"
+        required: false
 
 jobs:
   e2e-tests:
@@ -64,6 +72,20 @@ jobs:
       webhook: true
     steps:
       - uses: actions/checkout@v4
+
+      - name: Get artifact name
+        id: get_artifact_name
+        run: |
+          if [ "${{ inputs.edition }}" == "ee" ]; then
+            echo "artifact_name=${{ inputs.artifact_name_ee || format('metabase-ee-{0}-uberjar', github.event.pull_request.head.sha || github.sha) }}" >> $GITHUB_OUTPUT
+          else
+            echo "artifact_name=${{ inputs.artifact_name_oss || format('metabase-oss-{0}-uberjar', github.event.pull_request.head.sha || github.sha) }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Retrieve uberjar artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.get_artifact_name.outputs.artifact_name }}
 
       - name: Prepare Docker containers
         uses: ./.github/actions/e2e-prepare-containers

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,14 @@ on:
       skip:
         type: boolean
         default: false
+      artifact_name_ee:
+        type: string
+        description: "Name of the EE uberjar artifact"
+        required: false
+      artifact_name_oss:
+        type: string
+        description: "Name of the OSS uberjar artifact"
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-e2e
@@ -50,7 +58,7 @@ jobs:
 
   build:
     needs: [get-build-requirements]
-    if: ${{ !cancelled() && !inputs.skip }}
+    if: ${{ !cancelled() && !inputs.skip && inputs.artifact_name_ee == '' && inputs.artifact_name_oss == '' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
@@ -121,7 +129,7 @@ jobs:
       - e2e-matrix-builder
       - build
     if: |
-      !cancelled() && needs.build.result == 'success'
+      !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped')
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.e2e-matrix-builder.outputs.matrix) }}
@@ -134,6 +142,8 @@ jobs:
       split_index: ${{ strategy.job-index }}
       tags: ${{ matrix.tags }}
       runner: ${{ matrix.runner }}
+      artifact_name_ee: ${{ inputs.artifact_name_ee }}
+      artifact_name_oss: ${{ inputs.artifact_name_oss }}
 
   # run this separately to make it non-blocking
   flaky-e2e-tests:
@@ -141,12 +151,14 @@ jobs:
     uses: ./.github/workflows/e2e-test.yml
     needs: build
     if: |
-      !cancelled() && needs.build.result == 'success'
+      !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped')
     secrets: inherit
     with:
       name: Flaky
       tags: "@flaky"
       specs: "./e2e/test/scenarios/**/*.cy.spec.*"
+      artifact_name_ee: ${{ inputs.artifact_name_ee }}
+      artifact_name_oss: ${{ inputs.artifact_name_oss }}
 
   e2e-tests-result:
     needs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,18 +60,22 @@ jobs:
 
   backend-tests:
     if: ${{ !cancelled() }}
-    needs: [files-changed, static-viz-files-changed]
+    needs: [files-changed, static-viz-files-changed, build-uberjars]
     uses: ./.github/workflows/backend.yml
     secrets: inherit
     with:
       skip: ${{ needs.files-changed.outputs.backend_all != 'true' && needs.static-viz-files-changed.outputs.static_viz != 'true' }}
+      artifact_name_ee: ${{ needs.build-uberjars.outputs.artifact_name_ee }}
+      artifact_name_oss: ${{ needs.build-uberjars.outputs.artifact_name_oss }}
 
   driver-tests:
-    needs: files-changed
+    needs: [files-changed, build-uberjars]
     uses: ./.github/workflows/drivers.yml
     secrets: inherit
     with:
       skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+      artifact_name_ee: ${{ needs.build-uberjars.outputs.artifact_name_ee }}
+      artifact_name_oss: ${{ needs.build-uberjars.outputs.artifact_name_oss }}
 
   frontend-tests:
     needs: files-changed
@@ -80,9 +84,54 @@ jobs:
     with:
       skip: ${{ needs.files-changed.outputs.frontend_all != 'true' }}
 
-  e2e-tests:
+  build-uberjars:
+    name: Build Uberjar
     needs: files-changed
+    if: ${{ !cancelled() && needs.files-changed.outputs.e2e_all == 'true' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    outputs:
+      artifact_name_ee: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+      artifact_name_oss: metabase-oss-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: uberjar
+          java-version: 21
+          
+      # Build EE version
+      - name: Build EE uberjar
+        run: |
+          MB_EDITION=ee ./bin/build.sh
+        shell: bash
+      - name: Prepare EE uberjar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          path: |
+            ./target/uberjar/metabase.jar
+            
+      # Build OSS version  
+      - name: Build OSS uberjar
+        run: |
+          MB_EDITION=oss ./bin/build.sh
+        shell: bash
+      - name: Prepare OSS uberjar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: metabase-oss-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          path: |
+            ./target/uberjar/metabase.jar
+
+  e2e-tests:
+    needs: [files-changed, build-uberjars]
     uses: ./.github/workflows/e2e-tests.yml
     secrets: inherit
     with:
       skip: ${{ needs.files-changed.outputs.e2e_all != 'true' }}
+      artifact_name_ee: ${{ needs.build-uberjars.outputs.artifact_name_ee }}
+      artifact_name_oss: ${{ needs.build-uberjars.outputs.artifact_name_oss }}


### PR DESCRIPTION
This PR centralizes the uberjar build in run-tests.yml to make it happen only once per CI run. It adds a build-uberjars job that creates both EE and OSS uberjars, which are then shared with other workflows using GitHub Actions artifacts. This reduces the overall build time by eliminating duplicate work.