### PR TITLE
Content translation: Introduce hook and utility to support translating user-generated strings

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/constants.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/constants.ts
@@ -1,6 +1,5 @@
-import type { DictionaryArray } from "metabase-api/types";
-
 import type { NonEmpty } from "metabase/i18n/types";
+import type { DictionaryArray } from "metabase-types/api";
 
 export const germanFieldNames: NonEmpty<DictionaryArray> = [
   { locale: "de", msgid: "Title", msgstr: "Titel" },

--- a/enterprise/frontend/src/metabase-enterprise/api/content-translation.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/content-translation.ts
@@ -4,7 +4,7 @@ import type { DictionaryResponse } from "metabase-types/api/content-translation"
 import { EnterpriseApi } from "./api";
 
 type ListContentTranslationsRequest = {
-  locale: string;
+  locale?: string;
 };
 
 type UploadContentTranslationDictionaryRequest = {

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
@@ -103,7 +103,7 @@ const UploadForm = () => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <Form>
+    <Form data-testid="content-localization-setting">
       <Stack gap="md">
         <FormSubmitButton
           disabled={status === "pending"}

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/index.ts
@@ -2,10 +2,12 @@ import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { ContentTranslationConfiguration } from "./components";
+import { useTranslateContent } from "./use-translate-content";
 
 if (hasPremiumFeature("content_translation")) {
   Object.assign(PLUGIN_CONTENT_TRANSLATION, {
     isEnabled: true,
+    useTranslateContent,
     ContentTranslationConfiguration,
   });
 }

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/use-translate-content.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/use-translate-content.ts
@@ -1,0 +1,22 @@
+import { useCallback } from "react";
+
+import { useLocale } from "metabase/common/hooks";
+import type { ContentTranslationFunction } from "metabase/i18n/types";
+import { useListContentTranslationsQuery } from "metabase-enterprise/api";
+
+import { translateContentString } from "./utils";
+
+export const useTranslateContent = (): ContentTranslationFunction => {
+  const locale = useLocale();
+
+  const { data } = useListContentTranslationsQuery({
+    locale,
+  });
+  const dictionary = data?.data;
+
+  return useCallback(
+    <T extends string | null | undefined>(msgid: T) =>
+      translateContentString(dictionary, locale, msgid),
+    [locale, dictionary],
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/use-translate-content.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/use-translate-content.unit.spec.tsx
@@ -1,0 +1,111 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupContentTranslationEndpoints } from "__support__/server-mocks/content-translation";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { RetrievedDictionaryArrayRow } from "metabase-types/api/content-translation";
+import {
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useTranslateContent } from "./use-translate-content";
+
+interface SetupOpts {
+  locale: string | undefined;
+  /** An untranslated string */
+  msgid: string | null | undefined;
+  translations: RetrievedDictionaryArrayRow[] | undefined;
+}
+
+const sampleSpanishDictionary: RetrievedDictionaryArrayRow[] = [
+  {
+    id: 1,
+    locale: "es",
+    msgid: "Hello World",
+    msgstr: "Hola Mundo",
+  },
+];
+
+const TestComponent = ({ msgid }: { msgid?: string | null }) => {
+  const tc = useTranslateContent();
+  const msgstr = tc(msgid);
+  return <>{msgstr}</>;
+};
+
+function setup({ locale, msgid, translations }: SetupOpts) {
+  setupEnterprisePlugins();
+  setupContentTranslationEndpoints({ dictionary: translations });
+
+  const storeInitialState = createMockState({
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures({ content_translation: true }),
+    }),
+    currentUser: createMockUser({ locale }),
+  });
+
+  return renderWithProviders(<TestComponent msgid={msgid} />, {
+    storeInitialState,
+  });
+}
+
+describe("useTranslateContent", () => {
+  it("should return the original string when dictionary is undefined", async () => {
+    setup({
+      msgid: "Hello World",
+      locale: "es",
+      translations: undefined,
+    });
+    expect(await screen.findByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("should return the original string when locale is undefined", async () => {
+    setup({
+      msgid: "Hello World",
+      locale: undefined,
+      translations: sampleSpanishDictionary,
+    });
+    expect(await screen.findByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("should return the msgid when it is not a string", async () => {
+    setup({
+      msgid: null,
+      locale: "es",
+      translations: sampleSpanishDictionary,
+    });
+    expect(screen.queryByText("Hello World")).not.toBeInTheDocument();
+  });
+
+  it("should return the original string when no translation is found", async () => {
+    setup({
+      msgid: "Hello? World?",
+      locale: "es",
+      translations: sampleSpanishDictionary,
+    });
+    expect(await screen.findByText("Hello? World?")).toBeInTheDocument();
+  });
+
+  it("should return the original string when translation is an empty string", async () => {
+    setup({
+      msgid: "Hello World",
+      locale: "es",
+      translations: [
+        {
+          ...sampleSpanishDictionary[0],
+          msgstr: "",
+        },
+      ],
+    });
+    expect(await screen.findByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("should return the translated string when a translation is found", async () => {
+    setup({
+      msgid: "Hello World",
+      locale: "es",
+      translations: sampleSpanishDictionary,
+    });
+    expect(await screen.findByText("Hola Mundo")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -1,0 +1,38 @@
+import type { DictionaryArray } from "metabase-types/api";
+
+/** Translate a user-generated string
+ *
+ * Terminology: A "msgid" is a 'raw', untranslated string. A "msgstr" is a
+ * translation of a msgid.
+ * */
+export const translateContentString = <
+  MsgidType extends string | null | undefined,
+>(
+  dictionary: DictionaryArray | undefined,
+  locale: string | undefined,
+  /** This argument will be translated only if it is a string. If it is not a
+   * string, it will be returned untranslated. */
+  msgid: MsgidType,
+) => {
+  if (!locale) {
+    return msgid;
+  }
+
+  if (typeof msgid !== "string") {
+    return msgid;
+  }
+
+  if (!msgid.trim()) {
+    return msgid;
+  }
+
+  const msgstr = dictionary?.find(
+    (row) => row.locale === locale && row.msgid === msgid,
+  )?.msgstr;
+
+  if (!msgstr || !msgstr.trim()) {
+    return msgid;
+  }
+
+  return msgstr;
+};

--- a/frontend/src/metabase/admin/settings/selectors/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors/selectors.js
@@ -197,6 +197,7 @@ export const ADMIN_SETTINGS_SECTIONS = {
     name: t`Localization`,
     order: 80,
     component: LocalizationSettingsPage,
+    settings: [],
   },
   uploads: {
     name: t`Uploads`,

--- a/frontend/src/metabase/i18n/hooks.ts
+++ b/frontend/src/metabase/i18n/hooks.ts
@@ -1,0 +1,9 @@
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
+
+import type { ContentTranslationFunction } from "./types";
+
+// To keep the components that require content translation tidier, they can
+// invoke this facade, which delegates to the plugin implementation
+export const useTranslateContent = (): ContentTranslationFunction => {
+  return PLUGIN_CONTENT_TRANSLATION.useTranslateContent();
+};

--- a/frontend/src/metabase/i18n/types.ts
+++ b/frontend/src/metabase/i18n/types.ts
@@ -2,4 +2,6 @@ export type NonEmpty<ArrayType> = ArrayType extends (infer ItemType)[]
   ? [ItemType, ...ItemType[]]
   : never;
 
-export type ContentTranslationFunction = <T>(msgid: T) => string | T;
+export type ContentTranslationFunction = <T extends string | null | undefined>(
+  msgid: T,
+) => string | T;

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -1,8 +1,10 @@
 import React, {
   type ComponentType,
+  type Dispatch,
   type HTMLAttributes,
   type ReactNode,
   type SetStateAction,
+  useCallback,
   useMemo,
 } from "react";
 import { t } from "ttag";
@@ -36,6 +38,7 @@ import type { LinkProps } from "metabase/core/components/Link";
 import type { DashCardMenuItem } from "metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu";
 import type { EmbeddingEntityType } from "metabase/embedding-sdk/store";
 import type { DataSourceSelectorProps } from "metabase/embedding-sdk/types/components/data-picker";
+import type { ContentTranslationFunction } from "metabase/i18n/types";
 import { getIconBase } from "metabase/lib/icon";
 import type { MetabotContext } from "metabase/metabot";
 import { SearchButton } from "metabase/nav/components/search/SearchButton";
@@ -78,7 +81,11 @@ import type {
   TimelineEvent,
   User,
 } from "metabase-types/api";
-import type { AdminPathKey, Dispatch, State } from "metabase-types/store";
+import type {
+  AdminPathKey,
+  Dispatch as ReduxDispatch,
+  State,
+} from "metabase-types/store";
 
 import type {
   GetAuthProviders,
@@ -726,7 +733,7 @@ export const PLUGIN_METABOT = {
 type DashCardMenuItemGetter = (
   question: Question,
   dashcardId: DashCardId | undefined,
-  dispatch: Dispatch,
+  dispatch: ReduxDispatch,
 ) => (DashCardMenuItem & { key: string }) | null;
 
 export type PluginDashcardMenu = {
@@ -740,6 +747,13 @@ export const PLUGIN_DASHCARD_MENU: PluginDashcardMenu = {
 export const PLUGIN_CONTENT_TRANSLATION = {
   isEnabled: false,
   ContentTranslationConfiguration: PluginPlaceholder,
+  useTranslateContent: (): ContentTranslationFunction => {
+    // In OSS, the input is not translated
+    return useCallback(
+      <T extends string | null | undefined>(arg: T) => arg,
+      [],
+    );
+  },
 };
 
 export const PLUGIN_DB_ROUTING = {

--- a/frontend/test/__support__/server-mocks/content-translation.ts
+++ b/frontend/test/__support__/server-mocks/content-translation.ts
@@ -1,0 +1,25 @@
+import fetchMock from "fetch-mock";
+
+import type { DictionaryResponse } from "metabase-types/api";
+
+export function setupContentTranslationEndpoints({
+  dictionary = [],
+  uploadSuccess = true,
+}: {
+  dictionary?: DictionaryResponse["data"];
+  uploadSuccess?: boolean;
+}) {
+  fetchMock.get(
+    "path:/api/content-translation/dictionary",
+    (url): DictionaryResponse => {
+      const localeCode = new URL(url).searchParams.get("locale");
+      const data = localeCode
+        ? dictionary.filter((row) => row.locale === localeCode)
+        : dictionary;
+      return { data };
+    },
+  );
+  fetchMock.post("path:/api/ee/content-translation/upload-dictionary", () => ({
+    success: uploadSuccess,
+  }));
+}


### PR DESCRIPTION
This PR introduces some simple logic for translating strings. It's used by downstream PRs that translate particular kinds of strings.

When reviewing this, you'll probably want to see how this is used. Check out https://github.com/metabase/metabase/pull/56557