### PR TITLE
ci: make cross versions tests run only if the pr is against a release branch

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -139,7 +139,7 @@ jobs:
     secrets: inherit
 
   cross-version-for-breaking-changes:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && ${{ startsWith(inputs.branch, 'release-x.') }}
     uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Closes EMB-341

We only run them on prs to master to get data on more runs, we can now set them as it should be to only prs on release branches
