### PR TITLE
Use mage for clj-kondo and cljfmt in GitHub Actions workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           m2-cache-key: 'kondo'
       - name: Run clj-kondo
-        run: ./bin/kondo.sh
+        run: ./bin/mage kondo
 
   be-linter-eastwood:
     if: ${{ !inputs.skip }}
@@ -185,7 +185,7 @@ jobs:
         with:
           m2-cache-key: 'cljfmt'
       - name: Run cljfmt
-        run: clojure -T:cljfmt check
+        run: ./bin/mage cljfmt-all --force-check
 
   be-tests-result:
     needs:

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           m2-cache-key: lint-migrations
       - name: Verify Liquibase Migrations
-        run: ./bin/lint-migrations-file.sh
+        run: ./bin/mage lint-migrations

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -369,17 +369,17 @@ some-ns=> (take 10 (keys environ.core/env))
 `clj-kondo` must be [installed separately](https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md).
 
 ```
+# Run clj-kondo
+mage kondo
+
+# Lint the migrations file (if you've written a database migration):
+mage lint-migrations
+
 # Run Eastwood
 clojure -X:dev:ee:ee-dev:drivers:drivers-dev:eastwood
 
 # Run the namespace checker
 clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:namespace-checker
-
-# Run clj-kondo
-./bin/kondo.sh
-
-# Lint the migrations file (if you've written a database migration):
-./bin/lint-migrations-file.sh
 ```
 
 ## Continuous integration


### PR DESCRIPTION
### Summary

- Updated GitHub Actions backend workflow to use mage commands (kondo and cljfmt-all) instead of direct script calls
- Updated developer documentation to reflect the use of mage for linting tasks

### Test plan

- Verify GitHub Actions workflow completes successfully with the new mage commands
- Confirm linting functionality remains the same