### PR TITLE
Fix expression diagnostic for mismatched siblings

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -78,12 +78,17 @@ describe("diagnostics", () => {
 
     describe("sibling tokens validation", () => {
       const left = ["[Total]", '"string"', "42", "(10 + 5)", "true"];
-      const right = ["[Total]", '"string"', "42", "(10 + 5)", "tax"];
+      const right = [
+        ["[Total]", "[Total]"],
+        ['"string"', '"string"'],
+        ["42", "42"],
+        ["(10 + 5)", "("],
+        ["tax", "tax"],
+        ["ceil(10.5)", "ceil"],
+      ];
 
       for (const leftToken of left) {
-        for (const rightToken of right) {
-          const errToken = rightToken.startsWith("(") ? "(" : rightToken;
-
+        for (const [rightToken, errToken] of right) {
           it(`should catch mismatched adjecent tokens in: ${leftToken} ${rightToken}`, () => {
             expect(err(`${leftToken} ${rightToken}`)).toBe(
               `Expecting operator but got ${errToken} instead`,

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -76,10 +76,33 @@ describe("diagnostics", () => {
       );
     });
 
-    it("should catch missing comma in function arguments", () => {
-      expect(err('concat([Tax] "test")')).toBe(
-        'Expecting operator but got "test" instead',
-      );
+    describe("sibling tokens validation", () => {
+      const left = ["[Total]", '"string"', "42", "(10 + 5)", "true"];
+      const right = ["[Total]", '"string"', "42", "(10 + 5)", "tax"];
+
+      for (const leftToken of left) {
+        for (const rightToken of right) {
+          const errToken = rightToken.startsWith("(") ? "(" : rightToken;
+
+          it(`should catch mismatched adjecent tokens in: ${leftToken} ${rightToken}`, () => {
+            expect(err(`${leftToken} ${rightToken}`)).toBe(
+              `Expecting operator but got ${errToken} instead`,
+            );
+          });
+
+          it(`should catch mismatched adjecent tokens in: concat(${leftToken} ${rightToken})`, () => {
+            expect(err(`concat(${leftToken} ${rightToken})`)).toBe(
+              `Expecting operator but got ${errToken} instead`,
+            );
+          });
+
+          it(`should catch mismatched adjecent tokens in: 2 * (${leftToken} ${rightToken})`, () => {
+            expect(err(`2 * (${leftToken} ${rightToken})`)).toBe(
+              `Expecting operator but got ${errToken} instead`,
+            );
+          });
+        }
+      }
     });
 
     it("should catch unknown functions", () => {

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-mismatched-siblings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-mismatched-siblings.ts
@@ -17,11 +17,7 @@ import { error } from "../utils";
 const left = [FIELD, STRING, NUMBER, BOOLEAN, IDENTIFIER, GROUP_CLOSE];
 const right = [FIELD, STRING, NUMBER, BOOLEAN, IDENTIFIER, GROUP];
 
-export function checkMissingCommasInArgumentList({
-  tokens,
-}: {
-  tokens: Token[];
-}) {
+export function checkMismatchedSiblings({ tokens }: { tokens: Token[] }) {
   for (let index = 1; index < tokens.length; index++) {
     const token = tokens[index];
     const prevToken = tokens[index - 1];

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-mismatched-siblings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-mismatched-siblings.ts
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 
-import type { Token } from "../../pratt";
 import {
   BAD_TOKEN,
   BOOLEAN,
@@ -11,6 +10,7 @@ import {
   IDENTIFIER,
   NUMBER,
   STRING,
+  type Token,
 } from "../../pratt";
 import { error } from "../utils";
 

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-mismatched-siblings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-mismatched-siblings.ts
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import {
   BAD_TOKEN,
   BOOLEAN,
+  CALL,
   END_OF_INPUT,
   FIELD,
   GROUP,
@@ -15,7 +16,7 @@ import {
 import { error } from "../utils";
 
 const left = [FIELD, STRING, NUMBER, BOOLEAN, IDENTIFIER, GROUP_CLOSE];
-const right = [FIELD, STRING, NUMBER, BOOLEAN, IDENTIFIER, GROUP];
+const right = [FIELD, STRING, NUMBER, BOOLEAN, IDENTIFIER, GROUP, CALL];
 
 export function checkMismatchedSiblings({ tokens }: { tokens: Token[] }) {
   for (let index = 1; index < tokens.length; index++) {

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
@@ -11,10 +11,10 @@ import { checkStringQuotes } from "./check-string-quotes";
 export const syntaxChecks = [
   checkOpenParenthesisAfterFunction,
   checkMatchingParentheses,
-  checkMissingCommasInArgumentList,
   checkNumberExponent,
   checkStringQuotes,
   checkFieldQuotes,
+  checkMissingCommasInArgumentList,
   checkBadTokens,
 ];
 

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
@@ -3,7 +3,7 @@ import type { Token } from "../../pratt";
 import { checkBadTokens } from "./check-bad-tokens";
 import { checkFieldQuotes } from "./check-field-quotes";
 import { checkMatchingParentheses } from "./check-matching-parenthesis";
-import { checkMissingCommasInArgumentList } from "./check-missing-comma-in-argument-list";
+import { checkMismatchedSiblings } from "./check-mismatched-siblings";
 import { checkNumberExponent } from "./check-number-exponent";
 import { checkOpenParenthesisAfterFunction } from "./check-open-parenthesis-after-function";
 import { checkStringQuotes } from "./check-string-quotes";
@@ -14,7 +14,7 @@ export const syntaxChecks = [
   checkNumberExponent,
   checkStringQuotes,
   checkFieldQuotes,
-  checkMissingCommasInArgumentList,
+  checkMismatchedSiblings,
   checkBadTokens,
 ];
 


### PR DESCRIPTION
The current expression editor has a check for missing comma's in an argument list.

This PR generalizes that check to catch all sibling tokens that do not belong next to each other and applies it everywhere, not just in argument lists.

This makes the check more general and less complex at the same time.

This does not change the set of valid expressions, but it does provide better error messages.

### To verify 

1. New -> Question -> Sample Database -> Orders
2. Custom Column
3. Type `"foo" 10`
4. The error message should be `Expecting operator but got 10 instead`