### PR TITLE
Fix subtotal label formatting for xlsx pivot exports

### DIFF
--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -337,11 +337,13 @@
 (defn- create-subtotal-node
   "Creates a subtotal node for the given row item."
   [row-item]
-  {:value (i18n/tru "Totals for {0}" (:value row-item))
-   :rawValue (:rawValue row-item)
-   :span 1
-   :isSubtotal true
-   :children []})
+  (let [subtotal-val (or (get-in row-item [:value :xlsx-formatted-value])
+                         (:value row-item))]
+    {:value (i18n/tru "Totals for {0}" subtotal-val)
+     :rawValue (:rawValue row-item)
+     :span 1
+     :isSubtotal true
+     :children []}))
 
 (defn- subtotal-permitted?
   "Returns true if subtotals are enabled for this column and visible for this row."

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.driver :as driver]
-   [metabase.formatter :as formatter]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
@@ -238,10 +237,3 @@
      ;; Column settings coming from the user settings in the ui
      ;; (E.g. Click the ⚙️ on the column)
      column-settings)))
-
-(defn get-formatter
-  "Returns a memoized formatter for a column"
-  [timezone settings format-rows?]
-  (memoize
-   (fn [column]
-     (formatter/create-formatter timezone column settings format-rows?))))

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.driver :as driver]
+   [metabase.formatter :as formatter]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
@@ -12,7 +13,13 @@
    [metabase.util.date-2 :as u.date])
   (:import
    (clojure.lang ISeq)
-   (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)))
+   (java.time
+    LocalDate
+    LocalDateTime
+    LocalTime
+    OffsetDateTime
+    OffsetTime
+    ZonedDateTime)))
 
 (defn export-filename-timestamp
   "Generates the current timestamp as a string to use in export filenames."
@@ -231,3 +238,10 @@
      ;; Column settings coming from the user settings in the ui
      ;; (E.g. Click the ⚙️ on the column)
      column-settings)))
+
+(defn get-formatter
+  "Returns a memoized formatter for a column"
+  [timezone settings format-rows?]
+  (memoize
+   (fn [column]
+     (formatter/create-formatter timezone column settings format-rows?))))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -59,16 +59,9 @@
                                 string))
                (when must-quote (.write writer "\"")))))
 
