### PR TITLE
Map settings array on fetch

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -4,10 +4,10 @@ import type {
   Engine,
   EngineField,
   EngineSource,
+  EnterpriseSettingKey,
   EnterpriseSettings,
   FontFile,
   SettingDefinition,
-  SettingKey,
   Settings,
   TokenFeatures,
   TokenStatus,
@@ -129,7 +129,7 @@ export const createMockTokenFeatures = (
 });
 
 export const createMockSettingDefinition = <
-  Key extends SettingKey = SettingKey,
+  Key extends EnterpriseSettingKey = EnterpriseSettingKey,
 >(
   opts: SettingDefinition<Key>,
 ): SettingDefinition<Key> => ({

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -255,12 +255,14 @@ export type PasswordComplexity = {
 
 export type SessionCookieSameSite = "lax" | "strict" | "none";
 
-export interface SettingDefinition<Key extends SettingKey = SettingKey> {
+export interface SettingDefinition<
+  Key extends EnterpriseSettingKey = EnterpriseSettingKey,
+> {
   key: Key;
   env_name?: string;
   is_env_setting?: boolean;
-  value?: SettingValue<Key>;
-  default?: SettingValue<Key>;
+  value?: EnterpriseSettingValue<Key>;
+  default?: EnterpriseSettingValue<Key>;
   display_name?: string;
   description?: string | ReactNode | null;
   type?: InputSettingType;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -266,6 +266,12 @@ export interface SettingDefinition<Key extends SettingKey = SettingKey> {
   type?: InputSettingType;
 }
 
+export type SettingDefinitionMap<
+  T extends EnterpriseSettingKey = EnterpriseSettingKey,
+> = {
+  [K in T]: SettingDefinition<K>;
+};
+
 export type UpdateChannel = "latest" | "beta" | "nightly";
 
 export interface OpenAiModel {

--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -1,7 +1,10 @@
+import _ from "underscore";
+
 import type {
   EnterpriseSettingKey,
   EnterpriseSettingValue,
   SettingDefinition,
+  SettingDefinitionMap,
 } from "metabase-types/api";
 
 import { Api } from "./api";
@@ -10,11 +13,13 @@ import { invalidateTags, tag } from "./tags";
 export const settingsApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     // admin-only endpoint that returns all settings with lots of extra metadata
-    getAdminSettingsDetails: builder.query<SettingDefinition[], void>({
+    getAdminSettingsDetails: builder.query<SettingDefinitionMap, void>({
       query: () => ({
         method: "GET",
         url: "/api/setting",
       }),
+      transformResponse: (response: SettingDefinition[]) =>
+        _.indexBy(response, "key") as SettingDefinitionMap,
     }),
     getSetting: builder.query<EnterpriseSettingValue, EnterpriseSettingKey>({
       query: (name) => ({

--- a/frontend/src/metabase/api/utils/settings.ts
+++ b/frontend/src/metabase/api/utils/settings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 
 import { useToast } from "metabase/common/hooks";
@@ -28,10 +28,7 @@ export const useAdminSetting = <SettingName extends EnterpriseSettingKey>(
     useGetAdminSettingsDetailsQuery();
   const [updateSetting, updateSettingResult] = useUpdateSettingMutation();
 
-  const settingDetails = useMemo(
-    () => settingsDetails?.find((setting) => setting.key === settingName),
-    [settingsDetails, settingName],
-  );
+  const settingDetails = settingsDetails?.[settingName];
 
   const [sendToast] = useToast();
 


### PR DESCRIPTION
### Description

In 100% of cases when we want data from `/api/setting`, we're looking for one or more specific settings, so we always end up using `_.indexBy(settingsArray, 'key')`  and memoizing it in an individual component.

Instead, let's just do it when we fetch it, so any time we pull it from the cache it's already a map 🤗 

