### PR TITLE
Fix `database_routing` enabled

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -818,7 +818,7 @@
    {:name      :database-routing
     :available (premium-features/enable-database-routing?)
     :enabled   (if (premium-features/enable-database-routing?)
-                 (t2/exists? :model/Database :router_database_id [:not= nil])
+                 (t2/exists? :model/DatabaseRouter)
                  false)}
    {:name      :config-text-file
     :available (premium-features/enable-config-text-file?)

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -817,7 +817,9 @@
     :enabled   (premium-features/enable-database-auth-providers?)}
    {:name      :database-routing
     :available (premium-features/enable-database-routing?)
-    :enabled   (t2/exists? :model/Database :router_database_id [:not= nil])}
+    :enabled   (if (premium-features/enable-database-routing?)
+                 (t2/exists? :model/Database :router_database_id [:not= nil])
+                 false)}
    {:name      :config-text-file
     :available (premium-features/enable-config-text-file?)
     :enabled   (some? (get env/env :mb-config-file-path))}

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -817,7 +817,7 @@
     :enabled   (premium-features/enable-database-auth-providers?)}
    {:name      :database-routing
     :available (premium-features/enable-database-routing?)
-    :enabled   (premium-features/enable-database-routing?)}
+    :enabled   (t2/exists? :model/Database :router_database_id [:not= nil])}
    {:name      :config-text-file
     :available (premium-features/enable-config-text-file?)
     :enabled   (some? (get env/env :mb-config-file-path))}


### PR DESCRIPTION
DB routing is enabled only if there is at least one routing DB