### PR TITLE
Refactor Build + Docker Uberjar Job

### DIFF
--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -13,6 +13,10 @@ on:
         type: string
       commit:
         type: string
+      dockerhub_username:
+        type: string
+      dockerhub_password:
+        type: string
   workflow_dispatch:
     inputs:
       artifact-name:
@@ -66,8 +70,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+        username: ${{ inputs.dockerhub_username || secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ inputs.dockerhub_password || secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Set up QEMU
       if: contains(steps.platforms.outputs.result, 'arm')
       uses: docker/setup-qemu-action@v3
@@ -103,8 +107,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+        username: ${{ inputs.dockerhub_username || secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ inputs.dockerhub_password || secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Pull the container image
       run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
     - name: Launch container
@@ -123,8 +127,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+        username: ${{ inputs.dockerhub_username || secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ inputs.dockerhub_password || secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Pull the container image
       run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
     - name: Launch container

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -13,10 +13,9 @@ on:
         type: string
       commit:
         type: string
-      dockerhub_username:
+      release:
         type: string
-      dockerhub_password:
-        type: string
+        default: 'true'
   workflow_dispatch:
     inputs:
       artifact-name:
@@ -70,8 +69,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ inputs.dockerhub_username || secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ inputs.dockerhub_password || secrets.DOCKERHUB_RELEASE_TOKEN }}
+        username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Set up QEMU
       if: contains(steps.platforms.outputs.result, 'arm')
       uses: docker/setup-qemu-action@v3
@@ -107,8 +106,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ inputs.dockerhub_username || secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ inputs.dockerhub_password || secrets.DOCKERHUB_RELEASE_TOKEN }}
+        username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Pull the container image
       run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
     - name: Launch container
@@ -127,8 +126,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ inputs.dockerhub_username || secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ inputs.dockerhub_password || secrets.DOCKERHUB_RELEASE_TOKEN }}
+        username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Pull the container image
       run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
     - name: Launch container

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -56,7 +56,7 @@ jobs:
           const version = "${{ inputs.tag }}".split('-')[0];
 
           if (!isValidVersionString(version)) {
-            return "linux/amd64";
+            return "linux/amd64,linux/arm64";
           }
           // versions before 53 need to be handled differently
           const buildInfo = getBuildRequirements(version);

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -141,8 +141,7 @@ jobs:
       commit: ${{ github.event.inputs.commit || github.sha }}
       repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
-      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+      release: "false"
 
   run-trivy:
     needs: [get-container-info, containerize]

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -1,12 +1,16 @@
 name: Build + Docker Uberjar
 
+# This workflow builds an uberjar and pushes it to dockerhub for any branch, either on-demand,
+# or automatically for the listed branches
+
 on:
   push:
     branches:
-      - "master"
+      - master
       - metabot-v3-second-try
       - feature-visualizer
-      - "internal-tools"
+      - internal-tools
+      - refactor-uberjar-job # FIXME for testing
     paths-ignore:
       # config files
       - ".**"
@@ -23,13 +27,69 @@ on:
         description: "Optional full-length commit SHA-1 hash"
 
 jobs:
+  get-container-info:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    name: Get container info
+    outputs:
+      editions: ${{ fromJson(steps.info.outputs.result).editions }}
+      ee: ${{ fromJson(steps.info.outputs.result).ee }}
+      oss: ${{ fromJson(steps.info.outputs.result).oss }}
+    steps:
+      - name: Get docker repo and tag
+        id: info
+        uses: actions/script@v7
+        with:
+          script: | # js
+            const branch = '${{ github.ref_name }}';
+            const owner = '${{ github.repository_owner }}';
+
+            console.log(`Branch: ${branch}`);
+
+            // TODO: remove when we're done testing metabot
+            if (branch === "metabot-v3-second-try") {
+              return {
+                editions: ["ee"],
+                ee: {
+                  repo: `${owner}/metabase-enterprise-head`,
+                  tag: "metabot"
+                };
+              }
+            }
+
+            if (branch === "master") {
+              return {
+                editions: ["ee", "oss"],
+                ee: {
+                  repo: `${owner}/metabase-enterprise-head`,
+                  tag: "latest"
+                },
+                oss: {
+                  repo: `${owner}/metabase-head`,
+                  tag: "latest"
+                }
+              };
+            }
+
+            return {
+              editions: ["ee"],
+              ee: {
+                repo: `${owner}/metabase-dev`,
+                tag: branch
+              },
+            };
+      - name: Print output
+        run: |
+          echo "editions: ${{ fromJson(steps.info.outputs.result) }}"
+
   build:
