### PR TITLE
Close table header popover on second click

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -445,8 +445,8 @@ export function tableHeaderClick(headerString) {
   tableHeaderColumn(headerString).click();
 }
 
-export function clickActionsPopover() {
-  return popover({ testId: "click-actions-popover" });
+export function clickActionsPopover({ skipVisibilityCheck = false } = {}) {
+  return popover({ testId: "click-actions-popover", skipVisibilityCheck });
 }
 
 export function segmentEditorPopover() {

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -377,26 +377,15 @@ describe("scenarios > visualizations > table", () => {
       .and("contain", "No description");
   });
 
-  it.skip("should close the colum popover on subsequent click (metabase#16789)", () => {
+  it("should close the colum popover on subsequent click (metabase#16789)", () => {
     H.openPeopleTable({ limit: 2 });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("City").click();
-    H.popover().within(() => {
-      cy.icon("arrow_up");
-      cy.icon("arrow_down");
-      cy.icon("gear");
-      cy.findByText("Filter by this column");
-      cy.findByText("Distribution");
-      cy.findByText("Distinct values");
-    });
+    H.tableHeaderColumn("City").click();
+    H.clickActionsPopover().should("be.visible");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("City").click();
-    // Although arbitrary waiting is considered an anti-pattern and a really bad practice, I couldn't find any other way to reproduce this issue.
-    // Cypress is too fast and is doing the assertions in that split second while popover is reloading which results in a false positive result.
-    cy.wait(100);
-    H.popover().should("not.exist");
+    H.tableHeaderColumn("City").click();
+    cy.wait(100); // Ensure popover is closed
+    H.clickActionsPopover({ skipVisibilityCheck: true }).should("not.exist");
   });
 
   it("popover should not be scrollable horizontally (metabase#31339)", () => {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -330,11 +330,21 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
       if (columnIndex === -1) {
         return;
       }
-      const clicked = getTableHeaderClickedObject(data, columnIndex, isPivoted);
-      onVisualizationClick({ ...clicked, element: event.currentTarget });
+      const newClicked = getTableHeaderClickedObject(
+        data,
+        columnIndex,
+        isPivoted,
+      );
+      if (clicked?.element === event.currentTarget) {
+        // Close the click actions popover after clicking on the column header the second time
+        onVisualizationClick(null);
+      } else {
+        onVisualizationClick({ ...newClicked, element: event.currentTarget });
+      }
     },
     [
       data,
+      clicked,
       isPivoted,
       onVisualizationClick,
       sorting,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #16789
### To verify

1. Open any table viz
2. Click on any table header
3. Ensure you can see the click actions popover
4. Click on the table header again
5. Ensure the popover is closed

### Demo

https://github.com/user-attachments/assets/cf03862c-8a15-43b4-9785-043e640b6891

