### PR TITLE
fix: display a header with actions (create) even when there is no data

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   rem,
 } from "metabase/ui";
+import NoResultsView from "metabase/visualizations/components/Visualization/NoResultsView";
 import type Question from "metabase-lib/v1/Question";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 import { formatRowCount } from "metabase-lib/v1/queries/utils/row-count";
@@ -142,32 +143,40 @@ export const EditTableDashcardVisualization = ({
           )}
         </Group>
       </Flex>
-      <Box pos="relative" className={S.gridWrapper}>
-        <EditTableDataOverlay
-          show={shouldDisableActions}
-          message={currentActionLabel ?? ""}
-        />
-        <EditTableDataGrid
-          data={data}
-          fieldMetadataMap={tableFieldMetadataMap}
-          onCellValueUpdate={handleCellValueUpdate}
-          onRowExpandClick={openEditRowModal}
-          columnsConfig={columnsConfig}
-          getColumnSortDirection={getColumnSortDirection}
-        />
-      </Box>
+      {data.rows.length === 0 ? (
+        <Stack h="100%" justify="center">
+          <NoResultsView />
+        </Stack>
+      ) : (
+        <>
+          <Box pos="relative" className={S.gridWrapper}>
+            <EditTableDataOverlay
+              show={shouldDisableActions}
+              message={currentActionLabel ?? ""}
+            />
+            <EditTableDataGrid
+              data={data}
+              fieldMetadataMap={tableFieldMetadataMap}
+              onCellValueUpdate={handleCellValueUpdate}
+              onRowExpandClick={openEditRowModal}
+              columnsConfig={columnsConfig}
+              getColumnSortDirection={getColumnSortDirection}
+            />
+          </Box>
 
-      <Flex
-        p="xs"
-        px="1rem"
-        justify="flex-end"
-        align="center"
-        className={S.gridFooterDashcardVisualization}
-      >
-        <Text fz="sm" fw="bold">
-          {getEditTableRowCountMessage(data)}
-        </Text>
-      </Flex>
+          <Flex
+            p="xs"
+            px="1rem"
+            justify="flex-end"
+            align="center"
+            className={S.gridFooterDashcardVisualization}
+          >
+            <Text fz="sm" fw="bold">
+              {getEditTableRowCountMessage(data)}
+            </Text>
+          </Flex>
+        </>
+      )}
       <EditingBaseRowModal
         modalState={modalState}
         onClose={closeModal}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -644,10 +644,13 @@ class Visualization extends PureComponent<
     }
 
     if (!error && !genericError && series) {
-      noResults = _.every(
-        series,
-        (s) => s && s.data && datasetContainsNoResults(s.data),
-      );
+      const isNoResultsDisabled = !!visualization?.noResults;
+      noResults = isNoResultsDisabled
+        ? false
+        : _.every(
+            series,
+            (s) => s && s.data && datasetContainsNoResults(s.data),
+          );
     }
 
     const extra = (
@@ -682,7 +685,7 @@ class Visualization extends PureComponent<
 
     const title = settings["card.title"];
     const hasHeaderContent = title || extra;
-    const isHeaderEnabled = !(visualization && visualization.noHeader);
+    const isHeaderEnabled = !visualization?.noHeader;
 
     const hasHeader =
       (showTitle &&

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -310,6 +310,7 @@ export type VisualizationDefinition = {
   disableClickBehavior?: boolean;
   canSavePng?: boolean;
   noHeader?: boolean;
+  noResults?: boolean;
   hidden?: boolean;
   disableSettingsConfig?: boolean;
   supportPreviewing?: boolean;

--- a/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
@@ -35,6 +35,7 @@ export class TableEditable extends Component<
   static disableSettingsConfig = true;
   static disableNavigateToNewCardFromDashboard = true;
   static noHeader = true;
+  static noResults = true;
 
   static additionalDashcardActionButtons = [TableEditableConfigureActionButton];
 


### PR DESCRIPTION
Resolves [WRK-357](https://linear.app/metabase/issue/WRK-357/editable-should-display-a-header-with-actions-create-even-when-there).
Also blocker for [WRK-358](https://linear.app/metabase/issue/WRK-358/editable-should-display-new-record-button-when-there-is-no-data).

Line `const isHeaderEnabled = !visualization?.noHeader;` is changed to bypass eslint complexity rule capped to 54.

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/902a8bcc-98c7-4e62-a008-c460ad744fe8" />
