### PR TITLE
Fix fast reload for some databases

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -23,7 +23,10 @@
   "Given a row, strip it down to just its primary keys."
   [pk-fields row]
   (->> (map (comp keyword :name) pk-fields)
-       (select-keys row)
+       ;; Hideous workaround for QP and direct JDBC disagreeing on case
+       (select-keys (merge (update-keys row (comp keyword u/upper-case-en name))
+                           (u/lower-case-map-keys row)
+                           row))
        ;; Hack for now, pending discussion of the ideal fix
        ;; https://linear.app/metabase/issue/WRK-281/undo-deletes-a-record-instead-of-reverting-the-edits
        ;; See https://metaboat.slack.com/archives/C0641E4PB9B/p1744978660610899

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -335,16 +335,16 @@
             ;; TODO -- this should probably be using [[metabase.driver/execute-write-query!]]
             rows-updated (with-auto-parse-sql-exception driver database action
                            (first (jdbc/execute! {:connection conn} sql-args {:transaction? false})))
+            _            (when-not (= rows-updated 1)
+                           (throw (ex-info (if (zero? rows-updated)
+                                             (tru "Sorry, the row you''re trying to update doesn''t exist")
+                                             (tru "Sorry, this would update {0} rows, but you can only act on 1" rows-updated))
+                                           {:status-code 400})))
             row-after    (as-> {:select [:*] :from from :where where} %
                            (prepare-query % driver action)
                            (sql.qp/format-honeysql driver %)
                            (jdbc/query {:connection conn} % {:transaction? false})
                            (first %))]
-        (when-not (= rows-updated 1)
-          (throw (ex-info (if (zero? rows-updated)
-                            (tru "Sorry, the row you''re trying to update doesn''t exist")
-                            (tru "Sorry, this would update {0} rows, but you can only act on 1" rows-updated))
-                          {:status-code 400})))
         {:table-id (-> query :query :source-table)
          :before row-before
          :after  row-after}))))


### PR DESCRIPTION
Databases are weird.

Sometimes we sync databases, and they tell us uppercase. Then, we query them and they tell us lowercase.

This puts a band-aid on the problem.