### PR TITLE
Move non-redux visualizer types to `metabase-types/api`

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -14,8 +14,8 @@ import type {
   Table,
   UserId,
   VirtualCardDisplay,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import type {
   ActionDisplayType,

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -46,6 +46,7 @@ export * from "./user";
 export * from "./util";
 export * from "./visualization";
 export * from "./visualization-settings";
+export * from "./visualizer";
 
 // ISO8601 timestamp
 export type ISO8601Time = string;

--- a/frontend/src/metabase-types/api/visualizer.ts
+++ b/frontend/src/metabase-types/api/visualizer.ts
@@ -1,0 +1,36 @@
+import type {
+  DatasetColumn,
+  VisualizationDisplay,
+  VisualizationSettings,
+} from "metabase-types/api";
+
+export type VisualizerDataSourceType = "card";
+export type VisualizerDataSourceId = `${VisualizerDataSourceType}:${number}`;
+
+export type VisualizerDataSource = {
+  id: VisualizerDataSourceId;
+  sourceId: number;
+  type: VisualizerDataSourceType;
+  name: string;
+};
+
+export type VisualizerColumnReference = {
+  sourceId: VisualizerDataSourceId;
+  name: string; // in combined dataset
+  originalName: string; // in original dataset
+};
+// a way to use dataset's name as a value
+
+export type VisualizerDataSourceNameReference =
+  `$_${VisualizerDataSourceId}_name`;
+
+export type VisualizerColumnValueSource =
+  | VisualizerColumnReference
+  | VisualizerDataSourceNameReference;
+
+export type VisualizerVizDefinition = {
+  display: VisualizationDisplay | null;
+  columns: DatasetColumn[];
+  columnValuesMapping: Record<string, VisualizerColumnValueSource[]>;
+  settings: VisualizationSettings;
+};

--- a/frontend/src/metabase-types/store/visualizer.ts
+++ b/frontend/src/metabase-types/store/visualizer.ts
@@ -2,25 +2,10 @@ import type {
   Card,
   Dataset,
   DatasetColumn,
-  VisualizationDisplay,
-  VisualizationSettings,
+  VisualizerDataSource,
+  VisualizerDataSourceId,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
-
-export type VisualizerDataSourceType = "card";
-export type VisualizerDataSourceId = `${VisualizerDataSourceType}:${number}`;
-
-export type VisualizerDataSource = {
-  id: VisualizerDataSourceId;
-  sourceId: number;
-  type: VisualizerDataSourceType;
-  name: string;
-};
-
-export type VisualizerColumnReference = {
-  sourceId: VisualizerDataSourceId;
-  name: string; // in combined dataset
-  originalName: string; // in original dataset
-};
 
 type BaseDraggedItem<T> = {
   id: string;
@@ -42,21 +27,6 @@ export type DraggedWellItem = BaseDraggedItem<{
 }>;
 
 export type DraggedItem = DraggedColumn | DraggedWellItem;
-
-// a way to use dataset's name as a value
-export type VisualizerDataSourceNameReference =
-  `$_${VisualizerDataSourceId}_name`;
-
-export type VisualizerColumnValueSource =
-  | VisualizerColumnReference
-  | VisualizerDataSourceNameReference;
-
-export type VisualizerVizDefinition = {
-  display: VisualizationDisplay | null;
-  columns: DatasetColumn[];
-  columnValuesMapping: Record<string, VisualizerColumnValueSource[]>;
-  settings: VisualizationSettings;
-};
 
 export interface VisualizerState extends VisualizerVizDefinition {
   initialState: VisualizerVizDefinition;

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -18,9 +18,9 @@ import type {
   DashboardId,
   DashboardTabId,
   VirtualCard,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import {
   trackCardCreated,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -38,9 +38,9 @@ import type {
   DashboardCard,
   VirtualCard,
   VisualizationSettings,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
 import type { StoreDashcard } from "metabase-types/store";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import S from "./DashCard.module.css";
 import { DashCardActionsPanel } from "./DashCardActionsPanel/DashCardActionsPanel";

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -34,19 +34,19 @@ import { Box, Flex } from "metabase/ui";
 import LegendS from "metabase/visualizations/components/Legend.module.css";
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import { VisualizerModal } from "metabase/visualizer/components/VisualizerModal";
-import {
-  type BaseDashboardCard,
-  type Card,
-  type CardId,
-  type DashCardId,
-  type Dashboard,
-  type DashboardCard,
-  type DashboardTabId,
-  type RecentItem,
-  isRecentCollectionItem,
+import type {
+  BaseDashboardCard,
+  Card,
+  CardId,
+  DashCardId,
+  Dashboard,
+  DashboardCard,
+  DashboardTabId,
+  RecentItem,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
+import { isRecentCollectionItem } from "metabase-types/api";
 import type { State } from "metabase-types/store";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import type { SetDashCardAttributesOpts } from "../actions";
 import {

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -12,8 +12,11 @@ import {
 import { useDispatch } from "metabase/lib/redux";
 import { Button, Flex } from "metabase/ui";
 import { VisualizerModal } from "metabase/visualizer/components/VisualizerModal";
-import type { Dashboard, VirtualDashboardCard } from "metabase-types/api";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
+import type {
+  Dashboard,
+  VirtualDashboardCard,
+  VisualizerVizDefinition,
+} from "metabase-types/api";
 
 import type { VisualizationProps } from "../types";
 

--- a/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
@@ -16,8 +16,7 @@ import {
   removeColumn,
   removeDataSource,
 } from "metabase/visualizer/visualizer.slice";
-import type { DatasetColumn } from "metabase-types/api";
-import type { VisualizerDataSource } from "metabase-types/store/visualizer";
+import type { DatasetColumn, VisualizerDataSource } from "metabase-types/api";
 
 import { useVisualizerUi } from "../../VisualizerUiContext";
 

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
@@ -11,11 +11,12 @@ import {
   addDataSource,
   removeDataSource,
 } from "metabase/visualizer/visualizer.slice";
-import type { DashboardId, SearchResult } from "metabase-types/api";
 import type {
+  DashboardId,
+  SearchResult,
   VisualizerDataSource,
   VisualizerDataSourceId,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import { useVisualizerUi } from "../../VisualizerUiContext";
 

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsListItem.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsListItem.tsx
@@ -10,7 +10,7 @@ import {
   getVisualizerPrimaryColumn,
 } from "metabase/visualizer/selectors";
 import { parseDataSourceId } from "metabase/visualizer/utils";
-import type { VisualizerDataSource } from "metabase-types/store/visualizer";
+import type { VisualizerDataSource } from "metabase-types/api";
 
 import { useVisualizerUi } from "../../VisualizerUiContext";
 

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -12,7 +12,7 @@ import {
   getVisualizationTitle,
 } from "metabase/visualizer/selectors";
 import { setTitle } from "metabase/visualizer/visualizer.slice";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
+import type { VisualizerVizDefinition } from "metabase-types/api";
 
 import { useVisualizerUi } from "../VisualizerUiContext";
 

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -24,10 +24,10 @@ import {
   setDraggedItem,
 } from "metabase/visualizer/visualizer.slice";
 import type {
-  DraggedItem,
   VisualizerDataSourceId,
   VisualizerVizDefinition,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
+import type { DraggedItem } from "metabase-types/store/visualizer";
 
 import { DataImporter } from "../DataImporter";
 import { DragOverlay as VisualizerDragOverlay } from "../DragOverlay";

--- a/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
@@ -9,11 +9,11 @@ import { Modal } from "metabase/ui";
 import { getIsDirty } from "metabase/visualizer/selectors";
 import { getDataSourceIdsFromColumnValueMappings } from "metabase/visualizer/utils";
 import { initializeVisualizer } from "metabase/visualizer/visualizer.slice";
-import type { CardId } from "metabase-types/api";
 import type {
+  CardId,
   VisualizerDataSourceId,
   VisualizerVizDefinition,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import { Visualizer } from "../Visualizer";
 

--- a/frontend/src/metabase/visualizer/components/VisualizerUiContext/VisualizerUiContext.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizerUiContext/VisualizerUiContext.tsx
@@ -14,7 +14,7 @@ import _ from "underscore";
 
 import { useSelector } from "metabase/lib/redux";
 import { getDatasets } from "metabase/visualizer/selectors";
-import type { VisualizerDataSourceId } from "metabase-types/store/visualizer";
+import type { VisualizerDataSourceId } from "metabase-types/api";
 
 type VisualizerUiState = {
   isDataSidebarOpen: boolean;

--- a/frontend/src/metabase/visualizer/utils/click-actions.ts
+++ b/frontend/src/metabase/visualizer/utils/click-actions.ts
@@ -1,6 +1,9 @@
 import type { ClickObject } from "metabase/visualizations/types";
-import type { DatasetColumn, RawSeries } from "metabase-types/api";
-import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
+import type {
+  DatasetColumn,
+  RawSeries,
+  VisualizerColumnValueSource,
+} from "metabase-types/api";
 
 import { isDataSourceNameRef, parseDataSourceId } from "./data-source";
 

--- a/frontend/src/metabase/visualizer/utils/column.ts
+++ b/frontend/src/metabase/visualizer/utils/column.ts
@@ -1,10 +1,10 @@
-import type { DatasetColumn } from "metabase-types/api";
 import type {
+  DatasetColumn,
   VisualizerColumnReference,
   VisualizerColumnValueSource,
   VisualizerDataSource,
   VisualizerDataSourceId,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 export function isReferenceToColumn(
   column: DatasetColumn,

--- a/frontend/src/metabase/visualizer/utils/data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/data-source.ts
@@ -4,7 +4,7 @@ import type {
   VisualizerDataSourceId,
   VisualizerDataSourceNameReference,
   VisualizerDataSourceType,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import { extractReferencedColumns } from "./column";
 

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -10,8 +10,8 @@ import type {
   Dataset,
   DatasetColumn,
   VisualizationDisplay,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import {
   copyColumn,

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -1,10 +1,12 @@
 import { isNotNull } from "metabase/lib/types";
-import type { Card, DatasetColumn, RawSeries } from "metabase-types/api";
 import type {
+  Card,
+  DatasetColumn,
+  RawSeries,
   VisualizerColumnReference,
   VisualizerDataSource,
   VisualizerVizDefinition,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import {
   copyColumn,

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -10,8 +10,8 @@ import type {
   DatasetColumn,
   VisualizationDisplay,
   VisualizationSettings,
+  VisualizerColumnValueSource,
 } from "metabase-types/api";
-import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
 
 import { isScalarFunnel } from "../visualizations/funnel";
 

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -1,10 +1,10 @@
 import registerVisualizations from "metabase/visualizations/register";
+import type { VisualizerColumnValueSource } from "metabase-types/api";
 import {
   createMockCategoryColumn,
   createMockDatetimeColumn,
   createMockNumericColumn,
 } from "metabase-types/api/mocks";
-import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
 
 import { createDataSourceNameRef } from "./data-source";
 import { getUpdatedSettingsForDisplay } from "./get-updated-settings-for-display";

--- a/frontend/src/metabase/visualizer/utils/merge-data.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.ts
@@ -5,12 +5,10 @@ import type {
   DatasetColumn,
   RowValue,
   RowValues,
-} from "metabase-types/api";
-import type {
   VisualizerColumnValueSource,
   VisualizerDataSource,
   VisualizerDataSourceId,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import { extractReferencedColumns } from "./column";
 import { getDataSourceIdFromNameRef, isDataSourceNameRef } from "./data-source";

--- a/frontend/src/metabase/visualizer/utils/split-series.ts
+++ b/frontend/src/metabase/visualizer/utils/split-series.ts
@@ -2,8 +2,11 @@ import _ from "underscore";
 
 import { isNotNull } from "metabase/lib/types";
 import { isCartesianChart } from "metabase/visualizations";
-import type { RawSeries, VisualizationSettings } from "metabase-types/api";
-import type { VisualizerColumnValueSource } from "metabase-types/store/visualizer";
+import type {
+  RawSeries,
+  VisualizationSettings,
+  VisualizerColumnValueSource,
+} from "metabase-types/api";
 
 import { isDataSourceNameRef } from "./data-source";
 

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.ts
@@ -21,13 +21,14 @@ import {
   isMetric,
   isString,
 } from "metabase-lib/v1/types/utils/isa";
-import type { Dataset, DatasetColumn } from "metabase-types/api";
 import type {
+  Dataset,
+  DatasetColumn,
   VisualizerColumnReference,
   VisualizerDataSource,
   VisualizerDataSourceId,
   VisualizerVizDefinition,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import { removeColumnFromStateUnlessUsedElseWhere } from "./utils";
 

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import type { VisualizerVizDefinition } from "metabase-types/api";
 import {
   createMockCategoryColumn,
   createMockColumn,
@@ -7,7 +8,6 @@ import {
   createMockDatetimeColumn,
   createMockNumericColumn,
 } from "metabase-types/api/mocks";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import {
   copyColumn,

--- a/frontend/src/metabase/visualizer/visualizations/funnel.ts
+++ b/frontend/src/metabase/visualizer/visualizations/funnel.ts
@@ -16,12 +16,13 @@ import {
   isMetric,
   isNumeric,
 } from "metabase-lib/v1/types/utils/isa";
-import type { Dataset, DatasetColumn } from "metabase-types/api";
 import type {
+  Dataset,
+  DatasetColumn,
   VisualizerColumnReference,
   VisualizerDataSource,
   VisualizerVizDefinition,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import { removeColumnFromStateUnlessUsedElseWhere } from "./utils";
 

--- a/frontend/src/metabase/visualizer/visualizations/funnel.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/funnel.unit.spec.ts
@@ -1,11 +1,11 @@
 import _ from "underscore";
 
+import type { VisualizerVizDefinition } from "metabase-types/api";
 import {
   createMockCategoryColumn,
   createMockDataset,
   createMockNumericColumn,
 } from "metabase-types/api/mocks";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import {
   createDataSource,

--- a/frontend/src/metabase/visualizer/visualizations/pie.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.ts
@@ -14,11 +14,12 @@ import {
   isMetric,
   isNumeric,
 } from "metabase-lib/v1/types/utils/isa";
-import type { Dataset, DatasetColumn } from "metabase-types/api";
 import type {
+  Dataset,
+  DatasetColumn,
   VisualizerDataSource,
   VisualizerVizDefinition,
-} from "metabase-types/store/visualizer";
+} from "metabase-types/api";
 
 import { removeColumnFromStateUnlessUsedElseWhere } from "./utils";
 

--- a/frontend/src/metabase/visualizer/visualizations/pie.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.unit.spec.ts
@@ -1,9 +1,9 @@
+import type { VisualizerVizDefinition } from "metabase-types/api";
 import {
   createMockCategoryColumn,
   createMockDataset,
   createMockNumericColumn,
 } from "metabase-types/api/mocks";
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
 
 import { createDataSource } from "../utils";
 

--- a/frontend/src/metabase/visualizer/visualizations/utils.ts
+++ b/frontend/src/metabase/visualizer/visualizations/utils.ts
@@ -1,4 +1,4 @@
-import type { VisualizerVizDefinition } from "metabase-types/store/visualizer";
+import type { VisualizerVizDefinition } from "metabase-types/api";
 
 /**
  * Ensures that the column is removed from the state if it is not used in any settings.

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -18,14 +18,14 @@ import type {
   DatasetColumn,
   VisualizationDisplay,
   VisualizationSettings,
+  VisualizerDataSource,
+  VisualizerDataSourceId,
+  VisualizerVizDefinition,
 } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
 import type {
   DraggedItem,
-  VisualizerDataSource,
-  VisualizerDataSourceId,
   VisualizerState,
-  VisualizerVizDefinition,
 } from "metabase-types/store/visualizer";
 
 import {


### PR DESCRIPTION
Moves all the visualizer types not specific to its redux states to `metabase-types/api/visualizer`