### PR TITLE
Add custom error message for zero-arg functions

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/compiler.unit.spec.ts
@@ -446,4 +446,16 @@ describe("Specific expressions", () => {
       value("-9223372036854775809", "type/BigInteger"),
     );
   });
+
+  it("should render a custom error message for unresolved fields that used to resolver to a function invocation", () => {
+    expect(() => expr("now")).toThrow(
+      "Unknown column: now. Use now() instead.",
+    );
+    expect(() => expr("Count")).toThrow(
+      "Unknown column: Count. Use Count() instead.",
+    );
+    expect(() => expr("CumulativeCount")).toThrow(
+      "Unknown column: CumulativeCount. Use CumulativeCount() instead.",
+    );
+  });
 });


### PR DESCRIPTION
Resolves [Slack thread](https://metaboat.slack.com/archives/C0645JP1W81/p1745781969201399).

Since we introduced the mandatory parens for zero-arg functions it is a bit annoying for well-wintered users:

> For example, my muscle memory from 5 years of using Metabase is to just quickly type Count (without using tab or click completion), but now this causes an error. Since I work here at Metabase, and I know about the change I linked, I can figure out know why the error is happening and replace it with Count(), but if someone doesn't obsessively read the release notes, and is used to just typing Count , they will suddenly find that none of the stuff they write is working and won't know why. 


This PR adds some more context to the error message to make clear what has changed.