### PR TITLE
ci: run linting when e2e specs are changed

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -110,9 +110,6 @@ e2e_ci: &e2e_ci
 e2e_specs: &e2e_specs
   - "**/*.cy.*.js"
   - "**/*.cy.*.ts"
-  - "e2e/runner/**"
-  - "e2e/support/**"
-  - "e2e/snapshot*/**"
 
 e2e_cross_version: &e2e_cross_version
   - ".github/workflows/e2e-cross-version.yml"
@@ -123,6 +120,9 @@ e2e_all:
   - *e2e_ci
   - *sources
   - *e2e_specs
+  - "e2e/runner/**"
+  - "e2e/support/**"
+  - "e2e/snapshot*/**"
 
 snowplow:
   - ".github/workflows/snowplow.yml"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,7 +18,6 @@ jobs:
     timeout-minutes: 3
     outputs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
-      e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,6 +6,9 @@ on:
       skip:
         type: boolean
         default: false
+      skip-lint:
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-frontend
@@ -13,7 +16,7 @@ concurrency:
 
 jobs:
   fe-lint:
-    if: ${{ !inputs.skip }}
+    if: ${{ !inputs.skip-lint }}
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/frontend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.frontend_all != 'true' && needs.files-changed.outputs.e2e_specs != 'true' }}
+      skip: ${{ needs.files-changed.outputs.frontend_all != 'true' }}
       skip-lint: ${{ needs.files-changed.outputs.frontend_all != 'true' && needs.files-changed.outputs.e2e_specs != 'true' }}
 
   e2e-tests:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       e2e_all: ${{ steps.changes.outputs.e2e_all }}
+      e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
       backend_all: ${{ steps.changes.outputs.backend_all }}
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       frontend_sources: ${{ steps.changes.outputs.frontend_sources }}
@@ -78,7 +79,8 @@ jobs:
     uses: ./.github/workflows/frontend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.frontend_all != 'true' }}
+      skip: ${{ needs.files-changed.outputs.frontend_all != 'true' && needs.files-changed.outputs.e2e_specs != 'true' }}
+      skip-lint: ${{ needs.files-changed.outputs.frontend_all != 'true' && needs.files-changed.outputs.e2e_specs != 'true' }}
 
   e2e-tests:
     needs: files-changed


### PR DESCRIPTION
we didn't run linting if only specs files were changed, but they are js/ts files, so we need to run linting

[context](https://metaboat.slack.com/archives/C5XHN8GLW/p1745412738517049)

<img width="347" alt="image" src="https://github.com/user-attachments/assets/8b5e030d-6ee7-435e-8ef2-cec5af2ff010" />
