### PR TITLE
Handle deleted connections in harbormaster

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -167,6 +167,14 @@
         (when-not (= delete-status :ok)
           (log/debugf "Unable to delete gdrive connection %s." id))))))
 
+(mu/defn hm-get-all-connections :- :hm-client/http-reply
+  "Get all connections from harbormaster."
+  []
+  (hm.client/make-request :get "/api/v2/mb/connections"))
+
+(comment
+  (hm-get-all-connections))
+
 (mu/defn hm-get-gdrive-conn :- :hm-client/http-reply
   "Get a specific gdrive connection by id."
   [id]
@@ -269,7 +277,7 @@
                                 cannot-check-message
                                 {:gdrive/conn-id conn-id
                                  :hm/exception e})))))
-        [hm-status {hm-body :body}] hm-response]
+        [hm-status {hm-status-code :status hm-body :body}] hm-response]
     (if (= :ok hm-status)
       (let [{:keys [status status-reason error last-sync-at last-sync-started-at]
              :as   _} (normalize-gdrive-conn hm-body)]
@@ -296,15 +304,30 @@
                           :last_sync_at (.getEpochSecond ^Instant (t/instant last-sync-at))
                           :hm/response (loggable-response hm-response))
             (analytics/inc! :metabase-gsheets/connection-creation-error {:reason "status_error"})
-            (log/errorf "Error getting status of connection %s: %s %s" conn-id (:status-reason hm-body) (:error-detail hm-body)))))
-      (if (empty? saved-setting)
+            (log/errorf "Error getting status of connection %s: status-reason=`%s` error-detail=`%s`" conn-id (:status-reason hm-body) (:error-detail hm-body)))))
+      (cond
+        (empty? saved-setting)
         {:status "not-connected"}
+
+        (= 403 hm-status-code)
+        (let [[list-status list-response] (hm-get-all-connections)]
+          (if (and (= :ok list-status) (not (some (partial = conn-id) (set (map :id (:body list-response))))))
+            (u/prog1 {:status "not-connected"}
+              (log/errorf "Removing google drive connection %s because harbormaster gives a 403 error for it." conn-id)
+              (reset-gsheets-status!))
+            ;; It doesn't look like a spot where we can remove the connection, so we just return the error
+            (assoc (setting->response saved-setting)
+                   :status "error"
+                   :error_message cannot-check-message
+                   :hm/response (loggable-response hm-response))))
+
+        :else
         (u/prog1 (assoc (setting->response saved-setting)
                         :status "error"
                         :error_message cannot-check-message
                         :hm/response (loggable-response hm-response))
           (analytics/inc! :metabase-gsheets/connection-creation-error {:reason "status_error"})
-          (log/errorf "Error getting status of connection %s: %s %s" conn-id (:status-reason hm-body) (:error-detail hm-body)))))))
+          (log/errorf "Error getting status of connection %s: status-reason=`%s` error-detail=`%s`" conn-id (:status-reason hm-body) (:error-detail hm-body)))))))
 
 (api.macros/defendpoint :get "/connection" :- :gsheets/response
   "Check the status of a connection. This endpoint gets polled by FE to determine when to

--- a/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/api.clj
@@ -313,7 +313,7 @@
         (let [[list-status list-response] (hm-get-all-connections)]
           (if (and (= :ok list-status) (not (some (partial = conn-id) (set (map :id (:body list-response))))))
             (u/prog1 {:status "not-connected"}
-              (log/errorf "Removing google drive connection %s because harbormaster gives a 403 error for it." conn-id)
+              (log/warnf "Removing google drive connection %s because harbormaster gives a 403 error for it." conn-id)
               (reset-gsheets-status!))
             ;; It doesn't look like a spot where we can remove the connection, so we just return the error
             (assoc (setting->response saved-setting)

--- a/test_resources/gsheets/mock_hm_responses.edn
+++ b/test_resources/gsheets/mock_hm_responses.edn
@@ -190,6 +190,30 @@
                                :updated-at                  "2025-03-25T14:54:26.824Z"},
        :trace-redirects       []}]
 
+ {:method :get, :url "/api/v2/mb/connections/e5b50d83-c1d6-4382-8351-ff95a23af60e", :body nil},
+ [:error {:cached                nil,
+          :request-time          23,
+          :repeatable?           false,
+          :protocol-version      {:name "HTTP", :major 1, :minor 1},
+          :streaming?            true,
+          ;; :http-client #object[org.apache.http.impl.client.InternalHttpClient 0x8f60f32 "org.apache.http.impl.client.InternalHttpClient@8f60f32"],
+          :chunked?              false,
+          :reason-phrase         "OK",
+          :headers
+          {"Date"                      "Mon, 27 Jan 2025 18:43:42 GMT",
+           "Connection"                "close",
+           "Content-Type"              "application/json;charset=utf-8",
+           "X-Frame-Options"           "SAMEORIGIN",
+           "X-Content-Type-Options"    "nosniff",
+           "Strict-Transport-Security" "max-age=31536000; includeSubDomains",
+           "Content-Length"            "386",
+           "Server"                    "Jetty(11.0.24)"},
+          :orig-content-encoding nil,
+          :status                403,
+          :length                53,
+          :body                  {:error "User not authorized to act over resource."},
+          :trace-redirects       []}]
+
  {:method :get, :url "/api/v2/mb/connections/e8653c8d-4d86-4ebc-92a3-0468252b9d07", :body nil},
  [:ok {:cached                nil,
        :request-time          23,


### PR DESCRIPTION
### Description

On requests to `GET /api/ee/gsheets/folder/ID`, if the harbormaster stats response returns a 403 AND the call to list connections in harbormaster returns a valid response that does not include the requested folder id, THEN delete the gsheet config

This handles cases where a connection was set up in metabase, but habormaster removed the connection for some reason (such as a change to feature flags)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
