### PR TITLE
[refs] Don't backfill `:result_metadata` on read; strip idents instead

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -2,8 +2,6 @@
   "Underlying DB model for what is now most commonly referred to as a 'Question' in most user-facing situations. Card
   is a historical name, but is the same thing; both terms are used interchangeably in the backend codebase."
   (:require
-   [clojure.core.cache :as cache]
-   [clojure.core.cache.wrapped :as cache.wrapped]
    [clojure.data :as data]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -78,7 +76,7 @@
 
   The core `after-select` logic compares each row's `card_schema` and runs the upgrade functions for all versions up to
   and including [[current-schema-version]]."
-  21)
+  22)
 
 (defmulti ^:private upgrade-card-schema-to
   "Upgrades a card on read, so that it fits the given schema version number.
@@ -803,82 +801,22 @@
        @hashed-eid (assoc :entity_id @entity-id)))))
 
 ;; Schema upgrade: 20 to 21 ==========================================================================================
-;; 21 begins storing `:ident`s on all columns in `:result_metadata`.
+;; Originally this backfilled `:ident`s on all columns in `:result_metadata`.
+;; However, that caused performance problems since it's often recursive, and the caching was ineffective.
+;; Now this upgrade is a no-op.
+(defmethod upgrade-card-schema-to 21 [card _schema-version]
+  card)
 