-(defn- get-formatter
-  "Returns a memoized formatter for a column"
-  [timezone settings format-rows?]
-  (memoize
-   (fn [column]
-     (formatter/create-formatter timezone column settings format-rows?))))
-
 (defn- create-formatters
   [columns indexes timezone settings format-rows?]
-  (let [formatter-fn (get-formatter timezone settings format-rows?)]
+  (let [formatter-fn (streaming.common/get-formatter timezone settings format-rows?)]
     (mapv (fn [idx]
             (let [column (nth columns idx)
                   formatter (formatter-fn column)]

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -59,9 +59,16 @@
                                 string))
                (when must-quote (.write writer "\"")))))
 
+(defn get-formatter
+  "Returns a memoized formatter for a column"
+  [timezone settings format-rows?]
+  (memoize
+   (fn [column]
+     (formatter/create-formatter timezone column settings format-rows?))))
+
 (defn- create-formatters
   [columns indexes timezone settings format-rows?]
-  (let [formatter-fn (streaming.common/get-formatter timezone settings format-rows?)]
+  (let [formatter-fn (get-formatter timezone settings format-rows?)]
     (mapv (fn [idx]
             (let [column (nth columns idx)
                   formatter (formatter-fn column)]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -619,21 +619,25 @@
     sheet))
 
 (defn- create-formatters
-  [cell-styles cols indexes]
-  (let [cell-styles (vec cell-styles)
-        cols        (vec cols)]
+  [cell-styles cols indexes timezone settings format-rows?]
+  (let [cell-styles  (vec cell-styles)
+        cols         (vec cols)
+        formatter-fn (streaming.common/get-formatter timezone settings format-rows?)]
     (mapv (fn [idx]
-            (fn [value]
-              {:col          (nth cols idx)
-               :value        value
-               :styles       (nth cell-styles idx)}))
+            (let [col (nth cols idx)
+                  formatter (formatter-fn col)]
+              (fn [value]
+                {:col                  (nth cols idx)
+                 :value                value
+                 :xlsx-formatted-value (formatter (streaming.common/format-value value))
+                 :styles               (nth cell-styles idx)})))
           indexes)))
 
 (defn- make-formatters
-  [cell-styles cols row-indexes col-indexes val-indexes]
-  {:row-formatters (create-formatters cell-styles cols row-indexes)
-   :col-formatters (create-formatters cell-styles cols col-indexes)
-   :val-formatters (create-formatters cell-styles cols val-indexes)})
+  [cell-styles cols row-indexes col-indexes val-indexes settings timezone format-rows?]
+  {:row-formatters (create-formatters cell-styles cols row-indexes timezone settings format-rows?)
+   :col-formatters (create-formatters cell-styles cols col-indexes timezone settings format-rows?)
+   :val-formatters (create-formatters cell-styles cols val-indexes timezone settings format-rows?)})
 
 (defn- generate-styles
   [workbook viz-settings non-pivot-cols format-rows?]
@@ -703,7 +707,7 @@
         (when @pivot-data
           ;; For pivoted exports, we pivot in-memory (same as CSVs) and then write the results to the
           ;; document all at once
-          (let [{:keys [settings non-pivot-cols pivot-export-options format-rows?]} @pivot-data
+          (let [{:keys [settings non-pivot-cols pivot-export-options timezone format-rows?]} @pivot-data
                 {:keys [pivot-rows pivot-cols pivot-measures]} pivot-export-options
 
                 {:keys [cell-styles typed-cell-styles]}
@@ -713,7 +717,10 @@
                                             non-pivot-cols
                                             pivot-rows
                                             pivot-cols
-                                            pivot-measures)
+                                            pivot-measures
+                                            settings
+                                            timezone
+                                            format-rows?)
                 output (qp.pivot.postprocess/build-pivot-output
                         (update-in @pivot-data [:data :rows] persistent!)
                         formatters)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -618,11 +618,18 @@
       (spreadsheet/add-row! sheet (streaming.common/column-titles ordered-cols (or col-settings []) format-rows?)))
     sheet))
 
+(defn get-formatter
+  "Returns a memoized formatter for a column"
+  [timezone settings format-rows?]
+  (memoize
+   (fn [column]
+     (formatter/create-formatter timezone column settings format-rows?))))
+
 (defn- create-formatters
   [cell-styles cols indexes timezone settings format-rows?]
   (let [cell-styles  (vec cell-styles)
         cols         (vec cols)
-        formatter-fn (streaming.common/get-formatter timezone settings format-rows?)]
+        formatter-fn (get-formatter timezone settings format-rows?)]
     (mapv (fn [idx]
             (let [col (nth cols idx)
                   formatter (formatter-fn col)]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -1645,3 +1645,27 @@
         (let [res (card-download card {:export-format :xlsx :format-rows true :pivot true})]
           (is (= "Custom Title"
                  (second (first res)))))))))
+
+(deftest pivot-subtotal-formatting-in-xlsx-test
+  (testing "Pivot table subtotals in XLSX exports use formatted values as strings rather than XLSX formatting codes (#57442)"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card {pivot-card-id :id}
+                     {:display                :pivot
+                      :visualization_settings {:pivot_table.column_split
+                                               {:rows    ["CREATED_AT", "CATEGORY"]
+                                                :columns []
+                                                :values  ["sum"]}
+                                               :column_settings
+                                               {"[\"name\",\"sum\"]" {:number_style "currency"
+                                                                      :currency_in_header false}}
+                                               :pivot.show_row_totals true}
+                      :dataset_query          (mt/mbql-query products
+                                                {:aggregation [[:sum $price]]
+                                                 :breakout    [$category !year.created_at]})}]
+        (let [result       (mt/user-http-request :crowberto :post 200
+                                                 (format "card/%d/query/xlsx" pivot-card-id)
+                                                 {:format_rows   true
+                                                  :pivot_results true})
+              pivot        (read-xlsx result)
+              subtotal-row (first (filter #(str/starts-with? (first %) "Totals for") pivot))]
+          (is (= "Totals for 2016" (first subtotal-row))))))))


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/57442

We're using Excel format codes to format values in pivot exports on top of the raw values, but this doesn't work for subtotal _labels_ since these are expected to be interpolated into a `"Totals for {0}"` translation string. 

I'm fixing this by also annotating the formatting data on xlsx with a formatted string value and using that for subtotals when it's available. This only applies to XLSX because for CSVs (and on the FE) we just use formatted strings directly.