### PR TITLE
Renamed /api/ee/gsheets/folder to /api/ee/gsheets/connection

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -6209,9 +6209,9 @@ redirect_from:
         "tags" : [ "/api/ee/database-routing" ]
       }
     },
-    "/api/ee/gsheets/folder" : {
+    "/api/ee/gsheets/connection" : {
       "post" : {
-        "summary" : "POST /api/ee/gsheets/folder",
+        "summary" : "POST /api/ee/gsheets/connection",
         "description" : "Hook up a new google drive folder that will be watched and have its content ETL'd into Metabase.",
         "parameters" : [ ],
         "requestBody" : {
@@ -6233,13 +6233,13 @@ redirect_from:
         "tags" : [ "/api/ee/gsheets" ]
       },
       "get" : {
-        "summary" : "GET /api/ee/gsheets/folder",
+        "summary" : "GET /api/ee/gsheets/connection",
         "description" : "Check the status of a newly created gsheets folder creation. This endpoint gets polled by FE to determine when to\n  stop showing the setup widget.\n\n  Returns the gsheets shape, with the attached datawarehouse db id at `:db_id`.",
         "parameters" : [ ],
         "tags" : [ "/api/ee/gsheets" ]
       },
       "delete" : {
-        "summary" : "DELETE /api/ee/gsheets/folder",
+        "summary" : "DELETE /api/ee/gsheets/connection",
         "description" : "Disconnect the google service account. There is only one (or zero) at the time of writing.",
         "parameters" : [ ],
         "tags" : [ "/api/ee/gsheets" ]

--- a/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/gdrive.ts
@@ -16,7 +16,7 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
     >({
       query: () => ({
         method: "GET",
-        url: "/api/ee/gsheets/folder",
+        url: "/api/ee/gsheets/connection",
       }),
       providesTags: ["gsheets-status"],
     }),
@@ -26,7 +26,7 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
     >({
       query: (body) => ({
         method: "POST",
-        url: "/api/ee/gsheets/folder",
+        url: "/api/ee/gsheets/connection",
         body: body,
       }),
       invalidatesTags: ["gsheets-status"],
@@ -34,14 +34,14 @@ export const gdriveApi = EnterpriseApi.injectEndpoints({
     deleteGsheetsFolderLink: builder.mutation<{ success: boolean }, void>({
       query: () => ({
         method: "DELETE",
-        url: "/api/ee/gsheets/folder",
+        url: "/api/ee/gsheets/connection",
       }),
       invalidatesTags: ["gsheets-status"],
     }),
     syncGsheetsFolder: builder.mutation<{ db_id: DatabaseId }, void>({
       query: () => ({
         method: "POST",
-        url: "/api/ee/gsheets/folder/sync",
+        url: "/api/ee/gsheets/connection/sync",
       }),
       invalidatesTags: ["gsheets-status"],
     }),

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.unit.spec.tsx
@@ -104,7 +104,7 @@ describe("Google Drive > Connect / Disconnect modal", () => {
     expect(await screen.findByText("Import file")).toBeInTheDocument();
   });
 
-  it("should POST folder data to /api/ee/gsheets/folder", async () => {
+  it("should POST folder data to /api/ee/gsheets/connection", async () => {
     setup({
       status: "not-connected",
     });
@@ -133,7 +133,7 @@ describe("Google Drive > Connect / Disconnect modal", () => {
     });
   });
 
-  it("should POST file data to /api/ee/gsheets/folder", async () => {
+  it("should POST file data to /api/ee/gsheets/connection", async () => {
     setup({
       status: "not-connected",
     });

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
@@ -206,7 +206,7 @@ describe("Google Drive > DB Menu", () => {
     // sync should cause a refetch
     expect(await screen.findByText("Syncing")).toBeInTheDocument();
 
-    const syncCalls = fetchMock.calls("path:/api/ee/gsheets/folder/sync");
+    const syncCalls = fetchMock.calls("path:/api/ee/gsheets/connection/sync");
     expect(syncCalls).toHaveLength(1);
 
     await closeMenu();

--- a/frontend/test/__support__/server-mocks/gdrive.ts
+++ b/frontend/test/__support__/server-mocks/gdrive.ts
@@ -7,14 +7,14 @@ export function setupGdriveGetFolderEndpoint({
   ...gdrivePayload
 }: Partial<GdrivePayload> & { errorCode?: number }) {
   if (errorCode) {
-    fetchMock.get("path:/api/ee/gsheets/folder", errorCode, {
+    fetchMock.get("path:/api/ee/gsheets/connection", errorCode, {
       overwriteRoutes: true,
     });
     return;
   }
 
   fetchMock.get(
-    "path:/api/ee/gsheets/folder",
+    "path:/api/ee/gsheets/connection",
     () => {
       // fetchmock gets confused if you try to return only a 'status' property
       return { ...gdrivePayload, _test: "" };
@@ -32,11 +32,11 @@ export function setupGdriveServiceAccountEndpoint(
 }
 
 export function setupGdrivePostFolderEndpoint() {
-  fetchMock.post("path:/api/ee/gsheets/folder", { status: 202 });
+  fetchMock.post("path:/api/ee/gsheets/connection", { status: 202 });
 }
 
 export function setupGdriveSyncEndpoint() {
-  fetchMock.post("path:/api/ee/gsheets/folder/sync", () => {
+  fetchMock.post("path:/api/ee/gsheets/connection/sync", () => {
     return { db_id: 1 };
   });
 }


### PR DESCRIPTION
### Description

With the added support for google sheets which use the same APIs, the /api/gsheets/folder name is confusing.

Rename it to `/api/gsheets/connection` to make more sense for the expanded usage

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
