### PR TITLE
Sample event info with table value

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -265,9 +265,11 @@
   (is (=? {:context {:event_name "event/row.created"}
            :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
            :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :table {:id 1 :name "orders"}
+           :table {:id (mt/id :orders) :name "ORDERS"}
            :settings {}
-           :record {:id 1 :name "Product A" :price 29.99 :status "active"}}
+           :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                          :USER_ID :TAX :CREATED_AT}
+                                        (set (keys %)))])}
           (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
                                           {:payload_type :notification/system-event
                                            :payload      {:event_name :event/row.created
@@ -278,25 +280,33 @@
   (is (=? {:context {:event_name "event/row.updated"}
            :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
            :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :table {:id 1 :name "orders"}
+           :table {:id (mt/id :orders) :name "ORDERS"}
            :settings {}
-           :record {:id 1 :name "Product A" :price 24.99 :status "on sale"}
-           :changes {:price {:before 29.99 :after 24.99} :status {:before "active" :after "on sale"}}}
+           :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                          :USER_ID :TAX :CREATED_AT}
+                                        (set (keys %)))])
+           :changes (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                           :USER_ID :TAX :CREATED_AT}
+                                         (set (keys %)))])}
           (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
                                           {:payload_type :notification/system-event
-                                           :payload      {:event_name :event/row.updated}
+                                           :payload      {:event_name :event/row.updated
+                                                          :table_id   (mt/id :orders)}
                                            :creator_id   (mt/user->id :crowberto)})))))
 
 (deftest example-payload-row-delete-test
   (is (=? {:context {:event_name "event/row.deleted"}
            :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
            :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :table {:id 1 :name "orders"}
+           :table {:id (mt/id :orders) :name "ORDERS"}
            :settings {}
-           :record {:id 1 :name "Product A" :price 24.99 :status "discontinued"}}
+           :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                          :USER_ID :TAX :CREATED_AT}
+                                        (set (keys %)))])}
           (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
                                           {:payload_type :notification/system-event
-                                           :payload      {:event_name :event/row.deleted}
+                                           :payload      {:event_name :event/row.deleted
+                                                          :table_id   (mt/id :orders)}
                                            :creator_id   (mt/user->id :crowberto)})))))
 
 (deftest preview-notification-test

--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -270,7 +270,8 @@
            :record {:id 1 :name "Product A" :price 29.99 :status "active"}}
           (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
                                           {:payload_type :notification/system-event
-                                           :payload      {:event_name :event/row.created}
+                                           :payload      {:event_name :event/row.created
+                                                          :table_id   (mt/id :orders)}
                                            :creator_id   (mt/user->id :crowberto)})))))
 
 (deftest example-payload-row-update-test

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -173,7 +173,8 @@
   [notification]
   (case (:payload_type notification)
     :notification/system-event
-    (mu/generate-example (notification/notification-payload-schema notification))
+    (binding [metabase.notification.payload.impl.system-event/*sample-table-id* (get-in notification [:payload :table_id])]
+      (mu/generate-example (notification/notification-payload-schema notification)))
 
     ;; else
     (notification/notification-payload notification)))

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -173,8 +173,7 @@
   [notification]
   (case (:payload_type notification)
     :notification/system-event
-    (binding [metabase.notification.payload.impl.system-event/*sample-table-id* (get-in notification [:payload :table_id])]
-      (mu/generate-example (notification/notification-payload-schema notification)))
+    (notification/sample-payload notification)
 
     ;; else
     (notification/notification-payload notification)))

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -14,7 +14,8 @@
 
 (p/import-vars
  [notification.payload
-  notification-payload]
+  notification-payload
+  notification-payload-schema]
  [notification.payload.system-event
   sample-payload]
  [notification.task.send

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -2,6 +2,7 @@
   "Core functionality for notifications."
   (:require
    [metabase.notification.payload.core :as notification.payload]
+   [metabase.notification.payload.impl.system-event :as notification.payload.system-event]
    [metabase.notification.seed :as notification.seed]
    [metabase.notification.send :as notification.send]
    [metabase.notification.task.send :as notification.task.send]
@@ -13,8 +14,9 @@
 
 (p/import-vars
  [notification.payload
-  notification-payload
-  notification-payload-schema]
+  notification-payload]
+ [notification.payload.system-event
+  sample-payload]
  [notification.task.send
   update-send-notification-triggers-timezone!]
  [notification.seed

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -118,9 +118,6 @@
                                 :status "active"}))}
      :map]]])
 
-(binding [*sample-table-id* 1]
-  (metabase.util.malli/generate-example ::row.updated))
-
 (mr/def ::row.updated
   [:merge
    ::row.mutate
@@ -157,10 +154,13 @@
                [:event_name [:enum :event/row.deleted "event/row.deleted"]]
                timestamp-schema]]
     [:record {:description "The row that was deleted, showing all field values before deletion"
-              :gen/return  {:id     1
-                            :name   "Product A"
-                            :price  24.99
-                            :status "discontinued"}}
+              :gen/fmap    (fn [_]
+                             (if *sample-table-id*
+                               (sample-for-table *sample-table-id* false)
+                               {:id     1
+                                :name   "Product A"
+                                :price  24.99
+                                :status "on sale"}))}
      :map]]])
 
 (defn- coercion-fn
@@ -314,3 +314,9 @@
   (if-let [condition (not-empty (:condition notification-info))]
     (notification.condition/evaluate-expression condition (:event_info notification-info))
     true))
+
+(defn sample-payload
+  "Generate sample payload for a system event notification"
+  [notification]
+  (binding [*sample-table-id* (get-in notification [:payload :table_id])]
+    (mu/generate-example (notification.payload/notification-payload-schema notification))))

--- a/src/metabase/notification/payload/sample.clj
+++ b/src/metabase/notification/payload/sample.clj
@@ -1,0 +1,163 @@
+(ns metabase.notification.payload.sample
+  (:require
+   [clojure.string :as str]
+   [metabase.models.table :as table]
+   [metabase.types :as types]
+   [metabase.util :as u]
+   [metabase.util.random :as u.random]
+   [metabase.util.time :as u.time]
+   [toucan2.core :as t2])
+  (:import
+   (java.util Random)))
+
+(set! *warn-on-reflection* true)
+
+(defn rand-nth
+  "Reimplementation of [[clojure.core/rand-nth]] using [[*generator*]]."
+  [coll]
+  (nth coll (rand-int (count coll))))
+
+(defn- gen-int []
+  (rand-int 1000000))
+
+(defn- gen-string
+  ([]
+   (u.random/random-name))
+  ([symbols max-len]
+   (apply str (repeatedly (inc (rand-int max-len)) #(rand-nth symbols)))))
+
+(defn- gen-time []
+  (u.time/local-time (rand-int 24) (rand-int 60) (rand-int 60)))
+
+(defn- gen-date []
+  ;; Random day of the year, from 2000-01-01 through 2037-12-31.
+  ;; Avoids 2038 because of the 32-bit timestamp overflow.
+  ;; TODO: Always adds 0-364 days, so it can't return Dec 31st of a leap year. I don't think it matters, but I will
+  ;; highlight it.
+  (u.time/add (u.time/local-date (+ 2000 (rand-int 38)) 1 1) ;; Jan 1, from 2000 through 2037
+              :day
+              (rand-int 365)))
+
+(defn- gen-datetime []
+  (u.time/local-date-time (gen-date) (gen-time)))
+
+(defn- gen-latitude []
+  ;; +/- 75 degrees is a generous but plausible range for latitudes.
+  (* 150 (- (rand) 0.5)))
+
+(defn- gen-longitude []
+  ;; +/- 180 degrees
+  (- (* 360 (rand)) 180))
+
+(defn- gen-category []
+  (rand-nth ["Electronics" "Clothing" "Food" "Books" "Sports" "Home" "Beauty" "Toys"]))
+
+(defn- gen-ip-address []
+  (str (rand-int 256) "." (rand-int 256) "." (rand-int 256) "." (rand-int 256)))
+
+(defn- gen-url []
+  (let [domains ["example.com" "metabase.com" "github.com" "google.com"]
+        paths ["/docs" "/api" "/users" "/products" "/search"]
+        protocols ["http" "https"]]
+    (str (rand-nth protocols) "://" (rand-nth domains) (rand-nth paths))))
+
+(defn- gen-email []
+  (let [domains ["gmail.com" "example.com" "metabase.com"]
+        names ["john" "jane" "bob" "alice" "user"]]
+    (str (rand-nth names) (rand-int 1000) "@" (rand-nth domains))))
+
+(defn- gen-currency []
+  (* (rand) 10000))
+
+(defn- gen-percentage []
+  (* (rand) 100))
+
+(defn- gen-share []
+  (rand))
+
+(defn- gen-quantity []
+  (rand-int 1000))
+
+(defn- gen-score []
+  (rand-int 100))
+
+(defn- gen-duration []
+  (rand-int 86400)) ; seconds in a day
+
+(defn- gen-structured []
+  {:id         (rand-int 1000)
+   :name       (gen-string)
+   :created_at (gen-datetime)
+   :metadata   {:tags ["sample" "test" "data"]
+                :version "1.0"}})
+
+(defn- gen-enum []
+  (rand-nth ["ACTIVE" "INACTIVE" "PENDING" "COMPLETED" "FAILED"]))
+
+(defn- gen-location []
+  (rand-nth ["New York" "London" "Tokyo" "Paris" "Berlin"]))
+
+(defn- gen-description []
+  (let [sentences ["This is a sample description."
+                   "It contains multiple sentences."
+                   "Each sentence provides additional context."
+                   "The description helps understand the data better."]
+        num-sentences (inc (rand-int 3))]
+    (str/join " " (take num-sentences (shuffle sentences)))))
+
+(defn- gen-comment []
+  (let [templates ["Great work on %s!"
+                   "I have a question about %s."
+                   "This %s needs more attention."
+                   "The %s looks good."]
+        subjects ["the implementation" "this feature" "the design" "the code"]]
+    (format (rand-nth templates) (rand-nth subjects))))
+
+(defn sample-field
+  "Given a field, sample a value based on its type."
+  [{:keys [semantic_type] :as field}]
+  (let [semantic-type-is #(isa? % semantic_type)
+        gen-by-base-type (fn []
+                           (cond
+                             (types/field-is-type? :type/Text field)     (gen-string)
+                             (types/field-is-type? :type/TextLike field) (gen-string)
+                             (types/field-is-type? :type/Number field)   (gen-int)
+                             (types/field-is-type? :type/Integer field)  (gen-int)
+                             (types/field-is-type? :type/Float field)    (* (rand) 1000)
+                             (types/field-is-type? :type/Decimal field)  (* (rand) 1000)
+                             (types/field-is-type? :type/DateTime field) (gen-datetime)
+                             (types/field-is-type? :type/Date field)     (gen-date)
+                             (types/field-is-type? :type/Time field)     (gen-time)
+                             (types/field-is-type? :type/Boolean field)  (rand-nth [true false])
+                             :else nil))]
+    (if-not semantic_type
+      (gen-by-base-type)
+      (cond
+        ;; Text-based types
+        (semantic-type-is :type/IPAddress)   (gen-ip-address)
+        (semantic-type-is :type/URL)         (gen-url)
+        (semantic-type-is :type/Category)    (gen-category)
+        (semantic-type-is :type/Structured)  (gen-structured)
+        (semantic-type-is :type/Email)       (gen-email)
+        (semantic-type-is :type/Description) (gen-description)
+        (semantic-type-is :type/Comment)     (gen-comment)
+        (semantic-type-is :type/Enum)        (gen-enum)
+
+        ;; Numeric types
+        (semantic-type-is :type/Currency)   (gen-currency)
+        (semantic-type-is :type/Quantity)   (gen-quantity)
+        (semantic-type-is :type/Percentage) (gen-percentage)
+        (semantic-type-is :type/Share)      (gen-share)
+        (semantic-type-is :type/Score)      (gen-score)
+        (semantic-type-is :type/Duration)   (gen-duration)
+        (semantic-type-is :type/Latitude)   (gen-latitude)
+        (semantic-type-is :type/Location)   (gen-location)
+
+        ;; Temporal types
+        (semantic-type-is :type/DeletionTemporal)    (gen-datetime)
+        (semantic-type-is :type/Birthdate)           (gen-date)
+        (semantic-type-is :type/CreationTemporal)    (gen-datetime)
+        (semantic-type-is :type/CancelationTemporal) (gen-datetime)
+        (semantic-type-is :type/UpdatedTemporal)     (gen-datetime)
+        (semantic-type-is :type/JoinTemporal)        (gen-datetime)
+        :else                                        (gen-by-base-type)))))

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -245,8 +245,6 @@
 (derive :type/DeletionDate :type/DeletionTemporal)
 (derive :type/DeletionDate :type/Date)
 
-(descendants :Semantic/*)
-
 (derive :type/UpdatedTemporal :Semantic/*)
 (derive :type/UpdatedTimestamp :type/UpdatedTemporal)
 (derive :type/UpdatedTimestamp :type/DateTime)

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -245,6 +245,8 @@
 (derive :type/DeletionDate :type/DeletionTemporal)
 (derive :type/DeletionDate :type/Date)
 
+(descendants :Semantic/*)
+
 (derive :type/UpdatedTemporal :Semantic/*)
 (derive :type/UpdatedTimestamp :type/UpdatedTemporal)
 (derive :type/UpdatedTimestamp :type/DateTime)


### PR DESCRIPTION
Improve the generate example payload by making it return record value with real column names.

The values are still sampled, we try the best to generate a sensible value by inferring from its types.