### PR TITLE
refactor: column config for editable tables

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
@@ -53,44 +53,21 @@ export const EditTableDataGrid = ({
 
   const columnOrder = useMemo(
     () =>
-      columnsConfig
-        ? columnsConfig.filter((it) => it.enabled).map(({ name }) => name)
-        : cols.map(({ name }) => name),
+      columnsConfig ? columnsConfig.columnOrder : cols.map(({ name }) => name),
     [cols, columnsConfig],
   );
 
   const columnVisibility = useMemo(
-    () =>
-      columnsConfig
-        ? columnsConfig.reduce(
-            (acc, { name, enabled }) => ({
-              ...acc,
-              [name]: enabled,
-            }),
-            {},
-          )
-        : undefined,
+    () => (columnsConfig ? columnsConfig.columnVisibilityMap : undefined),
     [columnsConfig],
   );
-
-  // if columnsConfig is not provided, all columns are editable and columnsConfiguredForEditing is undefined
-  const columnsConfiguredForEditing = useMemo(() => {
-    if (!columnsConfig) {
-      return undefined;
-    }
-
-    return new Set(
-      columnsConfig.filter((it) => it.editable).map(({ name }) => name),
-    );
-  }, [columnsConfig]);
 
   const columnSizingMap = useMemo(() => ({}), []);
 
   const columnsOptions: ColumnOptions<RowValues, RowValue>[] = useMemo(() => {
     return cols.map((column, columnIndex) => {
       const isEditableColumn =
-        !columnsConfiguredForEditing ||
-        columnsConfiguredForEditing.has(column.name);
+        !columnsConfig || !columnsConfig.isColumnReadonly(column.name);
 
       const sortDirection = getColumnSortDirection?.(column);
 
@@ -141,7 +118,7 @@ export const EditTableDataGrid = ({
     onCellValueUpdate,
     onCellEditCancel,
     editingCellId,
-    columnsConfiguredForEditing,
+    columnsConfig,
   ]);
 
   const rowId: RowIdColumnOptions = useMemo(
@@ -174,10 +151,7 @@ export const EditTableDataGrid = ({
     ) => {
       const field = fieldMetadataMap?.[columnId];
 
-      if (
-        columnsConfiguredForEditing &&
-        !columnsConfiguredForEditing.has(columnId)
-      ) {
+      if (columnsConfig && columnsConfig.isColumnReadonly(columnId)) {
         return;
       }
 
@@ -192,12 +166,7 @@ export const EditTableDataGrid = ({
         onCellClickToEdit(cellId);
       }
     },
-    [
-      onCellClickToEdit,
-      editingCellId,
-      fieldMetadataMap,
-      columnsConfiguredForEditing,
-    ],
+    [onCellClickToEdit, editingCellId, fieldMetadataMap, columnsConfig],
   );
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
@@ -119,7 +119,8 @@ export const EditingBodyCellCategorySelect = ({
   ]);
 
   const isNullable = field?.database_is_nullable;
-  const shouldDisplayClearButton = isNullable && !!value;
+  const shouldDisplayClearButton =
+    isNullable && !!value && !inputProps?.disabled;
 
   return (
     <Combobox

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
@@ -130,25 +130,14 @@ export function EditingBaseRowModal({
     }
   }, [currentRowIndex, closeDeletionModal, onRowDelete]);
 
-  const disabledColumnNames = useMemo(() => {
-    if (!columnsConfig) {
-      return undefined;
-    }
-
-    return new Set(
-      columnsConfig.filter((it) => !it.editable).map(({ name }) => name),
-    );
-  }, [columnsConfig]);
-
   // Columns might be reordered to match the order in `columnsConfig`
   const orderedDatasetColumns = useMemo(() => {
     if (!columnsConfig) {
       return datasetColumns;
     }
 
-    return columnsConfig
-      .filter((it) => it.enabled)
-      .map(({ name }) => datasetColumns.find((it) => it.name === name))
+    return columnsConfig.columnOrder
+      .map((name) => datasetColumns.find((it) => it.name === name))
       .filter((it): it is DatasetColumn => it !== undefined);
   }, [columnsConfig, datasetColumns]);
 
@@ -229,7 +218,7 @@ export function EditingBaseRowModal({
                     onSubmitValue={handleValueEdit}
                     onChangeValue={setFieldValue}
                     error={!isEditingMode && !!errors[column.name]}
-                    disabled={disabledColumnNames?.has(column.name)}
+                    disabled={columnsConfig?.isColumnReadonly(column.name)}
                   />
                 </Fragment>
               );

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
@@ -6,10 +6,11 @@ import type {
 } from "metabase-types/api";
 
 export type EditableTableColumnConfig = {
-  name: string;
-  enabled: boolean;
-  editable: boolean;
-}[];
+  columnOrder: string[];
+  columnVisibilityMap: Record<string, boolean>;
+  isColumnReadonly: (columnName: string) => boolean;
+  isColumnHidden: (columnName: string) => boolean;
+};
 
 export function useEditableTableColumnConfigFromVisualizationSettings(
   visualizationSettings?: VisualizationSettings & DashCardVisualizationSettings,
@@ -27,13 +28,35 @@ export function useEditableTableColumnConfigFromVisualizationSettings(
       return undefined;
     }
 
-    const enableAllEditableColumns = editableColumns.length === 0;
-    const editableColumnsSet = new Set(editableColumns);
+    const isAllColumnsEditable = editableColumns.length === 0;
+    const editableColumnSet = new Set(editableColumns);
 
-    return columnSettings.map((column) => ({
-      name: column.name,
-      enabled: column.enabled,
-      editable: enableAllEditableColumns || editableColumnsSet.has(column.name),
-    }));
+    const columnOrder: string[] = [];
+    const columnVisibilityMap: Record<string, boolean> = {};
+    const readonlyColumnSet = new Set<string>();
+    const hiddenColumnSet = new Set<string>();
+
+    for (let i = 0; i < columnSettings.length; i++) {
+      const column = columnSettings[i];
+
+      columnOrder.push(column.name);
+      columnVisibilityMap[column.name] = column.enabled;
+
+      if (!column.enabled) {
+        hiddenColumnSet.add(column.name);
+      }
+
+      if (!isAllColumnsEditable && !editableColumnSet.has(column.name)) {
+        readonlyColumnSet.add(column.name);
+      }
+    }
+
+    return {
+      columnOrder,
+      columnVisibilityMap,
+      isColumnHidden: (columnName: string) => hiddenColumnSet.has(columnName),
+      isColumnReadonly: (columnName: string) =>
+        readonlyColumnSet.has(columnName),
+    };
   }, [visualizationSettings]);
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
@@ -36,9 +36,8 @@ export function useEditableTableColumnConfigFromVisualizationSettings(
     const readonlyColumnSet = new Set<string>();
     const hiddenColumnSet = new Set<string>();
 
-    for (let i = 0; i < columnSettings.length; i++) {
-      const column = columnSettings[i];
-
+    for (const column of columnSettings) {
+      columnOrder.push(column.name);
       columnOrder.push(column.name);
       columnVisibilityMap[column.name] = column.enabled;
 


### PR DESCRIPTION
Cleaner code without redundant `useMemo`s 