### PR TITLE
[DB Routing] Callout db routing enabled on permissions page

### DIFF
--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -372,6 +372,35 @@ describe("admin > database > database routing", () => {
         .should("have.attr", "data-combobox-disabled", "true");
     });
 
+    it("should highlight that a dabtabase has routing enabled on the permissions pages", () => {
+      cy.log("setup");
+      cy.request("PUT", "/api/database/2", {
+        settings: { "database-enable-actions": false },
+      });
+      configurDbRoutingViaAPI({
+        router_database_id: 2,
+        user_attribute: "role",
+      });
+
+      cy.log("should highlight on group perms page at db level");
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+      cy.findByTestId("permission-table")
+        .findByText("(Database routing enabled)")
+        .should("exist");
+
+      cy.log("should highlight on group perms page at table level");
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}/database/2`);
+      cy.findByTestId("permissions-editor-breadcrumbs")
+        .findByText("(Database routing enabled)")
+        .should("exist");
+
+      cy.log("should highlight on group perms page at table level");
+      cy.visit("/admin/permissions/data/database/2");
+      cy.findByTestId("permissions-editor-breadcrumbs")
+        .findByText("(Database routing enabled)")
+        .should("exist");
+    });
+
     describe("feature visibility", () => {
       it("should only show db routing for valid database types", () => {
         cy.log("should not show for sample databases");

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorBreadcrumbs.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorBreadcrumbs.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 
-import { Icon } from "metabase/ui";
+import { Icon, Text } from "metabase/ui";
 
 import {
   BreadcrumbsLink,
@@ -21,15 +21,28 @@ export const PermissionsEditorBreadcrumbs = ({
     <Fragment>
       {items.map((item, index) => {
         const isLast = index === items.length - 1;
+        const subtext = item.subtext ? (
+          <Text display="inline-block" c="text-secondary" fw="500" fz="1em">
+            {item.subtext}
+          </Text>
+        ) : null;
+
         return (
           <Fragment key={index}>
             {isLast ? (
-              item.text
+              <>
+                {item.text} {subtext}
+              </>
             ) : (
               <Fragment>
-                <BreadcrumbsLink onClick={() => onBreadcrumbsItemSelect(item)}>
-                  {item.text}
-                </BreadcrumbsLink>
+                <>
+                  <BreadcrumbsLink
+                    onClick={() => onBreadcrumbsItemSelect(item)}
+                  >
+                    {item.text}
+                  </BreadcrumbsLink>
+                  {subtext ? <> {subtext}</> : null}
+                </>
                 <BreadcrumbsSeparator>
                   <Icon name="chevronright" />
                 </BreadcrumbsSeparator>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -68,7 +68,7 @@ export function PermissionsEditorContent({
   return (
     <PermissionEditorContentRoot data-testid="permissions-editor">
       <PreHeaderContent />
-      <Subhead>
+      <Subhead data-testid="permissions-editor-breadcrumbs">
         {title}{" "}
         {breadcrumbs && (
           <PermissionsEditorBreadcrumbs

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -5,7 +5,7 @@ import { useRef, useState } from "react";
 import { ConfirmModal } from "metabase/components/ConfirmModal";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
-import { Tooltip } from "metabase/ui";
+import { Text, Tooltip } from "metabase/ui";
 
 import { PermissionsSelect } from "../PermissionsSelect";
 
@@ -103,7 +103,7 @@ export function PermissionsTable({
             const entityName = (
               <span className={cx(CS.flex, CS.alignCenter)}>
                 <Ellipsified>{entity.name}</Ellipsified>
-                {entity.hint && (
+                {typeof entity.hint === "string" && (
                   <Tooltip tooltip={entity.hint}>
                     <HintIcon />
                   </Tooltip>
@@ -119,6 +119,9 @@ export function PermissionsTable({
                     </EntityNameLink>
                   ) : (
                     <EntityName>{entityName}</EntityName>
+                  )}
+                  {entity.callout && (
+                    <Text c="text-secondary">{entity.callout}</Text>
                   )}
                 </PermissionsTableCell>
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.ts
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import { isNotFalsy } from "metabase/lib/types";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type Schema from "metabase-lib/v1/metadata/Schema";
@@ -47,6 +49,9 @@ export const getDatabasesEditorBreadcrumbs = (
   const databaseItem = {
     id: database.id,
     text: database.name,
+    subtext: database.hasDatabaseRoutingEnabled()
+      ? t`(Database routing enabled)`
+      : undefined,
     url: getGroupFocusPermissionsUrl(group.id, getDatabaseEntityId(database)),
   };
 
@@ -76,6 +81,9 @@ export const getGroupsDataEditorBreadcrumbs = (
 
   const databaseItem = {
     text: database.name,
+    subtext: database.hasDatabaseRoutingEnabled()
+      ? t`(Database routing enabled)`
+      : undefined,
     id: databaseId,
     url: getDatabaseFocusPermissionsUrl(getDatabaseEntityId(database)),
   };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -157,6 +157,7 @@ type EntityWithPermissions = {
   entityId: EntityId;
   canSelect?: boolean;
   permissions: PermissionSectionConfig[];
+  callout?: string;
 };
 
 export const getDatabasesPermissionEditor = createSelector(
@@ -261,6 +262,9 @@ export const getDatabasesPermissionEditor = createSelector(
             id: database.id,
             name: database.name,
             entityId,
+            callout: database.hasDatabaseRoutingEnabled()
+              ? t`(Database routing enabled)`
+              : undefined,
             canSelect: true,
             permissions: buildSchemasPermissions(
               entityId,
@@ -319,7 +323,7 @@ export const getDatabasesPermissionEditor = createSelector(
 type DataPermissionEditorEntity = {
   id: Group["id"];
   name: Group["name"];
-  hint: string | null;
+  hint: React.ReactNode | string | null;
   entityId: {
     databaseId?: DatabaseId;
     schemaName?: Schema["name"];


### PR DESCRIPTION
Closes ADM-583

### Description

Calls out that db routing is enabled for a database on the permissions pages

Page|Preview
--|--
Group permissions @ database level|![CleanShot 2025-04-22 at 12 42 43@2x](https://github.com/user-attachments/assets/311db52c-728b-4729-8e50-f2f67087ad81)
Group permissions @ schema level|![CleanShot 2025-04-22 at 12 43 21@2x](https://github.com/user-attachments/assets/c4932722-bd54-485e-9112-3cf334f2c45a)
Group permissions @ table level|![CleanShot 2025-04-22 at 12 43 40@2x](https://github.com/user-attachments/assets/ac9b9aea-fda8-45e4-8cd1-17b95c137fb2)
Database permissions|![CleanShot 2025-04-22 at 12 44 07@2x](https://github.com/user-attachments/assets/97b1b463-148f-4638-a500-6dd8a06ded64)

### How to verify

- Enable db routing for a db
- Visit permissions pages

### Checklist

- [x] Tests have been added/updated to cover changes in this PR