### PR TITLE
Delete indexed rows from the search index which correspond to deleted rows

### DIFF
--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -355,7 +355,7 @@ describe("scenarios > models", () => {
 
         cy.findByText("Everywhere").click();
         getResults().should("have.length", 5);
-        cy.findByText("6 results").should("be.visible");
+        cy.findByText("5 results").should("be.visible");
         getResults()
           .eq(0)
           .should("have.attr", "data-model-type", "dataset")

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -354,7 +354,7 @@ describe("scenarios > models", () => {
           .and("contain.text", "Orders");
 
         cy.findByText("Everywhere").click();
-        getResults().should("have.length", 6);
+        getResults().should("have.length", 5);
         cy.findByText("6 results").should("be.visible");
         getResults()
           .eq(0)

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -374,10 +374,6 @@ describe("scenarios > models", () => {
           .and("contain.text", "Orders, Count");
         getResults()
           .eq(4)
-          .should("have.attr", "data-model-type", "card")
-          .and("contain.text", "Orders");
-        getResults()
-          .eq(5)
           .should("have.attr", "data-model-type", "table")
           .and("contain.text", "Orders");
       });

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -198,7 +198,8 @@
                                                                   (card-with-view i))))
                 _               (search.ingestion/update!
                                  (#'search.ingestion/query->documents
-                                  (#'search.ingestion/spec-index-reducible "card" [:= :this.name search-term])))
+                                  (#'search.ingestion/spec-index-reducible "card" [:= :this.name search-term]))
+                                 [])
                 first-result-id (-> (search-results* search-term) first second)]
             (is (some? first-result-id))
            ;; Ideally we would make the outlier slightly less attractive in another way, with a weak weight,

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -5,12 +5,14 @@
    [clojure.set :as set]
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.api.card :as api.card]
    [metabase.api.common :as api]
    [metabase.config :as config]
    [metabase.search.config :as search.config]
    [metabase.search.core :as search]
    [metabase.search.impl :as search.impl]
    [metabase.search.in-place.legacy :as search.legacy]
+   [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -275,3 +277,37 @@
           (test-search "thisyear" new-result)
           (test-search "past1years-from-12months" old-result)
           (test-search "today" new-result))))))
+
+(deftest old-values-removed-from-index
+  (let [search-term (str (random-uuid))]
+    (binding [search.ingestion/*force-sync* true]
+      (mt/with-temp
+        [:model/Card {card-id :id} {:name search-term}]
+        (mt/with-current-user (mt/user->id :crowberto)
+          (testing "Initially finds the question"
+            (is (= #{["card" card-id]}
+                   (->> (search.impl/search (search.impl/search-context
+                                             {:search-string      search-term
+                                              :search-engine      "appdb"
+                                              :archived           false
+                                              :models             search.config/all-models
+                                              :current-user-id    (mt/user->id :crowberto)
+                                              :is-superuser?      true
+                                              :current-user-perms @api/*current-user-permissions-set*}))
+                        :data
+                        (map (juxt :model :id))
+                        set))))
+          (testing "Changing to a different type removes the old value from the index"
+            (api.card/update-card! card-id {:type :model} true)
+            (is (= #{["dataset" card-id]}
+                   (->> (search.impl/search (search.impl/search-context
+                                             {:search-string      search-term
+                                              :search-engine      "appdb"
+                                              :archived           false
+                                              :models             search.config/all-models
+                                              :current-user-id    (mt/user->id :crowberto)
+                                              :is-superuser?      true
+                                              :current-user-perms @api/*current-user-permissions-set*}))
+                        :data
+                        (map (juxt :model :id))
+                        set)))))))))

--- a/test/metabase/search/ingestion_test.clj
+++ b/test/metabase/search/ingestion_test.clj
@@ -4,7 +4,10 @@
    [metabase.search.ingestion :as search.ingestion]))
 
 (deftest extract-model-and-id
-  (is (= ["action" "1895"] (#'search.ingestion/extract-model-and-id ["action" [:= 1895 :this.model_id]])))
-  (is (= ["action" "2000"] (#'search.ingestion/extract-model-and-id ["action" [:= :this.model_id 2000]])))
+  (is (= ["action" "1895"] (#'search.ingestion/extract-model-and-id ["action" [:= 1895 :this.id]])))
+  (is (= ["action" "2000"] (#'search.ingestion/extract-model-and-id ["action" [:= :this.id 2000]])))
+  (is (nil? (#'search.ingestion/extract-model-and-id ["action" [:= 1895 :this.model_id]])))
   (is (= ["dataset" "1901"] (#'search.ingestion/extract-model-and-id ["dataset" [:and [:= 1901 :this.id] [:= true true] [:= "Card" "Card"]]])))
-  (is (= ["dataset" "1901"] (#'search.ingestion/extract-model-and-id ["dataset" [:and [:= true true] [:= :this.id 1901] [:= "Card" "Card"]]]))))
+  (is (= ["dataset" "1901"] (#'search.ingestion/extract-model-and-id ["dataset" [:and [:= true true] [:= :this.id 1901] [:= "Card" "Card"]]])))
+  (is (= nil (#'search.ingestion/extract-model-and-id ["dataset" [:and [:= true true] [:= :this.model_id 1901] [:= "Card" "Card"]]])))
+  (is (= nil (#'search.ingestion/extract-model-and-id ["indexed-entity" [:and [:= 26 :this.model_index_id] [:= 38004300 :this.model_pk]]]))))

--- a/test/metabase/search/ingestion_test.clj
+++ b/test/metabase/search/ingestion_test.clj
@@ -1,0 +1,10 @@
+(ns metabase.search.ingestion-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.search.ingestion :as search.ingestion]))
+
+(deftest extract-model-and-id
+  (is (= ["action" "1895"] (#'search.ingestion/extract-model-and-id ["action" [:= 1895 :this.model_id]])))
+  (is (= ["action" "2000"] (#'search.ingestion/extract-model-and-id ["action" [:= :this.model_id 2000]])))
+  (is (= ["dataset" "1901"] (#'search.ingestion/extract-model-and-id ["dataset" [:and [:= 1901 :this.id] [:= true true] [:= "Card" "Card"]]])))
+  (is (= ["dataset" "1901"] (#'search.ingestion/extract-model-and-id ["dataset" [:and [:= true true] [:= :this.id 1901] [:= "Card" "Card"]]]))))


### PR DESCRIPTION
### Description

When ingesting update messages, compare the expected model+id pairs with the documents that will be upserted and attempt to delete any "missing" pairs from the index.

Because we don't have a delete hook to trigger "delete from the index" messages, we need to figure that out based on the "updated" messages.

### How to verify

1. Create a question
2. Convert it to a model
3. Search for it
4. Ensure there is only a search result for the model, not both the model and the question

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
