### PR TITLE
Switch to bar without relying on Category

### DIFF
--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -268,16 +268,16 @@ class Question {
       previousSensibleDisplays.includes(this.display());
     const isSensible = sensibleDisplays.includes(this.display());
     const shouldUnlock = wasSensible && !isSensible;
-    const defaultDisplay = this.setDefaultDisplay().display();
+    const defaultDisplay = this.setDefaultDisplay(data).display();
 
     let question;
     if (isSensible && defaultDisplay === "table") {
       // any sensible display is better than the default table display
       question = this;
     } else if (shouldUnlock && this.displayIsLocked()) {
-      question = this.setDisplayIsLocked(false).setDefaultDisplay();
+      question = this.setDisplayIsLocked(false).setDefaultDisplay(data);
     } else {
-      question = this.setDefaultDisplay();
+      question = this.setDefaultDisplay(data);
     }
 
     return question._maybeSwitchToScalar(data);
@@ -293,13 +293,13 @@ class Question {
     return this;
   }
 
-  setDefaultDisplay(): Question {
+  setDefaultDisplay(data?: DatasetData): Question {
     if (this.displayIsLocked()) {
       return this;
     }
 
     const query = this.query();
-    const { display, settings = {} } = Lib.defaultDisplay(query);
+    const { display, settings = {} } = Lib.defaultDisplay(query, data);
 
     return this.setDisplay(display).updateSettings(settings);
   }

--- a/frontend/src/metabase-lib/viz/display.ts
+++ b/frontend/src/metabase-lib/viz/display.ts
@@ -1,15 +1,21 @@
 import * as Lib from "metabase-lib";
 import type {
   CardDisplayType,
+  DatasetData,
   VisualizationSettings,
 } from "metabase-types/api";
+
+const CATEGORY_CARDINALITY_THRESHOLD = 30;
 
 type DefaultDisplay = {
   display: CardDisplayType;
   settings?: Partial<VisualizationSettings>;
 };
 
-export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
+export const defaultDisplay = (
+  query: Lib.Query,
+  data?: DatasetData,
+): DefaultDisplay => {
   const { isNative } = Lib.queryDisplayInfo(query);
 
   if (isNative) {
@@ -74,7 +80,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       return { display: "bar" };
     }
 
-    if (Lib.isBoolean(column) || Lib.isCategory(column)) {
+    if (data != null && data.rows.length <= CATEGORY_CARDINALITY_THRESHOLD) {
       return { display: "bar" };
     }
   }
@@ -118,10 +124,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       };
     }
 
-    const areBreakoutsCategories = breakoutsWithColumns.every(({ column }) => {
-      return Lib.isBoolean(column) || Lib.isCategory(column);
-    });
-    if (areBreakoutsCategories) {
+    if (data != null && data.rows.length <= CATEGORY_CARDINALITY_THRESHOLD) {
       return { display: "bar" };
     }
   }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-264/replace-category-check-when-computing-default-display-type

Instead of relying on `Category` when deciding whether to switch to `bar`, we rely on the threshold of `30` rows which is used by code that sets `Category` automatically on fields https://github.com/metabase/metabase/blob/78077ba2e067766ae54e43f719525292ab450ebf/src/metabase/analyze/classifiers/category.clj#L20. It should give similar results in simple cases. Other conditions, such as aggregation and breakout count, remain the same:
1. aggregations >=1, breakouts = 1 OR
2. aggregations = 1, breakouts = 2

How to verify:
- New -> Question -> Products
- Aggregation -> Count, Breakout -> Category
- Visualize
- You should get a bar chart, but the logic is based on the number of rows now instead of semantic types.