### PR TITLE
Add min-width to popover

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1323,3 +1323,30 @@ describe("issue 56771", () => {
       });
   });
 });
+
+describe("issue 57132", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dataset", function (req) {
+      req.continue((res) => {
+        // remove description from the CATEGORY column
+        const index = res.body.data.cols.findIndex(
+          (col) => col.name === "CATEGORY",
+        );
+        delete res.body.data.cols[index].description;
+      });
+    });
+  });
+
+  it("should render more values when hovering colum header without description (metabase#57132)", () => {
+    H.openProductsTable();
+    H.tableInteractive().findByText("Category").realHover();
+
+    cy.log("The popover should be wide enough to show at least some values");
+    H.popover()
+      .findByText(/^Doohickey, Gadget, Gizmo/)
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
@@ -5,6 +5,7 @@ import { HoverCard } from "metabase/ui";
 
 export const WidthBound = styled.div<{ width?: number }>`
   font-size: 14px;
+  min-width: ${(props) => props.width ?? 220}px;
   max-width: ${(props) => props.width ?? 300}px;
 `;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57132

This PR adds a minimum width to the column popover to avoid the distinct values to be truncated too much.

<img width="283" alt="Screenshot 2025-04-24 at 15 48 06" src="https://github.com/user-attachments/assets/952b0b49-72fd-45b8-8e4f-ae7f7920cbd1" />

### To verify
1. Databases -> Sample Database -> Accounts
2. Hover the `Source` table header
3. See most if not all distinct values