### PR TITLE
fix visualizer entities persistence

### DIFF
--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import EditableText from "metabase/core/components/EditableText";
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -45,7 +46,14 @@ export function Header({
   const dispatch = useDispatch();
 
   const handleSave = () => {
-    onSave(visualizerState);
+    onSave(
+      _.pick(visualizerState, [
+        "display",
+        "columns",
+        "columnValuesMapping",
+        "settings",
+      ]),
+    );
   };
 
   const handleChangeTitle = useCallback(


### PR DESCRIPTION
### Description

Currently, created via visualizer dashcards crash after saving and a page refresh because they include more unnecessary properties from the VisualizerState. This PR ensures only necessary data is being saved in visualizer cards.

### How to verify

- Create a visualizer card and save it
- Refresh the page
- Ensure the card does not crash
