### PR TITLE
Fix druid jdbc parameterized query with date type

### DIFF
--- a/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
+++ b/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
@@ -21,7 +21,7 @@
    [metabase.util.log :as log])
   (:import
    (java.sql ResultSet Types)
-   (java.time LocalDateTime ZonedDateTime)))
+   (java.time LocalDateTime ZonedDateTime LocalDate)))
 
 (set! *warn-on-reflection* true)
 
@@ -134,6 +134,16 @@
 (defmethod sql.qp/inline-value [:druid-jdbc LocalDateTime]
   [_driver t]
   (format "'%s'" (format-datetime t)))
+
+(defn- format-date [d] (t/format "yyyy-MM-dd" d))
+
+(defmethod sql-jdbc.execute/set-parameter [:druid-jdbc LocalDate]
+  [driver ps i d]
+  (sql-jdbc.execute/set-parameter driver ps i (format-date d)))
+
+(defmethod sql.qp/inline-value [:druid-jdbc LocalDate]
+  [_driver d]
+  (format "'%s'" (format-date d)))
 
 (defmethod sql.qp/json-query :druid-jdbc
   [_driver unwrapped-identifier nfc-field]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45616

### Description

We were using the sql jdbc implementation which passed a `LocalDate` which the druid driver didn't like. Instead use a druid jdbc implementation to pass a string which the druid driver can handle.

### How to verify

1. Create a native sql question with a variable parameter comparison to a timestamp column.
2. Set the variable type to Date
3. Enter a date value and run the query
4. It should work as expected

### Demo

<details>

<summary>demo</summary>

https://github.com/user-attachments/assets/0f935b69-38e3-4981-8c21-8b86d7c5d94d

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
