### PR TITLE
[refs] Turn bad `:ident`s in `result_metadata` into a warning

### DIFF
--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -297,5 +297,5 @@ saved later when it is ready."
   (when-let [invalid (seq (remove #(or (nil? (:ident %))
                                        (valid-ident? % card))
                                   cols))]
-    (throw (ex-info "Some columns in :result_metadata have bad :idents!"
-                    {:invalid invalid}))))
+    (log/warnf "Some columns in :result_metadata (card %d %s %s) have bad :idents! Query %s and bad columns %s"
+               (:id card) (:entity_id card) (str (:type card)) (:dataset_query card) invalid)))


### PR DESCRIPTION
### Description

There are at least two cases right now where the idents are bad or
missing that need debugging, but throwing errors is breaking things.

### How to verify

Using your eyeballs. I can't suggest a better test since I don't know yet how to reproduce any of
the "bad idents" cases that are throwing errors in stats!

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~ Not possible or necessary.
