### PR TITLE
fix(sdk): clicking on "and X more" in chart legend throws error

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -61,7 +61,11 @@ describe("scenarios > embedding-sdk > popovers", () => {
 
     getSdkRoot().within(() => {
       cy.log("click on the legend overflow");
-      cy.findByText(/And \d+ more/).click();
+      cy.findByText("And 39 more").click();
     });
+
+    cy.log("check that the popover is showing chart legends");
+    H.popover().findByText("IA").should("be.visible");
+    H.popover().findByText("ID").should("be.visible");
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -1,0 +1,67 @@
+import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import * as H from "e2e/support/helpers";
+import {
+  mockAuthProviderAndJwtSignIn,
+  mountSdkContent,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/component-testing-sdk";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+
+const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
+
+describe("scenarios > embedding-sdk > popovers", () => {
+  it("should show legend overflow popover for charts with many series", () => {
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    H.createDashboardWithQuestions({
+      questions: [
+        {
+          name: "vertical legend with popover",
+          display: "line",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "field",
+                ORDERS.CREATED_AT,
+                { "temporal-unit": "year", "base-type": "type/DateTime" },
+              ],
+              [
+                "field",
+                PEOPLE.STATE,
+                { "source-field": ORDERS.USER_ID, "base-type": "type/Text" },
+              ],
+            ],
+          },
+          visualization_settings: {
+            "graph.dimensions": ["CREATED_AT", "STATE"],
+            "graph.metrics": ["count"],
+          },
+        },
+      ],
+      cards: [{ col: 0, row: 0, size_x: 24, size_y: 6 }],
+    }).then(({ dashboard }) => cy.wrap(dashboard.id).as("dashboardId"));
+
+    cy.signOut();
+
+    mockAuthProviderAndJwtSignIn();
+
+    cy.get<string>("@dashboardId").then((dashboardId) => {
+      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+    });
+
+    cy.wait("@dashcardQuery");
+
+    getSdkRoot().within(() => {
+      cy.log("click on the legend overflow");
+      cy.findByText(/And \d+ more/).click();
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -12,7 +12,7 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding-sdk > popovers", () => {
-  it("should show legend overflow popover for charts with many series", () => {
+  it("should show legend overflow popover for charts with many series (metabase#57131)", () => {
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
       "dashcardQuery",
     );

--- a/frontend/src/metabase/visualizations/components/legend/Legend.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/Legend.jsx
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import { useRef, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -50,9 +49,6 @@ const Legend = ({
   isReversed,
   canRemoveSeries = alwaysTrue,
 }) => {
-  const targetRef = useRef();
-  const [isOpened, setIsOpened] = useState(null);
-
   const items = isReversed ? _.clone(originalItems).reverse() : originalItems;
 
   const overflowIndex = visibleIndex + visibleLength;
@@ -90,18 +86,10 @@ const Legend = ({
         );
       })}
       {overflowLength > 0 && (
-        <Popover
-          width="target"
-          opened={isOpened}
-          onDismiss={() => setIsOpened(false)}
-          offset={POPOVER_OFFSET}
-          placement="top-start"
-        >
+        <Popover width="target" offset={POPOVER_OFFSET} placement="top-start">
           <Popover.Target>
-            <LegendLinkContainer ref={targetRef} isVertical={isVertical}>
-              <LegendLink onMouseDown={() => setIsOpened(true)}>
-                {t`And ${overflowLength} more`}
-              </LegendLink>
+            <LegendLinkContainer isVertical={isVertical}>
+              <LegendLink>{t`And ${overflowLength} more`}</LegendLink>
             </LegendLinkContainer>
           </Popover.Target>
           <Popover.Dropdown>

--- a/frontend/src/metabase/visualizations/components/legend/Legend.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/Legend.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -12,6 +12,10 @@ import {
   LegendRoot,
 } from "./Legend.styled";
 import LegendItem from "./LegendItem";
+
+const POPOVER_BORDER = 1;
+const POPOVER_PADDING = 8;
+const POPOVER_OFFSET = POPOVER_BORDER + POPOVER_PADDING;
 
 const propTypes = {
   className: PropTypes.string,
@@ -48,10 +52,6 @@ const Legend = ({
 }) => {
   const targetRef = useRef();
   const [isOpened, setIsOpened] = useState(null);
-
-  const togglePopover = useCallback(() => {
-    setIsOpened(!isOpened);
-  }, [isOpened, setIsOpened]);
 
   const items = isReversed ? _.clone(originalItems).reverse() : originalItems;
 
@@ -94,11 +94,12 @@ const Legend = ({
           width="target"
           opened={isOpened}
           onDismiss={() => setIsOpened(false)}
-          position="top-start"
+          offset={POPOVER_OFFSET}
+          placement="top-start"
         >
           <Popover.Target>
             <LegendLinkContainer ref={targetRef} isVertical={isVertical}>
-              <LegendLink onMouseDown={togglePopover}>
+              <LegendLink onMouseDown={() => setIsOpened(true)}>
                 {t`And ${overflowLength} more`}
               </LegendLink>
             </LegendLinkContainer>

--- a/frontend/src/metabase/visualizations/components/legend/Legend.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/Legend.jsx
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import Popover from "metabase/components/Popover";
+import { Popover } from "metabase/ui";
 
 import {
   LegendLink,
@@ -12,10 +12,6 @@ import {
   LegendRoot,
 } from "./Legend.styled";
 import LegendItem from "./LegendItem";
-
-const POPOVER_BORDER = 1;
-const POPOVER_PADDING = 8;
-const POPOVER_OFFSET = POPOVER_BORDER + POPOVER_PADDING;
 
 const propTypes = {
   className: PropTypes.string,
@@ -52,17 +48,10 @@ const Legend = ({
 }) => {
   const targetRef = useRef();
   const [isOpened, setIsOpened] = useState(null);
-  const [maxWidth, setMaxWidth] = useState(0);
 
-  const handleOpen = useCallback(() => {
-    setIsOpened(true);
-    setMaxWidth(targetRef.current.offsetWidth);
-  }, []);
-
-  const handleClose = useCallback(() => {
-    setIsOpened(false);
-    setMaxWidth(0);
-  }, []);
+  const togglePopover = useCallback(() => {
+    setIsOpened(!isOpened);
+  }, [isOpened, setIsOpened]);
 
   const items = isReversed ? _.clone(originalItems).reverse() : originalItems;
 
@@ -101,36 +90,36 @@ const Legend = ({
         );
       })}
       {overflowLength > 0 && (
-        <LegendLinkContainer ref={targetRef} isVertical={isVertical}>
-          <LegendLink onMouseDown={handleOpen}>
-            {t`And ${overflowLength} more`}
-          </LegendLink>
-        </LegendLinkContainer>
-      )}
-      {isOpened && (
         <Popover
-          target={targetRef.current}
-          targetOffsetX={POPOVER_OFFSET}
-          horizontalAttachments={["left"]}
-          verticalAttachments={["top", "bottom"]}
-          sizeToFit
-          onClose={handleClose}
+          width="target"
+          opened={isOpened}
+          onDismiss={() => setIsOpened(false)}
+          position="top-start"
         >
-          <LegendPopoverContainer style={{ maxWidth }}>
-            <Legend
-              items={originalItems}
-              hovered={hovered}
-              visibleIndex={overflowIndex}
-              visibleLength={overflowLength}
-              isVertical={isVertical}
-              isInsidePopover
-              onHoverChange={onHoverChange}
-              onSelectSeries={onSelectSeries}
-              onToggleSeriesVisibility={onToggleSeriesVisibility}
-              onRemoveSeries={onRemoveSeries}
-              isReversed={isReversed}
-            />
-          </LegendPopoverContainer>
+          <Popover.Target>
+            <LegendLinkContainer ref={targetRef} isVertical={isVertical}>
+              <LegendLink onMouseDown={togglePopover}>
+                {t`And ${overflowLength} more`}
+              </LegendLink>
+            </LegendLinkContainer>
+          </Popover.Target>
+          <Popover.Dropdown>
+            <LegendPopoverContainer>
+              <Legend
+                items={originalItems}
+                hovered={hovered}
+                visibleIndex={overflowIndex}
+                visibleLength={overflowLength}
+                isVertical={isVertical}
+                isInsidePopover
+                onHoverChange={onHoverChange}
+                onSelectSeries={onSelectSeries}
+                onToggleSeriesVisibility={onToggleSeriesVisibility}
+                onRemoveSeries={onRemoveSeries}
+                isReversed={isReversed}
+              />
+            </LegendPopoverContainer>
+          </Popover.Dropdown>
         </Popover>
       )}
     </LegendRoot>


### PR DESCRIPTION
Closes EMB-338
Closes #57131

### Description

When rendering a chart with lots of legends in the InteractiveDashboard, the "And 19 more" text shows up.. In the main Metabase app, clicking on it would've opened a popover with the rest of the legends:

![image](https://github.com/user-attachments/assets/1fbad7c1-d1d5-4aab-83a9-997712d315ae)

In the SDK however it crashes the dashboard card:

![image](https://github.com/user-attachments/assets/695f2870-3767-4159-97a0-24bcee0567ea)

The issue was caused by legacy Tooltip component as usual. This PR migrates the tooltip to use Mantine's Tooltip instead, so now the legend shows as expected:

![CleanShot 2568-04-24 at 18 57 40@2x](https://github.com/user-attachments/assets/50a2f707-d556-4ca7-b8ce-399200f64fb1)

### How to verify

Create a native question using [this static SQL](https://gist.github.com/heypoom/e800696dc2b3a8a5a1f20987ec528b11) and make it a bar chart. It will look like this:

![CleanShot 2568-04-24 at 18 59 29@2x](https://github.com/user-attachments/assets/91c04f77-13a3-43bc-9405-97ec1030cc08)

Add it to the dashboard and render it via the SDK's InteractiveDashboard. It should look like the screenshot above.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
