### PR TITLE
fix(sdk): manual fixes for module level ttag calls causing broken translations

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/ChartTypeSelectorList/ChartTypeDropdown.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/ChartTypeSelectorList/ChartTypeDropdown.tsx
@@ -40,7 +40,7 @@ export const ChartTypeDropdown = ({
     visualizationType: CardDisplayType,
   ): {
     value: CardDisplayType;
-    label: Visualization["uiName"];
+    label: ReturnType<Visualization["getUiName"]>;
     iconName: IconName;
   } | null => {
     const visualization = visualizations.get(visualizationType);
@@ -50,7 +50,7 @@ export const ChartTypeDropdown = ({
 
     return {
       value: visualizationType,
-      label: visualization.uiName,
+      label: visualization.getUiName(),
       iconName: visualization.iconName,
     };
   };

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.jsx
@@ -47,6 +47,7 @@ export class AuditTableVisualization extends Component {
   static identifier = "audit-table";
   static noHeader = true;
   static hidden = true;
+  static getUiName = () => "Audit Table";
 
   // copy Table's settings and columnSettings
   static settings = Table.settings;

--- a/frontend/src/metabase/actions/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionViz.tsx
@@ -13,8 +13,7 @@ const isForm = (object: any, computedSettings: VisualizationSettings) =>
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default Object.assign(Action, {
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  uiName: t`Action`,
+  getUiName: () => t`Action`,
   identifier: "action",
   iconName: "play",
 

--- a/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
+++ b/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
@@ -2,12 +2,9 @@ import { t } from "ttag";
 
 import { areParameterValuesIdentical } from "metabase-lib/v1/parameters/utils/parameter-values";
 
-// eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-const UPDATE = t`Update filter`;
-// eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-const ADD = t`Add filter`;
-// eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-const RESET = t`Set to default`;
+const getUpdateLabel = () => t`Update filter`;
+const getAddLabel = () => t`Add filter`;
+const getResetLabel = () => t`Set to default`;
 
 /**
  * This is used to show the correct button when picking filter values.
@@ -28,8 +25,8 @@ export function getUpdateButtonProps(
       label:
         !hasValue(unsavedValue) ||
         areParameterValuesIdentical(unsavedValue, defaultValue)
-          ? RESET
-          : UPDATE,
+          ? getResetLabel()
+          : getUpdateLabel(),
       isDisabled:
         areParameterValuesIdentical(unsavedValue, value) &&
         hasValue(unsavedValue),
@@ -39,14 +36,14 @@ export function getUpdateButtonProps(
   if (hasValue(defaultValue)) {
     return {
       label: areParameterValuesIdentical(unsavedValue, defaultValue)
-        ? RESET
-        : UPDATE,
+        ? getResetLabel()
+        : getUpdateLabel(),
       isDisabled: areParameterValuesIdentical(value, unsavedValue),
     };
   }
 
   return {
-    label: hasValue(value) ? UPDATE : ADD,
+    label: hasValue(value) ? getUpdateLabel() : getAddLabel(),
     isDisabled: areParameterValuesIdentical(value, unsavedValue),
   };
 }

--- a/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeList/ChartTypeList.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeList/ChartTypeList.unit.spec.tsx
@@ -9,8 +9,8 @@ import { ChartTypeList, type ChartTypeListProps } from "./ChartTypeList";
 
 registerVisualizations();
 
-const VISUALIZATION_TEST_LABELS = DEFAULT_VIZ_ORDER.map(
-  (display) => visualizations.get(display)?.uiName,
+const VISUALIZATION_TEST_LABELS = DEFAULT_VIZ_ORDER.map((display) =>
+  visualizations.get(display)?.getUiName(),
 );
 
 const setup = ({

--- a/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeOption/ChartTypeOption.tsx
+++ b/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeOption/ChartTypeOption.tsx
@@ -30,7 +30,7 @@ export const ChartTypeOption = ({
         gap="xs"
         role="option"
         aria-selected={isSelected}
-        data-testid={`${visualization.uiName}-container`}
+        data-testid={`${visualization.getUiName()}-container`}
       >
         <ActionIcon
           w="3.125rem"
@@ -50,7 +50,7 @@ export const ChartTypeOption = ({
             ChartTypeOptionS.BorderedButton,
             ChartTypeOptionS.VisualizationButton,
           )}
-          data-testid={`${visualization.uiName}-button`}
+          data-testid={`${visualization.getUiName()}-button`}
         >
           <Icon
             name={visualization.iconName}
@@ -86,7 +86,7 @@ export const ChartTypeOption = ({
           color={isSelected ? "brand" : "text-medium"}
           data-testid="chart-type-option-label"
         >
-          {visualization.uiName}
+          {visualization.getUiName()}
         </Text>
       </Stack>
     </Center>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.tsx
@@ -36,7 +36,7 @@ function ChartSettingsSidebarInner({
 
   const sidebarContentProps = showSidebarTitle
     ? {
-        title: t`${visualizations.get(question.display())?.uiName} options`,
+        title: t`${visualizations.get(question.display())?.getUiName()} options`,
         onBack: () => dispatch(onOpenChartType()),
       }
     : {};

--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -31,7 +31,7 @@ const MAP_COMPONENTS_BY_TYPE = {
 };
 
 export default class PinMap extends Component {
-  static uiName = t`Pin Map`;
+  static getUiName = () => t`Pin Map`;
   static identifier = "pin_map";
   static iconName = "pinmap";
 

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -696,7 +696,7 @@ class Visualization extends PureComponent<
           className={className}
           style={style}
           data-testid="visualization-root"
-          data-viz-ui-name={visualization?.uiName}
+          data-viz-ui-name={visualization?.getUiName()}
           ref={this.props.forwardedRef}
         >
           {!!hasHeader && (

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -696,7 +696,9 @@ class Visualization extends PureComponent<
           className={className}
           style={style}
           data-testid="visualization-root"
-          data-viz-ui-name={visualization?.getUiName()}
+          // `getUiName` should be defined (and is a required field on the TS type), but because we have javascript
+          // files about visualizations, it's best if we don't risk crashing the app, hence the `?.()`
+          data-viz-ui-name={visualization?.getUiName?.()}
           ref={this.props.forwardedRef}
         >
           {!!hasHeader && (

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
@@ -19,6 +19,7 @@ const MockedVisualization = (props) => {
 
   return <div>Hello, I am mocked</div>;
 };
+MockedVisualization.getUiName = () => "Mocked Visualization";
 
 MockedVisualization.propTypes = {
   onRenderError: PropTypes.func.isRequired,

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -298,7 +298,7 @@ export type Visualization = React.ComponentType<
 export type VisualizationDefinition = {
   name?: string;
   noun?: string;
-  uiName: string;
+  getUiName: () => string;
   identifier: VisualizationDisplay;
   aliases?: string[];
   iconName: IconName;

--- a/frontend/src/metabase/visualizations/visualizations/AreaChart/AreaChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart/AreaChart.tsx
@@ -18,8 +18,7 @@ import type {
 Object.assign(
   AreaChart,
   getCartesianChartDefinition({
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    uiName: t`Area`,
+    getUiName: () => t`Area`,
     identifier: "area",
     iconName: "area",
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045

--- a/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
@@ -18,8 +18,7 @@ import type {
 Object.assign(
   BarChart,
   getCartesianChartDefinition({
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    uiName: t`Bar`,
+    getUiName: () => t`Bar`,
     identifier: "bar",
     iconName: "bar",
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045

--- a/frontend/src/metabase/visualizations/visualizations/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/ComboChart/ComboChart.tsx
@@ -18,8 +18,7 @@ import type {
 Object.assign(
   ComboChart,
   getCartesianChartDefinition({
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    uiName: t`Combo`,
+    getUiName: () => t`Combo`,
     identifier: "combo",
     iconName: "lineandbar",
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -84,7 +84,7 @@ function preventDragging(e: React.MouseEvent<HTMLButtonElement>) {
 
 export const DashCardPlaceholder = Object.assign(DashCardPlaceholderInner, {
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  uiName: t`Empty card`,
+  getUiName: () => t`Empty card`,
   identifier: "placeholder",
   iconName: "table_spaced", // TODO replace
 

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -83,7 +83,6 @@ function preventDragging(e: React.MouseEvent<HTMLButtonElement>) {
 }
 
 export const DashCardPlaceholder = Object.assign(DashCardPlaceholderInner, {
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
   getUiName: () => t`Empty card`,
   identifier: "placeholder",
   iconName: "table_spaced", // TODO replace

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -39,8 +39,7 @@ const getUniqueFunnelRows = (rows: FunnelRow[]) => {
 };
 
 Object.assign(Funnel, {
-  // eslint-disable-next-line ttag/no-module-declaration
-  uiName: t`Funnel`,
+  getUiName: () => t`Funnel`,
   identifier: "funnel",
   iconName: "funnel",
   noHeader: true,

--- a/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
@@ -59,7 +59,7 @@ const degrees = (radians) => (radians * 180) / Math.PI;
 const segmentIsValid = (s) => !isNaN(s.min) && !isNaN(s.max);
 
 export default class Gauge extends Component {
-  static uiName = t`Gauge`;
+  static getUiName = () => t`Gauge`;
   static identifier = "gauge";
   static iconName = "gauge";
 

--- a/frontend/src/metabase/visualizations/visualizations/Heading/index.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/index.ts
@@ -8,8 +8,7 @@ import {
 import { Heading } from "./Heading";
 
 const HeadingWrapper = Object.assign(Heading, {
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  uiName: t`Heading`,
+  getUiName: () => t`Heading`,
   identifier: "heading",
   iconName: "heading",
   canSavePng: false,

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameVizSettings.ts
@@ -6,7 +6,7 @@ import {
 } from "metabase/visualizations/shared/utils/sizes";
 
 export const settings = {
-  uiName: "iframe",
+  getUiName: () => "iframe",
   canSavePng: false,
   identifier: "iframe",
   iconName: "link",

--- a/frontend/src/metabase/visualizations/visualizations/LineChart/LineChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LineChart/LineChart.tsx
@@ -18,8 +18,7 @@ import type {
 Object.assign(
   LineChart,
   getCartesianChartDefinition({
-    // eslint-disable-next-line ttag/no-module-declaration
-    uiName: t`Line`,
+    getUiName: () => t`Line`,
     identifier: "line",
     iconName: "line",
     // eslint-disable-next-line ttag/no-module-declaration

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
@@ -6,7 +6,7 @@ import {
 } from "metabase/visualizations/shared/utils/sizes";
 
 export const settings = {
-  uiName: "Link",
+  getUiName: () => "Link",
   canSavePng: false,
   identifier: "link",
   iconName: "link",

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -39,7 +39,7 @@ import { CustomMapFooter } from "./CustomMapFooter";
 const PIN_MAP_TYPES = new Set(["pin", "heat", "grid"]);
 
 export class Map extends Component {
-  static uiName = t`Map`;
+  static getUiName = () => t`Map`;
   static identifier = "map";
   static iconName = "pinmap";
 

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -12,7 +12,7 @@ import {
 } from "metabase/visualizations/shared/utils/sizes";
 
 const ObjectDetailProperties = {
-  get uiName() {
+  getUiName() {
     return t`Detail`;
   },
   identifier: "object",

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
@@ -48,9 +48,7 @@ const pieRowsReadDeps = [
 ];
 
 export const PIE_CHART_DEFINITION: VisualizationDefinition = {
-  get uiName() {
-    return t`Pie`;
-  },
+  getUiName: () => t`Pie`,
   identifier: "pie",
   iconName: "pie",
   minSize: getMinSize("pie"),

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -609,8 +609,7 @@ const PivotTable = ExplicitSize<
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default Object.assign(connect(mapStateToProps)(PivotTable), {
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  uiName: t`Pivot Table`,
+  getUiName: () => t`Pivot Table`,
   identifier: "pivot",
   iconName: "pivot_table",
   minSize: getMinSize("pivot"),

--- a/frontend/src/metabase/visualizations/visualizations/Progress/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress/Progress.jsx
@@ -35,7 +35,7 @@ export default class Progress extends Component {
     this.barRef = createRef();
   }
 
-  static uiName = t`Progress`;
+  static getUiName = () => t`Progress`;
   static identifier = "progress";
   static iconName = "progress";
 

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -330,8 +330,7 @@ const RowChartVisualization = ({
   );
 };
 
-// eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-RowChartVisualization.uiName = t`Row`;
+RowChartVisualization.getUiName = () => t`Row`;
 RowChartVisualization.identifier = "row";
 RowChartVisualization.iconName = "horizontal_bar";
 // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
@@ -424,6 +423,8 @@ RowChartVisualization.checkRenderable = (
 };
 
 RowChartVisualization.hasEmptyState = true;
+
+RowChartVisualization.getUiName = () => t`Row`;
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default RowChartVisualization;

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -142,8 +142,7 @@ export const SETTINGS_DEFINITIONS = {
 };
 
 export const SANKEY_CHART_DEFINITION = {
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  uiName: t`Sankey`,
+  getUiName: () => t`Sankey`,
   identifier: "sankey",
   iconName: "sankey",
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.jsx
@@ -39,7 +39,7 @@ function legacyScalarSettingsToFormatOptions(settings) {
 // Scalar visualization shows a single number
 // Multiseries Scalar is transformed to a Funnel
 export class Scalar extends Component {
-  static uiName = t`Number`;
+  static getUiName = () => t`Number`;
   static identifier = "scalar";
   static iconName = "number";
   static canSavePng = false;

--- a/frontend/src/metabase/visualizations/visualizations/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/ScatterPlot/ScatterPlot.tsx
@@ -24,8 +24,7 @@ import type {
 Object.assign(
   ScatterPlot,
   getCartesianChartDefinition({
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    uiName: t`Scatter`,
+    getUiName: () => t`Scatter`,
     identifier: "scatter",
     iconName: "bubble",
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -363,8 +363,7 @@ function PreviousValueComparison({
 }
 
 Object.assign(SmartScalar, {
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  uiName: t`Trend`,
+  getUiName: () => t`Trend`,
   identifier: "smartscalar",
   iconName: "smartscalar",
   canSavePng: true,

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -65,7 +65,7 @@ interface TableState {
 }
 
 class Table extends Component<TableProps, TableState> {
-  static uiName = t`Table`;
+  static getUiName = () => t`Table`;
   static identifier = "table";
   static iconName = "table2";
   static canSavePng = false;

--- a/frontend/src/metabase/visualizations/visualizations/Text/index.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Text/index.ts
@@ -8,8 +8,7 @@ import {
 import { Text } from "./Text";
 
 const TextWrapper = Object.assign(Text, {
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  uiName: t`Text`,
+  getUiName: () => t`Text`,
   identifier: "text",
   iconName: "text",
   canSavePng: false,

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart/WaterfallChart.tsx
@@ -23,8 +23,7 @@ import { getCartesianChartDefinition } from "../CartesianChart/chart-definition"
 Object.assign(
   WaterfallChart,
   getCartesianChartDefinition({
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    uiName: t`Waterfall`,
+    getUiName: () => t`Waterfall`,
     identifier: "waterfall",
     iconName: "waterfall",
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045


### PR DESCRIPTION
### Description

Part of EMB-335, manually change some `t` calls to make them work in the context of the sdk and static/public, where the locale is not loaded when modules initially loads,

Changes:
- changed labels defined in `frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts`
- `uiName` -> `getUiName()` on visualizations (for @metabase/core-frontend-dashviz )

### How to verify

For the viz names the easier way is to start sdk storybook (`yarn storybook-embedding-sdk`, [full instructions and setup here](https://github.com/metabase/metabase/blob/daab776f89b1d01519cf1eaf8e5069e7f63f1175/enterprise/frontend/src/embedding-sdk/dev.md?plain=1#L23-L41)), and go to http://localhost:6006/?path=/story/embeddingsdk-interactivequestion--default&globals=locale:de (notice the locale in the flags)

Note: for the

### Demo

<img width="805" alt="image" src="https://github.com/user-attachments/assets/0c2d0f50-08ec-49c8-a930-c17ada59744c" />
