### PR TITLE
Apply filter split button

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -682,10 +682,8 @@ describe("issue 25990", () => {
       cy.findByText("People").click();
       cy.findByText("ID").click();
       cy.findByPlaceholderText("Enter an ID").type("10").blur();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
 
     cy.findByTestId("qb-filters-panel")
@@ -1208,9 +1206,8 @@ describe("issue 45252", { tags: "@external" }, () => {
     H.popover().within(() => {
       cy.findByText("Binary").click();
       cy.findByLabelText("Is empty").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
     H.assertQueryBuilderRowCount(0);
 
@@ -1226,9 +1223,8 @@ describe("issue 45252", { tags: "@external" }, () => {
     H.popover().within(() => {
       cy.findByText("Jsonb").click();
       cy.findByLabelText("Not empty").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
     H.assertQueryBuilderRowCount(2);
   });

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -94,9 +94,9 @@ describe("scenarios > filters > bulk filtering", () => {
     H.popover().within(() => {
       cy.findByText("Quantity").click();
       cy.findByText("20").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    applyFilters();
+    cy.wait("@dataset");
 
     H.queryBuilderFiltersPanel()
       .findByText("Quantity is equal to 20")
@@ -124,9 +124,9 @@ describe("scenarios > filters > bulk filtering", () => {
       cy.findByText("Summaries").click();
       cy.findByText("Count").click();
       cy.findByPlaceholderText("Min").type("500");
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    applyFilters();
+    cy.wait("@dataset");
     H.queryBuilderFiltersPanel()
       .findByText("Count is greater than or equal to 500")
       .should("be.visible");
@@ -140,9 +140,9 @@ describe("scenarios > filters > bulk filtering", () => {
       cy.findByText("Product").click();
       cy.findByText("Category").click();
       cy.findByText("Gadget").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    applyFilters();
+    cy.wait("@dataset");
     H.queryBuilderFiltersPanel()
       .findByText("Product → Category is Gadget")
       .should("be.visible");
@@ -215,9 +215,9 @@ describe("scenarios > filters > bulk filtering", () => {
       cy.findByText("Summaries (3)").click();
       cy.findByText("Category").click();
       cy.findByText("Doohickey").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    applyFilters();
+    cy.wait("@dataset");
 
     cy.log("check filters from all stages to be present in the filter panel");
     H.queryBuilderFiltersPanel().within(() => {
@@ -295,7 +295,7 @@ describe("scenarios > filters > bulk filtering", () => {
       });
 
       H.popover().findByText(SEGMENT_2_NAME).click();
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText(SEGMENT_2_NAME)
         .should("be.visible");
@@ -343,9 +343,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("boolean").click();
         cy.findByText("True").click();
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.assertQueryBuilderRowCount(2);
     });
 
@@ -353,9 +353,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("boolean").click();
         cy.findByText("True").click();
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.assertQueryBuilderRowCount(2);
 
       H.queryBuilderFiltersPanel().findByText("boolean is true").click();
@@ -371,9 +371,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("boolean").click();
         cy.findByText("True").click();
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.assertQueryBuilderRowCount(2);
 
       H.queryBuilderFiltersPanel()
@@ -396,7 +396,7 @@ describe("scenarios > filters > bulk filtering", () => {
         cy.findByText("Created At").click();
         cy.findByText("Today").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
 
       H.queryBuilderFiltersPanel()
         .findByText("Created At is today")
@@ -408,7 +408,7 @@ describe("scenarios > filters > bulk filtering", () => {
         cy.findByText("Created At").click();
         cy.findByText("Previous 3 months").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("Created At is in the previous 3 months")
         .should("be.visible");
@@ -425,9 +425,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("Source").click();
         cy.findByText("Affiliate").click();
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("Source is Affiliate")
         .should("be.visible");
@@ -438,9 +438,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("State").click();
         cy.findByText("AZ").click();
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("State is AZ")
         .should("be.visible");
@@ -458,9 +458,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("ID").click();
         cy.findByLabelText("Filter value").type("17,18");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.assertQueryBuilderRowCount(2);
       H.tableInteractive().within(() => {
         cy.findByText("131.68").should("be.visible"); // total for order id 17
@@ -472,9 +472,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("Product ID").click();
         cy.findByLabelText("Filter value").type("65");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.assertQueryBuilderRowCount(107);
     });
   });
@@ -490,9 +490,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.selectFilterOperator("Contains");
       H.popover().within(() => {
         cy.findByLabelText("Filter value").type("Indian");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.assertQueryBuilderRowCount(5);
     });
 
@@ -501,9 +501,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.selectFilterOperator("Ends with");
       H.popover().within(() => {
         cy.findByLabelText("Filter value").type("Valley");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.assertQueryBuilderRowCount(8);
     });
 
@@ -513,9 +513,9 @@ describe("scenarios > filters > bulk filtering", () => {
         cy.findByLabelText("Filter value")
           .type("Indiantown,Indian Valley")
           .blur();
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("City is 2 selections")
         .should("be.visible");
@@ -534,9 +534,9 @@ describe("scenarios > filters > bulk filtering", () => {
         cy.findByText("Price").click();
         cy.findByPlaceholderText("Min").type("50");
         cy.findByPlaceholderText("Max").type("80");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("Price is between 50 and 80")
         .should("be.visible");
@@ -548,9 +548,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.selectFilterOperator("Greater than");
       H.popover().within(() => {
         cy.findByLabelText("Filter value").type("50");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("Price is greater than 50")
         .should("be.visible");
@@ -561,9 +561,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.popover().within(() => {
         cy.findByText("Price").click();
         cy.findByPlaceholderText("Max").type("50");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("Price is less than or equal to 50")
         .should("be.visible");
@@ -597,9 +597,9 @@ describe("scenarios > filters > bulk filtering", () => {
       H.selectFilterOperator("Greater than");
       H.popover().within(() => {
         cy.findByLabelText("Filter value").type("90");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      applyFilters();
+      cy.wait("@dataset");
       H.queryBuilderFiltersPanel()
         .findByText("Price is greater than 90")
         .should("be.visible");
@@ -607,8 +607,3 @@ describe("scenarios > filters > bulk filtering", () => {
     });
   });
 });
-
-const applyFilters = () => {
-  H.runButtonOverlay().click();
-  cy.wait("@dataset");
-};

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -184,6 +184,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
   it("should be able to add and remove filters for all query stages", () => {
     H.visitQuestionAdhoc(multiStageQuestionDetails);
+    cy.get("@dataset.all").should("have.length", 1);
 
     cy.log("add filters for all stages in the filter modal");
     cy.log("stage 0");
@@ -191,26 +192,29 @@ describe("scenarios > filters > bulk filtering", () => {
     H.popover().within(() => {
       cy.findByText("Category").click();
       cy.findByText("Gadget").click();
-      cy.button("Add filter").click();
+      cy.button("Add another filter").click();
     });
+    cy.get("@dataset.all").should("have.length", 1);
+
     cy.log("stage 1");
-    H.filter();
     H.popover().within(() => {
       cy.findByText("Summaries").click();
       cy.findByText("Category").click();
       cy.findByText("Widget").click();
-      cy.button("Add filter").click();
+      cy.button("Add another filter").click();
     });
+    cy.get("@dataset.all").should("have.length", 1);
+
     cy.log("stage 2");
-    H.filter();
     H.popover().within(() => {
       cy.findByText("Summaries (2)").click();
       cy.findByText("Category").click();
       cy.findByText("Gizmo").click();
-      cy.button("Add filter").click();
+      cy.button("Add another filter").click();
     });
+    cy.get("@dataset.all").should("have.length", 1);
+
     cy.log("stage 3");
-    H.filter();
     H.popover().within(() => {
       cy.findByText("Summaries (3)").click();
       cy.findByText("Category").click();
@@ -218,6 +222,7 @@ describe("scenarios > filters > bulk filtering", () => {
       cy.button("Apply filter").click();
     });
     cy.wait("@dataset");
+    cy.get("@dataset.all").should("have.length", 2);
 
     cy.log("check filters from all stages to be present in the filter panel");
     H.queryBuilderFiltersPanel().within(() => {

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -106,9 +106,8 @@ describe("scenarios > question > filter", () => {
     H.popover().within(() => {
       cy.findByText("Product ID").click();
       cy.findByText("Aerodynamic Linen Coat").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
 
     cy.log("Reported failing on v0.36.4 and v0.36.5.1");
     cy.findByTestId("loading-indicator").should("not.exist");
@@ -738,9 +737,8 @@ describe("scenarios > question > filter", () => {
     H.popover().within(() => {
       cy.findByText("Category").click();
       cy.findByText("Gizmo").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     H.openNotebook();
 
     H.verifyNotebookQuery("Products", [

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1330,9 +1330,8 @@ describe("issue 45300", () => {
       cy.findAllByText("Product").should("have.length", 2).first().click();
       cy.findByText("Category").click();
       cy.findByText("Doohickey").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
 
     cy.findByTestId("filter-pill").should(

--- a/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
@@ -74,9 +74,8 @@ describe("scenarios > metrics > question", () => {
       cy.findByText("Product").click();
       cy.findByText("Category").click();
       cy.findByText("Gadget").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.findByTestId("scalar-container")
       .findByText("4,939")
       .should("be.visible");

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -393,9 +393,8 @@ describe("scenarios > models metadata", () => {
           cy.findByText("User").click();
           cy.findByText("Source").click();
           cy.findByText("Twitter").click();
-          cy.button("Add filter").click();
+          cy.button("Apply filter").click();
         });
-        H.runButtonOverlay().click();
         cy.wait("@dataset");
         cy.findByTestId("question-row-count")
           .invoke("text")

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -52,9 +52,8 @@ describe("scenarios > models", () => {
       H.selectFilterOperator("Contains");
       H.popover().within(() => {
         cy.findByLabelText("Filter value").type("Fisher");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      H.runButtonOverlay().click();
       cy.wait("@dataset");
 
       assertQuestionIsBasedOnModel({
@@ -103,9 +102,8 @@ describe("scenarios > models", () => {
     H.selectFilterOperator("Contains");
     H.popover().within(() => {
       cy.findByLabelText("Filter value").type("Fisher");
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
 
     assertQuestionIsBasedOnModel({
@@ -170,9 +168,8 @@ describe("scenarios > models", () => {
     H.selectFilterOperator("Greater than");
     H.popover().within(() => {
       cy.findByLabelText("Filter value").type("30");
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset").then(({ response }) => {
       expect(response.body.error).to.not.exist;
     });
@@ -465,8 +462,7 @@ describe("scenarios > models", () => {
       H.filter();
       H.popover().findByText("Discount").click();
       H.selectFilterOperator("Not empty");
-      H.popover().button("Add filter").click();
-      H.runButtonOverlay().click();
+      H.popover().button("Apply filter").click();
       cy.wait("@dataset");
 
       assertQuestionIsBasedOnModel({

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -613,7 +613,6 @@ describe(
         cy.findByText("Created At").click();
         cy.findByText("Today").click();
       });
-      H.runButtonOverlay().click();
       cy.wait("@dataset");
       cy.get("[data-testid=cell-data]")
         .should("have.length", 4)
@@ -956,9 +955,8 @@ describe("issue 28971", () => {
     H.popover().within(() => {
       cy.findByText("Quantity").click();
       cy.findByText("20").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is equal to 20").should("exist");
@@ -997,9 +995,8 @@ describe("issue 28971", () => {
     H.popover().within(() => {
       cy.findByText("Quantity").click();
       cy.findByText("20").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is equal to 20").should("exist");
@@ -2133,7 +2130,6 @@ describe("cumulative count - issue 33330", () => {
       cy.findByText("Created At").click();
       cy.findByText("Today").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
 
     H.queryBuilderHeader().findByLabelText("Show filters").click();

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -197,9 +197,8 @@ describe("scenarios > question > native", () => {
       H.selectFilterOperator(operator);
       H.popover().within(() => {
         cy.findByLabelText("Filter value").type("This has a value");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      H.runButtonOverlay().click();
 
       cy.log(
         `**Mid-point assertion for "${operator}" filter| FAILING in v0.36.6**`,

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -571,9 +571,8 @@ describe(
           H.popover().within(() => {
             cy.findAllByText("ID").should("have.length", 2).first().click();
             cy.findByLabelText("Filter value").type(id).click();
-            cy.button("Add filter").click();
+            cy.button("Apply filter").click();
           });
-          H.runButtonOverlay().click();
           H.assertQueryBuilderRowCount(1);
           removeFilter();
 
@@ -2291,7 +2290,7 @@ describe("issue 48829", () => {
     H.modal().should("not.exist");
   });
 
-  it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after adding a filter via the filter modal (metabase#48829)", () => {
+  it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after adding a filter via the filter picker (metabase#48829)", () => {
     H.createQuestion(questionDetails, { visitQuestion: true });
 
     H.queryBuilderHeader()
@@ -2300,9 +2299,8 @@ describe("issue 48829", () => {
     H.popover().within(() => {
       cy.findByText("Category").click();
       cy.findByText("Doohickey").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
 
     H.queryBuilderHeader()
       .button(/Editor/)

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -1164,7 +1164,7 @@ describe("scenarios > question > multiple column breakouts", () => {
             cy.findByText("Between").click();
             cy.findByLabelText("Start date").clear().type(columnMinValue);
             cy.findByLabelText("End date").clear().type(columnMaxValue);
-            cy.button("Add filter").click();
+            cy.button("Apply filter").click();
           });
         }
 
@@ -1202,7 +1202,6 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          H.runButtonOverlay().click();
           cy.wait("@dataset");
         }
 
@@ -1225,7 +1224,7 @@ describe("scenarios > question > multiple column breakouts", () => {
             cy.findByPlaceholderText("Max")
               .clear()
               .type(String(columnMaxValue));
-            cy.button("Add filter").click();
+            cy.button("Apply filter").click();
           });
         }
 
@@ -1263,7 +1262,6 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          H.runButtonOverlay().click();
           cy.wait("@dataset");
         }
 

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -482,9 +482,8 @@ describe("scenarios > question > nested", () => {
     H.selectFilterOperator("Equal to");
     H.popover().within(() => {
       cy.findByLabelText("Filter value").type("4");
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
 
     cy.findAllByTestId("cell-data")
       .should("contain", "Murray, Watsica and Wunsch")
@@ -524,9 +523,8 @@ describe("scenarios > question > nested", () => {
     H.selectFilterOperator("Equal to");
     H.popover().within(() => {
       cy.findByLabelText("Filter value").type("5");
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
     cy.wait("@dataset");
 
     H.queryBuilderFiltersPanel().findByText("Count is equal to 5");

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -188,9 +188,8 @@ describe("scenarios > visualizations > bar chart", () => {
       H.selectFilterOperator("Is not");
       H.popover().within(() => {
         cy.findByText("Gadget").click();
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      H.runButtonOverlay().click();
       H.getDraggableElements().should("have.length", 2);
       H.getDraggableElements().eq(0).should("have.text", "Doohickey");
       H.getDraggableElements().eq(1).should("have.text", "Widget");

--- a/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
@@ -79,9 +79,8 @@ describe("scenarios > visualizations > funnel chart", () => {
     H.selectFilterOperator("Is not");
     H.popover().within(() => {
       cy.findByText("Facebook").click();
-      cy.button("Add filter").click();
+      cy.button("Apply filter").click();
     });
-    H.runButtonOverlay().click();
 
     H.getDraggableElements().should("have.length", 4);
 

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -185,9 +185,8 @@ describe("issue 17524", () => {
       H.selectFilterOperator("Greater than");
       H.popover().within(() => {
         cy.findByLabelText("Filter value").type("1");
-        cy.button("Add filter").click();
+        cy.button("Apply filter").click();
       });
-      H.runButtonOverlay().click();
       cy.get("polygon");
     });
   });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -8,6 +8,7 @@ import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut"
 import { updateQuestion } from "metabase/query_builder/actions";
 import { getFilterItems } from "metabase/querying/filters/components/FilterPanel/utils";
 import { MultiStageFilterPicker } from "metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker";
+import type { FilterChangeOpts } from "metabase/querying/filters/components/FilterPicker/types";
 import { Button, Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -37,9 +38,9 @@ export function FilterHeaderButton({
   const hasFilters = items.length > 0;
   const label = isExpanded ? t`Hide filters` : t`Show filters`;
 
-  const handleQueryChange = (newQuery: Lib.Query) => {
+  const handleQueryChange = (newQuery: Lib.Query, opts: FilterChangeOpts) => {
     const newQuestion = question.setQuery(newQuery);
-    dispatch(updateQuestion(newQuestion));
+    dispatch(updateQuestion(newQuestion, { run: opts.run }));
   };
 
   useRegisterShortcut([

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -7,8 +7,10 @@ import { useDispatch } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { updateQuestion } from "metabase/query_builder/actions";
 import { getFilterItems } from "metabase/querying/filters/components/FilterPanel/utils";
-import { MultiStageFilterPicker } from "metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker";
-import type { FilterChangeOpts } from "metabase/querying/filters/components/FilterPicker/types";
+import {
+  MultiStageFilterPicker,
+  type QueryChangeOpts,
+} from "metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker";
 import { Button, Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -38,7 +40,7 @@ export function FilterHeaderButton({
   const hasFilters = items.length > 0;
   const label = isExpanded ? t`Hide filters` : t`Show filters`;
 
-  const handleQueryChange = (newQuery: Lib.Query, opts: FilterChangeOpts) => {
+  const handleQueryChange = (newQuery: Lib.Query, opts: QueryChangeOpts) => {
     const newQuestion = question.setQuery(newQuery);
     dispatch(updateQuestion(newQuestion, { run: opts.run }));
   };

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -7,10 +7,8 @@ import { useDispatch } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { updateQuestion } from "metabase/query_builder/actions";
 import { getFilterItems } from "metabase/querying/filters/components/FilterPanel/utils";
-import {
-  MultiStageFilterPicker,
-  type QueryChangeOpts,
-} from "metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker";
+import { MultiStageFilterPicker } from "metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker";
+import type { FilterChangeOpts } from "metabase/querying/filters/components/FilterPicker/types";
 import { Button, Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -40,7 +38,7 @@ export function FilterHeaderButton({
   const hasFilters = items.length > 0;
   const label = isExpanded ? t`Hide filters` : t`Show filters`;
 
-  const handleQueryChange = (newQuery: Lib.Query, opts: QueryChangeOpts) => {
+  const handleQueryChange = (newQuery: Lib.Query, opts: FilterChangeOpts) => {
     const newQuestion = question.setQuery(newQuery);
     dispatch(updateQuestion(newQuestion, { run: opts.run }));
   };

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -376,7 +376,7 @@ export const triggerVisualizationQueryChange = async () => {
   await userEvent.click(within(popover).getByText("Total"));
   const maxInput = within(popover).getByPlaceholderText("Max");
   await userEvent.type(maxInput, "1000");
-  await userEvent.click(await screen.findByText("Add filter"));
+  await userEvent.click(await screen.findByText("Apply filter"));
 };
 
 export const triggerNotebookQueryChange = async () => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,4 @@
 import { type ReactNode, useState } from "react";
-import { t } from "ttag";
 
 import {
   DATE_PICKER_OPERATORS,
@@ -12,13 +11,13 @@ import type {
   DatePickerUnit,
   DatePickerValue,
 } from "metabase/querying/filters/types";
-import { Button } from "metabase/ui";
 
 import { DateShortcutPicker } from "./DateShortcutPicker";
 import { ExcludeDatePicker } from "./ExcludeDatePicker";
 import { RelativeDatePicker } from "./RelativeDatePicker";
 import { SpecificDatePicker } from "./SpecificDatePicker";
 import type { DatePickerSubmitButtonProps } from "./types";
+import { renderDefaultSubmitButton } from "./utils";
 
 type DatePickerProps = {
   value?: DatePickerValue;
@@ -35,7 +34,7 @@ export function DatePicker({
   availableOperators = DATE_PICKER_OPERATORS,
   availableShortcuts = DATE_PICKER_SHORTCUTS,
   availableUnits = DATE_PICKER_UNITS,
-  renderSubmitButton = defaultRenderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   renderBackButton,
   onChange,
 }: DatePickerProps) {
@@ -89,14 +88,4 @@ export function DatePicker({
         />
       );
   }
-}
-
-function defaultRenderSubmitButton({
-  isDisabled,
-}: DatePickerSubmitButtonProps) {
-  return (
-    <Button type="submit" variant="filled" disabled={isDisabled}>
-      {t`Apply`}
-    </Button>
-  );
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -12,21 +12,22 @@ import type {
   DatePickerUnit,
   DatePickerValue,
 } from "metabase/querying/filters/types";
+import { Button } from "metabase/ui";
 
 import { DateShortcutPicker } from "./DateShortcutPicker";
 import { ExcludeDatePicker } from "./ExcludeDatePicker";
 import { RelativeDatePicker } from "./RelativeDatePicker";
 import { SpecificDatePicker } from "./SpecificDatePicker";
+import type { DatePickerSubmitButtonProps } from "./types";
 
 type DatePickerProps = {
   value?: DatePickerValue;
   availableOperators?: DatePickerOperator[];
   availableShortcuts?: DatePickerShortcut[];
   availableUnits?: DatePickerUnit[];
-  submitButtonLabel?: string;
-  backButtonLabel?: string;
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderBackButton?: () => ReactNode;
   onChange: (value: DatePickerValue) => void;
-  onBack?: () => void;
 };
 
 export function DatePicker({
@@ -34,10 +35,9 @@ export function DatePicker({
   availableOperators = DATE_PICKER_OPERATORS,
   availableShortcuts = DATE_PICKER_SHORTCUTS,
   availableUnits = DATE_PICKER_UNITS,
-  submitButtonLabel = t`Apply`,
-  backButtonLabel,
+  renderSubmitButton = defaultRenderSubmitButton,
+  renderBackButton,
   onChange,
-  onBack,
 }: DatePickerProps) {
   const [type, setType] = useState(value?.type);
 
@@ -52,7 +52,7 @@ export function DatePicker({
           value={value?.type === type ? value : undefined}
           availableOperators={availableOperators}
           availableUnits={availableUnits}
-          submitButtonLabel={submitButtonLabel}
+          renderSubmitButton={renderSubmitButton}
           onChange={onChange}
           onBack={handleBack}
         />
@@ -62,7 +62,7 @@ export function DatePicker({
         <RelativeDatePicker
           value={value?.type === type ? value : undefined}
           availableUnits={availableUnits}
-          submitButtonLabel={submitButtonLabel}
+          renderSubmitButton={renderSubmitButton}
           onChange={onChange}
           onBack={handleBack}
         />
@@ -73,7 +73,7 @@ export function DatePicker({
           value={value?.type === type ? value : undefined}
           availableOperators={availableOperators}
           availableUnits={availableUnits}
-          submitButtonLabel={submitButtonLabel}
+          renderSubmitButton={renderSubmitButton}
           onChange={onChange}
           onBack={handleBack}
         />
@@ -83,11 +83,20 @@ export function DatePicker({
         <DateShortcutPicker
           availableOperators={availableOperators}
           availableShortcuts={availableShortcuts}
-          backButtonLabel={backButtonLabel}
+          renderBackButton={renderBackButton}
           onChange={onChange}
           onSelectType={setType}
-          onBack={onBack}
         />
       );
   }
+}
+
+function defaultRenderSubmitButton({
+  isDisabled,
+}: DatePickerSubmitButtonProps) {
+  return (
+    <Button type="submit" variant="filled" disabled={isDisabled}>
+      {t`Apply`}
+    </Button>
+  );
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -27,7 +27,7 @@ type DatePickerProps = {
   availableUnits?: DatePickerUnit[];
   renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   renderBackButton?: () => ReactNode;
-  onSubmit: (value: DatePickerValue) => void;
+  onChange: (value: DatePickerValue) => void;
 };
 
 export function DatePicker({
@@ -37,7 +37,7 @@ export function DatePicker({
   availableUnits = DATE_PICKER_UNITS,
   renderSubmitButton = defaultRenderSubmitButton,
   renderBackButton,
-  onSubmit,
+  onChange,
 }: DatePickerProps) {
   const [type, setType] = useState(value?.type);
 
@@ -53,7 +53,7 @@ export function DatePicker({
           availableOperators={availableOperators}
           availableUnits={availableUnits}
           renderSubmitButton={renderSubmitButton}
-          onSubmit={onSubmit}
+          onChange={onChange}
           onBack={handleBack}
         />
       );
@@ -63,7 +63,7 @@ export function DatePicker({
           value={value?.type === type ? value : undefined}
           availableUnits={availableUnits}
           renderSubmitButton={renderSubmitButton}
-          onSubmit={onSubmit}
+          onChange={onChange}
           onBack={handleBack}
         />
       );
@@ -74,7 +74,7 @@ export function DatePicker({
           availableOperators={availableOperators}
           availableUnits={availableUnits}
           renderSubmitButton={renderSubmitButton}
-          onSubmit={onSubmit}
+          onChange={onChange}
           onBack={handleBack}
         />
       );
@@ -84,7 +84,7 @@ export function DatePicker({
           availableOperators={availableOperators}
           availableShortcuts={availableShortcuts}
           renderBackButton={renderBackButton}
-          onSubmit={onSubmit}
+          onChange={onChange}
           onSelectType={setType}
         />
       );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -27,7 +27,7 @@ type DatePickerProps = {
   availableUnits?: DatePickerUnit[];
   renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   renderBackButton?: () => ReactNode;
-  onChange: (value: DatePickerValue) => void;
+  onSubmit: (value: DatePickerValue) => void;
 };
 
 export function DatePicker({
@@ -37,7 +37,7 @@ export function DatePicker({
   availableUnits = DATE_PICKER_UNITS,
   renderSubmitButton = defaultRenderSubmitButton,
   renderBackButton,
-  onChange,
+  onSubmit,
 }: DatePickerProps) {
   const [type, setType] = useState(value?.type);
 
@@ -53,7 +53,7 @@ export function DatePicker({
           availableOperators={availableOperators}
           availableUnits={availableUnits}
           renderSubmitButton={renderSubmitButton}
-          onChange={onChange}
+          onSubmit={onSubmit}
           onBack={handleBack}
         />
       );
@@ -63,7 +63,7 @@ export function DatePicker({
           value={value?.type === type ? value : undefined}
           availableUnits={availableUnits}
           renderSubmitButton={renderSubmitButton}
-          onChange={onChange}
+          onSubmit={onSubmit}
           onBack={handleBack}
         />
       );
@@ -74,7 +74,7 @@ export function DatePicker({
           availableOperators={availableOperators}
           availableUnits={availableUnits}
           renderSubmitButton={renderSubmitButton}
-          onChange={onChange}
+          onSubmit={onSubmit}
           onBack={handleBack}
         />
       );
@@ -84,7 +84,7 @@ export function DatePicker({
           availableOperators={availableOperators}
           availableShortcuts={availableShortcuts}
           renderBackButton={renderBackButton}
-          onChange={onChange}
+          onSubmit={onSubmit}
           onSelectType={setType}
         />
       );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo } from "react";
+import { Fragment, type ReactNode, useMemo } from "react";
 
 import type {
   DatePickerOperator,
@@ -6,7 +6,7 @@ import type {
   DatePickerValueType,
   RelativeDatePickerValue,
 } from "metabase/querying/filters/types";
-import { Box, Button, Divider, PopoverBackButton } from "metabase/ui";
+import { Box, Button, Divider } from "metabase/ui";
 
 import { MIN_WIDTH } from "../constants";
 
@@ -16,19 +16,17 @@ import { getShortcutOptionGroups, getTypeOptions } from "./utils";
 interface DateShortcutPickerProps {
   availableOperators: DatePickerOperator[];
   availableShortcuts: DatePickerShortcut[];
-  backButtonLabel?: string;
+  renderBackButton?: () => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onSelectType: (type: DatePickerValueType) => void;
-  onBack?: () => void;
 }
 
 export function DateShortcutPicker({
   availableOperators,
   availableShortcuts,
-  backButtonLabel,
+  renderBackButton,
   onChange,
   onSelectType,
-  onBack,
 }: DateShortcutPickerProps) {
   const shortcutGroups = useMemo(() => {
     return getShortcutOptionGroups(availableShortcuts);
@@ -40,11 +38,7 @@ export function DateShortcutPicker({
 
   return (
     <Box p="sm" miw={MIN_WIDTH}>
-      {onBack && (
-        <PopoverBackButton p="sm" onClick={onBack}>
-          {backButtonLabel}
-        </PopoverBackButton>
-      )}
+      {renderBackButton?.()}
       {shortcutGroups.map((group, groupIndex) => (
         <Fragment key={groupIndex}>
           {groupIndex > 0 && <Divider mx="md" my="sm" />}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
@@ -17,7 +17,7 @@ interface DateShortcutPickerProps {
   availableOperators: DatePickerOperator[];
   availableShortcuts: DatePickerShortcut[];
   renderBackButton?: () => ReactNode;
-  onChange: (value: RelativeDatePickerValue) => void;
+  onSubmit: (value: RelativeDatePickerValue) => void;
   onSelectType: (type: DatePickerValueType) => void;
 }
 
@@ -25,7 +25,7 @@ export function DateShortcutPicker({
   availableOperators,
   availableShortcuts,
   renderBackButton,
-  onChange,
+  onSubmit,
   onSelectType,
 }: DateShortcutPickerProps) {
   const shortcutGroups = useMemo(() => {
@@ -50,7 +50,7 @@ export function DateShortcutPicker({
               }}
               display="block"
               variant="subtle"
-              onClick={() => onChange(option.value)}
+              onClick={() => onSubmit(option.value)}
             >
               {option.label}
             </Button>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
@@ -17,7 +17,7 @@ interface DateShortcutPickerProps {
   availableOperators: DatePickerOperator[];
   availableShortcuts: DatePickerShortcut[];
   renderBackButton?: () => ReactNode;
-  onSubmit: (value: RelativeDatePickerValue) => void;
+  onChange: (value: RelativeDatePickerValue) => void;
   onSelectType: (type: DatePickerValueType) => void;
 }
 
@@ -25,7 +25,7 @@ export function DateShortcutPicker({
   availableOperators,
   availableShortcuts,
   renderBackButton,
-  onSubmit,
+  onChange,
   onSelectType,
 }: DateShortcutPickerProps) {
   const shortcutGroups = useMemo(() => {
@@ -50,7 +50,7 @@ export function DateShortcutPicker({
               }}
               display="block"
               variant="subtle"
-              onClick={() => onSubmit(option.value)}
+              onClick={() => onChange(option.value)}
             >
               {option.label}
             </Button>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -38,7 +38,7 @@ export interface ExcludeDatePickerProps {
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onSubmit: (value: ExcludeDatePickerValue) => void;
+  onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -47,7 +47,7 @@ export function ExcludeDatePicker({
   availableOperators,
   availableUnits,
   renderSubmitButton,
-  onSubmit,
+  onChange,
   onBack,
 }: ExcludeDatePickerProps) {
   const [unit, setUnit] = useState(value?.unit);
@@ -67,7 +67,7 @@ export function ExcludeDatePicker({
       unit={unit}
       initialValues={values}
       renderSubmitButton={renderSubmitButton}
-      onSubmit={onSubmit}
+      onChange={onChange}
       onBack={handleBack}
     />
   ) : (
@@ -75,7 +75,7 @@ export function ExcludeDatePicker({
       value={value}
       availableOperators={availableOperators}
       availableUnits={availableUnits}
-      onSubmit={onSubmit}
+      onChange={onChange}
       onSelectUnit={handleSelectUnit}
       onBack={onBack}
     />
@@ -86,7 +86,7 @@ interface ExcludeOptionPickerProps {
   value: ExcludeDatePickerValue | undefined;
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
-  onSubmit: (value: ExcludeDatePickerValue) => void;
+  onChange: (value: ExcludeDatePickerValue) => void;
   onSelectUnit: (unit: DatePickerExtractionUnit) => void;
   onBack: () => void;
 }
@@ -95,7 +95,7 @@ export function ExcludeOptionPicker({
   value,
   availableOperators,
   availableUnits,
-  onSubmit,
+  onChange,
   onSelectUnit,
   onBack,
 }: ExcludeOptionPickerProps) {
@@ -108,7 +108,7 @@ export function ExcludeOptionPicker({
   }, [availableOperators]);
 
   const handleChange = (operator: ExcludeDatePickerOperator) => {
-    onSubmit(getExcludeOperatorValue(operator));
+    onChange(getExcludeOperatorValue(operator));
   };
 
   return (
@@ -154,7 +154,7 @@ interface ExcludeValuePickerProps {
   unit: DatePickerExtractionUnit;
   initialValues: number[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onSubmit: (value: ExcludeDatePickerValue) => void;
+  onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -162,7 +162,7 @@ function ExcludeValuePicker({
   unit,
   initialValues,
   renderSubmitButton,
-  onSubmit,
+  onChange,
   onBack,
 }: ExcludeValuePickerProps) {
   const [values, setValues] = useState(initialValues);
@@ -194,7 +194,7 @@ function ExcludeValuePicker({
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     if (isValid) {
-      onSubmit(getExcludeUnitValue(unit, values));
+      onChange(getExcludeUnitValue(unit, values));
     }
   };
 
@@ -228,7 +228,10 @@ function ExcludeValuePicker({
       </Stack>
       <Divider />
       <Group p="sm" justify="flex-end">
-        {renderSubmitButton({ isDisabled: !isValid })}
+        {renderSubmitButton({
+          value: getExcludeUnitValue(unit, values),
+          isDisabled: !isValid,
+        })}
       </Group>
     </Box>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -22,6 +22,7 @@ import {
 
 import { MIN_WIDTH } from "../constants";
 import type { DatePickerSubmitButtonProps } from "../types";
+import { renderDefaultSubmitButton } from "../utils";
 
 import type { ExcludeValueOption } from "./types";
 import {
@@ -37,7 +38,7 @@ export interface ExcludeDatePickerProps {
   value?: ExcludeDatePickerValue;
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
-  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
 }
@@ -46,7 +47,7 @@ export function ExcludeDatePicker({
   value,
   availableOperators,
   availableUnits,
-  renderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onBack,
 }: ExcludeDatePickerProps) {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -38,7 +38,7 @@ export interface ExcludeDatePickerProps {
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onChange: (value: ExcludeDatePickerValue) => void;
+  onSubmit: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -47,7 +47,7 @@ export function ExcludeDatePicker({
   availableOperators,
   availableUnits,
   renderSubmitButton,
-  onChange,
+  onSubmit,
   onBack,
 }: ExcludeDatePickerProps) {
   const [unit, setUnit] = useState(value?.unit);
@@ -67,7 +67,7 @@ export function ExcludeDatePicker({
       unit={unit}
       initialValues={values}
       renderSubmitButton={renderSubmitButton}
-      onChange={onChange}
+      onSubmit={onSubmit}
       onBack={handleBack}
     />
   ) : (
@@ -75,7 +75,7 @@ export function ExcludeDatePicker({
       value={value}
       availableOperators={availableOperators}
       availableUnits={availableUnits}
-      onChange={onChange}
+      onSubmit={onSubmit}
       onSelectUnit={handleSelectUnit}
       onBack={onBack}
     />
@@ -86,7 +86,7 @@ interface ExcludeOptionPickerProps {
   value: ExcludeDatePickerValue | undefined;
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
-  onChange: (value: ExcludeDatePickerValue) => void;
+  onSubmit: (value: ExcludeDatePickerValue) => void;
   onSelectUnit: (unit: DatePickerExtractionUnit) => void;
   onBack: () => void;
 }
@@ -95,7 +95,7 @@ export function ExcludeOptionPicker({
   value,
   availableOperators,
   availableUnits,
-  onChange,
+  onSubmit,
   onSelectUnit,
   onBack,
 }: ExcludeOptionPickerProps) {
@@ -108,7 +108,7 @@ export function ExcludeOptionPicker({
   }, [availableOperators]);
 
   const handleChange = (operator: ExcludeDatePickerOperator) => {
-    onChange(getExcludeOperatorValue(operator));
+    onSubmit(getExcludeOperatorValue(operator));
   };
 
   return (
@@ -154,7 +154,7 @@ interface ExcludeValuePickerProps {
   unit: DatePickerExtractionUnit;
   initialValues: number[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onChange: (value: ExcludeDatePickerValue) => void;
+  onSubmit: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -162,7 +162,7 @@ function ExcludeValuePicker({
   unit,
   initialValues,
   renderSubmitButton,
-  onChange,
+  onSubmit,
   onBack,
 }: ExcludeValuePickerProps) {
   const [values, setValues] = useState(initialValues);
@@ -194,7 +194,7 @@ function ExcludeValuePicker({
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     if (isValid) {
-      onChange(getExcludeUnitValue(unit, values));
+      onSubmit(getExcludeUnitValue(unit, values));
     }
   };
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { type FormEvent, type ReactNode, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import type {
@@ -21,6 +21,7 @@ import {
 } from "metabase/ui";
 
 import { MIN_WIDTH } from "../constants";
+import type { DatePickerSubmitButtonProps } from "../types";
 
 import type { ExcludeValueOption } from "./types";
 import {
@@ -36,7 +37,7 @@ export interface ExcludeDatePickerProps {
   value?: ExcludeDatePickerValue;
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
-  submitButtonLabel: string;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
 }
@@ -45,7 +46,7 @@ export function ExcludeDatePicker({
   value,
   availableOperators,
   availableUnits,
-  submitButtonLabel,
+  renderSubmitButton,
   onChange,
   onBack,
 }: ExcludeDatePickerProps) {
@@ -65,7 +66,7 @@ export function ExcludeDatePicker({
     <ExcludeValuePicker
       unit={unit}
       initialValues={values}
-      submitButtonLabel={submitButtonLabel}
+      renderSubmitButton={renderSubmitButton}
       onChange={onChange}
       onBack={handleBack}
     />
@@ -152,7 +153,7 @@ export function ExcludeOptionPicker({
 interface ExcludeValuePickerProps {
   unit: DatePickerExtractionUnit;
   initialValues: number[];
-  submitButtonLabel: string;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
 }
@@ -160,7 +161,7 @@ interface ExcludeValuePickerProps {
 function ExcludeValuePicker({
   unit,
   initialValues,
-  submitButtonLabel,
+  renderSubmitButton,
   onChange,
   onBack,
 }: ExcludeValuePickerProps) {
@@ -169,7 +170,7 @@ function ExcludeValuePicker({
   const groups = useMemo(() => getExcludeValueOptionGroups(unit), [unit]);
   const options = groups.flat();
   const isAll = values.length === options.length;
-  const isNone = values.length === 0;
+  const isValid = values.length > 0;
 
   const handleToggleAll = (isChecked: boolean) => {
     if (isChecked) {
@@ -190,12 +191,15 @@ function ExcludeValuePicker({
     }
   };
 
-  const handleSubmit = () => {
-    onChange(getExcludeUnitValue(unit, values));
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (isValid) {
+      onChange(getExcludeUnitValue(unit, values));
+    }
   };
 
   return (
-    <Box miw={MIN_WIDTH}>
+    <Box component="form" miw={MIN_WIDTH} onSubmit={handleSubmit}>
       <BackButton onClick={onBack}>{option?.label}</BackButton>
       <Divider />
       <Stack p="md">
@@ -224,9 +228,7 @@ function ExcludeValuePicker({
       </Stack>
       <Divider />
       <Group p="sm" justify="flex-end">
-        <Button variant="filled" disabled={isNone} onClick={handleSubmit}>
-          {submitButtonLabel}
-        </Button>
+        {renderSubmitButton({ isDisabled: !isValid })}
       </Group>
     </Box>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import {
@@ -8,18 +9,23 @@ import {
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
+  ExcludeDatePickerValue,
 } from "metabase/querying/filters/types";
+
+import type { DatePickerSubmitButtonProps } from "../types";
 
 import { ExcludeDatePicker } from "./ExcludeDatePicker";
 
 interface SetupOpts {
   availableOperators?: DatePickerOperator[];
   availableUnits?: DatePickerExtractionUnit[];
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
 }
 
 function setup({
   availableOperators = DATE_PICKER_OPERATORS,
   availableUnits = DATE_PICKER_EXTRACTION_UNITS,
+  renderSubmitButton,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -28,6 +34,7 @@ function setup({
     <ExcludeDatePicker
       availableOperators={availableOperators}
       availableUnits={availableUnits}
+      renderSubmitButton={renderSubmitButton}
       onChange={onChange}
       onBack={onBack}
     />,
@@ -161,6 +168,29 @@ describe("ExcludeDatePicker", () => {
       type: "exclude",
       operator: "is-null",
       values: [],
+    });
+  });
+
+  it("should pass the value to the submit button callback", async () => {
+    const renderSubmitButton = jest.fn().mockReturnValue(null);
+    setup({ renderSubmitButton });
+
+    const defaultValue: ExcludeDatePickerValue = {
+      type: "exclude",
+      operator: "!=",
+      unit: "hour-of-day",
+      values: [],
+    };
+    await userEvent.click(screen.getByText("Hours of the day…"));
+    expect(renderSubmitButton).toHaveBeenLastCalledWith({
+      value: defaultValue,
+      isDisabled: true,
+    });
+
+    await userEvent.click(screen.getByLabelText("5 PM"));
+    expect(renderSubmitButton).toHaveBeenLastCalledWith({
+      value: { ...defaultValue, values: [17] },
+      isDisabled: false,
     });
   });
 });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -28,7 +28,6 @@ function setup({
     <ExcludeDatePicker
       availableOperators={availableOperators}
       availableUnits={availableUnits}
-      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -15,13 +15,11 @@ import { ExcludeDatePicker } from "./ExcludeDatePicker";
 interface SetupOpts {
   availableOperators?: DatePickerOperator[];
   availableUnits?: DatePickerExtractionUnit[];
-  submitButtonLabel?: string;
 }
 
 function setup({
   availableOperators = DATE_PICKER_OPERATORS,
   availableUnits = DATE_PICKER_EXTRACTION_UNITS,
-  submitButtonLabel = "Apply",
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -30,7 +28,7 @@ function setup({
     <ExcludeDatePicker
       availableOperators={availableOperators}
       availableUnits={availableUnits}
-      submitButtonLabel={submitButtonLabel}
+      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
@@ -15,13 +15,13 @@ import { getCurrentValue, getUnitGroups } from "./utils";
 interface CurrentDatePickerProps {
   value: RelativeDatePickerValue | undefined;
   availableUnits: DatePickerUnit[];
-  onSubmit: (value: RelativeDatePickerValue) => void;
+  onChange: (value: RelativeDatePickerValue) => void;
 }
 
 export function CurrentDatePicker({
   value,
   availableUnits,
-  onSubmit,
+  onChange,
 }: CurrentDatePickerProps) {
   const unitGroups = getUnitGroups(availableUnits);
 
@@ -30,7 +30,7 @@ export function CurrentDatePicker({
   };
 
   const handleClick = (unit: DatePickerTruncationUnit) => {
-    onSubmit(getCurrentValue(unit));
+    onChange(getCurrentValue(unit));
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
@@ -15,13 +15,13 @@ import { getCurrentValue, getUnitGroups } from "./utils";
 interface CurrentDatePickerProps {
   value: RelativeDatePickerValue | undefined;
   availableUnits: DatePickerUnit[];
-  onChange: (value: RelativeDatePickerValue) => void;
+  onSubmit: (value: RelativeDatePickerValue) => void;
 }
 
 export function CurrentDatePicker({
   value,
   availableUnits,
-  onChange,
+  onSubmit,
 }: CurrentDatePickerProps) {
   const unitGroups = getUnitGroups(availableUnits);
 
@@ -30,7 +30,7 @@ export function CurrentDatePicker({
   };
 
   const handleClick = (unit: DatePickerTruncationUnit) => {
-    onChange(getCurrentValue(unit));
+    onSubmit(getCurrentValue(unit));
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from "react";
+import type { FormEvent, ReactNode } from "react";
 import { t } from "ttag";
 
 import type {
@@ -17,6 +17,7 @@ import {
   Tooltip,
 } from "metabase/ui";
 
+import type { DatePickerSubmitButtonProps } from "../../types";
 import { IncludeCurrentSwitch } from "../IncludeCurrentSwitch";
 import {
   formatDateRange,
@@ -30,7 +31,7 @@ import { setDefaultOffset, setUnit } from "./utils";
 interface DateIntervalPickerProps {
   value: RelativeDatePickerValue;
   availableUnits: DatePickerUnit[];
-  submitButtonLabel: string;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onSubmit: () => void;
 }
@@ -38,7 +39,7 @@ interface DateIntervalPickerProps {
 export function DateIntervalPicker({
   value,
   availableUnits,
-  submitButtonLabel,
+  renderSubmitButton,
   onChange,
   onSubmit,
 }: DateIntervalPickerProps) {
@@ -107,9 +108,7 @@ export function DateIntervalPicker({
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>
-        <Button variant="filled" type="submit">
-          {submitButtonLabel}
-        </Button>
+        {renderSubmitButton({})}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -18,6 +18,7 @@ import {
 } from "metabase/ui";
 
 import type { DatePickerSubmitButtonProps } from "../../types";
+import { renderDefaultSubmitButton } from "../../utils";
 import { IncludeCurrentSwitch } from "../IncludeCurrentSwitch";
 import {
   formatDateRange,
@@ -31,7 +32,7 @@ import { setDefaultOffset, setUnit } from "./utils";
 interface DateIntervalPickerProps {
   value: RelativeDatePickerValue;
   availableUnits: DatePickerUnit[];
-  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onSubmit: () => void;
 }
@@ -39,7 +40,7 @@ interface DateIntervalPickerProps {
 export function DateIntervalPicker({
   value,
   availableUnits,
-  renderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onSubmit,
 }: DateIntervalPickerProps) {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -108,7 +108,7 @@ export function DateIntervalPicker({
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>
-        {renderSubmitButton({})}
+        {renderSubmitButton({ value })}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -109,7 +109,7 @@ export function DateIntervalPicker({
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>
-        {renderSubmitButton({ value })}
+        {renderSubmitButton({ value, isDisabled: false })}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { DATE_PICKER_UNITS } from "metabase/querying/filters/constants";
@@ -7,6 +8,8 @@ import type {
   RelativeDatePickerValue,
   RelativeIntervalDirection,
 } from "metabase/querying/filters/types";
+
+import type { DatePickerSubmitButtonProps } from "../../types";
 
 import { DateIntervalPicker } from "./DateIntervalPicker";
 
@@ -23,9 +26,14 @@ function getDefaultValue(
 interface SetupOpts {
   value: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
 }
 
-function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
+function setup({
+  value,
+  availableUnits = DATE_PICKER_UNITS,
+  renderSubmitButton,
+}: SetupOpts) {
   const onChange = jest.fn();
   const onSubmit = jest.fn();
 
@@ -33,6 +41,7 @@ function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
     <DateIntervalPicker
       value={value}
       availableUnits={availableUnits}
+      renderSubmitButton={renderSubmitButton}
       onChange={onChange}
       onSubmit={onSubmit}
     />,
@@ -212,6 +221,15 @@ describe("DateIntervalPicker", () => {
         const rangeText =
           direction === "last" ? "Dec 2, 2019 – Jan 1, 2020" : "Jan 1–31, 2020";
         expect(screen.getByText(rangeText)).toBeInTheDocument();
+      });
+
+      it("should pass the value to the submit button callback", async () => {
+        const renderSubmitButton = jest.fn().mockReturnValue(null);
+        setup({ value: defaultValue, renderSubmitButton });
+        expect(renderSubmitButton).toHaveBeenCalledWith({
+          value: defaultValue,
+          isDisabled: false,
+        });
       });
     },
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -23,14 +23,9 @@ function getDefaultValue(
 interface SetupOpts {
   value: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
-  submitButtonLabel?: string;
 }
 
-function setup({
-  value,
-  availableUnits = DATE_PICKER_UNITS,
-  submitButtonLabel = "Apply",
-}: SetupOpts) {
+function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
   const onChange = jest.fn();
   const onSubmit = jest.fn();
 
@@ -38,7 +33,7 @@ function setup({
     <DateIntervalPicker
       value={value}
       availableUnits={availableUnits}
-      submitButtonLabel={submitButtonLabel}
+      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -33,7 +33,6 @@ function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
     <DateIntervalPicker
       value={value}
       availableUnits={availableUnits}
-      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -150,7 +150,7 @@ export function DateOffsetIntervalPicker({
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>
-        {renderSubmitButton({})}
+        {renderSubmitButton({ value })}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -17,6 +17,7 @@ import {
 } from "metabase/ui";
 
 import type { DatePickerSubmitButtonProps } from "../../types";
+import { renderDefaultSubmitButton } from "../../utils";
 import {
   formatDateRange,
   getInterval,
@@ -38,7 +39,7 @@ import {
 interface DateOffsetIntervalPickerProps {
   value: RelativeDatePickerValue;
   availableUnits: DatePickerUnit[];
-  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onSubmit: () => void;
 }
@@ -46,7 +47,7 @@ interface DateOffsetIntervalPickerProps {
 export function DateOffsetIntervalPicker({
   value,
   availableUnits,
-  renderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onSubmit,
 }: DateOffsetIntervalPickerProps) {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from "react";
+import type { FormEvent, ReactNode } from "react";
 import { t } from "ttag";
 
 import type {
@@ -16,6 +16,7 @@ import {
   Text,
 } from "metabase/ui";
 
+import type { DatePickerSubmitButtonProps } from "../../types";
 import {
   formatDateRange,
   getInterval,
@@ -37,7 +38,7 @@ import {
 interface DateOffsetIntervalPickerProps {
   value: RelativeDatePickerValue;
   availableUnits: DatePickerUnit[];
-  submitButtonLabel: string;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onSubmit: () => void;
 }
@@ -45,7 +46,7 @@ interface DateOffsetIntervalPickerProps {
 export function DateOffsetIntervalPicker({
   value,
   availableUnits,
-  submitButtonLabel,
+  renderSubmitButton,
   onChange,
   onSubmit,
 }: DateOffsetIntervalPickerProps) {
@@ -149,9 +150,7 @@ export function DateOffsetIntervalPicker({
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>
-        <Button variant="filled" type="submit">
-          {submitButtonLabel}
-        </Button>
+        {renderSubmitButton({})}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -39,7 +39,6 @@ function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
     <DateOffsetIntervalPicker
       value={value}
       availableUnits={availableUnits}
-      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -1,4 +1,5 @@
 import _userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { DATE_PICKER_UNITS } from "metabase/querying/filters/constants";
@@ -7,6 +8,8 @@ import type {
   RelativeDatePickerValue,
   RelativeIntervalDirection,
 } from "metabase/querying/filters/types";
+
+import type { DatePickerSubmitButtonProps } from "../../types";
 
 import { DateOffsetIntervalPicker } from "./DateOffsetIntervalPicker";
 
@@ -29,9 +32,14 @@ const userEvent = _userEvent.setup({
 interface SetupOpts {
   value: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
 }
 
-function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
+function setup({
+  value,
+  availableUnits = DATE_PICKER_UNITS,
+  renderSubmitButton,
+}: SetupOpts) {
   const onChange = jest.fn();
   const onSubmit = jest.fn();
 
@@ -39,6 +47,7 @@ function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
     <DateOffsetIntervalPicker
       value={value}
       availableUnits={availableUnits}
+      renderSubmitButton={renderSubmitButton}
       onChange={onChange}
       onSubmit={onSubmit}
     />,
@@ -319,6 +328,14 @@ describe("DateOffsetIntervalPicker", () => {
           offsetUnit: undefined,
         });
         expect(onSubmit).not.toHaveBeenCalled();
+      });
+
+      it("should pass the value to the submit button callback", async () => {
+        const renderSubmitButton = jest.fn().mockReturnValue(null);
+        setup({ value: defaultValue, renderSubmitButton });
+        expect(renderSubmitButton).toHaveBeenCalledWith({
+          value: defaultValue,
+        });
       });
     },
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -29,14 +29,9 @@ const userEvent = _userEvent.setup({
 interface SetupOpts {
   value: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
-  submitButtonLabel?: string;
 }
 
-function setup({
-  value,
-  availableUnits = DATE_PICKER_UNITS,
-  submitButtonLabel = "Apply",
-}: SetupOpts) {
+function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
   const onChange = jest.fn();
   const onSubmit = jest.fn();
 
@@ -44,7 +39,7 @@ function setup({
     <DateOffsetIntervalPicker
       value={value}
       availableUnits={availableUnits}
-      submitButtonLabel={submitButtonLabel}
+      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import type {
   DatePickerUnit,
   RelativeDatePickerValue,
 } from "metabase/querying/filters/types";
 import { Box, Divider, Flex, PopoverBackButton, Tabs } from "metabase/ui";
+
+import type { DatePickerSubmitButtonProps } from "../types";
 
 import { CurrentDatePicker } from "./CurrentDatePicker";
 import { DateIntervalPicker } from "./DateIntervalPicker";
@@ -21,7 +23,7 @@ import {
 interface RelativeDatePickerProps {
   value: RelativeDatePickerValue | undefined;
   availableUnits: DatePickerUnit[];
-  submitButtonLabel: string;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onBack: () => void;
 }
@@ -29,7 +31,7 @@ interface RelativeDatePickerProps {
 export function RelativeDatePicker({
   value: initialValue,
   availableUnits,
-  submitButtonLabel,
+  renderSubmitButton,
   onChange,
   onBack,
 }: RelativeDatePickerProps) {
@@ -70,7 +72,7 @@ export function RelativeDatePicker({
             <DateOffsetIntervalPicker
               value={value}
               availableUnits={availableUnits}
-              submitButtonLabel={submitButtonLabel}
+              renderSubmitButton={renderSubmitButton}
               onChange={setValue}
               onSubmit={handleSubmit}
             />
@@ -78,7 +80,7 @@ export function RelativeDatePicker({
             <DateIntervalPicker
               value={value}
               availableUnits={availableUnits}
-              submitButtonLabel={submitButtonLabel}
+              renderSubmitButton={renderSubmitButton}
               onChange={setValue}
               onSubmit={handleSubmit}
             />

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -7,6 +7,7 @@ import type {
 import { Box, Divider, Flex, PopoverBackButton, Tabs } from "metabase/ui";
 
 import type { DatePickerSubmitButtonProps } from "../types";
+import { renderDefaultSubmitButton } from "../utils";
 
 import { CurrentDatePicker } from "./CurrentDatePicker";
 import { DateIntervalPicker } from "./DateIntervalPicker";
@@ -23,7 +24,7 @@ import {
 interface RelativeDatePickerProps {
   value: RelativeDatePickerValue | undefined;
   availableUnits: DatePickerUnit[];
-  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onBack: () => void;
 }
@@ -31,7 +32,7 @@ interface RelativeDatePickerProps {
 export function RelativeDatePicker({
   value: initialValue,
   availableUnits,
-  renderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onBack,
 }: RelativeDatePickerProps) {
@@ -89,7 +90,7 @@ export function RelativeDatePicker({
               <CurrentDatePicker
                 value={value}
                 availableUnits={availableUnits}
-                onSubmit={onChange}
+                onChange={onChange}
               />
             </Box>
           )}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -24,7 +24,7 @@ interface RelativeDatePickerProps {
   value: RelativeDatePickerValue | undefined;
   availableUnits: DatePickerUnit[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onSubmit: (value: RelativeDatePickerValue) => void;
+  onChange: (value: RelativeDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -32,7 +32,7 @@ export function RelativeDatePicker({
   value: initialValue,
   availableUnits,
   renderSubmitButton,
-  onSubmit,
+  onChange,
   onBack,
 }: RelativeDatePickerProps) {
   const [value, setValue] = useState<RelativeDatePickerValue | undefined>(
@@ -49,7 +49,7 @@ export function RelativeDatePicker({
 
   const handleSubmit = () => {
     if (value != null) {
-      onSubmit(value);
+      onChange(value);
     }
   };
 
@@ -89,7 +89,7 @@ export function RelativeDatePicker({
               <CurrentDatePicker
                 value={value}
                 availableUnits={availableUnits}
-                onSubmit={onSubmit}
+                onSubmit={onChange}
               />
             </Box>
           )}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -24,7 +24,7 @@ interface RelativeDatePickerProps {
   value: RelativeDatePickerValue | undefined;
   availableUnits: DatePickerUnit[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onChange: (value: RelativeDatePickerValue) => void;
+  onSubmit: (value: RelativeDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -32,7 +32,7 @@ export function RelativeDatePicker({
   value: initialValue,
   availableUnits,
   renderSubmitButton,
-  onChange,
+  onSubmit,
   onBack,
 }: RelativeDatePickerProps) {
   const [value, setValue] = useState<RelativeDatePickerValue | undefined>(
@@ -49,7 +49,7 @@ export function RelativeDatePicker({
 
   const handleSubmit = () => {
     if (value != null) {
-      onChange(value);
+      onSubmit(value);
     }
   };
 
@@ -89,7 +89,7 @@ export function RelativeDatePicker({
               <CurrentDatePicker
                 value={value}
                 availableUnits={availableUnits}
-                onChange={onChange}
+                onSubmit={onSubmit}
               />
             </Box>
           )}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -17,14 +17,9 @@ const TAB_CASES = TABS.flatMap((fromTab) =>
 interface SetupOpts {
   value?: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
-  submitButtonLabel?: string;
 }
 
-function setup({
-  value,
-  availableUnits = DATE_PICKER_UNITS,
-  submitButtonLabel = "Apply",
-}: SetupOpts = {}) {
+function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
 
@@ -32,7 +27,7 @@ function setup({
     <RelativeDatePicker
       value={value}
       availableUnits={availableUnits}
-      submitButtonLabel={submitButtonLabel}
+      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -27,7 +27,6 @@ function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts = {}) {
     <RelativeDatePicker
       value={value}
       availableUnits={availableUnits}
-      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -2,28 +2,28 @@ import type { FormEvent, ReactNode } from "react";
 
 import { Box, Divider, Group } from "metabase/ui";
 
-import type { DatePickerSubmitButtonProps } from "../../types";
 import { TimeToggle } from "../TimeToggle";
 import { clearTimePart } from "../utils";
 
 import { DateRangePickerBody } from "./DateRangePickerBody";
 import type { DateRangePickerValue } from "./types";
 
-export interface DateRangePickerProps {
+export type DateRangePickerProps = {
   value: DateRangePickerValue;
   hasTimeToggle: boolean;
-  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderSubmitButton: () => ReactNode;
   onChange: (value: DateRangePickerValue) => void;
   onSubmit: () => void;
-}
+};
 
 export function DateRangePicker({
-  value: { dateRange, hasTime },
+  value,
   hasTimeToggle,
   renderSubmitButton,
   onChange,
   onSubmit,
 }: DateRangePickerProps) {
+  const { dateRange, hasTime } = value;
   const [startDate, endDate] = dateRange;
 
   const handleDateRangeChange = (newDateRange: [Date, Date]) => {
@@ -56,7 +56,7 @@ export function DateRangePicker({
         {hasTimeToggle && (
           <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
         )}
-        {renderSubmitButton({})}
+        {renderSubmitButton()}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -1,7 +1,8 @@
-import type { FormEvent } from "react";
+import type { FormEvent, ReactNode } from "react";
 
-import { Box, Button, Divider, Group } from "metabase/ui";
+import { Box, Divider, Group } from "metabase/ui";
 
+import type { DatePickerSubmitButtonProps } from "../../types";
 import { TimeToggle } from "../TimeToggle";
 import { clearTimePart } from "../utils";
 
@@ -10,16 +11,16 @@ import type { DateRangePickerValue } from "./types";
 
 export interface DateRangePickerProps {
   value: DateRangePickerValue;
-  submitButtonLabel: string;
   hasTimeToggle: boolean;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: DateRangePickerValue) => void;
   onSubmit: () => void;
 }
 
 export function DateRangePicker({
   value: { dateRange, hasTime },
-  submitButtonLabel,
   hasTimeToggle,
+  renderSubmitButton,
   onChange,
   onSubmit,
 }: DateRangePickerProps) {
@@ -55,9 +56,7 @@ export function DateRangePicker({
         {hasTimeToggle && (
           <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
         )}
-        <Button variant="filled" type="submit">
-          {submitButtonLabel}
-        </Button>
+        {renderSubmitButton({})}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -2,6 +2,7 @@ import type { FormEvent, ReactNode } from "react";
 
 import { Box, Divider, Group } from "metabase/ui";
 
+import { renderDefaultSubmitButton } from "../../utils";
 import { TimeToggle } from "../TimeToggle";
 import { clearTimePart } from "../utils";
 
@@ -11,7 +12,7 @@ import type { DateRangePickerValue } from "./types";
 export type DateRangePickerProps = {
   value: DateRangePickerValue;
   hasTimeToggle: boolean;
-  renderSubmitButton: () => ReactNode;
+  renderSubmitButton?: () => ReactNode;
   onChange: (value: DateRangePickerValue) => void;
   onSubmit: () => void;
 };
@@ -19,7 +20,7 @@ export type DateRangePickerProps = {
 export function DateRangePicker({
   value,
   hasTimeToggle,
-  renderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onSubmit,
 }: DateRangePickerProps) {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
@@ -13,7 +13,6 @@ const END_DATE_TIME = new Date(2020, 1, 9, 20, 30);
 
 interface SetupOpts {
   value?: DateRangePickerValue;
-  submitButtonLabel?: string;
   hasTimeToggle?: boolean;
 }
 
@@ -23,7 +22,6 @@ const userEvent = _userEvent.setup({
 
 function setup({
   value = { dateRange: [START_DATE, END_DATE], hasTime: false },
-  submitButtonLabel = "Apply",
   hasTimeToggle = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
@@ -32,8 +30,8 @@ function setup({
   renderWithProviders(
     <DateRangePicker
       value={value}
-      submitButtonLabel={submitButtonLabel}
       hasTimeToggle={hasTimeToggle}
+      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
@@ -31,7 +31,6 @@ function setup({
     <DateRangePicker
       value={value}
       hasTimeToggle={hasTimeToggle}
-      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -2,7 +2,6 @@ import type { FormEvent, ReactNode } from "react";
 
 import { Box, Divider, Group } from "metabase/ui";
 
-import type { DatePickerSubmitButtonProps } from "../../types";
 import { TimeToggle } from "../TimeToggle";
 import { clearTimePart } from "../utils";
 
@@ -12,7 +11,7 @@ import type { SingleDatePickerValue } from "./types";
 interface SingleDatePickerProps {
   value: SingleDatePickerValue;
   hasTimeToggle: boolean;
-  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderSubmitButton: () => ReactNode;
   onChange: (value: SingleDatePickerValue) => void;
   onSubmit: () => void;
 }
@@ -53,7 +52,7 @@ export function SingleDatePicker({
         {hasTimeToggle && (
           <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
         )}
-        {renderSubmitButton({})}
+        {renderSubmitButton()}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -2,6 +2,7 @@ import type { FormEvent, ReactNode } from "react";
 
 import { Box, Divider, Group } from "metabase/ui";
 
+import { renderDefaultSubmitButton } from "../../utils";
 import { TimeToggle } from "../TimeToggle";
 import { clearTimePart } from "../utils";
 
@@ -11,7 +12,7 @@ import type { SingleDatePickerValue } from "./types";
 interface SingleDatePickerProps {
   value: SingleDatePickerValue;
   hasTimeToggle: boolean;
-  renderSubmitButton: () => ReactNode;
+  renderSubmitButton?: () => ReactNode;
   onChange: (value: SingleDatePickerValue) => void;
   onSubmit: () => void;
 }
@@ -19,7 +20,7 @@ interface SingleDatePickerProps {
 export function SingleDatePicker({
   value,
   hasTimeToggle,
-  renderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onSubmit,
 }: SingleDatePickerProps) {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -1,7 +1,8 @@
-import type { FormEvent } from "react";
+import type { FormEvent, ReactNode } from "react";
 
-import { Box, Button, Divider, Group } from "metabase/ui";
+import { Box, Divider, Group } from "metabase/ui";
 
+import type { DatePickerSubmitButtonProps } from "../../types";
 import { TimeToggle } from "../TimeToggle";
 import { clearTimePart } from "../utils";
 
@@ -10,19 +11,21 @@ import type { SingleDatePickerValue } from "./types";
 
 interface SingleDatePickerProps {
   value: SingleDatePickerValue;
-  submitButtonLabel: string;
   hasTimeToggle: boolean;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: SingleDatePickerValue) => void;
   onSubmit: () => void;
 }
 
 export function SingleDatePicker({
-  value: { date, hasTime },
-  submitButtonLabel,
+  value,
   hasTimeToggle,
+  renderSubmitButton,
   onChange,
   onSubmit,
 }: SingleDatePickerProps) {
+  const { date, hasTime } = value;
+
   const handleDateChange = (newDate: Date) => {
     onChange({ date: newDate, hasTime });
   };
@@ -50,9 +53,7 @@ export function SingleDatePicker({
         {hasTimeToggle && (
           <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
         )}
-        <Button variant="filled" type="submit">
-          {submitButtonLabel}
-        </Button>
+        {renderSubmitButton({})}
       </Group>
     </form>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
@@ -10,7 +10,6 @@ const DATE_TIME = new Date(2020, 0, 10, 10, 20);
 
 interface SetupOpts {
   value?: SingleDatePickerValue;
-  submitButtonLabel?: string;
   hasTimeToggle?: boolean;
 }
 
@@ -20,7 +19,6 @@ const userEvent = _userEvent.setup({
 
 function setup({
   value = { date: DATE, hasTime: false },
-  submitButtonLabel = "Apply",
   hasTimeToggle = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
@@ -29,8 +27,8 @@ function setup({
   renderWithProviders(
     <SingleDatePicker
       value={value}
-      submitButtonLabel={submitButtonLabel}
       hasTimeToggle={hasTimeToggle}
+      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
@@ -28,7 +28,6 @@ function setup({
     <SingleDatePicker
       value={value}
       hasTimeToggle={hasTimeToggle}
-      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onSubmit={onSubmit}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -32,7 +32,7 @@ interface SpecificDatePickerProps {
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onChange: (value: SpecificDatePickerValue) => void;
+  onSubmit: (value: SpecificDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -41,7 +41,7 @@ export function SpecificDatePicker({
   availableOperators,
   availableUnits,
   renderSubmitButton,
-  onChange,
+  onSubmit,
   onBack,
 }: SpecificDatePickerProps) {
   const tabs = useMemo(() => getTabs(availableOperators), [availableOperators]);
@@ -67,7 +67,7 @@ export function SpecificDatePicker({
   };
 
   const handleSubmit = () => {
-    onChange(coerceValue(value));
+    onSubmit(coerceValue(value));
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 import type {
   DatePickerOperator,
@@ -6,6 +6,8 @@ import type {
   SpecificDatePickerValue,
 } from "metabase/querying/filters/types";
 import { Divider, Flex, PopoverBackButton, Tabs } from "metabase/ui";
+
+import type { DatePickerSubmitButtonProps } from "../types";
 
 import { DateRangePicker, type DateRangePickerValue } from "./DateRangePicker";
 import {
@@ -29,7 +31,7 @@ interface SpecificDatePickerProps {
   value?: SpecificDatePickerValue;
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
-  submitButtonLabel: string;
+  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: SpecificDatePickerValue) => void;
   onBack: () => void;
 }
@@ -38,7 +40,7 @@ export function SpecificDatePicker({
   value: initialValue,
   availableOperators,
   availableUnits,
-  submitButtonLabel,
+  renderSubmitButton,
   onChange,
   onBack,
 }: SpecificDatePickerProps) {
@@ -86,16 +88,16 @@ export function SpecificDatePicker({
           {isDateRange(value.values) ? (
             <DateRangePicker
               value={{ dateRange: value.values, hasTime: value.hasTime }}
-              submitButtonLabel={submitButtonLabel}
               hasTimeToggle={hasTimeToggle}
+              renderSubmitButton={renderSubmitButton}
               onChange={handleDateRangeChange}
               onSubmit={handleSubmit}
             />
           ) : (
             <SingleDatePicker
               value={{ date: getDate(value), hasTime: value.hasTime }}
-              submitButtonLabel={submitButtonLabel}
               hasTimeToggle={hasTimeToggle}
+              renderSubmitButton={renderSubmitButton}
               onChange={handleDateChange}
               onSubmit={handleSubmit}
             />

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -8,6 +8,7 @@ import type {
 import { Divider, Flex, PopoverBackButton, Tabs } from "metabase/ui";
 
 import type { DatePickerSubmitButtonProps } from "../types";
+import { renderDefaultSubmitButton } from "../utils";
 
 import { DateRangePicker, type DateRangePickerValue } from "./DateRangePicker";
 import {
@@ -31,7 +32,7 @@ interface SpecificDatePickerProps {
   value?: SpecificDatePickerValue;
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
-  renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: SpecificDatePickerValue) => void;
   onBack: () => void;
 }
@@ -40,7 +41,7 @@ export function SpecificDatePicker({
   value: initialValue,
   availableOperators,
   availableUnits,
-  renderSubmitButton,
+  renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onBack,
 }: SpecificDatePickerProps) {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -48,6 +48,7 @@ export function SpecificDatePicker({
   const tabs = useMemo(() => getTabs(availableOperators), [availableOperators]);
   const [value, setValue] = useState(() => initialValue ?? getDefaultValue());
   const hasTimeToggle = canSetTime(value, availableUnits);
+  const coercedValue = coerceValue(value);
 
   const handleTabChange = (tabValue: string | null) => {
     const tab = tabs.find((tab) => tab.operator === tabValue);
@@ -68,7 +69,7 @@ export function SpecificDatePicker({
   };
 
   const handleSubmit = () => {
-    onChange(coerceValue(value));
+    onChange(coercedValue);
   };
 
   return (
@@ -90,7 +91,9 @@ export function SpecificDatePicker({
             <DateRangePicker
               value={{ dateRange: value.values, hasTime: value.hasTime }}
               hasTimeToggle={hasTimeToggle}
-              renderSubmitButton={() => renderSubmitButton({ value })}
+              renderSubmitButton={() =>
+                renderSubmitButton({ value: coercedValue })
+              }
               onChange={handleDateRangeChange}
               onSubmit={handleSubmit}
             />
@@ -98,7 +101,9 @@ export function SpecificDatePicker({
             <SingleDatePicker
               value={{ date: getDate(value), hasTime: value.hasTime }}
               hasTimeToggle={hasTimeToggle}
-              renderSubmitButton={() => renderSubmitButton({ value })}
+              renderSubmitButton={() =>
+                renderSubmitButton({ value: coercedValue })
+              }
               onChange={handleDateChange}
               onSubmit={handleSubmit}
             />

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -32,7 +32,7 @@ interface SpecificDatePickerProps {
   availableOperators: DatePickerOperator[];
   availableUnits: DatePickerUnit[];
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
-  onSubmit: (value: SpecificDatePickerValue) => void;
+  onChange: (value: SpecificDatePickerValue) => void;
   onBack: () => void;
 }
 
@@ -41,7 +41,7 @@ export function SpecificDatePicker({
   availableOperators,
   availableUnits,
   renderSubmitButton,
-  onSubmit,
+  onChange,
   onBack,
 }: SpecificDatePickerProps) {
   const tabs = useMemo(() => getTabs(availableOperators), [availableOperators]);
@@ -67,7 +67,7 @@ export function SpecificDatePicker({
   };
 
   const handleSubmit = () => {
-    onSubmit(coerceValue(value));
+    onChange(coerceValue(value));
   };
 
   return (
@@ -89,7 +89,7 @@ export function SpecificDatePicker({
             <DateRangePicker
               value={{ dateRange: value.values, hasTime: value.hasTime }}
               hasTimeToggle={hasTimeToggle}
-              renderSubmitButton={renderSubmitButton}
+              renderSubmitButton={() => renderSubmitButton({ value })}
               onChange={handleDateRangeChange}
               onSubmit={handleSubmit}
             />
@@ -97,7 +97,7 @@ export function SpecificDatePicker({
             <SingleDatePicker
               value={{ date: getDate(value), hasTime: value.hasTime }}
               hasTimeToggle={hasTimeToggle}
-              renderSubmitButton={renderSubmitButton}
+              renderSubmitButton={() => renderSubmitButton({ value })}
               onChange={handleDateChange}
               onSubmit={handleSubmit}
             />

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
@@ -36,7 +36,6 @@ function setup({
       value={value}
       availableOperators={availableOperators}
       availableUnits={availableUnits}
-      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
@@ -17,7 +17,6 @@ interface SetupOpts {
   value?: SpecificDatePickerValue;
   availableOperators?: DatePickerOperator[];
   availableUnits?: DatePickerUnit[];
-  submitButtonLabel?: string;
 }
 
 const userEvent = _userEvent.setup({
@@ -28,7 +27,6 @@ function setup({
   value,
   availableOperators = DATE_PICKER_OPERATORS,
   availableUnits = DATE_PICKER_UNITS,
-  submitButtonLabel = "Apply",
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -38,7 +36,7 @@ function setup({
       value={value}
       availableOperators={availableOperators}
       availableUnits={availableUnits}
-      submitButtonLabel={submitButtonLabel}
+      renderSubmitButton={() => <button>Apply</button>}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
@@ -1,4 +1,5 @@
 import _userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 import {
@@ -11,12 +12,15 @@ import type {
   SpecificDatePickerValue,
 } from "metabase/querying/filters/types";
 
+import type { DatePickerSubmitButtonProps } from "../types";
+
 import { SpecificDatePicker } from "./SpecificDatePicker";
 
 interface SetupOpts {
   value?: SpecificDatePickerValue;
   availableOperators?: DatePickerOperator[];
   availableUnits?: DatePickerUnit[];
+  renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
 }
 
 const userEvent = _userEvent.setup({
@@ -27,6 +31,7 @@ function setup({
   value,
   availableOperators = DATE_PICKER_OPERATORS,
   availableUnits = DATE_PICKER_UNITS,
+  renderSubmitButton,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -36,6 +41,7 @@ function setup({
       value={value}
       availableOperators={availableOperators}
       availableUnits={availableUnits}
+      renderSubmitButton={renderSubmitButton}
       onChange={onChange}
       onBack={onBack}
     />,
@@ -159,5 +165,62 @@ describe("SpecificDatePicker", () => {
       hasTime: false,
     });
     expect(screen.queryByText("Add time")).not.toBeInTheDocument();
+  });
+
+  it("should pass the date value to the submit button callback", async () => {
+    const renderSubmitButton = jest.fn().mockReturnValue(null);
+    setup({ renderSubmitButton });
+
+    await userEvent.click(screen.getByText("On"));
+    await userEvent.click(screen.getByText("15"));
+
+    expect(renderSubmitButton).toHaveBeenLastCalledWith({
+      value: {
+        type: "specific",
+        operator: "=",
+        values: [new Date(2020, 0, 15)],
+        hasTime: false,
+      },
+    });
+  });
+
+  it("should pass the date range value to the submit button callback", async () => {
+    const renderSubmitButton = jest.fn().mockReturnValue(null);
+    setup({ renderSubmitButton });
+
+    const calendars = screen.getAllByRole("table");
+    await userEvent.click(within(calendars[0]).getByText("12"));
+    await userEvent.click(within(calendars[1]).getByText("5"));
+
+    expect(renderSubmitButton).toHaveBeenLastCalledWith({
+      value: {
+        type: "specific",
+        operator: "between",
+        values: [new Date(2019, 11, 12), new Date(2020, 0, 5)],
+        hasTime: false,
+      },
+    });
+  });
+
+  it('should swap values for "between" filter when min > max when passing to the submit button callback', async () => {
+    const renderSubmitButton = jest.fn().mockReturnValue(null);
+    setup({ renderSubmitButton });
+
+    const startDateInput = screen.getByLabelText("Start date");
+    await userEvent.clear(startDateInput);
+    await userEvent.type(startDateInput, "Feb 15, 2020");
+
+    const endDateInput = screen.getByLabelText("End date");
+    await userEvent.clear(endDateInput);
+    await userEvent.type(endDateInput, "Dec 29, 2019");
+
+    expect(renderSubmitButton).toHaveBeenLastCalledWith({
+      value: {
+        type: "specific",
+        operator: "between",
+        values: [new Date(2019, 11, 29), new Date(2020, 1, 15)],
+        hasTime: false,
+      },
+    });
   });
 });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/utils.ts
@@ -121,12 +121,10 @@ export function clearTimePart(value: Date) {
   return dayjs(value).startOf("date").toDate();
 }
 
-export function coerceValue({
-  type,
-  operator,
-  values,
-  hasTime,
-}: SpecificDatePickerValue): SpecificDatePickerValue {
+export function coerceValue(
+  value: SpecificDatePickerValue,
+): SpecificDatePickerValue {
+  const { type, operator, values, hasTime } = value;
   if (operator === "between") {
     const [startDate, endDate] = values;
 
@@ -140,5 +138,5 @@ export function coerceValue({
     };
   }
 
-  return { type, operator, values, hasTime };
+  return value;
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
@@ -1,0 +1,3 @@
+export type DatePickerSubmitButtonProps = {
+  isDisabled?: boolean;
+};

--- a/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
@@ -1,3 +1,6 @@
+import type { DatePickerValue } from "metabase/querying/filters/types";
+
 export type DatePickerSubmitButtonProps = {
+  value: DatePickerValue;
   isDisabled?: boolean;
 };

--- a/frontend/src/metabase/querying/filters/components/DatePicker/utils.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/utils.tsx
@@ -1,0 +1,17 @@
+import { t } from "ttag";
+
+import { Button } from "metabase/ui";
+
+type DefaultSubmitButtonProps = {
+  isDisabled?: boolean;
+};
+
+export function renderDefaultSubmitButton({
+  isDisabled,
+}: DefaultSubmitButtonProps = {}) {
+  return (
+    <Button type="submit" variant="filled" disabled={isDisabled}>
+      {t`Apply`}
+    </Button>
+  );
+}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -53,11 +53,11 @@ export function BooleanFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ source: "default" });
+    handleFilterChange({ run: true });
   };
 
   const handleAddButtonClick = () => {
-    handleFilterChange({ source: "add-button" });
+    handleFilterChange({ run: false });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -47,13 +47,17 @@ export function BooleanFilterPicker({
     }
   };
 
-  const handleSubmit = (opts: FilterChangeOpts) => {
+  const handleFilterChange = (opts: FilterChangeOpts) => {
     onChange(getFilterClause(), opts);
   };
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleSubmit({ run: true });
+    handleFilterChange({ source: "default" });
+  };
+
+  const handleAddButtonClick = () => {
+    handleFilterChange({ source: "add-button" });
   };
 
   return (
@@ -98,7 +102,7 @@ export function BooleanFilterPicker({
           isNew={isNew}
           isValid
           withAddButton={withAddButton}
-          onSubmit={handleSubmit}
+          onAddButtonClick={handleAddButtonClick}
         />
       </div>
     </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -9,7 +9,7 @@ import * as Lib from "metabase-lib";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
 import { WIDTH } from "../constants";
-import type { FilterPickerWidgetProps } from "../types";
+import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function BooleanFilterPicker({
   query,
@@ -17,6 +17,7 @@ export function BooleanFilterPicker({
   column,
   filter,
   isNew,
+  withAddButton,
   onBack,
   onChange,
 }: FilterPickerWidgetProps) {
@@ -46,9 +47,13 @@ export function BooleanFilterPicker({
     }
   };
 
-  const handleSubmit = (event: FormEvent) => {
+  const handleSubmit = (opts: FilterChangeOpts) => {
+    onChange(getFilterClause(), opts);
+  };
+
+  const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    onChange(getFilterClause());
+    handleSubmit({ run: true });
   };
 
   return (
@@ -56,7 +61,7 @@ export function BooleanFilterPicker({
       component="form"
       miw={WIDTH}
       data-testid="boolean-filter-picker"
-      onSubmit={handleSubmit}
+      onSubmit={handleFormSubmit}
     >
       {onBack && (
         <FilterPickerHeader
@@ -89,7 +94,12 @@ export function BooleanFilterPicker({
             {t`More options`}
           </Button>
         )}
-        <FilterPickerFooter isNew={isNew} canSubmit />
+        <FilterPickerFooter
+          isNew={isNew}
+          isValid
+          withAddButton={withAddButton}
+          onSubmit={handleSubmit}
+        />
       </div>
     </Box>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -17,12 +17,14 @@ type SetupOpts = {
   query?: Lib.Query;
   column?: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
+  withAddButton?: boolean;
 };
 
 function setup({
   query = createQuery(),
   column = findBooleanColumn(query),
   filter,
+  withAddButton = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -34,6 +36,7 @@ function setup({
       column={column}
       filter={filter}
       isNew={!filter}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -158,14 +158,14 @@ describe("BooleanFilterPicker", () => {
     });
 
     it.each([
-      { label: "Apply filter", source: "default" },
-      { label: "Add another filter", source: "add-button" },
+      { label: "Apply filter", run: true },
+      { label: "Add another filter", run: false },
     ])(
       'should add a filter via the "$label" button when the add button is enabled',
-      async ({ label, source }) => {
+      async ({ label, run }) => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await userEvent.click(screen.getByRole("button", { name: label }));
-        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+        expect(getNextFilterChangeOpts()).toMatchObject({ run });
       },
     );
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -54,11 +54,17 @@ function setup({
     return Lib.displayInfo(query, 0, column).longDisplayName;
   }
 
+  const getNextFilterChangeOpts = () => {
+    const [_filter, opts] = onChange.mock.lastCall;
+    return opts;
+  };
+
   return {
     query,
     column,
     getNextFilterParts,
     getNextFilterColumnName,
+    getNextFilterChangeOpts,
     onChange,
     onBack,
   };
@@ -150,6 +156,18 @@ describe("BooleanFilterPicker", () => {
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { label: "Apply filter", source: "default" },
+      { label: "Add another filter", source: "add-button" },
+    ])(
+      'should add a filter via the "$label" button when the add button is enabled',
+      async ({ label, source }) => {
+        const { getNextFilterChangeOpts } = setup({ withAddButton: true });
+        await userEvent.click(screen.getByRole("button", { name: label }));
+        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+      },
+    );
   });
 
   describe("existing filter", () => {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -71,11 +71,11 @@ export function CoordinateFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ source: "default" });
+    handleFilterChange({ run: true });
   };
 
   const handleAddButtonClick = () => {
-    handleFilterChange({ source: "add-button" });
+    handleFilterChange({ run: false });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -16,7 +16,7 @@ import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
 import { COMBOBOX_PROPS, WIDTH } from "../constants";
-import type { FilterPickerWidgetProps } from "../types";
+import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 import { CoordinateColumnPicker } from "./CoordinateColumnPicker";
 
@@ -26,6 +26,7 @@ export function CoordinateFilterPicker({
   column,
   filter,
   isNew,
+  withAddButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -61,13 +62,16 @@ export function CoordinateFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-
+  const handleSubmit = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, secondColumn, values);
     if (filter) {
-      onChange(filter);
+      onChange(filter, opts);
     }
+  };
+
+  const handleFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    handleSubmit({ run: true });
   };
 
   return (
@@ -75,7 +79,7 @@ export function CoordinateFilterPicker({
       component="form"
       w={WIDTH}
       data-testid="coordinate-filter-picker"
-      onSubmit={handleSubmit}
+      onSubmit={handleFormSubmit}
     >
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
@@ -107,7 +111,12 @@ export function CoordinateFilterPicker({
           hasMultipleValues={hasMultipleValues}
           onChange={setValues}
         />
-        <FilterPickerFooter isNew={isNew} canSubmit={isValid} />
+        <FilterPickerFooter
+          isNew={isNew}
+          isValid={isValid}
+          withAddButton={withAddButton}
+          onSubmit={handleSubmit}
+        />
       </Box>
     </Box>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -62,7 +62,7 @@ export function CoordinateFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (opts: FilterChangeOpts) => {
+  const handleFilterChange = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, secondColumn, values);
     if (filter) {
       onChange(filter, opts);
@@ -71,7 +71,11 @@ export function CoordinateFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleSubmit({ run: true });
+    handleFilterChange({ source: "default" });
+  };
+
+  const handleAddButtonClick = () => {
+    handleFilterChange({ source: "add-button" });
   };
 
   return (
@@ -115,7 +119,7 @@ export function CoordinateFilterPicker({
           isNew={isNew}
           isValid={isValid}
           withAddButton={withAddButton}
-          onSubmit={handleSubmit}
+          onAddButtonClick={handleAddButtonClick}
         />
       </Box>
     </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -371,17 +371,17 @@ describe("CoordinateFilterPicker", () => {
     });
 
     it.each([
-      { label: "Apply filter", source: "default" },
-      { label: "Add another filter", source: "add-button" },
+      { label: "Apply filter", run: true },
+      { label: "Add another filter", run: false },
     ])(
       'should add a filter via the "$label" button when the add button is enabled',
-      async ({ label, source }) => {
+      async ({ label, run }) => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await setOperator("Greater than");
         const input = screen.getByPlaceholderText("Enter a number");
         await userEvent.type(input, "15");
         await userEvent.click(screen.getByRole("button", { name: label }));
-        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+        expect(getNextFilterChangeOpts()).toMatchObject({ run });
       },
     );
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -379,7 +379,7 @@ describe("CoordinateFilterPicker", () => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await setOperator("Greater than");
         const input = screen.getByPlaceholderText("Enter a number");
-        await userEvent.type(input, "15{enter}");
+        await userEvent.type(input, "15");
         await userEvent.click(screen.getByRole("button", { name: label }));
         expect(getNextFilterChangeOpts()).toMatchObject({ source });
       },

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -45,12 +45,14 @@ type SetupOpts = {
   query?: Lib.Query;
   column?: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
+  withAddButton?: boolean;
 };
 
 function setup({
   query = createQuery(),
   column = findLatitudeColumn(query),
   filter,
+  withAddButton = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -62,6 +64,7 @@ function setup({
       column={column}
       filter={filter}
       isNew={!filter}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -53,11 +53,13 @@ export function DateFilterPicker({
             onAddButtonClick={() => handleAddButtonClick(value)}
           />
         )}
-        renderBackButton={() => (
-          <PopoverBackButton p="sm" onClick={onBack}>
-            {columnInfo.longDisplayName}
-          </PopoverBackButton>
-        )}
+        renderBackButton={() =>
+          onBack ? (
+            <PopoverBackButton p="sm" onClick={onBack}>
+              {columnInfo.longDisplayName}
+            </PopoverBackButton>
+          ) : null
+        }
         onChange={handleChange}
       />
     </div>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -31,7 +31,7 @@ export function DateFilterPicker({
       filter,
     });
 
-  const handleChange = (value: DatePickerValue) => {
+  const handleSubmit = (value: DatePickerValue) => {
     onChange(getFilterClause(value), { source: "default" });
   };
 
@@ -58,7 +58,7 @@ export function DateFilterPicker({
             {columnInfo.longDisplayName}
           </PopoverBackButton>
         )}
-        onChange={handleChange}
+        onSubmit={handleSubmit}
       />
     </div>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -31,7 +31,7 @@ export function DateFilterPicker({
       filter,
     });
 
-  const handleSubmit = (value: DatePickerValue) => {
+  const handleChange = (value: DatePickerValue) => {
     onChange(getFilterClause(value), { source: "default" });
   };
 
@@ -58,7 +58,7 @@ export function DateFilterPicker({
             {columnInfo.longDisplayName}
           </PopoverBackButton>
         )}
-        onSubmit={handleSubmit}
+        onChange={handleChange}
       />
     </div>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -32,11 +32,11 @@ export function DateFilterPicker({
     });
 
   const handleChange = (value: DatePickerValue) => {
-    onChange(getFilterClause(value), { source: "default" });
+    onChange(getFilterClause(value), { run: true });
   };
 
   const handleAddButtonClick = (value: DatePickerValue) => {
-    onChange(getFilterClause(value), { source: "add-button" });
+    onChange(getFilterClause(value), { run: false });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -30,7 +30,7 @@ export function DateFilterPicker({
     });
 
   const handleChange = (value: DatePickerValue) => {
-    onChange(getFilterClause(value), { run: true });
+    onChange(getFilterClause(value), { source: "default" });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -35,8 +35,8 @@ export function DateFilterPicker({
     onChange(getFilterClause(value), { source: "default" });
   };
 
-  const handleAddButtonClick = () => {
-    // TODO
+  const handleAddButtonClick = (value: DatePickerValue) => {
+    onChange(getFilterClause(value), { source: "add-button" });
   };
 
   return (
@@ -45,12 +45,12 @@ export function DateFilterPicker({
         value={value}
         availableOperators={availableOperators}
         availableUnits={availableUnits}
-        renderSubmitButton={({ isDisabled }) => (
+        renderSubmitButton={({ value, isDisabled }) => (
           <FilterSubmitButton
             isNew={isNew}
             isDisabled={isDisabled}
             withAddButton={withAddButton}
-            onAddButtonClick={handleAddButtonClick}
+            onAddButtonClick={() => handleAddButtonClick(value)}
           />
         )}
         renderBackButton={() => (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
-import { t } from "ttag";
 
 import { useDateFilter } from "metabase/querying/filters/hooks/use-date-filter";
 import type { DatePickerValue } from "metabase/querying/filters/types";
+import { PopoverBackButton } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { DatePicker } from "../../DatePicker";
+import { FilterSubmitButton } from "../FilterSubmitButton";
 import type { FilterPickerWidgetProps } from "../types";
 
 export function DateFilterPicker({
@@ -14,6 +15,7 @@ export function DateFilterPicker({
   column,
   filter,
   isNew,
+  withAddButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -33,16 +35,30 @@ export function DateFilterPicker({
     onChange(getFilterClause(value), { source: "default" });
   };
 
+  const handleAddButtonClick = () => {
+    // TODO
+  };
+
   return (
     <div data-testid="date-filter-picker">
       <DatePicker
         value={value}
         availableOperators={availableOperators}
         availableUnits={availableUnits}
-        submitButtonLabel={isNew ? t`Add filter` : t`Update filter`}
-        backButtonLabel={columnInfo.longDisplayName}
+        renderSubmitButton={({ isDisabled }) => (
+          <FilterSubmitButton
+            isNew={isNew}
+            isDisabled={isDisabled}
+            withAddButton={withAddButton}
+            onAddButtonClick={handleAddButtonClick}
+          />
+        )}
+        renderBackButton={() => (
+          <PopoverBackButton p="sm" onClick={onBack}>
+            {columnInfo.longDisplayName}
+          </PopoverBackButton>
+        )}
         onChange={handleChange}
-        onBack={onBack}
       />
     </div>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -30,7 +30,7 @@ export function DateFilterPicker({
     });
 
   const handleChange = (value: DatePickerValue) => {
-    onChange(getFilterClause(value));
+    onChange(getFilterClause(value), { run: true });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
@@ -23,9 +23,16 @@ interface SetupOpts {
   column: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
   isNew?: boolean;
+  withAddButton?: boolean;
 }
 
-function setup({ query, column, filter, isNew = false }: SetupOpts) {
+function setup({
+  query,
+  column,
+  filter,
+  isNew = false,
+  withAddButton = false,
+}: SetupOpts) {
   const onChange = jest.fn();
   const onBack = jest.fn();
 
@@ -36,6 +43,7 @@ function setup({ query, column, filter, isNew = false }: SetupOpts) {
       column={column}
       filter={filter}
       isNew={isNew}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
@@ -113,7 +113,7 @@ describe("DateFilterPicker", () => {
       unit: "day",
     });
     expect(getNextFilterChangeOpts()).toMatchObject({
-      source: "default",
+      run: true,
     });
   });
 
@@ -272,11 +272,11 @@ describe("DateFilterPicker", () => {
   });
 
   it.each([
-    { label: "Apply filter", source: "default" },
-    { label: "Add another filter", source: "add-button" },
+    { label: "Apply filter", run: true },
+    { label: "Add another filter", run: false },
   ])(
     'should add a filter via the "$label" button when the add button is enabled',
-    async ({ label, source }) => {
+    async ({ label, run }) => {
       const {
         getNextFilterColumnName,
         getNextSpecificFilterParts,
@@ -300,9 +300,7 @@ describe("DateFilterPicker", () => {
         column: expect.anything(),
         values: [new Date(2020, 1, 15)],
       });
-      expect(getNextFilterChangeOpts()).toMatchObject({
-        source,
-      });
+      expect(getNextFilterChangeOpts()).toMatchObject({ run });
     },
   );
 });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
@@ -8,7 +8,7 @@ import * as Lib from "metabase-lib";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
 import { WIDTH } from "../constants";
-import type { FilterPickerWidgetProps } from "../types";
+import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function DefaultFilterPicker({
   query,
@@ -16,6 +16,7 @@ export function DefaultFilterPicker({
   column,
   filter,
   isNew,
+  withAddButton,
   onBack,
   onChange,
 }: FilterPickerWidgetProps) {
@@ -42,13 +43,16 @@ export function DefaultFilterPicker({
     }
   };
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-
+  const handleSubmit = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator);
     if (filter) {
-      onChange(filter);
+      onChange(filter, opts);
     }
+  };
+
+  const handleFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    handleSubmit({ run: true });
   };
 
   return (
@@ -56,7 +60,7 @@ export function DefaultFilterPicker({
       component="form"
       miw={WIDTH}
       data-testid="default-filter-picker"
-      onSubmit={handleSubmit}
+      onSubmit={handleFormSubmit}
     >
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
@@ -76,7 +80,12 @@ export function DefaultFilterPicker({
             ))}
           </Stack>
         </Radio.Group>
-        <FilterPickerFooter isNew={isNew} canSubmit />
+        <FilterPickerFooter
+          isNew={isNew}
+          isValid
+          withAddButton={withAddButton}
+          onSubmit={handleSubmit}
+        />
       </div>
     </Box>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
@@ -43,7 +43,7 @@ export function DefaultFilterPicker({
     }
   };
 
-  const handleSubmit = (opts: FilterChangeOpts) => {
+  const handleFilterChange = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator);
     if (filter) {
       onChange(filter, opts);
@@ -52,7 +52,11 @@ export function DefaultFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleSubmit({ run: true });
+    handleFilterChange({ source: "default" });
+  };
+
+  const handleAddButtonClick = () => {
+    handleFilterChange({ source: "add-button" });
   };
 
   return (
@@ -84,7 +88,7 @@ export function DefaultFilterPicker({
           isNew={isNew}
           isValid
           withAddButton={withAddButton}
-          onSubmit={handleSubmit}
+          onAddButtonClick={handleAddButtonClick}
         />
       </div>
     </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
@@ -52,11 +52,11 @@ export function DefaultFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ source: "default" });
+    handleFilterChange({ run: true });
   };
 
   const handleAddButtonClick = () => {
-    handleFilterChange({ source: "add-button" });
+    handleFilterChange({ run: false });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
@@ -17,6 +17,7 @@ type SetupOpts = {
   stageIndex?: number;
   column?: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
+  withAddButton?: boolean;
 };
 
 function setup({
@@ -24,6 +25,7 @@ function setup({
   stageIndex = -1,
   column = findUnknownColumn(query),
   filter,
+  withAddButton = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -35,6 +37,7 @@ function setup({
       column={column}
       filter={filter}
       isNew={!filter}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
@@ -105,14 +105,14 @@ describe("DefaultFilterPicker", () => {
     });
 
     it.each([
-      { label: "Apply filter", source: "default" },
-      { label: "Add another filter", source: "add-button" },
+      { label: "Apply filter", run: true },
+      { label: "Add another filter", run: false },
     ])(
       'should add a filter via the "$label" button when the add button is enabled',
-      async ({ label, source }) => {
+      async ({ label, run }) => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await userEvent.click(screen.getByRole("button", { name: label }));
-        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+        expect(getNextFilterChangeOpts()).toMatchObject({ run });
       },
     );
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
@@ -51,10 +51,16 @@ function setup({
       : null;
   }
 
+  const getNextFilterChangeOpts = () => {
+    const [_filter, opts] = onChange.mock.lastCall;
+    return opts;
+  };
+
   return {
     query,
     column,
     getNextFilterName,
+    getNextFilterChangeOpts,
     onChange,
     onBack,
   };
@@ -97,6 +103,18 @@ describe("DefaultFilterPicker", () => {
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { label: "Apply filter", source: "default" },
+      { label: "Add another filter", source: "add-button" },
+    ])(
+      'should add a filter via the "$label" button when the add button is enabled',
+      async ({ label, source }) => {
+        const { getNextFilterChangeOpts } = setup({ withAddButton: true });
+        await userEvent.click(screen.getByRole("button", { name: label }));
+        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+      },
+    );
   });
 
   describe("existing filter", () => {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -7,6 +7,7 @@ import { DefaultFilterPicker } from "../DefaultFilterPicker";
 import { NumberFilterPicker } from "../NumberFilterPicker";
 import { StringFilterPicker } from "../StringFilterPicker";
 import { TimeFilterPicker } from "../TimeFilterPicker";
+import type { FilterChangeOpts } from "../types";
 
 interface FilterPickerBodyProps {
   query: Lib.Query;
@@ -14,7 +15,8 @@ interface FilterPickerBodyProps {
   column: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
   isNew?: boolean;
-  onChange: (filter: Lib.ExpressionClause) => void;
+  withAddButton?: boolean;
+  onChange: (filter: Lib.ExpressionClause, opts: FilterChangeOpts) => void;
   onBack?: () => void;
 }
 
@@ -24,6 +26,7 @@ export function FilterPickerBody({
   column,
   filter,
   isNew = filter == null,
+  withAddButton = false,
   onChange,
   onBack,
 }: FilterPickerBodyProps) {
@@ -39,6 +42,7 @@ export function FilterPickerBody({
       column={column}
       filter={filter}
       isNew={isNew}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
@@ -100,6 +100,7 @@ type SetupOpts = {
   column: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
   isNew?: boolean;
+  withAddButton?: boolean;
 };
 
 function setup({
@@ -108,6 +109,7 @@ function setup({
   column,
   filter,
   isNew = false,
+  withAddButton = false,
 }: SetupOpts) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -119,6 +121,7 @@ function setup({
       column={column}
       filter={filter}
       isNew={isNew}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
@@ -27,7 +27,7 @@ export function FilterPickerFooter({
       {isValidElement(children) ? children : <Box />}
       <FilterSubmitButton
         isNew={isNew}
-        isValid={isValid}
+        isDisabled={!isValid}
         withAddButton={withAddButton}
         onAddButtonClick={onAddButtonClick}
       />

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
@@ -1,28 +1,37 @@
 import type { ReactNode } from "react";
 import { isValidElement } from "react";
-import { t } from "ttag";
 
-import { Box, Button, Flex } from "metabase/ui";
+import { Box, Flex } from "metabase/ui";
+
+import { FilterSubmitButton } from "../FilterSubmitButton";
+import type { FilterChangeOpts } from "../types";
 
 import S from "./FilterPickerFooter.module.css";
 
 interface FilterPickerFooterProps {
   isNew: boolean;
-  canSubmit: boolean;
+  isValid: boolean;
+  withAddButton?: boolean;
   children?: ReactNode;
+  onSubmit: (opts: FilterChangeOpts) => void;
 }
 
 export function FilterPickerFooter({
   isNew,
-  canSubmit,
+  isValid,
+  withAddButton = false,
   children,
+  onSubmit,
 }: FilterPickerFooterProps) {
   return (
     <Flex className={S.FilterFooterRoot} p="md" justify="space-between">
       {isValidElement(children) ? children : <Box />}
-      <Button type="submit" variant="filled" disabled={!canSubmit}>
-        {isNew ? t`Add filter` : t`Update filter`}
-      </Button>
+      <FilterSubmitButton
+        isNew={isNew}
+        isValid={isValid}
+        withAddButton={withAddButton}
+        onSubmit={onSubmit}
+      />
     </Flex>
   );
 }

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
@@ -4,16 +4,15 @@ import { isValidElement } from "react";
 import { Box, Flex } from "metabase/ui";
 
 import { FilterSubmitButton } from "../FilterSubmitButton";
-import type { FilterChangeOpts } from "../types";
 
 import S from "./FilterPickerFooter.module.css";
 
 interface FilterPickerFooterProps {
   isNew: boolean;
   isValid: boolean;
-  withAddButton?: boolean;
+  withAddButton: boolean;
   children?: ReactNode;
-  onSubmit: (opts: FilterChangeOpts) => void;
+  onAddButtonClick: () => void;
 }
 
 export function FilterPickerFooter({
@@ -21,7 +20,7 @@ export function FilterPickerFooter({
   isValid,
   withAddButton = false,
   children,
-  onSubmit,
+  onAddButtonClick,
 }: FilterPickerFooterProps) {
   return (
     <Flex className={S.FilterFooterRoot} p="md" justify="space-between">
@@ -30,7 +29,7 @@ export function FilterPickerFooter({
         isNew={isNew}
         isValid={isValid}
         withAddButton={withAddButton}
-        onSubmit={onSubmit}
+        onAddButtonClick={onAddButtonClick}
       />
     </Flex>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
@@ -2,36 +2,22 @@ import { t } from "ttag";
 
 import { Button, Divider, Icon, Tooltip } from "metabase/ui";
 
-import type { FilterChangeOpts } from "../types";
-
 type FilterSubmitButtonProps = {
   isNew: boolean;
   isValid: boolean;
   withAddButton: boolean;
-  onSubmit: (opts: FilterChangeOpts) => void;
+  onAddButtonClick: () => void;
 };
 
 export function FilterSubmitButton({
   isNew,
   isValid,
   withAddButton,
-  onSubmit,
+  onAddButtonClick,
 }: FilterSubmitButtonProps) {
-  const handleApplyButtonClick = () => {
-    onSubmit({ run: true });
-  };
-
-  const handleAddButtonClick = () => {
-    onSubmit({ run: false });
-  };
-
   if (!withAddButton) {
     return (
-      <Button
-        variant="filled"
-        disabled={!isValid}
-        onClick={handleApplyButtonClick}
-      >
+      <Button type="submit" variant="filled" disabled={!isValid}>
         {isNew ? t`Add filter` : t`Update filter`}
       </Button>
     );
@@ -39,20 +25,17 @@ export function FilterSubmitButton({
 
   return (
     <Button.Group>
-      <Button
-        variant="filled"
-        disabled={!isValid}
-        onClick={handleApplyButtonClick}
-      >
+      <Button type="submit" variant="filled" disabled={!isValid}>
         {t`Apply filter`}
       </Button>
       <Divider orientation="vertical" />
-      <Tooltip label={t`Add filter without running the query`}>
+      <Tooltip label={t`Add another filter`}>
         <Button
+          type="button"
           variant="filled"
           disabled={!isValid}
           leftSection={<Icon name="add" />}
-          onClick={handleAddButtonClick}
+          onClick={onAddButtonClick}
         />
       </Tooltip>
     </Button.Group>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
@@ -1,0 +1,60 @@
+import { t } from "ttag";
+
+import { Button, Divider, Icon, Tooltip } from "metabase/ui";
+
+import type { FilterChangeOpts } from "../types";
+
+type FilterSubmitButtonProps = {
+  isNew: boolean;
+  isValid: boolean;
+  withAddButton: boolean;
+  onSubmit: (opts: FilterChangeOpts) => void;
+};
+
+export function FilterSubmitButton({
+  isNew,
+  isValid,
+  withAddButton,
+  onSubmit,
+}: FilterSubmitButtonProps) {
+  const handleApplyButtonClick = () => {
+    onSubmit({ run: true });
+  };
+
+  const handleAddButtonClick = () => {
+    onSubmit({ run: false });
+  };
+
+  if (!withAddButton) {
+    return (
+      <Button
+        variant="filled"
+        disabled={!isValid}
+        onClick={handleApplyButtonClick}
+      >
+        {isNew ? t`Add filter` : t`Update filter`}
+      </Button>
+    );
+  }
+
+  return (
+    <Button.Group>
+      <Button
+        variant="filled"
+        disabled={!isValid}
+        onClick={handleApplyButtonClick}
+      >
+        {t`Apply filter`}
+      </Button>
+      <Divider orientation="vertical" />
+      <Tooltip label={t`Add filter without running the query`}>
+        <Button
+          variant="filled"
+          disabled={!isValid}
+          leftSection={<Icon name="add" />}
+          onClick={handleAddButtonClick}
+        />
+      </Tooltip>
+    </Button.Group>
+  );
+}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
@@ -23,18 +23,20 @@ export function FilterSubmitButton({
     );
   }
 
+  const addButtonLabel = t`Add another filter`;
   return (
     <Button.Group>
       <Button type="submit" variant="filled" disabled={isDisabled}>
         {t`Apply filter`}
       </Button>
       <Divider orientation="vertical" />
-      <Tooltip label={t`Add another filter`}>
+      <Tooltip label={addButtonLabel}>
         <Button
           type="button"
           variant="filled"
           disabled={isDisabled}
           leftSection={<Icon name="add" />}
+          aria-label={addButtonLabel}
           onClick={onAddButtonClick}
         />
       </Tooltip>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.tsx
@@ -3,21 +3,21 @@ import { t } from "ttag";
 import { Button, Divider, Icon, Tooltip } from "metabase/ui";
 
 type FilterSubmitButtonProps = {
-  isNew: boolean;
-  isValid: boolean;
-  withAddButton: boolean;
-  onAddButtonClick: () => void;
+  isNew?: boolean;
+  isDisabled?: boolean;
+  withAddButton?: boolean;
+  onAddButtonClick?: () => void;
 };
 
 export function FilterSubmitButton({
   isNew,
-  isValid,
+  isDisabled,
   withAddButton,
   onAddButtonClick,
 }: FilterSubmitButtonProps) {
   if (!withAddButton) {
     return (
-      <Button type="submit" variant="filled" disabled={!isValid}>
+      <Button type="submit" variant="filled" disabled={isDisabled}>
         {isNew ? t`Add filter` : t`Update filter`}
       </Button>
     );
@@ -25,7 +25,7 @@ export function FilterSubmitButton({
 
   return (
     <Button.Group>
-      <Button type="submit" variant="filled" disabled={!isValid}>
+      <Button type="submit" variant="filled" disabled={isDisabled}>
         {t`Apply filter`}
       </Button>
       <Divider orientation="vertical" />
@@ -33,7 +33,7 @@ export function FilterSubmitButton({
         <Button
           type="button"
           variant="filled"
-          disabled={!isValid}
+          disabled={isDisabled}
           leftSection={<Icon name="add" />}
           onClick={onAddButtonClick}
         />

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/FilterSubmitButton.unit.spec.tsx
@@ -1,0 +1,98 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { FilterSubmitButton } from "./FilterSubmitButton";
+
+type SetupOpts = {
+  isNew?: boolean;
+  isDisabled?: boolean;
+  withAddButton?: boolean;
+};
+
+function setup({ isNew, isDisabled, withAddButton }: SetupOpts = {}) {
+  const onAddButtonClick = jest.fn();
+
+  renderWithProviders(
+    <FilterSubmitButton
+      isNew={isNew}
+      isDisabled={isDisabled}
+      withAddButton={withAddButton}
+      onAddButtonClick={onAddButtonClick}
+    />,
+  );
+
+  return { onAddButtonClick };
+}
+
+describe("FilterSubmitButton", () => {
+  describe("without add button", () => {
+    it('should render the "Add filter" label for new filters', () => {
+      setup({ isNew: true });
+      expect(
+        screen.getByRole("button", { name: "Add filter" }),
+      ).toBeInTheDocument();
+    });
+
+    it('should render the "Update filter" label for existing filters', () => {
+      setup({ isNew: false });
+      expect(
+        screen.getByRole("button", { name: "Update filter" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should disable the button when the option is passed", () => {
+      setup({ isNew: true, isDisabled: true });
+      expect(screen.getByRole("button", { name: "Add filter" })).toBeDisabled();
+    });
+
+    it("should not render the add button", () => {
+      setup();
+      expect(
+        screen.queryByRole("button", { name: "Add another filter" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with add button", () => {
+    it.each([{ isNew: false }, { isNew: true }])(
+      'should render the "Apply filter" label for new and existing filters',
+      ({ isNew }) => {
+        setup({ isNew, withAddButton: true });
+        expect(
+          screen.getByRole("button", { name: "Apply filter" }),
+        ).toBeInTheDocument();
+      },
+    );
+
+    it("should render the add button", () => {
+      setup({ withAddButton: true });
+      expect(
+        screen.getByRole("button", { name: "Add another filter" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should call the callback only when the add button is clicked", async () => {
+      const { onAddButtonClick } = setup({ withAddButton: true });
+      await userEvent.click(
+        screen.getByRole("button", { name: "Apply filter" }),
+      );
+      expect(onAddButtonClick).not.toHaveBeenCalled();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Add another filter" }),
+      );
+      expect(onAddButtonClick).toHaveBeenCalled();
+    });
+
+    it("should disable both buttons when the option is passed", () => {
+      setup({ isDisabled: true, withAddButton: true });
+      expect(
+        screen.getByRole("button", { name: "Apply filter" }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Add another filter" }),
+      ).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/index.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterSubmitButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./FilterSubmitButton";

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
@@ -4,12 +4,16 @@ import * as Lib from "metabase-lib";
 
 import { FilterColumnPicker } from "../FilterColumnPicker";
 import { FilterPickerBody } from "../FilterPickerBody";
-import type { ColumnListItem, SegmentListItem } from "../types";
+import type {
+  ColumnListItem,
+  FilterChangeOpts,
+  SegmentListItem,
+} from "../types";
 
 type MultiStageFilterPickerProps = {
   query: Lib.Query;
   canAppendStage: boolean;
-  onChange: (newQuery: Lib.Query) => void;
+  onChange: (newQuery: Lib.Query, opts: FilterChangeOpts) => void;
   onClose?: () => void;
 };
 
@@ -29,20 +33,27 @@ export function MultiStageFilterPicker({
 
   const [selectedItem, setSelectedItem] = useState<ColumnListItem>();
 
-  const handleChange = (filter: Lib.Filterable, stageIndex: number) => {
+  const handleChange = (
+    filter: Lib.Filterable,
+    stageIndex: number,
+    opts: FilterChangeOpts,
+  ) => {
     const newQuery = Lib.filter(query, stageIndex, filter);
-    onChange(newQuery);
+    onChange(newQuery, opts);
   };
 
-  const handleFilterChange = (filter: Lib.ExpressionClause) => {
+  const handleFilterChange = (
+    filter: Lib.ExpressionClause,
+    opts: FilterChangeOpts,
+  ) => {
     if (selectedItem != null) {
-      handleChange(filter, selectedItem.stageIndex);
+      handleChange(filter, selectedItem.stageIndex, opts);
       onClose?.();
     }
   };
 
   const handleSegmentChange = (item: SegmentListItem) => {
-    handleChange(item.segment, item.stageIndex);
+    handleChange(item.segment, item.stageIndex, { run: true });
     onClose?.();
   };
 
@@ -68,6 +79,7 @@ export function MultiStageFilterPicker({
       stageIndex={selectedItem.stageIndex}
       column={selectedItem.column}
       isNew
+      withAddButton
       onChange={handleFilterChange}
       onBack={handleBack}
     />

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
@@ -10,14 +10,10 @@ import type {
   SegmentListItem,
 } from "../types";
 
-export type QueryChangeOpts = {
-  run: boolean;
-};
-
 export type MultiStageFilterPickerProps = {
   query: Lib.Query;
   canAppendStage: boolean;
-  onChange: (newQuery: Lib.Query, opts: QueryChangeOpts) => void;
+  onChange: (newQuery: Lib.Query, opts: FilterChangeOpts) => void;
   onClose?: () => void;
 };
 
@@ -40,7 +36,7 @@ export function MultiStageFilterPicker({
   const handleChange = (
     filter: Lib.Filterable,
     stageIndex: number,
-    opts: QueryChangeOpts,
+    opts: FilterChangeOpts,
   ) => {
     const newQuery = Lib.filter(query, stageIndex, filter);
     onChange(newQuery, opts);
@@ -54,14 +50,12 @@ export function MultiStageFilterPicker({
       return;
     }
 
-    handleChange(filter, selectedItem.stageIndex, {
-      run: opts.source !== "add-button",
-    });
+    handleChange(filter, selectedItem.stageIndex, opts);
 
-    if (opts.source === "add-button") {
-      setSelectedItem(undefined);
-    } else {
+    if (opts.run) {
       onClose?.();
+    } else {
+      setSelectedItem(undefined);
     }
   };
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
@@ -13,7 +13,7 @@ import type {
 type MultiStageFilterPickerProps = {
   query: Lib.Query;
   canAppendStage: boolean;
-  onChange: (newQuery: Lib.Query, opts: FilterChangeOpts) => void;
+  onChange: (newQuery: Lib.Query) => void;
   onClose?: () => void;
 };
 
@@ -33,13 +33,9 @@ export function MultiStageFilterPicker({
 
   const [selectedItem, setSelectedItem] = useState<ColumnListItem>();
 
-  const handleChange = (
-    filter: Lib.Filterable,
-    stageIndex: number,
-    opts: FilterChangeOpts,
-  ) => {
+  const handleChange = (filter: Lib.Filterable, stageIndex: number) => {
     const newQuery = Lib.filter(query, stageIndex, filter);
-    onChange(newQuery, opts);
+    onChange(newQuery);
   };
 
   const handleFilterChange = (
@@ -47,13 +43,16 @@ export function MultiStageFilterPicker({
     opts: FilterChangeOpts,
   ) => {
     if (selectedItem != null) {
-      handleChange(filter, selectedItem.stageIndex, opts);
+      handleChange(filter, selectedItem.stageIndex);
+      setSelectedItem(undefined);
+    }
+    if (opts.source !== "add-button") {
       onClose?.();
     }
   };
 
   const handleSegmentChange = (item: SegmentListItem) => {
-    handleChange(item.segment, item.stageIndex, { run: true });
+    handleChange(item.segment, item.stageIndex);
     onClose?.();
   };
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
@@ -10,10 +10,14 @@ import type {
   SegmentListItem,
 } from "../types";
 
-type MultiStageFilterPickerProps = {
+export type QueryChangeOpts = {
+  run: boolean;
+};
+
+export type MultiStageFilterPickerProps = {
   query: Lib.Query;
   canAppendStage: boolean;
-  onChange: (newQuery: Lib.Query) => void;
+  onChange: (newQuery: Lib.Query, opts: QueryChangeOpts) => void;
   onClose?: () => void;
 };
 
@@ -33,26 +37,36 @@ export function MultiStageFilterPicker({
 
   const [selectedItem, setSelectedItem] = useState<ColumnListItem>();
 
-  const handleChange = (filter: Lib.Filterable, stageIndex: number) => {
+  const handleChange = (
+    filter: Lib.Filterable,
+    stageIndex: number,
+    opts: QueryChangeOpts,
+  ) => {
     const newQuery = Lib.filter(query, stageIndex, filter);
-    onChange(newQuery);
+    onChange(newQuery, opts);
   };
 
   const handleFilterChange = (
     filter: Lib.ExpressionClause,
     opts: FilterChangeOpts,
   ) => {
-    if (selectedItem != null) {
-      handleChange(filter, selectedItem.stageIndex);
-      setSelectedItem(undefined);
+    if (selectedItem == null) {
+      return;
     }
-    if (opts.source !== "add-button") {
+
+    handleChange(filter, selectedItem.stageIndex, {
+      run: opts.source !== "add-button",
+    });
+
+    if (opts.source === "add-button") {
+      setSelectedItem(undefined);
+    } else {
       onClose?.();
     }
   };
 
   const handleSegmentChange = (item: SegmentListItem) => {
-    handleChange(item.segment, item.stageIndex);
+    handleChange(item.segment, item.stageIndex, { run: true });
     onClose?.();
   };
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -65,11 +65,11 @@ export function NumberFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ source: "default" });
+    handleFilterChange({ run: true });
   };
 
   const handleAddButtonClick = () => {
-    handleFilterChange({ source: "add-button" });
+    handleFilterChange({ run: false });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -16,7 +16,7 @@ import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
 import { COMBOBOX_PROPS, WIDTH } from "../constants";
-import type { FilterPickerWidgetProps } from "../types";
+import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function NumberFilterPicker({
   query,
@@ -24,6 +24,7 @@ export function NumberFilterPicker({
   column,
   filter,
   isNew,
+  withAddButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -55,13 +56,16 @@ export function NumberFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-
+  const handleSubmit = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, values);
     if (filter) {
-      onChange(filter);
+      onChange(filter, opts);
     }
+  };
+
+  const handleFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    handleSubmit({ run: true });
   };
 
   return (
@@ -69,7 +73,7 @@ export function NumberFilterPicker({
       component="form"
       w={WIDTH}
       data-testid="number-filter-picker"
-      onSubmit={handleSubmit}
+      onSubmit={handleFormSubmit}
     >
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
@@ -91,7 +95,12 @@ export function NumberFilterPicker({
           hasMultipleValues={hasMultipleValues}
           onChange={setValues}
         />
-        <FilterPickerFooter isNew={isNew} canSubmit={isValid} />
+        <FilterPickerFooter
+          isNew={isNew}
+          isValid={isValid}
+          withAddButton={withAddButton}
+          onSubmit={handleSubmit}
+        />
       </div>
     </Box>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -56,7 +56,7 @@ export function NumberFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (opts: FilterChangeOpts) => {
+  const handleFilterChange = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, values);
     if (filter) {
       onChange(filter, opts);
@@ -65,7 +65,11 @@ export function NumberFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleSubmit({ run: true });
+    handleFilterChange({ source: "default" });
+  };
+
+  const handleAddButtonClick = () => {
+    handleFilterChange({ source: "add-button" });
   };
 
   return (
@@ -99,7 +103,7 @@ export function NumberFilterPicker({
           isNew={isNew}
           isValid={isValid}
           withAddButton={withAddButton}
-          onSubmit={handleSubmit}
+          onAddButtonClick={handleAddButtonClick}
         />
       </div>
     </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -323,17 +323,17 @@ describe("NumberFilterPicker", () => {
     });
 
     it.each([
-      { label: "Apply filter", source: "default" },
-      { label: "Add another filter", source: "add-button" },
+      { label: "Apply filter", run: true },
+      { label: "Add another filter", run: false },
     ])(
       'should add a filter via the "$label" button when the add button is enabled',
-      async ({ label, source }) => {
+      async ({ label, run }) => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await setOperator("Greater than");
         const input = screen.getByPlaceholderText("Enter a number");
         await userEvent.type(input, "15");
         await userEvent.click(screen.getByRole("button", { name: label }));
-        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+        expect(getNextFilterChangeOpts()).toMatchObject({ run });
       },
     );
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -331,7 +331,7 @@ describe("NumberFilterPicker", () => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await setOperator("Greater than");
         const input = screen.getByPlaceholderText("Enter a number");
-        await userEvent.type(input, "15{enter}");
+        await userEvent.type(input, "15");
         await userEvent.click(screen.getByRole("button", { name: label }));
         expect(getNextFilterChangeOpts()).toMatchObject({ source });
       },

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -46,12 +46,14 @@ type SetupOpts = {
   query?: Lib.Query;
   column?: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
+  withAddButton?: boolean;
 };
 
 function setup({
   query = createQuery(),
   column = findNumericColumn(query),
   filter,
+  withAddButton = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -63,6 +65,7 @@ function setup({
       column={column}
       filter={filter}
       isNew={!filter}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -72,22 +72,28 @@ function setup({
     { storeInitialState },
   );
 
-  function getNextFilterParts() {
+  const getNextFilterParts = () => {
     const [filter] = onChange.mock.lastCall;
     return Lib.numberFilterParts(query, 0, filter);
-  }
+  };
 
-  function getNextFilterColumnName() {
+  const getNextFilterColumnName = () => {
     const parts = getNextFilterParts();
     const column = checkNotNull(parts?.column);
     return Lib.displayInfo(query, 0, column).longDisplayName;
-  }
+  };
+
+  const getNextFilterChangeOpts = () => {
+    const [_filter, opts] = onChange.mock.lastCall;
+    return opts;
+  };
 
   return {
     query,
     column,
     getNextFilterParts,
     getNextFilterColumnName,
+    getNextFilterChangeOpts,
     onChange,
     onBack,
   };
@@ -128,7 +134,7 @@ describe("NumberFilterPicker", () => {
     describe("with one value", () => {
       it.each(NUMERIC_TEST_CASES)(
         "should add a filter with a %s value",
-        async (title, value) => {
+        async (_title, value) => {
           const { getNextFilterParts, getNextFilterColumnName } = setup();
 
           await setOperator("Greater than");
@@ -315,13 +321,28 @@ describe("NumberFilterPicker", () => {
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { label: "Apply filter", source: "default" },
+      { label: "Add another filter", source: "add-button" },
+    ])(
+      'should add a filter via the "$label" button when the add button is enabled',
+      async ({ label, source }) => {
+        const { getNextFilterChangeOpts } = setup({ withAddButton: true });
+        await setOperator("Greater than");
+        const input = screen.getByPlaceholderText("Enter a number");
+        await userEvent.type(input, "15{enter}");
+        await userEvent.click(screen.getByRole("button", { name: label }));
+        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+      },
+    );
   });
 
   describe("existing filter", () => {
     describe("with one value", () => {
       it.each(NUMERIC_TEST_CASES)(
         "should render a filter with a %s value",
-        (title, value) => {
+        (_title, value) => {
           setup(
             createQueryWithNumberFilter({
               operator: ">",
@@ -338,7 +359,7 @@ describe("NumberFilterPicker", () => {
 
       it.each(NUMERIC_TEST_CASES)(
         "should update a filter with a %s value",
-        async (title, value) => {
+        async (_title, value) => {
           const { getNextFilterParts, getNextFilterColumnName } = setup(
             createQueryWithNumberFilter({
               operator: ">",

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -14,7 +14,7 @@ import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
 import { COMBOBOX_PROPS, WIDTH } from "../constants";
-import type { FilterPickerWidgetProps } from "../types";
+import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function StringFilterPicker({
   query,
@@ -22,6 +22,7 @@ export function StringFilterPicker({
   column,
   filter,
   isNew,
+  withAddButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -54,13 +55,16 @@ export function StringFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-
+  const handleSubmit = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, values, options);
     if (filter) {
-      onChange(filter);
+      onChange(filter, opts);
     }
+  };
+
+  const handleFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    handleSubmit({ run: true });
   };
 
   return (
@@ -68,7 +72,7 @@ export function StringFilterPicker({
       component="form"
       w={WIDTH}
       data-testid="string-filter-picker"
-      onSubmit={handleSubmit}
+      onSubmit={handleFormSubmit}
     >
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
@@ -89,7 +93,12 @@ export function StringFilterPicker({
           type={type}
           onChange={setValues}
         />
-        <FilterPickerFooter isNew={isNew} canSubmit={isValid}>
+        <FilterPickerFooter
+          isNew={isNew}
+          isValid={isValid}
+          withAddButton={withAddButton}
+          onSubmit={handleSubmit}
+        >
           {type === "partial" && (
             <CaseSensitiveOption
               value={options.caseSensitive ?? false}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -64,11 +64,11 @@ export function StringFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ source: "default" });
+    handleFilterChange({ run: true });
   };
 
   const handleAddButtonClick = () => {
-    handleFilterChange({ source: "add-button" });
+    handleFilterChange({ run: false });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -64,7 +64,7 @@ export function StringFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ source: "submit" });
+    handleFilterChange({ source: "default" });
   };
 
   const handleAddButtonClick = () => {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -64,11 +64,11 @@ export function StringFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ type: "submit" });
+    handleFilterChange({ source: "submit" });
   };
 
   const handleAddButtonClick = () => {
-    handleFilterChange({ type: "add-button" });
+    handleFilterChange({ source: "add-button" });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -55,7 +55,7 @@ export function StringFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (opts: FilterChangeOpts) => {
+  const handleFilterChange = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, values, options);
     if (filter) {
       onChange(filter, opts);
@@ -64,7 +64,11 @@ export function StringFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleSubmit({ run: true });
+    handleFilterChange({ type: "submit" });
+  };
+
+  const handleAddButtonClick = () => {
+    handleFilterChange({ type: "add-button" });
   };
 
   return (
@@ -97,7 +101,7 @@ export function StringFilterPicker({
           isNew={isNew}
           isValid={isValid}
           withAddButton={withAddButton}
-          onSubmit={handleSubmit}
+          onAddButtonClick={handleAddButtonClick}
         >
           {type === "partial" && (
             <CaseSensitiveOption

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -353,17 +353,17 @@ describe("StringFilterPicker", () => {
     });
 
     it.each([
-      { label: "Apply filter", source: "default" },
-      { label: "Add another filter", source: "add-button" },
+      { label: "Apply filter", run: true },
+      { label: "Add another filter", run: false },
     ])(
       'should add a filter via the "$label" button when the add button is enabled',
-      async ({ label, source }) => {
+      async ({ label, run }) => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await setOperator("Contains");
         const input = screen.getByPlaceholderText("Enter some text");
         await userEvent.type(input, "abc");
         await userEvent.click(screen.getByRole("button", { name: label }));
-        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+        expect(getNextFilterChangeOpts()).toMatchObject({ run });
       },
     );
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -28,12 +28,6 @@ import {
 
 import { StringFilterPicker } from "./StringFilterPicker";
 
-type SetupOpts = {
-  query?: Lib.Query;
-  column?: Lib.ColumnMetadata;
-  filter?: Lib.FilterClause;
-};
-
 const EXPECTED_OPERATORS = [
   "Is",
   "Is not",
@@ -45,10 +39,18 @@ const EXPECTED_OPERATORS = [
   "Not empty",
 ];
 
+type SetupOpts = {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+  withAddButton?: boolean;
+};
+
 function setup({
   query = createQuery(),
   column = findStringColumn(query),
   filter,
+  withAddButton = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -62,6 +64,7 @@ function setup({
       column={column}
       filter={filter}
       isNew={!filter}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -60,11 +60,11 @@ export function TimeFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleFilterChange({ source: "default" });
+    handleFilterChange({ run: true });
   };
 
   const handleAddButtonClick = () => {
-    handleFilterChange({ source: "add-button" });
+    handleFilterChange({ run: false });
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -13,7 +13,7 @@ import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FilterPickerFooter } from "../FilterPickerFooter";
 import { FilterPickerHeader } from "../FilterPickerHeader";
 import { WIDTH } from "../constants";
-import type { FilterPickerWidgetProps } from "../types";
+import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function TimeFilterPicker({
   query,
@@ -21,6 +21,7 @@ export function TimeFilterPicker({
   column,
   filter,
   isNew,
+  withAddButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -50,13 +51,16 @@ export function TimeFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-
+  const handleSubmit = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, values);
     if (filter) {
-      onChange(filter);
+      onChange(filter, opts);
     }
+  };
+
+  const handleFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    handleSubmit({ run: true });
   };
 
   return (
@@ -64,7 +68,7 @@ export function TimeFilterPicker({
       component="form"
       w={WIDTH}
       data-testid="time-filter-picker"
-      onSubmit={handleSubmit}
+      onSubmit={handleFormSubmit}
     >
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
@@ -86,7 +90,12 @@ export function TimeFilterPicker({
             />
           </Flex>
         )}
-        <FilterPickerFooter isNew={isNew} canSubmit />
+        <FilterPickerFooter
+          isNew={isNew}
+          isValid
+          withAddButton={withAddButton}
+          onSubmit={handleSubmit}
+        />
       </Box>
     </Box>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -51,7 +51,7 @@ export function TimeFilterPicker({
     setValues(getDefaultValues(newOperator, values));
   };
 
-  const handleSubmit = (opts: FilterChangeOpts) => {
+  const handleFilterChange = (opts: FilterChangeOpts) => {
     const filter = getFilterClause(operator, values);
     if (filter) {
       onChange(filter, opts);
@@ -60,7 +60,11 @@ export function TimeFilterPicker({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    handleSubmit({ run: true });
+    handleFilterChange({ source: "default" });
+  };
+
+  const handleAddButtonClick = () => {
+    handleFilterChange({ source: "add-button" });
   };
 
   return (
@@ -94,7 +98,7 @@ export function TimeFilterPicker({
           isNew={isNew}
           isValid
           withAddButton={withAddButton}
-          onSubmit={handleSubmit}
+          onAddButtonClick={handleAddButtonClick}
         />
       </Box>
     </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -13,12 +13,6 @@ import {
 
 import { TimeFilterPicker } from "./TimeFilterPicker";
 
-type SetupOpts = {
-  query?: Lib.Query;
-  column?: Lib.ColumnMetadata;
-  filter?: Lib.FilterClause;
-};
-
 const EXPECTED_OPERATORS = [
   "Before",
   "After",
@@ -38,10 +32,18 @@ const typeTime = async (input: HTMLInputElement, text: string) => {
   });
 };
 
+type SetupOpts = {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+  withAddButton?: boolean;
+};
+
 function setup({
   query = createQuery(),
   column = findTimeColumn(query),
   filter,
+  withAddButton = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onBack = jest.fn();
@@ -53,6 +55,7 @@ function setup({
       column={column}
       filter={filter}
       isNew={!filter}
+      withAddButton={withAddButton}
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -61,22 +61,28 @@ function setup({
     />,
   );
 
-  function getNextFilterParts() {
+  const getNextFilterParts = () => {
     const [filter] = onChange.mock.lastCall;
     return Lib.timeFilterParts(query, 0, filter);
-  }
+  };
 
-  function getNextFilterColumnName() {
+  const getNextFilterColumnName = () => {
     const parts = getNextFilterParts();
     const column = checkNotNull(parts?.column);
     return Lib.displayInfo(query, 0, column).longDisplayName;
-  }
+  };
+
+  const getNextFilterChangeOpts = () => {
+    const [_filter, opts] = onChange.mock.lastCall;
+    return opts;
+  };
 
   return {
     query,
     column,
     getNextFilterParts,
     getNextFilterColumnName,
+    getNextFilterChangeOpts,
     onChange,
     onBack,
   };
@@ -272,6 +278,18 @@ describe("TimeFilterPicker", () => {
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { label: "Apply filter", source: "default" },
+      { label: "Add another filter", source: "add-button" },
+    ])(
+      'should add a filter via the "$label" button when the add button is enabled',
+      async ({ label, source }) => {
+        const { getNextFilterChangeOpts } = setup({ withAddButton: true });
+        await userEvent.click(screen.getByRole("button", { name: label }));
+        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+      },
+    );
   });
 
   describe("existing filter", () => {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -280,14 +280,14 @@ describe("TimeFilterPicker", () => {
     });
 
     it.each([
-      { label: "Apply filter", source: "default" },
-      { label: "Add another filter", source: "add-button" },
+      { label: "Apply filter", run: true },
+      { label: "Add another filter", run: false },
     ])(
       'should add a filter via the "$label" button when the add button is enabled',
-      async ({ label, source }) => {
+      async ({ label, run }) => {
         const { getNextFilterChangeOpts } = setup({ withAddButton: true });
         await userEvent.click(screen.getByRole("button", { name: label }));
-        expect(getNextFilterChangeOpts()).toMatchObject({ source });
+        expect(getNextFilterChangeOpts()).toMatchObject({ run });
       },
     );
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -1,22 +1,19 @@
 import type * as Lib from "metabase-lib";
 
-export interface FilterPickerWidgetProps {
+export type FilterPickerWidgetProps = {
   query: Lib.Query;
   stageIndex: number;
   column: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
   isNew: boolean;
-  onChange: (filter: Lib.ExpressionClause) => void;
+  withAddButton?: boolean;
+  onChange: (filter: Lib.ExpressionClause, opts: FilterChangeOpts) => void;
   onBack?: () => void;
-}
+};
 
-export interface PickerOperatorOption<Operator> {
-  operator: Operator;
-
-  // An operator's longDisplayName is going to be used by default,
-  // but widgets can overwrite it with a custom name.
-  name?: string;
-}
+export type FilterChangeOpts = {
+  run: boolean;
+};
 
 export type ColumnListItem = {
   name: string;

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -6,13 +6,15 @@ export type FilterPickerWidgetProps = {
   column: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
   isNew: boolean;
-  withAddButton?: boolean;
+  withAddButton: boolean;
   onChange: (filter: Lib.ExpressionClause, opts: FilterChangeOpts) => void;
   onBack?: () => void;
 };
 
+export type FilterChangeSource = "default" | "add-button";
+
 export type FilterChangeOpts = {
-  run: boolean;
+  source: FilterChangeSource;
 };
 
 export type ColumnListItem = {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -11,10 +11,8 @@ export type FilterPickerWidgetProps = {
   onBack?: () => void;
 };
 
-export type FilterChangeSource = "default" | "add-button";
-
 export type FilterChangeOpts = {
-  source: FilterChangeSource;
+  run?: boolean;
 };
 
 export type ColumnListItem = {

--- a/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -11,6 +11,7 @@ import {
   deserializeDateParameterValue,
   serializeDateParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
+import { Button } from "metabase/ui";
 import type { ParameterValueOrArray } from "metabase-types/api";
 
 type DateAllOptionsWidgetProps = {
@@ -36,7 +37,11 @@ export function DateAllOptionsWidget({
     <DatePicker
       value={pickerValue}
       availableOperators={availableOperators}
-      submitButtonLabel={submitButtonLabel}
+      renderSubmitButton={({ isDisabled }) => (
+        <Button type="submit" variant="filled" disabled={isDisabled}>
+          {submitButtonLabel}
+        </Button>
+      )}
       onChange={handleChange}
     />
   );

--- a/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -29,7 +29,7 @@ export function DateAllOptionsWidget({
 }: DateAllOptionsWidgetProps) {
   const pickerValue = useMemo(() => getPickerValue(value), [value]);
 
-  const handleSubmit = (newPickerValue: DatePickerValue) => {
+  const handleChange = (newPickerValue: DatePickerValue) => {
     onChange(serializeDateParameterValue(newPickerValue));
   };
 
@@ -42,7 +42,7 @@ export function DateAllOptionsWidget({
           {submitButtonLabel}
         </Button>
       )}
-      onSubmit={handleSubmit}
+      onChange={handleChange}
     />
   );
 }

--- a/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/querying/parameters/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -29,7 +29,7 @@ export function DateAllOptionsWidget({
 }: DateAllOptionsWidgetProps) {
   const pickerValue = useMemo(() => getPickerValue(value), [value]);
 
-  const handleChange = (newPickerValue: DatePickerValue) => {
+  const handleSubmit = (newPickerValue: DatePickerValue) => {
     onChange(serializeDateParameterValue(newPickerValue));
   };
 
@@ -42,7 +42,7 @@ export function DateAllOptionsWidget({
           {submitButtonLabel}
         </Button>
       )}
-      onChange={handleChange}
+      onSubmit={handleSubmit}
     />
   );
 }

--- a/frontend/src/metabase/querying/parameters/components/DateRangeWidget/DateRangeWidget.tsx
+++ b/frontend/src/metabase/querying/parameters/components/DateRangeWidget/DateRangeWidget.tsx
@@ -11,6 +11,7 @@ import {
   deserializeDateParameterValue,
   serializeDateParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
+import { Button } from "metabase/ui";
 import type { ParameterValueOrArray } from "metabase-types/api";
 
 type DateRangeWidgetProps = {
@@ -35,8 +36,12 @@ export function DateRangeWidget({
   return (
     <DateRangePicker
       value={pickerValue}
-      submitButtonLabel={submitButtonLabel}
       hasTimeToggle
+      renderSubmitButton={() => (
+        <Button type="submit" variant="filled">
+          {submitButtonLabel}
+        </Button>
+      )}
       onChange={setPickerValue}
       onSubmit={handleSubmit}
     />

--- a/frontend/src/metabase/querying/parameters/components/DateSingleWidget/DateSingleWidget.tsx
+++ b/frontend/src/metabase/querying/parameters/components/DateSingleWidget/DateSingleWidget.tsx
@@ -11,6 +11,7 @@ import {
   deserializeDateParameterValue,
   serializeDateParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
+import { Button } from "metabase/ui";
 import type { ParameterValueOrArray } from "metabase-types/api";
 
 type DateSingleWidgetProps = {
@@ -35,8 +36,12 @@ export function DateSingleWidget({
   return (
     <SingleDatePicker
       value={pickerValue}
-      submitButtonLabel={submitButtonLabel}
       hasTimeToggle
+      renderSubmitButton={() => (
+        <Button type="submit" variant="filled">
+          {submitButtonLabel}
+        </Button>
+      )}
       onChange={setPickerValue}
       onSubmit={handleSubmit}
     />


### PR DESCRIPTION
Product doc https://www.notion.so/metabase/Make-it-less-annoying-to-add-a-single-filter-in-the-chill-mode-1d869354c90180b7997ef2c1712bf004
Demo https://www.loom.com/share/871bd83091de4921b2fb930485dc8e3e

Adds a split button specifically in the multi-stage filter picker in chill mode. When the plus button is used, the filter is added without running the query, and the state of the filter picker is reset so that the column list is available again.

In terms of the implementation:
- I've added `renderSubmitButton` and `renderBackButton` to the `DatePicker`. I wanted to do this before but ended up with `submitButtonLabel` instead. These changes made me re-think this solution and use render props instead. `renderSubmitButton` receives the current date picker value that can be used when clicking on the plus button.
- `FilterPicker` widgets now have the second `opts` parameter in the `onChange` callback, which has the additional `run` parameter. `MultiStageFilterPicker` uses this extra info to compute whether a) the changed query needs to be run automatically b) the state of the picker should be reset.
- E2E and unit tests are updated to match this behavior. There is 1 E2E test that applies multiple filters at once with the new plus button, with assertions that there are no extra api calls being made.

<img width="428" alt="Screenshot 2025-04-24 at 21 18 48" src="https://github.com/user-attachments/assets/4f3a1b99-6e16-412b-bd96-1b7b1e87837c" />

