### PR TITLE
Prevent non-admins from calling admin-only gsheets endpoints

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -30,7 +30,7 @@ import {
 import Styles from "./Gdrive.module.css";
 import { getStrings } from "./GdriveConnectionModal.strings";
 import { trackSheetImportClick } from "./analytics";
-import { getErrorMessage, getStatus } from "./utils";
+import { getErrorMessage, getStatus, useShowGdrive } from "./utils";
 
 export function GdriveConnectionModal({
   isModalOpen,
@@ -41,10 +41,17 @@ export function GdriveConnectionModal({
   onClose: () => void;
   reconnect: boolean;
 }) {
+  const shouldShow = useShowGdrive();
   const { data: { email: serviceAccountEmail } = {} } =
-    useGetServiceAccountQuery();
+    useGetServiceAccountQuery(shouldShow ? undefined : skipToken);
 
-  const { data: gSheetData, error } = useGetGsheetsFolderQuery();
+  const { data: gSheetData, error } = useGetGsheetsFolderQuery(
+    shouldShow ? undefined : skipToken,
+  );
+
+  if (!shouldShow) {
+    return null;
+  }
 
   const status = getStatus({ status: gSheetData?.status, error });
 


### PR DESCRIPTION
### Description

The Add data button in the sidebar (for cloud instances with a data warehouse connected), has the gdrive connection modal embedded in it. That modal was making API requests for gdrive connections even if the user was not an admin, which were always throwing 403 errors.

This adds a proper check to the connection modal (using the `useShowGdrive` hook to prevent those api requests. (this hook was already used in the other relevant components).


![Screenshot 2025-04-24 at 8 16 03 AM](https://github.com/user-attachments/assets/11fb6ad1-7d42-45ec-a05c-c694ed43740d)

![image_720](https://github.com/user-attachments/assets/d752c465-ce8e-4701-88cc-79ab13eec993)

- [x] added unit test