### PR TITLE
[Backend modularization] create new `api-routes` module

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -61,23 +61,70 @@
    :uses #{config driver legacy-mbql lib models sync util}}
 
   api
-  {:api #{metabase.api.auth
+  {:api #{metabase.api.api-key
+          metabase.api.auth
           metabase.api.card
+          metabase.api.cards
           metabase.api.collection
           metabase.api.common
           metabase.api.common.validation
           metabase.api.dashboard
           metabase.api.database
           metabase.api.dataset
+          metabase.api.docs
           metabase.api.field
+          metabase.api.geojson
+          metabase.api.logger
           metabase.api.macros
           metabase.api.open-api
           metabase.api.query-metadata
-          metabase.api.routes
           metabase.api.routes.common
+          metabase.api.slack
           metabase.api.table
+          metabase.api.testing
           metabase.api.user
+          metabase.api.util
           metabase.api.util.handlers}
+   :uses #{actions
+           analytics
+           analyze
+           api-routes
+           channel
+           config
+           database-routing
+           db
+           driver
+           eid-translation
+           embedding
+           events
+           integrations
+           legacy-mbql
+           lib
+           logger
+           model-persistence
+           models
+           permissions
+           plugins
+           premium-features
+           pulse
+           query-processor
+           request
+           revisions
+           sample-data
+           search
+           server
+           session
+           settings
+           sso
+           sync
+           types
+           upload
+           util
+           xrays
+           enterprise/advanced-permissions}}
+
+  api-routes
+  {:api  #{metabase.api-routes.core}
    :uses :any}
 
   audit
@@ -136,7 +183,7 @@
   {:api  #{metabase.cmd
            metabase.cmd.copy
            metabase.cmd.dump-to-h2}
-   :uses #{api config db legacy-mbql models plugins query-processor search settings util}}
+   :uses #{api api-routes config db legacy-mbql models plugins query-processor search settings util}}
 
   ;; technically this 'uses' `enterprise/core` and `test` since it tries to load them to see if they exists so we know
   ;; if EE/test code is available; however we can ignore them since they're not real usages.
@@ -550,7 +597,7 @@
           metabase.server.middleware.json
           metabase.server.middleware.session
           metabase.server.streaming-response}
