### PR TITLE
[refs] Debugging `card-entity-id` missing from some queries

### DIFF
--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -272,16 +272,17 @@
 
 (defn- pulse-card-query-results
   {:arglists '([card])}
-  [{query :dataset_query, card-id :id}]
+  [{query :dataset_query, card-id :id, card-entity-id :entity_id}]
   (binding [qp.perms/*card-id* card-id]
     (qp/process-query
      (qp/userland-query
       (assoc query
              :middleware {:process-viz-settings? true
                           :js-int-to-string?     false})
-      {:executed-by api/*current-user-id*
-       :context     :pulse
-       :card-id     card-id}))))
+      {:executed-by    api/*current-user-id*
+       :context        :pulse
+       :card-id        card-id
+       :card-entity-id card-entity-id}))))
 
 (api.macros/defendpoint :get "/preview_card/:id"
   "Get HTML rendering of a Card with `id`."


### PR DESCRIPTION
### Description

Based on errors in Stats, there are some code paths where native queries are being run without the card's `entity_id`
available, so `:ident`s cannot be computed. That shouldn't happen!

- I found one obvious missing case in pulses and fixed it.
- Adding more precise logging in the `annotate` middleware

**Temporary debugging aid:** The stack traces are getting truncated in Grafana so I can't see who called QP
without specifying the card correctly. So temporarily adding an atom that holds the most recent 5 such errors,
which I can examine at the stats REPL and track down the culprits.

### How to verify

Fixes one source of incorrect native queries. See new logs in stdout and Grafana.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
