### PR TITLE
Give editables better default names

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -852,7 +852,7 @@
   A quick solution, and a very extensible one, but perhaps overloading a core primitive too much, and could be leaky."
   [dashboard-id dashcard table-id]
   (let [tab-id  (:dashboard_tab_id dashcard)
-        table   (t2/select-one [:model/Table :db_id :name] table-id)
+        table   (t2/select-one [:model/Table :db_id :display_name] table-id)
         card    (some->> dashcard :card_id (t2/select-one [:model/Card :id :dataset_query :display :card_schema]))
         ;; If the currently attached card is not editing the expected the table, then create a new one.
         keep?    (and (= :table-editable (:display card))
@@ -880,7 +880,7 @@
                                            :type     :query}
                   :description            nil
                   :display                "table-editable"
-                  :name                   (:name table)
+                  :name                   (str (:display_name table) " (editable)")
                   :result_metadata        nil
                   :type                   "model"
                   ;; Redundant with :display, but just in case it's useful. Revisit once FE is built.

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1815,6 +1815,8 @@
                       :card_id                int?
                       :visualization_settings {:table_id table-id}}]
                     (:dashcards resp))))
+          (testing "a clear name"
+            (is (= "Venues (editable)" (:name (t2/select-one :model/Card card-id)))))
           (testing "if we save the dashboard again, we keep using the same card, and preserve its settings"
             (t2/update! :model/Card card-id {:visualization_settings {:editable? true, :other_settings 42}})
             (let [new-resp (mt/user-http-request :rasta :put 200 url (assoc-in dash-map [:dashcards 0 :card_id] card-id))]


### PR DESCRIPTION
IMHO you should be able to edit this name from the dashboard as well, but this should help for now.