### PR TITLE
WRK-306, WRK-307, WRK-324: Template preview. UI improvements for custom templates.

### DIFF
--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -86,7 +86,7 @@ export type TemplateDetails = {
 };
 
 export type ChannelTemplate = {
-  name: string;
+  name?: string;
   channel_type: string;
   details: TemplateDetails;
 };
@@ -226,6 +226,27 @@ export type TableNotification = BaseNotification &
   };
 
 export type Notification = AlertNotification | TableNotification;
+
+export type PreviewNotificationTemplateRequest = {
+  notification:
+    | Notification
+    | CreateNotificationRequest
+    | UpdateNotificationRequest;
+  template: ChannelTemplate;
+};
+type RenderedEmailPayload = {
+  bcc: string[];
+  from: string;
+  subject: string;
+  body: Array<{
+    type: "text/html; charset=utf-8";
+    content: string;
+  }>;
+};
+export type PreviewNotificationTemplateResponse = {
+  context: unknown;
+  rendered: RenderedEmailPayload;
+};
 
 // Initial schema for conditional expression.
 // Will be updated later.

--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -93,7 +93,7 @@ export const notificationApi = Api.injectEndpoints({
         body,
       }),
     }),
-    getNotificationPayloadExample: builder.mutation<
+    getNotificationPayloadExample: builder.query<
       GetNotificationPayloadExampleResponse,
       GetNotificationPayloadExampleRequest
     >({
@@ -143,7 +143,8 @@ export const {
   useUpdateNotificationMutation,
   useUnsubscribeFromNotificationMutation,
   useSendUnsavedNotificationMutation,
-  useGetNotificationPayloadExampleMutation,
+  useGetNotificationPayloadExampleQuery,
+  useLazyGetNotificationPayloadExampleQuery,
   useGetDefaultNotificationTemplateQuery,
 } = notificationApi;
 

--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -8,6 +8,8 @@ import type {
   ListNotificationsRequest,
   Notification,
   NotificationId,
+  PreviewNotificationTemplateRequest,
+  PreviewNotificationTemplateResponse,
   TableNotification,
   UpdateNotificationRequest,
 } from "metabase-types/api/notification";
@@ -129,6 +131,16 @@ export const notificationApi = Api.injectEndpoints({
         body,
       }),
     }),
+    previewNotificationTemplate: builder.query<
+      PreviewNotificationTemplateResponse,
+      PreviewNotificationTemplateRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: "/api/notification/preview_template",
+        body,
+      }),
+    }),
   }),
 });
 
@@ -144,8 +156,9 @@ export const {
   useUnsubscribeFromNotificationMutation,
   useSendUnsavedNotificationMutation,
   useGetNotificationPayloadExampleQuery,
-  useLazyGetNotificationPayloadExampleQuery,
   useGetDefaultNotificationTemplateQuery,
+  usePreviewNotificationTemplateQuery,
+  useLazyPreviewNotificationTemplateQuery,
 } = notificationApi;
 
 export const useTableNotificationsQuery = (

--- a/frontend/src/metabase/common/hooks/use-escape-to-close-modal/use-escape-to-close-modal.tsx
+++ b/frontend/src/metabase/common/hooks/use-escape-to-close-modal/use-escape-to-close-modal.tsx
@@ -22,5 +22,6 @@ export const useEscapeToCloseModal = (
       handler(e);
     },
     { options: opts },
+    [handler],
   );
 };

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.module.css
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.module.css
@@ -1,0 +1,46 @@
+.root {
+  /* position: relative; */
+  display: grid;
+  width: 100%;
+  height: calc(100% - 5.5rem);
+  overflow: auto;
+}
+
+.rootPreviewOpen {
+  grid-template-columns: 50% 50%;
+  transition: grid-template-columns 0.3s ease;
+}
+
+.rootNoPreview {
+  grid-template-columns: 100%;
+  transition: grid-template-columns 0.3s ease;
+}
+
+.modalContent {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.modalBody {
+  padding: 0;
+  height: 100%;
+  overflow: auto;
+  flex-grow: 1;
+}
+
+.modalFooter {
+  position: relative;
+  z-index: 1002;
+  background-color: var(--mb-color-bg-white);
+}
+
+.modalHeader {
+  position: relative;
+  z-index: 1003;
+  background: transparent;
+}
+
+.modalClose {
+  z-index: 1004;
+}

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewMessagePanel.module.css
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewMessagePanel.module.css
@@ -1,0 +1,55 @@
+.root {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 50%;
+  border-left: 1px solid var(--mb-color-border);
+  display: flex;
+  flex-direction: column;
+  padding: 2.5rem;
+  gap: var(--mantine-spacing-md);
+  background: var(--mb-color-bg-white);
+}
+
+.header {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mantine-spacing-sm);
+  height: 1.625rem;
+  z-index: 1003;
+  max-width: calc(100% - 1.5rem);
+}
+
+.closePreviewIcon {
+  color: var(--mb-color-text-tertiary);
+  cursor: pointer;
+  &:hover {
+    color: var(--mb-color-text-secondary);
+  }
+}
+
+.scrollBox {
+  overflow-y: auto;
+  flex-grow: 1;
+  padding: 0;
+}
+
+.previewStack {
+  background: var(--mb-color-bg-white);
+  width: 100%;
+}
+
+.previewHeader {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  column-gap: 1rem;
+}
+
+.previewDetails {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  gap: 0.25rem 0.5rem;
+}

