### PR TITLE
Replace ee-extra release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,6 +402,28 @@ jobs:
               }
             });
 
+  trigger-ee-extra-pr:
+    needs: verify-s3-download
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          script: | # js
+            const version = '${{ inputs.version }}';
+            const enterpriseVersion = version.replace(/^v0\./, "v1.");
+
+            github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: 'metabase-ee-extra',
+              event_type: 'update-ee-extra-build',
+              client_payload: {
+                version: enterpriseVersion,
+                auto: 'true', // always auto-merge
+              }
+            });
+
   draft-release-notes:
     if: ${{ !inputs.auto }}
     needs: add-extra-tags


### PR DESCRIPTION
#56575 inadvertently deleted the release step that does our cloud builds, this reverts that change