### PR TITLE
closes viz-360 esc key should not add a recipient

### DIFF
--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -109,8 +109,8 @@ describe("scenarios > dashboard > subscriptions", () => {
 
       it("should not add a recipient when Escape is pressed (metabase#24629)", () => {
         openDashboardSubscriptions(ORDERS_DASHBOARD_ID);
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Email it").click();
+
+        H.sidebar().findByText("Email it").click();
 
         const input = cy.findByPlaceholderText(
           "Enter user names or email addresses",

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -107,6 +107,22 @@ describe("scenarios > dashboard > subscriptions", () => {
         cy.findByText("Emailed hourly");
       });
 
+      it("should not add a recipient when Escape is pressed (metabase#24629)", () => {
+        openDashboardSubscriptions(ORDERS_DASHBOARD_ID);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Email it").click();
+
+        const input = cy.findByPlaceholderText(
+          "Enter user names or email addresses",
+        );
+        input.click().type(`${admin.first_name}`);
+        input.type("{esc}");
+
+        input.should("have.value", `${admin.first_name}`);
+
+        cy.findByTestId("token-field-popover").should("not.exist");
+      });
+
       it("should not render people dropdown outside of the borders of the screen (metabase#17186)", () => {
         openDashboardSubscriptions();
 
@@ -739,10 +755,15 @@ function assignRecipient({
 } = {}) {
   openDashboardSubscriptions(dashboard_id);
   cy.findByText("Email it").click();
-  cy.findByPlaceholderText("Enter user names or email addresses")
-    .click()
-    .type(`${user.first_name} ${user.last_name}{enter}`)
-    .blur(); // blur is needed to close the popover
+
+  const input = cy.findByPlaceholderText("Enter user names or email addresses");
+  input.click().type(`${user.first_name} ${user.last_name}`);
+
+  cy.findByTestId("token-field-popover").within(() => {
+    cy.findByText(`${user.first_name} ${user.last_name}`).click();
+  });
+
+  input.blur(); // blur is needed to close the popover
 }
 
 function assignRecipients({

--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -267,9 +267,12 @@ class _TokenField extends Component<TokenFieldProps, TokenFieldState> {
 
     const { filteredOptions, selectedOptionValue } = this.state;
 
-    // enter, tab, comma
-    if (
-      keyCode === KEYCODE_ESCAPE ||
+    if (keyCode === KEYCODE_ESCAPE) {
+      event.preventDefault();
+      this.inputRef.current?.blur();
+      this.setState({ isFocused: false });
+    } else if (
+      // enter, tab, comma
       keyCode === KEYCODE_TAB ||
       // We check event.key for comma presses because some keyboard layouts
       // (e.g. Russian) have a letter on that key and require a modifier to type
@@ -668,7 +671,7 @@ const DefaultTokenFieldLayout = ({
   <div>
     <TippyPopover
       visible={isFocused && !!optionsList}
-      content={<div>{optionsList}</div>}
+      content={<div data-testid="token-field-popover">{optionsList}</div>}
       placement="bottom-start"
     >
       <div>{valuesList}</div>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #24629
Closes [VIZ-360: `Esc` key behaves like `Enter` key on `<TokenField />` in email subscriptions pane](https://linear.app/metabase/issue/VIZ-360/esc-key-behaves-like-enter-key-on-tokenfield-in-email-subscriptions)

### Description

Escape key should hides the recipients popover instead of adding what's currently highlighted.

### How to verify

In any dashboard, open the subscription panel. In the recipients input, type anything, then hit Esc. The popover should hide away and no recipient should be added to the list.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
