### PR TITLE
Make CumulativeCount a window function and Sum an aggregation

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -50,14 +50,14 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
   {
     name: "cum-count",
     structure: "CumulativeCount",
-    category: "aggregation",
+    category: "window",
     description: () => t`The additive total of rows across a breakout.`,
     docsPage: "cumulative",
   },
   {
     name: "sum",
     structure: "Sum",
-    category: "window",
+    category: "aggregation",
     description: () => t`Adds up all the values of the column.`,
     args: [
       {


### PR DESCRIPTION
Fixes an error where `Sum` was marked as a window function and `CumulativeCount` as an aggregation in the function browser.

Slack: https://metaboat.slack.com/archives/C01LQQ2UW03/p1745699059344099