### PR TITLE
[Permissions] Improve performance of admin permissions pages

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -2,6 +2,7 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { DataPermissionValue } from "metabase/admin/permissions/types";
+import { permissionOptionsToIconPaths } from "metabase/admin/permissions/utils/icons";
 import {
   getDatabaseFocusPermissionsUrl,
   getGroupFocusPermissionsUrl,
@@ -16,8 +17,11 @@ import {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_OPTIONS,
   PLUGIN_ADVANCED_PERMISSIONS,
   PLUGIN_DATA_PERMISSIONS,
+  PLUGIN_PERMISSIONS,
   PLUGIN_REDUCERS,
 } from "metabase/plugins";
+import closeIcon from "metabase/ui/components/icons/Icon/icons/close.svg";
+import databaseIcon from "metabase/ui/components/icons/Icon/icons/database.svg";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { ImpersonationModal } from "./components/ImpersonationModal";
@@ -32,6 +36,7 @@ const IMPERSONATED_PERMISSION_OPTION = {
   label: t`Impersonated`,
   value: DataPermissionValue.IMPERSONATED,
   icon: "database",
+  iconPath: databaseIcon,
   iconColor: "warning",
 };
 
@@ -39,6 +44,7 @@ const BLOCK_PERMISSION_OPTION = {
   label: t`Blocked`,
   value: DataPermissionValue.BLOCKED,
   icon: "close",
+  iconPath: closeIcon,
   iconColor: "danger",
 };
 
@@ -145,6 +151,14 @@ if (hasPremiumFeature("advanced_permissions")) {
 
   PLUGIN_DATA_PERMISSIONS.shouldRestrictNativeQueryPermissions =
     shouldRestrictNativeQueryPermissions;
+
+  PLUGIN_PERMISSIONS.permissionIconPaths = {
+    ...PLUGIN_PERMISSIONS.permissionIconPaths,
+    ...permissionOptionsToIconPaths({
+      impersonated: IMPERSONATED_PERMISSION_OPTION,
+      blocked: BLOCK_PERMISSION_OPTION,
+    }),
+  };
 }
 
 const getDatabaseViewImpersonationModalUrl = (entityId, groupId) => {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -1,10 +1,13 @@
+import { permissionOptionsToIconPaths } from "metabase/admin/permissions/utils/icons";
 import {
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS,
   PLUGIN_FEATURE_LEVEL_PERMISSIONS,
+  PLUGIN_PERMISSIONS,
 } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { getFeatureLevelDataPermissions } from "./permission-management";
+import { DOWNLOAD_PERMISSION_OPTIONS } from "./permission-management/download-permission";
 import {
   canDownloadResults,
   getDownloadWidgetMessageOverride,
@@ -35,5 +38,10 @@ if (hasPremiumFeature("advanced_permissions")) {
 
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDetailsQueryProps = {
     exclude_uneditable_details: true,
+  };
+
+  PLUGIN_PERMISSIONS.permissionIconPaths = {
+    ...PLUGIN_PERMISSIONS.permissionIconPaths,
+    ...permissionOptionsToIconPaths(DOWNLOAD_PERMISSION_OPTIONS),
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -22,6 +22,10 @@ import {
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
+import tenKIcon from "metabase/ui/components/icons/Icon/icons/10k.svg";
+import oneMIcon from "metabase/ui/components/icons/Icon/icons/1m.svg";
+import closeIcon from "metabase/ui/components/icons/Icon/icons/close.svg";
+import permissionsLimitedIcon from "metabase/ui/components/icons/Icon/icons/permissions_limited.svg";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 export const UNABLE_TO_DOWNLOAD_RESULTS = t`Groups with Block data access can't download results`;
@@ -43,24 +47,28 @@ export const DOWNLOAD_PERMISSION_OPTIONS = {
     label: t`No`,
     value: DataPermissionValue.NONE,
     icon: "close",
+    iconPath: closeIcon,
     iconColor: "danger",
   },
   limited: {
     label: t`10 thousand rows`,
     value: DataPermissionValue.LIMITED,
     icon: "10k",
+    iconPath: tenKIcon,
     iconColor: "accent7",
   },
   full: {
     label: t`1 million rows`,
     value: DataPermissionValue.FULL,
     icon: "1m",
+    iconPath: oneMIcon,
     iconColor: "accent7",
   },
   controlled: {
     label: t`Granular`,
     value: DataPermissionValue.CONTROLLED,
     icon: "permissions_limited",
+    iconPath: permissionsLimitedIcon,
     iconColor: "warning",
   },
 };

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
@@ -24,9 +24,11 @@ export const getGroupTableAccessPolicy = (
   );
 };
 
-export const getDraftPolicies = (state: SandboxesState) => {
-  return Object.values(state.plugins.sandboxingPlugin.groupTableAccessPolicies);
-};
+export const getDraftPolicies = createSelector(
+  (state: SandboxesState) =>
+    state.plugins.sandboxingPlugin.groupTableAccessPolicies,
+  (groupTableAccessPolicies) => Object.values(groupTableAccessPolicies),
+);
 
 export const hasPolicyChanges = createSelector(
   getDraftPolicies,

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
@@ -4,7 +4,10 @@ import { Fragment, memo, useState } from "react";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Toggle from "metabase/core/components/Toggle";
 import { lighten } from "metabase/lib/colors";
-import { Icon, Tooltip } from "metabase/ui";
+import { Tooltip } from "metabase/ui";
+import chevrondownIcon from "metabase/ui/components/icons/Icon/icons/chevrondown.svg";
+
+const chevrondownIconPath = new URL(chevrondownIcon).pathname;
 
 import {
   ActionsList,
@@ -78,11 +81,14 @@ export const PermissionsSelect = memo(function PermissionsSelect({
         </Tooltip>
       )}
 
-      <Icon
-        style={{ visibility: isDisabled ? "hidden" : "visible" }}
-        name="chevrondown"
-        size={16}
-        color={lighten("text-light", 0.15)}
+      <div
+        style={{
+          width: 16,
+          height: 16,
+          maskImage: `url("${chevrondownIconPath}")`,
+          background: lighten("text-light", 0.15),
+          visibility: isDisabled ? "hidden" : "visible",
+        }}
       />
     </PermissionsSelectRoot>
   );

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.jsx
@@ -1,7 +1,8 @@
 import PropTypes from "prop-types";
 import { useState } from "react";
 
-import { Icon, Tooltip } from "metabase/ui";
+import { PLUGIN_PERMISSIONS } from "metabase/plugins";
+import { Box, Tooltip } from "metabase/ui";
 
 import {
   IconContainer,
@@ -23,24 +24,53 @@ const propTypes = {
 
 export function PermissionsSelectOption({
   label,
-  icon,
+  icon: iconName,
   iconColor,
   className,
   hint,
 }) {
   const [shouldShowTooltip, setShouldShowTooltip] = useState(false);
 
+  // NOTE: this design is for performance reasons. all icons used by this
+  // component must be registered in the following plugin with a key of the
+  // icon name and and a value of the relative path the browser can use to load
+  // an svg icon from. since this component can be rendered several thousand times
+  // on a page, rendering individual svg tags is very expensive (making the page
+  // some ~4x slower).
+  const iconPath = PLUGIN_PERMISSIONS.permissionIconPaths[iconName];
+  if (!iconPath) {
+    console.warn(
+      "You have failed to register the path for the permission icon: " +
+        iconName,
+    );
+  }
+
+  const icon = (
+    <IconContainer color={iconColor}>
+      <Box
+        h="1rem"
+        w="1rem"
+        bg="white"
+        style={{ maskImage: `url("${iconPath}")` }}
+      />
+    </IconContainer>
+  );
+
+  // NOTE: optional rendering of tooltip provides performance gains due to # rendered
   return (
     <PermissionsSelectOptionRoot
       className={className}
       onMouseEnter={() => setShouldShowTooltip(true)}
       onMouseLeave={() => setShouldShowTooltip(false)}
     >
-      <Tooltip label={hint} disabled={!hint} opened={shouldShowTooltip}>
-        <IconContainer color={iconColor}>
-          <Icon name={icon} />
-        </IconContainer>
-      </Tooltip>
+      {hint ? (
+        <Tooltip label={hint} disabled={!hint} opened={shouldShowTooltip}>
+          {icon}
+        </Tooltip>
+      ) : (
+        icon
+      )}
+
       <PermissionsSelectLabel>{label}</PermissionsSelectLabel>
     </PermissionsSelectOptionRoot>
   );

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -102,7 +102,7 @@ export function PermissionsTable({
           {entities.map((entity) => {
             const entityName = (
               <span className={cx(CS.flex, CS.alignCenter)}>
-                <Ellipsified>{entity.name}</Ellipsified>
+                <Ellipsified resizable={false}>{entity.name}</Ellipsified>
                 {entity.hint && (
                   <Tooltip tooltip={entity.hint}>
                     <HintIcon />

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -1,5 +1,11 @@
 import { t } from "ttag";
 
+import checkIcon from "metabase/ui/components/icons/Icon/icons/check.svg";
+import closeIcon from "metabase/ui/components/icons/Icon/icons/close.svg";
+import eyeIcon from "metabase/ui/components/icons/Icon/icons/eye.svg";
+import eyeCrossedOutIcon from "metabase/ui/components/icons/Icon/icons/eye_crossed_out.svg";
+import permissionsLimitedIcon from "metabase/ui/components/icons/Icon/icons/permissions_limited.svg";
+
 import { DataPermissionValue } from "../types";
 
 export const DATA_PERMISSION_OPTIONS = {
@@ -7,36 +13,42 @@ export const DATA_PERMISSION_OPTIONS = {
     label: t`Can view`,
     value: DataPermissionValue.UNRESTRICTED,
     icon: "eye",
+    iconPath: eyeIcon,
     iconColor: "success",
   },
   controlled: {
     label: t`Granular`,
     value: DataPermissionValue.CONTROLLED,
     icon: "permissions_limited",
+    iconPath: permissionsLimitedIcon,
     iconColor: "warning",
   },
   noSelfServiceDeprecated: {
     label: t`No self-service (Deprecated)`,
     value: DataPermissionValue.LEGACY_NO_SELF_SERVICE,
     icon: "eye_crossed_out",
+    iconPath: eyeCrossedOutIcon,
     iconColor: "accent5",
   },
   no: {
     label: t`No`,
     value: DataPermissionValue.NO,
     icon: "close",
+    iconPath: closeIcon,
     iconColor: "danger",
   },
   queryBuilder: {
     label: t`Query builder only`,
     value: DataPermissionValue.QUERY_BUILDER,
     icon: "permissions_limited",
+    iconPath: permissionsLimitedIcon,
     iconColor: "warning",
   },
   queryBuilderAndNative: {
     label: t`Query builder and native`,
     value: DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
     icon: "check",
+    iconPath: checkIcon,
     iconColor: "success",
   },
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
@@ -8,9 +8,11 @@ import type { Group } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 export const getIsDirty = createSelector(
-  (state: State) => state.admin.permissions.dataPermissions,
-  (state: State) => state.admin.permissions.originalDataPermissions,
-  (state: State) => state,
+  [
+    (state: State) => state.admin.permissions.dataPermissions,
+    (state: State) => state.admin.permissions.originalDataPermissions,
+    (state: State) => state,
+  ],
   (permissions, originalPermissions, state) =>
     !_.isEqual(permissions, originalPermissions) ||
     PLUGIN_DATA_PERMISSIONS.hasChanges.some((hasChanges) => hasChanges(state)),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
@@ -9,17 +9,16 @@ import type { RawGroupRouteParams } from "../../types";
 
 import { getOrderedGroups } from "./groups";
 
-const getGroupRouteParams = (
-  _state: State,
-  props: { params: RawGroupRouteParams },
-) => {
-  const { groupId, databaseId, schemaName } = props.params;
-  return {
-    groupId: groupId != null ? parseInt(groupId) : null,
-    databaseId,
-    schemaName,
-  };
-};
+const getGroupRouteParams = createSelector(
+  (_state: State, props: { params: RawGroupRouteParams }) => props.params,
+  ({ groupId, databaseId, schemaName }) => {
+    return {
+      groupId: groupId != null ? parseInt(groupId) : null,
+      databaseId,
+      schemaName,
+    };
+  },
+);
 
 export const getGroupsSidebar = createSelector(
   getOrderedGroups,
@@ -48,4 +47,5 @@ export const getGroupsSidebar = createSelector(
       filterPlaceholder: t`Search for a group`,
     };
   },
+  { devModeChecks: { inputStabilityCheck: "never" } },
 );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -91,17 +91,16 @@ export const getDataPermissions = (state: State) =>
 const getOriginalDataPermissions = (state: State) =>
   state.admin.permissions.originalDataPermissions;
 
-const getGroupRouteParams = (
-  _state: State,
-  props: { params: RawGroupRouteParams },
-) => {
-  const { groupId, databaseId, schemaName } = props.params;
-  return {
-    groupId: groupId != null ? parseInt(groupId) : undefined,
-    databaseId: databaseId != null ? parseInt(databaseId) : undefined,
-    schemaName,
-  };
-};
+const getGroupRouteParams = createSelector(
+  (_state: State, props: { params: RawGroupRouteParams }) => props.params,
+  ({ groupId, databaseId, schemaName }) => {
+    return {
+      groupId: groupId != null ? parseInt(groupId) : undefined,
+      databaseId: databaseId != null ? parseInt(databaseId) : undefined,
+      schemaName,
+    };
+  },
+);
 
 const getEditorEntityName = (
   { databaseId, schemaName }: DataRouteParams,

--- a/frontend/src/metabase/admin/permissions/utils/icons.ts
+++ b/frontend/src/metabase/admin/permissions/utils/icons.ts
@@ -1,0 +1,10 @@
+export const permissionOptionsToIconPaths = (
+  options: Record<string, { icon: string; iconPath: string }>,
+) => {
+  return Object.fromEntries(
+    Object.values(options).map((option) => [
+      option.icon,
+      new URL(option.iconPath).pathname,
+    ]),
+  );
+};

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -16,6 +16,7 @@ interface EllipsifiedProps {
   multiline?: boolean;
   placement?: FloatingPosition;
   "data-testid"?: string;
+  resizable?: boolean;
   id?: string;
 }
 
@@ -31,17 +32,35 @@ export const Ellipsified = ({
   multiline = false,
   placement = "top",
   "data-testid": dataTestId,
+  resizable = true,
   id,
 }: EllipsifiedProps) => {
   const canSkipTooltipRendering = !showTooltip && !alwaysShowTooltip;
   const { isTruncated, ref } = useIsTruncated<HTMLDivElement>({
     disabled: canSkipTooltipRendering,
+    isResizeable: resizable,
   });
   const isEnabled =
     (showTooltip && (isTruncated || alwaysShowTooltip)) || false;
 
   const truncatedProps: Partial<TextProps> =
     lines > 1 ? { lineClamp: lines } : { truncate: true };
+
+  const text = (
+    <Text
+      c="inherit"
+      ref={ref}
+      className={className}
+      style={style}
+      data-testid={dataTestId}
+      id={id}
+      fz="inherit"
+      lh="inherit"
+      {...truncatedProps}
+    >
+      {children}
+    </Text>
+  );
 
   return (
     <Tooltip
@@ -52,19 +71,7 @@ export const Ellipsified = ({
       w={tooltipMaxWidth}
       multiline={multiline}
     >
-      <Text
-        c="inherit"
-        ref={ref}
-        className={className}
-        style={style}
-        data-testid={dataTestId}
-        id={id}
-        fz="inherit"
-        lh="inherit"
-        {...truncatedProps}
-      >
-        {children}
-      </Text>
+      {text}
     </Tooltip>
   );
 };

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -5,10 +5,12 @@ import resizeObserver from "metabase/lib/resize-observer";
 
 type UseIsTruncatedProps = {
   disabled?: boolean;
+  isResizeable?: boolean;
 };
 
 export const useIsTruncated = <E extends Element>({
   disabled = false,
+  isResizeable = true,
 }: UseIsTruncatedProps = {}) => {
   const ref = useRef<E | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
@@ -18,6 +20,11 @@ export const useIsTruncated = <E extends Element>({
 
     if (!element || disabled) {
       return;
+    }
+
+    if (isResizeable) {
+      setIsTruncated(getIsTruncated(element));
+      return () => {};
     }
 
     const handleResize = () => {
@@ -30,7 +37,7 @@ export const useIsTruncated = <E extends Element>({
     return () => {
       resizeObserver.unsubscribe(element, handleResize);
     };
-  }, [disabled]);
+  }, [disabled, isResizeable]);
 
   return { isTruncated, ref };
 };

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -15,6 +15,7 @@ import {
   strategies,
 } from "metabase/admin/performance/constants/complex";
 import type { ModelWithClearableCache } from "metabase/admin/performance/types";
+import { DATA_PERMISSION_OPTIONS } from "metabase/admin/permissions/constants/data-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import {
   type DataPermission,
@@ -23,6 +24,7 @@ import {
   type EntityId,
   type PermissionSubject,
 } from "metabase/admin/permissions/types";
+import { permissionOptionsToIconPaths } from "metabase/admin/permissions/utils/icons";
 import { InteractiveEmbeddingSettings } from "metabase/admin/settings/components/EmbeddingSettings/InteractiveEmbeddingSettings";
 import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors";
 import type {
@@ -450,6 +452,10 @@ export const PLUGIN_REDUCERS: {
   applicationPermissionsPlugin: () => null,
   sandboxingPlugin: () => null,
   shared: () => null,
+};
+
+export const PLUGIN_PERMISSIONS = {
+  permissionIconPaths: permissionOptionsToIconPaths(DATA_PERMISSION_OPTIONS),
 };
 
 export const PLUGIN_ADVANCED_PERMISSIONS = {


### PR DESCRIPTION
### Description

This PR improves the performance of the admin permissions pages making it 3x faster to load database with 2000 tables and removes the lag that was happening when opening the sandbox configuration modal.

### Technical changes

This PR makes several changes since there was really no one single issue causing all the slow down:
- **Make permissions redux selectors return stable references** - this was busted in a few places and in turn breaking memoization for our main permissions editor selector which is quite expensive to run. fixing this solved slowness around updating the permissions values when there's lots of records and makes opening the sandbox config modal instant.
- **Do not render thousands of svgs** - we were rendering 8 svgs per permissions row, with thousands of rows this is a lot for the browser to render which is notoriously slow in browsers. leveraging css to accomplish this brought ~80% of the speed up to loading large lists.
- **Do not render tooltips if they're not needed** - rendering lots of unused tooltips was slowing the page down, even if they were disabled.

### Demo

**Before video**
https://github.com/user-attachments/assets/3029b187-a241-4651-8bb0-6fb979ad7aed

**After video**
https://github.com/user-attachments/assets/da140d15-4471-4c6d-86b9-ae9ba7f2db18


### Why not faster?

I found a few things that are slowing the page down, that I just couldn't solve in one pass.
1. `<Ellipsified />` is quite slow when rendering lots of items. Would result in a 2x speed up on top of what I was able to produce with these changes if we didn't try to show tooltips if the name was truncated.
2. Styled components appear to take ~10-15% of the render time based on my performance profiling, moving to CSS modules would provide some marginal wins.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