+    needs: get-container-info
     name: Build MB ${{ matrix.edition }}
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:
-        edition: [ee, oss]
+        edition: ${{ needs.get-container-info.outputs.editions }}
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
@@ -52,14 +112,14 @@ jobs:
         with:
           name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
 
-  check_jar_health:
+  check-jar-health:
     runs-on: ubuntu-22.04
     name: Is ${{ matrix.edition }} (java ${{ matrix.java-version }}) healthy?
-    needs: build
+    needs: [build, get-container-info]
     timeout-minutes: 10
     strategy:
       matrix:
-        edition: [ee, oss]
+        edition: ${{ needs.get-container-info.outputs.editions }}
         java-version: [21]
     steps:
       - name: Prepare JRE (Java Run-time Environment)
@@ -79,254 +139,37 @@ jobs:
       - name: Wait for Metabase to start
         run: while ! curl 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
 
-  containerize_test_and_push_container:
-    runs-on: ubuntu-22.04
-    name: Containerize ${{ matrix.edition }}
-    needs: check_jar_health
+  containerize:
+    needs: [check-jar-health, get-container-info]
     strategy:
       matrix:
-        edition: [ee, oss]
-      fail-fast: false
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-    steps:
-      - name: Extract and clean branch name
-        shell: bash
-        run: echo "branch=$(echo $GITHUB_REF_NAME | sed 's/[^-._a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
-        id: extract_branch
-      - name: Verify the intended tag of the container image
-        run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
-      - name: Check out the code (Dockerfile needed)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.commit }}
-      - name: Download uploaded artifacts to insert into container
-        uses: actions/download-artifact@v4
-        with:
-          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
-          path: bin/docker/
-      - name: Move the ${{ matrix.edition }} uberjar to the context dir
-        run: mv bin/docker/target/uberjar/metabase.jar bin/docker/.
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2.5.0
-        with:
-          driver-opts: network=host
-      - name: Build ${{ matrix.edition }} container
-        uses: docker/build-push-action@v3
-        with:
-          context: bin/docker/.
-          platforms: linux/amd64,linux/arm64
-          network: host
-          tags: localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}
-          build-args: |
-            GIT_COMMIT_SHA=${{ github.sha }}
-          no-cache: true
-          push: true
-      - name: Launch ${{ matrix.edition }} container
-        run: docker run --rm -dp 3000:3000 localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}
-        timeout-minutes: 5
-      - name: Is Docker running?
-        run: docker ps
-      - name: Wait for Metabase to start and reach 100% health
-        run: while ! curl 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-        timeout-minutes: 3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        edition: ${{ needs.get-container-info.outputs.editions }}
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
+      commit: ${{ github.sha }}
+      repo: ${{ needs.get-container-info.outputs[matrix.edition].repo }}
+      tag: ${{ needs.get-container-info.outputs[matrix.edition].tag }}
 
