### PR TITLE
Temporarily disable Shoppy sample app tests

### DIFF
--- a/.github/workflows/e2e-sample-apps-tests.yml
+++ b/.github/workflows/e2e-sample-apps-tests.yml
@@ -17,13 +17,10 @@ env:
   TEST_SUITES: |
     [
       "metabase-nodejs-react-sdk-embedding-sample-e2e",
-      "metabase-nextjs-sdk-embedding-sample-e2e",
-      "shoppy-e2e"
+      "metabase-nextjs-sdk-embedding-sample-e2e"
     ]
   TEST_SUITES_TO_RUN_IN_MASTER_ONLY: |
-    [
-      "shoppy-e2e"
-    ]
+    []
   SAMPLE_APP_MAIN_BRANCH_NAME: "main"
   SAMPLE_APP_STABLE_RELEASE_BRANCH_NAME_SUFFIX: "stable"
 


### PR DESCRIPTION
Temporarily disable Shoppy sample app tests

According to the Shoppy deployment plan to avoid any unexpected CI failures caused by adjusted Shoppy setup.
It'll be enabled back in a follow-up.