-;; On reading an old card and upgrading it to 21, the idents are inferred from the query and filled in.
-;; Since this operation is expensive (and recursive when cards depend on cards!), a bounded cache is used to prevent
-;; too much repeated work being performed.
-(defn- backfill-result-metadata-idents*
-  [result-metadata {query :dataset_query, eid :entity_id, :as card}]
-  (case (:type query)
-    ;; For native queries, the `:ident`s are always based directly on the column names.
-    :native (if eid
-              ;; NOTE: Deliberately prefer the field_ref name over :name here! :name is sometimes not unique, if the
-              ;; SQL contains duplicate names. Instead, using the string name from the `:field_ref`, which is
-              ;; disambiguated properly. Fall back to the :name if the :field_ref isn't provided.
-              (mapv (fn [{column-name :name, [_field ref-name] :field_ref, :as col}]
-                      (cond-> (assoc col :ident (lib/native-ident (or ref-name column-name)
-                                                                  eid))
-                        (= (:type card) :model) (lib/add-model-ident eid)))
-                    result-metadata)
-              (throw (ex-info (str "Cannot backfill result_metadata for a native card without an entity_id! "
-                                   "Include :entity_id in your query.")
-                              {:card card})))
-
-    ;; For MBQL queries, re-run the inference, which will include correct idents.
-    :query  (let [inferred (card.metadata/infer-metadata-with-model-overrides query card) ; These already have [[lib/model-ident]] applied.
-                  by-ref   (group-by :field_ref inferred)
-                  by-name  (group-by :name inferred)]
-              (mapv (fn [original]
-                      (let [matches (or (get by-ref (:field_ref original))
-                                        (get by-name (:name original)))]
-                        (when (empty? matches)
-                          (log/warn "No match of saved result_metadata with inferred metadata."
-                                    {:column original}))
-                        (when (next matches)
-                          (log/warn "Ambiguous match of saved result_metadata with inferred metadata."
-                                    {:column original
-                                     :candidates matches}))
-                        (or (first matches)
-                            original)))
-                    result-metadata))
-    ;; Fallback: Do nothing.
-    result-metadata))
-
-;; NOTE: This is safe to cache even with horizontal scaling, since the cache is only used when old cards are read.
-;; If any Metabase instance updates the card, it will be at version 21+ and already have :idents, so the cache will
-;; never be checked.
-(def ^:private backfill-result-metadata-idents-cache
-  "Using LIRS caching for a balance of recently-used and often-reused, with the default limits for now.
-
-  Since `:result_metadata` is written out after each card gets (directly) executed, the often-executed cards will
-  rapidly get updated to schema 21 and no longer need to run this inference.
-
-  The bad case is widely used cards/models that are never executed directly but often referenced."
-  ;; TODO: Consider feeding this cache's misses to a queue for a background job to populate often-referenced,
-  ;; never-executed cards with the results.
-  (atom (cache/lirs-cache-factory {})))
-
-(defn- backfill-result-metadata-idents
-  "Cache wrapper for [[backfill-result-metadata-idents**]]; bounded caching on the card ID."
-  [result-metadata card]
-  (cache.wrapped/lookup-or-miss backfill-result-metadata-idents-cache (:id card)
-                                (fn [_]
-                                  (backfill-result-metadata-idents* result-metadata card))))
-
-(defmethod upgrade-card-schema-to 21
-  ;; If we're fetching this card's `:result_metadata`, and it has a `:dataset_query`, we can compute the
-  ;; idents and fill them in.
-  ;; If we fetched non-empty `:result_metadata` without `:ident`s in it, but didn't fetch the `:dataset_query`,
-  ;; then throw - that query needs to be fixed.
-  [{query :dataset_query, cols :result_metadata, :as card} _schema-version]
-  (let [needs-idents? (and (seq cols) (some (complement :ident) cols))]
-    (when (and needs-idents? (not query))
-      (throw (ex-info "Cannot backfill :result_metadata without :dataset_query" {:card (:id card)})))
-    (cond-> card
-      ;; Have the query and result_metadata, and the idents are not already filled in.
-      (and query needs-idents?)
-      (update :result_metadata backfill-result-metadata-idents card))))
+;; Schema upgrade: 21 to 22 ==========================================================================================
+;; Two bugs during development of the field refs overhaul resulted in bad `:ident`s being saved into
+;; `:result_metadata` in certain cases.
+;; - Early on, some old "field__Database__Schema__TableName__FieldName" idents got saved for models.
+;; - A bug in #56244 computed bad idents given a fresh column (like an aggregation) while the source was a model.
+;; To avoid both of these issues, the upgrade to 22 simply discards any old idents.
+(defmethod upgrade-card-schema-to 22
+  [card _schema-version]
+  (update card :result_metadata (fn [cols]
+                                  (mapv #(dissoc % :ident :model/inner_ident) cols))))
 
 (defn- upgrade-card-schema-to-latest [card]
   (if (and (:id card)

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -17,7 +17,7 @@
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
 
-(declare ^:private fix-incoming-idents valid-ident?)
+(declare ^:private fix-incoming-idents)
 
 (mr/def ::future
   [:fn {:error/message "A future"} future?])
@@ -144,21 +144,22 @@ saved later when it is ready."
   minutes."
   (u/minutes->ms 15))
 
-(defn- valid-ident?
-  "Validates that model columns have idents that always start with `model[CardEntityId]__`, and that all idents are
-  nonempty strings.
+;; TODO: Bring this back once we can count on idents again.
+#_(defn- valid-ident?
+    "Validates that model columns have idents that always start with `model[CardEntityId]__`, and that all idents are
+    nonempty strings.
 
-  Note that this **does not** check that `:type :native` queries have native idents - SQL-based sandboxing stores
-  `:native` queries but returns MBQL-like metadata with IDs and the Field `entity_id`s as idents."
-  ;; TODO: That limitation that prevents checking native queries have native-looking :idents is unfortunate.
-  ;; At least this checks that we never store `native[]__`, ie. native queries without a card entity_id.
-  ([column card]
-   (valid-ident? column (= (:type card) :model) (:entity_id card)))
-  ([column model? entity-id]
-   (let [valid-fn (cond
-                    model?               lib/valid-model-ident?
-                    :else                lib/valid-basic-ident?)]
-     (valid-fn column entity-id))))
+    Note that this **does not** check that `:type :native` queries have native idents - SQL-based sandboxing stores
+    `:native` queries but returns MBQL-like metadata with IDs and the Field `entity_id`s as idents."
+    ;; TODO: That limitation that prevents checking native queries have native-looking :idents is unfortunate.
+    ;; At least this checks that we never store `native[]__`, ie. native queries without a card entity_id.
+    ([column card]
+     (valid-ident? column (= (:type card) :model) (:entity_id card)))
+    ([column model? entity-id]
+     (let [valid-fn (cond
+                      model?               lib/valid-model-ident?
+                      :else                lib/valid-basic-ident?)]
+       (valid-fn column entity-id))))
 
 (mu/defn save-metadata-async!
   "Save metadata when (and if) it is ready. Takes a chan that will eventually return metadata. Waits up
@@ -211,7 +212,8 @@ saved later when it is ready."
     (let [eid (:entity_id card)]
       (map (fn [col]
              (cond-> col
-               (not (lib/valid-model-ident? col eid)) (lib/add-model-ident eid)))))
+               (and (lib/valid-basic-ident? col eid)
+                    (not (lib/valid-model-ident? col eid))) (lib/add-model-ident eid)))))
     identity))
 
 (defn infer-metadata-with-model-overrides
@@ -246,7 +248,7 @@ saved later when it is ready."
   - Be for an inner query, not for a model, and need to be wrapped with the [[lib/model-ident]]."
   [results-metadata card]
   ;; It's important that the placeholders are handled first, otherwise the check for double-wrapping will fail.
-  (into [] (comp (map #(update % :ident lib/replace-placeholder-idents (:entity_id card)))
+  (into [] (comp (map #(m/update-existing % :ident lib/replace-placeholder-idents (:entity_id card)))
                  (xform-maybe-fix-idents-for-model card))
         results-metadata))
 
@@ -292,10 +294,11 @@ saved later when it is ready."
 
 (defn assert-valid-idents!
   "Given a card (or updates being made to a card) check the `:result_metadata` has correctly formed idents."
-  [{cols :result_metadata :as card}]
-  (lib/assert-idents-present! cols {:card-id (:id card)})
-  (when-let [invalid (seq (remove #(or (nil? (:ident %))
-                                       (valid-ident? % card))
-                                  cols))]
-    (log/warnf "Some columns in :result_metadata (card %d %s %s) have bad :idents! Query %s and bad columns %s"
-               (:id card) (:entity_id card) (str (:type card)) (:dataset_query card) invalid)))
+  [{_cols :result_metadata :as _card}]
+  ;; TODO: Bring back these safety checks when we can rely on card having `:ident`s.
+  #_(lib/assert-idents-present! cols {:card-id (:id card)})
+  #_(when-let [invalid (seq (remove #(or (nil? (:ident %))
+                                         (valid-ident? % card))
+                                    cols))]
+      (log/warnf "Some columns in :result_metadata (card %d %s %s) have bad :idents! Query %s and bad columns %s"
+                 (:id card) (:entity_id card) (str (:type card)) (:dataset_query card) invalid)))

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
@@ -21,7 +21,7 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: OMuZ0wHe2O5Z_59-cLmn4
   label: series_question_a

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
@@ -21,7 +21,7 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: XsxiHuzwlGIFNq245HdZC
   label: series_question_b

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
@@ -21,7 +21,7 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: f1C68pznmrpN1F5xFDj6d
   label: some_question

--- a/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
+++ b/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
@@ -25,7 +25,7 @@ dataset_query:
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: aqpA3mIKUnfzYUlwjuGwT
   label: source_question

--- a/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
+++ b/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
@@ -21,7 +21,7 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: ze7O4-8qRFH1v2Ho2apT1
   label: root_card

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
@@ -21,7 +21,7 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: m98z04nYGCF5n7cvOTfbj
   label: grandparent_card

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
@@ -21,7 +21,7 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: IBZSKSt2-QOMviIaGcQE6
   label: parent_card

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
@@ -21,7 +21,7 @@ dataset_query: {}
 result_metadata: null
 visualization_settings:
   column_settings: null
-card_schema: 21
+card_schema: 22
 serdes/meta:
 - id: Ra0JVOCXKTxH5TPbwZm0x
   label: child_card


### PR DESCRIPTION
Fixes QUE-989, QUE-905.

### Description

Stop backfilling idents in `result_metadata` on reading cards. That's costly and recursive, and was the source
of the perf issues on stats.

We're planning instead to support optional, best-effort idents for a longer period, and let the background job do
the work.

### How to verify

Cards get loaded without idents in their `result_metadata` if they had an old schema.
Idents can still be saved with query results.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
