### PR TITLE
Remove react 19 as a limitation

### DIFF
--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -90,7 +90,6 @@ The SDK doesn't support:
 - Alerts
 - Server-side rendering (SSR)
 - Multiple _interactive_ dashboards on the same application page. If you need to embed multiple dashboards on the same application page, you can embed static dashboards.
-- React 19
 
 ## Issues, feature requests and support
 


### PR DESCRIPTION
We [support React 19](https://www.metabase.com/docs/latest/embedding/sdk/introduction#embedded-analytics-sdk-prerequisites) now so it is no longer a limitation