### PR TITLE
feat: add job factory to handle jobs with missing classes

### DIFF
--- a/src/metabase/task/impl.clj
+++ b/src/metabase/task/impl.clj
@@ -25,6 +25,7 @@
    [metabase.app-db.core :as mdb]
    [metabase.classloader.core :as classloader]
    [metabase.task.bootstrap]
+   [metabase.task.job-factory :as job-factory]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -123,6 +124,7 @@
     (let [new-scheduler (qs/initialize)]
       (when (compare-and-set! *quartz-scheduler* nil new-scheduler)
         (qs/standby new-scheduler)
+        (job-factory/add-to-scheduler new-scheduler)
         (log/info "Task scheduler initialized into standby mode.")
         ;; Register Prometheus listeners
 

--- a/src/metabase/task/job_factory.clj
+++ b/src/metabase/task/job_factory.clj
@@ -1,0 +1,65 @@
+(ns metabase.task.job-factory
+  "Provides a job factory for our quartz scheduler. The primary purpose of the custom factory is to prevent us from mark jobs as 'ERROR' when a metabase instance
+  picks up a job by cannot find a class to instatiate it. This will occur during rolling upgrades when a newer metabase instance adds a job that an older instance
+  does not have a class for."
+  (:require
+   [metabase.util.log :as log])
+  (:import
+   (org.quartz Job Scheduler TriggerListener)
+   (org.quartz.simpl SimpleJobFactory)
+   (org.quartz.spi JobFactory)))
+
+(set! *warn-on-reflection* true)
+
+(defrecord ^:private NoOpJob []
+  Job
+  (execute [_ _]
+    (log/info "No-op job ran")))
+
+(defn- no-op-job
+  "Logs the exception and returns a no-op job."
+  ^Job [e]
+  (log/error e "Failed to load a job class. Usually this means an old version of metabase tried to run a job from a newer version")
+  (->NoOpJob))
+
+(defn create
+  "Build a JobFactory object which wraps the default `SimpleJobFactory`. The task of this wrapper is to check if a job
+  exists on the classpath before trying to run it. If the job does not exist this returns a no-op-Job to the scheduler.
+
+  This can be used with a scheduler by setting it as the scheduler's jobFactory with `.setJobFactory`. It will either create
+  a new SimpleJobFactory or wrap an existing factory, so you can reuse an existing job factory with it."
+  (^JobFactory []
+   (create (SimpleJobFactory.)))
+  (^JobFactory [^JobFactory existing-factory]
+   (reify JobFactory
+     (newJob [_ bundle scheduler]
+       (try
+         (.newJob existing-factory bundle scheduler)
+         (catch java.lang.ClassNotFoundException e (no-op-job e))
+         (catch java.lang.NoClassDefFoundError e (no-op-job e)))))))
+
+(def ^:private noop-trigger-listener-name ::noop-trigger-listener)
+
+(defn create-listener
+  "Create a TriggerListener that is able to veto executions of no-op jobs"
+  ^TriggerListener []
+  (reify TriggerListener
+    (getName [_]
+      (name noop-trigger-listener-name))
+
+    (triggerFired [_ _ _])
+
+    (vetoJobExecution [_ _ job-execution-context]
+      (instance? NoOpJob (.getJobInstance job-execution-context)))
+
+    (triggerMisfired [_ _])
+
+    (triggerComplete [_ _ _ _])))
+
+(defn add-to-scheduler
+  "Attach the customer job factory to a scheduler instance."
+  [^Scheduler scheduler]
+  (.setJobFactory scheduler (create))
+  (.. scheduler
+      getListenerManager
+      (addTriggerListener (create-listener))))

--- a/test/metabase/task/job_factory_test.clj
+++ b/test/metabase/task/job_factory_test.clj
@@ -1,0 +1,54 @@
+(ns metabase.task.job-factory-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.task.job-factory :as sut]
+   [metabase.test :as mt])
+  (:import
+   (org.quartz Job JobExecutionContext)
+   (org.quartz.spi JobFactory)))
+
+(set! *warn-on-reflection* true)
+
+(deftest new-job-class-not-found-test
+  (testing "JobFactory should return a no-op job and log an error when the underlying factory fails to load the class"
+    (testing "Handles ClassNotFoundException"
+      (mt/with-log-messages-for-level [logs :error]
+        (let [custom-factory (sut/create (reify JobFactory
+                                           (newJob [_ _ _]
+                                             (throw (java.lang.ClassNotFoundException. "Test ClassNotFoundException")))))]
+          (is (instance? Job (.newJob custom-factory nil nil))
+              "Should return a Job instance"))
+        (is (some #(re-find #"Failed to load a job class. Usually this means an old version of metabase tried to run a job from a newer version" %)
+                  (map :message (logs)))
+            "Should log an error about failing to load the job class")))))
+
+(deftest new-job-no-class-def-found-test
+  (testing "JobFactory should return a no-op job and log an error when the underlying factory fails to load the class"
+    (testing "Handles NoClassDefFoundError"
+      (mt/with-log-messages-for-level [logs :error]
+        (let [custom-factory (sut/create (reify JobFactory
+                                           (newJob [_ _ _]
+                                             (throw (java.lang.NoClassDefFoundError. "Test NoClassDefFoundError")))))]
+          (is (instance? Job (.newJob custom-factory nil nil))
+              "Should return a Job instance"))
+        (is (some #(re-find #"Failed to load a job class. Usually this means an old version of metabase tried to run a job from a newer version" %)
+                  (map :message (logs)))
+            "Should log an error about failing to load the job class")))))
+
+(deftest create-listener-test
+  (testing "The TriggerListener returned by create-listener should veto NoOpJob instances"
+    (let [listener (sut/create-listener)
+          noop-job (#'sut/->NoOpJob) ; Access private record constructor
+          other-job (reify Job (execute [_ _]))]
+
+      (testing "should return true (veto) for NoOpJob"
+        (let [context (reify JobExecutionContext
+                        (getJobInstance [_] noop-job))]
+          (is (true? (.vetoJobExecution listener nil context))
+              "Listener should veto NoOpJob")))
+
+      (testing "should return false (don't veto) for other Job types"
+        (let [context (reify JobExecutionContext
+                        (getJobInstance [_] other-job))]
+          (is (false? (.vetoJobExecution listener nil context))
+              "Listener should not veto other job types"))))))


### PR DESCRIPTION
### Description

**ADDS A FILE TO `metabase.task` NS**: This is done because this JobFactory for quartz to handle jobs being moved to the ERROR state is entirely internal to our quartz wrapper.

This creates a JobFactory for quartz that wraps the scheduler's underlying JobFactory catching any `ClassNotFoundException` and `NoClassDefFoundError` and returning a "No-op" job. Ordinarily if these exceptions are raised to the scheduler it causes all triggers for this job to be moved to the ERROR state which means they will never run. 

This exception mostly happens during upgrades of a metabase cluster where an older instance is trying to run jobs scheduled by a newer instance. Since the old instance does not have the class definitions for the job, one of these exceptions is raised and the task is marked as ERROR. 

Because don't actually want to run these no-ops we can use a `TriggerListener` to veto the job execution before we try running it. 

I considered using the existing classloader we supply to quartz for this, but looking into the quartz code the classloader is used to load other classes like Database adapters in addition to jobs, so we do not want to totally swallow `ClassNotFoundException` there. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
