### PR TITLE
ci: add uberjar build job to run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -79,6 +79,41 @@ jobs:
     secrets: inherit
     with:
       skip: ${{ needs.files-changed.outputs.frontend_all != 'true' }}
+      
+  # Build uberjar to be shared by all jobs
+  build-uberjar:
+    name: Build Uberjar ${{ matrix.edition }}
+    needs: [files-changed]
+    if: ${{ !cancelled() && (needs.files-changed.outputs.e2e_all == 'true' || needs.files-changed.outputs.backend_all == 'true') }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [ee, oss]
+    env:
+      MB_EDITION: ${{ matrix.edition }}
+      INTERACTIVE: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: uberjar
+          java-version: 21
+          
+      - name: Build uberjar with ./bin/build.sh
+        timeout-minutes: 10
+        run: ./bin/build.sh
+        shell: bash
+        
+      - name: Prepare uberjar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          path: |
+            ./target/uberjar/metabase.jar
 
   e2e-tests:
     needs: files-changed


### PR DESCRIPTION
This PR adds a uberjar build job to run-tests.yml that creates both EE and OSS uberjars once per CI run. They're shared as GitHub Actions artifacts that can be downloaded by other workflows.

This is the first step toward centralizing uberjar building. In future PRs, we'll update the downstream workflows to use these artifacts rather than building their own uberjars.