### PR TITLE
[VISUALIZER] Fix static viz for echart types

### DIFF
--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -17,6 +17,7 @@ import { extractRemappings, isCartesianChart } from "metabase/visualizations";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import {
   createDataSource,
+  getVisualizationColumns,
   mergeVisualizerData,
   shouldSplitVisualizerSeries,
   splitVisualizerSeries,
@@ -53,7 +54,7 @@ function getRawSeriesWithDashcardSettings(rawSeries, dashcardSettings) {
 }
 
 function getVisualizerRawSeries(rawSeries, dashcardSettings) {
-  const { columns, columnValuesMapping } = dashcardSettings.visualization;
+  const { columnValuesMapping } = dashcardSettings.visualization;
   const datasets = rawSeries.reduce((acc, series) => {
     if (series.card.id) {
       acc[`card:${series.card.id}`] = series;
@@ -63,6 +64,12 @@ function getVisualizerRawSeries(rawSeries, dashcardSettings) {
 
   const dataSources = rawSeries.map((series) =>
     createDataSource("card", series.card.id, series.card.name),
+  );
+
+  const columns = getVisualizationColumns(
+    dashcardSettings.visualization,
+    datasets,
+    dataSources,
   );
 
   const mergedData = mergeVisualizerData({

--- a/frontend/src/metabase/visualizer/utils/index.ts
+++ b/frontend/src/metabase/visualizer/utils/index.ts
@@ -10,3 +10,4 @@ export * from "./get-initial-state-for-multiple-series";
 export * from "./is-visualizer-dashboard-card";
 export * from "./merge-data";
 export * from "./split-series";
+export * from "./get-visualization-columns";

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -612,7 +612,7 @@
                          (get-in dashcard [:visualization_settings :visualization])
                          (get card :visualization_settings))
         funnel-type    (if visualizer?
-                         (get-in viz-settings [:settings :funnel.type])
+                         (get-in viz-settings [:settings :funnel.type] "funnel")
                          (get viz-settings :funnel.type))
         processed-data (if (and visualizer? (= "funnel" funnel-type))
                          (render.util/merge-visualizer-data (series-cards-with-data dashcard card data) viz-settings)


### PR DESCRIPTION
Changes include:
  - Static viz types that run through `:javascript_visualization` previously depended on `columns` being present in viz settings
    - Since we removed columns from viz settings and now use `getVisualizationColumns`, the static viz bundle needs to follow suit, so this PR does that
  - Fixes small bug in funnel backend code so we correctly identify funnel type