### PR TITLE
Keyboard Shortcut Polish

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -373,7 +373,7 @@ describe("command palette", () => {
   });
 });
 
-H.describeWithSnowplow.only("shortcuts", { tags: ["@actions"] }, () => {
+H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -373,7 +373,7 @@ describe("command palette", () => {
   });
 });
 
-H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
+H.describeWithSnowplow.only("shortcuts", { tags: ["@actions"] }, () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();
@@ -393,6 +393,15 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
       cy.findByRole("tab", { name: "General" }).should("exist");
       cy.findByRole("tab", { name: "Dashboard" }).should("exist");
     });
+    cy.realPress("Escape");
+    H.shortcutModal().should("not.exist");
+    H.openShortcutModal();
+    cy.realPress("?");
+    H.shortcutModal().should("not.exist");
+
+    H.appBar().findByRole("img", { name: /gear/ }).click();
+    H.popover().findByText("Keyboard Shortcuts").click();
+    H.shortcutModal().should("exist");
     cy.realPress("Escape");
     H.shortcutModal().should("not.exist");
 
@@ -504,6 +513,11 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("Escape");
     cy.realPress("e");
     cy.findByTestId("edit-bar").should("not.exist");
+
+    cy.realPress("]");
+    cy.findByRole("dialog", { name: "Info" }).should("exist");
+    cy.realPress("]");
+    cy.findByRole("dialog", { name: "Info" }).should("not.exist");
   });
 
   it("should support query builder shortcuts", () => {
@@ -527,14 +541,13 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     // Sidesheet
     cy.realPress("]");
     cy.findByRole("dialog", { name: "Info" }).should("exist");
-    // Should be able to toggle again in ], but modals disable shortcuts
-    cy.realPress("Escape");
+    cy.realPress("]");
     cy.findByRole("dialog", { name: "Info" }).should("not.exist");
 
     // Viz Settings
-    cy.realPress("z").realPress("s");
+    cy.realPress("y");
     cy.findByTestId("chartsettings-sidebar").should("exist");
-    cy.realPress("z").realPress("s");
+    cy.realPress("y");
     cy.findByTestId("chartsettings-sidebar").should("not.exist");
 
     // Viz toggle

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddQuestionButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddQuestionButton.tsx
@@ -29,6 +29,10 @@ export const AddQuestionButton = () => {
         id: "dashboard-add-native-question",
         perform: () => dispatch(addDashboardQuestion("native")),
       },
+      {
+        id: "dashboard-toggle-add-question-sidepanel",
+        perform: () => dispatch(toggleSidebar(SIDEBAR_NAME.addQuestion)),
+      },
     ],
     [sidebarOpen],
   );

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -1,6 +1,6 @@
 import type { FocusEvent } from "react";
 import { useCallback, useMemo, useState } from "react";
