### PR TITLE
Add check to prevent double comma's in the custom expression editor

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -369,8 +369,8 @@ describe("diagnostics", () => {
       );
     });
 
-    describe("double comma", () => {
-      it("should reject repeated comma's", () => {
+    describe("double commas", () => {
+      it("should reject repeated commas", () => {
         expect(err(`concat("foo",, "bar")`)).toBe(
           "Expected expression but got: ,",
         );

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -368,6 +368,20 @@ describe("diagnostics", () => {
         },
       );
     });
+
+    describe("double comma", () => {
+      it("should reject repeated comma's", () => {
+        expect(err(`concat("foo",, "bar")`)).toBe(
+          "Expected expression but got: ,",
+        );
+        expect(err(`concat("foo", , "bar")`)).toBe(
+          "Expected expression but got: ,",
+        );
+        expect(err(`concat("foo",,, "bar")`)).toBe(
+          "Expected expression but got: ,",
+        );
+      });
+    });
   });
 
   describe("diagnoseAndCompile", () => {

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-double-comma.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-double-comma.ts
@@ -1,0 +1,19 @@
+import { t } from "ttag";
+
+import { COMMA, type Token } from "../../pratt";
+import { error } from "../utils";
+
+export function checkDoubleComma({ tokens }: { tokens: Token[] }) {
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    const prevToken = tokens[i - 1];
+
+    if (!token || !prevToken) {
+      continue;
+    }
+
+    if (token.type === COMMA && prevToken.type === COMMA) {
+      error(token, t`Expected expression but got: ,`);
+    }
+  }
+}

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-double-commas.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/check-double-commas.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { COMMA, type Token } from "../../pratt";
 import { error } from "../utils";
 
-export function checkDoubleComma({ tokens }: { tokens: Token[] }) {
+export function checkDoubleCommas({ tokens }: { tokens: Token[] }) {
   for (let i = 1; i < tokens.length; i++) {
     const token = tokens[i];
     const prevToken = tokens[i - 1];

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
@@ -1,7 +1,7 @@
 import type { Token } from "../../pratt";
 
 import { checkBadTokens } from "./check-bad-tokens";
-import { checkDoubleComma } from "./check-double-comma";
+import { checkDoubleCommas } from "./check-double-commas";
 import { checkFieldQuotes } from "./check-field-quotes";
 import { checkMatchingParentheses } from "./check-matching-parenthesis";
 import { checkMissingCommasInArgumentList } from "./check-missing-comma-in-argument-list";
@@ -17,7 +17,7 @@ export const syntaxChecks = [
   checkStringQuotes,
   checkFieldQuotes,
   checkBadTokens,
-  checkDoubleComma,
+  checkDoubleCommas,
 ];
 
 export function diagnoseExpressionSyntax(options: {

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/syntax/index.ts
@@ -1,6 +1,7 @@
 import type { Token } from "../../pratt";
 
 import { checkBadTokens } from "./check-bad-tokens";
+import { checkDoubleComma } from "./check-double-comma";
 import { checkFieldQuotes } from "./check-field-quotes";
 import { checkMatchingParentheses } from "./check-matching-parenthesis";
 import { checkMissingCommasInArgumentList } from "./check-missing-comma-in-argument-list";
@@ -16,6 +17,7 @@ export const syntaxChecks = [
   checkStringQuotes,
   checkFieldQuotes,
   checkBadTokens,
+  checkDoubleComma,
 ];
 
 export function diagnoseExpressionSyntax(options: {


### PR DESCRIPTION
Currently it's possible to write an expression like 
```
concat("foo",, "bar")
```

This PR adds a syntax checker to prevent that.