### PR TITLE
fix: wrong syntax on if was making 'cross-version-for-breaking-changes' always run

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -139,7 +139,7 @@ jobs:
     secrets: inherit
 
   cross-version-for-breaking-changes:
-    if: github.event_name == 'pull_request' && ${{ startsWith(inputs.branch, 'release-x.') }}
+    if: github.event_name == 'pull_request' &&  startsWith(inputs.branch, 'release-x.')
     uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
     secrets: inherit
     with:

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -139,7 +139,7 @@ jobs:
     secrets: inherit
 
   cross-version-for-breaking-changes:
-    if: github.event_name == 'pull_request' &&  startsWith(inputs.branch, 'release-x.')
+    if: github.event_name == 'pull_request' && startsWith(inputs.branch, 'release-x.')
     uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
     secrets: inherit
     with:


### PR DESCRIPTION
I think i broke it with https://github.com/metabase/metabase/pull/57197/files 😞 

Apparently you can't put `${{  }}` like that, cursor even said we don't even need it wrapping the entire line as we usually do on `if:` as it's already evaluated as expression

How to verify:
It should be like this on this pr, and also on commits on master hopefully
<img width="729" alt="image" src="https://github.com/user-attachments/assets/322e665e-835a-4936-ac15-728ad2fd940d" />

