### PR TITLE
[SEM-219] Humanize error message even more

### DIFF
--- a/test/metabase/api/logger_test.clj
+++ b/test/metabase/api/logger_test.clj
@@ -116,3 +116,20 @@
       (finally
         (logger/remove-ns-logger! trace-ns)
         (logger/remove-ns-logger! fatal-ns)))))
+
+(deftest ^:sequential invalid-adjustment-test
+  (testing "invalid level"
+    (is (= {:specific-errors
+            {:my.namespace
+             ["should be either \"trace\", \"debug\", \"info\", \"warn\", \"error\", \"fatal\" or \"off\", received: \"ok\""],
+             :my.other.namespace
+             ["should be either \"trace\", \"debug\", \"info\", \"warn\", \"error\", \"fatal\" or \"off\", received: \"catastophic\""]},
+            :errors
+            [{:log_levels
+              "The format of the provided logging configuration is incorrect. Please follow the following JSON structure:
+{
+  \"namespace\": \"trace\" | \"debug\" | \"info\" | \"warn\" | \"error\" | \"fatal\" | \"off\"
+}"}]}
+           (mt/user-http-request :crowberto :post 400 "logger/adjustment"
+                                 {:duration 1, :duration_unit :hours, :log_levels {"my.namespace" :ok
+                                                                                   "my.other.namespace" :catastophic}})))))


### PR DESCRIPTION
### Description

To provide the customized error message, the type check built into the defendpoint framework has to be disabled, which results in less specific API documentation.

(Malli has an experimental feature we currently don't use for looking up humanized errors from parent schemas, that would let us configure the error message AND keep the input type information.)

### How to verify

Check out the new test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
