### PR TITLE
Support custom context for 'ad hoc' queries

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -89,15 +89,18 @@
   [_route-params
    _query-params
    query :- [:map
-             [:database {:optional true} [:maybe :int]]]]
+             [:database {:optional true} [:maybe :int]]
+             [:context  {:optional true} [:maybe :keyword]]]]
   ;; TODO augment the response with a boolean indicating whether the query is editable, probably through middleware
   ;;      also we want to indicate which columns are editable (e.g. not a custom expression)
   ;;      we should also consider whether the column is configured as editable, for "editables"
   ;;      ... this information might still be in the visualization settings only (:-c)
   (run-streaming-query
    (-> query
+       (dissoc :context)
        (update-in [:middleware :js-int-to-string?] (fnil identity true))
-       qp/userland-query-with-default-constraints)))
+       qp/userland-query-with-default-constraints)
+   (select-keys query [:context])))
 
 ;;; ----------------------------------- Downloading Query Results in Other Formats -----------------------------------
 

--- a/src/metabase/lib/schema/info.cljc
+++ b/src/metabase/lib/schema/info.cljc
@@ -34,7 +34,8 @@
    :embedded-csv-download
    :embedded-xlsx-download
    :embedded-json-download
-   :table-grid])
+   :table-grid
+   :table-grid-editable])
 
 (mr/def ::hash
   #?(:clj bytes?


### PR DESCRIPTION
This change allows us to track queries used to populate editable grids, but adding support for an optional `context` parameter in the query.

This is a little bit dirty, and we might opt for a dedicated route rather in future, especially if we add custom middleware as suggested in the nearby comment.