### PR TITLE
Fix - Cannot schedule automatic value scanning for postgres database

### DIFF
--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -683,6 +683,43 @@ describe("scenarios > admin > databases > sample database", () => {
     });
   });
 
+  it("allows to save the default schedule (metabase#57198)", () => {
+    visitDatabase(SAMPLE_DB_ID);
+    editDatabase();
+    H.modal().findByText("Show advanced options").click();
+    cy.findByLabelText("Choose when syncs and scans happen").click();
+    cy.button("Save changes").click();
+    cy.wait("@databaseUpdate").then(({ request: { body }, response }) => {
+      expect(body.is_full_sync).to.equal(false);
+      expect(body.is_on_demand).to.equal(false);
+      // frontend sends wrong value but backend automatically corrects it for us:
+      expect(response.body.schedules.cache_field_values).to.equal(null);
+    });
+
+    editDatabase();
+    cy.findByLabelText("Regularly, on a schedule").click();
+    cy.button("Save changes").click();
+    cy.wait("@databaseUpdate").then(({ request: { body } }) => {
+      expect(body.is_full_sync).to.equal(true);
+      expect(body.is_on_demand).to.equal(false);
+      expect(body.schedules.cache_field_values).to.deep.eq({
+        schedule_day: "mon",
+        schedule_frame: null,
+        schedule_hour: 0,
+        schedule_type: "daily",
+      });
+    });
+
+    editDatabase();
+    cy.findByLabelText("Only when adding a new filter widget").click();
+    cy.button("Save changes").click();
+    cy.wait("@databaseUpdate").then(({ request: { body } }) => {
+      expect(body.is_full_sync).to.equal(false);
+      expect(body.is_on_demand).to.equal(true);
+      expect(body.schedules.cache_field_values).to.equal(null);
+    });
+  });
+
   it("database actions", () => {
     cy.intercept("POST", `/api/database/${SAMPLE_DB_ID}/sync_schema`).as(
       "sync_schema",

--- a/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
@@ -55,20 +55,20 @@ const DatabaseCacheScheduleField = ({
   const handleFullSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", true);
     setFieldValue("is_on_demand", false);
-    setFieldValue("cache_field_values", DEFAULT_SCHEDULE);
-  }, [setFieldValue]);
+    setValue(DEFAULT_SCHEDULE);
+  }, [setFieldValue, setValue]);
 
   const handleOnDemandSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", false);
     setFieldValue("is_on_demand", true);
-    setFieldValue("cache_field_values", null);
-  }, [setFieldValue]);
+    setValue(null);
+  }, [setFieldValue, setValue]);
 
   const handleNoneSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", false);
     setFieldValue("is_on_demand", false);
-    setFieldValue("cache_field_values", null);
-  }, [setFieldValue]);
+    setValue(null);
+  }, [setFieldValue, setValue]);
 
   return (
     <FormField title={title} description={description}>

--- a/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
@@ -55,16 +55,19 @@ const DatabaseCacheScheduleField = ({
   const handleFullSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", true);
     setFieldValue("is_on_demand", false);
+    setFieldValue("cache_field_values", DEFAULT_SCHEDULE);
   }, [setFieldValue]);
 
   const handleOnDemandSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", false);
     setFieldValue("is_on_demand", true);
+    setFieldValue("cache_field_values", null);
   }, [setFieldValue]);
 
   const handleNoneSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", false);
     setFieldValue("is_on_demand", false);
+    setFieldValue("cache_field_values", null);
   }, [setFieldValue]);
 
   return (

--- a/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseCacheScheduleField/DatabaseCacheScheduleField.tsx
@@ -55,8 +55,16 @@ const DatabaseCacheScheduleField = ({
   const handleFullSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", true);
     setFieldValue("is_on_demand", false);
-    setValue(DEFAULT_SCHEDULE);
-  }, [setFieldValue, setValue]);
+    const isChangingOption = !values.is_full_sync;
+    if (isChangingOption) {
+      // We only want to set the default schedule if user is changing a schedule option.
+      setValue(DEFAULT_SCHEDULE);
+    } else {
+      // "Regularly, on a schedule" ScheduleOption has a form inside.
+      // Interacting with form elements causes this handleFullSyncSelect handler to be called.
+      // We don't want to reset schedule state in this case.
+    }
+  }, [setFieldValue, setValue, values]);
 
   const handleOnDemandSyncSelect = useCallback(() => {
     setFieldValue("is_full_sync", false);


### PR DESCRIPTION
Fixes #57198 ([SEM-272](https://linear.app/metabase/issue/SEM-272/cannot-schedule-automatic-value-scanning-for-postgres-database))

### Description

Manually sets correct default `schedules.cache_field_values` when changing `is_full_sync`/`is_on_demand` in the form.

See Slack for details: https://metaboat.slack.com/archives/C08E17FN206/p1745577538363939

### How to verify

1. Admin > Databases > Click any non-sample db (sample db will fail)
2. Click "Edit connection details"
3. Click "Show advanced options"
4. Click "Choose when syncs and scans happen"
5. Click "Save changes"
6. Click "Edit connection details"
7. Click "Regularly, on a schedule"
8. Click "Save changes"

There should be no error.
