### PR TITLE
deps: remove simpleclient_jetty and javax.servlet

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -86,10 +86,8 @@
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.25"}             ; Parse native SQL queries
   io.github.resilience4j/resilience4j-retry ^:antq/exclude                      ; 2.x do not support Java 8
-  {:mvn/version "1.7.1"}              ; Support for retrying operations
+                                            {:mvn/version "1.7.1"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
-  io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
-  javax.servlet/servlet-api                 {:mvn/version "2.5"}                ; used by ring's multipart-params (file upload)
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.7"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}


### PR DESCRIPTION
### Description

Remove the simpleclient_jetty lib because we have replaced it with internal code. Remove the javax.servlet dep because jetty will pull in the correct jakarta.servlet lib. 
