### PR TITLE
Fix sync for 66K tables db

### DIFF
--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -314,12 +314,21 @@
   {:active          true
    :visibility_type nil})
 
+(def ^:dynamic *batch-size*
+  "Size of table update partition."
+  20000)
+
 (defn set-initial-table-sync-complete-for-db!
   "Marks initial sync for all tables in `db` as complete so that it becomes usable in the UI, if not already
   set."
   [database-or-id]
-  (t2/update! :model/Table (merge sync-tables-kv-args {:db_id (u/the-id database-or-id)})
-              {:initial_sync_status "complete"}))
+  (let [where-clause {:where (into [:and]
+                                   (map (partial into [:=]))
+                                   (merge sync-tables-kv-args
+                                          {:db_id (u/the-id database-or-id)}))}
+        ids (t2/select :model/Table where-clause)]
+    (doseq [ids' (partition-all *batch-size* ids)]
+      (t2/update! :model/Table :id [:in ids'] {:initial_sync_status "complete"}))))
 
 (defn set-initial-database-sync-complete!
   "Marks initial sync as complete for this database so that this is reflected in the UI, if not already set"

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -326,9 +326,11 @@
                                    (map (partial into [:=]))
                                    (merge sync-tables-kv-args
                                           {:db_id (u/the-id database-or-id)}))}
-        ids (t2/select :model/Table where-clause)]
-    (doseq [ids' (partition-all *batch-size* ids)]
-      (t2/update! :model/Table :id [:in ids'] {:initial_sync_status "complete"}))))
+        ids (t2/select-fn-vec :id :model/Table where-clause)]
+    (reduce (fn [acc ids']
+              (+ acc (t2/update! :model/Table :id [:in ids'] {:initial_sync_status "complete"})))
+            0
+            (partition-all *batch-size* ids))))
 
 (defn set-initial-database-sync-complete!
   "Marks initial sync as complete for this database so that this is reflected in the UI, if not already set"

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -11,6 +11,7 @@
    [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.sync.sync-metadata.fks :as sync-fks]
+   [metabase.sync.util :as sync-util]
    [metabase.sync.util-test :as sync.util-test]
    [metabase.test :as mt]
    [metabase.test.data.one-off-dbs :as one-off-dbs]
@@ -310,7 +311,7 @@
      {:field-name "continent_id", :base-type :type/Integer :fk :continent}]
     [["Ghana" 1]]]])
 
-(deftest sync-fks-and-fields-test
+(deftest ^:synchronized sync-fks-and-fields-test
   (testing (str "[[sync-fields/sync-fields-for-table!]] and [[sync-fks/sync-fks-for-table!]] should sync fields and fks"
                 "in the same way that [[sync-fields/sync-fields!]] and [[sync-fks/sync-fks!]] do")
     (mt/test-drivers (mt/normal-drivers-with-feature :metadata/key-constraints)
@@ -328,7 +329,18 @@
                 ;; 1. delete the fields that were just synced
                 (t2/delete! :model/Field :table_id [:in (map :id tables)])
                 ;; 2. sync the metadata for each table
-                (sync-fields-and-fks!)
+                (if (= "for entire DB" message)
+                  (let [tables-updated (atom nil)
+                        original-set-initial-table-sync-complete-for-db! sync-util/set-initial-table-sync-complete-for-db!]
+                    (with-redefs [sync-util/set-initial-table-sync-complete-for-db!
+                                  (fn [& args]
+                                    (let [r (apply original-set-initial-table-sync-complete-for-db! args)]
+                                      (reset! tables-updated r)
+                                      r))]
+                      (sync-fields-and-fks!)
+                      (testing "Correct number fo tables updated by set-initial-table-sync-complete-for-db! in batches"
+                        (is (= 2 @tables-updated)))))
+                  (sync-fields-and-fks!))
                 (let [continent-id-field (t2/select-one :model/Field :%lower.name "id" :table_id (mt/id :continent))]
                   (is (= [{:name "continent_id", :semantic_type :type/FK, :fk_target_field_id (u/the-id continent-id-field)}
                           {:name "id",           :semantic_type :type/PK, :fk_target_field_id nil}

--- a/test/metabase/sync/sync_metadata/sync_table_privileges_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_table_privileges_test.clj
@@ -11,7 +11,7 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest sync-table-privileges!-test
+(deftest ^:synchronized sync-table-privileges!-test
   (mt/test-drivers (set/intersection (mt/normal-drivers-with-feature :table-privileges)
                                      (mt/normal-drivers-with-feature :schemas))
     (testing "`TablePrivileges` should store the correct data for current_user and role privileges for databases with schemas"
@@ -21,7 +21,16 @@
                                         "CREATE SCHEMA foo; "
                                         "CREATE TABLE foo.baz (id INTEGER);"))
           (sync-tables/sync-tables-and-database! (mt/db))
-          (sync-table-privileges/sync-table-privileges! (mt/db))
+          (let [synced-privileges (atom nil)
+                original-sync-table-privileges! sync-table-privileges/sync-table-privileges!]
+            (with-redefs [sync-table-privileges/sync-table-privileges!
+                          (fn [& args]
+                            (let [{:keys [total-table-privileges]} (apply original-sync-table-privileges! args)]
+                              (reset! synced-privileges total-table-privileges)))]
+              (binding [sync-table-privileges/*batch-size* 1000]
+                (sync-table-privileges/sync-table-privileges! (mt/db))
+                (testing "Correct number of privileges synced for batch size"
+                  (is (= 1 @synced-privileges))))))
           (let [table-id (t2/select-one-pk :model/Table :name "baz" :schema "foo")]
             (is (=? [{:table_id        table-id
                       :role            nil
@@ -37,7 +46,16 @@
         (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
           (jdbc/execute! conn-spec "CREATE TABLE baz (id INTEGER);")
           (sync-tables/sync-tables-and-database! (mt/db))
-          (sync-table-privileges/sync-table-privileges! (mt/db))
+          (let [synced-privileges (atom nil)
+                original-sync-table-privileges! sync-table-privileges/sync-table-privileges!]
+            (with-redefs [sync-table-privileges/sync-table-privileges!
+                          (fn [& args]
+                            (let [{:keys [total-table-privileges]} (apply original-sync-table-privileges! args)]
+                              (reset! synced-privileges total-table-privileges)))]
+              (binding [sync-table-privileges/*batch-size* 1000]
+                (sync-table-privileges/sync-table-privileges! (mt/db))
+                (testing "Correct number of privileges synced for batch size"
+                  (is (= 1 @synced-privileges))))))
           (let [table-id (t2/select-one-pk :model/Table :name "baz" :schema nil)]
             (is (=? [{:table_id        table-id
                       :role            nil

--- a/test/metabase/sync/sync_metadata/sync_table_privileges_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_table_privileges_test.clj
@@ -27,10 +27,9 @@
                           (fn [& args]
                             (let [{:keys [total-table-privileges]} (apply original-sync-table-privileges! args)]
                               (reset! synced-privileges total-table-privileges)))]
-              (binding [sync-table-privileges/*batch-size* 1000]
-                (sync-table-privileges/sync-table-privileges! (mt/db))
-                (testing "Correct number of privileges synced for batch size"
-                  (is (= 1 @synced-privileges))))))
+              (sync-table-privileges/sync-table-privileges! (mt/db))
+              (testing "Correct number of privileges synced with batch size in use"
+                (is (= 1 @synced-privileges)))))
           (let [table-id (t2/select-one-pk :model/Table :name "baz" :schema "foo")]
             (is (=? [{:table_id        table-id
                       :role            nil
@@ -52,10 +51,9 @@
                           (fn [& args]
                             (let [{:keys [total-table-privileges]} (apply original-sync-table-privileges! args)]
                               (reset! synced-privileges total-table-privileges)))]
-              (binding [sync-table-privileges/*batch-size* 1000]
-                (sync-table-privileges/sync-table-privileges! (mt/db))
-                (testing "Correct number of privileges synced for batch size"
-                  (is (= 1 @synced-privileges))))))
+              (sync-table-privileges/sync-table-privileges! (mt/db))
+              (testing "Correct number of privileges synced with batch size in use"
+                (is (= 1 @synced-privileges)))))
           (let [table-id (t2/select-one-pk :model/Table :name "baz" :schema nil)]
             (is (=? [{:table_id        table-id
                       :role            nil


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. -->closes #56803
Closes https://linear.app/metabase/issue/SEM-251/sync-fails-if-you-have-more-than-65535-tables


### Description

Postgres, the ultimate application database, allows 65K params per prepared statement. We use to exceed that number during sync in various places. This PR addresses that by partitioning db queries.

### How to verify

Run new tests or try to sync 66K tables db. It is noteworthy I had to set `MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS` to 0 to get a result set from sync-fields query.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
