### PR TITLE
Disable sqlite for array-query-can-be-cached-test 

### DIFF
--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -302,7 +302,7 @@
                   result)))))))
 
 (deftest array-query-can-be-cached-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :test/arrays)
+  (mt/test-drivers (disj (mt/normal-drivers-with-feature :test/arrays) :sqlite)
     (with-mock-cache! [save-chan]
       (mt/with-temporary-setting-values [enable-query-caching true]
         (mt/with-clock #t "2025-02-06T00:00:00.000Z[UTC]"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -302,7 +302,8 @@
                   result)))))))
 
 (deftest array-query-can-be-cached-test
-  (mt/test-drivers (disj (mt/normal-drivers-with-feature :test/arrays) :sqlite)
+  (mt/test-drivers (disj (mt/normal-drivers-with-feature :test/arrays)
+                         :sqlite) ;; Disabling until issue #57301 is resolved
     (with-mock-cache! [save-chan]
       (mt/with-temporary-setting-values [enable-query-caching true]
         (mt/with-clock #t "2025-02-06T00:00:00.000Z[UTC]"


### PR DESCRIPTION
### Description

The sqlite driver flakes for `array-query-can-be-cached-test`. The changes in https://github.com/metabase/metabase/pull/57226 didn't work so we're disabling it until https://github.com/metabase/metabase/issues/57301 is resolved.