### PR TITLE
sdk-storybook: disable reactDocGen to speed up storybook

### DIFF
--- a/.storybook-sdk/main.js
+++ b/.storybook-sdk/main.js
@@ -25,7 +25,7 @@ module.exports = {
     options: {},
   },
   typescript: {
-    reactDocgen: "react-docgen-typescript",
+    reactDocgen: false,
   },
   webpackFinal: storybookConfig => ({
     ...storybookConfig,


### PR DESCRIPTION
https://storybook.js.org/docs/api/main-config/main-config-typescript#reactdocgen
>react-docgen-typescript invokes the TypeScript compiler, which makes it slow but generally accurate. 

I noticed my storybook was stuck on that plugin for a while, I don't think we need it and it's probably trying to parse the entire typescript codebase.
This should speed up storybook locally