### PR TITLE
Speed up edits to databases with high latency or huge tables

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -513,6 +513,7 @@
         (let [table-id     @table
               url          (data-editing.tu/table-url table-id)
               field-id     (t2/select-one-fn :id :model/Field :table_id table-id :name "n")
+              _            (t2/update! :model/Field {:id field-id} {:semantic_type "type/Category"})
               field-values #(vec (:values (field-values/get-latest-full-field-values field-id)))
               create!      #(mt/user-http-request :crowberto :post 200 url {:rows %})
               update!      #(mt/user-http-request :crowberto :put  200 url {:rows %})]


### PR DESCRIPTION
Closes WRK-334

It turns out that re-scannign fieldvalues in Bruno's test database was a big performance hog.

**Improvement:** avoid false positives where we rescan non-categorical fields

**Improvement:** skip fields which already have all the corresponding values from the last scan.

**Bug fix:** we could trip over case insensitivity and fail to rescan fields.

**Behavior change:** we no longer synchronously remove values when their last instance is removed.

We can bring back the old behavior by looking at the `before` side of the diffs, but I think this is actually an improvement.