### PR TITLE
Closes viz-922 missing tabId on certain viz cards

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -377,4 +377,48 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       cy.findByTestId("chartsettings-sidebar").should("not.be.visible");
     });
   });
+
+  it("should add the proper tabId to a new card", () => {
+    // make an empty dashboard
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+    });
+
+    // edit the dashboard
+    H.editDashboard();
+
+    // add a new tab
+    H.createNewTab();
+
+    // save the dashboard
+    H.saveDashboard();
+
+    // edit the dashboard
+    H.editDashboard();
+
+    // delete the first tab so it defaults to the second tab
+    H.deleteTab("Tab 1");
+
+    // save the dashboard
+    H.saveDashboard();
+
+    // edit the dashboard
+    H.editDashboard();
+
+    // add a new card to the first tab
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
+    cy.wait("@cardQuery");
+    H.modal().within(() => {
+      cy.findByText("Add to dashboard").click({ force: true });
+    });
+
+    // // save the dashboard
+    H.saveDashboard();
+
+    // // check that the dashboard saved and the card is in the first tab
+    H.getDashboardCard(0).within(() => {
+      cy.findByText(ORDERS_COUNT_BY_CREATED_AT.name).should("exist");
+    });
+  });
 });

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -254,7 +254,13 @@ export const replaceCard =
   };
 
 export const addCardWithVisualization =
-  ({ visualization }: { visualization: VisualizerVizDefinition }) =>
+  ({
+    visualization,
+    tabId,
+  }: {
+    visualization: VisualizerVizDefinition;
+    tabId: number | null;
+  }) =>
   async (dispatch: Dispatch, getState: GetState) => {
     const cardIds = getCardIdsFromColumnValueMappings(
       visualization.columnValuesMapping,
@@ -275,7 +281,7 @@ export const addCardWithVisualization =
     const dashcard = dispatch(
       addDashCardToDashboard({
         dashId: getState().dashboard.dashboardId!,
-        tabId: getState().dashboard.selectedTabId,
+        tabId,
         dashcardOverrides: {
           id: dashcardId,
           card: mainCard,

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -13,11 +13,12 @@ import { PaginationControls } from "metabase/components/PaginationControls";
 import SelectList from "metabase/components/SelectList";
 import type { BaseSelectListItemProps } from "metabase/components/SelectList/BaseSelectListItem";
 import { addCardWithVisualization } from "metabase/dashboard/actions";
+import { getSelectedTabId } from "metabase/dashboard/selectors";
 import Search from "metabase/entities/search";
 import { isEmbeddingSdk } from "metabase/env";
 import { usePagination } from "metabase/hooks/use-pagination";
 import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { ActionIcon, Box, Flex, Icon, Tooltip } from "metabase/ui";
 import { VisualizerModal } from "metabase/visualizer/components/VisualizerModal";
@@ -46,6 +47,8 @@ export function QuestionList({
   const [visualizerModalCardId, setVisualizerModalCardId] =
     useState<CardId | null>(null);
   const isVisualizerModalOpen = !!visualizerModalCardId;
+
+  const selectedTabId = useSelector(getSelectedTabId);
 
   useEffect(() => {
     setQueryOffset(0);
@@ -178,7 +181,9 @@ export function QuestionList({
         <VisualizerModalWithCardId
           cardId={visualizerModalCardId}
           onSave={(visualization) => {
-            dispatch(addCardWithVisualization({ visualization }));
+            dispatch(
+              addCardWithVisualization({ visualization, tabId: selectedTabId }),
+            );
             setVisualizerModalCardId(null);
           }}
           onClose={() => setVisualizerModalCardId(null)}


### PR DESCRIPTION
Closes [VIZ-922: Vizualizer cards added by using the "Visualize another way" button don't have a Tab ID](https://linear.app/metabase/issue/VIZ-922/vizualizer-cards-added-by-using-the-visualize-another-way-button-dont)

### Description

Under certain circumstances (see test) a card could have an empty tab id.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
