### PR TITLE
[serdes] break endless loops

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -2,6 +2,7 @@
   "Loading is the interesting part of deserialization: integrating the maps \"ingested\" from files into the appdb.
   See the detailed breakdown of the (de)serialization processes in [[metabase.models.serialization]]."
   (:require
+   [clojure.string :as str]
    [medley.core :as m]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
@@ -22,25 +23,16 @@
   This map works around this: given a model (e.g. `Card`) that triggered a dependency loop, it provides a set of paths to
   keys to remove from the model so that we'll be able to successfully load it. You can remove keys in vectors using :* to
   indicate that all items in that vector should have a key removed."
-  {"Dashboard" #{[:dashcards :* :visualization_settings]}
-   "Card" #{[:dashboard_id]}})
+  {"Dashboard" #{:dashcards}
+   "Card"      #{:dashboard_id}})
 
-(defn- remove-by-path
-  [entity [first-key & rest]]
-  (cond
-    (empty? rest) (dissoc entity first-key)
-    (= :* first-key) (mapv #(remove-by-path % rest) entity)
-    :else (update entity first-key remove-by-path rest)))
-
-(defn- without-references
-  "Remove references to other entities from a given one. Used to break circular dependencies when loading."
-  [model entity]
-  (let [keys-to-remove (or (model->circular-dependency-keys model)
-                           (throw (ex-info "Don't know which keys to remove to break circular dependency!"
-                                           {:entity entity
-                                            :model model
-                                            :error ::no-known-references})))]
-    (reduce remove-by-path entity keys-to-remove)))
+(defn- keys-to-strip [ingested]
+  (let [model (-> ingested :serdes/meta last :model)]
+    (or (model->circular-dependency-keys model)
+        (throw (ex-info "Don't know which keys to remove to break circular dependency!"
+                        {:entity ingested
+                         :model  model
+                         :error  ::no-known-references})))))
 
 (defn- load-deps!
   "Given a list of `deps` (hierarchies), [[load-one]] them all.
@@ -59,13 +51,6 @@
                          (serdes/load-find-local dep))
                     ctx
 
-                    ;; It's a circular dep, strip off probable cause and retry. This will store an incomplete version
-                    ;; of an entity, but this is not a problem - a full version is waiting to be stored up the stack.
-                    (= (:error (ex-data e)) ::circular)
-                    (let [model (:model (ex-data e))]
-                      (log/debug "Detected circular dependency" (serdes/log-path-str dep))
-                      (load-one! (update ctx :expanding disj dep) dep (partial without-references model)))
-
                     :else
                     (throw e)))))]
       (reduce loader ctx deps))))
