### PR TITLE
fix docs bump workflow

### DIFF
--- a/.github/workflows/docs_bump_detected.yml
+++ b/.github/workflows/docs_bump_detected.yml
@@ -13,37 +13,6 @@ jobs:
         run: |
           echo "A change in the docs directory was detected."
 
-      - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.7.0
-        with:
-          babashka-version: 1.3.189
-
-      - name: Filter non-dox branches
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref  }}
-        run: |
-          cat <<EOF > script.bb
-          (def ^:private release-regex #"release-x\.(\d+)\.x")
-          (defn- extract-release-num [release-branchname]
-            (let [[_ num] (re-matches release-regex release-branchname)]
-              (Integer/parseInt num)))
-          (defn- categorize-branchname [branchname]
-            (cond
-              (= branchname "master")                             [:master]
-              (re-matches release-regex branchname)               [:release (extract-release-num branchname)]
-              (str/starts-with? branchname "docs-workflow-test-") [:test branchname]))
-          (let [branchname             (first *command-line-args*)
-                [category release-num] (categorize-branchname branchname)]
-            (case category
-              :master  (println "Master branch detected.")
-              :release (println "Release branch detected. Release number:" release-num)
-              :test    (println "Test branch detected. Branchname:" branchname)
-              (do (println "Unpublishable branchname:" branchname)
-                  (System/exit 1)))
-            (System/exit 0))
-          EOF
-          bb script.bb "$BRANCH_NAME"
-
       - name: Trigger repo dispatch
         uses: actions/github-script@v7
         env:
@@ -51,11 +20,15 @@ jobs:
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           script: | #js
-            github.rest.repos.createDispatchEvent({
-              owner: "${{ github.repository_owner }}",
-              repo: "docs.metabase.github.io",
-              event_type: "docs_update",
-              client_payload: {
-                branch_name: process.env.BRANCH_NAME  // This needs to match the workflow file
-              }
-            });
+            if (process.env.BRANCH_NAME === "master" ||
+                /^release-x\.\d+\.x$/.test(process.env.BRANCH_NAME)) {
+              github.rest.repos.createDispatchEvent({
+                owner: "${{ github.repository_owner }}",
+                repo: "docs.metabase.github.io",
+                event_type: "docs_update",
+                client_payload: { branch_name: process.env.BRANCH_NAME
+                }
+              });
+            } else {
+              console.log("Branch name is not to be published: ", process.env.BRANCH_NAME);
+            }


### PR DESCRIPTION
Instead of using an exit with 1 to stop the workflow (and not trigger the docs build workflow in the docs repo), instead conditionally sends workflow when it matches a regex, or does nothing.
