### PR TITLE
refactor: make useTableCRUD consume primary key instead of row index

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
@@ -66,8 +66,8 @@ export const EditTableDashcardVisualization = ({
     tableFieldMetadataMap,
 
     handleRowCreate,
-    handleCellValueUpdate,
-    handleExpandedRowDelete,
+    handleRowUpdate,
+    handleRowDelete,
     handleModalOpenAndExpandedRow,
   } = useTableCRUD({ tableId, datasetData: data, stateUpdateStrategy });
 
@@ -143,7 +143,7 @@ export const EditTableDashcardVisualization = ({
         <EditTableDataGrid
           data={data}
           fieldMetadataMap={tableFieldMetadataMap}
-          onCellValueUpdate={handleCellValueUpdate}
+          onRowUpdate={handleRowUpdate}
           onRowExpandClick={handleModalOpenAndExpandedRow}
           columnsConfig={columnsConfig}
           getColumnSortDirection={getColumnSortDirection}
@@ -165,9 +165,9 @@ export const EditTableDashcardVisualization = ({
         opened={isCreateRowModalOpen}
         hasDeleteAction={hasDeleteAction}
         onClose={closeCreateRowModal}
-        onEdit={handleCellValueUpdate}
+        onEdit={handleRowUpdate}
         onRowCreate={handleRowCreate}
-        onRowDelete={handleExpandedRowDelete}
+        onRowDelete={handleRowDelete}
         datasetColumns={data.cols}
         currentRowIndex={expandedRowIndex}
         currentRowData={

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
@@ -72,8 +72,8 @@ export const EditTableDataContainer = ({
     tableFieldMetadataMap,
 
     handleRowCreate,
-    handleCellValueUpdate,
-    handleExpandedRowDelete,
+    handleRowUpdate,
+    handleRowDelete,
     handleModalOpenAndExpandedRow,
   } = useTableCRUD({ tableId, datasetData, stateUpdateStrategy });
 
@@ -126,7 +126,7 @@ export const EditTableDataContainer = ({
               <EditTableDataGrid
                 data={datasetData}
                 fieldMetadataMap={tableFieldMetadataMap}
-                onCellValueUpdate={handleCellValueUpdate}
+                onRowUpdate={handleRowUpdate}
                 onRowExpandClick={handleModalOpenAndExpandedRow}
               />
             </Box>
@@ -154,9 +154,9 @@ export const EditTableDataContainer = ({
       <EditingBaseRowModal
         opened={isCreateRowModalOpen}
         onClose={closeCreateRowModal}
-        onEdit={handleCellValueUpdate}
+        onEdit={handleRowUpdate}
         onRowCreate={handleRowCreate}
-        onRowDelete={handleExpandedRowDelete}
+        onRowDelete={handleRowDelete}
         datasetColumns={datasetData.cols}
         currentRowIndex={expandedRowIndex}
         currentRowData={

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.tsx
@@ -8,8 +8,6 @@ import type {
   RowValues,
 } from "metabase-types/api";
 
-import type { UpdatedRowCellsHandlerParams } from "../types";
-
 import S from "./EditingBodyCell.module.css";
 import { EditingBodyCellConditional } from "./inputs";
 
@@ -17,7 +15,7 @@ interface EditingBodyCellWrapperProps<TRow, TValue> {
   column: DatasetColumn;
   field?: FieldWithMetadata;
   cellContext: CellContext<TRow, TValue>;
-  onCellValueUpdate: (params: UpdatedRowCellsHandlerParams) => void;
+  onCellValueUpdate: (rowIndex: number, data: Record<string, RowValue>) => void;
   onCellEditCancel: () => void;
 }
 
@@ -41,10 +39,7 @@ export const EditingBodyCellWrapper = (
   const doCellValueUpdate = useCallback(
     (value: RowValue) => {
       if (value !== initialValue) {
-        onCellValueUpdate({
-          updatedData: { [columnName]: value },
-          rowIndex,
-        });
+        onCellValueUpdate(rowIndex, { [columnName]: value });
       }
 
       // Hide the editing cell after submitting the value

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
@@ -29,11 +29,6 @@ export type TableDeleteRowsRequest = {
 
 export type TableDeleteRowsResponse = { success: boolean };
 
-export type UpdatedRowCellsHandlerParams = {
-  updatedData: Record<DatasetColumn["name"], RowValue>;
-  rowIndex: number;
-};
-
 export type TableUndoRedoRequest = {
   tableId: ConcreteTableId;
   /**


### PR DESCRIPTION
`useTableCRUD` hooks now consume `primaryKey` instead of `rowIndex`, so it's a better and clearer abstraction. Also some hooks and functions are renamed to be more consistent
