### PR TITLE
Fix Python newline in code-templates.ts

### DIFF
--- a/frontend/src/metabase/public/lib/code-templates.ts
+++ b/frontend/src/metabase/public/lib/code-templates.ts
@@ -116,8 +116,8 @@ payload = {
 }
 token = jwt.encode(payload, METABASE_SECRET_KEY, algorithm="HS256")
 
-iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token +
-  ${python.getIframeQuerySource(displayOptions)}`,
+iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token + ${python.getIframeQuerySource(displayOptions)}
+`,
 };
 
 export const ruby = {


### PR DESCRIPTION
This PR fixes the Python example to create an embedding URL. Python doesn't support a line break here. You either have to put it on one line (this PR) or use parentheses or a backslash to make the new line work as part of the expression.

<img width="533" alt="Screenshot 2025-04-28 at 21 17 57" src="https://github.com/user-attachments/assets/1d9aefa8-80d7-4bfd-ab07-abbcc3e07772" />
