### PR TITLE
Add Access-Control-Max-Age header to cache CORS preflight requests made by SDK

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/requests.cy.spec.tsx
@@ -1,0 +1,29 @@
+import { CollectionBrowser } from "@metabase/embedding-sdk-react";
+
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/component-testing-sdk";
+import {
+  mockAuthProviderAndJwtSignIn,
+  mountSdkContent,
+} from "e2e/support/helpers/component-testing-sdk/component-embedding-sdk-helpers";
+
+describe("scenarios > embedding-sdk > requests", () => {
+  describe("cache preflight requests", () => {
+    beforeEach(() => {
+      signInAsAdminAndEnableEmbeddingSdk();
+      cy.signOut();
+      mockAuthProviderAndJwtSignIn();
+    });
+
+    it("caches preflight requests by setting Access-Control-Max-Age header", () => {
+      cy.intercept("GET", "/api/user/current").as("getCurrentUser");
+
+      mountSdkContent(<CollectionBrowser />);
+
+      cy.wait("@getCurrentUser").then(({ response }) => {
+        const maxAgeHeader = response?.headers["access-control-max-age"];
+
+        expect(maxAgeHeader).to.equal("60");
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -599,7 +599,7 @@ describe("[EE, with token] embedding settings", () => {
 
         expect(
           screen.getByText(
-            "Enter the origins for the websites or apps where you want to allow SDK embedding, separated by a space. Localhost is automatically included.",
+            "Enter the origins for the websites or apps where you want to allow SDK embedding, separated by a space. Localhost is automatically included. Changes will take effect within one minute.",
           ),
         ).toBeInTheDocument();
       });
@@ -692,7 +692,7 @@ describe("[EE, with token] embedding settings", () => {
 
         expect(
           screen.getByText(
-            "Enter the origins for the websites or apps where you want to allow SDK embedding, separated by a space. Localhost is automatically included.",
+            "Enter the origins for the websites or apps where you want to allow SDK embedding, separated by a space. Localhost is automatically included. Changes will take effect within one minute.",
           ),
         ).toBeInTheDocument();
       });

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -67,7 +67,7 @@ export function EmbeddingSdkSettings({
           key: "embedding-app-origins-sdk",
           placeholder: "https://*.example.com",
           display_name: t`Cross-Origin Resource Sharing (CORS)`,
-          description: t`Enter the origins for the websites or apps where you want to allow SDK embedding, separated by a space. Localhost is automatically included.`,
+          description: t`Enter the origins for the websites or apps where you want to allow SDK embedding, separated by a space. Localhost is automatically included. Changes will take effect within one minute.`,
         },
   );
 

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -231,7 +231,9 @@
         "Vary"                        "Origin"})
      {"Access-Control-Allow-Headers"  "*"
       "Access-Control-Allow-Methods"  "*"
-      "Access-Control-Expose-Headers" "X-Metabase-Anti-CSRF-Token"})))
+      "Access-Control-Expose-Headers" "X-Metabase-Anti-CSRF-Token"
+      ;; Needed for Embedding SDK. Should cache preflight requests for the specified number of seconds.
+      "Access-Control-Max-Age"  "60"})))
 
 (defn security-headers
   "Fetch a map of security headers that should be added to a response based on the passed options."

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -213,7 +213,16 @@
                  (get (mw.security/access-control-headers "https://example.com"
                                                           (embed.settings/enable-embedding-sdk)
                                                           (aos/embedding-app-origins-sdk))
-                      "Access-Control-Allow-Origin"))))))))
+                      "Access-Control-Allow-Origin"))))))
+    (testing "Should set Access-Control-Max-Age to 60"
+      (mt/with-temporary-setting-values [enable-embedding-sdk true
+                                         embedding-app-origins-sdk "https://example.com"]
+        (let [headers (mw.security/access-control-headers
+                       "https://example.com"
+                       (embed.settings/enable-embedding-sdk)
+                       (aos/embedding-app-origins-sdk))]
+          (is (= "60" (get headers "Access-Control-Max-Age"))
+              "Expected Access-Control-Max-Age header to be set to 60"))))))
 
 (deftest ^:parallel allowed-iframe-hosts-test
   (testing "The allowed iframe hosts parse in the expected way."


### PR DESCRIPTION
How to verify:
- CI is green
- I tested it manually with the Shoppy