--- a/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewMessagePanel.tsx
+++ b/frontend/src/metabase/notifications/modals/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewMessagePanel.tsx
@@ -1,0 +1,113 @@
+import { t } from "ttag";
+
+import { Avatar } from "metabase/components/UserAvatar";
+import {
+  ActionIcon,
+  Box,
+  Flex,
+  Icon,
+  Loader,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from "metabase/ui";
+import type { PreviewNotificationTemplateResponse } from "metabase-types/api";
+
+import S from "./PreviewMessagePanel.module.css";
+
+interface PreviewMessagePanelProps {
+  opened: boolean;
+  onClose: () => void;
+  isLoading: boolean;
+  error: any;
+  previewContent?: PreviewNotificationTemplateResponse["rendered"];
+}
+
+export const PreviewMessagePanel = ({
+  opened,
+  onClose,
+  isLoading,
+  error,
+  previewContent,
+}: PreviewMessagePanelProps) => {
+  if (!opened) {
+    return null;
+  }
+
+  const htmlContent = previewContent?.body?.[0]?.content;
+
+  return (
+    <Flex direction="column" h="100%" gap="md" className={S.root}>
+      <Flex gap="sm" align="center" h="1.625rem" className={S.header}>
+        <Icon name="eye" size={16} />
+        <Title size="h4">{t`Email message preview`}</Title>
+        <Tooltip label={t`Close Preview`}>
+          <ActionIcon variant="transparent" ml="auto">
+            <Icon
+              name="arrow_left_to_line"
+              size={20}
+              onClick={onClose}
+              className={S.closePreviewIcon}
+            />
+          </ActionIcon>
+        </Tooltip>
+      </Flex>
+      <Box p={0} className={S.scrollBox}>
+        {isLoading && (
+          <Flex align="center" justify="center" gap="sm" py="md">
+            <Loader size={12} />
+            <Text
+              size="lg"
+              lh="1.25rem"
+              c="text-medium"
+            >{t`Loading preview...`}</Text>
+          </Flex>
+        )}
+        {error && (
+          <Text color="error">
+            {t`Error loading preview:`} {JSON.stringify(error)}
+          </Text>
+        )}
+        {previewContent ? (
+          <Stack className={S.previewStack}>
+            <Box className={S.previewHeader}>
+              <Avatar>{previewContent.from || "?"}</Avatar>
+
+              <Box className={S.previewDetails}>
+                <Text size="sm" fw={600}>
+                  {t`From:`}
+                </Text>
+                <Text size="sm">{previewContent.from}</Text>
+
+                {previewContent.bcc && previewContent.bcc.length > 0 && (
+                  <>
+                    <Text size="sm" fw={600}>
+                      {t`BCC:`}
+                    </Text>
+                    <Text size="sm">{previewContent.bcc.join(", ")}</Text>
+                  </>
+                )}
+
+                <Text size="sm" fw={600}>
+                  {t`Subject:`}
+                </Text>
+                <Text size="sm">{previewContent.subject}</Text>
+              </Box>
+            </Box>
+            <Box>
+              {htmlContent ? (
+                <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
+              ) : (
+                <Text c="text-medium">{t`(No body content)`}</Text>
+              )}
+            </Box>
+          </Stack>
+        ) : (
+          !isLoading &&
+          !error && <Text color="text-medium">{t`No preview available.`}</Text>
+        )}
+      </Box>
+    </Flex>
+  );
+};

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.module.css
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.module.css
@@ -15,15 +15,17 @@
   color: var(--mb-color-text-primary);
 }
 
