### PR TITLE
Introduce Metabase branding to PDF exports

### DIFF
--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -445,7 +445,7 @@ describe("scenarios > dashboard > download pdf", () => {
 
     H.openSharingMenu("Export as PDF");
     cy.log("We're adding a 'Metabase-' prefix for non-whitelabelled instances");
-    cy.verifyDownload(`Metabase-saving pdf dashboard - ${date}.pdf`);
+    cy.verifyDownload(`Metabase - saving pdf dashboard - ${date}.pdf`);
   });
 });
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -444,7 +444,8 @@ describe("scenarios > dashboard > download pdf", () => {
     });
 
     H.openSharingMenu("Export as PDF");
-    cy.verifyDownload(`saving pdf dashboard - ${date}.pdf`);
+    cy.log("We're adding a 'Metabase-' prefix for non-whitelabelled instances");
+    cy.verifyDownload(`Metabase-saving pdf dashboard - ${date}.pdf`);
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
+import { useHasTokenFeature } from "metabase/common/hooks";
 import {
   type DashboardAccessedVia,
   trackExportDashboardToPDF,
@@ -28,6 +29,8 @@ export const ExportAsPdfButton = ({
   hasVisibleParameters?: boolean;
 }) => {
   const dispatch = useDispatch();
+  const isWhitelabeled = useHasTokenFeature("whitelabel");
+  const includeBranding = !isWhitelabeled;
 
   const saveAsPDF = () => {
     const dashboardAccessedVia = match(dashboard?.id)
@@ -41,10 +44,11 @@ export const ExportAsPdfButton = ({
     });
 
     const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
-    return saveDashboardPdf(
-      cardNodeSelector,
-      dashboard.name ?? t`Exported dashboard`,
-    );
+    return saveDashboardPdf({
+      selector: cardNodeSelector,
+      dashboardName: dashboard.name ?? t`Exported dashboard`,
+      includeBranding,
+    });
   };
 
   const hasDashboardTabs = dashboard?.tabs && dashboard.tabs.length > 1;

--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/ExportPdfMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/ExportPdfMenuItem.tsx
@@ -1,3 +1,4 @@
+import { useHasTokenFeature } from "metabase/common/hooks";
 import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
 import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
 import { isWithinIframe } from "metabase/lib/dom";
@@ -8,9 +9,13 @@ import {
 } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { Dashboard } from "metabase-types/api";
 
-const handleClick = async (dashboard: Dashboard) => {
+const handleClick = async (dashboard: Dashboard, includeBranding: boolean) => {
   const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
-  await saveDashboardPdf(cardNodeSelector, dashboard.name).then(() => {
+  await saveDashboardPdf({
+    selector: cardNodeSelector,
+    dashboardName: dashboard.name,
+    includeBranding,
+  }).then(() => {
     trackExportDashboardToPDF({
       dashboardId: dashboard.id,
       dashboardAccessedVia: isWithinIframe()
@@ -21,11 +26,14 @@ const handleClick = async (dashboard: Dashboard) => {
 };
 
 export const ExportPdfMenuItem = ({ dashboard }: { dashboard: Dashboard }) => {
+  const isWhitelabeled = useHasTokenFeature("whitelabel");
+  const includeBranding = !isWhitelabeled;
+
   return (
     <Menu.Item
       data-testid="dashboard-export-pdf-button"
       leftSection={<Icon name="document" />}
-      onClick={() => handleClick(dashboard)}
+      onClick={() => handleClick(dashboard, includeBranding)}
     >
       {getExportTabAsPdfButtonText(dashboard.tabs)}
     </Menu.Item>

--- a/frontend/src/metabase/visualizations/lib/exports-branding-utils.tsx
+++ b/frontend/src/metabase/visualizations/lib/exports-branding-utils.tsx
@@ -3,10 +3,10 @@ import { t } from "ttag";
 
 import BrandingLogo from "metabase/public/components/EmbedFrame/LogoBadge/metabase_logo_with_text.svg?component";
 
-type FooterSize = "xs" | "s" | "m" | "l" | "xl" | "xxl" | "xxxl";
+type BrandingSize = "xs" | "s" | "m" | "l" | "xl" | "xxl" | "xxxl";
 
-export const getFooterSize = (width: number): FooterSize => {
-  const sizes: [number, FooterSize][] = [
+export const getBrandingSize = (width: number): BrandingSize => {
+  const sizes: [number, BrandingSize][] = [
     [200, "xs"],
     [600, "s"],
     [960, "m"],
@@ -30,26 +30,26 @@ const svgComponentToBase64 = (Component: JSX.Element): string => {
   return `data:image/svg+xml;base64,${encoded}`;
 };
 
-type FooterConfig = {
+type BrandingConfig = {
   /** Font size */
   fz: number;
   /** Margin between the text and the logo (if any) */
   m: number;
-  /** Footer padding */
+  /** Container padding */
   p: number;
-  /** Footer height */
+  /** Container height */
   h: number;
   /** Logo height */
   ly: number;
 };
 
 /**
- * Returns a configuration object for footer layout based on the given size.
+ * Returns a configuration object for a branding element based on the given size.
  *
- * @param size - The desired footer size (e.g., 's', 'm', 'l', etc.)
+ * @param size - The desired element size (e.g., 's', 'm', 'l', etc.)
  * @returns An object containing font size, margin, padding, height, and logo height.
  */
-export const getFooterConfig = (size: FooterSize): FooterConfig => {
+export const getBrandingConfig = (size: BrandingSize): BrandingConfig => {
   const sizes = ["xs", "s", "m", "l", "xl", "xxl", "xxxl"];
   const sizeIndex = sizes.indexOf(size);
 
@@ -70,8 +70,8 @@ export const getFooterConfig = (size: FooterSize): FooterConfig => {
   };
 };
 
-export const createFooterElement = (size: FooterSize) => {
-  const { fz, h, ly, m, p } = getFooterConfig(size);
+export const createBrandingElement = (size: BrandingSize) => {
+  const { fz, h, ly, m, p } = getBrandingConfig(size);
 
   const LOGO_ASCPECT_RATIO = 4.0625;
   const LOGO_HEIGHT = ly;
@@ -81,8 +81,8 @@ export const createFooterElement = (size: FooterSize) => {
     <BrandingLogo width={LOGO_WIDTH} height={LOGO_HEIGHT} />
   );
 
-  const footer = document.createElement("div");
-  footer.style.cssText = `
+  const container = document.createElement("div");
+  container.style.cssText = `
     height: ${h}px;
     width: 100%;
     padding-inline: ${p}px;
@@ -90,16 +90,12 @@ export const createFooterElement = (size: FooterSize) => {
     display: flex;
     align-items: center;
     justify-content: ${size === "xs" ? "center" : "flex-end"};
-    z-index: 1000;
-    position: absolute;
-    bottom: -${h}px;
-    left: 0;
   `;
 
   if (size !== "xs") {
-    const footerText = document.createElement("span");
-    footerText.textContent = t`Made with`;
-    footerText.style.cssText = `
+    const brandingCopy = document.createElement("span");
+    brandingCopy.textContent = t`Made with`;
+    brandingCopy.style.cssText = `
       font-family: "Lato", sans-serif;
       font-size: ${fz}px;
       color: var(--mb-color-text-medium);
@@ -108,7 +104,7 @@ export const createFooterElement = (size: FooterSize) => {
       vertical-align: middle;
       line-height: 1;
     `;
-    footer.appendChild(footerText);
+    container.appendChild(brandingCopy);
   }
 
   const logoDataUrl = svgComponentToBase64(LogoComponent);
@@ -118,7 +114,7 @@ export const createFooterElement = (size: FooterSize) => {
   logo.width = LOGO_WIDTH;
   logo.height = LOGO_HEIGHT;
 
-  footer.appendChild(logo);
+  container.appendChild(logo);
 
-  return footer;
+  return container;
 };

--- a/frontend/src/metabase/visualizations/lib/exports-branding-utils.tsx
+++ b/frontend/src/metabase/visualizations/lib/exports-branding-utils.tsx
@@ -115,8 +115,6 @@ export const createFooterElement = (size: FooterSize) => {
 
   const logo = document.createElement("img");
   logo.src = logoDataUrl;
-  // eslint-disable-next-line no-literal-metabase-strings -- This is used only in non-whitelabeled instances!
-  logo.alt = t`Metabase company logo`;
   logo.width = LOGO_WIDTH;
   logo.height = LOGO_HEIGHT;
 

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -75,13 +75,11 @@ export const saveChartImage = async ({
   const contentWidth = node.getBoundingClientRect().width;
 
   const size = getBrandingSize(contentWidth);
-  const BRANDING_HEIGHT = getBrandingConfig(size).h;
+  const brandingHeight = getBrandingConfig(size).h;
+  const verticalOffset = includeBranding ? brandingHeight : 0;
 
   // Appending any element to the node does not automatically increase the canvas height.
-  // We have to manually calculate it or the branding will not be visible.
-  const canvasHeight = includeBranding
-    ? contentHeight + BRANDING_HEIGHT
-    : contentHeight;
+  const canvasHeight = contentHeight + verticalOffset;
 
   const { default: html2canvas } = await import("html2canvas-pro");
   const canvas = await html2canvas(node, {
@@ -105,7 +103,7 @@ export const saveChartImage = async ({
          */
         branding.style.position = "absolute";
         branding.style.left = "0";
-        branding.style.bottom = `-${BRANDING_HEIGHT}px`;
+        branding.style.bottom = `-${brandingHeight}px`;
         branding.style.zIndex = "1000";
 
         node.appendChild(branding);

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -9,9 +9,9 @@ import { openImageBlobOnStorybook } from "metabase/lib/loki-utils";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 
 import {
-  createFooterElement,
-  getFooterConfig,
-  getFooterSize,
+  createBrandingElement,
+  getBrandingConfig,
+  getBrandingSize,
 } from "./exports-branding-utils";
 
 export const SAVING_DOM_IMAGE_CLASS = "saving-dom-image";
@@ -74,13 +74,13 @@ export const saveChartImage = async ({
   const contentHeight = node.getBoundingClientRect().height;
   const contentWidth = node.getBoundingClientRect().width;
 
-  const size = getFooterSize(contentWidth);
-  const FOOTER_HEIGHT = getFooterConfig(size).h;
+  const size = getBrandingSize(contentWidth);
+  const BRANDING_HEIGHT = getBrandingConfig(size).h;
 
   // Appending any element to the node does not automatically increase the canvas height.
-  // We have to manually calculate it or the footer will not be visible.
+  // We have to manually calculate it or the branding will not be visible.
   const canvasHeight = includeBranding
-    ? contentHeight + FOOTER_HEIGHT
+    ? contentHeight + BRANDING_HEIGHT
     : contentHeight;
 
   const { default: html2canvas } = await import("html2canvas-pro");
@@ -96,8 +96,19 @@ export const saveChartImage = async ({
       node.style.border = "none";
 
       if (includeBranding) {
-        const footer = createFooterElement(size);
-        node.appendChild(footer);
+        const branding = createBrandingElement(size);
+        /**
+         * The DOM node that encapsulates the dashboard card is absolutely positioned.
+         * That node is the container for the chart, and for the branding element.
+         * Unless we sanitize the container, we have to position the branding content
+         * appropriately, or it will not be visible.
+         */
+        branding.style.position = "absolute";
+        branding.style.left = "0";
+        branding.style.bottom = `-${BRANDING_HEIGHT}px`;
+        branding.style.zIndex = "1000";
+
+        node.appendChild(branding);
       }
     },
   });

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -150,11 +150,23 @@ const HEADER_MARGIN_BOTTOM = 12;
 const PARAMETERS_MARGIN_BOTTOM = 12;
 const PAGE_PADDING = 16;
 
-export const saveDashboardPdf = async (
-  selector: string,
-  dashboardName: string,
-) => {
-  const fileName = `${dashboardName}.pdf`;
+interface SavePdfProps {
+  selector: string;
+  dashboardName: string;
+  includeBranding: boolean;
+}
+
+export const saveDashboardPdf = async ({
+  selector,
+  dashboardName,
+  includeBranding,
+}: SavePdfProps) => {
+  const originalFileName = `${dashboardName}.pdf`;
+  const fileName = includeBranding
+    ? // eslint-disable-next-line no-literal-metabase-strings -- Used explicitly in non-whitelabeled instances
+      `Metabase-${originalFileName}`
+    : originalFileName;
+
   const dashboardRoot = document.querySelector(selector);
   const gridNode = dashboardRoot?.querySelector(".react-grid-layout");
 
@@ -188,7 +200,8 @@ export const saveDashboardPdf = async (
 
   const size = getBrandingSize(width);
   const brandingHeight = getBrandingConfig(size).h;
-  const verticalOffset = headerHeight + parametersHeight + brandingHeight;
+  const verticalOffset =
+    headerHeight + parametersHeight + (includeBranding ? brandingHeight : 0);
   const contentHeight = gridNode.offsetHeight + verticalOffset;
 
   const backgroundColor = getComputedStyle(document.documentElement)
@@ -209,8 +222,10 @@ export const saveDashboardPdf = async (
       }
       node.insertBefore(pdfHeader, node.firstChild);
 
-      const branding = createBrandingElement(size);
-      node.insertBefore(branding, node.firstChild);
+      if (includeBranding) {
+        const branding = createBrandingElement(size);
+        node.insertBefore(branding, node.firstChild);
+      }
     },
   });
 
@@ -291,7 +306,7 @@ export const saveDashboardPdf = async (
         sourceHeight,
       );
 
-      if (isFirstPage) {
+      if (isFirstPage && includeBranding) {
         const url =
           "https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=pdf_export";
 

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -242,6 +242,7 @@ export const saveDashboardPdf = async (
   let prevBreak = 0;
 
   pageEnds.forEach((pageBreak, index) => {
+    const isFirstPage = index === 0;
     const isLastPage = index === pageEnds.length - 1;
     const pageBreaksDiff = pageBreak - prevBreak;
 
@@ -289,6 +290,15 @@ export const saveDashboardPdf = async (
         contentWidth,
         sourceHeight,
       );
+
+      if (isFirstPage) {
+        const url =
+          "https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=pdf_export";
+
+        pdf.link(PAGE_PADDING, PAGE_PADDING, contentWidth, brandingHeight, {
+          url,
+        });
+      }
     }
 
     prevBreak = pageBreak;

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -3,6 +3,11 @@ import { t } from "ttag";
 import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import type { Dashboard } from "metabase-types/api";
 
+import {
+  createBrandingElement,
+  getBrandingConfig,
+  getBrandingSize,
+} from "./exports-branding-utils";
 import { SAVING_DOM_IMAGE_CLASS } from "./save-chart-image";
 
 const TARGET_ASPECT_RATIO = 21 / 17;
@@ -178,10 +183,13 @@ export const saveDashboardPdf = async (
     pdfHeader.getBoundingClientRect().height + HEADER_MARGIN_BOTTOM;
   gridNode.removeChild(pdfHeader);
 
-  const verticalOffset = headerHeight + parametersHeight;
   const contentWidth = gridNode.offsetWidth;
-  const contentHeight = gridNode.offsetHeight + verticalOffset;
   const width = contentWidth + PAGE_PADDING * 2;
+
+  const size = getBrandingSize(width);
+  const brandingHeight = getBrandingConfig(size).h;
+  const verticalOffset = headerHeight + parametersHeight + brandingHeight;
+  const contentHeight = gridNode.offsetHeight + verticalOffset;
 
   const backgroundColor = getComputedStyle(document.documentElement)
     .getPropertyValue("--mb-color-bg-dashboard")
@@ -200,6 +208,9 @@ export const saveDashboardPdf = async (
         node.insertBefore(parametersNode, node.firstChild);
       }
       node.insertBefore(pdfHeader, node.firstChild);
+
+      const branding = createBrandingElement(size);
+      node.insertBefore(branding, node.firstChild);
     },
   });
 

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -164,7 +164,7 @@ export const saveDashboardPdf = async ({
   const originalFileName = `${dashboardName}.pdf`;
   const fileName = includeBranding
     ? // eslint-disable-next-line no-literal-metabase-strings -- Used explicitly in non-whitelabeled instances
-      `Metabase-${originalFileName}`
+      `Metabase - ${originalFileName}`
     : originalFileName;
 
   const dashboardRoot = document.querySelector(selector);


### PR DESCRIPTION
## What does this PR accomplish?
Resolves PRG-1 by introducing the branding content to the dashboard PDF exports
Resolves PRG-7 by making the branding content clickable

Additionally resolves PRG-14

- The blue shaded area is clickable.
- The yellow/orange shaded area is static (not clickable). That is the canvas content that existed prior to this PR.
<img width="402" alt="image" src="https://github.com/user-attachments/assets/c1270fc4-7d0e-46c0-a563-0162bdbdbead" />

### Technical details and the trade-off
In order to add the value to the product faster, I opted for the simplified approach by first creating a new branding DOM element and appending it to the dashboard (node we're grabbing using a specific selector). All that together gets painted on a canvas that we then pass to the PDF library. But before we export the final PDF, we're adding a link (area) that overlays the upper part of the PDF, and matches the height of the branding content. It spans the full width of the PDF (sans margins).

> [!NOTE]
> We want to re-use the utilities from `frontend/src/metabase/visualizations/lib/exports-branding-utils.tsx` so I had to make them "position-agnostic". They were previously used only for PNG exports in the form of a footer. Hence why this PR is slightly bigger and includes a few extra files in the diff.

### Testing
The existing E2E test was failing because we're now changing the file name structure. I've updated it.

If you want to test this manually, follow these steps:

**Regular dashboard**
1. open a dashboard
2. click on the "sharing" icon
3. click on "Export as PDF"
4. the file name should start with "Metabase - "
5. the exported PDF should have the branding content at the top of the first page
6. the content should be clickable and should lead to the www.metabase.com (with some utm params)

**Static embedding**
1. open a dashboard
2. click on the "sharing" icon
3. click on the "Embed"
4. choose a "Static embedding"
5. click on "Look and feel", and then "Preview" to see the content of the dashboard
6. locate the download icon at the very top right of this preview and download the dashboard
7. you can do this for both the "light" and the "dark" modes
8. all the same rules (4,5,6) that apply to regular dashboards should apply here as well