### PR TITLE
properly invalidate collections when x-raying a table

### DIFF
--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -187,6 +187,12 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
     cy.findAllByTestId("dashcard").contains("18,760");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("How these transactions are distributed");
+
+    H.openNavigationSidebar();
+
+    H.navigationSidebar()
+      .findByRole("link", { name: /Automatically generated dashboards/i })
+      .should("exist");
   });
 
   it("should start loading cards from top to bottom", () => {

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -113,7 +113,7 @@ const AutomaticDashboardAppInner = ({
       if (!newDashboard) {
         return;
       }
-      invalidateCollections();
+      dispatch(dashboardApi.util.invalidateTags(invalidateCollections()));
       dispatch(
         addUndo({
           message: (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57493
### Description
Dispatches the invalidate action when an x-day dashboard is saved

### How to verify
1. Ensure your instance does not have an "Automatically Generated Dashboards" folder. If it does, trash it
2. Go to browse -> Database -> x-ray a table
3. save the dashboard
4. Open the navigation sidebar. You should see the new "Automatically Generated Dashboards" folder


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