-.customTemplateIcon {
-  color: var(--mb-color-text-primary);
-
-  path {
-    stroke-width: 0.75;
-  }
-}
-
 .customTemplateItem,
 .customTemplateChevron {
   border: none !important;
+}
+.customTemplateChevron {
+  margin-left: 0;
+}
+
+:global(.cm-line) {
+  transition: opacity 200ms ease;
+}
+.defaultTemplate :global(.cm-editor:not(.cm-focused) .cm-line) {
+  opacity: 0.5;
 }

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.module.css
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.module.css
@@ -10,7 +10,7 @@
       box-shadow 100ms ease;
     font-family: var(--mantine-font-family);
     color: var(--mb-color-text-dark);
-    font-size: var(--mantine-font-size-md);
+    font-size: var(--mantine-font-size-sm);
   }
 
   :global(.cm-editor.cm-focused) {
@@ -51,7 +51,6 @@
     :global(.cm-scroller) {
       overflow-x: hidden;
       overflow-y: hidden;
-      display: flex;
       align-items: center;
     }
 

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -36,6 +36,7 @@ export interface TemplateEditorProps
     | "basicSetup"
     | "value"
     | "onBlur"
+    | "onFocus"
     | "minHeight"
   > {
   variant?: "textarea" | "textinput";
@@ -43,6 +44,7 @@ export interface TemplateEditorProps
   defaultValue?: string;
   onChange?: (value: string) => void;
   onBlur?: (value: string) => void;
+  onFocus?: (value: string) => void;
   minHeight?: string;
   placeholder?: string;
   templateContext?: Record<string, any>;
@@ -93,6 +95,7 @@ export const TemplateEditor = ({
   error,
   templateContext,
   onBlur,
+  onFocus,
   ...rest
 }: TemplateEditorProps) => {
   const helpers = useSetting("default-handlebars-helpers");
@@ -165,6 +168,9 @@ export const TemplateEditor = ({
           if (ref.current && !ref.current.view?.hasFocus) {
             ref.current.view?.focus();
           }
+        }}
+        onFocus={() => {
+          onFocus?.(internalValue);
         }}
         onKeyDown={(e) => {
           // Prevent Escape key from propagating to the modal


### PR DESCRIPTION
Closes WRK-306, WRK-307, WRK-324

### Description

- Update existing layout for custom templates UI and CreateOrEditTableNotificationModal based on the latest designs and comments.
- Add button to reset to default template.
- Add "Preview template" feature.

### How to verify

1. Open table alerts modal
2. Check the following:
	- template inputs have borders
	- single-line template input handles tab correctly (moves focus to next field)
	- if channel has template-related changes, confirmation modal is displayed if closing without saving
	- check that template section has "Reset to default" button
	- check that template section with default template has grayed out text
	- check that text becomes normal on focusing any template field
3. Click "Show preview", check that the modal displays Preview section with correct template

### Demo

<img width="726" alt="image" src="https://github.com/user-attachments/assets/18f87ba0-0a41-415c-85c1-50cf453b6078" />

<img width="1420" alt="image" src="https://github.com/user-attachments/assets/32b1de43-e419-4de3-966d-5d62277da656" />