### PR TITLE
WRK-348 Hide schema from payload example

### DIFF
--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -96,7 +96,7 @@ export const notificationApi = Api.injectEndpoints({
       }),
     }),
     getNotificationPayloadExample: builder.query<
-      GetNotificationPayloadExampleResponse,
+      { payload: GetNotificationPayloadExampleResponse["payload"] },
       GetNotificationPayloadExampleRequest
     >({
       query: (body) => ({
@@ -104,6 +104,9 @@ export const notificationApi = Api.injectEndpoints({
         url: `/api/notification/payload`,
         body,
       }),
+      transformResponse(response: GetNotificationPayloadExampleResponse) {
+        return { payload: response.payload };
+      },
     }),
     getDefaultNotificationTemplate: builder.query<
       Record<


### PR DESCRIPTION
Closes [WRK-348](https://linear.app/metabase/issue/WRK-348/fix-notification-payload-example)

### Description

The 'schema' field from notification event payload should not be presented in payload example and in autocomplete.

### Demo

<img width="355" alt="image" src="https://github.com/user-attachments/assets/8204ce98-08e5-48b5-b2de-59d02807647d" />

<img width="436" alt="image" src="https://github.com/user-attachments/assets/d57ec8ec-6652-4b8d-8301-3852ca5e8710" />

