### PR TITLE
closes VIZ-924 edit viz button gone

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -364,7 +364,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     });
 
     // TODO editing a dashcard when it isn't done loading
-    // causes the visualizr modal to be in error for some reason
+    // causes the visualizer modal to be in error for some reason
     // this should be fixed in the future
     cy.wait(1000);
 
@@ -375,6 +375,67 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       cy.get("@undoButton").should("be.disabled");
       cy.get("@redoButton").should("be.disabled");
       cy.findByTestId("chartsettings-sidebar").should("not.be.visible");
+    });
+  });
+
+  describe("edit visualization action button", () => {
+    it("should work for compatible visualizations (table)", () => {
+      H.createDashboard().then(({ body: { id: dashboardId } }) => {
+        H.visitDashboard(dashboardId);
+      });
+
+      H.editDashboard();
+      H.openQuestionsSidebar();
+      H.sidebar().within(() => {
+        cy.findByRole("menuitem", { name: "Orders" }).click({ force: true });
+      });
+
+      // Edit visualization in "dashboard edit mode"
+      H.showDashcardVisualizerModal(0);
+      H.modal().within(() => {
+        cy.findByText("Save").closest("button").should("be.disabled");
+      });
+      cy.get("body").type("{esc}");
+
+      H.saveDashboard();
+
+      // Edit visualization in "dashboard view mode"
+      H.showDashboardCardActions();
+      H.getDashboardCardMenu().click();
+      H.popover().findByText("Edit visualization").should("be.visible").click();
+      H.modal().within(() => {
+        // TODO history should be empty at startup, and therefore the save button
+        // should be disabled
+        // cy.findByText("Save").closest("button").should("be.disabled");
+      });
+    });
+
+    it("should work for visualizer cards", () => {
+      H.createDashboard().then(({ body: { id: dashboardId } }) => {
+        H.visitDashboard(dashboardId);
+      });
+
+      // Edit visualization in "dashboard edit mode"
+      H.editDashboard();
+      H.openQuestionsSidebar();
+      H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
+
+      H.modal().within(() => {
+        cy.findByText("Add to dashboard")
+          .closest("button")
+          .should("not.be.disabled")
+          .click({ force: true });
+      });
+
+      H.saveDashboard();
+
+      // Edit visualization in "dashboard view mode"
+      H.showDashboardCardActions();
+      H.getDashboardCardMenu().click();
+      H.popover().findByText("Edit visualization").click();
+      H.modal().within(() => {
+        cy.findByText("Save").closest("button").should("be.disabled");
+      });
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -29,7 +29,6 @@ import {
   getInitialStateForMultipleSeries,
   getInitialStateForVisualizerCard,
   isVisualizerDashboardCard,
-  isVisualizerSupportedVisualization,
 } from "metabase/visualizer/utils";
 import type {
   Card,
@@ -318,13 +317,6 @@ function DashCardInner({
 
   const datasets = useSelector((state) => getDashcardData(state, dashcard.id));
   const onEditVisualizationClick = useMemo(() => {
-    if (
-      !isVisualizerDashboardCard(dashcard) &&
-      !isVisualizerSupportedVisualization(dashcard.card.display)
-    ) {
-      return;
-    }
-
     return () => {
       let initialState: VisualizerVizDefinitionWithColumns;
 


### PR DESCRIPTION
Closes [VIZ-924: "Edit visualization" button gone for non compatible visualizations](https://linear.app/metabase/issue/VIZ-924/edit-visualization-button-gone-for-non-compatible-visualizations)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