-      - name: Retag and push images if master (ee) - should be cached at this point
-        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-        uses: docker/build-push-action@v3
-        with:
-          context: bin/docker/.
-          platforms: linux/amd64,linux/arm64
-          network: host
-          tags: ${{ github.repository_owner }}/metabase-enterprise-head:latest
-          build-args: |
-            GIT_COMMIT_SHA=${{ github.sha }}
-          no-cache: false
-          push: true
-
-      # TODO: remove when we're done testing metabot
-      - name: Retag and push images if metabot-v3-second-try (ee) - should be cached at this point
-        if: ${{ (github.ref_name == 'metabot-v3-second-try') && matrix.edition == 'ee' }}
-        uses: docker/build-push-action@v3
-        with:
-          context: bin/docker/.
-          platforms: linux/amd64,linux/arm64
-          network: host
-          tags: ${{ github.repository_owner }}/metabase-enterprise-head:metabot
-          build-args: |
-            GIT_COMMIT_SHA=${{ github.sha }}
-          no-cache: false
-          push: true
-
-      - name: Retag and push images if master (oss) - should be cached at this point
-        if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
-        uses: docker/build-push-action@v3
-        with:
-          context: bin/docker/.
-          platforms: linux/amd64,linux/arm64
-          network: host
-          tags: ${{ github.repository_owner }}/metabase-head:latest
-          build-args: |
-            GIT_COMMIT_SHA=${{ github.sha }}
-          no-cache: false
-          push: true
-
-      - name: Retag and push images if dev branch - should be cached at this point
-        if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
-        uses: docker/build-push-action@v3
-        with:
-          context: bin/docker/.
-          platforms: linux/amd64,linux/arm64
-          network: host
-          tags: ${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
-          build-args: |
-            GIT_COMMIT_SHA=${{ github.sha }}
-          no-cache: false
-          push: true
-
-      - name: Run Trivy vulnerability scanner if master (ee)
-        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-        uses: aquasecurity/trivy-action@0.29.0
-        env:
-          TRIVY_OFFLINE_SCAN: true
-        with:
-          image-ref: docker.io/${{ github.repository_owner }}/metabase-enterprise-head:latest
-          format: sarif
-          output: trivy-results.sarif
-          version: "v0.57.1"
-
-      - name: Run Trivy vulnerability scanner if master (oss)
-        if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
-        uses: aquasecurity/trivy-action@0.29.0
-        env:
-          TRIVY_OFFLINE_SCAN: true
-        with:
-          image-ref: docker.io/${{ github.repository_owner }}/metabase-head:latest
-          format: sarif
-          output: trivy-results.sarif
-          version: "v0.57.1"
-
-      - name: Run Trivy vulnerability scanner if dev branch
-        if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
-        uses: aquasecurity/trivy-action@0.29.0
-        env:
-          TRIVY_OFFLINE_SCAN: true
-        with:
-          version: "v0.57.1"
-          image-ref: docker.io/${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
-          format: sarif
-          output: trivy-results.sarif
-
-      - name: Upload Trivy scan results to GitHub Security tab if master (ee)
-        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "trivy-results.sarif"
-
-      - name: Upload Trivy scan results to GitHub Security tab if master (oss)
-        if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "trivy-results.sarif"
-
-      - name: Upload Trivy scan results to GitHub Security tab if dev branch
-        if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "trivy-results.sarif"
-
-  containerize_multi_arch:
-    runs-on: ubuntu-22.04
-    name: Containerize multi-arch ${{ matrix.edition }}
-    needs: check_jar_health
+  run-trivy:
+    needs: [get-container-info, containerize]
     strategy:
       matrix:
-        edition: [ee, oss]
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
+        edition: ${{ needs.get-container-info.outputs.editions }}
+    runs-on: ubuntu-22.04
+    name: Run Trivy vulnerability scanner
     steps:
-      - name: Extract and clean branch name
-        shell: bash
-        run: echo "branch=$(echo $GITHUB_REF_NAME | sed 's/[^-._a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
-        id: extract_branch
-      - name: Verify the intended tag of the container image
-        run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
-      - name: Check out the code (Dockerfile needed)
-        uses: actions/checkout@v4
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.29.0
+        env:
+          TRIVY_OFFLINE_SCAN: true
         with:
-          ref: ${{ github.event.inputs.commit }}
-      - name: Download uploaded artifacts to insert into container
-        uses: actions/download-artifact@v4
+          image-ref: docker.io/${{ github.repository_owner }}/${{ needs.get-container-info.outputs[matrix.edition].repo }}:${{ needs.get-container-info.outputs[matrix.edition].tag }}
+          format: sarif
+          output: trivy-results.sarif
+          version: "v0.57.1"
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
         with:
-          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
-          path: bin/docker/
-      - name: Move the ${{ matrix.edition }} uberjar to the context dir
-        run: mv bin/docker/target/uberjar/metabase.jar bin/docker/.
-      # We need it for multi-arch build
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: "arm64"
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2.5.0
-        with:
-          driver-opts: network=host
-      # Build experimental ubuntu-based images only for master
-      - name: Build ${{ matrix.edition }} Ubuntu based multi-arch container
-        uses: docker/build-push-action@v3
-        with:
-          context: bin/docker/.
-          platforms: linux/amd64,linux/arm64
-          file: bin/docker/Dockerfile_ubuntu
-          network: host
-          tags: localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}-ubuntu
-          build-args: |
-            GIT_COMMIT_SHA=${{ github.sha }}
-          no-cache: true
-          push: true
-      - name: Launch ${{ matrix.edition }} Ubuntu based container
-        run: docker run --rm -dp 3001:3000 localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}-ubuntu
-        timeout-minutes: 5
-      - name: Is Docker with Ubuntu running?
-        run: docker ps
-      - name: Wait for Ubuntu-based Metabase container to start and reach 100% health
-        run: while ! curl 'http://localhost:3001/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-        timeout-minutes: 3
-      - name: Login to Docker Hub
-        if: ${{ github.ref_name == 'master' }}
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      # Push experimental ubuntu image only for versions based on a master
-      - name: Install regctl
-        if: ${{ github.ref_name == 'master' }}
-        uses: regclient/actions/regctl-installer@main
-        with:
-          release: "v0.4.7"
-      - name: Switch regctl to point to localhost:5000 via http
-        if: ${{ github.ref_name == 'master' }}
-        run: regctl registry set --tls disabled localhost:5000
-      - name: Retag and push ubuntu-based images if master (ee)
-        if: ${{ (matrix.edition == 'ee') && (github.ref_name == 'master') }}
-        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu ${{ github.repository_owner }}/metabase-enterprise-head:latest-ubuntu
-      - name: Retag and push ubuntu-based images if master (oss)
-        if: ${{ (matrix.edition == 'oss') && (github.ref_name == 'master') }}
-        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu ${{ github.repository_owner }}/metabase-head:latest-ubuntu
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -53,7 +53,7 @@ jobs:
                 ee: {
                   repo: `${owner}/metabase-enterprise-head`,
                   tag: "metabot"
-                };
+                },
               }
             }
 
