### PR TITLE
fix: remove version-info from settings list api

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1286,19 +1286,15 @@ describe("admin > settings > updates", () => {
     cy.signInAsAdmin();
     cy.visit("/admin/settings/updates");
 
-    cy.intercept("GET", "/api/session/properties", (req, _) => {
+    cy.intercept("GET", "/api/session/properties", (req) => {
       req.continue((res) => {
         res.body.version.tag = currentVersion;
         return res.body;
       });
     });
 
-    cy.intercept("GET", "/api/setting/version-info", (req, _) => {
-      req.continue((res) => {
-        res.body = versionInfo;
-        res.body.version.tag = currentVersion;
-        return res.body;
-      });
+    cy.intercept("GET", "/api/setting/version-info", (req) => {
+      req.reply(versionInfo);
     });
   });
 

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1286,9 +1286,16 @@ describe("admin > settings > updates", () => {
     cy.signInAsAdmin();
     cy.visit("/admin/settings/updates");
 
-    cy.intercept("GET", "/api/session/properties", (req, res) => {
+    cy.intercept("GET", "/api/session/properties", (req, _) => {
       req.continue((res) => {
-        res.body["version-info"] = versionInfo;
+        res.body.version.tag = currentVersion;
+        return res.body;
+      });
+    });
+
+    cy.intercept("GET", "/api/setting/version-info", (req, _) => {
+      req.continue((res) => {
+        res.body = versionInfo;
         res.body.version.tag = currentVersion;
         return res.body;
       });

--- a/e2e/test/scenarios/onboarding/navbar/whats-new.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/whats-new.cy.spec.js
@@ -56,10 +56,13 @@ describe("nav > what's new notification", () => {
 
 function mockVersions({ currentVersion, versions = [] }) {
   const [latest, ...older] = versions;
+  cy.intercept("GET", "/api/setting/version-info", (req) => {
+    req.reply(createMockVersionInfo({ latest, older }));
+  }).as("versionInfo");
+
   cy.intercept("GET", "/api/session/properties", (req) => {
     req.reply((res) => {
       res.body["version"] = { tag: currentVersion };
-      res.body["version-info"] = createMockVersionInfo({ latest, older });
     });
   }).as("sessionProperties");
 }
@@ -68,6 +71,7 @@ function loadHomepage() {
   cy.visit("/");
 
   cy.wait("@sessionProperties");
+  cy.wait("@versionInfo");
 
   // make sure page is loaded
   cy.findByText("loading").should("not.exist");

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -347,7 +347,7 @@ interface AdminSettings {
   "other-sso-enabled?"?: boolean; // yes the question mark is in the variable name
   "show-database-syncing-modal": boolean;
   "token-status": TokenStatus | null;
-  "version-info": VersionInfo | null;
+  "version-info"?: VersionInfo | null;
   "last-acknowledged-version": string | null;
   "show-static-embed-terms": boolean | null;
   "show-sdk-embed-terms": boolean | null;

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx
@@ -11,21 +11,24 @@ import ErrorBoundary from "metabase/ErrorBoundary";
 import { SwagButton } from "metabase/admin/settings/components/Swag/SwagButton";
 import { UpsellSSO } from "metabase/admin/upsells";
 import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
+import { useGetSettingQuery } from "metabase/api";
+import { useSetting } from "metabase/common/hooks";
 import { AdminLayout } from "metabase/components/AdminLayout";
 import { NotFound } from "metabase/components/ErrorPages";
 import SaveStatus from "metabase/components/SaveStatus";
 import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
 import title from "metabase/hoc/Title";
-import { connect } from "metabase/lib/redux";
+import { connect, useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
+import { newVersionAvailable } from "metabase/lib/utils";
 import { Box, Group } from "metabase/ui";
 
 import {
   getActiveSection,
   getActiveSectionName,
+  getCurrentVersion,
   getDerivedSettingValues,
-  getNewVersionAvailable,
   getSections,
   getSettingValues,
   getSettings,
@@ -47,7 +50,6 @@ const mapStateToProps = (state, props) => {
     sections: getSections(state, props),
     activeSection: getActiveSection(state, props),
     activeSectionName: getActiveSectionName(state, props),
-    newVersionAvailable: getNewVersionAvailable(state, props),
   };
 };
 
@@ -62,6 +64,18 @@ const mapDispatchToProps = (dispatch) => ({
   ),
   dispatch,
 });
+
+const NewVersionIndicatorWrapper = () => {
+  const { data: versionInfo } = useGetSettingQuery("version-info");
+  const currentVersion = useSelector(getCurrentVersion);
+  const updateChannel = useSetting("update-channel") ?? "latest";
+  const latestVersion = versionInfo?.[updateChannel]?.version;
+
+  if (newVersionAvailable({ currentVersion, latestVersion })) {
+    return <NewVersionIndicator>1</NewVersionIndicator>;
+  }
+  return null;
+};
 
 class SettingsEditor extends Component {
   layout = null; // the reference to AdminLayout
@@ -202,7 +216,7 @@ class SettingsEditor extends Component {
   }
 
   renderSettingsSections() {
-    const { sections, activeSectionName, newVersionAvailable } = this.props;
+    const { sections, activeSectionName } = this.props;
 
     const renderedSections = Object.entries(sections).map(
       ([slug, section], idx) => {
@@ -229,12 +243,10 @@ class SettingsEditor extends Component {
 
         // if this is the Updates section && there is a new version then lets add a little indicator
         const shouldDisplayNewVersionIndicator =
-          slug === "updates" &&
-          newVersionAvailable &&
-          !MetabaseSettings.isHosted();
+          slug === "updates" && !MetabaseSettings.isHosted();
 
         const newVersionIndicator = shouldDisplayNewVersionIndicator ? (
-          <NewVersionIndicator>1</NewVersionIndicator>
+          <NewVersionIndicatorWrapper />
         ) : null;
 
         return (

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/setup.tsx
@@ -5,6 +5,7 @@ import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupApiKeyEndpoints,
   setupPropertiesEndpoints,
+  setupSettingEndpoint,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
@@ -65,6 +66,10 @@ export const setup = async ({
   }
 
   setupApiKeyEndpoints([]);
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: settingValuesWithToken["version-info"],
+  });
   setupSettingsEndpoints(settings);
   setupPropertiesEndpoints(settingValuesWithToken);
 

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.unit.spec.tsx
@@ -4,6 +4,7 @@ import { act } from "react-dom/test-utils";
 
 import {
   setupPropertiesEndpoints,
+  setupSettingEndpoint,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
@@ -33,7 +34,14 @@ const setup = async (props: {
       tag: props.versionTag,
       hash: "4742ea1",
     },
-    "version-info": {
+  } as const;
+
+  const settings = createMockSettings(updatesSettings);
+  setupPropertiesEndpoints(settings);
+  setupUpdateSettingEndpoint();
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: {
       beta: {
         version: "v1.54.0-beta",
         released: "2025-03-24",
@@ -48,11 +56,7 @@ const setup = async (props: {
         released: "2024-12-16",
       },
     },
-  } as const;
-
-  const settings = createMockSettings(updatesSettings);
-  setupPropertiesEndpoints(settings);
-  setupUpdateSettingEndpoint();
+  });
   setupSettingsEndpoints(
     Object.entries(settings).map(([key, value]) =>
       createMockSettingDefinition({ key: key as SettingKey, value }),

--- a/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.unit.spec.tsx
@@ -1,5 +1,6 @@
 import {
   setupPropertiesEndpoints,
+  setupSettingEndpoint,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
@@ -27,11 +28,18 @@ const setup = (props: {
       hash: "4742ea1",
     },
     "update-channel": props.updateChannel,
-    "version-info": {
+    "is-hosted?": props.isHosted,
+  };
+
+  const settings = createMockSettings(versionNoticeSettings);
+  setupPropertiesEndpoints(settings);
+  setupUpdateSettingEndpoint();
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: {
       beta: {
         version: "v1.54.0-beta",
         released: "2025-03-24",
-        rollout: 100,
         highlights: [],
       },
       latest: {
@@ -39,21 +47,15 @@ const setup = (props: {
         released: "2025-03-25",
         patch: true,
         highlights: [],
-        rollout: 100,
       },
       nightly: {
         version: "v1.52.3",
         released: "2024-12-16",
-        rollout: 100,
         highlights: [],
       },
     },
-    "is-hosted?": props.isHosted,
-  };
+  });
 
-  const settings = createMockSettings(versionNoticeSettings);
-  setupPropertiesEndpoints(settings);
-  setupUpdateSettingEndpoint();
   setupSettingsEndpoints(
     Object.entries(settings).map(([key, value]) =>
       createMockSettingDefinition({ key: key as SettingKey, value }),

--- a/frontend/src/metabase/admin/settings/selectors/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors/selectors.js
@@ -6,7 +6,6 @@ import _ from "underscore";
 import { SMTPConnectionForm } from "metabase/admin/settings/components/Email/SMTPConnectionForm";
 import { UpsellWhitelabel } from "metabase/admin/upsells";
 import MetabaseSettings from "metabase/lib/settings";
-import { newVersionAvailable } from "metabase/lib/utils";
 import {
   PLUGIN_ADMIN_SETTINGS,
   PLUGIN_ADMIN_SETTINGS_AUTH_TABS,
@@ -436,25 +435,6 @@ export const getCurrentVersion = createSelector(
   getDerivedSettingValues,
   (settings) => {
     return settings.version?.tag;
-  },
-);
-
-export const getLatestVersion = createSelector(
-  getDerivedSettingValues,
-  (settings) => {
-    const updateChannel = settings["update-channel"] ?? "latest";
-    return settings["version-info"]?.[updateChannel]?.version;
-  },
-);
-
-export const getNewVersionAvailable = createSelector(
-  getCurrentVersion,
-  getLatestVersion,
-  (currentVersion, latestVersion) => {
-    return newVersionAvailable({
-      currentVersion,
-      latestVersion,
-    });
   },
 );
 

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
@@ -2,12 +2,14 @@ import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
 import { updateSetting } from "metabase/admin/settings/settings";
+import { useGetSettingQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { color } from "metabase/lib/colors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import { Anchor, Flex, Icon, Paper, Stack, Text } from "metabase/ui";
+import type { VersionInfo } from "metabase-types/api";
 
 import { DismissIconButtonWrapper } from "./WhatsNewNotification.styled";
 import Sparkles from "./sparkles.svg?component";
@@ -16,7 +18,9 @@ import { getLatestEligibleReleaseNotes } from "./utils";
 export function WhatsNewNotification() {
   const dispatch = useDispatch();
   const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
-  const versionInfo = useSetting("version-info");
+  const { data: versionInfo } = useGetSettingQuery("version-info") as {
+    data: VersionInfo;
+  };
   const currentVersion = useSetting("version");
   const lastAcknowledgedVersion = useSetting("last-acknowledged-version");
   const isWhiteLabeling = useSelector(getIsWhiteLabeling);

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.unit.spec.tsx
@@ -3,12 +3,13 @@ import fetchMock from "fetch-mock";
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupPropertiesEndpoints,
+  setupSettingEndpoint,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import * as domUtils from "metabase/lib/dom";
-import type { VersionInfoRecord } from "metabase-types/api";
+import type { VersionInfo, VersionInfoRecord } from "metabase-types/api"; // Add VersionInfo
 import {
   createMockSettings,
   createMockTokenFeatures,
@@ -22,14 +23,19 @@ import { WhatsNewNotification } from "./WhatsNewNotification";
 
 const LAST_ACK_SETTINGS_URL = `path:/api/setting/last-acknowledged-version`;
 
-const notification = () => screen.queryByText("See what's new");
+// Helper functions for querying notification link
+const getNotificationLink = async () =>
+  screen.findByRole("link", { name: /see what's new/i });
+const queryNotificationLink = () =>
+  screen.queryByRole("link", { name: /see what's new/i });
 
 const setup = ({
   isWhiteLabeling = false,
   isEmbedded = false,
   lastAcknowledged = null,
-  currentVersion = "v0.48.0",
+  currentVersionTag = "v0.48.0", // Renamed for clarity
   versions = [
+    // Default versions from original test
     mockVersion({ version: "v0.48.2" }),
     mockVersion({ version: "v0.48.1" }),
     mockVersion({
@@ -41,23 +47,29 @@ const setup = ({
 }: {
   isWhiteLabeling?: boolean;
   isEmbedded?: boolean;
-  currentVersion?: string;
+  currentVersionTag?: string;
   lastAcknowledged?: string | null;
   versions?: VersionInfoRecord[];
-}) => {
+} = {}) => {
+  // Added default empty object
   jest.spyOn(domUtils, "isWithinIframe").mockReturnValue(isEmbedded);
 
-  const versionMock = createMockVersion({ tag: currentVersion });
-
+  const versionMock = createMockVersion({ tag: currentVersionTag });
   const [latest, ...older] = versions;
+  const versionInfo: VersionInfo = createMockVersionInfo({ latest, older });
 
+  // Mock the API endpoint for version-info
   setupPropertiesEndpoints(createMockSettings());
   setupSettingsEndpoints([]);
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: versionInfo,
+  });
 
-  const mockState = createMockState({
+  // Mock the Redux state for settings read by useSetting and other selectors
+  const state = createMockState({
     settings: mockSettings({
       version: versionMock,
-      "version-info": createMockVersionInfo({ latest, older }),
       "last-acknowledged-version": lastAcknowledged,
       "application-name": isWhiteLabeling ? "My App" : "Metabase",
       "token-features": createMockTokenFeatures({
@@ -67,76 +79,125 @@ const setup = ({
   });
 
   if (isWhiteLabeling) {
-    setupEnterprisePlugins();
+    setupEnterprisePlugins(); // Keep this if whitelabeling is EE
   }
 
-  return renderWithProviders(<WhatsNewNotification></WhatsNewNotification>, {
-    storeInitialState: mockState,
+  return renderWithProviders(<WhatsNewNotification />, {
+    storeInitialState: state,
   });
 };
 
 describe("WhatsNewNotification", () => {
   describe("display logic", () => {
-    it("should show the notification if the last acknowledged version is null", () => {
-      setup({ currentVersion: "v0.48.0", lastAcknowledged: null });
-      expect(notification()).toBeInTheDocument();
+    it("should show the notification if the last acknowledged version is null", async () => {
+      setup({ currentVersionTag: "v0.48.0", lastAcknowledged: null });
+      expect(await getNotificationLink()).toBeInTheDocument();
     });
 
-    it("should not show the notification is whitelabeling is being used", () => {
-      setup({ currentVersion: "v0.48.0", isWhiteLabeling: true });
-      expect(notification()).not.toBeInTheDocument();
+    it("should not show the notification if whitelabeling is being used", async () => {
+      setup({ currentVersionTag: "v0.48.0", isWhiteLabeling: true });
+      // Wait briefly to ensure it doesn't appear after potential fetch
+      await waitFor(() => {
+        expect(queryNotificationLink()).not.toBeInTheDocument();
+      });
     });
 
-    it("should show the notification for a version in the range (last acknowledged, currentVresion]", () => {
-      setup({ currentVersion: "v0.48.2", lastAcknowledged: "v0.47.1" });
-      expect(notification()).toBeInTheDocument();
+    it("should not show the notification if embedding", async () => {
+      setup({ currentVersionTag: "v0.48.0", isEmbedded: true });
+      await waitFor(() => {
+        expect(queryNotificationLink()).not.toBeInTheDocument();
+      });
     });
 
-    it("should show the notification if the last acknowledged version is the previous major", () => {
-      setup({ currentVersion: "v0.48.0", lastAcknowledged: "v0.47.0" });
-      expect(notification()).toBeInTheDocument();
+    it("should show the notification for a version in the range (last acknowledged, currentVersion]", async () => {
+      setup({ currentVersionTag: "v0.48.2", lastAcknowledged: "v0.47.1" });
+      expect(await getNotificationLink()).toBeInTheDocument();
+    });
+
+    it("should show the notification if the last acknowledged version is the previous major", async () => {
+      setup({ currentVersionTag: "v0.48.0", lastAcknowledged: "v0.47.0" });
+      expect(await getNotificationLink()).toBeInTheDocument();
+    });
+
+    it("should not show the notification if the latest version is not newer than acknowledged", async () => {
+      setup({ currentVersionTag: "v0.48.2", lastAcknowledged: "v0.48.2" });
+      await waitFor(() => {
+        expect(queryNotificationLink()).not.toBeInTheDocument();
+      });
+    });
+
+    it("should not show the notification if the latest version is not newer than current (and nothing acknowledged)", async () => {
+      setup({
+        currentVersionTag: "v0.48.2",
+        lastAcknowledged: null,
+        versions: [mockVersion({ version: "v0.48.2" })], // Latest is same as current
+      });
+      await waitFor(() => {
+        expect(queryNotificationLink()).not.toBeInTheDocument();
+      });
     });
   });
 
   describe("link behaviour", () => {
-    it("should have target blank", () => {
+    it("should have target blank", async () => {
       setup({});
-      expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+      expect(await getNotificationLink()).toHaveAttribute("target", "_blank");
     });
 
     it("should call the backend when clicking dismiss", async () => {
-      fetchMock.put(LAST_ACK_SETTINGS_URL, {});
-      setup({});
+      // fetchMock is used here to intercept the PUT request made by the updateSetting thunk
+      fetchMock.putOnce(LAST_ACK_SETTINGS_URL, { status: 200, body: {} });
+      const currentVersionTag = "v0.48.0";
+      setup({ currentVersionTag });
 
-      screen.getByRole("button").click();
+      // Find the dismiss button (ensure it has an accessible name, e.g., aria-label="Dismiss")
+      const dismissButton = await screen.findByRole("button", {
+        name: /close/i,
+      }); // Use the icon name if no specific label
+      dismissButton.click();
 
       await waitFor(() => {
-        expect(
-          fetchMock.called(LAST_ACK_SETTINGS_URL, { method: "PUT" }),
-        ).toBeTruthy();
+        expect(fetchMock.called(LAST_ACK_SETTINGS_URL)).toBe(true);
       });
+
+      await waitFor(() => {
+        const fetchOptions = fetchMock.lastOptions(LAST_ACK_SETTINGS_URL);
+        expect(fetchOptions?.method).toBe("PUT");
+      });
+
+      await waitFor(async () => {
+        const fetchOptions = fetchMock.lastOptions(LAST_ACK_SETTINGS_URL);
+        expect(
+          JSON.parse(await (fetchOptions?.body as Promise<string>)),
+        ).toEqual({ value: currentVersionTag });
+      });
+
+      // Clean up fetchMock after the test
+      fetchMock.reset();
     });
 
-    it("should link the most recent release if two versions have the release notes", () => {
+    it("should link the most recent eligible release notes", async () => {
+      const expectedUrl = "https://metabase.com/releases/48";
       setup({
-        currentVersion: "v0.48.0",
+        currentVersionTag: "v0.48.0",
         lastAcknowledged: "v0.46.0",
         versions: [
           mockVersion({
-            version: "v0.48.0",
-            announcement_url: "https://metabase.com/releases/48",
+            version: "v0.48.0", // Eligible
+            announcement_url: expectedUrl,
           }),
           mockVersion({
-            version: "v0.47.0",
+            version: "v0.47.0", // Also eligible, but older
             announcement_url: "https://metabase.com/releases/47",
+          }),
+          mockVersion({
+            version: "v0.46.0", // Not eligible (same as acknowledged)
+            announcement_url: "https://metabase.com/releases/46",
           }),
         ],
       });
 
-      expect(screen.getByRole("link")).toHaveAttribute(
-        "href",
-        "https://metabase.com/releases/48",
-      );
+      expect(await getNotificationLink()).toHaveAttribute("href", expectedUrl);
     });
   });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/tests/setup.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/tests/setup.tsx
@@ -10,6 +10,7 @@ import {
   setupCollectionsEndpoints,
   setupDatabasesEndpoints,
   setupSearchEndpoints,
+  setupSettingEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
@@ -132,6 +133,12 @@ export async function setup({
     collection: createMockCollection(OUR_ANALYTICS),
     collectionItems: [],
   });
+
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: {},
+  });
+
   fetchMock.get("path:/api/bookmark", []);
 
   if (openQuestionCard) {

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -8,6 +8,7 @@ import {
   setupDatabasesEndpoints,
   setupGdriveGetFolderEndpoint,
   setupSearchEndpoints,
+  setupSettingEndpoint,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -61,6 +62,11 @@ async function setup({
   });
   setupGdriveGetFolderEndpoint({ status: "active" });
   fetchMock.get("path:/api/bookmark", []);
+
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: {},
+  });
 
   const storeInitialState = createMockState({
     app: createMockAppState({

--- a/frontend/test/__support__/server-mocks/settings.ts
+++ b/frontend/test/__support__/server-mocks/settings.ts
@@ -1,9 +1,26 @@
 import fetchMock from "fetch-mock";
 
-import type { SettingDefinition } from "metabase-types/api";
+import type {
+  EnterpriseSettingKey,
+  EnterpriseSettingValue,
+  SettingDefinition,
+} from "metabase-types/api";
 
 export function setupSettingsEndpoints(settings: SettingDefinition[]) {
   fetchMock.get("path:/api/setting", settings);
+}
+
+export function setupSettingEndpoint<K extends EnterpriseSettingKey>({
+  settingKey,
+  settingValue,
+}: {
+  settingKey: K;
+  settingValue: EnterpriseSettingValue<K>;
+}) {
+  if (settingValue === null || settingValue === undefined) {
+    throw new Error("settingValue must be non-null and non-undefined");
+  }
+  fetchMock.get("path:/api/setting/" + settingKey, settingValue);
 }
 
 export function setupUpdateSettingEndpoint(

--- a/src/metabase/settings/deprecated_grab_bag.clj
+++ b/src/metabase/settings/deprecated_grab_bag.clj
@@ -140,7 +140,8 @@
   :getter     (fn []
                 (let [raw-vi (setting/get-value-of-type :json :version-info)
                       current-major (config/current-major-version)]
-                  (version-info* raw-vi {:current-major current-major :upgrade-threshold-value (upgrade-threshold)}))))
+                  (version-info* raw-vi {:current-major current-major :upgrade-threshold-value (upgrade-threshold)})))
+  :include-in-list? false)
 
 (defsetting version-info-last-checked
   (deferred-tru "Indicates when Metabase last checked for new versions.")

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -235,7 +235,7 @@
    [:audit [:maybe [:enum :never :no-value :raw-value :getter]]]])
 
 (defonce ^{:doc "Map of loaded defsettings"}
-  registered-settings
+ registered-settings
   (atom {}))
 
 (defprotocol ^:private Resolvable
@@ -966,6 +966,7 @@
                  :deprecated     nil
                  :enabled?       nil
                  :can-read-from-env?       true
+                 :include-in-list?         true
                  ;; Disable auditing by default for user- or database-local settings
                  :audit          (if (site-wide-only? setting) :no-value :never)}
                 (dissoc setting :name :type :default)))
@@ -1220,6 +1221,12 @@
   (default: `:no-value` for most settings; `:never` for user- and database-local settings, settings with no setter,
   and `:sensitive` settings.)
 
+  ###### `include-in-list?`
+
+  Boolean that determines if this setting is included in the list of all settings when settings are listed through
+  either the `GET /api/session/properties` or `GET /api/setting` endpoints. `true` by default but should be set to
+  false for settings with very large sizes or that are only used in specific places.
+
   ###### `base`
 
   A map which can provide values for any of the above options, except for :export?.
@@ -1385,7 +1392,8 @@
       (user-facing-settings-matching
        (fn [setting]
          (and (contains? writable-visibilities (:visibility setting))
-              (not= (:database-local setting) :only)))
+              (not= (:database-local setting) :only)
+              (:include-in-list? setting)))
        options))))
 
 (defn admin-writable-site-wide-settings
@@ -1431,7 +1439,8 @@
      {}
      (comp (filter (fn [[_setting-name setting]]
                      (and (not (database-local-only? setting))
-                          (can-read-setting? setting visibilities))))
+                          (can-read-setting? setting visibilities)
+                          (:include-in-list? setting))))
            (map (fn [[setting-name]]
                   [setting-name (get setting-name)])))
      @registered-settings)))

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -235,7 +235,7 @@
    [:audit [:maybe [:enum :never :no-value :raw-value :getter]]]])
 
 (defonce ^{:doc "Map of loaded defsettings"}
- registered-settings
+  registered-settings
   (atom {}))
 
 (defprotocol ^:private Resolvable

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -523,6 +523,14 @@
              (-> (mt/client :get 200 "session/properties" (mt/user->credentials :rasta))
                  keys #{:premium-embedding-token}))))))
 
+(deftest properties-skip-include-in-list?=false
+  (reset-throttlers!)
+  (testing "GET /session/properties"
+    (testing "don't return the version-info property"
+      (is (= nil
+             (-> (mt/client :get 200 "session/properties" (mt/user->credentials :crowberto))
+                 keys #{:version-info}))))))
+
 ;;; ------------------------------------------- TESTS FOR GOOGLE SIGN-IN ---------------------------------------------
 
 (deftest google-auth-test

--- a/test/metabase/settings/api_test.clj
+++ b/test/metabase/settings/api_test.clj
@@ -88,6 +88,10 @@
                :default        "[Default Value]"}]
              (fetch-test-settings [:test-setting-1 :test-setting-2 :test-setting-3]))))
 
+    (testing "Check that fetching Settings does not return settings marked as :include-in-list?=false"
+      (is (empty?
+           (fetch-test-settings [:test-setting-that-is-not-included-when-listing-in-api]))))
+
     (testing "Check that non-admin setting managers can fetch Settings with `:visibility :settings-manager`"
       (test-settings-manager-visibility! nil)
       (with-mocked-settings-manager-access!

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -132,6 +132,11 @@
   :encryption :no
   :default "the default value")
 
+(defsetting test-setting-that-is-not-included-when-listing-in-api
+  "Setting to test that a setting can marked as excluded from API list operations"
+  :encryption :no
+  :include-in-list? false)
+
 ;; ## HELPER FUNCTIONS
 
 (defn db-fetch-setting
@@ -1617,3 +1622,21 @@
   (testing "You can set them normally though"
     (test-setting-that-doesnt-allow-env! "this works")
     (is (= "this works" (test-setting-that-doesnt-allow-env)))))
+
+(deftest hide-settings-from-list-test
+  ;; we'll use `::not-present` below to signify that the Setting isn't returned AT ALL (as opposed to being returned
+  ;; with a `nil` value)
+  (mt/with-test-user :crowberto
+    (doseq [[fn-name f] {`setting/writable-settings
+                         (fn [k]
+                           (let [m (into {} (map (juxt :key :value)) (setting/writable-settings))]
+                             (get m k ::not-present)))
+
+                         `setting/user-readable-values-map
+                         (fn [k]
+                           (get (setting/user-readable-values-map #{:authenticated}) k ::not-present))}]
+      (testing fn-name
+        (testing "should not return settings that are excluded from being listed"
+          (mt/with-temporary-setting-values [test-setting-that-is-not-included-when-listing-in-api "fun-times"]
+            (is (= ::not-present
+                   (f :test-setting-that-is-not-included-when-listing-in-api)))))))))


### PR DESCRIPTION
### Description

Adds a new option to `defsetting`, `:include-in-list?` that prevents a setting from being serialized in the API 'list' responses for settings `api/session/properties` and `api/setting`. This allows us to exclude settings that are large, like `version-info` (~170kb) from the API response. This then fixes the front-end to be able to get version-info from the `api/setting/:key-name` request. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
