### PR TITLE
[Backend Modularization] `query-analysis` module cleanup

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -770,10 +770,10 @@
    metabase.lib.filter/deffilter                                                        macros.metabase.lib.filter/deffilter
    metabase.models.params.chain-filter-test/chain-filter                                macros.metabase.models.params.chain-filter-test/chain-filter
    metabase.models.params.chain-filter-test/chain-filter-search                         macros.metabase.models.params.chain-filter-test/chain-filter
-   metabase.models.query-analysis-test/with-test-setup                                  macros.metabase.models.query-analysis-test/with-test-setup
    metabase.models.user-test/with-groups                                                macros.metabase.models.user-test/with-groups
    metabase.public-sharing.api-test/with-sharing-enabled-and-temp-card-referencing!     macros.metabase.public-sharing.api-test/with-sharing-enabled-and-temp-card-referencing!
    metabase.public-sharing.api-test/with-sharing-enabled-and-temp-dashcard-referencing! macros.metabase.public-sharing.api-test/with-sharing-enabled-and-temp-dashcard-referencing!
+   metabase.query-analysis.models.query-analysis-test/with-test-setup                   macros.metabase.query-analysis.models.query-analysis-test/with-test-setup
    metabase.query-analysis.task.test-setup/with-test-setup!                             macros.metabase.query-analysis.task.test-setup/with-test-setup!
    metabase.query-processor.streaming/streaming-response                                macros.metabase.query-processor.streaming/streaming-response
    metabase.server.statistics-handler-test/with-server                                  macros.metabase.server.statistics-handler-test/with-server

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -54,7 +54,6 @@
            models
            premium-features
            public-settings
-           server
            util}}
   analyze
   {:api  #{metabase.analyze.core metabase.analyze.query-results}
@@ -180,6 +179,7 @@
           metabase.driver.sync
           metabase.driver.util}
    :uses #{actions
+           api
            auth-provider
            config
            connection-pool
@@ -196,10 +196,8 @@
            pulse
            query-processor
            sync
-           task
            upload
-           util
-           enterprise/database-routing}}
+           util}}
 
   eid-translation
   {:api  #{metabase.eid-translation.core}
@@ -207,7 +205,7 @@
 
   embed
   {:api  #{metabase.embed.settings metabase.embed.app-origins-sdk}
-   :uses #{analytics models premium-features tiles util}}
+   :uses #{analytics models premium-features util}}
 
   events
   {:api  #{metabase.events metabase.events.init metabase.events.notification}
@@ -274,7 +272,7 @@
           metabase.lib.util
           metabase.lib.util.match
           metabase.lib.walk}
-   :uses #{config driver legacy-mbql models types util}}
+   :uses #{config legacy-mbql models types util}}
 
   lib-be
   {:api #{metabase.lib-be.init}
@@ -322,7 +320,6 @@
           metabase.models.moderation-review
           metabase.models.native-query-snippet
           metabase.models.native-query-snippet.permissions
-          metabase.notification.models
           metabase.models.params
           metabase.models.params.chain-filter
           metabase.models.params.custom-values
@@ -369,7 +366,6 @@
            server
            setup
            sync
-           task
            types
            util
            enterprise/advanced-permissions}}
@@ -383,7 +379,9 @@
            metabase.notification.core
            metabase.notification.init
            metabase.notification.models
-           metabase.notification.payload.core}
+           metabase.notification.api.notification
+           metabase.notification.payload.core
+           metabase.notification.send}
    :uses #{analytics
            api
            channel
@@ -442,7 +440,7 @@
 
   query-analysis
   {:api  #{metabase.query-analysis.core metabase.query-analysis.init}
-   :uses #{config driver legacy-mbql lib public-settings query-processor task util}}
+   :uses #{config driver legacy-mbql lib models public-settings query-processor task util}}
 
   query-processor
   {:api #{metabase.query-processor
@@ -549,12 +547,9 @@
            channel
            config
            db
-           embed
            events
-           integrations
            models
            permissions
-           premium-features
            public-settings
            request
            session
@@ -573,13 +568,12 @@
           metabase.sync.schedules
           metabase.sync.task.sync-databases
           metabase.sync.util}
-   :uses #{analyze api audit config db driver events lib models plugins query-processor task util}}
+   :uses #{analyze api audit config db driver events lib models query-processor task util}}
 
   task
   {:api #{metabase.task
           metabase.task.bootstrap
-          metabase.task.init
-          metabase.task.notification}
+          metabase.task.init}
    :uses #{analytics
            channel
            config
@@ -587,11 +581,9 @@
            driver
            integrations
            models
-           notification
            plugins
            premium-features
            public-settings
-           query-processor
            util
            enterprise/task}}
 
