### PR TITLE
Re-check token features at the end of the setup process

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -550,6 +550,7 @@
            events
            models
            permissions
+           premium-features
            settings
            request
            session

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -21,6 +21,7 @@
   airgap-enabled
   assert-has-feature
   assert-has-any-features
+  clear-token-check-cache
   ee-feature-error
   is-hosted?
   has-any-features?

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -163,6 +163,13 @@
 
    :ttl/threshold token-status-cache-ttl))
 
+(defn clear-token-check-cache
+  "Clears the token check cache. This is used when the features in the token may have changed in the store."
+  []
+  (when config/ee-available?
+    (log/info "Clearing token check cache.")
+    (memoize/memo-clear! fetch-token-and-parse-body*)))
+
 (def ^:private store-circuit-breaker-config
   {;; if 10 requests within 10 seconds fail, open the circuit breaker.
    ;; (a lower threshold ratio wouldn't make sense here because successful results are cached, so as soon as we get

--- a/src/metabase/setup/api.clj
+++ b/src/metabase/setup/api.clj
@@ -9,6 +9,7 @@
    [metabase.events :as events]
    [metabase.models.user :as user]
    [metabase.permissions.core :as perms]
+   [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.session.models.session :as session]
    [metabase.settings.core :as setting]
@@ -134,6 +135,8 @@
                 ;; this because there is `io!` in this block
                 (setting/restore-cache!)
                 (throw e))))]
+    ;; Sometimes the token features are being updated as the setup process is running, so force a fresh check during setup
+    (premium-features/clear-token-check-cache)
     (let [{:keys [user-id session-key session]} (create!)
           superuser (t2/select-one :model/User :id user-id)]
       (events/publish-event! :event/user-login {:user-id user-id})


### PR DESCRIPTION
### Description

During new-site initialization, the instance feature list may change after the first check of the token so the normal cache time is too long.

So clear out that token check cache when the setup API is called to ensure we have the most recent data. 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
