### PR TITLE
Hide approved domains

### DIFF
--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -146,8 +146,8 @@ describe("scenarios > alert", () => {
       const allowedDomain = "metabase.test";
       const deniedDomain = "metabase.example";
       const deniedEmail = `mailer@${deniedDomain}`;
-      const subscriptionError = `Only allowed domains are supported`;
-      const alertError = `Only allowed domains are supported`;
+      const subscriptionError = "Only allowed domains are supported";
+      const alertError = "Only allowed domains are supported";
 
       function addEmailRecipient(email) {
         cy.findByRole("textbox").click().type(`${email}`).blur();

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -146,8 +146,8 @@ describe("scenarios > alert", () => {
       const allowedDomain = "metabase.test";
       const deniedDomain = "metabase.example";
       const deniedEmail = `mailer@${deniedDomain}`;
-      const subscriptionError = `You're only allowed to email subscriptions to addresses ending in ${allowedDomain}`;
-      const alertError = `You're only allowed to email alerts to addresses ending in ${allowedDomain}`;
+      const subscriptionError = `Only allowed domains are supported`;
+      const alertError = `Only allowed domains are supported`;
 
       function addEmailRecipient(email) {
         cy.findByRole("textbox").click().type(`${email}`).blur();

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -102,7 +102,7 @@ export const AddEditEmailSidebar = ({
               onChannelPropertyChange("recipients", recipients)
             }
             invalidRecipientText={(domains) =>
-              t`You're only allowed to email subscriptions to addresses ending in ${domains}`
+              t`Only allowed domains are supported`
             }
           />
         </div>

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -101,7 +101,7 @@ export const AddEditEmailSidebar = ({
             onRecipientsChange={(recipients) =>
               onChannelPropertyChange("recipients", recipients)
             }
-            invalidRecipientText={(domains) =>
+            invalidRecipientText={() =>
               t`Only allowed domains are supported`
             }
           />

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -344,7 +344,7 @@ export const CreateOrEditQuestionAlertModal = ({
               });
             }}
             emailRecipientText={t`Email alerts to:`}
-            getInvalidRecipientText={(domains) =>
+            getInvalidRecipientText={() =>
               t`Only allowed domains are supported`
             }
           />

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -345,7 +345,7 @@ export const CreateOrEditQuestionAlertModal = ({
             }}
             emailRecipientText={t`Email alerts to:`}
             getInvalidRecipientText={(domains) =>
-              t`You're only allowed to email alerts to addresses ending in ${domains}`
+              t`Only allowed domains are supported`
             }
           />
         </AlertModalSettingsBlock>


### PR DESCRIPTION
https://metaboat.slack.com/archives/C97M2U8M6/p1745424448589089 ... We need to hide the list of allowed domains when there is an error