### PR TITLE
Exclude nil card IDs for preemptive caching reruns

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/task/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/cache.clj
@@ -222,9 +222,7 @@
     "question" [model_id]
     "dashboard" (let [dashboard (-> (t2/select-one :model/Dashboard :id model_id)
                                     (t2/hydrate :dashcards))]
-                  (->> (map :card_id (:dashcards dashboard))
-                       (filter some?)
-                       distinct))))
+                  (distinct (keep :card_id (:dashcards dashboard))))))
 
 (defn- refresh-schedule-cache!
   "Given a cache config with the :schedule strategy, preemptively rerun the query (and a fixed number of parameterized

--- a/enterprise/backend/src/metabase_enterprise/task/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/cache.clj
@@ -222,7 +222,9 @@
     "question" [model_id]
     "dashboard" (let [dashboard (-> (t2/select-one :model/Dashboard :id model_id)
                                     (t2/hydrate :dashcards))]
-                  (map :card_id (:dashcards dashboard)))))
+                  (->> (map :card_id (:dashcards dashboard))
+                       (filter some?)
+                       distinct))))
 
 (defn- refresh-schedule-cache!
   "Given a cache config with the :schedule strategy, preemptively rerun the query (and a fixed number of parameterized

--- a/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
@@ -81,6 +81,26 @@
    :parameterized false
    :started_at    (t/offset-date-time)})
 
+(deftest schedule-cache-config->card-ids-test
+  (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Dashboard"}
+                 :model/Card {card-id-1 :id} {:name "Cached card 1"
+                                              :dataset_query {:database 1}}
+                 :model/Card {card-id-2 :id} {:name "Cached card 2"
+                                              :dataset_query {:database 1}}
+                 :model/DashboardCard {} {:dashboard_id dashboard-id
+                                          :card_id      card-id-1}
+                 :model/DashboardCard {} {:dashboard_id dashboard-id
+                                          :card_id      card-id-2}
+                 :model/DashboardCard {} {:dashboard_id dashboard-id
+                                          :card_id      card-id-2}
+                 :model/DashboardCard {} {:dashboard_id dashboard-id
+                                          :card_id      card-id-2}]
+    (testing "Returns the card ID directly for a question cahce config"
+      (is (= [card-id-1] (@#'task.cache/schedule-cache-config->card-ids {:model_id card-id-1 :model "question"}))))
+
+    (testing "Fetches card IDs associated with a dashboard cache config"
+      (is (= [card-id-1 card-id-2] (@#'task.cache/schedule-cache-config->card-ids {:model_id dashboard-id :model "dashboard"}))))))
+
 (deftest scheduled-queries-to-rerun-test
   (mt/with-premium-features #{:cache-granular-controls :cache-preemptive}
     (testing "Given a card, we rerun a limited number of variations of the card's query"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/57061

When a `schedule`-type cache config is set up on a dashboard, and preemptive caching is enabled, we'll look for queries to re-run by first fetching the cards associated with the dashboard. This included text/header cards which have a `nil` card ID. But we look at `query_execution` to determine the queries to re-run, so `nil` card IDs result in some ad-hoc queries being picked up for re-run.

This doesn't hurt much from the user's POV aside from unintended load proportional to the number of text cards on the dashboard. But I've fixed it by filtering out `nil`s and added a corresponding unit test.