-   :uses #{analytics api config core db driver embedding models premium-features settings session request util enterprise/sso}}
+   :uses #{analytics api api-routes config core db driver embedding models premium-features settings session request util enterprise/sso}}
 
   session
   {:api  #{metabase.session.core

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.po~
 *.sqlite
 *.trace.db
+*.trace.db.old
 *.xcworkspacedata
 .DS_Store
 .\#*

--- a/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
@@ -7,7 +7,7 @@
 (comment metabase-enterprise.sso.api.saml/keep-me
          metabase-enterprise.sso.api.sso/keep-me)
 
-;; This needs to be injected into [[metabase.server.routes/routes]] -- not [[metabase.api.routes/routes]] !!!
+;; This needs to be injected into [[metabase.server.routes/routes]] -- not [[metabase.api-routes.core/routes]] !!!
 ;;
 ;; TODO -- should we make a `metabase-enterprise.routes` namespace where this can live instead of injecting it
 ;; directly?

--- a/src/metabase/api/docs.clj
+++ b/src/metabase/api/docs.clj
@@ -29,7 +29,7 @@
        (raise e)))))
 
 (defn- json-handler
-  "Given the [[metabase.api.routes/routes]] handler, return a Ring handler that returns `openapi.json`."
+  "Given the [[metabase.api-routes.core/routes]] handler, return a Ring handler that returns `openapi.json`."
   [root-handler]
   (fn handler*
     ([_request]
@@ -58,7 +58,7 @@
        (raise e)))))
 
 (defn make-routes
-  "/api/docs routes. Takes the [[metabase.api.routes/routes]] handler and returns a Ring handler with the signature
+  "/api/docs routes. Takes the [[metabase.api-routes.core/routes]] handler and returns a Ring handler with the signature
 
     (handler request respond raise)"
   [root-handler]

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -17,8 +17,8 @@
   ;; TODO -- context map instead of prefix?
   (open-api-spec [this prefix]
     "Get the OpenAPI spec base object (as a Clojure data structure) associated with a Ring handler. `prefix` is the
-    route prefix in the Compojure `context` sense, e.g. `/api/` for [[metabase.api.routes/routes]], or `/api/user/` by
-    the time we get to [[metabase.api.user]], etc."))
+    route prefix in the Compojure `context` sense, e.g. `/api/` for [[metabase.api-routes.core/routes]], or
+    `/api/user/` by the time we get to [[metabase.api.user]], etc."))
 
 (extend-protocol OpenAPISpec
   nil
@@ -319,4 +319,4 @@
 #_:clj-kondo/ignore
 (comment
   (open-api-spec (metabase.api.macros/ns-handler 'metabase.api.geojson) "/api/geojson")
-  (root-open-api-object (requiring-resolve 'metabase.api.routes/routes)))
+  (root-open-api-object (requiring-resolve 'metabase.api-routes.core/routes)))

--- a/src/metabase/api/routes/common.clj
+++ b/src/metabase/api/routes/common.clj
@@ -1,5 +1,5 @@
 (ns metabase.api.routes.common
-  "Shared helpers used by [[metabase.api.routes/routes]] as well as premium-only routes
+  "Shared helpers used by [[metabase.api-routes.core/routes]] as well as premium-only routes
   like [[metabase-enterprise.sandbox.api.routes/routes]]."
   (:require
    [metabase.api.open-api :as open-api]

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -141,5 +141,5 @@
   (api/check-superuser)
   {:status 200
    :body (merge
-          (open-api/root-open-api-object @(requiring-resolve 'metabase.api.routes/routes))
+          (open-api/root-open-api-object @(requiring-resolve 'metabase.api-routes.core/routes))
           {:servers [{:url "" :description "Metabase API"}]})})

--- a/src/metabase/api_routes/core.clj
+++ b/src/metabase/api_routes/core.clj
@@ -1,0 +1,10 @@
+(ns metabase.api-routes.core
+  (:require
+   [metabase.api-routes.routes]
+   [potemkin :as p]))
+
+(comment metabase.api-routes.routes/keep-me)
+
+(p/import-vars
+ [metabase.api-routes.routes
+  routes])

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -1,4 +1,4 @@
-(ns metabase.api.routes
+(ns metabase.api-routes.routes
   (:require
    [compojure.route :as route]
    [metabase.actions.api]

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -5,8 +5,8 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [metabase.api-routes.core]
    [metabase.api.open-api]
-   [metabase.api.routes]
    [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
@@ -20,7 +20,7 @@
 
 (defn- openapi-object []
   (merge
-   (metabase.api.open-api/root-open-api-object #'metabase.api.routes/routes)
+   (metabase.api.open-api/root-open-api-object #'metabase.api-routes.core/routes)
    scalar-config))
 
 (defn generate-dox!

--- a/src/metabase/server/auth_wrapper.clj
+++ b/src/metabase/server/auth_wrapper.clj
@@ -18,7 +18,7 @@
    {"/auth" {"/sso"  not-enabled}
     "/api"  {"/saml" not-enabled}}))
 
-;; This needs to be injected into [[metabase.server.routes/routes]] -- not [[metabase.api.routes/routes]] !!!
+;; This needs to be injected into [[metabase.server.routes/routes]] -- not [[metabase.api-routes.core/routes]] !!!
 ;;
 ;; TODO -- should we make a `metabase-enterprise.routes` namespace where this can live instead of injecting it
 ;; directly?

--- a/src/metabase/server/core.clj
+++ b/src/metabase/server/core.clj
@@ -34,7 +34,7 @@
   "Get the top-level Ring handler."
   []
   ;; dynamically resolved for now because [[metabase.server.handler]] depends on [[metabase.server.routes]] which
-  ;; depends on [[metabase.api.routes]] and thus would make a big old circular deps MESS...
+  ;; depends on [[metabase.api-routes.routes]] and thus would make a big old circular deps MESS...
   ;;
   ;; TODO -- we should clean this up somehow. Need to think about how. This is only used in one
   ;; place, [[metabase.core.core/start-normally]].

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -1,11 +1,11 @@
 (ns metabase.server.routes
   "Main Compojure routes tables. See https://github.com/weavejester/compojure/wiki/Routes-In-Detail for details about
-   how these work. `/api/` routes are in `metabase.api.routes`."
+   how these work. `/api/` routes are in [[metabase.api-routes.routes]]."
   (:require
    [compojure.core :refer #_{:clj-kondo/ignore [:discouraged-var]} [context defroutes GET OPTIONS]]
    [compojure.route :as route]
+   [metabase.api-routes.core :as api]
    [metabase.api.dataset :as api.dataset]
-   [metabase.api.routes :as api]
    [metabase.core.initialization-status :as init-status]
    [metabase.db :as mdb]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]

--- a/test/metabase/api/open_api_test.clj
+++ b/test/metabase/api/open_api_test.clj
@@ -1,9 +1,9 @@
 (ns metabase.api.open-api-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api-routes.core :as routes]
    [metabase.api.macros :as api.macros]
    [metabase.api.open-api :as open-api]
-   [metabase.api.routes :as routes]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]))
 

--- a/test/metabase/api_routes/routes_test.clj
+++ b/test/metabase/api_routes/routes_test.clj
@@ -30,7 +30,7 @@
       (z/find-next #(= (z/tag %) :map))))
 
 (defn- check-routes-map []
-  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. "src/metabase/api/routes.clj"))]
+  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. "src/metabase/api_routes/routes.clj"))]
     (let [zloc        (z/of-node (rewrite-clj.parser/parse-all r))
           route-map   (find-route-map zloc)
           actual-keys (find-map-keys route-map)]

--- a/test/metabase/api_routes/routes_test.clj
+++ b/test/metabase/api_routes/routes_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.api.routes-test
+(ns metabase.api-routes.routes-test
   (:require
    [clojure.test :refer :all]
    [rewrite-clj.parser]


### PR DESCRIPTION
Resolves DEV-343

Moves `metabase.api.routes` into its own module so things only using API utils like `defendpoint` don't have circular dependencies with the entire system.