### PR TITLE
Add a new metric button to browse metrics page

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -1,4 +1,5 @@
 const { H } = cy;
+import { USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
@@ -117,6 +118,35 @@ describe("scenarios > browse > metrics", () => {
         ).should("be.visible");
         cy.findByText("Create metric").should("not.exist");
       });
+
+      cy.log("New metric header button should not show either");
+      cy.findByTestId("browse-metrics-header")
+        .findByLabelText("Create a new metric")
+        .should("not.exist");
+    });
+
+    it("user without a collection access should still be able to create and save a metric in his own personal collection", () => {
+      cy.intercept("POST", "/api/card").as("createMetric");
+
+      cy.signIn("nocollection");
+      cy.visit("/browse/metrics");
+
+      cy.findByTestId("browse-metrics-header")
+        .findByLabelText("Create a new metric")
+        .click();
+      cy.findByTestId("entity-picker-modal").findByText("People").click();
+      cy.findByTestId("edit-bar")
+        .should("contain", "New metric")
+        .button("Save")
+        .click();
+      H.modal()
+        .should("contain", "Save metric")
+        .and("contain", H.getPersonalCollectionName(USERS["nocollection"]))
+        .button("Save")
+        .click();
+
+      cy.wait("@createMetric");
+      cy.location("pathname").should("match", /^\/metric\/\d+-.*$/);
     });
   });
 

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -5,10 +5,11 @@ import {
   FIRST_COLLECTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
-type StructuredQuestionDetailsWithName = H.StructuredQuestionDetails & {
+type StructuredQuestionDetailsWithName = StructuredQuestionDetails & {
   name: string;
 };
 

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -91,7 +91,7 @@ export function BrowseMetrics() {
             )}
             {hasDataAccess && (
               <ActionIcon
-                aria-label={t`Create a metric`}
+                aria-label={t`Create a new metric`}
                 size={32}
                 variant="viewHeader"
                 component={Link}
@@ -99,7 +99,7 @@ export function BrowseMetrics() {
               >
                 {/* Wrapping an outer component (Link) does not show the tooltip */}
                 <Tooltip
-                  label={t`Create a metric`}
+                  label={t`Create a new metric`}
                   position="bottom"
                   offset={16}
                 >

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -3,9 +3,8 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import NoResults from "assets/img/metrics_bot.svg";
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { skipToken, useListDatabasesQuery } from "metabase/api";
-import { useDatabaseListQuery, useDocsUrl } from "metabase/common/hooks";
+import { useDocsUrl } from "metabase/common/hooks";
 import { useFetchMetrics } from "metabase/common/hooks/use-fetch-metrics";
 import EmptyState from "metabase/components/EmptyState";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
@@ -109,7 +108,10 @@ export function BrowseMetrics() {
         <BrowseSection>
           <Stack mb="lg" gap="md" w="100%">
             {isEmpty ? (
-              <MetricsEmptyState />
+              <MetricsEmptyState
+                canCreateMetric={hasDataAccess}
+                newMetricLink={newMetricLink}
+              />
             ) : (
               <DelayedLoadingAndErrorWrapper
                 error={error}
@@ -127,18 +129,13 @@ export function BrowseMetrics() {
   );
 }
 
-function MetricsEmptyState() {
-  const isLoggedIn = Boolean(useSelector(getCurrentUser));
-  const { data: databases = [] } = useDatabaseListQuery({
-    enabled: isLoggedIn,
-  });
-  const hasDataAccess = getHasDataAccess(databases);
-
-  const newMetricLink = Urls.newQuestion({
-    mode: "query",
-    cardType: "metric",
-  });
-
+function MetricsEmptyState({
+  canCreateMetric,
+  newMetricLink,
+}: {
+  canCreateMetric: boolean;
+  newMetricLink: string;
+}) {
   const { url: metricsDocsLink, showMetabaseLinks } = useDocsUrl(
     "data-modeling/metrics",
   );
@@ -161,7 +158,7 @@ function MetricsEmptyState() {
                     variant="brandBold"
                   >{t`Read the docs`}</Link>
                 )}
-                {hasDataAccess && (
+                {canCreateMetric && (
                   <Button
                     component={Link}
                     to={newMetricLink}

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -13,6 +13,7 @@ import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
 import { getHasDataAccess } from "metabase/selectors/data";
+import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import {
   ActionIcon,
   Box,
@@ -58,6 +59,9 @@ export function BrowseMetrics() {
 
   const databases = data?.data ?? [];
   const hasDataAccess = getHasDataAccess(databases);
+  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+
+  const canCreateMetric = !isEmbeddingIframe && hasDataAccess;
 
   return (
     <BrowseContainer aria-labelledby={titleId}>
@@ -86,7 +90,7 @@ export function BrowseMetrics() {
                 setMetricFilters={setMetricFilters}
               />
             )}
-            {hasDataAccess && (
+            {canCreateMetric && (
               <Tooltip label={t`Create a new metric`} position="bottom">
                 <ActionIcon
                   aria-label={t`Create a new metric`}
@@ -107,7 +111,7 @@ export function BrowseMetrics() {
           <Stack mb="lg" gap="md" w="100%">
             {isEmpty ? (
               <MetricsEmptyState
-                canCreateMetric={hasDataAccess}
+                canCreateMetric={canCreateMetric}
                 newMetricLink={newMetricLink}
               />
             ) : (

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -90,17 +90,22 @@ export function BrowseMetrics() {
               />
             )}
             {hasDataAccess && (
-              <Tooltip label={t`Create a metric`}>
-                <ActionIcon
-                  aria-label={t`Create a metric`}
-                  size={32}
-                  variant="viewHeader"
-                  component={Link}
-                  to={newMetricLink}
+              <ActionIcon
+                aria-label={t`Create a metric`}
+                size={32}
+                variant="viewHeader"
+                component={Link}
+                to={newMetricLink}
+              >
+                {/* Wrapping an outer component (Link) does not show the tooltip */}
+                <Tooltip
+                  label={t`Create a metric`}
+                  position="bottom"
+                  offset={16}
                 >
                   <Icon name="add" />
-                </ActionIcon>
-              </Tooltip>
+                </Tooltip>
+              </ActionIcon>
             )}
           </Flex>
         </BrowseSection>

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -70,18 +70,16 @@ export function BrowseMetrics() {
             justify="space-between"
             align="center"
           >
-            <Tooltip label="foo">
-              <Title order={1} c="text-dark" id={titleId}>
-                <Group gap="sm">
-                  <Icon
-                    size={24}
-                    color="var(--mb-color-icon-primary)"
-                    name="metric"
-                  />
-                  {t`Metrics`}
-                </Group>
-              </Title>
-            </Tooltip>
+            <Title order={1} c="text-dark" id={titleId}>
+              <Group gap="sm">
+                <Icon
+                  size={24}
+                  color="var(--mb-color-icon-primary)"
+                  name="metric"
+                />
+                {t`Metrics`}
+              </Group>
+            </Title>
             {hasVerifiedMetrics && (
               <MetricFilterControls
                 metricFilters={metricFilters}

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -9,7 +9,7 @@ import { useDatabaseListQuery, useDocsUrl } from "metabase/common/hooks";
 import { useFetchMetrics } from "metabase/common/hooks/use-fetch-metrics";
 import EmptyState from "metabase/components/EmptyState";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
-import Link from "metabase/core/components/Link";
+import Link, { ForwardRefLink } from "metabase/core/components/Link";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
@@ -90,22 +90,17 @@ export function BrowseMetrics() {
               />
             )}
             {hasDataAccess && (
-              <ActionIcon
-                aria-label={t`Create a new metric`}
-                size={32}
-                variant="viewHeader"
-                component={Link}
-                to={newMetricLink}
-              >
-                {/* Wrapping an outer component (Link) does not show the tooltip */}
-                <Tooltip
-                  label={t`Create a new metric`}
-                  position="bottom"
-                  offset={16}
+              <Tooltip label={t`Create a new metric`} position="bottom">
+                <ActionIcon
+                  aria-label={t`Create a new metric`}
+                  size={32}
+                  variant="viewHeader"
+                  component={ForwardRefLink}
+                  to={newMetricLink}
                 >
                   <Icon name="add" />
-                </Tooltip>
-              </ActionIcon>
+                </ActionIcon>
+              </Tooltip>
             )}
           </Flex>
         </BrowseSection>

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -84,25 +84,27 @@ export function BrowseMetrics() {
                 {t`Metrics`}
               </Group>
             </Title>
-            {hasVerifiedMetrics && (
-              <MetricFilterControls
-                metricFilters={metricFilters}
-                setMetricFilters={setMetricFilters}
-              />
-            )}
-            {canCreateMetric && (
-              <Tooltip label={t`Create a new metric`} position="bottom">
-                <ActionIcon
-                  aria-label={t`Create a new metric`}
-                  size={32}
-                  variant="viewHeader"
-                  component={ForwardRefLink}
-                  to={newMetricLink}
-                >
-                  <Icon name="add" />
-                </ActionIcon>
-              </Tooltip>
-            )}
+            <Group gap="xs">
+              {canCreateMetric && (
+                <Tooltip label={t`Create a new metric`} position="bottom">
+                  <ActionIcon
+                    aria-label={t`Create a new metric`}
+                    size={32}
+                    variant="viewHeader"
+                    component={ForwardRefLink}
+                    to={newMetricLink}
+                  >
+                    <Icon name="add" />
+                  </ActionIcon>
+                </Tooltip>
+              )}
+              {hasVerifiedMetrics && (
+                <MetricFilterControls
+                  metricFilters={metricFilters}
+                  setMetricFilters={setMetricFilters}
+                />
+              )}
+            </Group>
           </Flex>
         </BrowseSection>
       </BrowseHeader>

--- a/frontend/src/metabase/browse/metrics/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/browse/metrics/tests/common.unit.spec.tsx
@@ -13,7 +13,16 @@ describe("BrowseMetrics (OSS)", () => {
     expect(await screen.findByText("Create metric")).toBeInTheDocument();
   });
 
-  it("should not show the Create metric button if the user does not have data access", async () => {
+  it("displays a new metric header button when no metrics are found", async () => {
+    setup({ metricCount: 0 });
+
+    const header = await screen.findByTestId("browse-metrics-header");
+    expect(
+      await within(header).findByLabelText("Create a new metric"),
+    ).toBeInTheDocument();
+  });
+
+  it("should not show the Create metric button in an empty state if the user does not have data access", async () => {
     setup({ metricCount: 0, databases: [] });
     expect(
       await screen.findByText(
@@ -21,6 +30,14 @@ describe("BrowseMetrics (OSS)", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Create metric")).not.toBeInTheDocument();
+  });
+
+  it("should not show the new metric header button if the user does not have data access", async () => {
+    setup({ metricCount: 0, databases: [] });
+    const header = await screen.findByTestId("browse-metrics-header");
+    expect(
+      within(header).queryByLabelText("Create a new metric"),
+    ).not.toBeInTheDocument();
   });
 
   it("displays a link to the metrics docs", async () => {


### PR DESCRIPTION
Resolves PRG-22 by adding a new metric button to the header of the `/browse/metrics` page.

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/09b232e4-31bd-459a-87a7-12ae7f109336" />

Here's how the layout looks when there is a "verified metrics" filter
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/5c4cb5da-ccd3-4f27-b447-b0e9423b649f" />

### Testing
- Expanded the existing unit tests
- Added new E2E test
