### PR TITLE
Better UI compatibility for bucketed filters and fields

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -235,7 +235,7 @@
                                        [:= [:field %title {}] "3" "4"]
                                        [:!= [:field %rating {}] 3 4]
                                        [:= [:get-month [:field %created_at {}]] 4 5 9]
-                                       [:!= !day-of-month.products.created_at 14 15 19]
+                                       [:!= [:get-day [:field %products.created_at {}]] 14 15 19]
                                        [:= [:get-day-of-week [:field %created_at {}] :iso] 1 7]
                                        [:= [:get-year [:field %created_at {}]] 2008]]})
                     :result_columns

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -97,9 +97,8 @@
                                                                     :iso]
                                                                    1 2 3]
                                                                   [:=
-                                                                   [:field (mt/id :orders :created_at)
-                                                                    {:base-type :type/DateTimeWithLocalTZ
-                                                                     :temporal-unit :month-of-year}]
+                                                                   [:get-month [:field (mt/id :orders :created_at)
+                                                                                {:base-type :type/DateTimeWithLocalTZ}]]
                                                                    6 7 8]]
                                                          :breakout [[:field (mt/id :orders :created_at)
                                                                      {:base-type :type/DateTimeWithLocalTZ
@@ -211,9 +210,8 @@
                                                  :filter [:and
                                                           [:!= [:get-week [:field "CREATED_AT" {}] :iso] 1 2 3]
                                                           [:=
-                                                           [:field "CREATED_AT"
-                                                            {:base-type :type/DateTimeWithLocalTZ
-                                                             :temporal-unit :month-of-year}]
+                                                           [:get-month [:field "CREATED_AT"
+                                                                        {:base-type :type/DateTimeWithLocalTZ}]]
                                                            6 7 8]]
                                                  :breakout [[:field "PRODUCT_ID" {}]
                                                             [:field "CREATED_AT"
@@ -247,8 +245,11 @@
                     :query-id string?
                     :query (mt/mbql-query orders
                              {:source-table model-card-id
-                              :expressions {"Created At: Day of week" [:get-day-of-week [:field "CREATED_AT" {}] :iso]}
-                              :fields [[:field "CREATED_AT" {:base-type :type/DateTimeWithLocalTZ, :temporal-unit :day-of-month}]
+                              :expressions {"Created At: Day of month"
+                                            [:get-day [:field "CREATED_AT" {:base-type :type/DateTimeWithLocalTZ}]],
+                                            "Created At: Day of week"
+                                            [:get-day-of-week [:field "CREATED_AT" {}] :iso]}
+                              :fields [[:expression "Created At: Day of month" {:base-type :type/Integer}]
                                        [:expression "Created At: Day of week" {:base-type :type/Integer}]
                                        [:field "TOTAL" {:base-type :type/Float}]]
                               :filter [:!= [:field "USER_ID" {}] 3 42]})}}


### PR DESCRIPTION
### Description

Some of the queries we generate is incompatible with the UI, because it doesn't allow bucketing and exprssions everywhere where the query processor does.

This PR changes the generated queries to use expressions in filters and fields whenever possible.

- Generating UI supported queries for buckets would be a large work.
- Disallowing truncation in filters and fields would reduce the work needed.
- Getting rid of the ISO handling for `day-of-week` and `week-of-year` would reduce it too. (And it's probably desired anyway to work according to the Metabase setting.)

### How to verify

Asking Metabot to show products created at 3 pm should generate a query with a filter that can be edited in the UI.

Before:
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/5daf3236-d66e-4658-9d65-110be362de17" />

After:
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/2185c745-f655-4ff4-a2be-438380ef829c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
