### PR TITLE
Prevent falling back on type before cast when qp/ignore-coercion

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -747,20 +747,21 @@
                                  (lib.metadata/field (qp.store/metadata-provider) id-or-name))
           allow-casting?       (and field-metadata
                                     (not (:qp/ignore-coercion options)))
-          database-type        (or database-type
-                                   (:database-type field-metadata))
+
           ;; preserve metadata attached to the original field clause, for example BigQuery temporal type information.
           identifier           (-> (apply h2x/identifier :field
                                           (concat source-table-aliases (->honeysql driver [::nfc-path source-nfc-path]) [source-alias]))
                                    (with-meta (meta field-clause)))
           identifier           (->honeysql driver identifier)
+          casted-field         (cast-field-if-needed driver field-metadata identifier)
+          database-type        (or (h2x/database-type casted-field)
+                                   (:database-type field-metadata))
           maybe-add-db-type    (fn [expr]
                                  (if (h2x/type-info->db-type (h2x/type-info expr))
                                    expr
                                    (h2x/with-database-type-info expr database-type)))]
       (u/prog1
-        (cond->> identifier
-          allow-casting?           (cast-field-if-needed driver field-metadata)
+        (cond->> (if allow-casting? casted-field identifier)
           ;; only add type info if it wasn't added by [[cast-field-if-needed]]
           database-type            maybe-add-db-type
           (:temporal-unit options) (apply-temporal-bucketing driver options)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -746,7 +746,6 @@
                                  (lib.metadata/field (qp.store/metadata-provider) id-or-name))
           allow-casting?       (and field-metadata
                                     (not (:qp/ignore-coercion options)))
-
           ;; preserve metadata attached to the original field clause, for example BigQuery temporal type information.
           identifier           (-> (apply h2x/identifier :field
                                           (concat source-table-aliases (->honeysql driver [::nfc-path source-nfc-path]) [source-alias]))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -733,8 +733,7 @@
   nil)
 
 (defmethod ->honeysql [:sql :field]
-  [driver [_ id-or-name {:keys [database-type] :as options}
-           :as field-clause]]
+  [driver [_ id-or-name options :as field-clause]]
   (try
     (let [source-table-aliases (field-source-table-aliases field-clause)
           source-nfc-path      (field-nfc-path field-clause)

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -970,6 +970,23 @@
             (is (= [[1020]]
                    (mt/formatted-rows [int] (qp/process-query query))))))))))
 
+(deftest ^:parallel coercion-with-expression-test-2
+  (testing "An expression in the breakout with a coerced column should work (#56886)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
+      (mt/dataset sad-toucan-incidents
+        (let [query (mt/mbql-query incidents
+                      {:expressions {"double severity" [:* $severity 2]}
+                       :aggregation [[:count]]
+                       :breakout    [$timestamp [:expression "double severity"]]
+                       :limit       3})]
+          (mt/with-native-query-testing-context query
+            (is (= [["2015-06-01T00:00:00Z" 2 3]
+                    ["2015-06-01T00:00:00Z" 6 1]
+                    ["2015-06-01T00:00:00Z" 8 1]]
+                   (mt/formatted-rows
+                    [u.date/temporal-str->iso8601-str int int]
+                    (qp/process-query query))))))))))
+
 (deftest ^:parallel null-array-test
   (testing "a null array should be handled gracefully and return nil"
     (mt/test-drivers (mt/normal-drivers-with-feature :test/null-arrays)


### PR DESCRIPTION
Fixes #56886

### Description

This is assuming that qp/ignore-coercion is set to avoid repeated casting.  That means, that we should type the expression as if the cast has happened and should not revert to the type before the cast.

### How to verify

The repro steps from #56886 should not lead to an error.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
