### PR TITLE
ci: use variant for trunk to distinguish tests from matrix

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -50,5 +50,6 @@ runs:
       with:
         junit-paths: ${{ inputs.input-path }}
         org-slug: metabase
+        variant: ${{ inputs.output-name }}
         token: ${{ inputs.trunk-api-token }}
       continue-on-error: true

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -18,6 +18,9 @@ inputs:
     required: true
   trunk-api-token:
     required: true
+  variant:
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -49,7 +52,7 @@ runs:
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: ${{ inputs.input-path }}
+        variant: ${{ inputs.variant || inputs.output-name }}
         org-slug: metabase
-        variant: ${{ inputs.output-name }}
         token: ${{ inputs.trunk-api-token }}
       continue-on-error: true

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -157,6 +157,7 @@ jobs:
         with:
           input-path: ./target/junit
           output-name: e2e-${{ inputs.name }}
+          variant: e2e-tests
           bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
           aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Add trunk's variant, all upload-test-results entries use output-name, so we can benefit from running tests with same name for different drivers