### PR TITLE
Closes VIZ-635 VIZ-657 filters for visualizer cards

### DIFF
--- a/e2e/support/test-visualizer-data.ts
+++ b/e2e/support/test-visualizer-data.ts
@@ -116,6 +116,20 @@ export const PRODUCTS_COUNT_BY_CATEGORY: StructuredQuestionDetailsWithName = {
   },
 };
 
+export const PRODUCTS_AVERAGE_BY_CATEGORY: StructuredQuestionDetailsWithName = {
+  display: "bar",
+  name: "Products average by Category",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["avg", ["field", PRODUCTS.PRICE, null]]],
+    breakout: [["field", PRODUCTS.CATEGORY, null]],
+  },
+  visualization_settings: {
+    "graph.dimensions": ["CATEGORY"],
+    "graph.metrics": ["avg"],
+  },
+};
+
 export const PRODUCTS_COUNT_BY_CATEGORY_PIE: StructuredQuestionDetailsWithName =
   {
     ...PRODUCTS_COUNT_BY_CATEGORY,

--- a/e2e/test/scenarios/dashboard/visualizer/filters.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/filters.cy.spec.ts
@@ -1,0 +1,69 @@
+const { H } = cy;
+
+import {
+  PRODUCTS_AVERAGE_BY_CATEGORY,
+  PRODUCTS_COUNT_BY_CATEGORY,
+} from "e2e/support/test-visualizer-data";
+
+describe("scenarios > dashboard > visualizer > filters", () => {
+  beforeEach(() => {
+    H.restore();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+
+    cy.signInAsNormalUser();
+
+    H.createQuestion(PRODUCTS_COUNT_BY_CATEGORY, {
+      idAlias: "productsCountByCategoryQuestionId",
+      wrapId: true,
+    });
+
+    H.createQuestion(PRODUCTS_AVERAGE_BY_CATEGORY, {
+      idAlias: "productsAvgByCreatedAtQuestionId",
+      wrapId: true,
+    });
+  });
+
+  it("should create and update a dashcard with 'Visualize another way' button", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+    });
+
+    H.editDashboard();
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(PRODUCTS_COUNT_BY_CATEGORY.name);
+
+    H.modal().within(() => {
+      H.switchToAddMoreData();
+      H.addDataset(PRODUCTS_AVERAGE_BY_CATEGORY.name);
+
+      cy.button("Add to dashboard").click();
+    });
+
+    H.setFilter("Text or Category", "Is");
+
+    // Doing it twice to populate the two filters
+    H.selectDashboardFilter(H.getDashboardCard(0), "Category");
+    H.selectDashboardFilter(H.getDashboardCard(0), "Category");
+
+    H.saveDashboard();
+
+    H.getDashboardCard(0).within(() => {
+      cy.findByText("Doohickey").should("exist");
+    });
+
+    H.filterWidget().contains("Text").click();
+    H.popover().within(() => {
+      cy.findByText("Gadget").click();
+      cy.button("Add filter").click();
+    });
+
+    H.getDashboardCard(0).within(() => {
+      cy.findByText("Doohickey").should("not.exist");
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -34,6 +34,7 @@ import {
   createDashCard,
   createVirtualCard,
   generateTemporaryDashcardId,
+  isQuestionDashCard,
   isVirtualDashCard,
 } from "../utils";
 
@@ -320,6 +321,11 @@ export const replaceCardWithVisualization =
 
     const [mainCard, ...secondaryCards] = cards;
 
+    const originalDashCard = getDashCardById(getState(), dashcardId);
+    const parameter_mappings = isQuestionDashCard(originalDashCard)
+      ? originalDashCard.parameter_mappings
+      : [];
+
     await dispatch(
       setDashCardAttributes({
         id: dashcardId,
@@ -327,7 +333,7 @@ export const replaceCardWithVisualization =
           card_id: mainCard.id,
           card: mainCard,
           series: secondaryCards,
-          parameter_mappings: [],
+          parameter_mappings,
           visualization_settings: {
             visualization,
           },

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -371,6 +371,7 @@ export const fetchCardDataAction = createAsyncThunk<
       const shouldUseCardQueryEndpoint =
         isNewDashcard(dashcard) ||
         (isQuestionDashCard(dashcard) &&
+          !isVisualizerDashboardCard(dashcard) &&
           isNewAdditionalSeriesCard(card, dashcard, dashcardBeforeEditing)) ||
         hasReplacedCard;
 


### PR DESCRIPTION
Closes [VIZ-657: Categorical dashboard filters only filtering the first source](https://linear.app/metabase/issue/VIZ-657/categorical-dashboard-filters-only-filtering-the-first-source)
Closes [VIZ-635: Converting a dashcard with multiple series to a Visualizer dashcard removes mapping of dashboard filters](https://linear.app/metabase/issue/VIZ-635/converting-a-dashcard-with-multiple-series-to-a-visualizer-dashcard)

### Description

Closes issues with filters (see respective tickets)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
