### PR TITLE
Segregate undo snapshots based on scope, not table

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -24,11 +24,6 @@
   (derive :metabase/model)
   (derive :hook/timestamped?))
 
-;; We must enforce the following invariant for the data in the Undo table:
-;;
-;; undone` is monotonic in `batch_num`, for each `scope`.
-;;  i.e., it can only change from `false` to `true` as `batch_num` increases.
-
 (defn- serialize-scope
   "Convert the scope map or string into a stable string we can do example matches on in the database. Idempotent."
   [scope]

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -10,7 +10,7 @@
 
 (def ^:private retention-total-batches 100)
 (def ^:private retention-total-rows 1000)
-(def ^:private retention-batches-per-table 100)
+(def ^:private retention-batches-per-scope 100)
 (def ^:private retention-batches-per-user 50)
 
 (methodical/defmethod t2/table-name :model/Undo [_model] :data_edit_undo_chain)
@@ -26,10 +26,17 @@
 
 ;; We must enforce the following invariant for the data in the Undo table:
 ;;
-;; undone` is monotonic in `batch_num`, for each `table_id`, `row_pk` combination.
-;;  i.e., it can only change from `false` to `true` for any logical "cell", as `batch_num` increases.
+;; undone` is monotonic in `batch_num`, for each `scope`.
+;;  i.e., it can only change from `false` to `true` as `batch_num` increases.
 
-(defn- next-batch [undo? user-id table-id]
+(defn- serialize-scope
+  "Convert the scope map or string into a stable string we can do example matches on in the database. Idempotent."
+  [scope]
+  (if (string? scope)
+    scope
+    (->> (or scope "unknown") (walk/postwalk #(if-not (map? %) % (apply sorted-map (apply concat %)))) pr-str)))
+
+(defn- next-batch [undo? user-id scope]
   ;; For now, we assume all the changes are to the same table.
   ;; In the future, we might want to skip multi-table changes when using cmd-Z.
   ;; We may also want to filter based on the type of interaction that caused the change (e.g., grid, workflow, etc)
@@ -38,8 +45,8 @@
                          {:select [[[(if undo? :max :min) :batch_num]]]
                           :from   [(t2/table-name :model/Undo)]
                           :where  [:and
-                                   [:= user-id :user_id]
-                                   [:= table-id :table_id]
+                                   [:= :user_id user-id]
+                                   [:= :scope (serialize-scope scope)]
                                    (if undo?
                                      [:not :undone]
                                      :undone)]}]))
@@ -82,63 +89,49 @@
 (defn- prune-batches! [batches-to-keep & [where]]
   (prune-from-batch! (batch-to-prune-from batches-to-keep where) where))
 
-(defn- serialize-scope
-  "Convert the scope map into a stable string we can do example matches on in the database."
-  [scope]
-  (->> (or scope "unknown") (walk/postwalk #(if-not (map? %) % (apply sorted-map (apply concat %)))) pr-str))
-
 (defn track-change!
   "Insert some snapshot data based on edits made to the given table."
   [user-id scope table-id->row-pk->old-new-values]
-  (t2/with-transaction [_conn]
-    (let [seq-name       "undo_batch_num"
-          next-batch-num (or (t2/select-one-fn :next_val [:sequences :next_val] :name seq-name {:for :update}) 1)]
-      (t2/update! :sequences {:name seq-name} {:next_val (inc next-batch-num)})
-      (t2/insert!
-       :model/Undo
-       (for [[table-id table-updates] table-id->row-pk->old-new-values
-             [row-pk [old new]] table-updates]
-         {:batch_num  next-batch-num
-          :table_id   table-id
-          :user_id    user-id
-          :row_pk     row-pk
-          :scope     (serialize-scope scope)
-          :raw_before old
-          :raw_after  new}))))
-  ;; We do this in multiple statements because:
-  ;; - it's much simpler
-  ;; - typically there is only one table, and this is more efficient in that case
-  (doseq [[table-id table-updates] table-id->row-pk->old-new-values
-          :let [_row-pks (keys table-updates)]]
-    ;; TODO This is the wrong batch number
-    ;; - we need to scope ourselves just to these row-pks
-    ;; - we want to look across all users
-    ;; - we can't rely on `undone` being monotonic if we're searching across multiple row-pks
-    (when-let [{:keys [batch_num]} (first (next-batch false user-id table-id))]
+  (let [scope (serialize-scope scope)]
+    (t2/with-transaction [_conn]
+      (let [seq-name       "undo_batch_num"
+            next-batch-num (or (t2/select-one-fn :next_val [:sequences :next_val] :name seq-name {:for :update}) 1)]
+        (t2/update! :sequences {:name seq-name} {:next_val (inc next-batch-num)})
+        (t2/insert!
+         :model/Undo
+         (for [[table-id table-updates] table-id->row-pk->old-new-values
+               [row-pk [old new]] table-updates]
+           {:batch_num  next-batch-num
+            :table_id   table-id
+            :user_id    user-id
+            :row_pk     row-pk
+            :scope      scope
+            :raw_before old
+            :raw_after  new}))))
+
+    ;; Delete snapshots that have been undone, as we keep a linear history and will no longer be able to "redo" them.
+    (when-let [{:keys [batch_num]} (first (next-batch false user-id scope))]
       (t2/delete! :model/Undo
-                  :table_id table-id
-                  ;; Note: we intentionally also orphan changes to other rows.
-                  ;:row_pk [:in row-pks]
                   :batch_num [:>= batch_num]
-                  :undone true)))
+                  :scope scope
+                  :undone true))
 
-  ;; Pruning. Fairly naive implementation. Doesn't assume we were fully pruned before this update.
+    ;; Pruning. Fairly naive implementation. Doesn't assume we were fully pruned before this update.
 
-  (prune-from-batch! (max (batch-to-prune-from-for-rows retention-total-rows)
-                          (batch-to-prune-from retention-total-batches)))
+    (prune-from-batch! (max (batch-to-prune-from-for-rows retention-total-rows)
+                            (batch-to-prune-from retention-total-batches)))
 
-  (doseq [table-id (keys table-id->row-pk->old-new-values)]
-    (let [where-table [:= :table_id table-id]]
-      (prune-batches! retention-batches-per-table where-table)))
+    (let [where-scope [:= :scope scope]]
+      (prune-batches! retention-batches-per-scope where-scope))
 
-  (let [where-user [:= :user_id user-id]]
-    (prune-batches! retention-batches-per-user where-user)))
+    (let [where-user [:= :user_id user-id]]
+      (prune-batches! retention-batches-per-user where-user))))
 
 (defn next-batch-num
   "Return the batch number of the new change that we would (un-)revert.
   NOTE: this does not check whether there is a conflict preventing us from actually performing it."
-  [undo? user-id table-id]
-  (:batch_num (first (next-batch undo? user-id table-id))))
+  [undo-or-redo user-id scope]
+  (:batch_num (first (next-batch (= :undo undo-or-redo) user-id scope))))
 
 ;; This will be used to fix conflict false positives
 #_{:clj-kondo/ignore [:unused-private-var]}
@@ -186,7 +179,7 @@
 
 (defn- update-table-data!
   "Revert the underlying table data."
-  [undo-or-redo user-id batch]
+  [undo-or-redo user-id scope batch]
   (let [undo?     (= :undo undo-or-redo)
         action-kw (keyword "undo" (name undo-or-redo))]
     (doseq [[[table-id category] sub-batch] (u/group-by (juxt :table_id categorize) batch)
@@ -195,7 +188,7 @@
                   opts {:existing-context {:invocation_id    iid
                                            :invocation-stack [[action-kw iid]]}}]]
       (case (if undo? (invert category) category)
-        :create (try (data-editing/perform-bulk-action! :bulk/create user-id table-id rows opts)
+        :create (try (data-editing/perform-bulk-action! :bulk/create user-id scope table-id rows opts)
                      (catch Exception e
                        ;; Sometimes cols don't support a custom value being provided, e.g., GENERATED ALWAYS AS IDENTITY
                        (throw (ex-info "Failed to un-delete row(s)"
@@ -204,26 +197,26 @@
                                         :table-id  table-id
                                         :pks       (map :row_pk batch)}
                                        e))))
-        :update (data-editing/perform-bulk-action! :bulk/update user-id table-id rows opts)
-        :delete (data-editing/perform-bulk-action! :bulk/delete user-id table-id rows opts)))))
+        :update (data-editing/perform-bulk-action! :bulk/update user-id scope table-id rows opts)
+        :delete (data-editing/perform-bulk-action! :bulk/delete user-id scope table-id rows opts)))))
 
-(defn- undo*! [undo-or-redo user-id table-id]
+(defn- undo*! [undo-or-redo user-id scope]
   (let [undo? (= :undo undo-or-redo)
-        batch (next-batch undo? user-id table-id)]
+        batch (next-batch undo? user-id scope)]
     (cond
       (not (seq batch)) (throw (ex-info (if undo?
                                           "No previous versions found"
                                           "No subsequent versions found")
-                                        {:error    :undo/none
-                                         :user-id  user-id
-                                         :table-id table-id}))
+                                        {:error   :undo/none
+                                         :user-id user-id
+                                         :scope   scope}))
       (conflict? undo? batch) (throw (ex-info "Blocked by other changes"
                                               ;; It would be nice if we gave the batch_num for the first conflict.
-                                              {:error    :undo/conflict
-                                               :user-id  user-id
-                                               :table-id table-id}))
+                                              {:error   :undo/conflict
+                                               :user-id user-id
+                                               :scope   scope}))
       :else
-      (do (update-table-data! undo-or-redo user-id batch)
+      (do (update-table-data! undo-or-redo user-id scope batch)
           (t2/update! :model/Undo
                       {:batch_num (:batch_num (first batch))}
                       {:undone undo?})
@@ -235,10 +228,10 @@
 
 (defn undo!
   "Rollback the given user's last change to the given table."
-  [user-id table-id]
-  (undo*! :undo user-id table-id))
+  [user-id scope]
+  (undo*! :undo user-id scope))
 
 (defn redo!
   "Rollback the given user's last change to the given table."
-  [user-id table-id]
-  (undo*! :redo user-id table-id))
+  [user-id scope]
+  (undo*! :redo user-id scope))

--- a/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
@@ -23,7 +23,10 @@
     (api/check-400 (seq rows) "Please supply at least one row.")
     (api/check-400 (every? seq rows) "Every row should not be empty.")
     ;; TODO just call the action directly once we have it, get rid of this `insert!` method.
-    {:created (count (:created-rows (data-editing/insert! (:creator_id hook) (:table_id hook) rows)))}))
+    {:created (count (:created-rows (data-editing/insert! (:creator_id hook)
+                                                          {:webhook-id (:id hook)}
+                                                          (:table_id hook)
+                                                          rows)))}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -86,18 +86,18 @@
                                              [{:type "section",
                                                :text
                                                {:type "mrkdwn",
-                                                :text "*Crowberto Corv has updated a row from CATEGORIES*\n*Update:*\n• name : Updated Category\n• id : 1"}}]}]
+                                                :text "*Crowberto Corv has updated a row from CATEGORIES*\n*Update:*\n• ID : 1\n• NAME : Updated Category"}}]}]
                               :channel-id  "#test-pulse"}
                              message)))
     :channel/email (fn [[email :as emails]]
                      (is (= 1 (count emails)))
                      (is (=? {:subject "Table CATEGORIES has been updated"
                               :body [{"Crowberto Corv has updated a row in CATEGORIES" true
-                                      "name: Updated Category"                         true}]}
+                                      "NAME: Updated Category"                         true}]}
                              (mt/summarize-multipart-single-email
                               email
                               #"Crowberto Corv has updated a row in CATEGORIES"
-                              #"name: Updated Category"))))
+                              #"NAME: Updated Category"))))
     :channel/http  (fn [[req :as reqs]]
                      (is (= 1 (count reqs)))
                      (is (=? {:body (mt/malli=? :map)} req)))}))
@@ -118,18 +118,18 @@
                                              [{:type "section",
                                                :text
                                                {:type "mrkdwn",
-                                                :text "*Crowberto Corv has deleted a row from CATEGORIES*\n*Deleted row:*\n• id : 1\n• name : African"}}]}]
+                                                :text "*Crowberto Corv has deleted a row from CATEGORIES*\n*Deleted row:*\n• ID : 1\n• NAME : African"}}]}]
                               :channel-id "#test-pulse"}
                              message)))
     :channel/email (fn [[email :as emails]]
                      (is (= 1 (count emails)))
                      (is (=? {:subject "Table CATEGORIES has a row deleted"
                               :body    [{"Crowberto Corv has deleted a row from CATEGORIES" true
-                                         "name: African" true}]}
+                                         "NAME: African" true}]}
                              (mt/summarize-multipart-single-email
                               email
                               #"Crowberto Corv has deleted a row from CATEGORIES"
-                              #"name: African"))))
+                              #"NAME: African"))))
     :channel/http  (fn [[req :as reqs]]
                      (is (= 1 (count reqs)))
                      (is (=? {:body (mt/malli=? :map)} req)))}))
@@ -211,11 +211,11 @@
 
 (deftest create-row-notification-webhook-test
   (test-row-notification!
-   {:event_name :event/row.updated}
+   {:event_name :event/row.created}
    (fn [_notification]
-     (let [token  (:token (mt/user-http-request :crowberto
-                                                :post "ee/data-editing/webhook"
-                                                {:table-id (mt/id :categories)}))]
+     (let [token (:token (mt/user-http-request :crowberto
+                                               :post "ee/data-editing/webhook"
+                                               {:table-id (mt/id :categories)}))]
        (mt/user-http-request
         :crowberto
         :post

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -64,59 +64,59 @@
 
             (is (= [] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-id table-id))
-            (is (not (undo/next-batch-num false user-id table-id)))
+            (is (undo/next-batch-num :undo user-id test-scope))
+            (is (not (undo/next-batch-num :redo user-id test-scope)))
             (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
-                   (undo/undo! user-id table-id)))
+                   (undo/undo! user-id test-scope table-id)))
             (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-id table-id))
-            (is (undo/next-batch-num false user-id table-id))
+            (is (undo/next-batch-num :undo user-id test-scope))
+            (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
-                   (undo/undo! user-id table-id)))
+                   (undo/undo! user-id test-scope table-id)))
             (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-id table-id))
-            (is (undo/next-batch-num false user-id table-id))
+            (is (undo/next-batch-num :undo user-id test-scope))
+            (is (undo/next-batch-num :redo user-id test-scope))
             ;; This doesn't tell the FE which rows to hide
             (is (= {table-id [[:delete {:id 1}]]}
-                   (undo/undo! user-id table-id)))
+                   (undo/undo! user-id test-scope table-id)))
             (is (= [] (table-rows table-id)))
 
-            (is (not (undo/next-batch-num true user-id table-id)))
-            (is (undo/next-batch-num false user-id table-id))
+            (is (not (undo/next-batch-num :undo user-id test-scope)))
+            (is (undo/next-batch-num :redo user-id test-scope))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No previous versions found"
-                 (undo/undo! user-id table-id)))
+                 (undo/undo! user-id test-scope table-id)))
 
-            (is (not (undo/next-batch-num true user-id table-id)))
-            (is (undo/next-batch-num false user-id table-id))
+            (is (not (undo/next-batch-num :undo user-id test-scope)))
+            (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
-                   (undo/redo! user-id table-id)))
+                   (undo/redo! user-id test-scope table-id)))
             (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-id table-id))
-            (is (undo/next-batch-num false user-id table-id))
+            (is (undo/next-batch-num :undo user-id test-scope))
+            (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
-                   (undo/redo! user-id table-id)))
+                   (undo/redo! user-id test-scope table-id)))
             (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-id table-id))
-            (is (undo/next-batch-num false user-id table-id))
+            (is (undo/next-batch-num :undo user-id test-scope))
+            (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:delete {:id 1}]]}
-                   (undo/redo! user-id table-id)))
+                   (undo/redo! user-id test-scope table-id)))
             (is (= [] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-id table-id))
-            (is (not (undo/next-batch-num false user-id table-id)))
+            (is (undo/next-batch-num :undo user-id test-scope))
+            (is (not (undo/next-batch-num :redo user-id test-scope)))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No subsequent versions found"
-                 (undo/redo! user-id table-id)))
+                 (undo/redo! user-id test-scope table-id)))
 
-            (is (undo/next-batch-num true user-id table-id))
-            (is (not (undo/next-batch-num false user-id table-id)))))))))
+            (is (undo/next-batch-num :undo user-id test-scope))
+            (is (not (undo/next-batch-num :redo user-id test-scope)))))))))
 
 ;; I'm OK reducing this scenario's scope once we have e2e tests.
 ;; Until then, I think this is ideal.
@@ -144,93 +144,93 @@
 
             (is (= [] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-2 table-id))
-            (is (not (undo/next-batch-num false user-2 table-id)))
+            (is (undo/next-batch-num :undo user-2 test-scope))
+            (is (not (undo/next-batch-num :redo user-2 test-scope)))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"Blocked by other changes"
-                 (undo/undo! user-2 table-id)))
+                 (undo/undo! user-2 test-scope table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (not (undo/next-batch-num false user-1 table-id)))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (not (undo/next-batch-num :redo user-1 test-scope)))
             (is (= {table-id [[:create {:id 2, :name "Moominswole", :power 9001}]]}
-                   (undo/undo! user-1 table-id)))
+                   (undo/undo! user-1 test-scope table-id)))
             (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"Blocked by other changes"
-                 (undo/undo! user-1 table-id)))
+                 (undo/undo! user-1 test-scope table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (undo/next-batch-num false user-1 table-id))
-            (is (undo/next-batch-num true user-2 table-id))
-            (is (not (undo/next-batch-num false user-2 table-id)))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (undo/next-batch-num :redo user-1 test-scope))
+            (is (undo/next-batch-num :undo user-2 test-scope))
+            (is (not (undo/next-batch-num :redo user-2 test-scope)))
             (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
-                   (undo/undo! user-2 table-id)))
+                   (undo/undo! user-2 test-scope table-id)))
             (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 3}]]}
-                   (undo/undo! user-1 table-id)))
+                   (undo/undo! user-1 test-scope table-id)))
             (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:delete {:id 2}]]}
-                   (undo/undo! user-1 table-id)))
+                   (undo/undo! user-1 test-scope table-id)))
             (is (= [] (table-rows table-id)))
 
-            (is (not (undo/next-batch-num true user-1 table-id)))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (not (undo/next-batch-num :undo user-1 test-scope)))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No previous versions found"
-                 (undo/undo! user-1 table-id)))
+                 (undo/undo! user-1 test-scope table-id)))
 
-            (is (not (undo/next-batch-num true user-1 table-id)))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (not (undo/next-batch-num :undo user-1 test-scope)))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:create {:id 2, :name "Moomintroll", :power 3}]]}
-                   (undo/redo! user-1 table-id)))
+                   (undo/redo! user-1 test-scope table-id)))
             (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
-                   (undo/redo! user-1 table-id)))
+                   (undo/redo! user-1 test-scope table-id)))
             (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:update {:id 2, :name "Moominswole", :power 9001}]]}
-                   (undo/redo! user-2 table-id)))
+                   (undo/redo! user-2 test-scope table-id)))
             (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (undo/next-batch-num false user-1 table-id))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:delete {:id 2}]]}
-                   (undo/redo! user-1 table-id)))
+                   (undo/redo! user-1 test-scope table-id)))
             (is (= [] (table-rows table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (not (undo/next-batch-num false user-1 table-id)))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (not (undo/next-batch-num :redo user-1 test-scope)))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No subsequent versions found"
-                 (undo/redo! user-1 table-id)))
+                 (undo/redo! user-1 test-scope table-id)))
 
-            (is (undo/next-batch-num true user-2 table-id))
-            (is (not (undo/next-batch-num false user-2 table-id)))
+            (is (undo/next-batch-num :undo user-2 test-scope))
+            (is (not (undo/next-batch-num :redo user-2 test-scope)))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No subsequent versions found"
-                 (undo/redo! user-2 table-id)))
+                 (undo/redo! user-2 test-scope table-id)))
 
-            (is (undo/next-batch-num true user-1 table-id))
-            (is (not (undo/next-batch-num false user-1 table-id)))))))))
+            (is (undo/next-batch-num :undo user-1 test-scope))
+            (is (not (undo/next-batch-num :redo user-1 test-scope)))))))))
 
 (deftest undo-orphan-integration-test
   (mt/with-empty-h2-app-db
@@ -256,10 +256,10 @@
                                                [user-id nil]])
 
             ;; Sad trick - use undo to initialize the underlying table state (since we only created the undo history)
-            (undo/undo! user-id table-id)
-            (undo/undo! user-id table-id)
-            (undo/undo! user-id table-id)
-            (undo/undo! user-id table-id)
+            (undo/undo! user-id test-scope table-id)
+            (undo/undo! user-id test-scope table-id)
+            (undo/undo! user-id test-scope table-id)
+            (undo/undo! user-id test-scope table-id)
 
             (is (= [[1 "Too-tickley" "squirming"]] (table-rows table-id)))
 
@@ -268,14 +268,14 @@
             ;; TLDR `write-sequence` should be updated to update the table itself, then these tests can be simpler.
             (undo/track-change! user-id test-scope {table-id {{:id 2} [{:name "Toggle" :status "restored"} nil]}})
 
-            (is (nil? (undo/next-batch-num false user-id table-id)))
-            (is (undo/next-batch-num true user-id table-id))
+            (is (nil? (undo/next-batch-num :redo user-id test-scope)))
+            (is (undo/next-batch-num :undo user-id test-scope))
 
-            (undo/undo! user-id table-id)
+            (undo/undo! user-id test-scope table-id)
             (is (= [[1 "Too-tickley" "squirming"]
                     [2 "Toggle" "restored"]] (table-rows table-id)))
 
-            (undo/redo! user-id table-id)
+            (undo/redo! user-id test-scope table-id)
             (is (= [[1 "Too-tickley" "squirming"]] (table-rows table-id)))))))))
 
 (defn- count-batches [& [where]]
@@ -340,28 +340,30 @@
                 (is (= 5 (count-batches [:= :user_id user-1])))
                 (is (= 5 (count-batches [:= :user_id user-2])))))
 
-            (testing "Table id"
-              (with-redefs [undo/retention-batches-per-table 9]
-                (dotimes [i 25]
+            (testing "Scope"
+              (t2/delete! :model/Undo)
+              (with-redefs [undo/retention-batches-per-scope 9]
+                (dotimes [i 35]
                   ;; just toggle existence
-                  (undo/track-change! user-1
-                                      test-scope
-                                      {(if (zero? (mod i 5)) table-1 table-2)
-                                       {{:id 1} [(if (even? i) {} nil)
-                                                 (if (even? i) nil {})]
-                                        {:id 2} [(if (odd? i) {} nil)
-                                                 (if (odd? i) nil {})]}}))
+                  (let [table-id (if (zero? (mod i 5)) table-1 table-2)]
+                    (undo/track-change! user-1
+                                        {:table-id table-id}
+                                        {table-id
+                                         {{:id 1} [(if (even? i) {} nil)
+                                                   (if (even? i) nil {})]
+                                          {:id 2} [(if (odd? i) {} nil)
+                                                   (if (odd? i) nil {})]}})))
 
-                (is (= 36 (t2/count :model/Undo)))
-                (is (= 18 (count-batches)))
-                (is (= 9 (count-batches [:= :table_id table-1])))
+                (is (= 32 (t2/count :model/Undo)))
+                (is (= 16 (count-batches)))
+                (is (= 7 (count-batches [:= :table_id table-1])))
                 (is (= 9 (count-batches [:= :table_id table-2])))))
 
             (testing "A haphazard mix"
               (with-redefs [undo/retention-total-rows        17
                             undo/retention-total-batches     21
                             undo/retention-batches-per-user  5
-                            undo/retention-batches-per-table 9]
+                            undo/retention-batches-per-scope 9]
 
                 (dotimes [i 25]
                   ;; just toggle existence

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -67,20 +67,20 @@
             (is (undo/next-batch-num :undo user-id test-scope))
             (is (not (undo/next-batch-num :redo user-id test-scope)))
             (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
-                   (undo/undo! user-id test-scope table-id)))
+                   (undo/undo! user-id test-scope)))
             (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-id test-scope))
             (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
-                   (undo/undo! user-id test-scope table-id)))
+                   (undo/undo! user-id test-scope)))
             (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-id test-scope))
             (is (undo/next-batch-num :redo user-id test-scope))
             ;; This doesn't tell the FE which rows to hide
             (is (= {table-id [[:delete {:id 1}]]}
-                   (undo/undo! user-id test-scope table-id)))
+                   (undo/undo! user-id test-scope)))
             (is (= [] (table-rows table-id)))
 
             (is (not (undo/next-batch-num :undo user-id test-scope)))
@@ -88,24 +88,24 @@
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No previous versions found"
-                 (undo/undo! user-id test-scope table-id)))
+                 (undo/undo! user-id test-scope)))
 
             (is (not (undo/next-batch-num :undo user-id test-scope)))
             (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:create {:id 1, :name "Snorkmaiden", :favourite_food "pork"}]]}
-                   (undo/redo! user-id test-scope table-id)))
+                   (undo/redo! user-id test-scope)))
             (is (= [[1 "Snorkmaiden" "pork"]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-id test-scope))
             (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:update {:id 1, :name "Snorkmaiden", :favourite_food "orc"}]]}
-                   (undo/redo! user-id test-scope table-id)))
+                   (undo/redo! user-id test-scope)))
             (is (= [[1 "Snorkmaiden" "orc"]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-id test-scope))
             (is (undo/next-batch-num :redo user-id test-scope))
             (is (= {table-id [[:delete {:id 1}]]}
-                   (undo/redo! user-id test-scope table-id)))
+                   (undo/redo! user-id test-scope)))
             (is (= [] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-id test-scope))
@@ -113,7 +113,7 @@
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No subsequent versions found"
-                 (undo/redo! user-id test-scope table-id)))
+                 (undo/redo! user-id test-scope)))
 
             (is (undo/next-batch-num :undo user-id test-scope))
             (is (not (undo/next-batch-num :redo user-id test-scope)))))))))
@@ -149,12 +149,12 @@
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"Blocked by other changes"
-                 (undo/undo! user-2 test-scope table-id)))
+                 (undo/undo! user-2 test-scope)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (not (undo/next-batch-num :redo user-1 test-scope)))
             (is (= {table-id [[:create {:id 2, :name "Moominswole", :power 9001}]]}
-                   (undo/undo! user-1 test-scope table-id)))
+                   (undo/undo! user-1 test-scope)))
             (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
@@ -162,26 +162,26 @@
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"Blocked by other changes"
-                 (undo/undo! user-1 test-scope table-id)))
+                 (undo/undo! user-1 test-scope)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (undo/next-batch-num :redo user-1 test-scope))
             (is (undo/next-batch-num :undo user-2 test-scope))
             (is (not (undo/next-batch-num :redo user-2 test-scope)))
             (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
-                   (undo/undo! user-2 test-scope table-id)))
+                   (undo/undo! user-2 test-scope)))
             (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 3}]]}
-                   (undo/undo! user-1 test-scope table-id)))
+                   (undo/undo! user-1 test-scope)))
             (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:delete {:id 2}]]}
-                   (undo/undo! user-1 test-scope table-id)))
+                   (undo/undo! user-1 test-scope)))
             (is (= [] (table-rows table-id)))
 
             (is (not (undo/next-batch-num :undo user-1 test-scope)))
@@ -189,30 +189,30 @@
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No previous versions found"
-                 (undo/undo! user-1 test-scope table-id)))
+                 (undo/undo! user-1 test-scope)))
 
             (is (not (undo/next-batch-num :undo user-1 test-scope)))
             (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:create {:id 2, :name "Moomintroll", :power 3}]]}
-                   (undo/redo! user-1 test-scope table-id)))
+                   (undo/redo! user-1 test-scope)))
             (is (= [[2 "Moomintroll" 3]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:update {:id 2, :name "Moomintroll", :power 9001}]]}
-                   (undo/redo! user-1 test-scope table-id)))
+                   (undo/redo! user-1 test-scope)))
             (is (= [[2 "Moomintroll" 9001]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:update {:id 2, :name "Moominswole", :power 9001}]]}
-                   (undo/redo! user-2 test-scope table-id)))
+                   (undo/redo! user-2 test-scope)))
             (is (= [[2 "Moominswole" 9001]] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (undo/next-batch-num :redo user-1 test-scope))
             (is (= {table-id [[:delete {:id 2}]]}
-                   (undo/redo! user-1 test-scope table-id)))
+                   (undo/redo! user-1 test-scope)))
             (is (= [] (table-rows table-id)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
@@ -220,14 +220,14 @@
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No subsequent versions found"
-                 (undo/redo! user-1 test-scope table-id)))
+                 (undo/redo! user-1 test-scope)))
 
             (is (undo/next-batch-num :undo user-2 test-scope))
             (is (not (undo/next-batch-num :redo user-2 test-scope)))
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"No subsequent versions found"
-                 (undo/redo! user-2 test-scope table-id)))
+                 (undo/redo! user-2 test-scope)))
 
             (is (undo/next-batch-num :undo user-1 test-scope))
             (is (not (undo/next-batch-num :redo user-1 test-scope)))))))))
@@ -256,10 +256,10 @@
                                                [user-id nil]])
 
             ;; Sad trick - use undo to initialize the underlying table state (since we only created the undo history)
-            (undo/undo! user-id test-scope table-id)
-            (undo/undo! user-id test-scope table-id)
-            (undo/undo! user-id test-scope table-id)
-            (undo/undo! user-id test-scope table-id)
+            (undo/undo! user-id test-scope)
+            (undo/undo! user-id test-scope)
+            (undo/undo! user-id test-scope)
+            (undo/undo! user-id test-scope)
 
             (is (= [[1 "Too-tickley" "squirming"]] (table-rows table-id)))
 
@@ -271,11 +271,11 @@
             (is (nil? (undo/next-batch-num :redo user-id test-scope)))
             (is (undo/next-batch-num :undo user-id test-scope))
 
-            (undo/undo! user-id test-scope table-id)
+            (undo/undo! user-id test-scope)
             (is (= [[1 "Too-tickley" "squirming"]
                     [2 "Toggle" "restored"]] (table-rows table-id)))
 
-            (undo/redo! user-id test-scope table-id)
+            (undo/redo! user-id test-scope)
             (is (= [[1 "Too-tickley" "squirming"]] (table-rows table-id)))))))))
 
 (defn- count-batches [& [where]]

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11627,6 +11627,33 @@ databaseChangeLog:
         - sql:
             sql: DELETE FROM sequences WHERE name = 'undo_batch_num';
 
+  - changeSet:
+      id: v55.2025-04-29T12:00:00
+      author: crisptrutski
+      comment: Remove old undo snapshots, which did not have a scope field. They would effectively be orphaned anyway.
+      rollback: # cannot roll back
+      changes:
+        - sql:
+            sql: DELETE FROM data_edit_undo_chain
+
+  - changeSet:
+      id: v55.2025-04-29T12:01:00
+      author: crisptrutski
+      comment: Add scope column, to restrict undo / redo actions to a given scope of interaction.
+      changes:
+        - addColumn:
+            tableName: data_edit_undo_chain
+            columns:
+              - column:
+                  name: scope
+                  type: ${text.type}
+                  remarks: Identifies where the changes were made from
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: data_edit_undo_chain
+            columnName: scope
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11640,6 +11640,11 @@ databaseChangeLog:
       id: v55.2025-04-29T12:01:00
       author: crisptrutski
       comment: Add scope column, to restrict undo / redo actions to a given scope of interaction.
+      preConditions:
+        - not:
+            - columnExists:
+                tableName: data_edit_undo_chain
+                columnName: scope
       changes:
         - addColumn:
             tableName: data_edit_undo_chain

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -198,12 +198,12 @@
    & {:as _opts}]
   (let [invocation-id  (nano-id/nano-id)
         context-before (-> (assoc ctx :invocation-id invocation-id)
-                           (update :invocation-scope u/conjv [action-kw invocation-id]))]
+                           (update :invocation-stack u/conjv [action-kw invocation-id]))]
     (actions.events/publish-action-invocation! action-kw context-before inputs)
     (try
       (u/prog1 (perform-action!* action-kw context-before inputs)
         (let [{context-after :context, :keys [outputs]} <>]
-          (doseq [k [:invocation-id :invocation-scope :user-id]]
+          (doseq [k [:invocation-id :invocation-stack :user-id]]
             (assert (= (k context-before) (k context-after)) (format "Output context must not change %s" k)))
           ;; We might in future want effects to propagate all the up to the root scope ¯\_(ツ)_/¯
           (handle-effects! context-after)


### PR DESCRIPTION
Closes WRK-285

This adds a new `:scope` parameter to the `/data-editing` APIs which allows us to record "where" a change was made from in the application, and to then restrict undo and redo operations to those same scopes as well.

This also means we can have multi-table scopes, e.g. an editable with joins.