@@ -622,20 +614,19 @@
 
   xrays
   {:api  #{metabase.xrays.api metabase.xrays.core}
-   :uses #{analyze api db driver legacy-mbql lib models public-settings query-processor util}}
+   :uses #{analyze api driver legacy-mbql lib models public-settings query-processor util}}
 
   enterprise/advanced-config
   {:api  #{metabase-enterprise.advanced-config.api.logs
            metabase-enterprise.advanced-config.models.pulse-channel
-           metabase-enterprise.advanced-config.file
-           metabase-enterprise.advanced-config.crufty}
+           metabase-enterprise.advanced-config.file}
    :uses #{api db driver models permissions premium-features setup sync util}}
 
   enterprise/advanced-permissions
   {:api  #{metabase-enterprise.advanced-permissions.api.routes
            metabase-enterprise.advanced-permissions.common
            metabase-enterprise.advanced-permissions.models.permissions.group-manager}
-   :uses #{api audit driver enterprise/impersonation lib models permissions premium-features query-processor util enterprise/sandbox}}
+   :uses #{api enterprise/impersonation lib models permissions premium-features query-processor util}}
 
   enterprise/airgap
   {:api  #{}
@@ -686,8 +677,12 @@
   {:api  #{}
    :uses #{premium-features}}
 
+  enterprise/data-editing
+  {:api  #{metabase-enterprise.data-editing.api}
+   :uses #{api actions util}}
+
   enterprise/database-routing
-  {:api #{metabase-enterprise.database-routing.core metabase-enterprise.database-routing.api}
+  {:api #{metabase-enterprise.database-routing.api}
    :uses #{api config database-routing events lib models premium-features query-processor util}}
 
   enterprise/enhancements
@@ -696,19 +691,18 @@
 
   enterprise/gsheets
   {:api  #{metabase-enterprise.gsheets.api}
-   :uses #{api analytics enterprise/harbormaster models premium-features server util}}
+   :uses #{api analytics enterprise/harbormaster models premium-features util}}
 
   enterprise/harbormaster
   {:api #{metabase-enterprise.harbormaster.client}
-   :uses #{api config cloud-migration models util}}
+   :uses #{api cloud-migration util}}
 
   enterprise/impersonation
-  {:api #{metabase-enterprise.impersonation.core
-          metabase-enterprise.impersonation.api}
-   :uses #{api audit driver enterprise/sandbox lib models permissions premium-features query-processor util}}
+  {:api #{metabase-enterprise.impersonation.api}
+   :uses #{api audit driver enterprise/sandbox lib models premium-features query-processor util}}
 
   enterprise/internal-stats
-  {:api #{metabase-enterprise.internal-stats}
+  {:api #{}
    :uses #{models premium-features}}
 
   enterprise/llm
@@ -717,7 +711,7 @@
 
   enterprise/query-reference-validation
   {:api  #{metabase-enterprise.query-reference-validation.api}
-   :uses #{api models public-settings request util}}
+   :uses #{api models query-analysis request util}}
 
   enterprise/sandbox
   {:api #{metabase-enterprise.sandbox.api.routes
@@ -734,7 +728,6 @@
            query-processor
            request
            util
-           enterprise/impersonation
            enterprise/api}}
 
   enterprise/scim
@@ -763,15 +756,11 @@
 
   enterprise/stale
   {:api  #{metabase-enterprise.stale.routes}
-   :uses #{analytics api embed models premium-features public-settings request util}}
+   :uses #{analytics api embed models premium-features request util}}
 
   enterprise/stats
   {:api  #{}
    :uses #{driver premium-features enterprise/advanced-config enterprise/scim enterprise/sso}}
-
-  enterprise/data-editing
-  {:api #{}
-   :uses #{api actions util}}
 
   enterprise/task
   {:api  #{metabase-enterprise.task.truncate-audit-tables}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -329,7 +329,6 @@
           metabase.models.params.field-values
           metabase.models.params.shared
           metabase.models.query
-          metabase.models.query-analysis
           metabase.models.query.permissions
           metabase.models.resolution
           metabase.models.secret

--- a/.clj-kondo/macros/metabase/query_analysis/models/query_analysis_test.clj
+++ b/.clj-kondo/macros/metabase/query_analysis/models/query_analysis_test.clj
@@ -1,4 +1,4 @@
-(ns macros.metabase.models.query-analysis-test)
+(ns macros.metabase.query-analysis.models.query-analysis-test)
 
 (defmacro with-test-setup [& body]
   `(let [~'card-id  1

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -220,15 +220,19 @@
           static-deps  (ns.parse/deps-from-ns-decl decl)
           dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
                          (vary-meta symb assoc ::dynamic :require-and-friends))
-          defenterprise-deps (for [symb (find-defenterprises file)]
-                               (vary-meta symb assoc ::dynamic :defenterprise))
-          defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
-                                      (vary-meta symb assoc ::dynamic :defenterprise-schema))
+          ;;
+          ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
+          ;; rationale.
+          ;;
+          ;; defenterprise-deps (for [symb (find-defenterprises file)]
+          ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
+          ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
+          ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
           deps         (into (sorted-set) cat
                              [static-deps
                               dynamic-deps
-                              defenterprise-deps
-                              defenterprise-schema-deps])]
+                              #_defenterprise-deps
+                              #_defenterprise-schema-deps])]
       {:namespace ns-symb
        :module    (module ns-symb)
        :deps      (sort-by pr-str

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -121,7 +121,7 @@
   [handler]
   (open-api/handler-with-open-api-spec
    (fn [request respond raise]
-     (if (public-settings/query-analysis-enabled)
+     (if (query-analysis/query-analysis-enabled)
        (handler request respond raise)
        (respond {:status 429 :body "Query Analysis must be enabled to use the Query Reference Validator"})))
    (fn [prefix]

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -6,8 +6,7 @@
    [metabase.api.open-api :as open-api]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.collection :as collection]
-   [metabase.query-analysis.models.query-analysis :as query-analysis]
-   [metabase.public-settings :as public-settings]
+   [metabase.query-analysis.core :as query-analysis]
    [metabase.request.core :as request]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -6,7 +6,7 @@
    [metabase.api.open-api :as open-api]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.collection :as collection]
-   [metabase.models.query-analysis :as query-analysis]
+   [metabase.query-analysis.models.query-analysis :as query-analysis]
    [metabase.public-settings :as public-settings]
    [metabase.request.core :as request]
    [metabase.util.malli.schema :as ms]

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -66,7 +66,7 @@
     :model/PulseChannelRecipient             metabase.pulse.models.pulse-channel-recipient
     :model/Query                             metabase.models.query
     :model/QueryAction                       metabase.actions.models
-    :model/QueryAnalysis                     metabase.models.query-analysis
+    :model/QueryAnalysis                     metabase.query-analysis.models.query-analysis
     :model/QueryCache                        metabase.models.query-cache
     :model/QueryExecution                    metabase.models.query-execution
     :model/QueryField                        metabase.models.query-field

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -1013,13 +1013,6 @@ See [fonts](../configuring-metabase/fonts.md).")
   :default    true
   :type       :boolean)
 
-(defsetting query-analysis-enabled
-  (deferred-tru "Whether or not we analyze any queries at all")
-  :visibility :admin
-  :export?    false
-  :default    false
-  :type       :boolean)
-
 ;;; TODO -- move the search-related settings into the `:search` module. Only settings used across the entire application
 ;;; should live in this namespace.
 

--- a/src/metabase/pulse/api/alert.clj
+++ b/src/metabase/pulse/api/alert.clj
@@ -2,7 +2,6 @@
   "/api/alert endpoints.
 
   Deprecated: will soon be migrated to notification APIs."
-  #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.set :as set]
    [metabase.api.common :as api]

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -3,7 +3,6 @@
   see [[metabase.pulse.api.unsubscribe]].
 
   Deprecated: will soon be migrated to notification APIs."
-  #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.set :refer [difference]]
    [hiccup.core :refer [html]]

--- a/src/metabase/query_analysis/core.clj
+++ b/src/metabase/query_analysis/core.clj
@@ -15,8 +15,10 @@
    [metabase.lib.core :as lib]
    [metabase.lib.util :as lib.util]
    [metabase.public-settings :as public-settings]
+   [metabase.query-analysis.models.query-analysis]
    [metabase.query-analysis.native-query-analyzer :as nqa]
    [metabase.query-analysis.native-query-analyzer.replacement :as nqa.replacement]
+   [metabase.query-analysis.settings]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.namespaces :as shared.ns]
@@ -26,8 +28,12 @@
 (set! *warn-on-reflection* true)
 
 (shared.ns/import-fns
+ [metabase.query-analysis.models.query-analysis
+  cards-with-reference-errors]
  [nqa
-  tables-for-native])
+  tables-for-native]
+ [metabase.query-analysis.settings
+  query-analysis-enabled])
 
 (def ^:private realtime-queue-capacity
   "The maximum number of cards which can be queued for async analysis. When exceeded, additional cards will be dropped."
@@ -83,7 +89,7 @@
 (defn enabled-type?
   "Is analysis of the given query type enabled?"
   [query-type]
-  (and (public-settings/query-analysis-enabled)
+  (and (query-analysis-enabled)
        (case query-type
          :native     (public-settings/sql-parsing-enabled)
          :query      true

--- a/src/metabase/query_analysis/core.clj
+++ b/src/metabase/query_analysis/core.clj
@@ -29,7 +29,8 @@
 
 (shared.ns/import-fns
  [metabase.query-analysis.models.query-analysis
-  cards-with-reference-errors]
+  cards-with-reference-errors
+  reference-errors]
  [nqa
   tables-for-native]
  [metabase.query-analysis.settings

--- a/src/metabase/query_analysis/init.clj
+++ b/src/metabase/query_analysis/init.clj
@@ -3,5 +3,6 @@
 
   See https://metaboat.slack.com/archives/CKZEMT1MJ/p1736556522733279 for rationale behind this pattern."
   (:require
+   [metabase.query-analysis.settings]
    [metabase.query-analysis.task.analyze-queries]
    [metabase.query-analysis.task.sweep-query-analysis]))

--- a/src/metabase/query_analysis/models/query_analysis.clj
+++ b/src/metabase/query_analysis/models/query_analysis.clj
@@ -1,4 +1,4 @@
-(ns metabase.models.query-analysis
+(ns metabase.query-analysis.models.query-analysis
   (:require
    [honey.sql.helpers :as sql.helpers]
    [metabase.util :as u]

--- a/src/metabase/query_analysis/settings.clj
+++ b/src/metabase/query_analysis/settings.clj
@@ -1,0 +1,11 @@
+(ns metabase.query-analysis.settings
+  (:require
+   [metabase.models.setting :as setting :refer [defsetting]]
+   [metabase.util.i18n :as i18n :refer [deferred-tru]]))
+
+(defsetting query-analysis-enabled
+  (deferred-tru "Whether or not we analyze any queries at all")
+  :visibility :admin
+  :export?    false
+  :default    false
+  :type       :boolean)

--- a/src/metabase/query_analysis/settings.clj
+++ b/src/metabase/query_analysis/settings.clj
@@ -1,10 +1,10 @@
 (ns metabase.query-analysis.settings
   (:require
-   [metabase.models.setting :as setting :refer [defsetting]]
-   [metabase.util.i18n :as i18n :refer [deferred-tru]]))
+   [metabase.models.setting :refer [defsetting]]
+   [metabase.util.i18n :as i18n]))
 
 (defsetting query-analysis-enabled
-  (deferred-tru "Whether or not we analyze any queries at all")
+  (i18n/deferred-tru "Whether or not we analyze any queries at all")
   :visibility :admin
   :export?    false
   :default    false

--- a/src/metabase/query_analysis/task/analyze_queries.clj
+++ b/src/metabase/query_analysis/task/analyze_queries.clj
@@ -6,9 +6,9 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.simple :as simple]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.public-settings :as public-settings]
    [metabase.query-analysis.core :as query-analysis]
    [metabase.query-analysis.failure-map :as failure-map]
+   [metabase.query-analysis.settings :as query-analysis.settings]
    [metabase.task :as task]
    [metabase.util :as u]
    [metabase.util.log :as log])
@@ -44,7 +44,7 @@
             card-id    (u/the-id card-or-id)
             timer      (u/start-timer)
             card       (query-analysis/->analyzable card-or-id)]
-        (when (public-settings/query-analysis-enabled)
+        (when (query-analysis.settings/query-analysis-enabled)
           (if (failure-map/non-retryable? card)
             (log/debugf "Skipping analysis of Card %s as its query has caused failures in the past." card-id)
             (try

--- a/src/metabase/query_analysis/task/sweep_query_analysis.clj
+++ b/src/metabase/query_analysis/task/sweep_query_analysis.clj
@@ -4,8 +4,8 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.public-settings :as public-settings]
    [metabase.query-analysis.core :as query-analysis]
+   [metabase.query-analysis.settings :as query-analysis.settings]
    [metabase.task :as task]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -92,7 +92,7 @@
 (task/defjob ^{DisallowConcurrentExecution true
                :doc                        "Backfill QueryField for cards created earlier. Runs once per instance."}
   SweepQueryAnalysis [_ctx]
-  (when (public-settings/query-analysis-enabled)
+  (when (query-analysis.settings/query-analysis-enabled)
     (sweep-query-analysis-loop!)))
 
 (defmethod task/init! ::SweepQueryAnalysis [_]

--- a/test/metabase/query_analysis/models/query_analysis_test.clj
+++ b/test/metabase/query_analysis/models/query_analysis_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.models.query-analysis-test
+(ns metabase.query-analysis.models.query-analysis-test
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -302,6 +302,7 @@
                   result)))))))
 
 (deftest array-query-can-be-cached-test
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :test/arrays)
                          :sqlite) ;; Disabling until issue #57301 is resolved
     (with-mock-cache! [save-chan]


### PR DESCRIPTION
Resolves DEV-356

Also updated the modules config using the latest generated output from `dev.deps-graph` after making some tweaks discussed in https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 