-import { useMount } from "react-use";
+import { useKey, useMount } from "react-use";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
@@ -54,6 +54,7 @@ export function DashboardInfoSidebar({
   onClose,
 }: DashboardInfoSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
+  useKey("]", onClose);
 
   useMount(() => {
     // this component is not rendered until it is "open"

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -1,6 +1,7 @@
+import { useHotkeys } from "@mantine/hooks";
 import type { FocusEvent } from "react";
 import { useCallback, useMemo, useState } from "react";
-import { useKey, useMount } from "react-use";
+import { useMount } from "react-use";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
@@ -54,7 +55,7 @@ export function DashboardInfoSidebar({
   onClose,
 }: DashboardInfoSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
-  useKey("]", onClose);
+  useHotkeys([["]", onClose]]);
 
   useMount(() => {
     // this component is not rendered until it is "open"

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
@@ -21,9 +21,10 @@ import {
 } from "metabase/home/selectors";
 import { color } from "metabase/lib/colors";
 import { capitalize } from "metabase/lib/formatting";
-import { connect, useSelector } from "metabase/lib/redux";
+import { connect, useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { openDiagnostics } from "metabase/redux/app";
+import { setOpenModal } from "metabase/redux/ui";
 import {
   getApplicationName,
   getIsWhiteLabeling,
@@ -59,6 +60,7 @@ function ProfileLink({
   const applicationName = useSelector(getApplicationName);
   const { tag, date, ...versionExtra } = version;
   const helpLink = useHelpLink();
+  const dispatch = useDispatch();
 
   const openModal = (modalName) => {
     setModalOpen(modalName);
@@ -100,6 +102,11 @@ function ProfileLink({
           link: "/getting-started",
           event: `Navbar;Profile Dropdown;Getting Started`,
         },
+      {
+        title: t`Keyboard Shortcuts`,
+        icon: null,
+        action: () => dispatch(setOpenModal("help")),
+      },
       {
         title: t`Report an issue`,
         icon: null,

--- a/frontend/src/metabase/palette/components/PaletteShortcutsModal/PaletteShortcutsModal.tsx
+++ b/frontend/src/metabase/palette/components/PaletteShortcutsModal/PaletteShortcutsModal.tsx
@@ -1,4 +1,5 @@
 import cx from "classnames";
+import { useKey } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -32,6 +33,8 @@ export const PaletteShortcutsModal = ({
   onClose: ModalProps["onClose"];
   open: boolean;
 }) => {
+  useKey("?", () => onClose());
+
   return (
     <Modal
       opened={open}

--- a/frontend/src/metabase/palette/components/PaletteShortcutsModal/PaletteShortcutsModal.tsx
+++ b/frontend/src/metabase/palette/components/PaletteShortcutsModal/PaletteShortcutsModal.tsx
@@ -1,5 +1,5 @@
+import { useWindowEvent } from "@mantine/hooks";
 import cx from "classnames";
-import { useKey } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -33,7 +33,8 @@ export const PaletteShortcutsModal = ({
   onClose: ModalProps["onClose"];
   open: boolean;
 }) => {
-  useKey("?", () => onClose());
+  // I don't know why this needs to be a window event. useHotKeys doesn't work with this modal.
+  useWindowEvent("keydown", (event) => event.key === "?" && onClose());
 
   return (
     <Modal

--- a/frontend/src/metabase/palette/shortcuts/dashboard.ts
+++ b/frontend/src/metabase/palette/shortcuts/dashboard.ts
@@ -21,11 +21,21 @@ export const dashboardShortcuts = {
       return t`When editing`;
     },
   },
+  "dashboard-toggle-add-question-sidepanel": {
+    get name() {
+      return t`Open Add Question Side Sheet`;
+    },
+    shortcut: ["a"],
+    shortcutGroup: "dashboard",
+    get shortcutContext() {
+      return t`When editing`;
+    },
+  },
   "dashboard-add-notebook-question": {
     get name() {
       return t`Add Notebook Question`;
     },
-    shortcut: ["a q"],
+    shortcut: ["q"],
     shortcutGroup: "dashboard",
     get shortcutContext() {
       return t`When editing`;
@@ -35,7 +45,7 @@ export const dashboardShortcuts = {
     get name() {
       return t`Add Native Question`;
     },
-    shortcut: ["a n"],
+    shortcut: ["n"],
     shortcutGroup: "dashboard",
     get shortcutContext() {
       return t`When editing`;

--- a/frontend/src/metabase/palette/shortcuts/question.ts
+++ b/frontend/src/metabase/palette/shortcuts/question.ts
@@ -55,14 +55,14 @@ export const questionShortcuts = {
       return t`Toggle viz settings`;
     },
     shortcutGroup: "question",
-    shortcut: ["z s"],
+    shortcut: ["s"],
   },
   "query-builder-toggle-viz-types": {
     get name() {
       return t`Toggle viz types`;
     },
     shortcutGroup: "question",
-    shortcut: ["z t"],
+    shortcut: ["t"],
   },
   "query-builder-send-to-trash": {
     get name() {

--- a/frontend/src/metabase/palette/shortcuts/question.ts
+++ b/frontend/src/metabase/palette/shortcuts/question.ts
@@ -45,7 +45,7 @@ export const questionShortcuts = {
   },
   "query-builder-toggle-visualization": {
     get name() {
-      return t`Toggle viz settings`;
+      return t`Toggle visualization`;
     },
     shortcut: ["v"],
     shortcutGroup: "question",
@@ -55,7 +55,7 @@ export const questionShortcuts = {
       return t`Toggle viz settings`;
     },
     shortcutGroup: "question",
-    shortcut: ["s"],
+    shortcut: ["y"],
   },
   "query-builder-toggle-viz-types": {
     get name() {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
@@ -1,5 +1,6 @@
+import { useHotkeys } from "@mantine/hooks";
 import { useMemo, useState } from "react";
-import { useKey, useMount } from "react-use";
+import { useMount } from "react-use";
 import { t } from "ttag";
 
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
@@ -53,7 +54,7 @@ export const QuestionInfoSidebar = ({
   const dispatch = useDispatch();
   const handleClose = () => dispatch(onCloseQuestionInfo());
 
-  useKey("]", handleClose);
+  useHotkeys([["]", handleClose]]);
 
   const [isOpen, setIsOpen] = useState(false);
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useMount } from "react-use";
+import { useKey, useMount } from "react-use";
 import { t } from "ttag";
 
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
@@ -52,6 +52,8 @@ export const QuestionInfoSidebar = ({
 
   const dispatch = useDispatch();
   const handleClose = () => dispatch(onCloseQuestionInfo());
+
+  useKey("]", handleClose);
 
   const [isOpen, setIsOpen] = useState(false);
 


### PR DESCRIPTION
Closes ADM-692
Closes ADM-693

### Description
A bundle of small changes. This updates some of the contextual shortcuts to be single key presses, allows you to toggle the shortcuts modal and question/dashboard sidesheets with their respective shortcuts, and adds a menu item in the profile menu to increase discoverability

### How to verify
1. In the app bar, click the gear icon, then click `Keyboard Shortcuts`
2. This should open the Shortcuts glossary. press `?` and it should close
3. open a question or dashboard. Pressing `]` should toggle the info sidesheet open and closed
4. Try some of the new shortcuts:
- - `t` open viz types in query builder
- - `y` open viz settings in query builder
- - `a` to open add question panel in dashboard edit mode
- - `q` to add a dashboard question in dashboard edit mode
- - `n` to add a native dashboard question in dashboard edit mode

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
