### PR TITLE
Do not set card when using browser back button

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1461,3 +1461,34 @@ describe("issue 56698", () => {
     H.assertQueryBuilderRowCount(1);
   });
 });
+
+describe("issue 56775", () => {
+  const MODEL_NAME = "Model 56775";
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createQuestion(
+      {
+        type: "model",
+        name: MODEL_NAME,
+        query: {
+          "source-table": PRODUCTS_ID,
+        },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("should render the correct query after using the back button in a model (metabase#56775)", () => {
+    H.openNotebook();
+    cy.button("Visualize").click();
+
+    cy.go("back");
+    H.openQuestionActions("Edit query definition");
+
+    cy.log("verify that the model definition is visible");
+    H.getNotebookStep("data").findByText(MODEL_NAME).should("not.exist");
+    H.getNotebookStep("data").findByText("Products").should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/navigation.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.ts
@@ -177,7 +177,7 @@ export const updateUrl = createThunkAction(
       }
 
       const newState = {
-        card: question._doNotCallSerializableCard(),
+        card: getCard(getState()),
         cardId: question.id(),
         objectId,
       };

--- a/frontend/src/metabase/query_builder/actions/navigation.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.ts
@@ -148,13 +148,14 @@ export const updateUrl = createThunkAction(
         }
       }
 
+      const originalQuestion = getOriginalQuestion(getState());
+      const isAdHocModelOrMetric = isAdHocModelOrMetricQuestion(
+        question,
+        originalQuestion,
+      );
+
       if (dirty == null) {
-        const originalQuestion = getOriginalQuestion(getState());
         const uiControls = getUiControls(getState());
-        const isAdHocModelOrMetric = isAdHocModelOrMetricQuestion(
-          question,
-          originalQuestion,
-        );
         dirty =
           !originalQuestion ||
           (!isAdHocModelOrMetric &&
@@ -176,8 +177,9 @@ export const updateUrl = createThunkAction(
         datasetEditorTab = getDatasetEditorTab(getState());
       }
 
+      const card = isAdHocModelOrMetric ? getCard(getState()) : question.card();
       const newState = {
-        card: getCard(getState()),
+        card,
         cardId: question.id(),
         objectId,
       };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56775

When clicking `Visualize` from a question started from a Model, we don't "uncompose" the question. This caused the wrong state being saved when clicking the back button.

### To verify


1. Open a model
2. Click on editor
3. Click on visualize
4. Hit the browser back button to return to the model
6. Click on edit query definition
7. The correct query should be shown (not the wrapped model).