### PR TITLE
[refs] Fix `annotate` so model idents are only applied to source columns

### DIFF
--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -562,7 +562,8 @@
 
   (for [col cols]
     (cond-> col
-      ;; Check that the ident isn't already set for this model, to avoid "double-bagging".
+      ;; Check that the ident isn't already set for the source model, to avoid "double-bagging".
+      ;; That only applies to `:source :fields` columns though - not expressions, aggregations, etc.
       (not (lib/valid-model-ident? col card-entity-id))
       (lib/add-model-ident card-entity-id))))
 
@@ -579,14 +580,14 @@
       source-query
       (cond-> (cols-for-source-query inner-query outer-query results)
         true       (u/prog1 #_sq-cols (qp.debug/debug> [`cols-for-source-query <>]))
-        (seq cols) ((fn [sq-cols]
-                      (u/prog1 (flow-field-metadata sq-cols cols model?)
-                        (qp.debug/debug> [`flow-field-metadata 'sq-cols sq-cols 'cols cols 'model? model? '=>
-                                          ^{:portal.viewer/default :portal.viewer/diff}
-                                          [(vec sq-cols) (vec <>)]]))))
         model?     ((fn [sq-cols]
                       (u/prog1 (idents-for-model sq-cols entity-id)
                         (qp.debug/debug> [`idents-for-model entity-id sq-cols '=>
+                                          ^{:portal.viewer/default :portal.viewer/diff}
+                                          [(vec sq-cols) (vec <>)]]))))
+        (seq cols) ((fn [sq-cols]
+                      (u/prog1 (flow-field-metadata sq-cols cols model?)
+                        (qp.debug/debug> [`flow-field-metadata 'sq-cols sq-cols 'cols cols 'model? model? '=>
                                           ^{:portal.viewer/default :portal.viewer/diff}
                                           [(vec sq-cols) (vec <>)]])))))
 


### PR DESCRIPTION
Fixes QUE-904.

### Description

With (1) a fresh column like an aggregation, and (2) when the source was a model:
`annotate` was wrapping the column's ident as if it came from the source model, but that's incorrect.

This adjusts the order of operations so that only columns inherited from the source get their idents
wrapped with the source model.

### How to verify

1. Create a model (which can be just a wrapper for a table)
2. Create a question based on that model
3. Add aggregations, breakouts or expressions to that question
4. Those fresh columns get plain NanoIDs as their idents, no `model[ModelEntityID]__FreshColumnIdent` wrapper.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
