### PR TITLE
fix: scheduler state management in cloud migration

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -124,7 +124,7 @@
   {:api  #{metabase.cloud-migration.api
            metabase.cloud-migration.core
            metabase.cloud-migration.init}
-   :uses #{api cmd config db models premium-features util}}
+   :uses #{api cmd config db models premium-features task util}}
 
   cmd
   {:api  #{metabase.cmd

--- a/src/metabase/cloud_migration/models/cloud_migration.clj
+++ b/src/metabase/cloud_migration/models/cloud_migration.clj
@@ -11,15 +11,15 @@
    [metabase.db :as mdb]
    [metabase.models.interface :as mi]
    [metabase.models.setting.cache :as setting.cache]
+   [metabase.task :as task]
+   [metabase.task.bootstrap :as task.bootstrap]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.pipeline :as t2.pipeline]
-   [metabase.task :as task]
-   [metabase.task.bootstrap :as task.bootstrap])
+   [toucan2.pipeline :as t2.pipeline])
   (:import
    (java.io File InputStream)
    (org.apache.commons.io.input BoundedInputStream)))

--- a/test/metabase/cloud_migration/models/cloud_migration_test.clj
+++ b/test/metabase/cloud_migration/models/cloud_migration_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.cloud-migration.models.cloud-migration :as cloud-migration]
    [metabase.cloud-migration.settings :as cloud-migration.settings]
+   [metabase.task :as task]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -18,6 +19,18 @@
                  cloud-migration/migrate! identity]
      ~@body))
 
+(defn- fake-upload-route-handler
+  [migration]
+  {(:upload_url migration)
+   (fn [{:keys [body request-method]}]
+             ;; slurp it to progress the upload
+     (slurp body)
+     (is (= :put
+            request-method))
+     {:status 200})
+   (cloud-migration/migration-url (:external_id migration) "/uploaded")
+   (constantly {:status 201})})
+
 (deftest cluster?-test
   (is (boolean? (cloud-migration/cluster?))))
 
@@ -27,27 +40,18 @@
   (is (= 99 (cloud-migration/abs-progress 100 51 99))))
 
 (deftest migrate!-test
-  (testing "works"
-    (let [migration         (mock-external-calls! (mt/user-http-request :crowberto :post 200 "cloud-migration"))
-          progress-calls    (atom {:setup  []
-                                   :dump   []
-                                   :upload []
-                                   :done   []})
-          orig-set-progress @#'cloud-migration/set-progress]
-      (with-redefs [cloud-migration/cluster?     (constantly false)
-                    cloud-migration/set-progress (fn [id state n]
-                                                   (swap! progress-calls update state conj n)
-                                                   (orig-set-progress id state n))]
-        (http-fake/with-fake-routes-in-isolation
-          {(:upload_url migration)
-           (fn [{:keys [body request-method]}]
-               ;; slurp it to progress the upload
-             (slurp body)
-             (is (= :put
-                    request-method))
-             {:status 200})
-           (cloud-migration/migration-url (:external_id migration) "/uploaded")
-           (constantly {:status 201})}
+  (let [migration         (mock-external-calls! (mt/user-http-request :crowberto :post 200 "cloud-migration"))
+        progress-calls    (atom {:setup  []
+                                 :dump   []
+                                 :upload []
+                                 :done   []})
+        orig-set-progress @#'cloud-migration/set-progress]
+    (with-redefs [cloud-migration/cluster?     (constantly false)
+                  cloud-migration/set-progress (fn [id state n]
+                                                 (swap! progress-calls update state conj n)
+                                                 (orig-set-progress id state n))]
+      (http-fake/with-fake-routes-in-isolation (fake-upload-route-handler migration)
+        (testing "works"
           (#'cloud-migration/migrate! migration)
           (is (-> @progress-calls :upload count (> 3))
               "several progress calls during upload")
@@ -56,6 +60,22 @@
           (is (= {:setup [1] :dump [20] :done [100]}
                  (dissoc @progress-calls :upload))
               "one progress call during other stages"))))))
+
+(deftest migrate!-test-menaged-scheduler
+  (let [migration         (mock-external-calls! (mt/user-http-request :crowberto :post 200 "cloud-migration"))]
+    (with-redefs [cloud-migration/cluster?     (constantly false)]
+      (http-fake/with-fake-routes-in-isolation (fake-upload-route-handler migration)
+        (testing "works when quartz scheduler is running"
+          (task/start-scheduler!)
+          (try
+            (let [ex (try
+                       (#'cloud-migration/migrate! migration)
+                       nil
+                       (catch Throwable e
+                         e))]
+              (is (nil? ex)))
+            (finally
+              (task/stop-scheduler!))))))))
 
 (deftest migrate!-test-2
   (testing "exits early on terminal state"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57307

### Description

When we create the h2 database to dump a metabase instance to during cloud migration we need to stop and start the quartz scheduler instance running on the instance during the migration.

Some liquibase migrations handling quartz job changes expect to control the scehduler and start/stop it while those migrations run. Recent changes to guard against this behaviour in testing case these migrations to throw an exception when they run during the cloud migration task.

This also fixes an older bug that the quartz scheduler would remain off on the instance being migrated after the cloud migration task finishes.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Start a new cloud migration
2. it should not error

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
