### PR TITLE
Allow null values for aggregation sort order

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -231,7 +231,7 @@
    [:map
     [:field_id :string]
     [:bucket {:optional true} ::bucket]
-    [:sort_order {:optional true} [:enum {:encode/tool-api-request keyword} "asc" "desc"]]
+    [:sort_order {:optional true} [:maybe [:enum {:encode/tool-api-request keyword} "asc" "desc"]]]
     [:function [:enum {:encode/tool-api-request keyword}
                 "avg" "count" "count-distinct" "max" "min" "sum"]]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])


### PR DESCRIPTION
Update query model API schema so aggregations can have `null` for the sort order attribute