@@ -78,6 +78,7 @@ jobs:
                 tag: branch
               },
             };
+
       - name: Print output
         run: |
           echo "editions: ${{ fromJson(steps.info.outputs.result) }}"

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
         with:
-          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
+          name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.sha  }}-uberjar
 
   check-jar-health:
     runs-on: ubuntu-22.04
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/download-artifact@v4
         name: Retrieve uberjar artifact
         with:
-          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
+          name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.sha  }}-uberjar
       - name: Launch uberjar
         run: >-
           java --add-opens java.base/java.nio=ALL-UNNAMED -jar ./target/uberjar/metabase.jar &
@@ -149,8 +149,8 @@ jobs:
     uses: ./.github/workflows/containerize-jar.yml
     secrets: inherit
     with:
-      artifact-name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
-      commit: ${{ github.sha }}
+      artifact-name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.sha }}-uberjar
+      commit: ${{ github.event.inputs.commit || github.sha }}
       repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
 
@@ -162,6 +162,10 @@ jobs:
     runs-on: ubuntu-22.04
     name: Run Trivy vulnerability scanner
     steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit || github.sha }}
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.29.0
         env:

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,13 +4,13 @@ name: Build + Docker Uberjar
 # or automatically for the listed branches
 
 on:
+  pull_request: # FIXME for testing
   push:
     branches:
       - master
       - metabot-v3-second-try
       - feature-visualizer
       - internal-tools
-      - refactor-uberjar-job # FIXME for testing
     paths-ignore:
       # config files
       - ".**"

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -33,8 +33,8 @@ jobs:
     name: Get container info
     outputs:
       editions: ${{ toJson((steps.info.outputs.result).editions) }}
-      ee: ${{ fromJson(steps.info.outputs.result).ee || '' }}
-      oss: ${{ fromJson(steps.info.outputs.result).oss || '' }}
+      ee: ${{ fromJson(steps.info.outputs.result).ee }}
+      oss: ${{ fromJson(steps.info.outputs.result).oss }}
     steps:
       - name: Get docker repo and tag
         id: info
@@ -81,7 +81,7 @@ jobs:
 
       - name: Print output
         run: |