@@ -73,7 +58,7 @@
 (defn- path-error-data [error-type expanding path]
   (let [last-model (:model (last path))]
     {:path       (mapv (partial into {}) path)
-     :deps-chain (set (map #(mapv (partial into {}) %) expanding))
+     :deps-chain expanding
      :model      last-model
      :table      (some->> last-model (keyword "model") t2/table-name)
      :error      error-type}))
@@ -102,55 +87,73 @@
   This is mostly bookkeeping for the overall deserialization process - the actual load of any given entity is done by
   [[metabase.models.serialization/load-one!]] and its various overridable parts, which see.
 
-  Error is thrown on a circular dependency, should be handled and retried at the caller. `modfn` is an optional
-  parameter to modify entity data after reading and before other processing (before loading dependencies, finding
-  local version, and storing in the db)."
-  [{:keys [expanding ingestion seen] :as ctx} path & [modfn]]
-  (log/infof "Loading %s" (serdes/log-path-str path))
+  The only tangling stuff is handling circular dependencies: parts of this is handled by the `serdes/load-one!`
+  function, just outright skipping processing for parts of ingested data."
+  [{:keys [expanding seen circular ingestion] :as ctx} path]
+  (log/info "Loading" (cond-> {:path (serdes/log-path-str path)}
+                        (circular path) (assoc :stripped true)))
   (cond
-    (expanding path) (throw (ex-info (format "Circular dependency on %s" (serdes/log-path-str path))
-                                     (path-error-data ::circular expanding path)))
-    (seen path) ctx ; Already been done, can skip it.
-    :else (let [ingested (try
-                           (serdes.ingest/ingest-one ingestion path)
-                           (catch Exception e
-                             (throw (ex-info (format "Failed to read file for %s" (serdes/log-path-str path))
-                                             (path-error-data ::not-found expanding path)
-                                             e))))
-                ;; Use the abstract path as attached by the ingestion process, not the original one we were passed.
-                rebuilt-path (serdes/path ingested)
-                ;; If nil or absent :entity_id is taken as a signal to create a new entity
-                ;; To get a nil entity_id, a user has to manually set the entity_id to null or remove it
-                ;; in the yaml file.
-                ;; In all other cases we should expect an :entity_id:
-                ;; - exported entities have a :entity_id for every model that can have one
-                ;; - backfill (pre import) guarantees all entities have ids in the appdb
-                expect-entity-id (some-> rebuilt-path peek :model exported-with-entity-id?)
-                require-new-entity (and expect-entity-id (nil? (:entity_id ingested)))
-                ingested (cond-> ingested
-                           require-new-entity (assoc :entity_id (u/generate-nano-id))
-                           modfn modfn)
-                deps     (serdes/dependencies ingested)
-                _        (log/debug "Loading dependencies" deps)
-                ctx      (-> ctx
-                             (update :expanding conj path)
-                             (load-deps! deps)
-                             (update :seen conj path)
-                             (update :expanding disj path))
-                local-or-nil (when-not require-new-entity (serdes/load-find-local rebuilt-path))]
-            (try
-              (serdes/load-one! ingested local-or-nil)
-              ctx
-              (catch Exception e
-                ;; ugly mapv here to convered #ordered/map into normal map so it's readable in the logs
-                (throw (ex-info (format "Failed to load into database for %s" (serdes/log-path-str path))
-                                (path-error-data ::load-failure expanding path)
-                                e)))))))
+    (and (expanding path)
+         (circular path)) (throw (ex-info (format "Circular dependency on %s" (serdes/log-path-str path))
+                                          (path-error-data ::circular expanding path)))
+    (expanding path)      (do
+                            (log/debug "Detected circular dependency" (serdes/log-path-str path))
+                            (load-one! (-> ctx
+                                           (update :expanding disj path)
+                                           (update :circular conj path))
+                                       path))
+    (seen path)           ctx           ; Already been done, can skip it.
+    :else
+    (let [ingested           (try
+                               (serdes.ingest/ingest-one ingestion path)
+                               (catch Exception e
+                                 (throw (ex-info (format "Failed to read file for %s" (serdes/log-path-str path))
+                                                 (path-error-data ::not-found expanding path)
+                                                 e))))
+          ;; Use the abstract path as attached by the ingestion process, not the original one we were passed.
+          rebuilt-path       (serdes/path ingested)
+          ;; If nil or absent :entity_id is taken as a signal to create a new entity
+          ;; To get a nil entity_id, a user has to manually set the entity_id to null or remove it
+          ;; in the yaml file.
+          ;; In all other cases we should expect an :entity_id:
+          ;; - exported entities have a :entity_id for every model that can have one
+          ;; - backfill (pre import) guarantees all entities have ids in the appdb
+          expect-entity-id   (some-> rebuilt-path peek :model exported-with-entity-id?)
+          require-new-entity (and expect-entity-id (nil? (:entity_id ingested)))
+          ingested           (cond-> ingested
+                               require-new-entity (assoc :entity_id (u/generate-nano-id))
+                               ;; `::strip` is handled in `metabase.serialization`
+                               (circular path)    (assoc ::serdes/strip (keys-to-strip ingested)))
+          ;; we need less deps when trying to load "stripped" data
+          deps               (->> (serdes/dependencies (apply dissoc ingested (::serdes/strip ingested)))
+                                  (remove seen))
+          _                  (when (seq deps)
+                               (log/debug "Loading dependencies"
+                                          {:entity_id (:entity_id ingested)
+                                           :level     (count expanding)
+                                           :deps      (str "[" (str/join ", " (map serdes/log-path-str deps)) "]")}))
+          ctx                (-> ctx
+                                 (update :expanding conj path)
+                                 (load-deps! deps)
+                                 (update :seen conj path)
+                                 (update :expanding disj path))
+          _                  (when (seq deps)
+                               (log/debug "Ended loading dependencies" {:entity_id (:entity_id ingested)
+                                                                        :level     (count expanding)}))
+          local-or-nil       (when-not require-new-entity (serdes/load-find-local rebuilt-path))]
+      (try
+        (serdes/load-one! ingested local-or-nil)
+        ctx
+        (catch Exception e
+          ;; ugly mapv here to convered #ordered/map into normal map so it's readable in the logs
+          (throw (ex-info (format "Failed to load into database for %s" (serdes/log-path-str path))
+                          (path-error-data ::load-failure expanding path)
+                          e)))))))
 
 (defn load-metabase!
   "Loads in a database export from an ingestion source, which is any Ingestable instance."
   [ingestion & {:keys [backfill? continue-on-error]
-                :or   {backfill?   true
+                :or   {backfill?         true
                        continue-on-error false}}]
   (t2/with-transaction [_tx]
     ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies
@@ -160,6 +163,7 @@
     (let [contents (serdes.ingest/ingest-list ingestion)
           ctx      {:expanding #{}
                     :seen      #{}
+                    :circular  #{}
                     :ingestion ingestion
                     :from-ids  (m/index-by :id contents)
                     :errors    []}]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
@@ -26,7 +26,7 @@
     (apply io/file (:root-dir ctx) (map escape-segment (concat dirnames [basename])))))
 
 (defn- store-entity! [opts entity]
-  (log/infof "Storing %s" (serdes/log-path-str (:serdes/meta entity)))
+  (log/info "Storing" {:path (serdes/log-path-str (:serdes/meta entity))})
   (spit-yaml! (file opts entity) entity)
   (:serdes/meta entity))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [metabase-enterprise.serialization.api :as api.serialization]
+   [metabase-enterprise.serialization.v2.ingest :as v2.ingest]
    [metabase-enterprise.serialization.v2.load :as v2.load]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.models.serialization :as serdes]
@@ -230,14 +231,11 @@
                                "error_message" nil}
                               (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
 
-                (mt/with-dynamic-fn-redefs [v2.load/load-one! (let [load-one! (mt/dynamic-value #'v2.load/load-one!)]
-                                                                (fn [ctx path & [modfn]]
-                                                                  (load-one! ctx path
-                                                                             (or modfn
-                                                                                 (fn [ingested]
-                                                                                   (cond-> ingested
-                                                                                     (= (:entity_id ingested) (:entity_id card))
-                                                                                     (assoc :collection_id "DoesNotExist")))))))]
+                (mt/with-dynamic-fn-redefs [v2.ingest/ingest-file (let [ingest-file (mt/dynamic-value #'v2.ingest/ingest-file)]
+                                                                    (fn [^File file]
+                                                                      (cond-> (ingest-file file)
+                                                                        (str/includes? (.getName file) (:entity_id card))
+                                                                        (assoc :collection_id "DoesNotExist"))))]
                   (testing "ERROR /api/ee/serialization/import"
                     (let [res (binding [api.serialization/*additive-logging* false]
                                 (mt/user-http-request :crowberto :post 500 "ee/serialization/import"

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -6,7 +6,6 @@
    [clojure.walk :as walk]
    [metabase-enterprise.serialization.api :as api.serialization]
    [metabase-enterprise.serialization.v2.ingest :as v2.ingest]
-   [metabase-enterprise.serialization.v2.load :as v2.load]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
@@ -49,7 +48,7 @@
   "Find out entity type by log message"
   [lines]
   (->> lines
-       (keep #(second (re-find #"(?:Extracting|Loading|Storing) (\w+)" %)))
+       (keep #(second (re-find #"(?:Extracting|Loading|Storing) \{:path (\w+)" %)))
        set))
 
 (defn- tar-file-types [f & [raw?]]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1173,30 +1173,33 @@
                    (t2/select-one-fn :name :model/Collection :id (:id coll))))))))))
 
 (deftest circular-links-test
-  (mt/with-empty-h2-app-db
-    (let [coll  (ts/create! :model/Collection :name "coll")
-          card  (ts/create! :model/Card :name "card" :collection_id (:id coll))
-          dash1 (ts/create! :model/Dashboard :name "dash1" :collection_id (:id coll))
-          dash2 (ts/create! :model/Dashboard :name "dash2" :collection_id (:id coll))
-          dash3 (ts/create! :model/Dashboard :name "dash3" :collection_id (:id coll))
-          dc1   (ts/create! :model/DashboardCard :dashboard_id (:id dash1) :card_id (:id card)
-                            :visualization_settings {:click_behavior {:type     "link"
-                                                                      :linkType "dashboard"
-                                                                      :targetId (:id dash2)}})
-          dc2   (ts/create! :model/DashboardCard :dashboard_id (:id dash2) :card_id (:id card)
-                            :visualization_settings {:click_behavior {:type     "link"
-                                                                      :linkType "dashboard"
-                                                                      :targetId (:id dash3)}})
-          dc3   (ts/create! :model/DashboardCard :dashboard_id (:id dash2) :card_id (:id card)
-                            :visualization_settings {:click_behavior {:type     "link"
-                                                                      :linkType "dashboard"
-                                                                      :targetId (:id dash1)}})
-          card-2 (ts/create! :model/Card :name "card-2" :dashboard_id (:id dash1))
-          ser   (into [] (serdes.extract/extract {:no-settings   true
-                                                  :no-data-model true}))]
-      (testing "Circular dependencies are loaded correctly"
-        (is (serdes.load/load-metabase! (ingestion-in-memory ser)))
-        (let [select-target #(-> % :visualization_settings :click_behavior :targetId)]
+  (ts/with-dbs [source-db dest-db]
+    (ts/with-db source-db
+      (let [coll          (ts/create! :model/Collection :name "coll")
+            card          (ts/create! :model/Card :name "card" :collection_id (:id coll))
+            dash1         (ts/create! :model/Dashboard :name "dash1" :collection_id (:id coll))
+            dash2         (ts/create! :model/Dashboard :name "dash2" :collection_id (:id coll))
+            dash3         (ts/create! :model/Dashboard :name "dash3" :collection_id (:id coll))
+            dc1           (ts/create! :model/DashboardCard :dashboard_id (:id dash1) :card_id (:id card)
+                                      :visualization_settings {:click_behavior {:type     "link"
+                                                                                :linkType "dashboard"
+                                                                                :targetId (:id dash2)}})
+            dc2           (ts/create! :model/DashboardCard :dashboard_id (:id dash2) :card_id (:id card)
+                                      :visualization_settings {:click_behavior {:type     "link"
+                                                                                :linkType "dashboard"
+                                                                                :targetId (:id dash3)}})
+            dc3           (ts/create! :model/DashboardCard :dashboard_id (:id dash2) :card_id (:id card)
+                                      :visualization_settings {:click_behavior {:type     "link"
+                                                                                :linkType "dashboard"
+                                                                                :targetId (:id dash1)}})
+            card-2        (ts/create! :model/Card :name "card-2" :dashboard_id (:id dash1))
+            _dc2-1        (ts/create! :model/DashboardCard :dashboard_id (:id dash1) :card_id (:id card-2))
+            ser           (into [] (serdes.extract/extract {:no-settings   true
+                                                            :no-data-model false}))
+            select-target #(-> % :visualization_settings :click_behavior :targetId)]
+        ;; loaded to the same db so we know ids won't be corrupted
+        (testing "Dashcard ids won't be changed by loading on top of them"
+          (is (serdes.load/load-metabase! (ingestion-in-memory ser)))
           (is (= (:id dc1)
                  (t2/select-one-fn :id :model/DashboardCard :entity_id (:entity_id dc1))))
           (is (= (:id dc2)
@@ -1209,15 +1212,19 @@
                  (t2/select-one-fn select-target :model/DashboardCard :entity_id (:entity_id dc2))))
           (is (= (:id dash1)
                  (t2/select-one-fn select-target :model/DashboardCard :entity_id (:entity_id dc3)))))
-        (testing "Circular dependencies work for Dashboard Questions as well"
-          (is (= (:id dash1)
-                 (t2/select-one-fn :dashboard_id :model/Card :entity_id (:entity_id card-2)))))))))
+        ;; loaded to a different db so we know it works for sure instead of relying on data being present in the
+        ;; database
+        (ts/with-db dest-db
+          (is (serdes.load/load-metabase! (ingestion-in-memory ser)))
+          (testing "Circular dependencies work for Dashboard Questions as well"
+            (is (= (t2/select-one-fn :id :model/Dashboard :entity_id (:entity_id dash1))
+                   (t2/select-one-fn :dashboard_id :model/Card :entity_id (:entity_id card-2))))))))))
 
 (deftest continue-on-error-test
-  (let [change-ser    (fn [ser changes] ;; kind of like left-join, but right side is indexed
+  (let [change-ser   (fn [ser changes] ;; kind of like left-join, but right side is indexed
                         (vec (for [entity ser]
                                (merge entity (get changes (:entity_id entity))))))
-        logs-extract  (fn [re logs]
+        logs-extract (fn [re logs]
                         (keep #(rest (re-find re %))
                               (map :message logs)))]
     (mt/with-empty-h2-app-db

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1222,11 +1222,11 @@
 
 (deftest continue-on-error-test
   (let [change-ser   (fn [ser changes] ;; kind of like left-join, but right side is indexed
-                        (vec (for [entity ser]
-                               (merge entity (get changes (:entity_id entity))))))
+                       (vec (for [entity ser]
+                              (merge entity (get changes (:entity_id entity))))))
         logs-extract (fn [re logs]
-                        (keep #(rest (re-find re %))
-                              (map :message logs)))]
+                       (keep #(rest (re-find re %))
+                             (map :message logs)))]
     (mt/with-empty-h2-app-db
       (mt/with-temp [:model/Collection coll {:name "coll"}
                      :model/Card       c1   {:name "card1" :collection_id (:id coll)}

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -473,6 +473,13 @@
   ;; This default works for most models, but needs overriding for those that don't rely on entity_id.
   (maybe-labeled model-name entity :name))
 
+(defn log-path-str
+  "Returns a string for logging from a serdes path sequence (i.e. in :serdes/meta)"
+  [elements]
+  (->> elements
+       (map #(str (:model %) " " (:id %)))
+       (str/join " > ")))
+
 ;;; # Export Process
 ;;; An *export* (writing a Metabase instance's entities to disk) happens in two stages: *extraction* and *storage*.
 ;;; These are independent, and deliberately decoupled. The result of extraction is a reducible stream of Clojure maps,
@@ -648,7 +655,7 @@
 (defn log-and-extract-one
   "Extracts a single entity; will replace `extract-one` as public interface once `extract-one` overrides are gone."
   [model opts instance]
-  (log/infof "Extracting %s %s %s" model (:id instance) (entity-id model instance))
+  (log/info "Extracting" {:path (log-path-str (generate-path model instance))})
   (try
     (extract-one model opts instance)
     (catch Exception e
@@ -1032,13 +1039,6 @@
                                   :let [parents (rest (str/split location #"/"))]]
                               [entity_id (map coll-names (concat parents [(str id)]))]))]
     {:collections coll->path}))
-
-(defn log-path-str
-  "Returns a string for logging from a serdes path sequence (i.e. in :serdes/meta)"
-  [elements]
-  (->> elements
-       (map #(str (:model %) " " (:id %)))
-       (str/join " > ")))
 
 ;;; # Utilities for implementing serdes
 ;;; Note that many of these use `^::cache` to cache their lookups during deserialization. This greatly reduces the


### PR DESCRIPTION
When making sure stuff can load even with a loop, the circuit breaker was removed, leading to endless loops. That would happen if the data causing the loop wasn't stripped properly. Right now if stripping things once did not help and the entity is in the pipeline again, the process will break (with hopefully enough data to detect why).

This also changes the logic from exception to just recursive calls. Plus it's back at skipping all dashcards in a Dashboard instead of just skipping visualization logic, which should make for a way faster processing (less deep for sure). Plus it tries to improve logging a bit so it's easier to understand what's going on in complex cases.
