### PR TITLE
Set send-server-version? to false to hide Server version from response headers

### DIFF
--- a/src/metabase/server/instance.clj
+++ b/src/metabase/server/instance.clj
@@ -43,7 +43,8 @@
             :max-threads   (config/config-int :mb-jetty-maxthreads)
             :min-threads   (config/config-int :mb-jetty-minthreads)
             :max-queued    (config/config-int :mb-jetty-maxqueued)
-            :max-idle-time (config/config-int :mb-jetty-maxidletime)})
+            :max-idle-time (config/config-int :mb-jetty-maxidletime)
+            :send-server-version? false})
     (config/config-int :mb-jetty-request-header-size) (assoc :request-header-size (config/config-int
                                                                                    :mb-jetty-request-header-size))
     (config/config-str :mb-jetty-daemon) (assoc :daemon? (config/config-bool :mb-jetty-daemon))

--- a/test/metabase/server/instance_test.clj
+++ b/test/metabase/server/instance_test.clj
@@ -8,20 +8,21 @@
   (testing "Make sure our Jetty config functions work as expected/we don't accidentally break things (#9333)"
     (with-redefs [config/config-str (constantly "10")
                   config/config-bool (constantly true)]
-      (is (= {:keystore            "10"
-              :max-queued          10
-              :request-header-size 10
-              :port                10
-              :min-threads         10
-              :host                "10"
-              :daemon?             true
-              :ssl?                true
-              :sni-host-check?     false
-              :client-auth         :need
-              :trust-password      "10"
-              :key-password        "10"
-              :truststore          "10"
-              :max-threads         10
-              :max-idle-time       10
-              :ssl-port            10}
+      (is (= {:keystore             "10"
+              :max-queued           10
+              :request-header-size  10
+              :port                 10
+              :min-threads          10
+              :host                 "10"
+              :daemon?              true
+              :ssl?                 true
+              :sni-host-check?      false
+              :client-auth          :need
+              :trust-password       "10"
+              :key-password         "10"
+              :truststore           "10"
+              :max-threads          10
+              :max-idle-time        10
+              :ssl-port             10
+              :send-server-version? false}
              (#'server.instance/jetty-config))))))


### PR DESCRIPTION
### Description

https://ring-clojure.github.io/ring/ring.adapter.jetty.html allows the server to hide the Server response header, which could be flagged by pentesters / security audits. Set it to false so it doesn't get exposed.

### How to verify

1. Run `clojure -M:run`
3. Verify that `Server` is not returned in the response headers (`curl -l localhost:3000 | grep Server`)

### Demo

Before changes:

```
~/Work/metabase @cd0965a2 *1 ?1 ❯ curl -I localhost:3000 | grep Server                                 24.9.0 11:53:59 p.m.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Server: Jetty(12.0.25)
```

After changes:

```
~/Work/metabase @cd0965a2 *1 ?1 ❯ curl -I localhost:3000 | grep Server                                 24.9.0 11:49:53 p.m.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