-          echo "editions: ${{ steps.info.outputs.result }}"
+          echo "${{ steps.info.outputs.result }}"
 
   build:
     needs: get-container-info

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,7 +4,6 @@ name: Build + Docker Uberjar
 # or automatically for the listed branches
 
 on:
-  pull_request: # FIXME for testing
   push:
     branches:
       - master

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/script@v7
         with:
           script: | # js
-            const branch = '${{ github.ref_name }}';
+            const branch = '${{ github.head_ref || github.ref_name }}';
             const owner = '${{ github.repository_owner }}';
 
             console.log(`Branch: ${branch}`);
@@ -94,6 +94,7 @@ jobs:
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
+      SKIP_LICENSES: true # faster builds for dev
     steps:
       - name: Check out the code
         uses: actions/checkout@v4

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - metabot-v3-second-try
       - feature-visualizer
       - internal-tools
     paths-ignore:
@@ -44,17 +43,6 @@ jobs:
             const owner = '${{ github.repository_owner }}';
 
             console.log(`Branch: ${branch}`);
-
-            // TODO: remove when we're done testing metabot
-            if (branch === "metabot-v3-second-try") {
-              return {
-                editions: ["ee"],
-                ee: {
-                  repo: `${owner}/metabase-enterprise-head`,
-                  tag: "metabot"
-                },
-              }
-            }
 
             if (branch === "master") {
               return {

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -75,7 +75,7 @@ jobs:
               editions: ["ee"],
               ee: {
                 repo: `${owner}/metabase-dev`,
-                tag: branch
+                tag: branch.replaceAll("/", "-"), // slashes make docker sad
               },
             };
 

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 5
     name: Get container info
     outputs:
-      editions: ${{ fromJson(steps.info.outputs.result).editions }}
-      ee: ${{ fromJson(steps.info.outputs.result).ee }}
-      oss: ${{ fromJson(steps.info.outputs.result).oss }}
+      editions: ${{ toJson((steps.info.outputs.result).editions) }}
+      ee: ${{ fromJson(steps.info.outputs.result).ee || '' }}
+      oss: ${{ fromJson(steps.info.outputs.result).oss || '' }}
     steps:
       - name: Get docker repo and tag
         id: info
@@ -81,7 +81,7 @@ jobs:
 
       - name: Print output
         run: |
-          echo "editions: ${{ fromJson(steps.info.outputs.result) }}"
+          echo "editions: ${{ steps.info.outputs.result }}"
 
   build:
     needs: get-container-info
@@ -90,7 +90,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        edition: ${{ needs.get-container-info.outputs.editions }}
+        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
@@ -120,7 +120,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        edition: ${{ needs.get-container-info.outputs.editions }}
+        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
         java-version: [21]
     steps:
       - name: Prepare JRE (Java Run-time Environment)
@@ -144,7 +144,7 @@ jobs:
     needs: [check-jar-health, get-container-info]
     strategy:
       matrix:
-        edition: ${{ needs.get-container-info.outputs.editions }}
+        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
     uses: ./.github/workflows/containerize-jar.yml
     secrets: inherit
     with:
@@ -157,7 +157,7 @@ jobs:
     needs: [get-container-info, containerize]
     strategy:
       matrix:
-        edition: ${{ needs.get-container-info.outputs.editions }}
+        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
     runs-on: ubuntu-22.04
     name: Run Trivy vulnerability scanner
     steps:

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,6 +4,7 @@ name: Build + Docker Uberjar
 # or automatically for the listed branches
 
 on:
+  pull_request: # FIXME for testing
   push:
     branches:
       - master
@@ -36,7 +37,7 @@ jobs:
     steps:
       - name: Get docker repo and tag
         id: info
-        uses: actions/script@v7
+        uses: actions/github-script@v7
         with:
           script: | # js
             const branch = '${{ github.head_ref || github.ref_name }}';
@@ -140,6 +141,8 @@ jobs:
       commit: ${{ github.event.inputs.commit || github.sha }}
       repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
   run-trivy:
     needs: [get-container-info, containerize]

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 5
     name: Get container info
     outputs:
-      editions: ${{ toJson((steps.info.outputs.result).editions) }}
-      ee: ${{ fromJson(steps.info.outputs.result).ee }}
-      oss: ${{ fromJson(steps.info.outputs.result).oss }}
+      editions: ${{ toJson(fromJson(steps.info.outputs.result).editions) }}
+      ee: ${{ toJson(fromJson(steps.info.outputs.result).ee) }}
+      oss: ${{ toJson(fromJson(steps.info.outputs.result).oss) }}
     steps:
       - name: Get docker repo and tag
         id: info
@@ -150,8 +150,8 @@ jobs:
     with:
       artifact-name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
       commit: ${{ github.sha }}
-      repo: ${{ needs.get-container-info.outputs[matrix.edition].repo }}
-      tag: ${{ needs.get-container-info.outputs[matrix.edition].tag }}
+      repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
+      tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
 
   run-trivy:
     needs: [get-container-info, containerize]
@@ -165,8 +165,10 @@ jobs:
         uses: aquasecurity/trivy-action@0.29.0
         env:
           TRIVY_OFFLINE_SCAN: true
+          repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
+          tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
         with:
-          image-ref: docker.io/${{ github.repository_owner }}/${{ needs.get-container-info.outputs[matrix.edition].repo }}:${{ needs.get-container-info.outputs[matrix.edition].tag }}
+          image-ref: docker.io/${{ env.repo }}:${{ env.tag }}
           format: sarif
           output: trivy-results.sarif
           version: "v0.57.1"


### PR DESCRIPTION
[test run](https://github.com/metabase/metabase/actions/runs/14717704289?pr=57298)
[dockerhub upload](https://hub.docker.com/layers/metabase/metabase-dev/refactor-uberjar-job/images/sha256-c4bc00cd9852968618e72bb36ab15f42d48825b7e8b4c35927dbc00a5f56b4ec)
## Description

As this job has grown over time, it has become an unmaintainable mess

This job can be triggered in 2 ways
- pushing a (substantive) commit to one of the specified branches
- running a workflow dispatch action

This job does a few things
- Builds a jar
- Containerizes the jar
- Pushes the container to dockerhub
- Runs Trivy Vulnerability scanning

The prior version of the job had a bunch of branching logic to do all this

e.g.

```yaml
      - name: Run Trivy vulnerability scanner if master (ee)
        if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
        uses: aquasecurity/trivy-action@0.29.0
        env:
          TRIVY_OFFLINE_SCAN: true
        with:
          image-ref: docker.io/${{ github.repository_owner }}/metabase-enterprise-head:latest
          format: sarif
          output: trivy-results.sarif
          version: "v0.57.1"

      - name: Run Trivy vulnerability scanner if master (oss)
        if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
        uses: aquasecurity/trivy-action@0.29.0
        env:
          TRIVY_OFFLINE_SCAN: true
        with:
          image-ref: docker.io/${{ github.repository_owner }}/metabase-head:latest
          format: sarif
          output: trivy-results.sarif
          version: "v0.57.1"

      - name: Run Trivy vulnerability scanner if dev branch
        if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
        uses: aquasecurity/trivy-action@0.29.0
        env:
          TRIVY_OFFLINE_SCAN: true
        with:
          version: "v0.57.1"
          image-ref: docker.io/${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
          format: sarif
          output: trivy-results.sarif
```
The only difference between these three yaml blocks are the `image-ref` propery, which passes the container name

The main thing this refactor does is eliminate all of these duplicated blocks by simply generating docker repo and tag information once, and reusing them via variables. So instead of having 3 (or more) blocks doing the same thing, we just have one:

```yaml
      - name: Run Trivy vulnerability scanner
        uses: aquasecurity/trivy-action@0.29.0
        env:
          TRIVY_OFFLINE_SCAN: true
          repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
          tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
        with:
          image-ref: docker.io/${{ env.repo }}:${{ env.tag }}
          format: sarif
          output: trivy-results.sarif
          version: "v0.57.1"
```

I've also improved the efficiency of this job in a few ways
- removing some redundant checking of docker containers - these are just test builds, after all
- reusing an existing `containerize` workflow that builds multi-arch containers by default
- not building OSS jars for branches that don't push them to dockerhub
