### PR TITLE
fix viz settings sidebar permanently crashed

### DIFF
--- a/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
+++ b/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
@@ -41,6 +41,7 @@ export function VizSettingsSidebar({ className }: { className?: string }) {
     }
 
     try {
+      setError(null);
       const widgets = getSettingsWidgetsForSeries(
         transformedSeries,
         handleChangeSettings,


### PR DESCRIPTION
### Description

[Slack thread](https://metaboat.slack.com/archives/C072Q9XNQJW/p1745943573431039)
Clear viz settings sidebar error when we try to recompute widgets after any changes.

### Demo

[Loom](https://www.loom.com/share/45bba1282427401bb9c314d15b452c4d?sid=9016339d-a111-4027-b7d6-5daef132c56b)
