### PR TITLE
Pass profile_id to AI service

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -4,6 +4,7 @@
    [malli.core :as mc]
    [malli.transform :as mtx]
    [metabase-enterprise.metabot-v3.client.schema :as metabot-v3.client.schema]
+   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.envelope :as metabot-v3.envelope]
    [metabase-enterprise.metabot-v3.reactions :as metabot-v3.reactions]
@@ -24,12 +25,13 @@
 (defn request
   "Handles an incoming request, making all required tool invocation, LLM call loops, etc."
   [{:keys [metabot_id message context history conversation_id state]
-    :or {metabot_id metabot-v3.tools.api/internal-metabot-id}}]
+    :or {metabot_id metabot-v3.config/internal-metabot-id}}]
   (let [initial-message (metabot-v3.envelope/user-message message)
         history         (conj (vec history) initial-message)
         env             (metabot-v3.tools.api/handle-envelope
                          {:context         (metabot-v3.context/create-context context)
                           :metabot-id      metabot_id
+                          :profile-id      (get-in metabot-v3.config/metabot-config [metabot_id :profile-id])
                           :conversation-id conversation_id
                           :messages        history
                           :state           state})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -85,10 +85,11 @@
 
 (mu/defn request :- ::metabot-v3.client.schema/ai-proxy.response
   "Make a V2 request to the AI Proxy."
-  [{:keys [context messages conversation-id session-id state]}
+  [{:keys [context messages profile-id conversation-id session-id state]}
    :- [:map
        [:context :map]
        [:messages ::metabot-v3.client.schema/messages]
+       [:profile-id :string]
        [:conversation-id :string]
        [:session-id :string]
        [:state :map]]]
@@ -98,6 +99,7 @@
           body     (-> {:messages        messages
                         :context         context
                         :conversation_id conversation-id
+                        :profile_id      profile-id
                         :state           state
                         :user_id         api/*current-user-id*}
                        (metabot-v3.u/recursive-update-keys metabot-v3.u/safe->snake_case_en))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
@@ -1,0 +1,16 @@
+(ns metabase-enterprise.metabot-v3.config)
+
+(def internal-metabot-id
+  "The ID of the internal Metabot instance."
+  "b5716059-ad40-4d83-a4e1-673af020b2d8")
+
+(def embedded-metabot-id
+  "The ID of the embedded Metabot instance."
+  "c61bf5f5-1025-47b6-9298-bf1827105bb6")
+
+(def metabot-config
+  "The name of the collection exposed by the answer-sources tool."
+  {internal-metabot-id {:profile-id "experimental"
+                        :collection-name "__METABOT__"}
+   embedded-metabot-id {:profile-id "default"
+                        :collection-name "__METABOT_EMBEDDING__"}})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -7,6 +7,7 @@
    [malli.core :as mc]
    [malli.transform :as mtx]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
+   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
    [metabase-enterprise.metabot-v3.envelope :as envelope]
@@ -491,19 +492,6 @@
                          [:models  [:sequential ::full-table]]]]]
    [:map [:output :string]]])
 
-(def internal-metabot-id
-  "The ID of the internal Metabot instance."
-  "b5716059-ad40-4d83-a4e1-673af020b2d8")
-
-(def embedded-metabot-id
-  "The ID of the embedded Metabot instance."
-  "c61bf5f5-1025-47b6-9298-bf1827105bb6")
-
-(def metabot-config
-  "The name of the collection exposed by the answer-sources tool."
-  {internal-metabot-id {:collection-name "__METABOT__"}
-   embedded-metabot-id {:collection-name "__METABOT_EMBEDDING__"}})
-
 (api.macros/defendpoint :post "/answer-sources" :- [:merge ::answer-sources-result ::tool-request]
   "Create a dashboard subscription."
   [_route-params
@@ -511,7 +499,7 @@
    {:keys [conversation_id] :as body} :- ::tool-request
    {:keys [metabot-v3/metabot-id]}]
   (metabot-v3.context/log (assoc body :api :answer-sources) :llm.log/llm->be)
-  (if-let [collection-name (get-in metabot-config [metabot-id :collection-name])]
+  (if-let [collection-name (get-in metabot-v3.config/metabot-config [metabot-id :collection-name])]
     (doto (-> (mc/decode ::answer-sources-result
                          (metabot-v3.dummy-tools/answer-sources collection-name)
                          (mtx/transformer {:name :tool-api-response}))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
+   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.tools.api :as metabot-v3.tools.api]
    [metabase.test :as mt]))
 
@@ -35,10 +36,13 @@
                         :messages [(update historical-message :role keyword) {:role :user, :content question}]
                         :state {}
                         :conversation-id conversation-id
+                        :profile-id (when-not metabot-id
+                                      (get-in metabot-v3.config/metabot-config
+                                              [metabot-v3.config/internal-metabot-id :profile-id]))
                         :session-id (fn [session-id]
                                       (when-let [token (#'metabot-v3.tools.api/decode-ai-service-token session-id)]
                                         (and (= (:metabot-id token) (or metabot-id
-                                                                        metabot-v3.tools.api/internal-metabot-id))
+                                                                        metabot-v3.config/internal-metabot-id))
                                              (= (:user token) (mt/user->id :rasta)))))}]
                       @ai-requests))
               (is (=? {:reactions [{:type "metabot.reaction/redirect", :url navigation-target}]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.tools.api :as metabot-v3.tools.api]
    [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription :as metabot-v3.tools.create-dashboard-subscription]
    [metabase-enterprise.metabot-v3.tools.filters :as metabot-v3.tools.filters]
@@ -359,7 +360,7 @@
                       :type :model}
           collection-name (str (random-uuid))
           metabot-id (str (random-uuid))]
-      (with-redefs [metabot-v3.tools.api/metabot-config {metabot-id {:collection-name collection-name}}]
+      (with-redefs [metabot-v3.config/metabot-config {metabot-id {:collection-name collection-name}}]
         (mt/with-temp [:model/Collection {collection-id :id} {:name collection-name}
                        :model/Card {metric-id :id} (assoc metric-data :collection_id collection-id)
                        :model/Card _ignored        metric-data


### PR DESCRIPTION
Fixes BOT-107

### Description

Added the profile selection information to the Metabot instance configuration and added it to the initial request to the AI service.

I've tested locally with both well known Metabot instances.

### How to verify

Observe the call logs, `profile_id` should show up the the BE invokes the AI service. A test has been extended to check that `profile_id` is getting sent.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
