### PR TITLE
trust semantic keys for any model not just native models

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -570,9 +570,8 @@
                                          cards)
           readable-cards (t2/hydrate (filter mi/can-read? cards) :metrics)]
       (for [card readable-cards]
-        ;; a native model can have columns with keys as semantic types only if a user configured them
-        (let [trust-semantic-keys? (and (= (:type card) :model)
-                                        (= (-> card :dataset_query :type) :native))]
+        ;; a model can have columns with keys as semantic types if a user configured them
+        (let [trust-semantic-keys? (= (:type card) :model)]
           (-> card
               (card->virtual-table :include-fields? true
                                    :databases dbs


### PR DESCRIPTION
Closes #38747

### Description

Set `trust-semantic-keys?` for any model, not just `:native` models in `batch-fetch-card-query-metadatas`.

### How to verify

See repro steps in the linked issue and new e2e regression tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
