### PR TITLE
fix invalid tooltip on interpolated values

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -334,3 +334,74 @@ where x < {{param}}`,
     H.chartPathWithFillColor("#88BF4D").should("have.length", 4);
   });
 });
+
+describe("issue 47757", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should show correct tooltips for interpolated data points (metabase#47757)", () => {
+    H.visitQuestionAdhoc({
+      visualization_settings: {
+        "graph.dimensions": ["X"],
+        "graph.metrics": ["Y"],
+        series_settings: { Y: { "line.missing": "zero" } },
+      },
+      dataset_query: {
+        type: "native",
+        native: {
+          query: `select '2020-01-01' x, 10 y
+union all select '2020-03-01' x, 30 y
+union all select '2020-04-01' x, 40 y`,
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "line",
+    });
+
+    H.cartesianChartCircleWithColor("#88BF4D").eq(0).trigger("mousemove");
+    H.assertEChartsTooltip({
+      header: "January 2020",
+      rows: [
+        {
+          color: "#88BF4D",
+          name: "Y",
+          value: 10,
+        },
+      ],
+      footer: null,
+      blurAfter: true,
+    });
+
+    H.cartesianChartCircleWithColor("#88BF4D").eq(1).trigger("mousemove");
+    H.assertEChartsTooltip({
+      header: "January 2020",
+      rows: [
+        {
+          color: "#88BF4D",
+          name: "Y",
+          value: 0,
+          secondaryValue: "-100%",
+        },
+      ],
+      footer: null,
+      blurAfter: true,
+    });
+
+    H.cartesianChartCircleWithColor("#88BF4D").eq(2).trigger("mousemove");
+    H.assertEChartsTooltip({
+      header: "March 2020",
+      rows: [
+        {
+          color: "#88BF4D",
+          name: "Y",
+          value: 30,
+          secondaryValue: "+∞%",
+        },
+      ],
+      footer: null,
+      blurAfter: true,
+    });
+  });
+});

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -376,7 +376,7 @@ union all select '2020-04-01' x, 40 y`,
 
     H.cartesianChartCircleWithColor("#88BF4D").eq(1).trigger("mousemove");
     H.assertEChartsTooltip({
-      header: "January 2020",
+      header: "February 2020",
       rows: [
         {
           color: "#88BF4D",

--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
@@ -17,12 +17,18 @@ export const IS_WATERFALL_TOTAL_DATA_KEY = `${NULL_CHAR}_is_total` as const;
 // Key of x-axis values
 export const X_AXIS_DATA_KEY = `${NULL_CHAR}_x` as const;
 
+// Key used to store original x-axis values in the transformed dataset
+// When working with time series or numeric scales, we process x-axis values for ECharts
+// to handle timezone adjustments or apply transformations (log, pow). Since this processing
+// is also applied to interpolated data points which are not in the original dataset, we store the unprocessed
+// x-axis values using this key to display accurate information in tooltips.
+export const X_AXIS_RAW_VALUE_DATA_KEY = `${NULL_CHAR}_x_raw` as const;
+
 // Key for the "other" series created by the `graph.max_categories` setting
 export const OTHER_DATA_KEY = `${NULL_CHAR}_other` as const;
 
-// In some cases a datum in `chartModel.transformedDataset` may include this
-// key, its value is equal to the index of that same datum in the original
-// dataset (e.g. `chartModel.dataset`)
+// Stores the index that links this data point to its source in the original dataset (chartModel.dataset)
+// This reference allows tracking the origin of each point after dataset transformations are applied.
 export const INDEX_KEY = `${NULL_CHAR}_index` as const;
 
 // For ticks we want to pick the largest interval that exist 3 times in the

--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
@@ -23,8 +23,7 @@ export const OTHER_DATA_KEY = `${NULL_CHAR}_other` as const;
 // In some cases a datum in `chartModel.transformedDataset` may include this
 // key, its value is equal to the index of that same datum in the original
 // dataset (e.g. `chartModel.dataset`)
-export const ORIGINAL_INDEX_DATA_KEY =
-  `${NULL_CHAR}_original_dataset_key` as const;
+export const INDEX_KEY = `${NULL_CHAR}_index` as const;
 
 // For ticks we want to pick the largest interval that exist 3 times in the
 // range. For example, if data has week granularity but the range is more than 3

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -6,8 +6,8 @@ import { checkNumber, isNotNull } from "metabase/lib/types";
 import { isEmpty } from "metabase/lib/validate";
 import {
   ECHARTS_CATEGORY_AXIS_NULL_VALUE,
+  INDEX_KEY,
   NEGATIVE_STACK_TOTAL_DATA_KEY,
-  ORIGINAL_INDEX_DATA_KEY,
   OTHER_DATA_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
@@ -185,7 +185,10 @@ export const getJoinedCardsDataset = (
     }
   });
 
-  return Array.from(groupedData.values());
+  return Array.from(groupedData.values()).map((datum, index) => ({
+    ...datum,
+    [INDEX_KEY]: index,
+  }));
 };
 
 type TransformFn = (
@@ -508,14 +511,13 @@ export function filterNullDimensionValues(
 ) {
   const filteredDataset: ChartDataset = [];
 
-  dataset.forEach((datum, originalIndex) => {
+  dataset.forEach((datum) => {
     if (datum[X_AXIS_DATA_KEY] == null) {
       showWarning?.(nullDimensionWarning().text);
       return;
     }
     filteredDataset.push({
       ...datum,
-      [ORIGINAL_INDEX_DATA_KEY]: originalIndex,
     });
   });
 
@@ -606,10 +608,7 @@ const interpolateTimeSeriesData = (
 
   for (let i = 0; i < dataset.length; i++) {
     const datum = dataset[i];
-    result.push({
-      ...datum,
-      [ORIGINAL_INDEX_DATA_KEY]: datum[ORIGINAL_INDEX_DATA_KEY] ?? i,
-    });
+    result.push(datum);
 
     if (i === dataset.length - 1) {
       break;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -11,6 +11,7 @@ import {
   OTHER_DATA_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
+  X_AXIS_RAW_VALUE_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { getBreakoutDistinctValues } from "metabase/visualizations/echarts/cartesian/model/series";
 import type {
@@ -270,6 +271,19 @@ export const getKeyBasedDatasetTransform = (
         transformedRecord[key] = valueTransform(datum[key]);
       }
     }
+    return transformedRecord;
+  };
+};
+
+export const applyXAxisTransformations = (
+  xAxisTransformFn: (value: RowValue) => RowValue,
+): TransformFn => {
+  return (datum) => {
+    const transformedRecord = { ...datum };
+    transformedRecord[X_AXIS_RAW_VALUE_DATA_KEY] = datum[X_AXIS_DATA_KEY];
+    transformedRecord[X_AXIS_DATA_KEY] = xAxisTransformFn(
+      datum[X_AXIS_DATA_KEY],
+    );
     return transformedRecord;
   };
 };
@@ -756,7 +770,7 @@ export const applyVisualizationSettingsDataTransformations = (
     ),
     {
       condition: isCategoryAxis(xAxisModel),
-      fn: getKeyBasedDatasetTransform([X_AXIS_DATA_KEY], (value) => {
+      fn: applyXAxisTransformations((value) => {
         return isCategoryAxis(xAxisModel) && value == null
           ? ECHARTS_CATEGORY_AXIS_NULL_VALUE
           : value;
@@ -764,7 +778,7 @@ export const applyVisualizationSettingsDataTransformations = (
     },
     {
       condition: isNumericAxis(xAxisModel) || isTimeSeriesAxis(xAxisModel),
-      fn: getKeyBasedDatasetTransform([X_AXIS_DATA_KEY], (value) => {
+      fn: applyXAxisTransformations((value) => {
         return isNumericAxis(xAxisModel) || isTimeSeriesAxis(xAxisModel)
           ? xAxisModel.toEChartsAxisValue(value)
           : value;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -186,7 +186,11 @@ export const getJoinedCardsDataset = (
     }
   });
 
-  return Array.from(groupedData.values()).map((datum, index) => ({
+  return Array.from(groupedData.values());
+};
+
+export const appendDataIndex = (dataset: ChartDataset) => {
+  return dataset.map((datum, index) => ({
     ...datum,
     [INDEX_KEY]: index,
   }));
@@ -724,6 +728,7 @@ export const applyVisualizationSettingsDataTransformations = (
   settings: ComputedVisualizationSettings,
   showWarning?: ShowWarning,
 ) => {
+  dataset = appendDataIndex(dataset);
   const barSeriesModels = seriesModels.filter((seriesModel) => {
     const seriesSettings = settings.series(
       seriesModel.legacySeriesSettingsObjectKey,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 import { createMockSeriesModel } from "__support__/echarts";
 import { checkNumber } from "metabase/lib/types";
 import {
-  ORIGINAL_INDEX_DATA_KEY,
+  INDEX_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
@@ -448,14 +448,14 @@ describe("dataset transform functions", () => {
 
         expect(result).toEqual([
           {
-            [ORIGINAL_INDEX_DATA_KEY]: 0,
+            [INDEX_KEY]: 0,
             [X_AXIS_DATA_KEY]: "2020-01-01T00:00:00.000Z",
             dimensionKey: "A",
             series1: 10,
           },
           { [X_AXIS_DATA_KEY]: "2020-02-01T00:00:00.000Z", series1: 0 },
           {
-            [ORIGINAL_INDEX_DATA_KEY]: 1,
+            [INDEX_KEY]: 1,
             [X_AXIS_DATA_KEY]: "2020-03-01T00:00:00.000Z",
             dimensionKey: "A",
             series1: 20,
@@ -524,7 +524,7 @@ describe("dataset transform functions", () => {
         expect(result).toEqual([
           {
             ...validDatum,
-            [ORIGINAL_INDEX_DATA_KEY]: 0,
+            [INDEX_KEY]: 0,
           },
         ]);
       });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -6,6 +6,7 @@ import {
   INDEX_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
+  X_AXIS_RAW_VALUE_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
   BreakoutChartColumns,
@@ -160,18 +161,21 @@ describe("dataset transform functions", () => {
       const result = getJoinedCardsDataset([rawSeries1], [columns1]);
       expect(result).toStrictEqual([
         {
+          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: 1,
           "1:category": "category1",
           "1:month": 1,
           "1:count": 200,
         },
         {
+          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: 2,
           "1:category": "category1",
           "1:month": 2,
           "1:count": 300,
         },
         {
+          [INDEX_KEY]: 2,
           [X_AXIS_DATA_KEY]: 3,
           "1:category": "category2",
           "1:month": 3,
@@ -184,18 +188,21 @@ describe("dataset transform functions", () => {
       const result = getJoinedCardsDataset([rawSeries2], [columns2]);
       expect(result).toStrictEqual([
         {
+          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: 1,
           "2:also_month:type1": 1,
           "2:count:type1": 100,
           "2:type:type1": "type1",
         },
         {
+          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: 2,
           "2:also_month:type1": 2,
           "2:count:type1": 200,
           "2:type:type1": "type1",
         },
         {
+          [INDEX_KEY]: 2,
           [X_AXIS_DATA_KEY]: 3,
           "2:also_month:type2": 3,
           "2:also_month:type3": 3,
@@ -214,6 +221,7 @@ describe("dataset transform functions", () => {
       );
       expect(result).toStrictEqual([
         {
+          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: 1,
           "1:category": "category1",
           "1:month": 1,
@@ -223,6 +231,7 @@ describe("dataset transform functions", () => {
           "2:type:type1": "type1",
         },
         {
+          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: 2,
           "1:category": "category1",
           "1:month": 2,
@@ -232,6 +241,7 @@ describe("dataset transform functions", () => {
           "2:type:type1": "type1",
         },
         {
+          [INDEX_KEY]: 2,
           [X_AXIS_DATA_KEY]: 3,
           "1:category": "category2",
           "1:month": 3,
@@ -313,6 +323,7 @@ describe("dataset transform functions", () => {
       expect(result).toEqual([
         {
           [X_AXIS_DATA_KEY]: "A",
+          [X_AXIS_RAW_VALUE_DATA_KEY]: "A",
           [POSITIVE_STACK_TOTAL_DATA_KEY]: Number.MIN_VALUE,
           dimensionKey: "A",
           series1: 100,
@@ -321,6 +332,7 @@ describe("dataset transform functions", () => {
         },
         {
           [X_AXIS_DATA_KEY]: "B",
+          [X_AXIS_RAW_VALUE_DATA_KEY]: "B",
           [POSITIVE_STACK_TOTAL_DATA_KEY]: Number.MIN_VALUE,
           dimensionKey: "B",
           series1: 300,
@@ -352,6 +364,7 @@ describe("dataset transform functions", () => {
       expect(result).toEqual([
         {
           [X_AXIS_DATA_KEY]: "A",
+          [X_AXIS_RAW_VALUE_DATA_KEY]: "A",
           dimensionKey: "A",
           series1: 1 / 3,
           series2: 2 / 3,
@@ -359,6 +372,7 @@ describe("dataset transform functions", () => {
         },
         {
           [X_AXIS_DATA_KEY]: "B",
+          [X_AXIS_RAW_VALUE_DATA_KEY]: "B",
           dimensionKey: "B",
           series1: 3 / 7,
           series2: 4 / 7,
@@ -395,6 +409,7 @@ describe("dataset transform functions", () => {
       expect(result).toEqual([
         {
           [X_AXIS_DATA_KEY]: "A",
+          [X_AXIS_RAW_VALUE_DATA_KEY]: "A",
           dimensionKey: "A",
           series1: 0,
           series2: 200,
@@ -448,15 +463,19 @@ describe("dataset transform functions", () => {
 
         expect(result).toEqual([
           {
-            [INDEX_KEY]: 0,
             [X_AXIS_DATA_KEY]: "2020-01-01T00:00:00.000Z",
+            [X_AXIS_RAW_VALUE_DATA_KEY]: "2020-01-01T00:00:00.000Z",
             dimensionKey: "A",
             series1: 10,
           },
-          { [X_AXIS_DATA_KEY]: "2020-02-01T00:00:00.000Z", series1: 0 },
           {
-            [INDEX_KEY]: 1,
+            [X_AXIS_DATA_KEY]: "2020-02-01T00:00:00.000Z",
+            [X_AXIS_RAW_VALUE_DATA_KEY]: "2020-02-01T00:00:00.000Z",
+            series1: 0,
+          },
+          {
             [X_AXIS_DATA_KEY]: "2020-03-01T00:00:00.000Z",
+            [X_AXIS_RAW_VALUE_DATA_KEY]: "2020-03-01T00:00:00.000Z",
             dimensionKey: "A",
             series1: 20,
           },
@@ -524,7 +543,7 @@ describe("dataset transform functions", () => {
         expect(result).toEqual([
           {
             ...validDatum,
-            [INDEX_KEY]: 0,
+            [X_AXIS_RAW_VALUE_DATA_KEY]: validDatum[X_AXIS_DATA_KEY],
           },
         ]);
       });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -161,21 +161,18 @@ describe("dataset transform functions", () => {
       const result = getJoinedCardsDataset([rawSeries1], [columns1]);
       expect(result).toStrictEqual([
         {
-          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: 1,
           "1:category": "category1",
           "1:month": 1,
           "1:count": 200,
         },
         {
-          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: 2,
           "1:category": "category1",
           "1:month": 2,
           "1:count": 300,
         },
         {
-          [INDEX_KEY]: 2,
           [X_AXIS_DATA_KEY]: 3,
           "1:category": "category2",
           "1:month": 3,
@@ -188,21 +185,18 @@ describe("dataset transform functions", () => {
       const result = getJoinedCardsDataset([rawSeries2], [columns2]);
       expect(result).toStrictEqual([
         {
-          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: 1,
           "2:also_month:type1": 1,
           "2:count:type1": 100,
           "2:type:type1": "type1",
         },
         {
-          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: 2,
           "2:also_month:type1": 2,
           "2:count:type1": 200,
           "2:type:type1": "type1",
         },
         {
-          [INDEX_KEY]: 2,
           [X_AXIS_DATA_KEY]: 3,
           "2:also_month:type2": 3,
           "2:also_month:type3": 3,
@@ -221,7 +215,6 @@ describe("dataset transform functions", () => {
       );
       expect(result).toStrictEqual([
         {
-          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: 1,
           "1:category": "category1",
           "1:month": 1,
@@ -231,7 +224,6 @@ describe("dataset transform functions", () => {
           "2:type:type1": "type1",
         },
         {
-          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: 2,
           "1:category": "category1",
           "1:month": 2,
@@ -241,7 +233,6 @@ describe("dataset transform functions", () => {
           "2:type:type1": "type1",
         },
         {
-          [INDEX_KEY]: 2,
           [X_AXIS_DATA_KEY]: 3,
           "1:category": "category2",
           "1:month": 3,
@@ -322,6 +313,7 @@ describe("dataset transform functions", () => {
 
       expect(result).toEqual([
         {
+          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: "A",
           [X_AXIS_RAW_VALUE_DATA_KEY]: "A",
           [POSITIVE_STACK_TOTAL_DATA_KEY]: Number.MIN_VALUE,
@@ -331,6 +323,7 @@ describe("dataset transform functions", () => {
           unusedSeries: 100,
         },
         {
+          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: "B",
           [X_AXIS_RAW_VALUE_DATA_KEY]: "B",
           [POSITIVE_STACK_TOTAL_DATA_KEY]: Number.MIN_VALUE,
@@ -363,6 +356,7 @@ describe("dataset transform functions", () => {
 
       expect(result).toEqual([
         {
+          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: "A",
           [X_AXIS_RAW_VALUE_DATA_KEY]: "A",
           dimensionKey: "A",
@@ -371,6 +365,7 @@ describe("dataset transform functions", () => {
           unusedSeries: 100,
         },
         {
+          [INDEX_KEY]: 1,
           [X_AXIS_DATA_KEY]: "B",
           [X_AXIS_RAW_VALUE_DATA_KEY]: "B",
           dimensionKey: "B",
@@ -408,6 +403,7 @@ describe("dataset transform functions", () => {
 
       expect(result).toEqual([
         {
+          [INDEX_KEY]: 0,
           [X_AXIS_DATA_KEY]: "A",
           [X_AXIS_RAW_VALUE_DATA_KEY]: "A",
           dimensionKey: "A",
@@ -463,6 +459,7 @@ describe("dataset transform functions", () => {
 
         expect(result).toEqual([
           {
+            [INDEX_KEY]: 0,
             [X_AXIS_DATA_KEY]: "2020-01-01T00:00:00.000Z",
             [X_AXIS_RAW_VALUE_DATA_KEY]: "2020-01-01T00:00:00.000Z",
             dimensionKey: "A",
@@ -474,6 +471,7 @@ describe("dataset transform functions", () => {
             series1: 0,
           },
           {
+            [INDEX_KEY]: 1,
             [X_AXIS_DATA_KEY]: "2020-03-01T00:00:00.000Z",
             [X_AXIS_RAW_VALUE_DATA_KEY]: "2020-03-01T00:00:00.000Z",
             dimensionKey: "A",
@@ -543,6 +541,7 @@ describe("dataset transform functions", () => {
         expect(result).toEqual([
           {
             ...validDatum,
+            [INDEX_KEY]: 0,
             [X_AXIS_RAW_VALUE_DATA_KEY]: validDatum[X_AXIS_DATA_KEY],
           },
         ]);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -2,8 +2,8 @@ import type { Dayjs } from "dayjs";
 import type { OptionAxisType } from "echarts/types/src/coord/axisCommonTypes";
 
 import type {
+  INDEX_KEY,
   NEGATIVE_STACK_TOTAL_DATA_KEY,
-  ORIGINAL_INDEX_DATA_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
@@ -27,7 +27,8 @@ export type DataKey =
   | SeriesDataKey
   | StackTotalDataKey
   | string
-  | typeof X_AXIS_DATA_KEY;
+  | typeof X_AXIS_DATA_KEY
+  | typeof INDEX_KEY;
 
 export type VizSettingsKey = string;
 
@@ -88,7 +89,7 @@ export type DimensionModel = {
 
 export type Datum = Record<DataKey, RowValue> & {
   [X_AXIS_DATA_KEY]: RowValue;
-  [ORIGINAL_INDEX_DATA_KEY]?: number;
+  [INDEX_KEY]?: number;
 };
 export type ChartDataset<D extends Datum = Datum> = D[];
 export type Extent = [number, number];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -7,8 +7,8 @@ import { getTextColorForBackground } from "metabase/lib/colors/palette";
 import { getObjectValues } from "metabase/lib/objects";
 import { isNotNull } from "metabase/lib/types";
 import {
+  INDEX_KEY,
   NEGATIVE_STACK_TOTAL_DATA_KEY,
-  ORIGINAL_INDEX_DATA_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
@@ -371,8 +371,7 @@ export const buildEChartsStackLabelOptions = (
     ),
     formatter: (params: CallbackDataParams) => {
       const transformedDatum = params.data as Datum;
-      const originalIndex =
-        transformedDatum[ORIGINAL_INDEX_DATA_KEY] ?? params.dataIndex;
+      const originalIndex = transformedDatum[INDEX_KEY] ?? params.dataIndex;
       const datum = originalDataset[originalIndex];
       const value = datum[seriesModel.dataKey];
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/dataset.ts
@@ -1,4 +1,7 @@
-import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import {
+  INDEX_KEY,
+  X_AXIS_DATA_KEY,
+} from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import type { RawSeries } from "metabase-types/api";
 
@@ -18,8 +21,8 @@ export function getScatterPlotDataset(
     } = cardSeries;
     const columnDescs = cardsColumns[index];
 
-    rows.forEach((row) => {
-      const datum: Datum = { [X_AXIS_DATA_KEY]: null };
+    rows.forEach((row, index) => {
+      const datum: Datum = { [X_AXIS_DATA_KEY]: null, [INDEX_KEY]: index };
 
       cols.forEach((column, columnIndex) => {
         const value = row[columnIndex];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
@@ -2,6 +2,7 @@ import { t } from "ttag";
 
 import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import {
+  INDEX_KEY,
   IS_WATERFALL_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
@@ -64,6 +65,7 @@ export const getWaterfallDataset = (
       [WATERFALL_VALUE_KEY]: value,
       [WATERFALL_START_KEY]: start,
       [WATERFALL_END_KEY]: end,
+      [INDEX_KEY]: index,
     };
 
     transformedDataset.push(waterfallDatum);
@@ -80,6 +82,7 @@ export const getWaterfallDataset = (
       [WATERFALL_VALUE_KEY]: lastDatum[WATERFALL_END_KEY],
       [WATERFALL_START_KEY]: 0,
       [WATERFALL_TOTAL_KEY]: lastDatum[WATERFALL_END_KEY],
+      [INDEX_KEY]: dataset.length,
     });
   }
 
@@ -123,6 +126,7 @@ export const extendOriginalDatasetWithTotalDatum = (
     [seriesDataKey]: waterfallDatasetTotalDatum[WATERFALL_TOTAL_KEY],
     [X_AXIS_DATA_KEY]: t`Total`,
     [IS_WATERFALL_TOTAL_DATA_KEY]: true,
+    [INDEX_KEY]: dataset.length,
   };
 
   return [...dataset, totalDatum];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
@@ -126,7 +126,6 @@ export const extendOriginalDatasetWithTotalDatum = (
     [seriesDataKey]: waterfallDatasetTotalDatum[WATERFALL_TOTAL_KEY],
     [X_AXIS_DATA_KEY]: t`Total`,
     [IS_WATERFALL_TOTAL_DATA_KEY]: true,
-    [INDEX_KEY]: dataset.length,
   };
 
   return [...dataset, totalDatum];

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   GOAL_LINE_SERIES_ID,
-  ORIGINAL_INDEX_DATA_KEY,
+  INDEX_KEY,
   TIMELINE_EVENT_DATA_NAME,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
@@ -417,7 +417,7 @@ function getTransformedDatumIndex(
   originalDatumIndex: number,
 ) {
   const transformedDatumIndex = transformedDataset.findIndex(
-    (datum) => datum[ORIGINAL_INDEX_DATA_KEY] === originalDatumIndex,
+    (datum) => datum[INDEX_KEY] === originalDatumIndex,
   );
 
   if (transformedDatumIndex === -1) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47757

### Description

When chart series has `Replace missing values with "Zero"` setting enabled we populate the transformed dataset displayed by ECharts with interpolated datums which don't have corresponding datums in the original dataset. Although these interpolated datums did not refer to actual rows we mistakenly used their dataIndex provided by ECharts events to find the original datum which caused showing completely irrelevant numbers in tooltips.  

### How to verify

```
select '2020-01-01' x, 10 y
union all select '2020-03-01' x, 30 y
union all select '2020-04-01' x, 40 y
```

- Make this a line chart
- Enable `Replace missing values with "Zero"`
- Hover the second datum and ensure it shows correct tooltip values for x and y axes.

### Demo

<img width="889" alt="Screenshot 2025-04-26 at 12 02 47 AM" src="https://github.com/user-attachments/assets/6cc2ae65-1a84-4fde-a832-9cd8d425c46c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
