### PR TITLE
Experiment to remove preconditions on migrations

### DIFF
--- a/resources/migrations/000_legacy_migrations.yaml
+++ b/resources/migrations/000_legacy_migrations.yaml
@@ -1,12066 +1,8091 @@
-# *** IMPORTANT: new migrations should be placed in 001_update_migrations.yml ***
-#
-# This file contains the legacy migrations that used to bootstrap metabase, now this file should be
-# replaced with the SQL file in resources/initialization.
-# In order to keep instances running metabase < 45 able to upgrade to the latest, we need to keep this file here.
-
 databaseChangeLog:
-  - property:
-      name: timestamp_type
-      value: timestamp with time zone
-      dbms: postgresql,h2
-  - property:
-      name: timestamp_type
-      value: timestamp(6)
-      dbms: mysql,mariadb
-  - property:
-      name: blob.type
-      value: blob
-      dbms: mysql,h2,mariadb
-  - property:
-      name: blob.type
-      value: bytea
-      dbms: postgresql
-  # In MySQL, use LONGTEXT instead of TEXT (#7006)
-  - property:
-      name: text.type
-      value: text
-      dbms: postgresql,h2
-  - property:
-      name: text.type
-      value: longtext
-      dbms: mysql,mariadb
-  # databasechangelog is uppercase in MySQL and H2 but lower-case in Postgres for reasons
-  - property:
-      name: databasechangelog.name
-      value: DATABASECHANGELOG
-      dbms: h2,mysql,mariadb
-  - property:
-      name: databasechangelog.name
-      value: databasechangelog
-      dbms: postgresql
-
-  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
-
-  - changeSet:
-      id: '1'
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-                unique: true
-              name: slug
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              name: description
-              type: text
-          - column:
-              name: logo_url
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: inherits
-              type: boolean
-          tableName: core_organization
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-                unique: true
-              name: email
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: first_name
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: last_name
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: password
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              defaultValue: default
-              name: password_salt
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: date_joined
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: true
-              name: last_login
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: is_staff
-              type: boolean
-          - column:
-              constraints:
-                nullable: false
-              name: is_superuser
-              type: boolean
-          - column:
-              constraints:
-                nullable: false
-              name: is_active
-              type: boolean
-          - column:
-              name: reset_token
-              type: varchar(254)
-          - column:
-              name: reset_triggered
-              type: BIGINT
-          tableName: core_user
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: admin
-              type: boolean
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_userorgperm_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: user_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_userorgperm_ref_organization_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_organization
-                referencedColumnNames: id
-              name: organization_id
-              type: int
-          tableName: core_userorgperm
-      - addUniqueConstraint:
-          columnNames: user_id, organization_id
-          constraintName: idx_unique_user_id_organization_id
-          tableName: core_userorgperm
-      - createIndex:
-          columns:
-          - column:
-              name: user_id
-              type: int
-          indexName: idx_userorgperm_user_id
-          tableName: core_userorgperm
-      - createIndex:
-          columns:
-          - column:
-              name: organization_id
-              type: int
-          indexName: idx_userorgperm_organization_id
-          tableName: core_userorgperm
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: url
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: timestamp
-              type: DATETIME
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_permissionviolation_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: user_id
-              type: int
-          tableName: core_permissionsviolation
-      - createIndex:
-          columns:
-          - column:
-              name: user_id
-              type: int
-          indexName: idx_permissionsviolation_user_id
-          tableName: core_permissionsviolation
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              name: description
-              type: text
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_database_ref_organization_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_organization
-                referencedColumnNames: id
-              name: organization_id
-              type: int
-          - column:
-              name: details
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: engine
-              type: varchar(254)
-          tableName: metabase_database
-      - createIndex:
-          columns:
-          - column:
-              name: organization_id
-          indexName: idx_database_organization_id
-          tableName: metabase_database
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              name: rows
-              type: int
-          - column:
-              name: description
-              type: text
-          - column:
-              name: entity_name
-              type: varchar(254)
-          - column:
-              name: entity_type
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: active
-              type: boolean
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_table_ref_database_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: metabase_database
-                referencedColumnNames: id
-              name: db_id
-              type: int
-          tableName: metabase_table
-      - createIndex:
-          columns:
-          - column:
-              name: db_id
-          indexName: idx_table_db_id
-          tableName: metabase_table
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: base_type
-              type: varchar(255)
-          - column:
-              name: special_type
-              type: varchar(255)
-          - column:
-              constraints:
-                nullable: false
-              name: active
-              type: boolean
-          - column:
-              name: description
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: preview_display
-              type: boolean
-          - column:
-              constraints:
-                nullable: false
-              name: position
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_field_ref_table_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: metabase_table
-                referencedColumnNames: id
-              name: table_id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: field_type
-              type: varchar(254)
-          tableName: metabase_field
-      - createIndex:
-          columns:
-          - column:
-              name: table_id
-          indexName: idx_field_table_id
-          tableName: metabase_field
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: relationship
-              type: varchar(254)
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_foreignkey_dest_ref_field_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: metabase_field
-                referencedColumnNames: id
-              name: destination_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_foreignkey_origin_ref_field_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: metabase_field
-                referencedColumnNames: id
-              name: origin_id
-              type: int
-          tableName: metabase_foreignkey
-      - createIndex:
-          columns:
-          - column:
-              name: destination_id
-          indexName: idx_foreignkey_destination_id
-          tableName: metabase_foreignkey
-      - createIndex:
-          columns:
-          - column:
-              name: origin_id
-          indexName: idx_foreignkey_origin_id
-          tableName: metabase_foreignkey
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              name: values
-              type: text
-          - column:
-              name: human_readable_values
-              type: text
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_fieldvalues_ref_field_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: metabase_field
-                referencedColumnNames: id
-              name: field_id
-              type: int
-          tableName: metabase_fieldvalues
-      - createIndex:
-          columns:
-          - column:
-              name: field_id
-          indexName: idx_fieldvalues_field_id
-          tableName: metabase_fieldvalues
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_tablesegment_ref_table_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: metabase_table
-                referencedColumnNames: id
-              name: table_id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: filter_clause
-              type: text
-          tableName: metabase_tablesegment
-      - createIndex:
-          columns:
-          - column:
-              name: table_id
-          indexName: idx_tablesegment_table_id
-          tableName: metabase_tablesegment
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: type
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: details
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: version
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: public_perms
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_query_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: creator_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_query_ref_database_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: metabase_database
-                referencedColumnNames: id
-              name: database_id
-              type: int
-          tableName: query_query
-      - createIndex:
-          columns:
-          - column:
-              name: creator_id
-          indexName: idx_query_creator_id
-          tableName: query_query
-      - createIndex:
-          columns:
-          - column:
-              name: database_id
-          indexName: idx_query_database_id
-          tableName: query_query
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-                unique: true
-              name: uuid
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: version
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: json_query
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: raw_query
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: status
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: started_at
-              type: DATETIME
-          - column:
-              name: finished_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: running_time
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: error
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: result_file
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: result_rows
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: result_data
-              type: text
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_queryexecution_ref_query_id
-                initiallyDeferred: false
-                nullable: true
-                referencedTableName: query_query
-                referencedColumnNames: id
-              name: query_id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: additional_info
-              type: text
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_queryexecution_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: executor_id
-              type: int
-          tableName: query_queryexecution
-      - createIndex:
-          columns:
-          - column:
-              name: query_id
-          indexName: idx_queryexecution_query_id
-          tableName: query_queryexecution
-      - createIndex:
-          columns:
-          - column:
-              name: executor_id
-          indexName: idx_queryexecution_executor_id
-          tableName: query_queryexecution
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              name: description
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: display
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: public_perms
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: dataset_query
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: visualization_settings
-              type: text
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_card_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: creator_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_card_ref_organization_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_organization
-                referencedColumnNames: id
-              name: organization_id
-              type: int
-          tableName: report_card
-      - createIndex:
-          columns:
-          - column:
-              name: creator_id
-          indexName: idx_card_creator_id
-          tableName: report_card
-      - createIndex:
-          columns:
-          - column:
-              name: organization_id
-          indexName: idx_card_organization_id
-          tableName: report_card
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_cardfavorite_ref_card_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: report_card
-                referencedColumnNames: id
-              name: card_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_cardfavorite_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: owner_id
-              type: int
-          tableName: report_cardfavorite
-      - addUniqueConstraint:
-          columnNames: card_id, owner_id
-          constraintName: idx_unique_cardfavorite_card_id_owner_id
-          tableName: report_cardfavorite
-      - createIndex:
-          columns:
-          - column:
-              name: card_id
-          indexName: idx_cardfavorite_card_id
-          tableName: report_cardfavorite
-      - createIndex:
-          columns:
-          - column:
-              name: owner_id
-          indexName: idx_cardfavorite_owner_id
-          tableName: report_cardfavorite
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              name: description
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: public_perms
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_dashboard_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: creator_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_dashboard_ref_organization_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_organization
-                referencedColumnNames: id
-              name: organization_id
-              type: int
-          tableName: report_dashboard
-      - createIndex:
-          columns:
-          - column:
-              name: creator_id
-          indexName: idx_dashboard_creator_id
-          tableName: report_dashboard
-      - createIndex:
-          columns:
-          - column:
-              name: organization_id
-          indexName: idx_dashboard_organization_id
-          tableName: report_dashboard
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: sizeX
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: sizeY
-              type: int
-          - column:
-              name: row
-              type: int
-          - column:
-              name: col
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_dashboardcard_ref_card_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: report_card
-                referencedColumnNames: id
-              name: card_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_dashboardcard_ref_dashboard_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: report_dashboard
-                referencedColumnNames: id
-              name: dashboard_id
-              type: int
-          tableName: report_dashboardcard
-      - createIndex:
-          columns:
-          - column:
-              name: card_id
-          indexName: idx_dashboardcard_card_id
-          tableName: report_dashboardcard
-      - createIndex:
-          columns:
-          - column:
-              name: dashboard_id
-          indexName: idx_dashboardcard_dashboard_id
-          tableName: report_dashboardcard
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_dashboardsubscription_ref_dashboard_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: report_dashboard
-                referencedColumnNames: id
-              name: dashboard_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_dashboardsubscription_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: user_id
-              type: int
-          tableName: report_dashboardsubscription
-      - addUniqueConstraint:
-          columnNames: dashboard_id, user_id
-          constraintName: idx_uniq_dashsubscrip_dashboard_id_user_id
-          tableName: report_dashboardsubscription
-      - createIndex:
-          columns:
-          - column:
-              name: dashboard_id
-          indexName: idx_dashboardsubscription_dashboard_id
-          tableName: report_dashboardsubscription
-      - createIndex:
-          columns:
-          - column:
-              name: user_id
-          indexName: idx_dashboardsubscription_user_id
-          tableName: report_dashboardsubscription
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: name
-              type: varchar(254)
-          - column:
-              name: description
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: public_perms
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: mode
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: version
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: dataset_query
-              type: text
-          - column:
-              name: email_addresses
-              type: text
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_emailreport_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: creator_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_emailreport_ref_organization_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_organization
-                referencedColumnNames: id
-              name: organization_id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: schedule
-              type: text
-          tableName: report_emailreport
-      - createIndex:
-          columns:
-          - column:
-              name: creator_id
-          indexName: idx_emailreport_creator_id
-          tableName: report_emailreport
-      - createIndex:
-          columns:
-          - column:
-              name: organization_id
-          indexName: idx_emailreport_organization_id
-          tableName: report_emailreport
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_emailreport_recipients_ref_emailreport_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: report_emailreport
-                referencedColumnNames: id
-              name: emailreport_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_emailreport_recipients_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: user_id
-              type: int
-          tableName: report_emailreport_recipients
-      - addUniqueConstraint:
-          columnNames: emailreport_id, user_id
-          constraintName: idx_uniq_emailreportrecip_emailreport_id_user_id
-          tableName: report_emailreport_recipients
-      - createIndex:
-          columns:
-          - column:
-              name: emailreport_id
-          indexName: idx_emailreport_recipients_emailreport_id
-          tableName: report_emailreport_recipients
-      - createIndex:
-          columns:
-          - column:
-              name: user_id
-          indexName: idx_emailreport_recipients_user_id
-          tableName: report_emailreport_recipients
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: details
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: status
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              name: started_at
-              type: DATETIME
-          - column:
-              name: finished_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: error
-              type: text
-          - column:
-              constraints:
-                nullable: false
-              name: sent_email
-              type: text
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_emailreportexecutions_ref_organization_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_organization
-                referencedColumnNames: id
-              name: organization_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_emailreportexecutions_ref_report_id
-                initiallyDeferred: false
-                nullable: true
-                referencedTableName: report_emailreport
-                referencedColumnNames: id
-              name: report_id
-              type: int
-          tableName: report_emailreportexecutions
-      - createIndex:
-          columns:
-          - column:
-              name: organization_id
-          indexName: idx_emailreportexecutions_organization_id
-          tableName: report_emailreportexecutions
-      - createIndex:
-          columns:
-          - column:
-              name: report_id
-          indexName: idx_emailreportexecutions_report_id
-          tableName: report_emailreportexecutions
-      - createTable:
-          columns:
-          - column:
-              autoIncrement: true
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: updated_at
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: start
-              type: DATETIME
-          - column:
-              constraints:
-                nullable: false
-              name: end
-              type: DATETIME
-          - column:
-              name: title
-              type: TEXT
-          - column:
-              constraints:
-                nullable: false
-              name: body
-              type: TEXT
-          - column:
-              constraints:
-                nullable: false
-              name: annotation_type
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: edit_count
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: object_type_id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: object_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_annotation_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: author_id
-              type: int
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_annotation_ref_organization_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_organization
-                referencedColumnNames: id
-              name: organization_id
-              type: int
-          tableName: annotation_annotation
-      - createIndex:
-          columns:
-          - column:
-              name: author_id
-          indexName: idx_annotation_author_id
-          tableName: annotation_annotation
-      - createIndex:
-          columns:
-          - column:
-              name: organization_id
-          indexName: idx_annotation_organization_id
-          tableName: annotation_annotation
-      - createIndex:
-          columns:
-          - column:
-              name: object_type_id
-          indexName: idx_annotation_object_type_id
-          tableName: annotation_annotation
-      - createIndex:
-          columns:
-          - column:
-              name: object_id
-          indexName: idx_annotation_object_id
-          tableName: annotation_annotation
-      - modifySql:
-          dbms: postgresql
-          replace:
-            replace: WITHOUT
-            with: WITH
-  - changeSet:
-      id: '2'
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-      - createTable:
-          columns:
-          - column:
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: id
-              type: varchar(254)
-          - column:
-              constraints:
-                deferrable: false
-                foreignKeyName: fk_session_ref_user_id
-                initiallyDeferred: false
-                nullable: false
-                referencedTableName: core_user
-                referencedColumnNames: id
-              name: user_id
-              type: int
-          - column:
-              constraints:
-                nullable: false
-              name: created_at
-              type: DATETIME
-          tableName: core_session
-      - modifySql:
-          dbms: postgresql
-          replace:
-            replace: WITHOUT
-            with: WITH
-  - changeSet:
-      id: '4'
-      author: cammsaul
-      changes:
-      - createTable:
-          columns:
-          - column:
-              constraints:
-                nullable: false
-                primaryKey: true
-              name: key
-              type: varchar(254)
-          - column:
-              constraints:
-                nullable: false
-              name: value
-              type: varchar(254)
-          tableName: setting
-  - changeSet:
-      id: '5'
-      author: agilliland
-      changes:
-      - addColumn:
-          columns:
-          - column:
-              name: report_timezone
-              type: varchar(254)
-          tableName: core_organization
-  - changeSet:
-      id: '6'
-      author: agilliland
-      changes:
-      - dropNotNullConstraint:
-          columnDataType: int
-          columnName: organization_id
-          tableName: metabase_database
-      - dropForeignKeyConstraint:
-          baseTableName: metabase_database
-          constraintName: fk_database_ref_organization_id
-      - dropNotNullConstraint:
-          columnDataType: int
-          columnName: organization_id
-          tableName: report_card
-      - dropForeignKeyConstraint:
-          baseTableName: report_card
-          constraintName: fk_card_ref_organization_id
-      - dropNotNullConstraint:
-          columnDataType: int
-          columnName: organization_id
-          tableName: report_dashboard
-      - dropForeignKeyConstraint:
-          baseTableName: report_dashboard
-          constraintName: fk_dashboard_ref_organization_id
-      - dropNotNullConstraint:
-          columnDataType: int
-          columnName: organization_id
-          tableName: report_emailreport
-      - dropForeignKeyConstraint:
-          baseTableName: report_emailreport
-          constraintName: fk_emailreport_ref_organization_id
-      - dropNotNullConstraint:
-          columnDataType: int
-          columnName: organization_id
-          tableName: report_emailreportexecutions
-      - dropForeignKeyConstraint:
-          baseTableName: report_emailreportexecutions
-          constraintName: fk_emailreportexecutions_ref_organization_id
-      - dropNotNullConstraint:
-          columnDataType: int
-          columnName: organization_id
-          tableName: annotation_annotation
-      - dropForeignKeyConstraint:
-          baseTableName: annotation_annotation
-          constraintName: fk_annotation_ref_organization_id
-  - changeSet:
-      id: '7'
-      author: cammsaul
-      validCheckSum: ANY
-      changes:
-      - addColumn:
-          columns:
-          - column:
-              constraints:
-                foreignKeyName: fk_field_parent_ref_field_id
-                nullable: true
-                referencedTableName: metabase_field
-                referencedColumnNames: id
-              name: parent_id
-              type: int
-          tableName: metabase_field
-  - changeSet:
-      id: '8'
-      author: tlrobinson
-      changes:
-      - addColumn:
-          columns:
-          - column:
-              name: display_name
-              type: varchar(254)
-          tableName: metabase_table
-      - addColumn:
-          columns:
-          - column:
-              name: display_name
-              type: varchar(254)
-          tableName: metabase_field
-  - changeSet:
-      id: '9'
-      author: tlrobinson
-      changes:
-      - addColumn:
-          columns:
-          - column:
-              name: visibility_type
-              type: varchar(254)
-          tableName: metabase_table
-  - changeSet:
-      id: 10
-      author: cammsaul
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: revision
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: model
-                  type: varchar(16)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: model_id
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_revision_ref_user_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: timestamp
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: object
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: is_reversion
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: revision
-            indexName: idx_revision_model_model_id
-            columns:
-              - column:
-                  name: model
-              - column:
-                  name: model_id
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-        - modifySql:
-            dbms: mysql,mariadb
-            replace:
-              replace: object VARCHAR
-              with: object TEXT
-  - changeSet:
-      id: 11
-      author: agilliland
-      changes:
-        - sql:
-            sql: update report_dashboard set public_perms = 2 where public_perms = 1
-  - changeSet:
-      id: 12
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: database_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: metabase_database
-                    referencedColumnNames: id
-                    foreignKeyName: fk_report_card_ref_database_id
-                    deferrable: false
-                    initiallyDeferred: false
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: table_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: metabase_table
-                    referencedColumnNames: id
-                    foreignKeyName: fk_report_card_ref_table_id
-                    deferrable: false
-                    initiallyDeferred: false
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: query_type
-                  type: varchar(16)
-                  constraints:
-                    nullable: true
-  - changeSet:
-      id: 13
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: activity
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: topic
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: timestamp
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_activity_ref_user_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: model
-                  type: varchar(16)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: model_id
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: database_id
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: table_id
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: custom_id
-                  type: varchar(48)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: details
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: activity
-            indexName: idx_activity_timestamp
-            columns:
-              column:
-                name: timestamp
-        - createIndex:
-            tableName: activity
-            indexName: idx_activity_user_id
-            columns:
-              column:
-                name: user_id
-        - createIndex:
-            tableName: activity
-            indexName: idx_activity_custom_id
-            columns:
-              column:
-                name: custom_id
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-        - modifySql:
-            dbms: mysql,mariadb
-            replace:
-              replace: details VARCHAR
-              with: details TEXT
-  - changeSet:
-      id: 14
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: view_log
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_view_log_ref_user_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: model
-                  type: varchar(16)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: model_id
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: timestamp
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: view_log
-            indexName: idx_view_log_user_id
-            columns:
-              column:
-                name: user_id
-        - createIndex:
-            tableName: view_log
-            indexName: idx_view_log_timestamp
-            columns:
-              column:
-                name: model_id
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 15
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: revision
-            columns:
-              - column:
-                  name: is_creation
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 16
-      author: agilliland
-      changes:
-        - dropNotNullConstraint:
-            tableName: core_user
-            columnName: last_login
-            columnDataType: DATETIME
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 17
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: is_sample
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - sql:
-            sql: update metabase_database set is_sample = true where name = 'Sample Dataset'
-  - changeSet:
-      id: 18
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: data_migrations
-            columns:
-              - column:
-                  name: id
-                  type: VARCHAR(254)
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: timestamp
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: data_migrations
-            indexName: idx_data_migrations_id
-            columns:
-              column:
-                name: id
-  - changeSet:
-      id: 19
-      author: camsaul
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: schema
-                  type: VARCHAR(256)
-  - changeSet:
-      id: 20
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: pulse
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_pulse_ref_creator_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: name
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: public_perms
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: pulse
-            indexName: idx_pulse_creator_id
-            columns:
-              column:
-                name: creator_id
-        - createTable:
-            tableName: pulse_card
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: pulse_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: pulse
-                    referencedColumnNames: id
-                    foreignKeyName: fk_pulse_card_ref_pulse_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: card_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_pulse_card_ref_card_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: position
-                  type: int
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: pulse_card
-            indexName: idx_pulse_card_pulse_id
-            columns:
-              column:
-                name: pulse_id
-        - createIndex:
-            tableName: pulse_card
-            indexName: idx_pulse_card_card_id
-            columns:
-              column:
-                name: card_id
-        - createTable:
-            tableName: pulse_channel
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: pulse_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: pulse
-                    referencedColumnNames: id
-                    foreignKeyName: fk_pulse_channel_ref_pulse_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: channel_type
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: details
-                  type: text
-                  constraints:
-                    nullable: false
-              - column:
-                  name: schedule_type
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: schedule_hour
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: schedule_day
-                  type: varchar(64)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: pulse_channel
-            indexName: idx_pulse_channel_pulse_id
-            columns:
-              column:
-                name: pulse_id
-        - createIndex:
-            tableName: pulse_channel
-            indexName: idx_pulse_channel_schedule_type
-            columns:
-              column:
-                name: schedule_type
-        - createTable:
-            tableName: pulse_channel_recipient
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: pulse_channel_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: pulse_channel
-                    referencedColumnNames: id
-                    foreignKeyName: fk_pulse_channel_recipient_ref_pulse_channel_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: user_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_pulse_channel_recipient_ref_user_id
-                    deferrable: false
-                    initiallyDeferred: false
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 21
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: segment
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: table_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_table
-                    referencedColumnNames: id
-                    foreignKeyName: fk_segment_ref_table_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_segment_ref_creator_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: name
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: description
-                  type: text
-                  constraints:
-                    nullable: true
-              - column:
-                  name: is_active
-                  type: boolean
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-              - column:
-                  name: definition
-                  type: text
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: segment
-            indexName: idx_segment_creator_id
-            columns:
-              column:
-                name: creator_id
-        - createIndex:
-            tableName: segment
-            indexName: idx_segment_table_id
-            columns:
-              column:
-                name: table_id
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 22
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: revision
-            columns:
-              - column:
-                  name: message
-                  type: text
-                  constraints:
-                    nullable: true
-  - changeSet:
-      id: 23
-      author: agilliland
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: rows
-            newDataType: BIGINT
-  - changeSet:
-      id: 24
-      author: agilliland
-      changes:
-        - createTable:
-            tableName: dependency
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: model
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: model_id
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: dependent_on_model
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: dependent_on_id
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: dependency
-            indexName: idx_dependency_model
-            columns:
-              column:
-                name: model
-        - createIndex:
-            tableName: dependency
-            indexName: idx_dependency_model_id
-            columns:
-              column:
-                name: model_id
-        - createIndex:
-            tableName: dependency
-            indexName: idx_dependency_dependent_on_model
-            columns:
-              column:
-                name: dependent_on_model
-        - createIndex:
-            tableName: dependency
-            indexName: idx_dependency_dependent_on_id
-            columns:
-              column:
-                name: dependent_on_id
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 25
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: metric
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: table_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_table
-                    referencedColumnNames: id
-                    foreignKeyName: fk_metric_ref_table_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_metric_ref_creator_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: name
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: description
-                  type: text
-                  constraints:
-                    nullable: true
-              - column:
-                  name: is_active
-                  type: boolean
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-              - column:
-                  name: definition
-                  type: text
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: metric
-            indexName: idx_metric_creator_id
-            columns:
-              column:
-                name: creator_id
-        - createIndex:
-            tableName: metric
-            indexName: idx_metric_table_id
-            columns:
-              column:
-                name: table_id
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 26
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: is_full_sync
-                  type: boolean
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-        - sql:
-            sql: update metabase_database set is_full_sync = true
-  - changeSet:
-      id: 27
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: dashboardcard_series
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: dashboardcard_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_dashboardcard
-                    referencedColumnNames: id
-                    foreignKeyName: fk_dashboardcard_series_ref_dashboardcard_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: card_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_dashboardcard_series_ref_card_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: position
-                  type: int
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: dashboardcard_series
-            indexName: idx_dashboardcard_series_dashboardcard_id
-            columns:
-              column:
-                name: dashboardcard_id
-        - createIndex:
-            tableName: dashboardcard_series
-            indexName: idx_dashboardcard_series_card_id
-            columns:
-              column:
-                name: card_id
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 28
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: is_qbnewb
-                  type: boolean
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 29
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: pulse_channel
-            columns:
-              - column:
-                  name: schedule_frame
-                  type: varchar(32)
-                  constraints:
-                    nullable: true
-  - changeSet:
-      id: 30
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: visibility_type
-                  type: varchar(32)
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-        - addNotNullConstraint:
-            columnDataType: varchar(32)
-            columnName: visibility_type
-            defaultNullValue: unset
-            tableName: metabase_field
-
-  - changeSet:
-      id: 31
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: fk_target_field_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-  - changeSet:
-      id: 32
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        ######################################## label table ########################################
-        - createTable:
-            tableName: label
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: name
-                  type: VARCHAR(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: slug
-                  type: VARCHAR(254)
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: icon
-                  type: VARCHAR(128)
-        - createIndex:
-            tableName: label
-            indexName: idx_label_slug
-            columns:
-              column:
-                name: slug
-        ######################################## card_label table ########################################
-        - createTable:
-            tableName: card_label
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: card_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_card_label_ref_card_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: label_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: label
-                    referencedColumnNames: id
-                    foreignKeyName: fk_card_label_ref_label_id
-                    deferrable: false
-                    initiallyDeferred: false
-        - addUniqueConstraint:
-            tableName: card_label
-            columnNames: card_id, label_id
-            constraintName: unique_card_label_card_id_label_id
-        - createIndex:
-            tableName: card_label
-            indexName: idx_card_label_card_id
-            columns:
-              column:
-                name: card_id
-        - createIndex:
-            tableName: card_label
-            indexName: idx_card_label_label_id
-            columns:
-              column:
-                name: label_id
-        ######################################## add archived column to report_card ########################################
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: archived
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 32
-      author: agilliland
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: raw_table
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: database_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_database
-                    referencedColumnNames: id
-                    foreignKeyName: fk_rawtable_ref_database
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: active
-                  type: boolean
-                  constraints:
-                    nullable: false
-              - column:
-                  name: schema
-                  type: varchar(255)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: name
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: details
-                  type: text
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: raw_table
-            indexName: idx_rawtable_database_id
-            columns:
-              column:
-                name: database_id
-        - addUniqueConstraint:
-            tableName: raw_table
-            columnNames: database_id, schema, name
-            constraintName: uniq_raw_table_db_schema_name
-        - createTable:
-            tableName: raw_column
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: raw_table_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: raw_table
-                    referencedColumnNames: id
-                    foreignKeyName: fk_rawcolumn_tableid_ref_rawtable
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: active
-                  type: boolean
-                  constraints:
-                    nullable: false
-              - column:
-                  name: name
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: column_type
-                  type: varchar(128)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: is_pk
-                  type: boolean
-                  constraints:
-                    nullable: false
-              - column:
-                  name: fk_target_column_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: raw_column
-                    referencedColumnNames: id
-                    foreignKeyName: fk_rawcolumn_fktarget_ref_rawcolumn
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: details
-                  type: text
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: raw_column
-            indexName: idx_rawcolumn_raw_table_id
-            columns:
-              column:
-                name: raw_table_id
-        - addUniqueConstraint:
-            tableName: raw_column
-            columnNames: raw_table_id, name
-            constraintName: uniq_raw_column_table_name
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: raw_table_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: raw_column_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: last_analyzed
-                  type: DATETIME
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-        - modifySql:
-            dbms: postgresql
-            replace:
-              replace: WITHOUT
-              with: WITH
-  - changeSet:
-      id: 34
-      author: tlrobinson
-      changes:
-        ######################################## add enabled column to pulse_channel ########################################
-        - addColumn:
-            tableName: pulse_channel
-            columns:
-              - column:
-                  name: enabled
-                  type: boolean
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 35
-      author: agilliland
-      changes:
-        - modifyDataType:
-            tableName: setting
-            columnName: value
-            newDataType: TEXT
-        - addNotNullConstraint:
-            tableName: setting
-            columnDataType: text
-            columnName: value
-      validCheckSum: 8:91b72167fca724e6b6a94b64f886cf09
-  - changeSet:
-      id: 36
-      author: agilliland
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: parameters
-                  type: text
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-        - addNotNullConstraint:
-            columnDataType: text
-            columnName: parameters
-            defaultNullValue: '[]'
-            tableName: report_dashboard
-        - addColumn:
-            tableName: report_dashboardcard
-            columns:
-              - column:
-                  name: parameter_mappings
-                  type: text
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-        - addNotNullConstraint:
-            columnDataType: text
-            columnName: parameter_mappings
-            defaultNullValue: '[]'
-            tableName: report_dashboardcard
-  - changeSet:
-      id: 37
-      author: tlrobinson
-      changes:
-        - addColumn:
-            tableName: query_queryexecution
-            columns:
-              - column:
-                  name: query_hash
-                  type: int
-                  constraints:
-                    nullable: true
-        - addNotNullConstraint:
-            tableName: query_queryexecution
-            columnName: query_hash
-            columnDataType: int
-            defaultNullValue: 0
-        - createIndex:
-            tableName: query_queryexecution
-            indexName: idx_query_queryexecution_query_hash
-            columns:
-              column:
-                name: query_hash
-        - createIndex:
-            tableName: query_queryexecution
-            indexName: idx_query_queryexecution_started_at
-            columns:
-              column:
-                name: started_at
-  - changeSet:
-      id: 38
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        ######################################## Add "points_of_interest" metadata column to various models ########################################
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: points_of_interest
-                  type: text
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: points_of_interest
-                  type: text
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: points_of_interest
-                  type: text
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: points_of_interest
-                  type: text
-        - addColumn:
-            tableName: metric
-            columns:
-              - column:
-                  name: points_of_interest
-                  type: text
-        - addColumn:
-            tableName: segment
-            columns:
-              - column:
-                  name: points_of_interest
-                  type: text
-        ######################################## Add "caveats" metadata column to various models ########################################
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: caveats
-                  type: text
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: caveats
-                  type: text
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: caveats
-                  type: text
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: caveats
-                  type: text
-        - addColumn:
-            tableName: metric
-            columns:
-              - column:
-                  name: caveats
-                  type: text
-        - addColumn:
-            tableName: segment
-            columns:
-              - column:
-                  name: caveats
-                  type: text
-        ######################################## Add "how_is_this_calculated" to metric ########################################
-        - addColumn:
-            tableName: metric
-            columns:
-              - column:
-                  name: how_is_this_calculated
-                  type: text
-        ######################################## Add "most important dashboard" (0 or 1 dashboards) ########################################
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: show_in_getting_started
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: report_dashboard
-            indexName: idx_report_dashboard_show_in_getting_started
-            columns:
-              column:
-                name: show_in_getting_started
-        ######################################## Add "most important metrics" (0+ metrics) ########################################
-        - addColumn:
-            tableName: metric
-            columns:
-              - column:
-                  name: show_in_getting_started
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: metric
-            indexName: idx_metric_show_in_getting_started
-            columns:
-              column:
-                name: show_in_getting_started
-        ######################################## Add "most important tables (0+ tables) ########################################
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: show_in_getting_started
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: metabase_table
-            indexName: idx_metabase_table_show_in_getting_started
-            columns:
-              column:
-                name: show_in_getting_started
-        ######################################## Add "most important segments" (0+ segments) ########################################
-        - addColumn:
-            tableName: segment
-            columns:
-              - column:
-                  name: show_in_getting_started
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: segment
-            indexName: idx_segment_show_in_getting_started
-            columns:
-              column:
-                name: show_in_getting_started
-        ######################################## Add "metric_important_field" table ########################################
-        - createTable:
-            tableName: metric_important_field
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: metric_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metric
-                    referencedColumnNames: id
-                    foreignKeyName: fk_metric_important_field_metric_id
-              - column:
-                  name: field_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_field
-                    referencedColumnNames: id
-                    foreignKeyName: fk_metric_important_field_metabase_field_id
-        - addUniqueConstraint:
-            tableName: metric_important_field
-            columnNames: metric_id, field_id
-            constraintName: unique_metric_important_field_metric_id_field_id
-        - createIndex:
-            tableName: metric_important_field
-            indexName: idx_metric_important_field_metric_id
-            columns:
-              column:
-                name: metric_id
-        - createIndex:
-            tableName: metric_important_field
-            indexName: idx_metric_important_field_field_id
-            columns:
-              column:
-                name: field_id
-  - changeSet:
-      id: 39
-      author: camsaul
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: google_auth
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 40
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        ############################################################ add PermissionsGroup table ############################################################
-        - createTable:
-            tableName: permissions_group
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              # TODO - it would be nice to make this a case-insensitive unique constraint / index?
-              - column:
-                  name: name
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-                    unique: true
-                    uniqueConstraintName: unique_permissions_group_name
-        - createIndex:
-            tableName: permissions_group
-            indexName: idx_permissions_group_name
-            columns:
-              column:
-                name: name
-        ############################################################ add PermissionsGroupMembership table ############################################################
-        - createTable:
-            tableName: permissions_group_membership
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_permissions_group_membership_user_id
-              - column:
-                  name: group_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: permissions_group
-                    referencedColumnNames: id
-                    foreignKeyName: fk_permissions_group_group_id
-        - addUniqueConstraint:
-            tableName: permissions_group_membership
-            columnNames: user_id, group_id
-            constraintName: unique_permissions_group_membership_user_id_group_id
-        # for things like all users in a given group
-        - createIndex:
-            tableName: permissions_group_membership
-            indexName: idx_permissions_group_membership_group_id
-            columns:
-              column:
-                name: group_id
-        # for things like all groups a user belongs to
-        - createIndex:
-            tableName: permissions_group_membership
-            indexName: idx_permissions_group_membership_user_id
-            columns:
-              column:
-                name: user_id
-        # for things like is given user a member of a given group (TODO - not sure we need this)
-        - createIndex:
-            tableName: permissions_group_membership
-            indexName: idx_permissions_group_membership_group_id_user_id
-            columns:
-              - column:
-                  name: group_id
-              - column:
-                  name: user_id
-        ############################################################ add Permissions table ############################################################
-        - createTable:
-            tableName: permissions
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: object
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: group_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: permissions_group
-                    referencedColumnNames: id
-                    foreignKeyName: fk_permissions_group_id
-        - createIndex:
-            tableName: permissions
-            indexName: idx_permissions_group_id
-            columns:
-              column:
-                name: group_id
-        - createIndex:
-            tableName: permissions
-            indexName: idx_permissions_object
-            columns:
-              column:
-                name: object
-        - createIndex:
-            tableName: permissions
-            indexName: idx_permissions_group_id_object
-            columns:
-              - column:
-                  name: group_id
-              - column:
-                  name: object
-        - addUniqueConstraint:
-            tableName: permissions
-            columnNames: group_id, object
-        ############################################################ Tweaks to metabase_table ############################################################
-        # Modify the length of metabase_table.schema from 256 -> 254
-        # It turns out MySQL InnoDB indices have to be 767 bytes or less (at least for older versions of MySQL)
-        # and 'utf8' text columns can use up to 3 bytes per character in MySQL -- see http://stackoverflow.com/a/22515986/1198455
-        # So 256 * 3 = 768 bytes (too large to index / add unique constraints)
-        # Drop this to 254; 254 * 3 = 762, which should give us room to index it along with a 4-byte integer as well if need be
-        # Hoping this doesn't break anyone's existing databases. Hopefully there aren't any schemas that are 255 or 256 bytes long out there; any longer
-        # and it would have already broke; any shorter and there's not problem.
-        # Anyway, better to break it now than to leave it as-is and have and break permissions where the columns have to be 254 characters wide
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: schema
-            newDataType: varchar(254)
-        # Add index: this is for doing things like getting all the tables that belong to a given schema
-        - createIndex:
-            tableName: metabase_table
-            indexName: idx_metabase_table_db_id_schema
-            columns:
-              - column:
-                  name: db_id
-              - column:
-                  name: schema
-  - changeSet:
-      id: 41
-      author: camsaul
-      changes:
-        - dropColumn:
-            tableName: metabase_field
-            columnName: field_type
-        - addDefaultValue:
-            tableName: metabase_field
-            columnName: active
-            defaultValueBoolean: true
-        - addDefaultValue:
-            tableName: metabase_field
-            columnName: preview_display
-            defaultValueBoolean: true
-        - addDefaultValue:
-            tableName: metabase_field
-            columnName: position
-            defaultValueNumeric: 0
-        - addDefaultValue:
-            tableName: metabase_field
-            columnName: visibility_type
-            defaultValue: "normal"
-  - changeSet:
-      id: 42
-      author: camsaul
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: query_queryexecution
-            constraintName: fk_queryexecution_ref_query_id
-        - dropColumn:
-            tableName: query_queryexecution
-            columnName: query_id
-        - dropColumn:
-            tableName: core_user
-            columnName: is_staff
-        - dropColumn:
-            tableName: metabase_database
-            columnName: organization_id
-        - dropColumn:
-            tableName: report_card
-            columnName: organization_id
-        - dropColumn:
-            tableName: report_dashboard
-            columnName: organization_id
-        - dropTable:
-            tableName: annotation_annotation
-        - dropTable:
-            tableName: core_permissionsviolation
-        - dropTable:
-            tableName: core_userorgperm
-        - dropTable:
-            tableName: core_organization
-        - dropTable:
-            tableName: metabase_foreignkey
-        - dropTable:
-            tableName: metabase_tablesegment
-        - dropTable:
-            tableName: query_query
-        - dropTable:
-            tableName: report_dashboardsubscription
-        - dropTable:
-            tableName: report_emailreport_recipients
-        - dropTable:
-            tableName: report_emailreportexecutions
-        - dropTable:
-            tableName: report_emailreport
-  - changeSet:
-      id: 43
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: permissions_revision
-            remarks: 'Used to keep track of changes made to permissions.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: before
-                  type: text
-                  remarks: 'Serialized JSON of the permissions before the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: after
-                  type: text
-                  remarks: 'Serialized JSON of the permissions after the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'The ID of the admin who made this set of changes.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_permissions_revision_user_id
-              - column:
-                  name: created_at
-                  type: datetime
-                  remarks: 'The timestamp of when these changes were made.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: remark
-                  type: text
-                  remarks: 'Optional remarks explaining why these changes were made.'
-  - changeSet:
-      id: 44
-      author: camsaul
-      changes:
-        - dropColumn:
-            tableName: report_card
-            columnName: public_perms
-        - dropColumn:
-            tableName: report_dashboard
-            columnName: public_perms
-        - dropColumn:
-            tableName: pulse
-            columnName: public_perms
-  - changeSet:
-      id: 45
-      author: tlrobinson
-      changes:
-        - addColumn:
-            tableName: report_dashboardcard
-            columns:
-              - column:
-                  name: visualization_settings
-                  type: text
-        - addNotNullConstraint:
-            tableName: report_dashboardcard
-            columnName: visualization_settings
-            columnDataType: text
-            defaultNullValue: '{}'
-  - changeSet:
-      id: 46
-      author: camsaul
-      changes:
-        - addNotNullConstraint:
-            tableName: report_dashboardcard
-            columnName: row
-            columnDataType: integer
-            defaultNullValue: 0
-        - addNotNullConstraint:
-            tableName: report_dashboardcard
-            columnName: col
-            columnDataType: integer
-            defaultNullValue: 0
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: row
-            defaultValueNumeric: 0
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: col
-            defaultValueNumeric: 0
-  - changeSet:
-      id: 47
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        ######################################## collection table ########################################
-        - createTable:
-            tableName: collection
-            remarks: 'Collections are an optional way to organize Cards and handle permissions for them.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: name
-                  type: text
-                  remarks: 'The unique, user-facing name of this Collection.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: slug
-                  type: varchar(254)
-                  remarks: 'URL-friendly, sluggified, indexed version of name.'
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: description
-                  type: text
-                  remarks: 'Optional description for this Collection.'
-              - column:
-                  name: color
-                  type: char(7)
-                  remarks: 'Seven-character hex color for this Collection, including the preceding hash sign.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: archived
-                  type: boolean
-                  remarks: 'Whether this Collection has been archived and should be hidden from users.'
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: collection
-            indexName: idx_collection_slug
-            columns:
-              column:
-                name: slug
-        ######################################## add collection_id to report_card ########################################
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: 'Optional ID of Collection this Card belongs to.'
-                  constraints:
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_card_collection_id
-        - createIndex:
-            tableName: report_card
-            indexName: idx_card_collection_id
-            columns:
-              column:
-                name: collection_id
-  - changeSet:
-      id: 48
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: collection_revision
-            remarks: 'Used to keep track of changes made to collections.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: before
-                  type: text
-                  remarks: 'Serialized JSON of the collections graph before the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: after
-                  type: text
-                  remarks: 'Serialized JSON of the collections graph after the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'The ID of the admin who made this set of changes.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_collection_revision_user_id
-              - column:
-                  name: created_at
-                  type: datetime
-                  remarks: 'The timestamp of when these changes were made.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: remark
-                  type: text
-                  remarks: 'Optional remarks explaining why these changes were made.'
-  - changeSet:
-      id: 49
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        ######################################## Card public_uuid & indices ########################################
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: public_uuid
-                  type: char(36)
-                  remarks: 'Unique UUID used to in publically-accessible links to this Card.'
-                  constraints:
-                    unique: true
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: made_public_by_id
-                  type: int
-                  remarks: 'The ID of the User who first publically shared this Card.'
-                  constraints:
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_card_made_public_by_id
-        - createIndex:
-            tableName: report_card
-            indexName: idx_card_public_uuid
-            columns:
-              column:
-                name: public_uuid
-        ######################################## Dashboard public_uuid & indices ########################################
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: public_uuid
-                  type: char(36)
-                  remarks: 'Unique UUID used to in publically-accessible links to this Dashboard.'
-                  constraints:
-                    unique: true
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: made_public_by_id
-                  type: int
-                  remarks: 'The ID of the User who first publically shared this Dashboard.'
-                  constraints:
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_dashboard_made_public_by_id
-        - createIndex:
-            tableName: report_dashboard
-            indexName: idx_dashboard_public_uuid
-            columns:
-              column:
-                name: public_uuid
-        ######################################## make query_queryexecution.executor_id nullable ########################################
-        - dropNotNullConstraint:
-            tableName: query_queryexecution
-            columnName: executor_id
-            columnDataType: int
-  - changeSet:
-      id: 50
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        ######################################## new Card columns ########################################
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: enable_embedding
-                  type: boolean
-                  remarks: 'Is this Card allowed to be embedded in different websites (using a signed JWT)?'
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: embedding_params
-                  type: text
-                  remarks: 'Serialized JSON containing information about required parameters that must be supplied when embedding this Card.'
-          ######################################## new Card columns ########################################
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: enable_embedding
-                  type: boolean
-                  remarks: 'Is this Dashboard allowed to be embedded in different websites (using a signed JWT)?'
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: embedding_params
-                  type: text
-                  remarks: 'Serialized JSON containing information about required parameters that must be supplied when embedding this Dashboard.'
-  - changeSet:
-      id: 51
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: query_execution
-            remarks: 'A log of executed queries, used for calculating historic execution times, auditing, and other purposes.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: hash
-                  type: binary(32)
-                  remarks: 'The hash of the query dictionary. This is a 256-bit SHA3 hash of the query.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: started_at
-                  type: datetime
-                  remarks: 'Timestamp of when this query started running.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: running_time
-                  type: integer
-                  remarks: 'The time, in milliseconds, this query took to complete.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: result_rows
-                  type: integer
-                  remarks: 'Number of rows in the query results.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: native
-                  type: boolean
-                  remarks: 'Whether the query was a native query, as opposed to an MBQL one (e.g., created with the GUI).'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: context
-                  type: varchar(32)
-                  remarks: 'Short string specifying how this query was executed, e.g. in a Dashboard or Pulse.'
-              - column:
-                  name: error
-                  type: text
-                  remarks: 'Error message returned by failed query, if any.'
-              # The following columns are foreign keys, but we don't keep FK constraints on them for a few reasons:
-              # - We don't want to keep indexes on these columns since they wouldn't be generally useful and for size and performance reasons
-              # - If a related object (e.g. a Dashboard) is deleted, we don't want to delete the related entries in the QueryExecution log.
-              #   We could do something like make the constraint ON DELETE SET NULL, but that would require a full table scan to handle;
-              #   If the QueryExecution log became tens of millions of rows large it would take a very long time to scan and update records
-              - column:
-                  name: executor_id
-                  type: integer
-                  remarks: 'The ID of the User who triggered this query execution, if any.'
-              - column:
-                  name: card_id
-                  type: integer
-                  remarks: 'The ID of the Card (Question) associated with this query execution, if any.'
-              - column:
-                  name: dashboard_id
-                  type: integer
-                  remarks: 'The ID of the Dashboard associated with this query execution, if any.'
-              - column:
-                  name: pulse_id
-                  type: integer
-                  remarks: 'The ID of the Pulse associated with this query execution, if any.'
-        # For things like auditing recently executed queries
-        - createIndex:
-            tableName: query_execution
-            indexName: idx_query_execution_started_at
-            columns:
-              column:
-                name: started_at
-        # For things like seeing the 10 most recent executions of a certain query
-        - createIndex:
-            tableName: query_execution
-            indexName: idx_query_execution_query_hash_started_at
-            columns:
-              - column:
-                  name: hash
-              - column:
-                  name: started_at
-  - changeSet:
-      id: 52
-      author: camsaul
-      changes:
-        - createTable:
-            tableName: query_cache
-            remarks: 'Cached results of queries are stored here when using the DB-based query cache.'
-            columns:
-              - column:
-                  name: query_hash
-                  type: binary(32)
-                  remarks: 'The hash of the query dictionary. (This is a 256-bit SHA3 hash of the query dict).'
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: datetime
-                  remarks: 'The timestamp of when these query results were last refreshed.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: results
-                  type: ${blob.type}
-                  remarks: 'Cached, compressed results of running the query with the given hash.'
-                  constraints:
-                    nullable: false
-        - createIndex:
-            tableName: query_cache
-            indexName: idx_query_cache_updated_at
-            columns:
-              column:
-                name: updated_at
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: cache_ttl
-                  type: int
-                  remarks: 'The maximum time, in seconds, to return cached results for this Card rather than running a new query.'
-  - changeSet:
-      id: 53
-      author: camsaul
-      changes:
-        - createTable:
-            tableName: query
-            remarks: 'Information (such as average execution time) for different queries that have been previously ran.'
-            columns:
-              - column:
-                  name: query_hash
-                  type: binary(32)
-                  remarks: 'The hash of the query dictionary. (This is a 256-bit SHA3 hash of the query dict.)'
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: average_execution_time
-                  type: int
-                  remarks: 'Average execution time for the query, round to nearest number of milliseconds. This is updated as a rolling average.'
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 54
-      author: tlrobinson
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: skip_if_empty
-                  type: boolean
-                  remarks: 'Skip a scheduled Pulse if none of its questions have any results'
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 55
-      author: camsaul
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: archived
-                  type: boolean
-                  remarks: 'Is this Dashboard archived (effectively treated as deleted?)'
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: position
-                  type: integer
-                  remarks: 'The position this Dashboard should appear in the Dashboards list, lower-numbered positions appearing before higher numbered ones.'
-        - createTable:
-            tableName: dashboard_favorite
-            remarks: 'Presence of a row here indicates a given User has favorited a given Dashboard.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'ID of the User who favorited the Dashboard.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_dashboard_favorite_user_id
-                    deleteCascade: true
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: 'ID of the Dashboard favorited by the User.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_dashboard
-                    referencedColumnNames: id
-                    foreignKeyName: fk_dashboard_favorite_dashboard_id
-                    deleteCascade: true
-        - addUniqueConstraint:
-            tableName: dashboard_favorite
-            columnNames: user_id, dashboard_id
-            constraintName: unique_dashboard_favorite_user_id_dashboard_id
-        - createIndex:
-            tableName: dashboard_favorite
-            indexName: idx_dashboard_favorite_user_id
-            columns:
-              - column:
-                  name: user_id
-        - createIndex:
-            tableName: dashboard_favorite
-            indexName: idx_dashboard_favorite_dashboard_id
-            columns:
-              - column:
-                  name: dashboard_id
-  - changeSet:
-      id: 56
-      author: wwwiiilll
-      comment: 'Added 0.25.0'
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: ldap_auth
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 57
-      author: camsaul
-      comment: 'Added 0.25.0'
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: result_metadata
-                  type: text
-                  remarks: 'Serialized JSON containing metadata about the result columns from running the query.'
-  - changeSet:
-      id: 58
-      author: senior
-      validCheckSum: ANY
-      comment: 'Added 0.25.0'
-      changes:
-        - createTable:
-            tableName: dimension
-            remarks: 'Stores references to alternate views of existing fields, such as remapping an integer to a description, like an enum'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: field_id
-                  type: int
-                  remarks: 'ID of the field this dimension row applies to'
-                  constraints:
-                    deferrable: false
-                    foreignKeyName: fk_dimension_ref_field_id
-                    initiallyDeferred: false
-                    nullable: false
-                    referencedTableName: metabase_field
-                    referencedColumnNames: id
-                    deleteCascade: true
-              - column:
-                  name: name
-                  type: VARCHAR(254)
-                  remarks: 'Short description used as the display name of this new column'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: type
-                  type: varchar(254)
-                  remarks: 'Either internal for a user defined remapping or external for a foreign key based remapping'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: human_readable_field_id
-                  type: int
-                  remarks: 'Only used with external type remappings. Indicates which field on the FK related table to use for display'
-                  constraints:
-                    deferrable: false
-                    foreignKeyName: fk_dimension_displayfk_ref_field_id
-                    initiallyDeferred: false
-                    nullable: true
-                    referencedTableName: metabase_field
-                    referencedColumnNames: id
-                    deleteCascade: true
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  remarks: 'The timestamp of when the dimension was created.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  remarks: 'The timestamp of when these dimension was last updated.'
-                  constraints:
-                    nullable: false
-        - addUniqueConstraint:
-            tableName: dimension
-            columnNames: field_id, name
-            constraintName: unique_dimension_field_id_name
-        - createIndex:
-            tableName: dimension
-            indexName: idx_dimension_field_id
-            columns:
-              - column:
-                  name: field_id
-  - changeSet:
-      id: 59
-      author: camsaul
-      comment: 'Added 0.26.0'
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: fingerprint
-                  type: text
-                  remarks: 'Serialized JSON containing non-identifying information about this Field, such as min, max, and percent JSON. Used for classification.'
-  - changeSet:
-      id: 60
-      author: camsaul
-      validCheckSum: ANY
-      comment: 'Added 0.26.0'
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: metadata_sync_schedule
-                  type: varchar(254)
-                  remarks: 'The cron schedule string for when this database should undergo the metadata sync process (and analysis for new fields).'
-                  defaultValue: '0 50 * * * ? *' # run at the end of every hour
-                  constraints:
-                    nullable: false
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: cache_field_values_schedule
-                  type: varchar(254)
-                  remarks: 'The cron schedule string for when FieldValues for eligible Fields should be updated.'
-                  defaultValue: '0 50 0 * * ? *' # run at 12:50 AM
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 61
-      author: camsaul
-      comment: 'Added 0.26.0'
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: fingerprint_version
-                  type: int
-                  remarks: 'The version of the fingerprint for this Field. Used so we can keep track of which Fields need to be analyzed again when new things are added to fingerprints.'
-                  defaultValue: 0
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 62
-      author: senior
-      comment: 'Added 0.26.0'
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: timezone
-                  type: VARCHAR(254)
-                  remarks: 'Timezone identifier for the database, set by the sync process'
-  - changeSet:
-      id: 63
-      author: camsaul
-      comment: 'Added 0.26.0'
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: is_on_demand
-                  type: boolean
-                  remarks: 'Whether we should do On-Demand caching of FieldValues for this DB. This means FieldValues are updated when their Field is used in a Dashboard or Card param.'
-                  defaultValue: false
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 64
-      author: senior
-      comment: 'Added 0.26.0'
-      changes:
-      - dropForeignKeyConstraint:
-          baseTableName: raw_table
-          constraintName: fk_rawtable_ref_database
-          remarks: 'This FK prevents deleting databases even though RAW_TABLE is no longer used. The table is still around to support downgrades, but the FK reference is no longer needed.'
-# Changeset 65 was accidentally released in 0.26.0.RC2. The changeset has been removed from the migrations list so that
-# users that haven't ran the migration (i.e. they didn't run 0.26.0.RC2) won't waste time running it just to have it
-# reversed. For 0.26.0.RC2 users, the below changeset will remove those tables if they are present
-  - changeSet:
-      id: 66
-      author: senior
-      comment: 'Added 0.26.0'
-      validCheckSum: ANY
-      changes:
-        - sql:
-            sql: drop table if exists computation_job_result cascade
-        - sql:
-            sql: drop table if exists computation_job cascade
-# NOTE Atte Keinänen 9/28/17: This was originally in changeset 65 as explained above
-  - changeSet:
-      id: 67
-      author: attekei
-      validCheckSum: ANY
-      comment: 'Added 0.27.0'
-      changes:
-        - createTable:
-            tableName: computation_job
-            remarks: 'Stores submitted async computation jobs.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  constraints:
-                    deferrable: false
-                    foreignKeyName: fk_computation_job_ref_user_id
-                    initiallyDeferred: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                  name: creator_id
-                  type: int
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: type
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: status
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-        - createTable:
-            tableName: computation_job_result
-            remarks: 'Stores results of async computation jobs.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  constraints:
-                    deferrable: false
-                    foreignKeyName: fk_computation_result_ref_job_id
-                    initiallyDeferred: false
-                    nullable: false
-                    referencedTableName: computation_job
-                    referencedColumnNames: id
-                  name: job_id
-                  type: int
-              - column:
-                  name: created_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: permanence
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: payload
-                  type: text
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 68
-      author: sbelak
-      comment: 'Added 0.27.0'
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: computation_job
-            columns:
-              - column:
-                  name: context
-                  type: text
-        - addColumn:
-            tableName: computation_job
-            columns:
-              - column:
-                  name: ended_at
-                  type: DATETIME
-  - changeSet:
-      id: 69
-      author: senior
-      validCheckSum: ANY
-      comment: 'Added 0.27.0'
-      remarks: 'Add columns to the pulse table for alerts'
-      changes:
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: alert_condition
-                  type: varchar(254)
-                  remarks: 'Condition (i.e. "rows" or "goal") used as a guard for alerts'
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: alert_first_only
-                  type: boolean
-                  remarks: 'True if the alert should be disabled after the first notification'
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: alert_above_goal
-                  type: boolean
-                  remarks: 'For a goal condition, alert when above the goal'
-        # There is no name for an alert, so this column is only required for pulses
-        - dropNotNullConstraint:
-            tableName: pulse
-            columnName: name
-            columnDataType: varchar(254)
-  - changeSet:
-      id: 70
-      author: camsaul
-      comment: 'Added 0.28.0'
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: database_type
-                  type: varchar(255)
-                  remarks: 'The actual type of this column in the database. e.g. VARCHAR or TEXT.'
-        # We want to enforce NOT NULL right away for all columns going forward so just put some sort of
-        # placeholder in place for existing columns.
-        - addNotNullConstraint:
-            tableName: metabase_field
-            columnName: database_type
-            columnDataType: varchar(255)
-            defaultNullValue: '?'
-  - changeSet:
-      id: 71
-      author: camsaul
-      comment: 'Added 0.28.0'
-      changes:
-        # drop the NOT NULL constraint on DashboardCard.card_id since we're now letting you add things other than Cards
-        # to Dashboards, for example static text cards
-        - dropNotNullConstraint:
-            tableName: report_dashboardcard
-            columnName: card_id
-            columnDataType: int
-  - changeSet:
-      id: 72
-      author: senior
-      validCheckSum: ANY
-      comment: 'Added 0.28.0'
-      changes:
-        - addColumn:
-            tableName: pulse_card
-            columns:
-              - column:
-                  name: include_csv
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: 'True if a CSV of the data should be included for this pulse card'
-                  constraints:
-                    nullable: false
-        - addColumn:
-            tableName: pulse_card
-            columns:
-              - column:
-                  name: include_xls
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: 'True if a XLS of the data should be included for this pulse card'
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: 73
-      author: camsaul
-      comment: 'Added 0.29.0'
-      changes:
-        # add a new 'options' (serialized JSON) column to Database to store things like whether we should default to
-        # making string searches case-insensitive
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: options
-                  type: text
-                  remarks: 'Serialized JSON containing various options like QB behavior.'
-  - changeSet:
-      id: 74
-      author: camsaul
-      comment: 'Added 0.29.0'
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: has_field_values
-                  type: text
-                  remarks: 'Whether we have FieldValues ("list"), should ad-hoc search ("search"), disable entirely ("none"), or infer dynamically (null)"'
-  - changeSet:
-      id: 75
-      author: camsaul
-      comment: 'Added 0.28.2'
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: read_permissions
-                  type: text
-                  remarks: 'Permissions required to view this Card and run its query.'
-  - changeSet:
-      id: 76
-      author: senior
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: fields_hash
-                  type: text
-                  remarks: 'Computed hash of all of the fields associated to this table'
-  - changeSet:
-      id: 77
-      author: senior
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: login_attributes
-                  type: text
-                  remarks: 'JSON serialized map with attributes used for row level permissions'
-  - changeSet:
-      id: 78
-      author: camsaul
-      validCheckSum: ANY
-      comment: 'Added 0.30.0'
-      changes:
-        - createTable:
-            tableName: group_table_access_policy
-            remarks: 'Records that a given Card (Question) should automatically replace a given Table as query source for a given a Perms Group.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: group_id
-                  type: int
-                  remarks: 'ID of the Permissions Group this policy affects.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: permissions_group
-                    referencedColumnNames: id
-                    foreignKeyName: fk_gtap_group_id
-                    deleteCascade: true
-              - column:
-                  name: table_id
-                  type: int
-                  remarks: 'ID of the Table that should get automatically replaced as query source for the Permissions Group.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_table
-                    referencedColumnNames: id
-                    foreignKeyName: fk_gtap_table_id
-                    deleteCascade: true
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: 'ID of the Card (Question) to be used to replace the Table.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_gtap_card_id
-              - column:
-                  name: attribute_remappings
-                  type: text
-                  remarks: 'JSON-encoded map of user attribute identifier to the param name used in the Card.'
-              # TODO - do we also want to include `created_at` and `updated_at` columns here? We can add them later if needed
-        # Add an index on table_id + group_id since that is what the Query Processor is going to be looking up 99% of
-        # the time in order to get the corresponding Card ID for query-rewriting purposes
-        #
-        # TODO - do we want indexes on any of the other FKs? Are we going to be looking up all the GTAPs for a given
-        # Table or for a given Group with enough regularity we would want to put indexes on those columns?
-        - createIndex:
-            indexName: idx_gtap_table_id_group_id
-            tableName: group_table_access_policy
-            columns:
-              - column:
-                  name: table_id
-              - column:
-                  name: group_id
-        # There should only ever be one GTAP entry for a give Group + Table combination.
-        - addUniqueConstraint:
-            tableName: group_table_access_policy
-            columnNames: table_id, group_id
-            constraintName: unique_gtap_table_id_group_id
-  - changeSet:
-      id: 79
-      author: camsaul
-      validCheckSum: ANY
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: 'Optional ID of Collection this Dashboard belongs to.'
-                  constraints:
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_dashboard_collection_id
-              # TODO - if someone deletes a collection, what should happen to the Dashboards that are in it? Should they
-              # get deleted as well? Or should collection_id be cleared, effectively putting them in the so-called
-              # "root" collection?
-        - createIndex:
-            tableName: report_dashboard
-            indexName: idx_dashboard_collection_id
-            columns:
-              - column:
-                  name: collection_id
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: 'Options ID of Collection this Pulse belongs to.'
-                  constraints:
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_pulse_collection_id
-        - createIndex:
-            tableName: pulse
-            indexName: idx_pulse_collection_id
-            columns:
-              - column:
-                  name: collection_id
-  - changeSet:
-      id: 80
-      author: camsaul
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: location
-                  type: varchar(254)
-                  remarks: 'Directory-structure path of ancestor Collections. e.g. "/1/2/" means our Parent is Collection 2, and their parent is Collection 1.'
-                  constraints:
-                    nullable: false
-                  defaultValue: "/"
-        - createIndex:
-            tableName: collection
-            indexName: idx_collection_location
-            columns:
-              - column:
-                  name: location
-  - changeSet:
-      id: 81
-      author: camsaul
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: collection_position
-                  type: smallint
-                  remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: collection_position
-                  type: smallint
-                  remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: collection_position
-                  type: smallint
-                  remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
-  - changeSet:
-      id: 82
-      author: senior
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: updated_at
-                  type: datetime
-                  remarks: 'When was this User last updated?'
-        - sql:
-            sql: update core_user set updated_at=date_joined
-# Remove the GTAP card_id constraint. When not included, will default to querying against the GTAP table_id.
-  - changeSet:
-      id: 83
-      author: senior
-      comment: 'Added 0.30.0'
-      changes:
-        - dropNotNullConstraint:
-            tableName: group_table_access_policy
-            columnName: card_id
-            columnDataType: int
-# Switch the logic for metric/segment archiving to be more consistent with other entities in the model.
-# Similarly, add the archived flag to pulses which doesn't have one.
-  - changeSet:
-      id: 84
-      author: senior
-      comment: 'Added 0.30.0'
-      changes:
-        - renameColumn:
-            tableName: metric
-            columnDataType: boolean
-            newColumnName: archived
-            oldColumnName: is_active
-        - addDefaultValue:
-            tableName: metric
-            columnDataType: boolean
-            columnName: archived
+- property: {name: timestamp_type, value: timestamp with time zone, dbms: 'postgresql,h2'}
+- property: {name: timestamp_type, value: timestamp(6), dbms: 'mysql,mariadb'}
+- property: {name: blob.type, value: blob, dbms: 'mysql,h2,mariadb'}
+- property: {name: blob.type, value: bytea, dbms: postgresql}
+- property: {name: text.type, value: text, dbms: 'postgresql,h2'}
+- property: {name: text.type, value: longtext, dbms: 'mysql,mariadb'}
+- property: {name: databasechangelog.name, value: DATABASECHANGELOG, dbms: 'h2,mysql,mariadb'}
+- property: {name: databasechangelog.name, value: databasechangelog, dbms: postgresql}
+- {objectQuotingStrategy: QUOTE_ALL_OBJECTS}
+- changeSet:
+    id: '1'
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false, unique: true}
+            name: slug
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column: {name: description, type: text}
+        - column: {name: logo_url, type: varchar(254)}
+        - column:
+            constraints: {nullable: false}
+            name: inherits
+            type: boolean
+        tableName: core_organization
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false, unique: true}
+            name: email
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: first_name
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: last_name
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: password
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            defaultValue: default
+            name: password_salt
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: date_joined
+            type: DATETIME
+        - column:
+            constraints: {nullable: true}
+            name: last_login
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: is_staff
+            type: boolean
+        - column:
+            constraints: {nullable: false}
+            name: is_superuser
+            type: boolean
+        - column:
+            constraints: {nullable: false}
+            name: is_active
+            type: boolean
+        - column: {name: reset_token, type: varchar(254)}
+        - column: {name: reset_triggered, type: BIGINT}
+        tableName: core_user
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: admin
+            type: boolean
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_userorgperm_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: user_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_userorgperm_ref_organization_id, initiallyDeferred: false, nullable: false, referencedTableName: core_organization, referencedColumnNames: id}
+            name: organization_id
+            type: int
+        tableName: core_userorgperm
+    - addUniqueConstraint: {columnNames: 'user_id, organization_id', constraintName: idx_unique_user_id_organization_id, tableName: core_userorgperm}
+    - createIndex:
+        columns:
+        - column: {name: user_id, type: int}
+        indexName: idx_userorgperm_user_id
+        tableName: core_userorgperm
+    - createIndex:
+        columns:
+        - column: {name: organization_id, type: int}
+        indexName: idx_userorgperm_organization_id
+        tableName: core_userorgperm
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: url
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: timestamp
+            type: DATETIME
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_permissionviolation_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: user_id
+            type: int
+        tableName: core_permissionsviolation
+    - createIndex:
+        columns:
+        - column: {name: user_id, type: int}
+        indexName: idx_permissionsviolation_user_id
+        tableName: core_permissionsviolation
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column: {name: description, type: text}
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_database_ref_organization_id, initiallyDeferred: false, nullable: false, referencedTableName: core_organization, referencedColumnNames: id}
+            name: organization_id
+            type: int
+        - column: {name: details, type: text}
+        - column:
+            constraints: {nullable: false}
+            name: engine
+            type: varchar(254)
+        tableName: metabase_database
+    - createIndex:
+        columns:
+        - column: {name: organization_id}
+        indexName: idx_database_organization_id
+        tableName: metabase_database
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column: {name: rows, type: int}
+        - column: {name: description, type: text}
+        - column: {name: entity_name, type: varchar(254)}
+        - column: {name: entity_type, type: varchar(254)}
+        - column:
+            constraints: {nullable: false}
+            name: active
+            type: boolean
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_table_ref_database_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_database, referencedColumnNames: id}
+            name: db_id
+            type: int
+        tableName: metabase_table
+    - createIndex:
+        columns:
+        - column: {name: db_id}
+        indexName: idx_table_db_id
+        tableName: metabase_table
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: base_type
+            type: varchar(255)
+        - column: {name: special_type, type: varchar(255)}
+        - column:
+            constraints: {nullable: false}
+            name: active
+            type: boolean
+        - column: {name: description, type: text}
+        - column:
+            constraints: {nullable: false}
+            name: preview_display
+            type: boolean
+        - column:
+            constraints: {nullable: false}
+            name: position
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_field_ref_table_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_table, referencedColumnNames: id}
+            name: table_id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: field_type
+            type: varchar(254)
+        tableName: metabase_field
+    - createIndex:
+        columns:
+        - column: {name: table_id}
+        indexName: idx_field_table_id
+        tableName: metabase_field
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: relationship
+            type: varchar(254)
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_foreignkey_dest_ref_field_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_field, referencedColumnNames: id}
+            name: destination_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_foreignkey_origin_ref_field_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_field, referencedColumnNames: id}
+            name: origin_id
+            type: int
+        tableName: metabase_foreignkey
+    - createIndex:
+        columns:
+        - column: {name: destination_id}
+        indexName: idx_foreignkey_destination_id
+        tableName: metabase_foreignkey
+    - createIndex:
+        columns:
+        - column: {name: origin_id}
+        indexName: idx_foreignkey_origin_id
+        tableName: metabase_foreignkey
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column: {name: values, type: text}
+        - column: {name: human_readable_values, type: text}
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_fieldvalues_ref_field_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_field, referencedColumnNames: id}
+            name: field_id
+            type: int
+        tableName: metabase_fieldvalues
+    - createIndex:
+        columns:
+        - column: {name: field_id}
+        indexName: idx_fieldvalues_field_id
+        tableName: metabase_fieldvalues
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_tablesegment_ref_table_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_table, referencedColumnNames: id}
+            name: table_id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: filter_clause
+            type: text
+        tableName: metabase_tablesegment
+    - createIndex:
+        columns:
+        - column: {name: table_id}
+        indexName: idx_tablesegment_table_id
+        tableName: metabase_tablesegment
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: type
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: details
+            type: text
+        - column:
+            constraints: {nullable: false}
+            name: version
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: public_perms
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_query_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: creator_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_query_ref_database_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_database, referencedColumnNames: id}
+            name: database_id
+            type: int
+        tableName: query_query
+    - createIndex:
+        columns:
+        - column: {name: creator_id}
+        indexName: idx_query_creator_id
+        tableName: query_query
+    - createIndex:
+        columns:
+        - column: {name: database_id}
+        indexName: idx_query_database_id
+        tableName: query_query
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false, unique: true}
+            name: uuid
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: version
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: json_query
+            type: text
+        - column:
+            constraints: {nullable: false}
+            name: raw_query
+            type: text
+        - column:
+            constraints: {nullable: false}
+            name: status
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: started_at
+            type: DATETIME
+        - column: {name: finished_at, type: DATETIME}
+        - column:
+            constraints: {nullable: false}
+            name: running_time
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: error
+            type: text
+        - column:
+            constraints: {nullable: false}
+            name: result_file
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: result_rows
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: result_data
+            type: text
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_queryexecution_ref_query_id, initiallyDeferred: false, nullable: true, referencedTableName: query_query, referencedColumnNames: id}
+            name: query_id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: additional_info
+            type: text
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_queryexecution_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: executor_id
+            type: int
+        tableName: query_queryexecution
+    - createIndex:
+        columns:
+        - column: {name: query_id}
+        indexName: idx_queryexecution_query_id
+        tableName: query_queryexecution
+    - createIndex:
+        columns:
+        - column: {name: executor_id}
+        indexName: idx_queryexecution_executor_id
+        tableName: query_queryexecution
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column: {name: description, type: text}
+        - column:
+            constraints: {nullable: false}
+            name: display
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: public_perms
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: dataset_query
+            type: text
+        - column:
+            constraints: {nullable: false}
+            name: visualization_settings
+            type: text
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_card_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: creator_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_card_ref_organization_id, initiallyDeferred: false, nullable: false, referencedTableName: core_organization, referencedColumnNames: id}
+            name: organization_id
+            type: int
+        tableName: report_card
+    - createIndex:
+        columns:
+        - column: {name: creator_id}
+        indexName: idx_card_creator_id
+        tableName: report_card
+    - createIndex:
+        columns:
+        - column: {name: organization_id}
+        indexName: idx_card_organization_id
+        tableName: report_card
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_cardfavorite_ref_card_id, initiallyDeferred: false, nullable: false, referencedTableName: report_card, referencedColumnNames: id}
+            name: card_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_cardfavorite_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: owner_id
+            type: int
+        tableName: report_cardfavorite
+    - addUniqueConstraint: {columnNames: 'card_id, owner_id', constraintName: idx_unique_cardfavorite_card_id_owner_id, tableName: report_cardfavorite}
+    - createIndex:
+        columns:
+        - column: {name: card_id}
+        indexName: idx_cardfavorite_card_id
+        tableName: report_cardfavorite
+    - createIndex:
+        columns:
+        - column: {name: owner_id}
+        indexName: idx_cardfavorite_owner_id
+        tableName: report_cardfavorite
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column: {name: description, type: text}
+        - column:
+            constraints: {nullable: false}
+            name: public_perms
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_dashboard_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: creator_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_dashboard_ref_organization_id, initiallyDeferred: false, nullable: false, referencedTableName: core_organization, referencedColumnNames: id}
+            name: organization_id
+            type: int
+        tableName: report_dashboard
+    - createIndex:
+        columns:
+        - column: {name: creator_id}
+        indexName: idx_dashboard_creator_id
+        tableName: report_dashboard
+    - createIndex:
+        columns:
+        - column: {name: organization_id}
+        indexName: idx_dashboard_organization_id
+        tableName: report_dashboard
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: sizeX
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: sizeY
+            type: int
+        - column: {name: row, type: int}
+        - column: {name: col, type: int}
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_dashboardcard_ref_card_id, initiallyDeferred: false, nullable: false, referencedTableName: report_card, referencedColumnNames: id}
+            name: card_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_dashboardcard_ref_dashboard_id, initiallyDeferred: false, nullable: false, referencedTableName: report_dashboard, referencedColumnNames: id}
+            name: dashboard_id
+            type: int
+        tableName: report_dashboardcard
+    - createIndex:
+        columns:
+        - column: {name: card_id}
+        indexName: idx_dashboardcard_card_id
+        tableName: report_dashboardcard
+    - createIndex:
+        columns:
+        - column: {name: dashboard_id}
+        indexName: idx_dashboardcard_dashboard_id
+        tableName: report_dashboardcard
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_dashboardsubscription_ref_dashboard_id, initiallyDeferred: false, nullable: false, referencedTableName: report_dashboard, referencedColumnNames: id}
+            name: dashboard_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_dashboardsubscription_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: user_id
+            type: int
+        tableName: report_dashboardsubscription
+    - addUniqueConstraint: {columnNames: 'dashboard_id, user_id', constraintName: idx_uniq_dashsubscrip_dashboard_id_user_id, tableName: report_dashboardsubscription}
+    - createIndex:
+        columns:
+        - column: {name: dashboard_id}
+        indexName: idx_dashboardsubscription_dashboard_id
+        tableName: report_dashboardsubscription
+    - createIndex:
+        columns:
+        - column: {name: user_id}
+        indexName: idx_dashboardsubscription_user_id
+        tableName: report_dashboardsubscription
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: name
+            type: varchar(254)
+        - column: {name: description, type: text}
+        - column:
+            constraints: {nullable: false}
+            name: public_perms
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: mode
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: version
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: dataset_query
+            type: text
+        - column: {name: email_addresses, type: text}
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_emailreport_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: creator_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_emailreport_ref_organization_id, initiallyDeferred: false, nullable: false, referencedTableName: core_organization, referencedColumnNames: id}
+            name: organization_id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: schedule
+            type: text
+        tableName: report_emailreport
+    - createIndex:
+        columns:
+        - column: {name: creator_id}
+        indexName: idx_emailreport_creator_id
+        tableName: report_emailreport
+    - createIndex:
+        columns:
+        - column: {name: organization_id}
+        indexName: idx_emailreport_organization_id
+        tableName: report_emailreport
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_emailreport_recipients_ref_emailreport_id, initiallyDeferred: false, nullable: false, referencedTableName: report_emailreport, referencedColumnNames: id}
+            name: emailreport_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_emailreport_recipients_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: user_id
+            type: int
+        tableName: report_emailreport_recipients
+    - addUniqueConstraint: {columnNames: 'emailreport_id, user_id', constraintName: idx_uniq_emailreportrecip_emailreport_id_user_id, tableName: report_emailreport_recipients}
+    - createIndex:
+        columns:
+        - column: {name: emailreport_id}
+        indexName: idx_emailreport_recipients_emailreport_id
+        tableName: report_emailreport_recipients
+    - createIndex:
+        columns:
+        - column: {name: user_id}
+        indexName: idx_emailreport_recipients_user_id
+        tableName: report_emailreport_recipients
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: details
+            type: text
+        - column:
+            constraints: {nullable: false}
+            name: status
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column: {name: started_at, type: DATETIME}
+        - column: {name: finished_at, type: DATETIME}
+        - column:
+            constraints: {nullable: false}
+            name: error
+            type: text
+        - column:
+            constraints: {nullable: false}
+            name: sent_email
+            type: text
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_emailreportexecutions_ref_organization_id, initiallyDeferred: false, nullable: false, referencedTableName: core_organization, referencedColumnNames: id}
+            name: organization_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_emailreportexecutions_ref_report_id, initiallyDeferred: false, nullable: true, referencedTableName: report_emailreport, referencedColumnNames: id}
+            name: report_id
+            type: int
+        tableName: report_emailreportexecutions
+    - createIndex:
+        columns:
+        - column: {name: organization_id}
+        indexName: idx_emailreportexecutions_organization_id
+        tableName: report_emailreportexecutions
+    - createIndex:
+        columns:
+        - column: {name: report_id}
+        indexName: idx_emailreportexecutions_report_id
+        tableName: report_emailreportexecutions
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: updated_at
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: start
+            type: DATETIME
+        - column:
+            constraints: {nullable: false}
+            name: end
+            type: DATETIME
+        - column: {name: title, type: TEXT}
+        - column:
+            constraints: {nullable: false}
+            name: body
+            type: TEXT
+        - column:
+            constraints: {nullable: false}
+            name: annotation_type
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: edit_count
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: object_type_id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: object_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_annotation_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: author_id
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_annotation_ref_organization_id, initiallyDeferred: false, nullable: false, referencedTableName: core_organization, referencedColumnNames: id}
+            name: organization_id
+            type: int
+        tableName: annotation_annotation
+    - createIndex:
+        columns:
+        - column: {name: author_id}
+        indexName: idx_annotation_author_id
+        tableName: annotation_annotation
+    - createIndex:
+        columns:
+        - column: {name: organization_id}
+        indexName: idx_annotation_organization_id
+        tableName: annotation_annotation
+    - createIndex:
+        columns:
+        - column: {name: object_type_id}
+        indexName: idx_annotation_object_type_id
+        tableName: annotation_annotation
+    - createIndex:
+        columns:
+        - column: {name: object_id}
+        indexName: idx_annotation_object_id
+        tableName: annotation_annotation
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: '2'
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        columns:
+        - column:
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            type: varchar(254)
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_session_ref_user_id, initiallyDeferred: false, nullable: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: user_id
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            type: DATETIME
+        tableName: core_session
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: '4'
+    author: cammsaul
+    changes:
+    - createTable:
+        columns:
+        - column:
+            constraints: {nullable: false, primaryKey: true}
+            name: key
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: value
+            type: varchar(254)
+        tableName: setting
+- changeSet:
+    id: '5'
+    author: agilliland
+    changes:
+    - addColumn:
+        columns:
+        - column: {name: report_timezone, type: varchar(254)}
+        tableName: core_organization
+- changeSet:
+    id: '6'
+    author: agilliland
+    changes:
+    - dropNotNullConstraint: {columnDataType: int, columnName: organization_id, tableName: metabase_database}
+    - dropForeignKeyConstraint: {baseTableName: metabase_database, constraintName: fk_database_ref_organization_id}
+    - dropNotNullConstraint: {columnDataType: int, columnName: organization_id, tableName: report_card}
+    - dropForeignKeyConstraint: {baseTableName: report_card, constraintName: fk_card_ref_organization_id}
+    - dropNotNullConstraint: {columnDataType: int, columnName: organization_id, tableName: report_dashboard}
+    - dropForeignKeyConstraint: {baseTableName: report_dashboard, constraintName: fk_dashboard_ref_organization_id}
+    - dropNotNullConstraint: {columnDataType: int, columnName: organization_id, tableName: report_emailreport}
+    - dropForeignKeyConstraint: {baseTableName: report_emailreport, constraintName: fk_emailreport_ref_organization_id}
+    - dropNotNullConstraint: {columnDataType: int, columnName: organization_id, tableName: report_emailreportexecutions}
+    - dropForeignKeyConstraint: {baseTableName: report_emailreportexecutions, constraintName: fk_emailreportexecutions_ref_organization_id}
+    - dropNotNullConstraint: {columnDataType: int, columnName: organization_id, tableName: annotation_annotation}
+    - dropForeignKeyConstraint: {baseTableName: annotation_annotation, constraintName: fk_annotation_ref_organization_id}
+- changeSet:
+    id: '7'
+    author: cammsaul
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            constraints: {foreignKeyName: fk_field_parent_ref_field_id, nullable: true, referencedTableName: metabase_field, referencedColumnNames: id}
+            name: parent_id
+            type: int
+        tableName: metabase_field
+- changeSet:
+    id: '8'
+    author: tlrobinson
+    changes:
+    - addColumn:
+        columns:
+        - column: {name: display_name, type: varchar(254)}
+        tableName: metabase_table
+    - addColumn:
+        columns:
+        - column: {name: display_name, type: varchar(254)}
+        tableName: metabase_field
+- changeSet:
+    id: '9'
+    author: tlrobinson
+    changes:
+    - addColumn:
+        columns:
+        - column: {name: visibility_type, type: varchar(254)}
+        tableName: metabase_table
+- changeSet:
+    id: 10
+    author: cammsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: revision
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: model
+            type: varchar(16)
+            constraints: {nullable: false}
+        - column:
+            name: model_id
+            type: int
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_revision_ref_user_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: timestamp
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: object
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            name: is_reversion
+            type: boolean
             defaultValueBoolean: false
-        - renameColumn:
-            tableName: segment
-            columnDataType: boolean
-            newColumnName: archived
-            oldColumnName: is_active
-        - addDefaultValue:
-            tableName: segment
-            columnDataType: boolean
-            columnName: archived
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: revision
+        indexName: idx_revision_model_model_id
+        columns:
+        - column: {name: model}
+        - column: {name: model_id}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+    - modifySql:
+        dbms: mysql,mariadb
+        replace: {replace: object VARCHAR, with: object TEXT}
+- changeSet:
+    id: 11
+    author: agilliland
+    changes:
+    - sql: {sql: update report_dashboard set public_perms = 2 where public_perms = 1}
+- changeSet:
+    id: 12
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: database_id
+            type: int
+            constraints: {nullable: true, referencedTableName: metabase_database, referencedColumnNames: id, foreignKeyName: fk_report_card_ref_database_id, deferrable: false, initiallyDeferred: false}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: table_id
+            type: int
+            constraints: {nullable: true, referencedTableName: metabase_table, referencedColumnNames: id, foreignKeyName: fk_report_card_ref_table_id, deferrable: false, initiallyDeferred: false}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: query_type
+            type: varchar(16)
+            constraints: {nullable: true}
+- changeSet:
+    id: 13
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: activity
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: topic
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: timestamp
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            constraints: {nullable: true, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_activity_ref_user_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: model
+            type: varchar(16)
+            constraints: {nullable: true}
+        - column:
+            name: model_id
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: database_id
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: table_id
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: custom_id
+            type: varchar(48)
+            constraints: {nullable: true}
+        - column:
+            name: details
+            type: ${text.type}
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: activity
+        indexName: idx_activity_timestamp
+        columns:
+          column: {name: timestamp}
+    - createIndex:
+        tableName: activity
+        indexName: idx_activity_user_id
+        columns:
+          column: {name: user_id}
+    - createIndex:
+        tableName: activity
+        indexName: idx_activity_custom_id
+        columns:
+          column: {name: custom_id}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+    - modifySql:
+        dbms: mysql,mariadb
+        replace: {replace: details VARCHAR, with: details TEXT}
+- changeSet:
+    id: 14
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: view_log
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            constraints: {nullable: true, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_view_log_ref_user_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: model
+            type: varchar(16)
+            constraints: {nullable: false}
+        - column:
+            name: model_id
+            type: int
+            constraints: {nullable: false}
+        - column:
+            name: timestamp
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: view_log
+        indexName: idx_view_log_user_id
+        columns:
+          column: {name: user_id}
+    - createIndex:
+        tableName: view_log
+        indexName: idx_view_log_timestamp
+        columns:
+          column: {name: model_id}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 15
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: revision
+        columns:
+        - column:
+            name: is_creation
+            type: boolean
             defaultValueBoolean: false
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: archived
-                  type: boolean
-                  remarks: 'Has this pulse been archived?'
-                  defaultValueBoolean: false
-        # Before this change, metrics/segments had opposite logic, rather than marking something as archived
-        # it was marked as active. Since the column is now an archived column, flip the boolean value
-        #
-        # As you may have noticed, we're not flipping the value for Metric here. @senior originally intended to do so,
-        # but the YAML was off slightly. We have corrected this issue at a later date -- see migration #100
-        - sql:
-            sql: update segment set archived = not(archived)
-  # Personal Collections, and removing Collection's unique constraint and index on slug
-  - changeSet:
-      id: 85
-      author: camsaul
-      validCheckSum: ANY
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: personal_owner_id
-                  type: int
-                  remarks: 'If set, this Collection is a personal Collection, for exclusive use of the User with this ID.'
-                  constraints:
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_collection_personal_owner_id
-                    unique: true
-                    uniqueConstraintName: unique_collection_personal_owner_id
-                    deleteCascade: true
-        # Needed so we can efficiently look up the Collection belonging to a User, and so we can efficiently enforce the
-        # unique constraint
-        - createIndex:
-            tableName: collection
-            indexName: idx_collection_personal_owner_id
-            columns:
-              - column:
-                  name: personal_owner_id
-        # We're no longer enforcing unique constraints on Collection slugs or using them directly in the URLs, so let's
-        # go ahead and remove stuff related to that...
-        #
-        # It's easier to just copy the value of slug to a new column and drop the old one than to try to deduce what the
-        # unique constraint is named locally across all of our different DBMSes
-        # (For example see https://stackoverflow.com/questions/10008476/dropping-unique-constraint-for-column-in-h2)
-        #
-        # Here's the plan: add new column _slug; copy values of slug into _slug; remove slug; rename _slug to slug
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: _slug
-                  type: varchar(254)
-                  remarks: 'Sluggified version of the Collection name. Used only for display purposes in URL; not unique or indexed.'
-        # I don't know of an easy way to copy existing values of slug to _slug with Liquibase as we create the column so
-        # just have to do it this way instead
-        - sql:
-            sql: UPDATE collection SET _slug = slug
-        - addNotNullConstraint:
-            tableName: collection
-            columnName: _slug
-            columnDataType: varchar(254)
-        - dropColumn:
-            tableName: collection
-            columnName: slug
-        - renameColumn:
-            tableName: collection
-            oldColumnName: _slug
-            newColumnName: slug
-            columnDataType: varchar(254)
-        # Let's try to make sure the comments on the name column of Collection actually reflect reality
-        - sql:
-            dbms: postgresql,h2
-            sql: "COMMENT ON COLUMN collection.name IS 'The user-facing name of this Collection.'"
-        - sql:
-            dbms: mysql,mariadb
-            sql: "ALTER TABLE `collection` CHANGE `name` `name` TEXT NOT NULL COMMENT 'The user-facing name of this Collection.'"
-
-# In 0.30.0 we finally removed the long-deprecated native read permissions. Since they're no longer considered valid by
-# our permissions code, remove any entries for them so they don't cause problems.
-  - changeSet:
-      id: 86
-      author: camsaul
-      comment: 'Added 0.30.0'
-      changes:
-        - sql:
-            sql: DELETE FROM permissions WHERE object LIKE '%/native/read/'
-
-# Time to finally get rid of the RawTable and RawColumn tables. Bye Felicia!
-  - changeSet:
-      id: 87
-      author: camsaul
-      comment: 'Added 0.30.0'
-      changes:
-        - dropTable:
-            tableName: raw_column
-        - dropTable:
-            tableName: raw_table
-  - changeSet:
-      id: 88
-      author: senior
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: saml_auth
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-                  remarks: 'Boolean to indicate if this user is authenticated via SAML'
-
-# The Quartz Task Scheduler can use a DB to 'cluster' tasks and make sure they are only ran by a single instance where
-# using a multi-instance Metabase setup.
-
-# Quartz identifiers are upper-case in MySQL and H2 but lower-case in PostgreSQL for reasons... so we'll have to
-# define properties for EVERYTHING and use the correct identifiers
-
-  - property: {name: quartz.blob_data.name,                         dbms: "postgresql",       value: blob_data}
-  - property: {name: quartz.blob_data.name,                         dbms: "mysql,mariadb,h2", value: BLOB_DATA}
-  - property: {name: quartz.bool_prop_1.name,                       dbms: "postgresql",       value: bool_prop_1}
-  - property: {name: quartz.bool_prop_1.name,                       dbms: "mysql,mariadb,h2", value: BOOL_PROP_1}
-  - property: {name: quartz.bool_prop_2.name,                       dbms: "postgresql",       value: bool_prop_2}
-  - property: {name: quartz.bool_prop_2.name,                       dbms: "mysql,mariadb,h2", value: BOOL_PROP_2}
-  - property: {name: quartz.calendar.name,                          dbms: "postgresql",       value: calendar}
-  - property: {name: quartz.calendar.name,                          dbms: "mysql,mariadb,h2", value: CALENDAR}
-  - property: {name: quartz.calendar_name.name,                     dbms: "postgresql",       value: calendar_name}
-  - property: {name: quartz.calendar_name.name,                     dbms: "mysql,mariadb,h2", value: CALENDAR_NAME}
-  - property: {name: quartz.checkin_interval.name,                  dbms: "postgresql",       value: checkin_interval}
-  - property: {name: quartz.checkin_interval.name,                  dbms: "mysql,mariadb,h2", value: CHECKIN_INTERVAL}
-  - property: {name: quartz.cron_expression.name,                   dbms: "postgresql",       value: cron_expression}
-  - property: {name: quartz.cron_expression.name,                   dbms: "mysql,mariadb,h2", value: CRON_EXPRESSION}
-  - property: {name: quartz.dec_prop_1.name,                        dbms: "postgresql",       value: dec_prop_1}
-  - property: {name: quartz.dec_prop_1.name,                        dbms: "mysql,mariadb,h2", value: DEC_PROP_1}
-  - property: {name: quartz.dec_prop_2.name,                        dbms: "postgresql",       value: dec_prop_2}
-  - property: {name: quartz.dec_prop_2.name,                        dbms: "mysql,mariadb,h2", value: DEC_PROP_2}
-  - property: {name: quartz.description.name,                       dbms: "postgresql",       value: description}
-  - property: {name: quartz.description.name,                       dbms: "mysql,mariadb,h2", value: DESCRIPTION}
-  - property: {name: quartz.end_time.name,                          dbms: "postgresql",       value: end_time}
-  - property: {name: quartz.end_time.name,                          dbms: "mysql,mariadb,h2", value: END_TIME}
-  - property: {name: quartz.entry_id.name,                          dbms: "postgresql",       value: entry_id}
-  - property: {name: quartz.entry_id.name,                          dbms: "mysql,mariadb,h2", value: ENTRY_ID}
-  - property: {name: quartz.fired_time.name,                        dbms: "postgresql",       value: fired_time}
-  - property: {name: quartz.fired_time.name,                        dbms: "mysql,mariadb,h2", value: FIRED_TIME}
-  - property: {name: quartz.fk_qrtz_blob_triggers_triggers.name,    dbms: "postgresql",       value: fk_qrtz_blob_triggers_triggers}
-  - property: {name: quartz.fk_qrtz_blob_triggers_triggers.name,    dbms: "mysql,mariadb,h2", value: FK_QRTZ_BLOB_TRIGGERS_TRIGGERS}
-  - property: {name: quartz.fk_qrtz_cron_triggers_triggers.name,    dbms: "postgresql",       value: fk_qrtz_cron_triggers_triggers}
-  - property: {name: quartz.fk_qrtz_cron_triggers_triggers.name,    dbms: "mysql,mariadb,h2", value: FK_QRTZ_CRON_TRIGGERS_TRIGGERS}
-  - property: {name: quartz.fk_qrtz_simple_triggers_triggers.name,  dbms: "postgresql",       value: fk_qrtz_simple_triggers_triggers}
-  - property: {name: quartz.fk_qrtz_simple_triggers_triggers.name,  dbms: "mysql,mariadb,h2", value: FK_QRTZ_SIMPLE_TRIGGERS_TRIGGERS}
-  - property: {name: quartz.fk_qrtz_simprop_triggers_triggers.name, dbms: "postgresql",       value: fk_qrtz_simprop_triggers_triggers}
-  - property: {name: quartz.fk_qrtz_simprop_triggers_triggers.name, dbms: "mysql,mariadb,h2", value: FK_QRTZ_SIMPROP_TRIGGERS_TRIGGERS}
-  - property: {name: quartz.fk_qrtz_triggers_job_details.name,      dbms: "postgresql",       value: fk_qrtz_triggers_job_details}
-  - property: {name: quartz.fk_qrtz_triggers_job_details.name,      dbms: "mysql,mariadb,h2", value: FK_QRTZ_TRIGGERS_JOB_DETAILS}
-  - property: {name: quartz.idx_qrtz_ft_inst_job_req_rcvry.name,    dbms: "postgresql",       value: idx_qrtz_ft_inst_job_req_rcvry}
-  - property: {name: quartz.idx_qrtz_ft_inst_job_req_rcvry.name,    dbms: "mysql,mariadb,h2", value: IDX_QRTZ_FT_INST_JOB_REQ_RCVRY}
-  - property: {name: quartz.idx_qrtz_ft_jg.name,                    dbms: "postgresql",       value: idx_qrtz_ft_jg}
-  - property: {name: quartz.idx_qrtz_ft_jg.name,                    dbms: "mysql,mariadb,h2", value: IDX_QRTZ_FT_JG}
-  - property: {name: quartz.idx_qrtz_ft_j_g.name,                   dbms: "postgresql",       value: idx_qrtz_ft_j_g}
-  - property: {name: quartz.idx_qrtz_ft_j_g.name,                   dbms: "mysql,mariadb,h2", value: IDX_QRTZ_FT_J_G}
-  - property: {name: quartz.idx_qrtz_ft_tg.name,                    dbms: "postgresql",       value: idx_qrtz_ft_tg}
-  - property: {name: quartz.idx_qrtz_ft_tg.name,                    dbms: "mysql,mariadb,h2", value: IDX_QRTZ_FT_TG}
-  - property: {name: quartz.idx_qrtz_ft_trig_inst_name.name,        dbms: "postgresql",       value: idx_qrtz_ft_trig_inst_name}
-  - property: {name: quartz.idx_qrtz_ft_trig_inst_name.name,        dbms: "mysql,mariadb,h2", value: IDX_QRTZ_FT_TRIG_INST_NAME}
-  - property: {name: quartz.idx_qrtz_ft_t_g.name,                   dbms: "postgresql",       value: idx_qrtz_ft_t_g}
-  - property: {name: quartz.idx_qrtz_ft_t_g.name,                   dbms: "mysql,mariadb,h2", value: IDX_QRTZ_FT_T_G}
-  - property: {name: quartz.idx_qrtz_j_grp.name,                    dbms: "postgresql",       value: idx_qrtz_j_grp}
-  - property: {name: quartz.idx_qrtz_j_grp.name,                    dbms: "mysql,mariadb,h2", value: IDX_QRTZ_J_GRP}
-  - property: {name: quartz.idx_qrtz_j_req_recovery.name,           dbms: "postgresql",       value: idx_qrtz_j_req_recovery}
-  - property: {name: quartz.idx_qrtz_j_req_recovery.name,           dbms: "mysql,mariadb,h2", value: IDX_QRTZ_J_REQ_RECOVERY}
-  - property: {name: quartz.idx_qrtz_t_c.name,                      dbms: "postgresql",       value: idx_qrtz_t_c}
-  - property: {name: quartz.idx_qrtz_t_c.name,                      dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_C}
-  - property: {name: quartz.idx_qrtz_t_g.name,                      dbms: "postgresql",       value: idx_qrtz_t_g}
-  - property: {name: quartz.idx_qrtz_t_g.name,                      dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_G}
-  - property: {name: quartz.idx_qrtz_t_j.name,                      dbms: "postgresql",       value: idx_qrtz_t_j}
-  - property: {name: quartz.idx_qrtz_t_j.name,                      dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_J}
-  - property: {name: quartz.idx_qrtz_t_jg.name,                     dbms: "postgresql",       value: idx_qrtz_t_jg}
-  - property: {name: quartz.idx_qrtz_t_jg.name,                     dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_JG}
-  - property: {name: quartz.idx_qrtz_t_next_fire_time.name,         dbms: "postgresql",       value: idx_qrtz_t_next_fire_time}
-  - property: {name: quartz.idx_qrtz_t_next_fire_time.name,         dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_NEXT_FIRE_TIME}
-  - property: {name: quartz.idx_qrtz_t_nft_misfire.name,            dbms: "postgresql",       value: idx_qrtz_t_nft_misfire}
-  - property: {name: quartz.idx_qrtz_t_nft_misfire.name,            dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_NFT_MISFIRE}
-  - property: {name: quartz.idx_qrtz_t_nft_st.name,                 dbms: "postgresql",       value: idx_qrtz_t_nft_st}
-  - property: {name: quartz.idx_qrtz_t_nft_st.name,                 dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_NFT_ST}
-  - property: {name: quartz.idx_qrtz_t_nft_st_misfire.name,         dbms: "postgresql",       value: idx_qrtz_t_nft_st_misfire}
-  - property: {name: quartz.idx_qrtz_t_nft_st_misfire.name,         dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_NFT_ST_MISFIRE}
-  - property: {name: quartz.idx_qrtz_t_nft_st_misfire_grp.name,     dbms: "postgresql",       value: idx_qrtz_t_nft_st_misfire_grp}
-  - property: {name: quartz.idx_qrtz_t_nft_st_misfire_grp.name,     dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_NFT_ST_MISFIRE_GRP}
-  - property: {name: quartz.idx_qrtz_t_n_g_state.name,              dbms: "postgresql",       value: idx_qrtz_t_n_g_state}
-  - property: {name: quartz.idx_qrtz_t_n_g_state.name,              dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_N_G_STATE}
-  - property: {name: quartz.idx_qrtz_t_n_state.name,                dbms: "postgresql",       value: idx_qrtz_t_n_state}
-  - property: {name: quartz.idx_qrtz_t_n_state.name,                dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_N_STATE}
-  - property: {name: quartz.idx_qrtz_t_state.name,                  dbms: "postgresql",       value: idx_qrtz_t_state}
-  - property: {name: quartz.idx_qrtz_t_state.name,                  dbms: "mysql,mariadb,h2", value: IDX_QRTZ_T_STATE}
-  - property: {name: quartz.instance_name.name,                     dbms: "postgresql",       value: instance_name}
-  - property: {name: quartz.instance_name.name,                     dbms: "mysql,mariadb,h2", value: INSTANCE_NAME}
-  - property: {name: quartz.int_prop_1.name,                        dbms: "postgresql",       value: int_prop_1}
-  - property: {name: quartz.int_prop_1.name,                        dbms: "mysql,mariadb,h2", value: INT_PROP_1}
-  - property: {name: quartz.int_prop_2.name,                        dbms: "postgresql",       value: int_prop_2}
-  - property: {name: quartz.int_prop_2.name,                        dbms: "mysql,mariadb,h2", value: INT_PROP_2}
-  - property: {name: quartz.is_durable.name,                        dbms: "postgresql",       value: is_durable}
-  - property: {name: quartz.is_durable.name,                        dbms: "mysql,mariadb,h2", value: IS_DURABLE}
-  - property: {name: quartz.is_nonconcurrent.name,                  dbms: "postgresql",       value: is_nonconcurrent}
-  - property: {name: quartz.is_nonconcurrent.name,                  dbms: "mysql,mariadb,h2", value: IS_NONCONCURRENT}
-  - property: {name: quartz.is_update_data.name,                    dbms: "postgresql",       value: is_update_data}
-  - property: {name: quartz.is_update_data.name,                    dbms: "mysql,mariadb,h2", value: IS_UPDATE_DATA}
-  - property: {name: quartz.job_class_name.name,                    dbms: "postgresql",       value: job_class_name}
-  - property: {name: quartz.job_class_name.name,                    dbms: "mysql,mariadb,h2", value: JOB_CLASS_NAME}
-  - property: {name: quartz.job_data.name,                          dbms: "postgresql",       value: job_data}
-  - property: {name: quartz.job_data.name,                          dbms: "mysql,mariadb,h2", value: JOB_DATA}
-  - property: {name: quartz.job_group.name,                         dbms: "postgresql",       value: job_group}
-  - property: {name: quartz.job_group.name,                         dbms: "mysql,mariadb,h2", value: JOB_GROUP}
-  - property: {name: quartz.job_name.name,                          dbms: "postgresql",       value: job_name}
-  - property: {name: quartz.job_name.name,                          dbms: "mysql,mariadb,h2", value: JOB_NAME}
-  - property: {name: quartz.last_checkin_time.name,                 dbms: "postgresql",       value: last_checkin_time}
-  - property: {name: quartz.last_checkin_time.name,                 dbms: "mysql,mariadb,h2", value: LAST_CHECKIN_TIME}
-  - property: {name: quartz.lock_name.name,                         dbms: "postgresql",       value: lock_name}
-  - property: {name: quartz.lock_name.name,                         dbms: "mysql,mariadb,h2", value: LOCK_NAME}
-  - property: {name: quartz.long_prop_1.name,                       dbms: "postgresql",       value: long_prop_1}
-  - property: {name: quartz.long_prop_1.name,                       dbms: "mysql,mariadb,h2", value: LONG_PROP_1}
-  - property: {name: quartz.long_prop_2.name,                       dbms: "postgresql",       value: long_prop_2}
-  - property: {name: quartz.long_prop_2.name,                       dbms: "mysql,mariadb,h2", value: LONG_PROP_2}
-  - property: {name: quartz.misfire_instr.name,                     dbms: "postgresql",       value: misfire_instr}
-  - property: {name: quartz.misfire_instr.name,                     dbms: "mysql,mariadb,h2", value: MISFIRE_INSTR}
-  - property: {name: quartz.next_fire_time.name,                    dbms: "postgresql",       value: next_fire_time}
-  - property: {name: quartz.next_fire_time.name,                    dbms: "mysql,mariadb,h2", value: NEXT_FIRE_TIME}
-  - property: {name: quartz.pk_qrtz_blob_triggers.name,             dbms: "postgresql",       value: pk_qrtz_blob_triggers}
-  - property: {name: quartz.pk_qrtz_blob_triggers.name,             dbms: "mysql,mariadb,h2", value: PK_QRTZ_BLOB_TRIGGERS}
-  - property: {name: quartz.pk_qrtz_calendars.name,                 dbms: "postgresql",       value: pk_qrtz_calendars}
-  - property: {name: quartz.pk_qrtz_calendars.name,                 dbms: "mysql,mariadb,h2", value: PK_QRTZ_CALENDARS}
-  - property: {name: quartz.pk_qrtz_cron_triggers.name,             dbms: "postgresql",       value: pk_qrtz_cron_triggers}
-  - property: {name: quartz.pk_qrtz_cron_triggers.name,             dbms: "mysql,mariadb,h2", value: PK_QRTZ_CRON_TRIGGERS}
-  - property: {name: quartz.pk_qrtz_fired_triggers.name,            dbms: "postgresql",       value: pk_qrtz_fired_triggers}
-  - property: {name: quartz.pk_qrtz_fired_triggers.name,            dbms: "mysql,mariadb,h2", value: PK_QRTZ_FIRED_TRIGGERS}
-  - property: {name: quartz.pk_qrtz_job_details.name,               dbms: "postgresql",       value: pk_qrtz_job_details}
-  - property: {name: quartz.pk_qrtz_job_details.name,               dbms: "mysql,mariadb,h2", value: PK_QRTZ_JOB_DETAILS}
-  - property: {name: quartz.pk_qrtz_locks.name,                     dbms: "postgresql",       value: pk_qrtz_locks}
-  - property: {name: quartz.pk_qrtz_locks.name,                     dbms: "mysql,mariadb,h2", value: PK_QRTZ_LOCKS}
-  - property: {name: quartz.pk_qrtz_scheduler_state.name,           dbms: "postgresql",       value: pk_qrtz_scheduler_state}
-  - property: {name: quartz.pk_qrtz_scheduler_state.name,           dbms: "mysql,mariadb,h2", value: PK_QRTZ_SCHEDULER_STATE}
-  - property: {name: quartz.pk_qrtz_simple_triggers.name,           dbms: "postgresql",       value: pk_qrtz_simple_triggers}
-  - property: {name: quartz.pk_qrtz_simple_triggers.name,           dbms: "mysql,mariadb,h2", value: PK_QRTZ_SIMPLE_TRIGGERS}
-  - property: {name: quartz.pk_qrtz_simprop_triggers.name,          dbms: "postgresql",       value: pk_qrtz_simprop_triggers}
-  - property: {name: quartz.pk_qrtz_simprop_triggers.name,          dbms: "mysql,mariadb,h2", value: PK_QRTZ_SIMPROP_TRIGGERS}
-  - property: {name: quartz.pk_qrtz_triggers.name,                  dbms: "postgresql",       value: pk_qrtz_triggers}
-  - property: {name: quartz.pk_qrtz_triggers.name,                  dbms: "mysql,mariadb,h2", value: PK_QRTZ_TRIGGERS}
-  - property: {name: quartz.pk_sched_name.name,                     dbms: "postgresql",       value: pk_sched_name}
-  - property: {name: quartz.pk_sched_name.name,                     dbms: "mysql,mariadb,h2", value: PK_SCHED_NAME}
-  - property: {name: quartz.prev_fire_time.name,                    dbms: "postgresql",       value: prev_fire_time}
-  - property: {name: quartz.prev_fire_time.name,                    dbms: "mysql,mariadb,h2", value: PREV_FIRE_TIME}
-  - property: {name: quartz.priority.name,                          dbms: "postgresql",       value: priority}
-  - property: {name: quartz.priority.name,                          dbms: "mysql,mariadb,h2", value: PRIORITY}
-  - property: {name: quartz.qrtz_blob_triggers.name,                dbms: "postgresql",       value: qrtz_blob_triggers}
-  - property: {name: quartz.qrtz_blob_triggers.name,                dbms: "mysql,mariadb,h2", value: QRTZ_BLOB_TRIGGERS}
-  - property: {name: quartz.qrtz_calendars.name,                    dbms: "postgresql",       value: qrtz_calendars}
-  - property: {name: quartz.qrtz_calendars.name,                    dbms: "mysql,mariadb,h2", value: QRTZ_CALENDARS}
-  - property: {name: quartz.qrtz_cron_triggers.name,                dbms: "postgresql",       value: qrtz_cron_triggers}
-  - property: {name: quartz.qrtz_cron_triggers.name,                dbms: "mysql,mariadb,h2", value: QRTZ_CRON_TRIGGERS}
-  - property: {name: quartz.qrtz_fired_triggers.name,               dbms: "postgresql",       value: qrtz_fired_triggers}
-  - property: {name: quartz.qrtz_fired_triggers.name,               dbms: "mysql,mariadb,h2", value: QRTZ_FIRED_TRIGGERS}
-  - property: {name: quartz.qrtz_job_details.name,                  dbms: "postgresql",       value: qrtz_job_details}
-  - property: {name: quartz.qrtz_job_details.name,                  dbms: "mysql,mariadb,h2", value: QRTZ_JOB_DETAILS}
-  - property: {name: quartz.qrtz_locks.name,                        dbms: "postgresql",       value: qrtz_locks}
-  - property: {name: quartz.qrtz_locks.name,                        dbms: "mysql,mariadb,h2", value: QRTZ_LOCKS}
-  - property: {name: quartz.qrtz_paused_trigger_grps.name,          dbms: "postgresql",       value: qrtz_paused_trigger_grps}
-  - property: {name: quartz.qrtz_paused_trigger_grps.name,          dbms: "mysql,mariadb,h2", value: QRTZ_PAUSED_TRIGGER_GRPS}
-  - property: {name: quartz.qrtz_scheduler_state.name,              dbms: "postgresql",       value: qrtz_scheduler_state}
-  - property: {name: quartz.qrtz_scheduler_state.name,              dbms: "mysql,mariadb,h2", value: QRTZ_SCHEDULER_STATE}
-  - property: {name: quartz.qrtz_simple_triggers.name,              dbms: "postgresql",       value: qrtz_simple_triggers}
-  - property: {name: quartz.qrtz_simple_triggers.name,              dbms: "mysql,mariadb,h2", value: QRTZ_SIMPLE_TRIGGERS}
-  - property: {name: quartz.qrtz_simprop_triggers.name,             dbms: "postgresql",       value: qrtz_simprop_triggers}
-  - property: {name: quartz.qrtz_simprop_triggers.name,             dbms: "mysql,mariadb,h2", value: QRTZ_SIMPROP_TRIGGERS}
-  - property: {name: quartz.qrtz_triggers.name,                     dbms: "postgresql",       value: qrtz_triggers}
-  - property: {name: quartz.qrtz_triggers.name,                     dbms: "mysql,mariadb,h2", value: QRTZ_TRIGGERS}
-  - property: {name: quartz.repeat_count.name,                      dbms: "postgresql",       value: repeat_count}
-  - property: {name: quartz.repeat_count.name,                      dbms: "mysql,mariadb,h2", value: REPEAT_COUNT}
-  - property: {name: quartz.repeat_interval.name,                   dbms: "postgresql",       value: repeat_interval}
-  - property: {name: quartz.repeat_interval.name,                   dbms: "mysql,mariadb,h2", value: REPEAT_INTERVAL}
-  - property: {name: quartz.requests_recovery.name,                 dbms: "postgresql",       value: requests_recovery}
-  - property: {name: quartz.requests_recovery.name,                 dbms: "mysql,mariadb,h2", value: REQUESTS_RECOVERY}
-  - property: {name: quartz.sched_name.name,                        dbms: "postgresql",       value: sched_name}
-  - property: {name: quartz.sched_name.name,                        dbms: "mysql,mariadb,h2", value: SCHED_NAME}
-  - property: {name: quartz.sched_time.name,                        dbms: "postgresql",       value: sched_time}
-  - property: {name: quartz.sched_time.name,                        dbms: "mysql,mariadb,h2", value: SCHED_TIME}
-  - property: {name: quartz.start_time.name,                        dbms: "postgresql",       value: start_time}
-  - property: {name: quartz.start_time.name,                        dbms: "mysql,mariadb,h2", value: START_TIME}
-  - property: {name: quartz.state.name,                             dbms: "postgresql",       value: state}
-  - property: {name: quartz.state.name,                             dbms: "mysql,mariadb,h2", value: STATE}
-  - property: {name: quartz.str_prop_1.name,                        dbms: "postgresql",       value: str_prop_1}
-  - property: {name: quartz.str_prop_1.name,                        dbms: "mysql,mariadb,h2", value: STR_PROP_1}
-  - property: {name: quartz.str_prop_2.name,                        dbms: "postgresql",       value: str_prop_2}
-  - property: {name: quartz.str_prop_2.name,                        dbms: "mysql,mariadb,h2", value: STR_PROP_2}
-  - property: {name: quartz.str_prop_3.name,                        dbms: "postgresql",       value: str_prop_3}
-  - property: {name: quartz.str_prop_3.name,                        dbms: "mysql,mariadb,h2", value: STR_PROP_3}
-  - property: {name: quartz.times_triggered.name,                   dbms: "postgresql",       value: times_triggered}
-  - property: {name: quartz.times_triggered.name,                   dbms: "mysql,mariadb,h2", value: TIMES_TRIGGERED}
-  - property: {name: quartz.time_zone_id.name,                      dbms: "postgresql",       value: time_zone_id}
-  - property: {name: quartz.time_zone_id.name,                      dbms: "mysql,mariadb,h2", value: TIME_ZONE_ID}
-  - property: {name: quartz.trigger_group.name,                     dbms: "postgresql",       value: trigger_group}
-  - property: {name: quartz.trigger_group.name,                     dbms: "mysql,mariadb,h2", value: TRIGGER_GROUP}
-  - property: {name: quartz.trigger_name.name,                      dbms: "postgresql",       value: trigger_name}
-  - property: {name: quartz.trigger_name.name,                      dbms: "mysql,mariadb,h2", value: TRIGGER_NAME}
-  - property: {name: quartz.trigger_state.name,                     dbms: "postgresql",       value: trigger_state}
-  - property: {name: quartz.trigger_state.name,                     dbms: "mysql,mariadb,h2", value: TRIGGER_STATE}
-  - property: {name: quartz.trigger_type.name,                      dbms: "postgresql",       value: trigger_type}
-  - property: {name: quartz.trigger_type.name,                      dbms: "mysql,mariadb,h2", value: TRIGGER_TYPE}
-
-  - changeSet:
-      id: 89
-      author: camsaul
-      comment: Added 0.30.0
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: ${quartz.qrtz_job_details.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.job_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.job_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.description.name}
-                  type: varchar(250)
-              - column:
-                  name: ${quartz.job_class_name.name}
-                  type: varchar(250)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.is_durable.name}
-                  type: bool
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.is_nonconcurrent.name}
-                  type: bool
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.is_update_data.name}
-                  type: bool
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.requests_recovery.name}
-                  type: bool
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.job_data.name}
-                  type: ${blob.type}
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_job_details.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.job_name.name}, ${quartz.job_group.name}
-            constraintName: ${quartz.pk_qrtz_job_details.name}
-        - createTable:
-            tableName: ${quartz.qrtz_triggers.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.job_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.job_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.description.name}
-                  type: varchar(250)
-              - column:
-                  name: ${quartz.next_fire_time.name}
-                  type: bigint
-              - column:
-                  name: ${quartz.prev_fire_time.name}
-                  type: bigint
-              - column:
-                  name: ${quartz.priority.name}
-                  type: integer
-              - column:
-                  name: ${quartz.trigger_state.name}
-                  type: varchar(16)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_type.name}
-                  type: varchar(8)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.start_time.name}
-                  type: bigint
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.end_time.name}
-                  type: bigint
-              - column:
-                  name: ${quartz.calendar_name.name}
-                  type: varchar(200)
-              - column:
-                  name: ${quartz.misfire_instr.name}
-                  type: smallint
-              - column:
-                  name: ${quartz.job_data.name}
-                  type: ${blob.type}
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_triggers.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.pk_qrtz_triggers.name}
-        - addForeignKeyConstraint:
-            baseTableName: ${quartz.qrtz_triggers.name}
-            baseColumnNames: ${quartz.sched_name.name}, ${quartz.job_name.name}, ${quartz.job_group.name}
-            referencedTableName: ${quartz.qrtz_job_details.name}
-            referencedColumnNames: ${quartz.sched_name.name}, ${quartz.job_name.name}, ${quartz.job_group.name}
-            constraintName: ${quartz.fk_qrtz_triggers_job_details.name}
-        - createTable:
-            tableName: ${quartz.qrtz_simple_triggers.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.repeat_count.name}
-                  type: bigint
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.repeat_interval.name}
-                  type: bigint
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.times_triggered.name}
-                  type: bigint
-                  constraints:
-                    nullable: false
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_simple_triggers.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.pk_qrtz_simple_triggers.name}
-        - addForeignKeyConstraint:
-            baseTableName: ${quartz.qrtz_simple_triggers.name}
-            baseColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            referencedTableName: ${quartz.qrtz_triggers.name}
-            referencedColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.fk_qrtz_simple_triggers_triggers.name}
-        - createTable:
-            tableName: ${quartz.qrtz_cron_triggers.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.cron_expression.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.time_zone_id.name}
-                  type: varchar(80)
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_cron_triggers.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.pk_qrtz_cron_triggers.name}
-        - addForeignKeyConstraint:
-            baseTableName: ${quartz.qrtz_cron_triggers.name}
-            baseColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            referencedTableName: ${quartz.qrtz_triggers.name}
-            referencedColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.fk_qrtz_cron_triggers_triggers.name}
-        - createTable:
-            tableName: ${quartz.qrtz_simprop_triggers.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.str_prop_1.name}
-                  type: varchar(512)
-              - column:
-                  name: ${quartz.str_prop_2.name}
-                  type: varchar(512)
-              - column:
-                  name: ${quartz.str_prop_3.name}
-                  type: varchar(512)
-              - column:
-                  name: ${quartz.int_prop_1.name}
-                  type: int
-              - column:
-                  name: ${quartz.int_prop_2.name}
-                  type: int
-              - column:
-                  name: ${quartz.long_prop_1.name}
-                  type: bigint
-              - column:
-                  name: ${quartz.long_prop_2.name}
-                  type: bigint
-              - column:
-                  name: ${quartz.dec_prop_1.name}
-                  type: numeric(13,4)
-              - column:
-                  name: ${quartz.dec_prop_2.name}
-                  type: numeric(13,4)
-              - column:
-                  name: ${quartz.bool_prop_1.name}
-                  type: bool
-              - column:
-                  name: ${quartz.bool_prop_2.name}
-                  type: bool
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_simprop_triggers.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.pk_qrtz_simprop_triggers.name}
-        - addForeignKeyConstraint:
-            baseTableName: ${quartz.qrtz_simprop_triggers.name}
-            baseColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            referencedTableName: ${quartz.qrtz_triggers.name}
-            referencedColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.fk_qrtz_simprop_triggers_triggers.name}
-        - createTable:
-            tableName: ${quartz.qrtz_blob_triggers.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.blob_data.name}
-                  type: ${blob.type}
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_blob_triggers.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.pk_qrtz_blob_triggers.name}
-        - addForeignKeyConstraint:
-            baseTableName: ${quartz.qrtz_blob_triggers.name}
-            baseColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            referencedTableName: ${quartz.qrtz_triggers.name}
-            referencedColumnNames: ${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.fk_qrtz_blob_triggers_triggers.name}
-        - createTable:
-            tableName: ${quartz.qrtz_calendars.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.calendar_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.calendar.name}
-                  type: ${blob.type}
-                  constraints:
-                    nullable: false
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_calendars.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.calendar_name.name}
-            constraintName: ${quartz.pk_qrtz_calendars.name}
-        - createTable:
-            tableName: ${quartz.qrtz_paused_trigger_grps.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_paused_trigger_grps.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.trigger_group.name}
-            constraintName: ${quartz.pk_sched_name.name}
-        - createTable:
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.entry_id.name}
-                  type: varchar(95)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.trigger_group.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.instance_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.fired_time.name}
-                  type: bigint
-                  constraints:
-                    nullable: false
-# Note: this column is not used on Quartz 2.1.x; it is used in 2.2.x, which recommends making it NOT NULL. I've made it
-# nullable since at the time of this migration we're still using 2.1.7; including it gives us an easy upgrade path in
-# the future.
-              - column:
-                  name: ${quartz.sched_time.name}
-                  type: bigint
-              - column:
-                  name: ${quartz.priority.name}
-                  type: integer
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.state.name}
-                  type: varchar(16)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.job_name.name}
-                  type: varchar(200)
-              - column:
-                  name: ${quartz.job_group.name}
-                  type: varchar(200)
-              - column:
-                  name: ${quartz.is_nonconcurrent.name}
-                  type: bool
-              - column:
-                  name: ${quartz.requests_recovery.name}
-                  type: bool
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.entry_id.name}
-            constraintName: ${quartz.pk_qrtz_fired_triggers.name}
-        - createTable:
-            tableName: ${quartz.qrtz_scheduler_state.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.instance_name.name}
-                  type: varchar(200)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.last_checkin_time.name}
-                  type: bigint
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.checkin_interval.name}
-                  type: bigint
-                  constraints:
-                    nullable: false
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_scheduler_state.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.instance_name.name}
-            constraintName: ${quartz.pk_qrtz_scheduler_state.name}
-        - createTable:
-            tableName: ${quartz.qrtz_locks.name}
-            remarks: Used for Quartz scheduler.
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-                  type: varchar(120)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ${quartz.lock_name.name}
-                  type: varchar(40)
-                  constraints:
-                    nullable: false
-        - addPrimaryKey:
-            tableName: ${quartz.qrtz_locks.name}
-            columnNames: ${quartz.sched_name.name}, ${quartz.lock_name.name}
-            constraintName: ${quartz.pk_qrtz_locks.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_j_req_recovery.name}
-            tableName: ${quartz.qrtz_job_details.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.requests_recovery.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_j_grp.name}
-            tableName: ${quartz.qrtz_job_details.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.job_group.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_j.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.job_name.name}
-              - column:
-                  name: ${quartz.job_group.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_jg.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.job_group.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_c.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.calendar_name.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_g.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.trigger_group.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_state.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.trigger_state.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_n_state.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.trigger_name.name}
-              - column:
-                  name: ${quartz.trigger_group.name}
-              - column:
-                  name: ${quartz.trigger_state.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_n_g_state.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.trigger_group.name}
-              - column:
-                  name: ${quartz.trigger_state.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_next_fire_time.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.next_fire_time.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_nft_st.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.trigger_state.name}
-              - column:
-                  name: ${quartz.next_fire_time.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_nft_misfire.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.misfire_instr.name}
-              - column:
-                  name: ${quartz.next_fire_time.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_nft_st_misfire.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.misfire_instr.name}
-              - column:
-                  name: ${quartz.next_fire_time.name}
-              - column:
-                  name: ${quartz.trigger_state.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_t_nft_st_misfire_grp.name}
-            tableName: ${quartz.qrtz_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.misfire_instr.name}
-              - column:
-                  name: ${quartz.next_fire_time.name}
-              - column:
-                  name: ${quartz.trigger_group.name}
-              - column:
-                  name: ${quartz.trigger_state.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_ft_trig_inst_name.name}
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.instance_name.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_ft_inst_job_req_rcvry.name}
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.instance_name.name}
-              - column:
-                  name: ${quartz.requests_recovery.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_ft_j_g.name}
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.job_name.name}
-              - column:
-                  name: ${quartz.job_group.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_ft_jg.name}
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.job_group.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_ft_t_g.name}
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.trigger_name.name}
-              - column:
-                  name: ${quartz.trigger_group.name}
-        - createIndex:
-            indexName: ${quartz.idx_qrtz_ft_tg.name}
-            tableName: ${quartz.qrtz_fired_triggers.name}
-            columns:
-              - column:
-                  name: ${quartz.sched_name.name}
-              - column:
-                  name: ${quartz.trigger_group.name}
-
-  - changeSet:
-      id: 90
-      author: senior
-      comment: 'Added 0.30.0'
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: sso_source
-                  type: varchar(254)
-                  remarks: 'String to indicate the SSO backend the user is from'
-        - sql:
-            sql: update core_user set sso_source='saml' where saml_auth=true
-        - dropColumn:
-            tableName: core_user
-            columnName: saml_auth
-
-# Forgot to get rid of the raw_table_id and raw_column_id columns when we dropped the tables they referenced in migration 87.
-
-  - changeSet:
-      id: 91
-      author: camsaul
-      comment: 'Added 0.30.0'
-      changes:
-        - dropColumn:
-            tableName: metabase_table
-            columnName: raw_table_id
-        - dropColumn:
-            tableName: metabase_field
-            columnName: raw_column_id
-
-# Add database_id column to query_execution
-
-  - changeSet:
-      id: 92
-      author: camsaul
-      comment: 'Added 0.31.0'
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: database_id
-                  type: integer
-                  remarks: 'ID of the database this query was ran against.'
-
-# Start recording the actual query dictionary that's been executed
-
-  - changeSet:
-      id: 93
-      author: camsaul
-      comment: 'Added 0.31.0'
-      changes:
-        - addColumn:
-            tableName: query
-            columns:
-              - column:
-                  name: query
-                  type: text
-                  remarks: 'The actual "query dictionary" for this query.'
-
-# Create the TaskHistory table, intended to provide debugging info on our background/quartz processes
-  - changeSet:
-      id: 94
-      author: senior
-      comment: 'Added 0.31.0'
-      changes:
-        - createTable:
-            tableName: task_history
-            remarks: 'Timing and metadata info about background/quartz processes'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: task
-                  type: VARCHAR(254)
-                  remarks: 'Name of the task'
-                  constraints:
-                    nullable: false
-              # The sync tasks all have a db_id, but there are others that won't, such as the pulses
-              # task or task history cleanup. The way around this is to create a join table between
-              # TASK_HISTORY and METABASE_DATABASE, but that doesn't seem worth it right now.
-              - column:
-                  name: db_id
-                  type: integer
-              - column:
-                  name: started_at
-                  type: datetime
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ended_at
-                  type: datetime
-                  constraints:
-                    nullable: false
-              - column:
-                  name: duration
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: task_details
-                  remarks: 'JSON string with additional info on the task'
-                  type: text
-        - createIndex:
-            indexName: idx_task_history_end_time
-            tableName: task_history
-            columns:
-              - column:
-                  name: ended_at
-        - createIndex:
-            indexName: idx_task_history_db_id
-            tableName: task_history
-            columns:
-              - column:
-                  name: db_id
-# Before this changeset, the databasechangelog table didn't include any uniqueness constraing for the databasechangelog
-# table. Not having anything that uniquely identifies a row can cause issues for database replication. In earlier
-# versions of Liquibase the uniquenes constraint was (ID, AUTHOR, FILENAME) but that was dropped
-# (https://liquibase.jira.com/browse/CORE-1909) as some as the combination of the three columns caused issues on some
-# databases. We only support PostgreSQL, MySQL and H2 which doesn't have that issue. This changeset puts back that
-# uniqueness constraint since the issue shouldn't affect us and it will allow replication without the user needed to
-# add their own constraint.
-  - changeSet:
-      id: 95
-      author: senior
-      comment: 'Added 0.31.0'
-      validCheckSum: ANY
-      # Don't add the constraint if there are already duplicates in the database change log! Migrations will fail!
-      # See #8909
-      preConditions:
-        - onFail: MARK_RAN
-        # If we're dumping the migration as a SQL file or trying to force-migrate we can't check the preconditions
-        # so just go ahead and skip the entire thing. This is a non-critical migration
-        - onUpdateSQL: IGNORE
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1
-      changes:
-        - addUniqueConstraint:
-            columnNames: id, author, filename
-            constraintName: idx_databasechangelog_id_author_filename
-            tableName: ${databasechangelog.name}
-#
-# ADD Field.settings COLUMN
-#
-  - changeSet:
-      id: 96
-      author: camsaul
-      comment: 'Added 0.31.0'
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: settings
-                  type: text
-                  remarks: 'Serialized JSON FE-specific settings like formatting, etc. Scope of what is stored here may increase in future.'
-#
-# Change MySQL/Maria's blob type to LONGBLOB to more closely match what H2 and PostgreSQL support for size limits
-#
-  - changeSet:
-      id: 97
-      author: senior
-      comment: 'Added 0.32.0'
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: query_cache
-            columnName: results
-            newDataType: longblob
-
-#
-# Add unique constraints for (Field name + table_id + parent_id) and for (Table name + schema + db_id) unless for one
-# reason or another those would-be constraints are already violated. This is to fix issue where sometimes the same Field
-# or Table is synced more than once (see #669, #8950, #9048)
-#
-# Note that the SQL standard says unique constraints should not apply to columns with NULL values. Consider the following:
-#
-# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, 'PUBLIC', 'my_table');
-# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, 'PUBLIC', 'my_table'); -- fails: violates UNIQUE constraint
-#
-# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, NULL, 'my_table');
-# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, NULL, 'my_table'); -- succeeds: because schema is NULL constraint does not apply
-#
-# Thus these constraints won't work if the data warehouse DB in question doesn't use schemas (e.g. MySQL or MongoDB). It
-# will work for other data warehouse types.
-#
-# Luckily Postgres (but not H2 or MySQL) supports constraints that only apply to columns matching conditions, so we can
-# add additional constraints to properly handle those cases.
-  - changeSet:
-      id: 98
-      author: camsaul
-      validCheckSum: 8:f036d20a4dc86fb60ffb64ea838ed6b9
-      comment: 'Added 0.32.0'
-      preConditions:
-        - onFail: MARK_RAN
-        - onUpdateSQL: IGNORE
-        - or:
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM (SELECT count(*) FROM `metabase_table` GROUP BY `db_id`, `schema`, `name` HAVING count(*) > 1) t1
-            - and:
-                - dbms:
-                    type: h2,postgresql
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_TABLE GROUP BY DB_ID, SCHEMA, NAME HAVING count(*) > 1) t1
-      changes:
-        - addUniqueConstraint:
-            tableName: metabase_table
-            columnNames: db_id, schema, name
-            constraintName: idx_uniq_table_db_id_schema_name
-        # For Postgres, add additional constraint to apply if schema is NULL
-        - sql:
-            dbms: postgresql
-            sql: CREATE UNIQUE INDEX idx_uniq_table_db_id_schema_name_2col ON "metabase_table" ("db_id", "name") WHERE "schema" IS NULL
-
-  - changeSet:
-      id: 99
-      author: camsaul
-      validCheckSum: 8:274bb516dd95b76c954b26084eed1dfe
-      comment: 'Added 0.32.0'
-      preConditions:
-        - onFail: MARK_RAN
-        - onUpdateSQL: IGNORE
-        - or:
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM (SELECT count(*) FROM `metabase_field` GROUP BY `table_id`, `parent_id`, `name` HAVING count(*) > 1) t1
-            - and:
-                - dbms:
-                    type: h2,postgresql
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_FIELD GROUP BY TABLE_ID, PARENT_ID, NAME HAVING count(*) > 1) t1
-      changes:
-        - addUniqueConstraint:
-            tableName: metabase_field
-            columnNames: table_id, parent_id, name
-            constraintName: idx_uniq_field_table_id_parent_id_name
-        # For Postgres, add additional constraint to apply if schema is NULL
-        - sql:
-            dbms: postgresql
-            sql: CREATE UNIQUE INDEX idx_uniq_field_table_id_parent_id_name_2col ON "metabase_field" ("table_id", "name") WHERE "parent_id" IS NULL
-
-#
-# Migration 84 was written slightly incorrectly and did not correctly migrate the values of is_active -> archived for
-# METRICS. If you look at the migration you will notice the raw SQL part is a `sql` map with 2 `sql` keys. The first key
-# is ignored, and that statement was never ran.
-#
-# To fix this we will migrate any metrics that haven't been updated since that migration ran and fix their archived
-# status
-  - changeSet:
-      id: 100
-      author: camsaul
-      comment: 'Added 0.32.0'
-      validCheckSum: ANY
-      changes:
-        # databasechangelog is upper-case in MySQL and MariaDB (and H2 for that matter, but H2 will upper-case the
-        # unquoted identifier)
-        - sql:
-            dbms: postgresql,h2
-            sql: >-
-              UPDATE metric
-              SET archived = NOT archived
-              WHERE EXISTS (
-                SELECT *
-                FROM databasechangelog dbcl
-                WHERE dbcl.id = '84'
-                  AND metric.updated_at < dbcl.dateexecuted
-              )
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE metric
-              SET archived = NOT archived
-              WHERE EXISTS (
-                SELECT *
-                FROM `DATABASECHANGELOG` dbcl
-                WHERE dbcl.id = '84'
-                  AND metric.updated_at < dbcl.dateexecuted
-              )
-
-# Very helpful for performance reasons. See #9519
-  - changeSet:
-      id: 101
-      author: camsaul
-      comment: 'Added 0.32.0'
-      changes:
-        - createIndex:
-            indexName: idx_field_parent_id
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: parent_id
-
-# A per-Database setting for the new Query Builder 3.0.
-  - changeSet:
-      id: 103
-      author: camsaul
-      comment: 'Added 0.32.10'
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: auto_run_queries
-                  remarks: 'Whether to automatically run queries when doing simple filtering and summarizing in the Query Builder.'
-                  type: boolean
-                  constraints:
-                    nullable: false
-                  defaultValueBoolean: true
-
-
-  # To fix EE full-app embedding without compromising security. Full-app embed sessions cannot have `SameSite` attributes in their cookies.
-  - changeSet:
-      id: 104
-      author: camsaul
-      comment: 'Added EE 1.1.6/CE 0.33.0'
-      changes:
-        - addColumn:
-            tableName: core_session
-            columns:
-              - column:
-                  name: anti_csrf_token
-                  type: text
-                  remarks: 'Anti-CSRF token for full-app embed sessions.'
-
-#
-# Change `metabase_field.database_type` to `text` to accomodate more exotic field types (enums in Clickhouse, rows in Presto, ...)
-#
-  - changeSet:
-      id: 106
-      author: sb
-      comment: 'Added 0.33.5'
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_type
-            newDataType: text
-
-#
-#  Migrations 107-160 are used to convert a MySQL or MariaDB database to utf8mb4 on launch -- see #11753 for a detailed explanation of these migrations
-#
-
-  - changeSet:
-        id: 107
-        author: camsaul
-        comment: Added 0.34.2
-        # If this migration fails for any reason continue with the next migration; do not fail the entire process if this one fails
-        failOnError: false
-        preConditions:
-          # If preconditions fail (i.e., dbms is not mysql or mariadb) then mark this migration as 'ran'
-          - onFail: MARK_RAN
-          # If we're generating SQL output for migrations instead of running via liquibase, fail the preconditions which means these migrations will be skipped
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER DATABASE CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
-  - changeSet:
-        id: 108
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `DATABASECHANGELOG` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 109
-        author: camsaul
-        comment: Added 0.34.2, but not necessary anymore with the liquibase session lock
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: none
-        changes:
-          - sql:
-                sql: ALTER TABLE `DATABASECHANGELOGLOCK` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 110
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_CALENDARS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 111
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_FIRED_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 112
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_JOB_DETAILS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 113
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_LOCKS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 114
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_PAUSED_TRIGGER_GRPS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 115
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_SCHEDULER_STATE` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 116
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `core_user` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 117
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `data_migrations` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 118
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `dependency` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 119
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `label` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 120
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `metabase_database` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 121
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `permissions_group` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 122
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `query` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 123
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `query_cache` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 124
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `query_execution` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 125
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `setting` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 126
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `task_history` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 127
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 128
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `activity` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 129
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `collection` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 130
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `collection_revision` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 131
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `computation_job` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 132
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `core_session` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 133
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `metabase_table` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 134
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `permissions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 135
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `permissions_revision` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 136
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `revision` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 137
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `view_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 138
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_BLOB_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 139
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_CRON_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 140
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_SIMPLE_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 141
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `QRTZ_SIMPROP_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 142
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `computation_job_result` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 143
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `metabase_field` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 144
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `permissions_group_membership` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 145
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `pulse` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 146
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `report_dashboard` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 147
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `dashboard_favorite` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 148
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `dimension` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 149
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `metabase_fieldvalues` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 150
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `metric` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 151
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `pulse_channel` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 152
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `segment` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 153
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `pulse_channel_recipient` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 154
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `report_card` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 155
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `metric_important_field` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 156
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `report_cardfavorite` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 157
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `card_label` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 158
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `pulse_card` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 159
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `report_dashboardcard` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  - changeSet:
-        id: 160
-        author: camsaul
-        comment: Added 0.34.2
-        failOnError: false
-        preConditions:
-          - onFail: MARK_RAN
-          - onSqlOutput: FAIL
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
-        changes:
-          - sql:
-                sql: ALTER TABLE `dashboardcard_series` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
-# [161 has been removed. Superceded by 166]
-
-# Drop the old query_queryexecution table if present. This was replaced by query_execution in 0.23.0. This was
-# formerly a data migration but was converted to a Liquibase migration so people running migrations manually will
-# still have the Table dropped.
-
-  - changeSet:
-      id: 162
-      author: camsaul
-      comment: 'Added 0.23.0 as a data migration; converted to Liquibase migration in 0.35.0'
-      preConditions:
-        - onFail: MARK_RAN
-        - tableExists:
-            tableName: query_queryexecution
-      changes:
-        - dropTable:
-            tableName: query_queryexecution
-
-# Drop Card.read_permissions. Prior to 0.30.0 Card permissions were always based on the Database/Table(s) being
-# queried (i.e., the permissions model we use for ad-hoc queries). These permissions were calculated and stored in
-# `read_permissions` for performance reasons. In 0.30.0, we switched to having Card permissions always be inherited
-# from their parent Collection, and the column hasn't been used since then. Time to let it go.
-
-  - changeSet:
-      id: 163
-      author: camsaul
-      comment: 'Added 0.35.0'
-      changes:
-        - dropColumn:
-            tableName: report_card
-            columnName: read_permissions
-
-# Add User `locale` -- when set, this User will see the Metabase in this Locale rather than the system default Locale
-# (the `site-locale` Setting).
-
-  - changeSet:
-      id: 164
-      author: camsaul
-      comment: 'Added 0.35.0'
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: locale
-                  remarks: 'Preferred ISO locale (language/country) code, e.g "en" or "en-US", for this User. Overrides site default.'
-                  type: varchar(5)
-
-# Add Field `database_position` to keep the order in which fields are ordered in the DB, `custom_position` for custom
-# position; and Table `field_order` setting.
-
-  - changeSet:
-      id: 165
-      author: sb
-      comment: 'Added field_order to Table and database_position to Field'
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: database_position
-                  type: int
-                  defaultValueNumeric: 0
-                  constraints:
-                    nullable: false
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: custom_position
-                  type: int
-                  defaultValueNumeric: 0
-                  constraints:
-                    nullable: false
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: field_order
-                  type: varchar(254)
-                  defaultValue: database
-                  constraints:
-                    nullable: false
-        - sql:
-            sql: update metabase_field set database_position = id
-
-# Change field_values.updated_at and query_cache.updated_at from datetime to timestamp [with time zone] to get >
-# second resolution on MySQL.
-#
-# query_cache.updated_at was originally converted to a timestamp in 161, but we used `timestamp` instead of
-# `timestamp(6)`. It is converted correctly here.
-
-  - changeSet:
-      id: 166
-      author: camsaul
-      comment: Added 0.36.0/1.35.4
-      changes:
-        - modifyDataType:
-            tableName: metabase_fieldvalues
-            columnName: updated_at
-            newDataType: ${timestamp_type}
-        - modifyDataType:
-            tableName: query_cache
-            columnName: updated_at
-            newDataType: ${timestamp_type}
-
-# Create the native query snippets table, intended to store snippets and their metadata
-  - changeSet:
-      id: 167
-      author: walterl, camsaul
-      validCheckSum: ANY
-      comment: 'Added 0.36.0'
-      changes:
-        # If an older version of this Table was created locally (during dev) drop it, we have an updated definition
-        - sql:
-            sql: drop table if exists native_query_snippet
-        - createTable:
-            tableName: native_query_snippet
-            remarks: 'Query snippets (raw text) to be substituted in native queries'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: name
-                  type: VARCHAR(254)
-                  remarks: 'Name of the query snippet'
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: description
-                  type: text
-              - column:
-                  name: content
-                  type: text
-                  remarks: 'Raw query snippet'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_snippet_creator_id
-                    # This primarily affects tests because under normal
-                    # circumstances we don't delete Users, we just archive them
-                    deleteCascade: true
-              - column:
-                  name: archived
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  # it seems like defaultValueComputed actaully just ends
-                  # getting ignored anyway -- see
-                  # https://stackoverflow.com/questions/58816496/force-liquibase-to-current-timestamp-instead-of-now
-                  # We set a custom value for MySQL/MariaDB in MetabaseMySqlCreateTableSqlGenerator.java
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-        # Needed to efficiently enforce the unique constraint on name and so we can lookup by name as well.
-        - createIndex:
-            tableName: native_query_snippet
-            indexName: idx_snippet_name
-            columns:
-              - column:
-                  name: name
-
-# Convert query execution from DATETIME to TIMESTAMP(6) so have normalize TZ
-# offset and so MySQL/MariaDB has better than second precision
-
-  - changeSet:
-      id: 168
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - modifyDataType:
-            tableName: query_execution
-            columnName: started_at
-            newDataType: ${timestamp_type}
-
-# Remove `Table.rows`, which hasn't been used for years now. Older versions of Metabase used to store the row count in
-# this column but we disabled it a long time ago for performance reasons. Now it's time to remove it entirely.
-
-  - changeSet:
-      id: 169
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropColumn:
-            tableName: metabase_table
-            columnName: rows
-
-# Remove fields_hash from Table model, as we no longer skip sync steps if metadata
-# hash hasn't changed.
-
-  - changeSet:
-      id: 170
-      author: sb
-      comment: Added 0.36.0
-      changes:
-        - dropColumn:
-            tableName: metabase_table
-            columnName: fields_hash
-
-# In EE, NativeQuerySnippets have a permissions system based on "snippet folders" which are Collections under the
-# hood. However, these Collections live in a separate "namespace" -- a completely separate hierarchy of Collections.
-
-  - changeSet:
-      id: 171
-      author: camsaul
-      validCheckSum: ANY
-      comment: Added 0.36.0
-      changes:
-        - addColumn:
-            tableName: native_query_snippet
-            columns:
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: 'ID of the Snippet Folder (Collection) this Snippet is in, if any'
-                  constraints:
-                    nullable: true
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_snippet_collection_id
-        - createIndex:
-            tableName: native_query_snippet
-            indexName: idx_snippet_collection_id
-            columns:
-              - column:
-                  name: collection_id
-
-  - changeSet:
-      id: 172
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: namespace
-                  type: varchar(254)
-                  remarks: 'The namespace (hierachy) this Collection belongs to. NULL means the Collection is in the default namespace.'
-                  constraints:
-                    nullable: true
-
-# These migrations convert various FK constraints in the DB to ones with ON DELETE CASCADE so the DB can handle this
-# instead of relying on Toucan pre-delete methods to do it, which are subject to race conditions.
-
-  # activity.user_id -> core_user.id
-  - changeSet:
-      id: 173
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: activity
-            constraintName: fk_activity_ref_user_id
-
-  - changeSet:
-      id: 174
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: activity
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_activity_ref_user_id
-            onDelete: CASCADE
-
-  # card_label.card_id -> report_card.id
-  - changeSet:
-      id: 175
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: card_label
-            constraintName: fk_card_label_ref_card_id
-
-  - changeSet:
-      id: 176
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: card_label
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_card_label_ref_card_id
-            onDelete: CASCADE
-
-  # card_label.label_id -> label.id
-  - changeSet:
-      id: 177
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: card_label
-            constraintName: fk_card_label_ref_label_id
-
-  - changeSet:
-      id: 178
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: card_label
-            baseColumnNames: label_id
-            referencedTableName: label
-            referencedColumnNames: id
-            constraintName: fk_card_label_ref_label_id
-            onDelete: CASCADE
-
-  # collection.personal_owner_id -> core_user.id
-  - changeSet:
-      id: 179
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: collection
-            constraintName: fk_collection_personal_owner_id
-
-  - changeSet:
-      id: 180
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: collection
-            baseColumnNames: personal_owner_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_collection_personal_owner_id
-            onDelete: CASCADE
-
-  # collection_revision.user_id -> core_user.id
-  - changeSet:
-      id: 181
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: collection_revision
-            constraintName: fk_collection_revision_user_id
-
-  - changeSet:
-      id: 182
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: collection_revision
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_collection_revision_user_id
-            onDelete: CASCADE
-
-  # computation_job.creator_id -> core_user.id
-  - changeSet:
-      id: 183
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: computation_job
-            constraintName: fk_computation_job_ref_user_id
-
-  - changeSet:
-      id: 184
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: computation_job
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_computation_job_ref_user_id
-            onDelete: CASCADE
-
-  # computation_job_result.job_id -> computation_job.id
-  - changeSet:
-      id: 185
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: computation_job_result
-            constraintName: fk_computation_result_ref_job_id
-
-  - changeSet:
-      id: 186
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: computation_job_result
-            baseColumnNames: job_id
-            referencedTableName: computation_job
-            referencedColumnNames: id
-            constraintName: fk_computation_result_ref_job_id
-            onDelete: CASCADE
-
-  # core_session.user_id -> core_user.id
-  - changeSet:
-      id: 187
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: core_session
-            constraintName: fk_session_ref_user_id
-
-  - changeSet:
-      id: 188
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: core_session
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_session_ref_user_id
-            onDelete: CASCADE
-
-  # dashboardcard_series.card_id -> report_card.id
-  - changeSet:
-      id: 189
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: dashboardcard_series
-            constraintName: fk_dashboardcard_series_ref_card_id
-
-  - changeSet:
-      id: 190
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: dashboardcard_series
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_dashboardcard_series_ref_card_id
-            onDelete: CASCADE
-
-  # dashboardcard_series.dashboardcard_id -> report_dashboardcard.id
-  - changeSet:
-      id: 191
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: dashboardcard_series
-            constraintName: fk_dashboardcard_series_ref_dashboardcard_id
-
-  - changeSet:
-      id: 192
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: dashboardcard_series
-            baseColumnNames: dashboardcard_id
-            referencedTableName: report_dashboardcard
-            referencedColumnNames: id
-            constraintName: fk_dashboardcard_series_ref_dashboardcard_id
-            onDelete: CASCADE
-
-  # group_table_access_policy.card_id -> report_card.id
-  - changeSet:
-      id: 193
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: group_table_access_policy
-            constraintName: fk_gtap_card_id
-
-  - changeSet:
-      id: 194
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: group_table_access_policy
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_gtap_card_id
-            onDelete: CASCADE
-
-  # metabase_field.parent_id -> metabase_field.id
-  - changeSet:
-      id: 195
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metabase_field
-            constraintName: fk_field_parent_ref_field_id
-
-  - changeSet:
-      id: 196
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_field
-            baseColumnNames: parent_id
-            referencedTableName: metabase_field
-            referencedColumnNames: id
-            constraintName: fk_field_parent_ref_field_id
-            onDelete: CASCADE
-
-  # metabase_field.table_id -> metabase_table.id
-  - changeSet:
-      id: 197
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metabase_field
-            constraintName: fk_field_ref_table_id
-
-  - changeSet:
-      id: 198
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_field
-            baseColumnNames: table_id
-            referencedTableName: metabase_table
-            referencedColumnNames: id
-            constraintName: fk_field_ref_table_id
-            onDelete: CASCADE
-
-  # metabase_fieldvalues.field_id -> metabase_field.id
-  - changeSet:
-      id: 199
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metabase_fieldvalues
-            constraintName: fk_fieldvalues_ref_field_id
-
-  - changeSet:
-      id: 200
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_fieldvalues
-            baseColumnNames: field_id
-            referencedTableName: metabase_field
-            referencedColumnNames: id
-            constraintName: fk_fieldvalues_ref_field_id
-            onDelete: CASCADE
-
-  # metabase_table.db_id -> metabase_database.id
-  - changeSet:
-      id: 201
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metabase_table
-            constraintName: fk_table_ref_database_id
-
-  - changeSet:
-      id: 202
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_table
-            baseColumnNames: db_id
-            referencedTableName: metabase_database
-            referencedColumnNames: id
-            constraintName: fk_table_ref_database_id
-            onDelete: CASCADE
-
-  # metric.creator_id -> core_user.id
-  - changeSet:
-      id: 203
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metric
-            constraintName: fk_metric_ref_creator_id
-
-  - changeSet:
-      id: 204
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metric
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_metric_ref_creator_id
-            onDelete: CASCADE
-
-  # metric.table_id -> metabase_table.id
-  - changeSet:
-      id: 205
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metric
-            constraintName: fk_metric_ref_table_id
-
-  - changeSet:
-      id: 206
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metric
-            baseColumnNames: table_id
-            referencedTableName: metabase_table
-            referencedColumnNames: id
-            constraintName: fk_metric_ref_table_id
-            onDelete: CASCADE
-
-  # metric_important_field.field_id -> metabase_field.id
-  - changeSet:
-      id: 207
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metric_important_field
-            constraintName: fk_metric_important_field_metabase_field_id
-
-  - changeSet:
-      id: 208
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metric_important_field
-            baseColumnNames: field_id
-            referencedTableName: metabase_field
-            referencedColumnNames: id
-            constraintName: fk_metric_important_field_metabase_field_id
-            onDelete: CASCADE
-
-  # metric_important_field.metric_id -> metric.id
-  - changeSet:
-      id: 209
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metric_important_field
-            constraintName: fk_metric_important_field_metric_id
-
-  - changeSet:
-      id: 210
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metric_important_field
-            baseColumnNames: metric_id
-            referencedTableName: metric
-            referencedColumnNames: id
-            constraintName: fk_metric_important_field_metric_id
-            onDelete: CASCADE
-
-  # native_query_snippet.collection_id -> collection.id
-  - changeSet:
-      id: 211
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: native_query_snippet
-            constraintName: fk_snippet_collection_id
-
-  - changeSet:
-      id: 212
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: native_query_snippet
-            baseColumnNames: collection_id
-            referencedTableName: collection
-            referencedColumnNames: id
-            constraintName: fk_snippet_collection_id
-            onDelete: SET NULL
-
-  # permissions.group_id -> permissions_group.id
-  - changeSet:
-      id: 213
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: permissions
-            constraintName: fk_permissions_group_id
-
-  - changeSet:
-      id: 214
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: permissions
-            baseColumnNames: group_id
-            referencedTableName: permissions_group
-            referencedColumnNames: id
-            constraintName: fk_permissions_group_id
-            onDelete: CASCADE
-
-  # permissions_group_membership.group_id -> permissions_group.id
-  - changeSet:
-      id: 215
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: permissions_group_membership
-            constraintName: fk_permissions_group_group_id
-
-  - changeSet:
-      id: 216
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: permissions_group_membership
-            baseColumnNames: group_id
-            referencedTableName: permissions_group
-            referencedColumnNames: id
-            constraintName: fk_permissions_group_group_id
-            onDelete: CASCADE
-
-  # permissions_group_membership.user_id -> core_user.id
-  - changeSet:
-      id: 217
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: permissions_group_membership
-            constraintName: fk_permissions_group_membership_user_id
-
-  - changeSet:
-      id: 218
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: permissions_group_membership
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_permissions_group_membership_user_id
-            onDelete: CASCADE
-
-  # permissions_revision.user_id -> core_user.id
-  - changeSet:
-      id: 219
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: permissions_revision
-            constraintName: fk_permissions_revision_user_id
-
-  - changeSet:
-      id: 220
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: permissions_revision
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_permissions_revision_user_id
-            onDelete: CASCADE
-
-  # pulse.collection_id -> collection.id
-  - changeSet:
-      id: 221
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse
-            constraintName: fk_pulse_collection_id
-
-  - changeSet:
-      id: 222
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse
-            baseColumnNames: collection_id
-            referencedTableName: collection
-            referencedColumnNames: id
-            constraintName: fk_pulse_collection_id
-            onDelete: SET NULL
-
-  # pulse.creator_id -> core_user.id
-  - changeSet:
-      id: 223
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse
-            constraintName: fk_pulse_ref_creator_id
-
-  - changeSet:
-      id: 224
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_pulse_ref_creator_id
-            onDelete: CASCADE
-
-  # pulse_card.card_id -> report_card.id
-  - changeSet:
-      id: 225
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse_card
-            constraintName: fk_pulse_card_ref_card_id
-
-  - changeSet:
-      id: 226
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse_card
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_pulse_card_ref_card_id
-            onDelete: CASCADE
-
-  # pulse_card.pulse_id -> pulse.id
-  - changeSet:
-      id: 227
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse_card
-            constraintName: fk_pulse_card_ref_pulse_id
-
-  - changeSet:
-      id: 228
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse_card
-            baseColumnNames: pulse_id
-            referencedTableName: pulse
-            referencedColumnNames: id
-            constraintName: fk_pulse_card_ref_pulse_id
-            onDelete: CASCADE
-
-  # pulse_channel.pulse_id -> pulse.id
-  - changeSet:
-      id: 229
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse_channel
-            constraintName: fk_pulse_channel_ref_pulse_id
-
-  - changeSet:
-      id: 230
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse_channel
-            baseColumnNames: pulse_id
-            referencedTableName: pulse
-            referencedColumnNames: id
-            constraintName: fk_pulse_channel_ref_pulse_id
-            onDelete: CASCADE
-
-  # pulse_channel_recipient.pulse_channel_id -> pulse_channel.id
-  - changeSet:
-      id: 231
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse_channel_recipient
-            constraintName: fk_pulse_channel_recipient_ref_pulse_channel_id
-
-  - changeSet:
-      id: 232
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse_channel_recipient
-            baseColumnNames: pulse_channel_id
-            referencedTableName: pulse_channel
-            referencedColumnNames: id
-            constraintName: fk_pulse_channel_recipient_ref_pulse_channel_id
-            onDelete: CASCADE
-
-  # pulse_channel_recipient.user_id -> core_user.id
-  - changeSet:
-      id: 233
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse_channel_recipient
-            constraintName: fk_pulse_channel_recipient_ref_user_id
-
-  - changeSet:
-      id: 234
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse_channel_recipient
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_pulse_channel_recipient_ref_user_id
-            onDelete: CASCADE
-
-  # report_card.collection_id -> collection.id
-  - changeSet:
-      id: 235
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_card_collection_id
-
-  - changeSet:
-      id: 236
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: collection_id
-            referencedTableName: collection
-            referencedColumnNames: id
-            constraintName: fk_card_collection_id
-            onDelete: SET NULL
-
-  # report_card.made_public_by_id -> core_user.id
-  - changeSet:
-      id: 237
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_card_made_public_by_id
-
-  - changeSet:
-      id: 238
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: made_public_by_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_card_made_public_by_id
-            onDelete: CASCADE
-
-  # report_card.creator_id -> core_user.id
-  - changeSet:
-      id: 239
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_card_ref_user_id
-
-  - changeSet:
-      id: 240
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_card_ref_user_id
-            onDelete: CASCADE
-
-  # report_card.database_id -> metabase_database.id
-  - changeSet:
-      id: 241
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_report_card_ref_database_id
-
-  - changeSet:
-      id: 242
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: database_id
-            referencedTableName: metabase_database
-            referencedColumnNames: id
-            constraintName: fk_report_card_ref_database_id
-            onDelete: CASCADE
-
-  # report_card.table_id -> metabase_table.id
-  - changeSet:
-      id: 243
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_card
-            constraintName: fk_report_card_ref_table_id
-
-  - changeSet:
-      id: 244
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: table_id
-            referencedTableName: metabase_table
-            referencedColumnNames: id
-            constraintName: fk_report_card_ref_table_id
-            onDelete: CASCADE
-
-  # report_cardfavorite.card_id -> report_card.id
-  - changeSet:
-      id: 245
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_cardfavorite
-            constraintName: fk_cardfavorite_ref_card_id
-
-  - changeSet:
-      id: 246
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_cardfavorite
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_cardfavorite_ref_card_id
-            onDelete: CASCADE
-
-  # report_cardfavorite.owner_id -> core_user.id
-  - changeSet:
-      id: 247
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_cardfavorite
-            constraintName: fk_cardfavorite_ref_user_id
-
-  - changeSet:
-      id: 248
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_cardfavorite
-            baseColumnNames: owner_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_cardfavorite_ref_user_id
-            onDelete: CASCADE
-
-  # report_dashboard.collection_id -> collection.id
-  - changeSet:
-      id: 249
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_dashboard
-            constraintName: fk_dashboard_collection_id
-
-  - changeSet:
-      id: 250
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboard
-            baseColumnNames: collection_id
-            referencedTableName: collection
-            referencedColumnNames: id
-            constraintName: fk_dashboard_collection_id
-            onDelete: SET NULL
-
-  # report_dashboard.made_public_by_id -> core_user.id
-  - changeSet:
-      id: 251
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_dashboard
-            constraintName: fk_dashboard_made_public_by_id
-
-  - changeSet:
-      id: 252
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboard
-            baseColumnNames: made_public_by_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_dashboard_made_public_by_id
-            onDelete: CASCADE
-
-  # report_dashboard.creator_id -> core_user.id
-  - changeSet:
-      id: 253
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_dashboard
-            constraintName: fk_dashboard_ref_user_id
-
-  - changeSet:
-      id: 254
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboard
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_dashboard_ref_user_id
-            onDelete: CASCADE
-
-  # report_dashboardcard.card_id -> report_card.id
-  - changeSet:
-      id: 255
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_dashboardcard
-            constraintName: fk_dashboardcard_ref_card_id
-
-  - changeSet:
-      id: 256
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboardcard
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_dashboardcard_ref_card_id
-            onDelete: CASCADE
-
-  # report_dashboardcard.dashboard_id -> report_dashboard.id
-  - changeSet:
-      id: 257
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: report_dashboardcard
-            constraintName: fk_dashboardcard_ref_dashboard_id
-
-  - changeSet:
-      id: 258
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboardcard
-            baseColumnNames: dashboard_id
-            referencedTableName: report_dashboard
-            referencedColumnNames: id
-            constraintName: fk_dashboardcard_ref_dashboard_id
-            onDelete: CASCADE
-
-  # revision.user_id -> core_user.id
-  - changeSet:
-      id: 259
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: revision
-            constraintName: fk_revision_ref_user_id
-
-  - changeSet:
-      id: 260
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: revision
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_revision_ref_user_id
-            onDelete: CASCADE
-
-  # segment.creator_id -> core_user.id
-  - changeSet:
-      id: 261
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: segment
-            constraintName: fk_segment_ref_creator_id
-
-  - changeSet:
-      id: 262
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: segment
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_segment_ref_creator_id
-            onDelete: CASCADE
-
-  # segment.table_id -> metabase_table.id
-  - changeSet:
-      id: 263
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: segment
-            constraintName: fk_segment_ref_table_id
-
-  - changeSet:
-      id: 264
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: segment
-            baseColumnNames: table_id
-            referencedTableName: metabase_table
-            referencedColumnNames: id
-            constraintName: fk_segment_ref_table_id
-            onDelete: CASCADE
-
-  # view_log.user_id -> core_user.id
-  - changeSet:
-      id: 265
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: view_log
-            constraintName: fk_view_log_ref_user_id
-
-  - changeSet:
-      id: 266
-      author: camsaul
-      comment: Added 0.36.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: view_log
-            baseColumnNames: user_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_view_log_ref_user_id
-            onDelete: CASCADE
-
-# changesets 268-272 allow for handling user account emails in lowercase (GH issue 3047)
-  - changeSet:
-      id: 268
-      author: rlotun
-      comment: Added 0.37.0  # create index on lower(email), for performance reasons (not availble on h2 and only on more recent versions of mysql)
-      failOnError: false
-      preConditions:
-        - onFail: MARK_RAN
-        - and:
-            - dbms:
-                type: postgresql
-      # This has maybe never succeeded in creating the index because (at least with the current DB versions)
-      # the syntax was wrong on all requested databases (postgresql, mysql and mariadb). Since this change is
-      # not critical it's OK to ignore it.
-      validCheckSum: 8:9da2f706a7cd42b5101601e0106fa929
-      changes:
-        - createIndex:
-            columns:
-             - column:
-                 name: lower(email)
-                 computed: true
-                 type: varchar(254)
-            tableName: core_user
-            indexName: idx_lower_email
-  - changeSet:
-      id: 269
-      author: rlotun
-      comment: Added 0.37.0  # set email values to lower(email) but do so defensively and in a way that works on postgres and mysql - skip over those that would introduce duplicates (e.g. Reza@email.com and reza@email.com)
-      changes:
-        - sql :
-            sql : UPDATE core_user SET email = lower(email) WHERE lower(email) NOT IN (SELECT * FROM (SELECT lower(email) FROM core_user GROUP BY lower(email) HAVING count(email) > 1) as e)
-  - changeSet:
-      id: 270
-      author: rlotun
-      comment: Added 0.37.0 # try to install citext extension on posgres (user requires privileges on postgres)
-      failOnError: false
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - dbms:
-                type: postgresql
-      changes:
-        - sql :
-            sql : CREATE EXTENSION IF NOT EXISTS citext
-  - changeSet:
-      id: 271
-      author: rlotun
-      comment: Added 0.37.0 # try to convert email column to citext on postgres, if citext extension installed
-      failOnError: false
-      preConditions:
-        - onFail: MARK_RAN
-        - and:
-            - dbms:
-                type: postgresql
-            - sqlCheck:
-                expectedResult: 1
-                sql: SELECT count(*) FROM pg_extension WHERE extname = 'citext'
-      changes:
-        - modifyDataType:
-            tableName: core_user
-            columnName: email
-            newDataType: citext
-  - changeSet:
-      id: 272
-      author: rlotun
-      comment: Added 0.37.0 # for H2 convert column to VARCHAR_IGNORECASE
-      failOnError: false
-      preConditions:
-         - onFail: MARK_RAN
-         - or:
-             - dbms:
-                   type: h2
-      changes:
-        - modifyDataType:
-            tableName: core_user
-            columnName: email
-            newDataType: varchar_ignorecase(254)
-
-  - changeSet:
-      id: 273
-      author: camsaul
-      comment: Added 0.37.1
-      changes:
-        - addDefaultValue:
-            tableName: core_user
-            columnName: is_superuser
-            columnDataType: boolean
+            constraints: {nullable: false}
+- changeSet:
+    id: 16
+    author: agilliland
+    changes:
+    - dropNotNullConstraint: {tableName: core_user, columnName: last_login, columnDataType: DATETIME}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 17
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: is_sample
+            type: boolean
             defaultValueBoolean: false
-
-  - changeSet:
-      id: 274
-      author: camsaul
-      comment: Added 0.37.1
-      changes:
-        - addDefaultValue:
-            tableName: core_user
-            columnName: is_active
-            columnDataType: boolean
+            constraints: {nullable: false}
+    - sql: {sql: update metabase_database set is_sample = true where name = 'Sample Dataset'}
+- changeSet:
+    id: 18
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: data_migrations
+        columns:
+        - column:
+            name: id
+            type: VARCHAR(254)
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: timestamp
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: data_migrations
+        indexName: idx_data_migrations_id
+        columns:
+          column: {name: id}
+- changeSet:
+    id: 19
+    author: camsaul
+    changes:
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column: {name: schema, type: VARCHAR(256)}
+- changeSet:
+    id: 20
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: pulse
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: creator_id
+            type: int
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_pulse_ref_creator_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: name
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            name: public_perms
+            type: int
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: pulse
+        indexName: idx_pulse_creator_id
+        columns:
+          column: {name: creator_id}
+    - createTable:
+        tableName: pulse_card
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: pulse_id
+            type: int
+            constraints: {nullable: false, referencedTableName: pulse, referencedColumnNames: id, foreignKeyName: fk_pulse_card_ref_pulse_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: card_id
+            type: int
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_pulse_card_ref_card_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: position
+            type: int
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: pulse_card
+        indexName: idx_pulse_card_pulse_id
+        columns:
+          column: {name: pulse_id}
+    - createIndex:
+        tableName: pulse_card
+        indexName: idx_pulse_card_card_id
+        columns:
+          column: {name: card_id}
+    - createTable:
+        tableName: pulse_channel
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: pulse_id
+            type: int
+            constraints: {nullable: false, referencedTableName: pulse, referencedColumnNames: id, foreignKeyName: fk_pulse_channel_ref_pulse_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: channel_type
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: details
+            type: text
+            constraints: {nullable: false}
+        - column:
+            name: schedule_type
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: schedule_hour
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: schedule_day
+            type: varchar(64)
+            constraints: {nullable: true}
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: pulse_channel
+        indexName: idx_pulse_channel_pulse_id
+        columns:
+          column: {name: pulse_id}
+    - createIndex:
+        tableName: pulse_channel
+        indexName: idx_pulse_channel_schedule_type
+        columns:
+          column: {name: schedule_type}
+    - createTable:
+        tableName: pulse_channel_recipient
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: pulse_channel_id
+            type: int
+            constraints: {nullable: false, referencedTableName: pulse_channel, referencedColumnNames: id, foreignKeyName: fk_pulse_channel_recipient_ref_pulse_channel_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: user_id
+            type: int
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_pulse_channel_recipient_ref_user_id, deferrable: false, initiallyDeferred: false}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 21
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: segment
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: table_id
+            type: int
+            constraints: {nullable: false, referencedTableName: metabase_table, referencedColumnNames: id, foreignKeyName: fk_segment_ref_table_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: creator_id
+            type: int
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_segment_ref_creator_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: name
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            name: description
+            type: text
+            constraints: {nullable: true}
+        - column:
+            name: is_active
+            type: boolean
             defaultValueBoolean: true
-
- # Add refingerprint to database to mark if fingerprinting or
- # not. Nullable in first pass so can be opt in and then in a
- # subsequent pass can be globally turned on where null, respecting
- # people who turned it on and then off.
-
-  - changeSet:
-      id: 275
-      author: dpsutton
-      comment: 'Added 0.38.0 refingerprint to Database'
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: refingerprint
-                  type: boolean
-                  remarks: 'Whether or not to enable periodic refingerprinting for this Database.'
-                  constraints:
-                    nullable: true
-  - changeSet:
-      id: 276
-      author: robroland
-      comment: Added 0.38.0 - Dashboard subscriptions
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: pulse_card
-            columns:
-            - column:
-                name: dashboard_card_id
-                type: int
-                remarks: 'If this Pulse is a Dashboard subscription, the ID of the DashboardCard that corresponds to this PulseCard.'
-                constraints:
-                  nullable: true
-                  referencedTableName: report_dashboardcard
-                  referencedColumnNames: id
-                  foreignKeyName: fk_pulse_card_ref_pulse_card_id
-                  deferrable: false
-                  initiallyDeferred: false
-
-  - changeSet:
-      id: 277
-      author: tsmacdonald
-      comment: Added 0.38.0 - Dashboard subscriptions
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: pulse_card
-            constraintName: fk_pulse_card_ref_pulse_card_id
-
-  - changeSet:
-      id: 278
-      author: tsmacdonald
-      comment: Added 0.38.0 - Dashboard subscrptions
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse_card
-            baseColumnNames: dashboard_card_id
-            referencedTableName: report_dashboardcard
-            referencedColumnNames: id
-            constraintName: fk_pulse_card_ref_pulse_card_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: 279
-      author: camsaul
-      comment: Added 0.38.0 - Dashboard subscriptions
-      changes:
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: 'ID of the Dashboard if this Pulse is a Dashboard Subscription.'
-
-  # FK constraint is added separately because deleteCascade doesn't work in addColumn -- see #14321
-  - changeSet:
-      id: 280
-      author: camsaul
-      comment: Added 0.38.0 - Dashboard subscriptions
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse
-            baseColumnNames: dashboard_id
-            referencedTableName: report_dashboard
-            referencedColumnNames: id
-            constraintName: fk_pulse_ref_dashboard_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: 281
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - rename special_type
-      changes:
-        - renameColumn:
-            tableName: metabase_field
-            oldColumnName: special_type
-            newColumnName: semantic_type
-            columnDataType: varchar(255)
-
-  # Change the TaskHistory timestamp columns to higher-resolution columns: on MySQL, they previously only had *second*
-  # resolution, which caused annoying test failures and made it hard to correctly sort tasks that happened in quick
-  # succession.
-  #
-  # We have to give these columns default values as well, or MySQL is going to be very fussy about having two
-  # NOT NULL timestamp columns without default values at the same time.
-  #
-  # This is done in raw SQL because AFAIK there's no way in Liquibase to change a column type and give it a default
-  # value in a single statement, which we have to do to make MySQL happy.
-  - changeSet:
-      id: 282
-      author: camsaul
-      validCheckSum: 8:d4b8566ee11d9f8a3d6c8c9539f6526d
-      comment: Added 0.39.0
-      changes:
-        - sql:
-            dbms: h2
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN started_at timestamp with time zone DEFAULT current_timestamp NOT NULL;
-        - sql:
-            dbms: postgresql
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN started_at TYPE timestamp with time zone,
-              ALTER COLUMN started_at SET DEFAULT current_timestamp;
-        - sql:
-            dbms: mysql,mariadb
-            sql: |
-              ALTER TABLE task_history
-              MODIFY started_at timestamp(6) DEFAULT current_timestamp(6) NOT NULL;
-
-  - changeSet:
-      id: 283
-      author: camsaul
-      validCheckSum: 8:2220e1b1cdb57212820b96fa3107f7c3
-      comment: Added 0.39.0
-      changes:
-        - sql:
-            dbms: h2
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN ended_at timestamp with time zone DEFAULT current_timestamp NOT NULL;
-        - sql:
-            dbms: postgresql
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN ended_at TYPE timestamp with time zone,
-              ALTER COLUMN ended_at SET DEFAULT current_timestamp;
-        - sql:
-            dbms: mysql,mariadb
-            sql: |
-              ALTER TABLE task_history
-              MODIFY ended_at timestamp(6) DEFAULT current_timestamp(6) NOT NULL;
-  - changeSet:
-      id: 284
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - add effective type
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: effective_type
-                  type: varchar(255)
-                  remarks: 'The effective type of the field after any coercions.'
-  - changeSet:
-      id: 285
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - add coercion column
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: coercion_strategy
-                  type: varchar(255)
-                  remarks: 'A strategy to coerce the base_type into the effective_type.'
-  - changeSet:
-      id: 286
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - set effective_type default
-      changes:
-        - sql:
-            sql: UPDATE metabase_field set effective_type = base_type
-  - changeSet:
-      id: 287
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - migrate ISO8601 strings
-      validCheckSum: ANY
-      changes:
-        - sql:
-            sql: >-
-              UPDATE metabase_field
-              SET effective_type    = (CASE semantic_type
-                                         WHEN 'type/ISO8601DateTimeString' THEN 'type/DateTime'
-                                         WHEN 'type/ISO8601TimeString'     THEN 'type/Time'
-                                         WHEN 'type/ISO8601DateString'     THEN 'type/Date'
-                                       END),
-                  coercion_strategy = (CASE semantic_type
-                                        WHEN 'type/ISO8601DateTimeString' THEN 'Coercion/ISO8601->DateTime'
-                                        WHEN 'type/ISO8601TimeString'     THEN 'Coercion/ISO8601->Time'
-                                        WHEN 'type/ISO8601DateString'     THEN 'Coercion/ISO8601->Date'
-                                       END)
-              WHERE semantic_type IN ('type/ISO8601DateTimeString',
-                                      'type/ISO8601TimeString',
-                                      'type/ISO8601DateString');
-  ## This includes values 'timestamp_milliseconds' and 'timestamp_seconds'. These are old "special_types" that were
-  ## migrated in a data migration for version 0.20. But these migrations occur after all liquibase migrations so
-  ## it would be possible for another type/UNIXTimestampSeconds to pop up after this migration that supposedly
-  ## got rid of them all
-  - changeSet:
-      id: 288
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - migrate unix timestamps
-      validCheckSum: ANY
-      changes:
-        - sql:
-              sql: >-
-                UPDATE metabase_field
-                set effective_type    = 'type/Instant',
-                    coercion_strategy = (case semantic_type
-                                          WHEN 'type/UNIXTimestampSeconds'      THEN 'Coercion/UNIXSeconds->DateTime'
-                                          WHEN 'timestamp_seconds'              THEN 'Coercion/UNIXSeconds->DateTime'
-                                          WHEN 'type/UNIXTimestampMilliSeconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
-                                          WHEN 'timestamp_milliseconds'         THEN 'Coercion/UNIXMilliSeconds->DateTime'
-                                          WHEN 'type/UNIXTimestampMicroSeconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
-                                         END)
-                WHERE semantic_type IN ('type/UNIXTimestampSeconds',
-                                        'type/UNIXTimestampMilliSeconds',
-                                        'type/UNIXTimestampMicroSeconds',
-                                        'timestamp_seconds',
-                                        'timestamp_milliseconds');
-
-  - changeSet:
-      id: 289
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - migrate unix timestamps (corrects typo- seconds was migrated correctly, not millis and micros)
-      validCheckSum: ANY
-      changes:
-        - sql:
-              sql: >-
-                UPDATE metabase_field
-                set effective_type    = 'type/Instant',
-                    coercion_strategy = (case semantic_type
-                                          WHEN 'type/UNIXTimestampMilliseconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
-                                          WHEN 'type/UNIXTimestampMicroseconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
-                                         END)
-                WHERE semantic_type IN ('type/UNIXTimestampMilliseconds',
-                                        'type/UNIXTimestampMicroseconds')
-
-  - changeSet:
-      id: 290
-      author: dpsutton
-      comment: Added 0.39 - Semantic type system - Clobber semantic_type where there was a coercion
-      changes:
-        - sql:
-              sql: UPDATE metabase_field set semantic_type = null where coercion_strategy is not null
-
-# 291-297 create the new login history Table
-
-  - changeSet:
-      id: 291
-      author: camsaul
-      validCheckSum: ANY
-      comment: Added 0.39.0
-      changes:
-        - createTable:
-            tableName: login_history
-            remarks: "Keeps track of various logins for different users and additional info such as location and device"
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: timestamp
-                  type: ${timestamp_type}
-                  remarks: "When this login occurred."
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: "ID of the User that logged in."
-                  constraints:
-                    foreignKeyName: fk_login_history_user_id
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    nullable: false
-                    deleteCascade: true
-              # FK constraint is created later, because we can't create it inline with ON DELETE SET NULL
-              - column:
-                  name: session_id
-                  type: varchar(254)
-                  remarks: "ID of the Session created by this login if one is currently active. NULL if Session is no longer active."
-              - column:
-                  name: device_id
-                  type: char(36)
-                  remarks: "Cookie-based unique identifier for the device/browser the user logged in from."
-                  constraints:
-                    nullable: false
-              - column:
-                  name: device_description
-                  type: text
-                  remarks: "Description of the device that login happened from, for example a user-agent string, but this might be something different if we support alternative auth mechanisms in the future."
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ip_address
-                  type: text
-                  remarks: "IP address of the device that login happened from, so we can geocode it and determine approximate location."
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: 292
-      author: camsaul
-      comment: Added 0.39.0
-      changes:
-        - createIndex:
-            tableName: login_history
-            indexName: idx_user_id
-            columns:
-              - column:
-                  name: user_id
-
-  - changeSet:
-      id: 293
-      author: camsaul
-      comment: Added 0.39.0
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: login_history
-            baseColumnNames: session_id
-            referencedTableName: core_session
-            referencedColumnNames: id
-            constraintName: fk_login_history_session_id
-            onDelete: SET NULL
-
-  - changeSet:
-      id: 294
-      author: camsaul
-      comment: Added 0.39.0
-      changes:
-        - createIndex:
-            tableName: login_history
-            indexName: idx_session_id
-            columns:
-              - column:
-                  name: session_id
-
-  # index on login history timestamp -- so admin can see *all* recent logins, or we can delete login history after a certain age
-  - changeSet:
-      id: 295
-      author: camsaul
-      comment: Added 0.39.0
-      changes:
-        - createIndex:
-            tableName: login_history
-            indexName: idx_timestamp
-            columns:
-              - column:
-                  name: timestamp
-
-  # index on login history user_id + device_id -- so we can easily see if this is the first time a device is used
-  - changeSet:
-      id: 296
-      author: camsaul
-      comment: Added 0.39.0
-      changes:
-        - createIndex:
-            tableName: login_history
-            indexName: idx_user_id_device_id
-            columns:
-              - column:
-                  name: session_id
-              - column:
-                  name: device_id
-
-  # index on login history user_id + timestamp -- so we can easily see recent logins for a user
-  - changeSet:
-      id: 297
-      author: camsaul
-      comment: Added 0.39.0
-      changes:
-        - createIndex:
-            tableName: login_history
-            indexName: idx_user_id_timestamp
-            columns:
-              - column:
-                  name: user_id
-              - column:
-                  name: timestamp
-
-  # Add parameter columns to pulses so that dashboard subscriptions can have their own filters
-  - changeSet:
-      id: 298
-      author: tsmacdonald
-      comment: Added 0.39.0
-      changes:
-        - addColumn:
-            tableName: pulse
-            columns:
-              - column:
-                  name: parameters
-                  type: text
-                  remarks: "Let dashboard subscriptions have their own filters"
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-  - changeSet:
-      id: 299
-      author: tsmacdonald
-      comment: Added 0.39.0
-      changes:
-        - addNotNullConstraint:
-            columnDataType: text
-            columnName: parameters
-            defaultNullValue: '[]'
-            tableName: pulse
-  - changeSet:
-      id: 300
-      author: dpsutton
-      comment: Added 0.40.0
-      changes:
-        - renameTable:
-            oldTableName: collection_revision
-            newTableName: collection_permission_graph_revision
-  - changeSet:
-      id: 301
-      author: dpsutton
-      comment: Added 0.40.0 renaming collection_revision to collection_permission_graph_revision
-      failOnError: false # mysql and h2 don't have this sequence
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql
-      changes:
-        - sql:
-            - sql: ALTER SEQUENCE collection_revision_id_seq RENAME TO collection_permission_graph_revision_id_seq
-
-  - changeSet:
-      id: 303
-      author: tsmacdonald
-      comment: Added 0.40.0
-      changes:
-        - createTable:
-            tableName: moderation_review
-            remarks: "Reviews (from moderators) for a given question/dashboard (BUCM)"
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  remarks: "most recent modification time"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  remarks: "creation time"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: status
-                  type: varchar(255)
-                  remarks: "verified, misleading, confusing, not_misleading, pending"
-              - column:
-                  name: text
-                  type: text
-                  remarks: "Explanation of the review"
-                  # I don't think it needs to be non-nullable
-              - column:
-                  name: moderated_item_id
-                  type: int
-                  remarks: "either a document or question ID; the item that needs review"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: moderated_item_type
-                  type: varchar(255)
-                  remarks: "whether it's a question or dashboard"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: moderator_id
-                  type: int
-                  remarks: "ID of the user who did the review"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: most_recent
-                  type: boolean
-                  remarks: "tag for most recent review"
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: 304
-      author: camsaul
-      comment: Added 0.40.0 (replaces a data migration dating back to 0.20.0)
-      changes:
-        - sql:
-              sql: >-
-                UPDATE metabase_field
-                SET semantic_type = (CASE semantic_type
-                                      WHEN 'avatar'    THEN 'type/AvatarURL'
-                                      WHEN 'category'  THEN 'type/Category'
-                                      WHEN 'city'      THEN 'type/City'
-                                      WHEN 'country'   THEN 'type/Country'
-                                      WHEN 'desc'      THEN 'type/Description'
-                                      WHEN 'fk'        THEN 'type/FK'
-                                      WHEN 'id'        THEN 'type/PK'
-                                      WHEN 'image'     THEN 'type/ImageURL'
-                                      WHEN 'json'      THEN 'type/SerializedJSON'
-                                      WHEN 'latitude'  THEN 'type/Latitude'
-                                      WHEN 'longitude' THEN 'type/Longitude'
-                                      WHEN 'name'      THEN 'type/Name'
-                                      WHEN 'number'    THEN 'type/Number'
-                                      WHEN 'state'     THEN 'type/State'
-                                      WHEN 'url'       THEN 'type/URL'
-                                      WHEN 'zip_code'  THEN 'type/ZipCode'
-                                     END)
-                WHERE semantic_type IN ('avatar', 'category', 'city', 'country', 'desc', 'fk', 'id', 'image',
-                                        'json', 'latitude', 'longitude', 'name', 'number', 'state', 'url',
-                                        'zip_code');
-
-  - changeSet:
-      id: 305
-      author: camsaul
-      comment: Added 0.40.0 (replaces a data migration dating back to 0.20.0)
-      changes:
-        - sql:
-            sql: >-
-              UPDATE metabase_field
-              SET base_type = (CASE base_type
-                                WHEN 'ArrayField'      THEN 'type/Array'
-                                WHEN 'BigIntegerField' THEN 'type/BigInteger'
-                                WHEN 'BooleanField'    THEN 'type/Boolean'
-                                WHEN 'CharField'       THEN 'type/Text'
-                                WHEN 'DateField'       THEN 'type/Date'
-                                WHEN 'DateTimeField'   THEN 'type/DateTime'
-                                WHEN 'DecimalField'    THEN 'type/Decimal'
-                                WHEN 'DictionaryField' THEN 'type/Dictionary'
-                                WHEN 'FloatField'      THEN 'type/Float'
-                                WHEN 'IntegerField'    THEN 'type/Integer'
-                                WHEN 'TextField'       THEN 'type/Text'
-                                WHEN 'TimeField'       THEN 'type/Time'
-                                WHEN 'UUIDField'       THEN 'type/UUID'
-                                WHEN 'UnknownField'    THEN 'type/*'
+            constraints: {nullable: false}
+        - column:
+            name: definition
+            type: text
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: segment
+        indexName: idx_segment_creator_id
+        columns:
+          column: {name: creator_id}
+    - createIndex:
+        tableName: segment
+        indexName: idx_segment_table_id
+        columns:
+          column: {name: table_id}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 22
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: revision
+        columns:
+        - column:
+            name: message
+            type: text
+            constraints: {nullable: true}
+- changeSet:
+    id: 23
+    author: agilliland
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: rows, newDataType: BIGINT}
+- changeSet:
+    id: 24
+    author: agilliland
+    changes:
+    - createTable:
+        tableName: dependency
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: model
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: model_id
+            type: int
+            constraints: {nullable: false}
+        - column:
+            name: dependent_on_model
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: dependent_on_id
+            type: int
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: dependency
+        indexName: idx_dependency_model
+        columns:
+          column: {name: model}
+    - createIndex:
+        tableName: dependency
+        indexName: idx_dependency_model_id
+        columns:
+          column: {name: model_id}
+    - createIndex:
+        tableName: dependency
+        indexName: idx_dependency_dependent_on_model
+        columns:
+          column: {name: dependent_on_model}
+    - createIndex:
+        tableName: dependency
+        indexName: idx_dependency_dependent_on_id
+        columns:
+          column: {name: dependent_on_id}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 25
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: metric
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: table_id
+            type: int
+            constraints: {nullable: false, referencedTableName: metabase_table, referencedColumnNames: id, foreignKeyName: fk_metric_ref_table_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: creator_id
+            type: int
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_metric_ref_creator_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: name
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            name: description
+            type: text
+            constraints: {nullable: true}
+        - column:
+            name: is_active
+            type: boolean
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+        - column:
+            name: definition
+            type: text
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: metric
+        indexName: idx_metric_creator_id
+        columns:
+          column: {name: creator_id}
+    - createIndex:
+        tableName: metric
+        indexName: idx_metric_table_id
+        columns:
+          column: {name: table_id}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 26
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: is_full_sync
+            type: boolean
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+    - sql: {sql: update metabase_database set is_full_sync = true}
+- changeSet:
+    id: 27
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: dashboardcard_series
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: dashboardcard_id
+            type: int
+            constraints: {nullable: false, referencedTableName: report_dashboardcard, referencedColumnNames: id, foreignKeyName: fk_dashboardcard_series_ref_dashboardcard_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: card_id
+            type: int
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_dashboardcard_series_ref_card_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: position
+            type: int
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: dashboardcard_series
+        indexName: idx_dashboardcard_series_dashboardcard_id
+        columns:
+          column: {name: dashboardcard_id}
+    - createIndex:
+        tableName: dashboardcard_series
+        indexName: idx_dashboardcard_series_card_id
+        columns:
+          column: {name: card_id}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 28
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column:
+            name: is_qbnewb
+            type: boolean
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+- changeSet:
+    id: 29
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: pulse_channel
+        columns:
+        - column:
+            name: schedule_frame
+            type: varchar(32)
+            constraints: {nullable: true}
+- changeSet:
+    id: 30
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: visibility_type
+            type: varchar(32)
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+    - addNotNullConstraint: {columnDataType: varchar(32), columnName: visibility_type, defaultNullValue: unset, tableName: metabase_field}
+- changeSet:
+    id: 31
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: fk_target_field_id
+            type: int
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+- changeSet:
+    id: 32
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: label
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: name
+            type: VARCHAR(254)
+            constraints: {nullable: false}
+        - column:
+            name: slug
+            type: VARCHAR(254)
+            constraints: {nullable: false, unique: true}
+        - column: {name: icon, type: VARCHAR(128)}
+    - createIndex:
+        tableName: label
+        indexName: idx_label_slug
+        columns:
+          column: {name: slug}
+    - createTable:
+        tableName: card_label
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: card_id
+            type: int
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_card_label_ref_card_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: label_id
+            type: int
+            constraints: {nullable: false, referencedTableName: label, referencedColumnNames: id, foreignKeyName: fk_card_label_ref_label_id, deferrable: false, initiallyDeferred: false}
+    - addUniqueConstraint: {tableName: card_label, columnNames: 'card_id, label_id', constraintName: unique_card_label_card_id_label_id}
+    - createIndex:
+        tableName: card_label
+        indexName: idx_card_label_card_id
+        columns:
+          column: {name: card_id}
+    - createIndex:
+        tableName: card_label
+        indexName: idx_card_label_label_id
+        columns:
+          column: {name: label_id}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: archived
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: 32
+    author: agilliland
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: raw_table
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: database_id
+            type: int
+            constraints: {nullable: false, referencedTableName: metabase_database, referencedColumnNames: id, foreignKeyName: fk_rawtable_ref_database, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: active
+            type: boolean
+            constraints: {nullable: false}
+        - column:
+            name: schema
+            type: varchar(255)
+            constraints: {nullable: true}
+        - column:
+            name: name
+            type: varchar(255)
+            constraints: {nullable: false}
+        - column:
+            name: details
+            type: text
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: raw_table
+        indexName: idx_rawtable_database_id
+        columns:
+          column: {name: database_id}
+    - addUniqueConstraint: {tableName: raw_table, columnNames: 'database_id, schema, name', constraintName: uniq_raw_table_db_schema_name}
+    - createTable:
+        tableName: raw_column
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: raw_table_id
+            type: int
+            constraints: {nullable: false, referencedTableName: raw_table, referencedColumnNames: id, foreignKeyName: fk_rawcolumn_tableid_ref_rawtable, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: active
+            type: boolean
+            constraints: {nullable: false}
+        - column:
+            name: name
+            type: varchar(255)
+            constraints: {nullable: false}
+        - column:
+            name: column_type
+            type: varchar(128)
+            constraints: {nullable: true}
+        - column:
+            name: is_pk
+            type: boolean
+            constraints: {nullable: false}
+        - column:
+            name: fk_target_column_id
+            type: int
+            constraints: {nullable: true, referencedTableName: raw_column, referencedColumnNames: id, foreignKeyName: fk_rawcolumn_fktarget_ref_rawcolumn, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: details
+            type: text
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: raw_column
+        indexName: idx_rawcolumn_raw_table_id
+        columns:
+          column: {name: raw_table_id}
+    - addUniqueConstraint: {tableName: raw_column, columnNames: 'raw_table_id, name', constraintName: uniq_raw_column_table_name}
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column:
+            name: raw_table_id
+            type: int
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: raw_column_id
+            type: int
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: last_analyzed
+            type: DATETIME
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+    - modifySql:
+        dbms: postgresql
+        replace: {replace: WITHOUT, with: WITH}
+- changeSet:
+    id: 34
+    author: tlrobinson
+    changes:
+    - addColumn:
+        tableName: pulse_channel
+        columns:
+        - column:
+            name: enabled
+            type: boolean
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+- changeSet:
+    id: 35
+    author: agilliland
+    changes:
+    - modifyDataType: {tableName: setting, columnName: value, newDataType: TEXT}
+    - addNotNullConstraint: {tableName: setting, columnDataType: text, columnName: value}
+    validCheckSum: 8:91b72167fca724e6b6a94b64f886cf09
+- changeSet:
+    id: 36
+    author: agilliland
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: parameters
+            type: text
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+    - addNotNullConstraint: {columnDataType: text, columnName: parameters, defaultNullValue: '[]', tableName: report_dashboard}
+    - addColumn:
+        tableName: report_dashboardcard
+        columns:
+        - column:
+            name: parameter_mappings
+            type: text
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+    - addNotNullConstraint: {columnDataType: text, columnName: parameter_mappings, defaultNullValue: '[]', tableName: report_dashboardcard}
+- changeSet:
+    id: 37
+    author: tlrobinson
+    changes:
+    - addColumn:
+        tableName: query_queryexecution
+        columns:
+        - column:
+            name: query_hash
+            type: int
+            constraints: {nullable: true}
+    - addNotNullConstraint: {tableName: query_queryexecution, columnName: query_hash, columnDataType: int, defaultNullValue: 0}
+    - createIndex:
+        tableName: query_queryexecution
+        indexName: idx_query_queryexecution_query_hash
+        columns:
+          column: {name: query_hash}
+    - createIndex:
+        tableName: query_queryexecution
+        indexName: idx_query_queryexecution_started_at
+        columns:
+          column: {name: started_at}
+- changeSet:
+    id: 38
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: points_of_interest, type: text}
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column: {name: points_of_interest, type: text}
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: points_of_interest, type: text}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column: {name: points_of_interest, type: text}
+    - addColumn:
+        tableName: metric
+        columns:
+        - column: {name: points_of_interest, type: text}
+    - addColumn:
+        tableName: segment
+        columns:
+        - column: {name: points_of_interest, type: text}
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: caveats, type: text}
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column: {name: caveats, type: text}
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: caveats, type: text}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column: {name: caveats, type: text}
+    - addColumn:
+        tableName: metric
+        columns:
+        - column: {name: caveats, type: text}
+    - addColumn:
+        tableName: segment
+        columns:
+        - column: {name: caveats, type: text}
+    - addColumn:
+        tableName: metric
+        columns:
+        - column: {name: how_is_this_calculated, type: text}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: show_in_getting_started
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: report_dashboard
+        indexName: idx_report_dashboard_show_in_getting_started
+        columns:
+          column: {name: show_in_getting_started}
+    - addColumn:
+        tableName: metric
+        columns:
+        - column:
+            name: show_in_getting_started
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: metric
+        indexName: idx_metric_show_in_getting_started
+        columns:
+          column: {name: show_in_getting_started}
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column:
+            name: show_in_getting_started
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: metabase_table
+        indexName: idx_metabase_table_show_in_getting_started
+        columns:
+          column: {name: show_in_getting_started}
+    - addColumn:
+        tableName: segment
+        columns:
+        - column:
+            name: show_in_getting_started
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: segment
+        indexName: idx_segment_show_in_getting_started
+        columns:
+          column: {name: show_in_getting_started}
+    - createTable:
+        tableName: metric_important_field
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: metric_id
+            type: int
+            constraints: {nullable: false, referencedTableName: metric, referencedColumnNames: id, foreignKeyName: fk_metric_important_field_metric_id}
+        - column:
+            name: field_id
+            type: int
+            constraints: {nullable: false, referencedTableName: metabase_field, referencedColumnNames: id, foreignKeyName: fk_metric_important_field_metabase_field_id}
+    - addUniqueConstraint: {tableName: metric_important_field, columnNames: 'metric_id, field_id', constraintName: unique_metric_important_field_metric_id_field_id}
+    - createIndex:
+        tableName: metric_important_field
+        indexName: idx_metric_important_field_metric_id
+        columns:
+          column: {name: metric_id}
+    - createIndex:
+        tableName: metric_important_field
+        indexName: idx_metric_important_field_field_id
+        columns:
+          column: {name: field_id}
+- changeSet:
+    id: 39
+    author: camsaul
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column:
+            name: google_auth
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: 40
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: permissions_group
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: name
+            type: varchar(255)
+            constraints: {nullable: false, unique: true, uniqueConstraintName: unique_permissions_group_name}
+    - createIndex:
+        tableName: permissions_group
+        indexName: idx_permissions_group_name
+        columns:
+          column: {name: name}
+    - createTable:
+        tableName: permissions_group_membership
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_permissions_group_membership_user_id}
+        - column:
+            name: group_id
+            type: int
+            constraints: {nullable: false, referencedTableName: permissions_group, referencedColumnNames: id, foreignKeyName: fk_permissions_group_group_id}
+    - addUniqueConstraint: {tableName: permissions_group_membership, columnNames: 'user_id, group_id', constraintName: unique_permissions_group_membership_user_id_group_id}
+    - createIndex:
+        tableName: permissions_group_membership
+        indexName: idx_permissions_group_membership_group_id
+        columns:
+          column: {name: group_id}
+    - createIndex:
+        tableName: permissions_group_membership
+        indexName: idx_permissions_group_membership_user_id
+        columns:
+          column: {name: user_id}
+    - createIndex:
+        tableName: permissions_group_membership
+        indexName: idx_permissions_group_membership_group_id_user_id
+        columns:
+        - column: {name: group_id}
+        - column: {name: user_id}
+    - createTable:
+        tableName: permissions
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: object
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            name: group_id
+            type: int
+            constraints: {nullable: false, referencedTableName: permissions_group, referencedColumnNames: id, foreignKeyName: fk_permissions_group_id}
+    - createIndex:
+        tableName: permissions
+        indexName: idx_permissions_group_id
+        columns:
+          column: {name: group_id}
+    - createIndex:
+        tableName: permissions
+        indexName: idx_permissions_object
+        columns:
+          column: {name: object}
+    - createIndex:
+        tableName: permissions
+        indexName: idx_permissions_group_id_object
+        columns:
+        - column: {name: group_id}
+        - column: {name: object}
+    - addUniqueConstraint: {tableName: permissions, columnNames: 'group_id, object'}
+    - modifyDataType: {tableName: metabase_table, columnName: schema, newDataType: varchar(254)}
+    - createIndex:
+        tableName: metabase_table
+        indexName: idx_metabase_table_db_id_schema
+        columns:
+        - column: {name: db_id}
+        - column: {name: schema}
+- changeSet:
+    id: 41
+    author: camsaul
+    changes:
+    - dropColumn: {tableName: metabase_field, columnName: field_type}
+    - addDefaultValue: {tableName: metabase_field, columnName: active, defaultValueBoolean: true}
+    - addDefaultValue: {tableName: metabase_field, columnName: preview_display, defaultValueBoolean: true}
+    - addDefaultValue: {tableName: metabase_field, columnName: position, defaultValueNumeric: 0}
+    - addDefaultValue: {tableName: metabase_field, columnName: visibility_type, defaultValue: normal}
+- changeSet:
+    id: 42
+    author: camsaul
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: query_queryexecution, constraintName: fk_queryexecution_ref_query_id}
+    - dropColumn: {tableName: query_queryexecution, columnName: query_id}
+    - dropColumn: {tableName: core_user, columnName: is_staff}
+    - dropColumn: {tableName: metabase_database, columnName: organization_id}
+    - dropColumn: {tableName: report_card, columnName: organization_id}
+    - dropColumn: {tableName: report_dashboard, columnName: organization_id}
+    - dropTable: {tableName: annotation_annotation}
+    - dropTable: {tableName: core_permissionsviolation}
+    - dropTable: {tableName: core_userorgperm}
+    - dropTable: {tableName: core_organization}
+    - dropTable: {tableName: metabase_foreignkey}
+    - dropTable: {tableName: metabase_tablesegment}
+    - dropTable: {tableName: query_query}
+    - dropTable: {tableName: report_dashboardsubscription}
+    - dropTable: {tableName: report_emailreport_recipients}
+    - dropTable: {tableName: report_emailreportexecutions}
+    - dropTable: {tableName: report_emailreport}
+- changeSet:
+    id: 43
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: permissions_revision
+        remarks: Used to keep track of changes made to permissions.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: before
+            type: text
+            remarks: Serialized JSON of the permissions before the changes.
+            constraints: {nullable: false}
+        - column:
+            name: after
+            type: text
+            remarks: Serialized JSON of the permissions after the changes.
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The ID of the admin who made this set of changes.
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_permissions_revision_user_id}
+        - column:
+            name: created_at
+            type: datetime
+            remarks: The timestamp of when these changes were made.
+            constraints: {nullable: false}
+        - column: {name: remark, type: text, remarks: Optional remarks explaining why these changes were made.}
+- changeSet:
+    id: 44
+    author: camsaul
+    changes:
+    - dropColumn: {tableName: report_card, columnName: public_perms}
+    - dropColumn: {tableName: report_dashboard, columnName: public_perms}
+    - dropColumn: {tableName: pulse, columnName: public_perms}
+- changeSet:
+    id: 45
+    author: tlrobinson
+    changes:
+    - addColumn:
+        tableName: report_dashboardcard
+        columns:
+        - column: {name: visualization_settings, type: text}
+    - addNotNullConstraint: {tableName: report_dashboardcard, columnName: visualization_settings, columnDataType: text, defaultNullValue: '{}'}
+- changeSet:
+    id: 46
+    author: camsaul
+    changes:
+    - addNotNullConstraint: {tableName: report_dashboardcard, columnName: row, columnDataType: integer, defaultNullValue: 0}
+    - addNotNullConstraint: {tableName: report_dashboardcard, columnName: col, columnDataType: integer, defaultNullValue: 0}
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: row, defaultValueNumeric: 0}
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: col, defaultValueNumeric: 0}
+- changeSet:
+    id: 47
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: collection
+        remarks: Collections are an optional way to organize Cards and handle permissions for them.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: name
+            type: text
+            remarks: The unique, user-facing name of this Collection.
+            constraints: {nullable: false}
+        - column:
+            name: slug
+            type: varchar(254)
+            remarks: URL-friendly, sluggified, indexed version of name.
+            constraints: {nullable: false, unique: true}
+        - column: {name: description, type: text, remarks: Optional description for this Collection.}
+        - column:
+            name: color
+            type: char(7)
+            remarks: Seven-character hex color for this Collection, including the preceding hash sign.
+            constraints: {nullable: false}
+        - column:
+            name: archived
+            type: boolean
+            remarks: Whether this Collection has been archived and should be hidden from users.
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: collection
+        indexName: idx_collection_slug
+        columns:
+          column: {name: slug}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: collection_id
+            type: int
+            remarks: Optional ID of Collection this Card belongs to.
+            constraints: {referencedTableName: collection, referencedColumnNames: id, foreignKeyName: fk_card_collection_id}
+    - createIndex:
+        tableName: report_card
+        indexName: idx_card_collection_id
+        columns:
+          column: {name: collection_id}
+- changeSet:
+    id: 48
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: collection_revision
+        remarks: Used to keep track of changes made to collections.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: before
+            type: text
+            remarks: Serialized JSON of the collections graph before the changes.
+            constraints: {nullable: false}
+        - column:
+            name: after
+            type: text
+            remarks: Serialized JSON of the collections graph after the changes.
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The ID of the admin who made this set of changes.
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_collection_revision_user_id}
+        - column:
+            name: created_at
+            type: datetime
+            remarks: The timestamp of when these changes were made.
+            constraints: {nullable: false}
+        - column: {name: remark, type: text, remarks: Optional remarks explaining why these changes were made.}
+- changeSet:
+    id: 49
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: public_uuid
+            type: char(36)
+            remarks: Unique UUID used to in publically-accessible links to this Card.
+            constraints: {unique: true}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: made_public_by_id
+            type: int
+            remarks: The ID of the User who first publically shared this Card.
+            constraints: {referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_card_made_public_by_id}
+    - createIndex:
+        tableName: report_card
+        indexName: idx_card_public_uuid
+        columns:
+          column: {name: public_uuid}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: public_uuid
+            type: char(36)
+            remarks: Unique UUID used to in publically-accessible links to this Dashboard.
+            constraints: {unique: true}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: made_public_by_id
+            type: int
+            remarks: The ID of the User who first publically shared this Dashboard.
+            constraints: {referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_dashboard_made_public_by_id}
+    - createIndex:
+        tableName: report_dashboard
+        indexName: idx_dashboard_public_uuid
+        columns:
+          column: {name: public_uuid}
+    - dropNotNullConstraint: {tableName: query_queryexecution, columnName: executor_id, columnDataType: int}
+- changeSet:
+    id: 50
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: enable_embedding
+            type: boolean
+            remarks: Is this Card allowed to be embedded in different websites (using a signed JWT)?
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: embedding_params, type: text, remarks: Serialized JSON containing information about required parameters that must be supplied when embedding this Card.}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: enable_embedding
+            type: boolean
+            remarks: Is this Dashboard allowed to be embedded in different websites (using a signed JWT)?
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column: {name: embedding_params, type: text, remarks: Serialized JSON containing information about required parameters that must be supplied when embedding this Dashboard.}
+- changeSet:
+    id: 51
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: query_execution
+        remarks: A log of executed queries, used for calculating historic execution times, auditing, and other purposes.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: hash
+            type: binary(32)
+            remarks: The hash of the query dictionary. This is a 256-bit SHA3 hash of the query.
+            constraints: {nullable: false}
+        - column:
+            name: started_at
+            type: datetime
+            remarks: Timestamp of when this query started running.
+            constraints: {nullable: false}
+        - column:
+            name: running_time
+            type: integer
+            remarks: The time, in milliseconds, this query took to complete.
+            constraints: {nullable: false}
+        - column:
+            name: result_rows
+            type: integer
+            remarks: Number of rows in the query results.
+            constraints: {nullable: false}
+        - column:
+            name: native
+            type: boolean
+            remarks: Whether the query was a native query, as opposed to an MBQL one (e.g., created with the GUI).
+            constraints: {nullable: false}
+        - column: {name: context, type: varchar(32), remarks: 'Short string specifying how this query was executed, e.g. in a Dashboard or Pulse.'}
+        - column: {name: error, type: text, remarks: 'Error message returned by failed query, if any.'}
+        - column: {name: executor_id, type: integer, remarks: 'The ID of the User who triggered this query execution, if any.'}
+        - column: {name: card_id, type: integer, remarks: 'The ID of the Card (Question) associated with this query execution, if any.'}
+        - column: {name: dashboard_id, type: integer, remarks: 'The ID of the Dashboard associated with this query execution, if any.'}
+        - column: {name: pulse_id, type: integer, remarks: 'The ID of the Pulse associated with this query execution, if any.'}
+    - createIndex:
+        tableName: query_execution
+        indexName: idx_query_execution_started_at
+        columns:
+          column: {name: started_at}
+    - createIndex:
+        tableName: query_execution
+        indexName: idx_query_execution_query_hash_started_at
+        columns:
+        - column: {name: hash}
+        - column: {name: started_at}
+- changeSet:
+    id: 52
+    author: camsaul
+    changes:
+    - createTable:
+        tableName: query_cache
+        remarks: Cached results of queries are stored here when using the DB-based query cache.
+        columns:
+        - column:
+            name: query_hash
+            type: binary(32)
+            remarks: The hash of the query dictionary. (This is a 256-bit SHA3 hash of the query dict).
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: updated_at
+            type: datetime
+            remarks: The timestamp of when these query results were last refreshed.
+            constraints: {nullable: false}
+        - column:
+            name: results
+            type: ${blob.type}
+            remarks: Cached, compressed results of running the query with the given hash.
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: query_cache
+        indexName: idx_query_cache_updated_at
+        columns:
+          column: {name: updated_at}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: cache_ttl, type: int, remarks: 'The maximum time, in seconds, to return cached results for this Card rather than running a new query.'}
+- changeSet:
+    id: 53
+    author: camsaul
+    changes:
+    - createTable:
+        tableName: query
+        remarks: Information (such as average execution time) for different queries that have been previously ran.
+        columns:
+        - column:
+            name: query_hash
+            type: binary(32)
+            remarks: The hash of the query dictionary. (This is a 256-bit SHA3 hash of the query dict.)
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: average_execution_time
+            type: int
+            remarks: Average execution time for the query, round to nearest number of milliseconds. This is updated as a rolling average.
+            constraints: {nullable: false}
+- changeSet:
+    id: 54
+    author: tlrobinson
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column:
+            name: skip_if_empty
+            type: boolean
+            remarks: Skip a scheduled Pulse if none of its questions have any results
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: 55
+    author: camsaul
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: archived
+            type: boolean
+            remarks: Is this Dashboard archived (effectively treated as deleted?)
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column: {name: position, type: integer, remarks: 'The position this Dashboard should appear in the Dashboards list, lower-numbered positions appearing before higher numbered ones.'}
+    - createTable:
+        tableName: dashboard_favorite
+        remarks: Presence of a row here indicates a given User has favorited a given Dashboard.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: ID of the User who favorited the Dashboard.
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_dashboard_favorite_user_id, deleteCascade: true}
+        - column:
+            name: dashboard_id
+            type: int
+            remarks: ID of the Dashboard favorited by the User.
+            constraints: {nullable: false, referencedTableName: report_dashboard, referencedColumnNames: id, foreignKeyName: fk_dashboard_favorite_dashboard_id, deleteCascade: true}
+    - addUniqueConstraint: {tableName: dashboard_favorite, columnNames: 'user_id, dashboard_id', constraintName: unique_dashboard_favorite_user_id_dashboard_id}
+    - createIndex:
+        tableName: dashboard_favorite
+        indexName: idx_dashboard_favorite_user_id
+        columns:
+        - column: {name: user_id}
+    - createIndex:
+        tableName: dashboard_favorite
+        indexName: idx_dashboard_favorite_dashboard_id
+        columns:
+        - column: {name: dashboard_id}
+- changeSet:
+    id: 56
+    author: wwwiiilll
+    comment: Added 0.25.0
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column:
+            name: ldap_auth
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: 57
+    author: camsaul
+    comment: Added 0.25.0
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: result_metadata, type: text, remarks: Serialized JSON containing metadata about the result columns from running the query.}
+- changeSet:
+    id: 58
+    author: senior
+    validCheckSum: ANY
+    comment: Added 0.25.0
+    changes:
+    - createTable:
+        tableName: dimension
+        remarks: Stores references to alternate views of existing fields, such as remapping an integer to a description, like an enum
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: field_id
+            type: int
+            remarks: ID of the field this dimension row applies to
+            constraints: {deferrable: false, foreignKeyName: fk_dimension_ref_field_id, initiallyDeferred: false, nullable: false, referencedTableName: metabase_field, referencedColumnNames: id, deleteCascade: true}
+        - column:
+            name: name
+            type: VARCHAR(254)
+            remarks: Short description used as the display name of this new column
+            constraints: {nullable: false}
+        - column:
+            name: type
+            type: varchar(254)
+            remarks: Either internal for a user defined remapping or external for a foreign key based remapping
+            constraints: {nullable: false}
+        - column:
+            name: human_readable_field_id
+            type: int
+            remarks: Only used with external type remappings. Indicates which field on the FK related table to use for display
+            constraints: {deferrable: false, foreignKeyName: fk_dimension_displayfk_ref_field_id, initiallyDeferred: false, nullable: true, referencedTableName: metabase_field, referencedColumnNames: id, deleteCascade: true}
+        - column:
+            name: created_at
+            type: DATETIME
+            remarks: The timestamp of when the dimension was created.
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            remarks: The timestamp of when these dimension was last updated.
+            constraints: {nullable: false}
+    - addUniqueConstraint: {tableName: dimension, columnNames: 'field_id, name', constraintName: unique_dimension_field_id_name}
+    - createIndex:
+        tableName: dimension
+        indexName: idx_dimension_field_id
+        columns:
+        - column: {name: field_id}
+- changeSet:
+    id: 59
+    author: camsaul
+    comment: Added 0.26.0
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: fingerprint, type: text, remarks: 'Serialized JSON containing non-identifying information about this Field, such as min, max, and percent JSON. Used for classification.'}
+- changeSet:
+    id: 60
+    author: camsaul
+    validCheckSum: ANY
+    comment: Added 0.26.0
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: metadata_sync_schedule
+            type: varchar(254)
+            remarks: The cron schedule string for when this database should undergo the metadata sync process (and analysis for new fields).
+            defaultValue: 0 50 * * * ? *
+            constraints: {nullable: false}
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: cache_field_values_schedule
+            type: varchar(254)
+            remarks: The cron schedule string for when FieldValues for eligible Fields should be updated.
+            defaultValue: 0 50 0 * * ? *
+            constraints: {nullable: false}
+- changeSet:
+    id: 61
+    author: camsaul
+    comment: Added 0.26.0
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: fingerprint_version
+            type: int
+            remarks: The version of the fingerprint for this Field. Used so we can keep track of which Fields need to be analyzed again when new things are added to fingerprints.
+            defaultValue: 0
+            constraints: {nullable: false}
+- changeSet:
+    id: 62
+    author: senior
+    comment: Added 0.26.0
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: timezone, type: VARCHAR(254), remarks: 'Timezone identifier for the database, set by the sync process'}
+- changeSet:
+    id: 63
+    author: camsaul
+    comment: Added 0.26.0
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: is_on_demand
+            type: boolean
+            remarks: Whether we should do On-Demand caching of FieldValues for this DB. This means FieldValues are updated when their Field is used in a Dashboard or Card param.
+            defaultValue: false
+            constraints: {nullable: false}
+- changeSet:
+    id: 64
+    author: senior
+    comment: Added 0.26.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: raw_table, constraintName: fk_rawtable_ref_database, remarks: 'This FK prevents deleting databases even though RAW_TABLE is no longer used. The table is still around to support downgrades, but the FK reference is no longer needed.'}
+- changeSet:
+    id: 66
+    author: senior
+    comment: Added 0.26.0
+    validCheckSum: ANY
+    changes:
+    - sql: {sql: drop table if exists computation_job_result cascade}
+    - sql: {sql: drop table if exists computation_job cascade}
+- changeSet:
+    id: 67
+    author: attekei
+    validCheckSum: ANY
+    comment: Added 0.27.0
+    changes:
+    - createTable:
+        tableName: computation_job
+        remarks: Stores submitted async computation jobs.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_computation_job_ref_user_id, initiallyDeferred: false, referencedTableName: core_user, referencedColumnNames: id}
+            name: creator_id
+            type: int
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: type
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            name: status
+            type: varchar(254)
+            constraints: {nullable: false}
+    - createTable:
+        tableName: computation_job_result
+        remarks: Stores results of async computation jobs.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_computation_result_ref_job_id, initiallyDeferred: false, nullable: false, referencedTableName: computation_job, referencedColumnNames: id}
+            name: job_id
+            type: int
+        - column:
+            name: created_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: permanence
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            name: payload
+            type: text
+            constraints: {nullable: false}
+- changeSet:
+    id: 68
+    author: sbelak
+    comment: Added 0.27.0
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: computation_job
+        columns:
+        - column: {name: context, type: text}
+    - addColumn:
+        tableName: computation_job
+        columns:
+        - column: {name: ended_at, type: DATETIME}
+- changeSet:
+    id: 69
+    author: senior
+    validCheckSum: ANY
+    comment: Added 0.27.0
+    remarks: Add columns to the pulse table for alerts
+    changes:
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column: {name: alert_condition, type: varchar(254), remarks: Condition (i.e. "rows" or "goal") used as a guard for alerts}
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column: {name: alert_first_only, type: boolean, remarks: True if the alert should be disabled after the first notification}
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column: {name: alert_above_goal, type: boolean, remarks: 'For a goal condition, alert when above the goal'}
+    - dropNotNullConstraint: {tableName: pulse, columnName: name, columnDataType: varchar(254)}
+- changeSet:
+    id: 70
+    author: camsaul
+    comment: Added 0.28.0
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: database_type, type: varchar(255), remarks: The actual type of this column in the database. e.g. VARCHAR or TEXT.}
+    - addNotNullConstraint: {tableName: metabase_field, columnName: database_type, columnDataType: varchar(255), defaultNullValue: '?'}
+- changeSet:
+    id: 71
+    author: camsaul
+    comment: Added 0.28.0
+    changes:
+    - dropNotNullConstraint: {tableName: report_dashboardcard, columnName: card_id, columnDataType: int}
+- changeSet:
+    id: 72
+    author: senior
+    validCheckSum: ANY
+    comment: Added 0.28.0
+    changes:
+    - addColumn:
+        tableName: pulse_card
+        columns:
+        - column:
+            name: include_csv
+            type: boolean
+            defaultValueBoolean: false
+            remarks: True if a CSV of the data should be included for this pulse card
+            constraints: {nullable: false}
+    - addColumn:
+        tableName: pulse_card
+        columns:
+        - column:
+            name: include_xls
+            type: boolean
+            defaultValueBoolean: false
+            remarks: True if a XLS of the data should be included for this pulse card
+            constraints: {nullable: false}
+- changeSet:
+    id: 73
+    author: camsaul
+    comment: Added 0.29.0
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: options, type: text, remarks: Serialized JSON containing various options like QB behavior.}
+- changeSet:
+    id: 74
+    author: camsaul
+    comment: Added 0.29.0
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: has_field_values, type: text, remarks: 'Whether we have FieldValues ("list"), should ad-hoc search ("search"), disable entirely ("none"), or infer dynamically (null)"'}
+- changeSet:
+    id: 75
+    author: camsaul
+    comment: Added 0.28.2
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: read_permissions, type: text, remarks: Permissions required to view this Card and run its query.}
+- changeSet:
+    id: 76
+    author: senior
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column: {name: fields_hash, type: text, remarks: Computed hash of all of the fields associated to this table}
+- changeSet:
+    id: 77
+    author: senior
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column: {name: login_attributes, type: text, remarks: JSON serialized map with attributes used for row level permissions}
+- changeSet:
+    id: 78
+    author: camsaul
+    validCheckSum: ANY
+    comment: Added 0.30.0
+    changes:
+    - createTable:
+        tableName: group_table_access_policy
+        remarks: Records that a given Card (Question) should automatically replace a given Table as query source for a given a Perms Group.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: group_id
+            type: int
+            remarks: ID of the Permissions Group this policy affects.
+            constraints: {nullable: false, referencedTableName: permissions_group, referencedColumnNames: id, foreignKeyName: fk_gtap_group_id, deleteCascade: true}
+        - column:
+            name: table_id
+            type: int
+            remarks: ID of the Table that should get automatically replaced as query source for the Permissions Group.
+            constraints: {nullable: false, referencedTableName: metabase_table, referencedColumnNames: id, foreignKeyName: fk_gtap_table_id, deleteCascade: true}
+        - column:
+            name: card_id
+            type: int
+            remarks: ID of the Card (Question) to be used to replace the Table.
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_gtap_card_id}
+        - column: {name: attribute_remappings, type: text, remarks: JSON-encoded map of user attribute identifier to the param name used in the Card.}
+    - createIndex:
+        indexName: idx_gtap_table_id_group_id
+        tableName: group_table_access_policy
+        columns:
+        - column: {name: table_id}
+        - column: {name: group_id}
+    - addUniqueConstraint: {tableName: group_table_access_policy, columnNames: 'table_id, group_id', constraintName: unique_gtap_table_id_group_id}
+- changeSet:
+    id: 79
+    author: camsaul
+    validCheckSum: ANY
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: collection_id
+            type: int
+            remarks: Optional ID of Collection this Dashboard belongs to.
+            constraints: {referencedTableName: collection, referencedColumnNames: id, foreignKeyName: fk_dashboard_collection_id}
+    - createIndex:
+        tableName: report_dashboard
+        indexName: idx_dashboard_collection_id
+        columns:
+        - column: {name: collection_id}
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column:
+            name: collection_id
+            type: int
+            remarks: Options ID of Collection this Pulse belongs to.
+            constraints: {referencedTableName: collection, referencedColumnNames: id, foreignKeyName: fk_pulse_collection_id}
+    - createIndex:
+        tableName: pulse
+        indexName: idx_pulse_collection_id
+        columns:
+        - column: {name: collection_id}
+- changeSet:
+    id: 80
+    author: camsaul
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: location
+            type: varchar(254)
+            remarks: Directory-structure path of ancestor Collections. e.g. "/1/2/" means our Parent is Collection 2, and their parent is Collection 1.
+            constraints: {nullable: false}
+            defaultValue: /
+    - createIndex:
+        tableName: collection
+        indexName: idx_collection_location
+        columns:
+        - column: {name: location}
+- changeSet:
+    id: 81
+    author: camsaul
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column: {name: collection_position, type: smallint, remarks: Optional pinned position for this item in its Collection. NULL means item is not pinned.}
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: collection_position, type: smallint, remarks: Optional pinned position for this item in its Collection. NULL means item is not pinned.}
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column: {name: collection_position, type: smallint, remarks: Optional pinned position for this item in its Collection. NULL means item is not pinned.}
+- changeSet:
+    id: 82
+    author: senior
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column: {name: updated_at, type: datetime, remarks: 'When was this User last updated?'}
+    - sql: {sql: update core_user set updated_at=date_joined}
+- changeSet:
+    id: 83
+    author: senior
+    comment: Added 0.30.0
+    changes:
+    - dropNotNullConstraint: {tableName: group_table_access_policy, columnName: card_id, columnDataType: int}
+- changeSet:
+    id: 84
+    author: senior
+    comment: Added 0.30.0
+    changes:
+    - renameColumn: {tableName: metric, columnDataType: boolean, newColumnName: archived, oldColumnName: is_active}
+    - addDefaultValue: {tableName: metric, columnDataType: boolean, columnName: archived, defaultValueBoolean: false}
+    - renameColumn: {tableName: segment, columnDataType: boolean, newColumnName: archived, oldColumnName: is_active}
+    - addDefaultValue: {tableName: segment, columnDataType: boolean, columnName: archived, defaultValueBoolean: false}
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column: {name: archived, type: boolean, remarks: 'Has this pulse been archived?', defaultValueBoolean: false}
+    - sql: {sql: update segment set archived = not(archived)}
+- changeSet:
+    id: 85
+    author: camsaul
+    validCheckSum: ANY
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: personal_owner_id
+            type: int
+            remarks: If set, this Collection is a personal Collection, for exclusive use of the User with this ID.
+            constraints: {referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_collection_personal_owner_id, unique: true, uniqueConstraintName: unique_collection_personal_owner_id, deleteCascade: true}
+    - createIndex:
+        tableName: collection
+        indexName: idx_collection_personal_owner_id
+        columns:
+        - column: {name: personal_owner_id}
+    - addColumn:
+        tableName: collection
+        columns:
+        - column: {name: _slug, type: varchar(254), remarks: Sluggified version of the Collection name. Used only for display purposes in URL; not unique or indexed.}
+    - sql: {sql: UPDATE collection SET _slug = slug}
+    - addNotNullConstraint: {tableName: collection, columnName: _slug, columnDataType: varchar(254)}
+    - dropColumn: {tableName: collection, columnName: slug}
+    - renameColumn: {tableName: collection, oldColumnName: _slug, newColumnName: slug, columnDataType: varchar(254)}
+    - sql: {dbms: 'postgresql,h2', sql: COMMENT ON COLUMN collection.name IS 'The user-facing name of this Collection.'}
+    - sql: {dbms: 'mysql,mariadb', sql: ALTER TABLE `collection` CHANGE `name` `name` TEXT NOT NULL COMMENT 'The user-facing name of this Collection.'}
+- changeSet:
+    id: 86
+    author: camsaul
+    comment: Added 0.30.0
+    changes:
+    - sql: {sql: DELETE FROM permissions WHERE object LIKE '%/native/read/'}
+- changeSet:
+    id: 87
+    author: camsaul
+    comment: Added 0.30.0
+    changes:
+    - dropTable: {tableName: raw_column}
+    - dropTable: {tableName: raw_table}
+- changeSet:
+    id: 88
+    author: senior
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column:
+            name: saml_auth
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+            remarks: Boolean to indicate if this user is authenticated via SAML
+- property: {name: quartz.blob_data.name, dbms: postgresql, value: blob_data}
+- property: {name: quartz.blob_data.name, dbms: 'mysql,mariadb,h2', value: BLOB_DATA}
+- property: {name: quartz.bool_prop_1.name, dbms: postgresql, value: bool_prop_1}
+- property: {name: quartz.bool_prop_1.name, dbms: 'mysql,mariadb,h2', value: BOOL_PROP_1}
+- property: {name: quartz.bool_prop_2.name, dbms: postgresql, value: bool_prop_2}
+- property: {name: quartz.bool_prop_2.name, dbms: 'mysql,mariadb,h2', value: BOOL_PROP_2}
+- property: {name: quartz.calendar.name, dbms: postgresql, value: calendar}
+- property: {name: quartz.calendar.name, dbms: 'mysql,mariadb,h2', value: CALENDAR}
+- property: {name: quartz.calendar_name.name, dbms: postgresql, value: calendar_name}
+- property: {name: quartz.calendar_name.name, dbms: 'mysql,mariadb,h2', value: CALENDAR_NAME}
+- property: {name: quartz.checkin_interval.name, dbms: postgresql, value: checkin_interval}
+- property: {name: quartz.checkin_interval.name, dbms: 'mysql,mariadb,h2', value: CHECKIN_INTERVAL}
+- property: {name: quartz.cron_expression.name, dbms: postgresql, value: cron_expression}
+- property: {name: quartz.cron_expression.name, dbms: 'mysql,mariadb,h2', value: CRON_EXPRESSION}
+- property: {name: quartz.dec_prop_1.name, dbms: postgresql, value: dec_prop_1}
+- property: {name: quartz.dec_prop_1.name, dbms: 'mysql,mariadb,h2', value: DEC_PROP_1}
+- property: {name: quartz.dec_prop_2.name, dbms: postgresql, value: dec_prop_2}
+- property: {name: quartz.dec_prop_2.name, dbms: 'mysql,mariadb,h2', value: DEC_PROP_2}
+- property: {name: quartz.description.name, dbms: postgresql, value: description}
+- property: {name: quartz.description.name, dbms: 'mysql,mariadb,h2', value: DESCRIPTION}
+- property: {name: quartz.end_time.name, dbms: postgresql, value: end_time}
+- property: {name: quartz.end_time.name, dbms: 'mysql,mariadb,h2', value: END_TIME}
+- property: {name: quartz.entry_id.name, dbms: postgresql, value: entry_id}
+- property: {name: quartz.entry_id.name, dbms: 'mysql,mariadb,h2', value: ENTRY_ID}
+- property: {name: quartz.fired_time.name, dbms: postgresql, value: fired_time}
+- property: {name: quartz.fired_time.name, dbms: 'mysql,mariadb,h2', value: FIRED_TIME}
+- property: {name: quartz.fk_qrtz_blob_triggers_triggers.name, dbms: postgresql, value: fk_qrtz_blob_triggers_triggers}
+- property: {name: quartz.fk_qrtz_blob_triggers_triggers.name, dbms: 'mysql,mariadb,h2', value: FK_QRTZ_BLOB_TRIGGERS_TRIGGERS}
+- property: {name: quartz.fk_qrtz_cron_triggers_triggers.name, dbms: postgresql, value: fk_qrtz_cron_triggers_triggers}
+- property: {name: quartz.fk_qrtz_cron_triggers_triggers.name, dbms: 'mysql,mariadb,h2', value: FK_QRTZ_CRON_TRIGGERS_TRIGGERS}
+- property: {name: quartz.fk_qrtz_simple_triggers_triggers.name, dbms: postgresql, value: fk_qrtz_simple_triggers_triggers}
+- property: {name: quartz.fk_qrtz_simple_triggers_triggers.name, dbms: 'mysql,mariadb,h2', value: FK_QRTZ_SIMPLE_TRIGGERS_TRIGGERS}
+- property: {name: quartz.fk_qrtz_simprop_triggers_triggers.name, dbms: postgresql, value: fk_qrtz_simprop_triggers_triggers}
+- property: {name: quartz.fk_qrtz_simprop_triggers_triggers.name, dbms: 'mysql,mariadb,h2', value: FK_QRTZ_SIMPROP_TRIGGERS_TRIGGERS}
+- property: {name: quartz.fk_qrtz_triggers_job_details.name, dbms: postgresql, value: fk_qrtz_triggers_job_details}
+- property: {name: quartz.fk_qrtz_triggers_job_details.name, dbms: 'mysql,mariadb,h2', value: FK_QRTZ_TRIGGERS_JOB_DETAILS}
+- property: {name: quartz.idx_qrtz_ft_inst_job_req_rcvry.name, dbms: postgresql, value: idx_qrtz_ft_inst_job_req_rcvry}
+- property: {name: quartz.idx_qrtz_ft_inst_job_req_rcvry.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_FT_INST_JOB_REQ_RCVRY}
+- property: {name: quartz.idx_qrtz_ft_jg.name, dbms: postgresql, value: idx_qrtz_ft_jg}
+- property: {name: quartz.idx_qrtz_ft_jg.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_FT_JG}
+- property: {name: quartz.idx_qrtz_ft_j_g.name, dbms: postgresql, value: idx_qrtz_ft_j_g}
+- property: {name: quartz.idx_qrtz_ft_j_g.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_FT_J_G}
+- property: {name: quartz.idx_qrtz_ft_tg.name, dbms: postgresql, value: idx_qrtz_ft_tg}
+- property: {name: quartz.idx_qrtz_ft_tg.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_FT_TG}
+- property: {name: quartz.idx_qrtz_ft_trig_inst_name.name, dbms: postgresql, value: idx_qrtz_ft_trig_inst_name}
+- property: {name: quartz.idx_qrtz_ft_trig_inst_name.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_FT_TRIG_INST_NAME}
+- property: {name: quartz.idx_qrtz_ft_t_g.name, dbms: postgresql, value: idx_qrtz_ft_t_g}
+- property: {name: quartz.idx_qrtz_ft_t_g.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_FT_T_G}
+- property: {name: quartz.idx_qrtz_j_grp.name, dbms: postgresql, value: idx_qrtz_j_grp}
+- property: {name: quartz.idx_qrtz_j_grp.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_J_GRP}
+- property: {name: quartz.idx_qrtz_j_req_recovery.name, dbms: postgresql, value: idx_qrtz_j_req_recovery}
+- property: {name: quartz.idx_qrtz_j_req_recovery.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_J_REQ_RECOVERY}
+- property: {name: quartz.idx_qrtz_t_c.name, dbms: postgresql, value: idx_qrtz_t_c}
+- property: {name: quartz.idx_qrtz_t_c.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_C}
+- property: {name: quartz.idx_qrtz_t_g.name, dbms: postgresql, value: idx_qrtz_t_g}
+- property: {name: quartz.idx_qrtz_t_g.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_G}
+- property: {name: quartz.idx_qrtz_t_j.name, dbms: postgresql, value: idx_qrtz_t_j}
+- property: {name: quartz.idx_qrtz_t_j.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_J}
+- property: {name: quartz.idx_qrtz_t_jg.name, dbms: postgresql, value: idx_qrtz_t_jg}
+- property: {name: quartz.idx_qrtz_t_jg.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_JG}
+- property: {name: quartz.idx_qrtz_t_next_fire_time.name, dbms: postgresql, value: idx_qrtz_t_next_fire_time}
+- property: {name: quartz.idx_qrtz_t_next_fire_time.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_NEXT_FIRE_TIME}
+- property: {name: quartz.idx_qrtz_t_nft_misfire.name, dbms: postgresql, value: idx_qrtz_t_nft_misfire}
+- property: {name: quartz.idx_qrtz_t_nft_misfire.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_NFT_MISFIRE}
+- property: {name: quartz.idx_qrtz_t_nft_st.name, dbms: postgresql, value: idx_qrtz_t_nft_st}
+- property: {name: quartz.idx_qrtz_t_nft_st.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_NFT_ST}
+- property: {name: quartz.idx_qrtz_t_nft_st_misfire.name, dbms: postgresql, value: idx_qrtz_t_nft_st_misfire}
+- property: {name: quartz.idx_qrtz_t_nft_st_misfire.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_NFT_ST_MISFIRE}
+- property: {name: quartz.idx_qrtz_t_nft_st_misfire_grp.name, dbms: postgresql, value: idx_qrtz_t_nft_st_misfire_grp}
+- property: {name: quartz.idx_qrtz_t_nft_st_misfire_grp.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_NFT_ST_MISFIRE_GRP}
+- property: {name: quartz.idx_qrtz_t_n_g_state.name, dbms: postgresql, value: idx_qrtz_t_n_g_state}
+- property: {name: quartz.idx_qrtz_t_n_g_state.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_N_G_STATE}
+- property: {name: quartz.idx_qrtz_t_n_state.name, dbms: postgresql, value: idx_qrtz_t_n_state}
+- property: {name: quartz.idx_qrtz_t_n_state.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_N_STATE}
+- property: {name: quartz.idx_qrtz_t_state.name, dbms: postgresql, value: idx_qrtz_t_state}
+- property: {name: quartz.idx_qrtz_t_state.name, dbms: 'mysql,mariadb,h2', value: IDX_QRTZ_T_STATE}
+- property: {name: quartz.instance_name.name, dbms: postgresql, value: instance_name}
+- property: {name: quartz.instance_name.name, dbms: 'mysql,mariadb,h2', value: INSTANCE_NAME}
+- property: {name: quartz.int_prop_1.name, dbms: postgresql, value: int_prop_1}
+- property: {name: quartz.int_prop_1.name, dbms: 'mysql,mariadb,h2', value: INT_PROP_1}
+- property: {name: quartz.int_prop_2.name, dbms: postgresql, value: int_prop_2}
+- property: {name: quartz.int_prop_2.name, dbms: 'mysql,mariadb,h2', value: INT_PROP_2}
+- property: {name: quartz.is_durable.name, dbms: postgresql, value: is_durable}
+- property: {name: quartz.is_durable.name, dbms: 'mysql,mariadb,h2', value: IS_DURABLE}
+- property: {name: quartz.is_nonconcurrent.name, dbms: postgresql, value: is_nonconcurrent}
+- property: {name: quartz.is_nonconcurrent.name, dbms: 'mysql,mariadb,h2', value: IS_NONCONCURRENT}
+- property: {name: quartz.is_update_data.name, dbms: postgresql, value: is_update_data}
+- property: {name: quartz.is_update_data.name, dbms: 'mysql,mariadb,h2', value: IS_UPDATE_DATA}
+- property: {name: quartz.job_class_name.name, dbms: postgresql, value: job_class_name}
+- property: {name: quartz.job_class_name.name, dbms: 'mysql,mariadb,h2', value: JOB_CLASS_NAME}
+- property: {name: quartz.job_data.name, dbms: postgresql, value: job_data}
+- property: {name: quartz.job_data.name, dbms: 'mysql,mariadb,h2', value: JOB_DATA}
+- property: {name: quartz.job_group.name, dbms: postgresql, value: job_group}
+- property: {name: quartz.job_group.name, dbms: 'mysql,mariadb,h2', value: JOB_GROUP}
+- property: {name: quartz.job_name.name, dbms: postgresql, value: job_name}
+- property: {name: quartz.job_name.name, dbms: 'mysql,mariadb,h2', value: JOB_NAME}
+- property: {name: quartz.last_checkin_time.name, dbms: postgresql, value: last_checkin_time}
+- property: {name: quartz.last_checkin_time.name, dbms: 'mysql,mariadb,h2', value: LAST_CHECKIN_TIME}
+- property: {name: quartz.lock_name.name, dbms: postgresql, value: lock_name}
+- property: {name: quartz.lock_name.name, dbms: 'mysql,mariadb,h2', value: LOCK_NAME}
+- property: {name: quartz.long_prop_1.name, dbms: postgresql, value: long_prop_1}
+- property: {name: quartz.long_prop_1.name, dbms: 'mysql,mariadb,h2', value: LONG_PROP_1}
+- property: {name: quartz.long_prop_2.name, dbms: postgresql, value: long_prop_2}
+- property: {name: quartz.long_prop_2.name, dbms: 'mysql,mariadb,h2', value: LONG_PROP_2}
+- property: {name: quartz.misfire_instr.name, dbms: postgresql, value: misfire_instr}
+- property: {name: quartz.misfire_instr.name, dbms: 'mysql,mariadb,h2', value: MISFIRE_INSTR}
+- property: {name: quartz.next_fire_time.name, dbms: postgresql, value: next_fire_time}
+- property: {name: quartz.next_fire_time.name, dbms: 'mysql,mariadb,h2', value: NEXT_FIRE_TIME}
+- property: {name: quartz.pk_qrtz_blob_triggers.name, dbms: postgresql, value: pk_qrtz_blob_triggers}
+- property: {name: quartz.pk_qrtz_blob_triggers.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_BLOB_TRIGGERS}
+- property: {name: quartz.pk_qrtz_calendars.name, dbms: postgresql, value: pk_qrtz_calendars}
+- property: {name: quartz.pk_qrtz_calendars.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_CALENDARS}
+- property: {name: quartz.pk_qrtz_cron_triggers.name, dbms: postgresql, value: pk_qrtz_cron_triggers}
+- property: {name: quartz.pk_qrtz_cron_triggers.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_CRON_TRIGGERS}
+- property: {name: quartz.pk_qrtz_fired_triggers.name, dbms: postgresql, value: pk_qrtz_fired_triggers}
+- property: {name: quartz.pk_qrtz_fired_triggers.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_FIRED_TRIGGERS}
+- property: {name: quartz.pk_qrtz_job_details.name, dbms: postgresql, value: pk_qrtz_job_details}
+- property: {name: quartz.pk_qrtz_job_details.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_JOB_DETAILS}
+- property: {name: quartz.pk_qrtz_locks.name, dbms: postgresql, value: pk_qrtz_locks}
+- property: {name: quartz.pk_qrtz_locks.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_LOCKS}
+- property: {name: quartz.pk_qrtz_scheduler_state.name, dbms: postgresql, value: pk_qrtz_scheduler_state}
+- property: {name: quartz.pk_qrtz_scheduler_state.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_SCHEDULER_STATE}
+- property: {name: quartz.pk_qrtz_simple_triggers.name, dbms: postgresql, value: pk_qrtz_simple_triggers}
+- property: {name: quartz.pk_qrtz_simple_triggers.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_SIMPLE_TRIGGERS}
+- property: {name: quartz.pk_qrtz_simprop_triggers.name, dbms: postgresql, value: pk_qrtz_simprop_triggers}
+- property: {name: quartz.pk_qrtz_simprop_triggers.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_SIMPROP_TRIGGERS}
+- property: {name: quartz.pk_qrtz_triggers.name, dbms: postgresql, value: pk_qrtz_triggers}
+- property: {name: quartz.pk_qrtz_triggers.name, dbms: 'mysql,mariadb,h2', value: PK_QRTZ_TRIGGERS}
+- property: {name: quartz.pk_sched_name.name, dbms: postgresql, value: pk_sched_name}
+- property: {name: quartz.pk_sched_name.name, dbms: 'mysql,mariadb,h2', value: PK_SCHED_NAME}
+- property: {name: quartz.prev_fire_time.name, dbms: postgresql, value: prev_fire_time}
+- property: {name: quartz.prev_fire_time.name, dbms: 'mysql,mariadb,h2', value: PREV_FIRE_TIME}
+- property: {name: quartz.priority.name, dbms: postgresql, value: priority}
+- property: {name: quartz.priority.name, dbms: 'mysql,mariadb,h2', value: PRIORITY}
+- property: {name: quartz.qrtz_blob_triggers.name, dbms: postgresql, value: qrtz_blob_triggers}
+- property: {name: quartz.qrtz_blob_triggers.name, dbms: 'mysql,mariadb,h2', value: QRTZ_BLOB_TRIGGERS}
+- property: {name: quartz.qrtz_calendars.name, dbms: postgresql, value: qrtz_calendars}
+- property: {name: quartz.qrtz_calendars.name, dbms: 'mysql,mariadb,h2', value: QRTZ_CALENDARS}
+- property: {name: quartz.qrtz_cron_triggers.name, dbms: postgresql, value: qrtz_cron_triggers}
+- property: {name: quartz.qrtz_cron_triggers.name, dbms: 'mysql,mariadb,h2', value: QRTZ_CRON_TRIGGERS}
+- property: {name: quartz.qrtz_fired_triggers.name, dbms: postgresql, value: qrtz_fired_triggers}
+- property: {name: quartz.qrtz_fired_triggers.name, dbms: 'mysql,mariadb,h2', value: QRTZ_FIRED_TRIGGERS}
+- property: {name: quartz.qrtz_job_details.name, dbms: postgresql, value: qrtz_job_details}
+- property: {name: quartz.qrtz_job_details.name, dbms: 'mysql,mariadb,h2', value: QRTZ_JOB_DETAILS}
+- property: {name: quartz.qrtz_locks.name, dbms: postgresql, value: qrtz_locks}
+- property: {name: quartz.qrtz_locks.name, dbms: 'mysql,mariadb,h2', value: QRTZ_LOCKS}
+- property: {name: quartz.qrtz_paused_trigger_grps.name, dbms: postgresql, value: qrtz_paused_trigger_grps}
+- property: {name: quartz.qrtz_paused_trigger_grps.name, dbms: 'mysql,mariadb,h2', value: QRTZ_PAUSED_TRIGGER_GRPS}
+- property: {name: quartz.qrtz_scheduler_state.name, dbms: postgresql, value: qrtz_scheduler_state}
+- property: {name: quartz.qrtz_scheduler_state.name, dbms: 'mysql,mariadb,h2', value: QRTZ_SCHEDULER_STATE}
+- property: {name: quartz.qrtz_simple_triggers.name, dbms: postgresql, value: qrtz_simple_triggers}
+- property: {name: quartz.qrtz_simple_triggers.name, dbms: 'mysql,mariadb,h2', value: QRTZ_SIMPLE_TRIGGERS}
+- property: {name: quartz.qrtz_simprop_triggers.name, dbms: postgresql, value: qrtz_simprop_triggers}
+- property: {name: quartz.qrtz_simprop_triggers.name, dbms: 'mysql,mariadb,h2', value: QRTZ_SIMPROP_TRIGGERS}
+- property: {name: quartz.qrtz_triggers.name, dbms: postgresql, value: qrtz_triggers}
+- property: {name: quartz.qrtz_triggers.name, dbms: 'mysql,mariadb,h2', value: QRTZ_TRIGGERS}
+- property: {name: quartz.repeat_count.name, dbms: postgresql, value: repeat_count}
+- property: {name: quartz.repeat_count.name, dbms: 'mysql,mariadb,h2', value: REPEAT_COUNT}
+- property: {name: quartz.repeat_interval.name, dbms: postgresql, value: repeat_interval}
+- property: {name: quartz.repeat_interval.name, dbms: 'mysql,mariadb,h2', value: REPEAT_INTERVAL}
+- property: {name: quartz.requests_recovery.name, dbms: postgresql, value: requests_recovery}
+- property: {name: quartz.requests_recovery.name, dbms: 'mysql,mariadb,h2', value: REQUESTS_RECOVERY}
+- property: {name: quartz.sched_name.name, dbms: postgresql, value: sched_name}
+- property: {name: quartz.sched_name.name, dbms: 'mysql,mariadb,h2', value: SCHED_NAME}
+- property: {name: quartz.sched_time.name, dbms: postgresql, value: sched_time}
+- property: {name: quartz.sched_time.name, dbms: 'mysql,mariadb,h2', value: SCHED_TIME}
+- property: {name: quartz.start_time.name, dbms: postgresql, value: start_time}
+- property: {name: quartz.start_time.name, dbms: 'mysql,mariadb,h2', value: START_TIME}
+- property: {name: quartz.state.name, dbms: postgresql, value: state}
+- property: {name: quartz.state.name, dbms: 'mysql,mariadb,h2', value: STATE}
+- property: {name: quartz.str_prop_1.name, dbms: postgresql, value: str_prop_1}
+- property: {name: quartz.str_prop_1.name, dbms: 'mysql,mariadb,h2', value: STR_PROP_1}
+- property: {name: quartz.str_prop_2.name, dbms: postgresql, value: str_prop_2}
+- property: {name: quartz.str_prop_2.name, dbms: 'mysql,mariadb,h2', value: STR_PROP_2}
+- property: {name: quartz.str_prop_3.name, dbms: postgresql, value: str_prop_3}
+- property: {name: quartz.str_prop_3.name, dbms: 'mysql,mariadb,h2', value: STR_PROP_3}
+- property: {name: quartz.times_triggered.name, dbms: postgresql, value: times_triggered}
+- property: {name: quartz.times_triggered.name, dbms: 'mysql,mariadb,h2', value: TIMES_TRIGGERED}
+- property: {name: quartz.time_zone_id.name, dbms: postgresql, value: time_zone_id}
+- property: {name: quartz.time_zone_id.name, dbms: 'mysql,mariadb,h2', value: TIME_ZONE_ID}
+- property: {name: quartz.trigger_group.name, dbms: postgresql, value: trigger_group}
+- property: {name: quartz.trigger_group.name, dbms: 'mysql,mariadb,h2', value: TRIGGER_GROUP}
+- property: {name: quartz.trigger_name.name, dbms: postgresql, value: trigger_name}
+- property: {name: quartz.trigger_name.name, dbms: 'mysql,mariadb,h2', value: TRIGGER_NAME}
+- property: {name: quartz.trigger_state.name, dbms: postgresql, value: trigger_state}
+- property: {name: quartz.trigger_state.name, dbms: 'mysql,mariadb,h2', value: TRIGGER_STATE}
+- property: {name: quartz.trigger_type.name, dbms: postgresql, value: trigger_type}
+- property: {name: quartz.trigger_type.name, dbms: 'mysql,mariadb,h2', value: TRIGGER_TYPE}
+- changeSet:
+    id: 89
+    author: camsaul
+    comment: Added 0.30.0
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: ${quartz.qrtz_job_details.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.job_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.job_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column: {name: '${quartz.description.name}', type: varchar(250)}
+        - column:
+            name: ${quartz.job_class_name.name}
+            type: varchar(250)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.is_durable.name}
+            type: bool
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.is_nonconcurrent.name}
+            type: bool
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.is_update_data.name}
+            type: bool
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.requests_recovery.name}
+            type: bool
+            constraints: {nullable: false}
+        - column: {name: '${quartz.job_data.name}', type: '${blob.type}'}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_job_details.name}', columnNames: '${quartz.sched_name.name}, ${quartz.job_name.name}, ${quartz.job_group.name}', constraintName: '${quartz.pk_qrtz_job_details.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_triggers.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.job_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.job_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column: {name: '${quartz.description.name}', type: varchar(250)}
+        - column: {name: '${quartz.next_fire_time.name}', type: bigint}
+        - column: {name: '${quartz.prev_fire_time.name}', type: bigint}
+        - column: {name: '${quartz.priority.name}', type: integer}
+        - column:
+            name: ${quartz.trigger_state.name}
+            type: varchar(16)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_type.name}
+            type: varchar(8)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.start_time.name}
+            type: bigint
+            constraints: {nullable: false}
+        - column: {name: '${quartz.end_time.name}', type: bigint}
+        - column: {name: '${quartz.calendar_name.name}', type: varchar(200)}
+        - column: {name: '${quartz.misfire_instr.name}', type: smallint}
+        - column: {name: '${quartz.job_data.name}', type: '${blob.type}'}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_triggers.name}', columnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.pk_qrtz_triggers.name}'}
+    - addForeignKeyConstraint: {baseTableName: '${quartz.qrtz_triggers.name}', baseColumnNames: '${quartz.sched_name.name}, ${quartz.job_name.name}, ${quartz.job_group.name}', referencedTableName: '${quartz.qrtz_job_details.name}', referencedColumnNames: '${quartz.sched_name.name}, ${quartz.job_name.name}, ${quartz.job_group.name}', constraintName: '${quartz.fk_qrtz_triggers_job_details.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_simple_triggers.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.repeat_count.name}
+            type: bigint
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.repeat_interval.name}
+            type: bigint
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.times_triggered.name}
+            type: bigint
+            constraints: {nullable: false}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_simple_triggers.name}', columnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.pk_qrtz_simple_triggers.name}'}
+    - addForeignKeyConstraint: {baseTableName: '${quartz.qrtz_simple_triggers.name}', baseColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', referencedTableName: '${quartz.qrtz_triggers.name}', referencedColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.fk_qrtz_simple_triggers_triggers.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_cron_triggers.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.cron_expression.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column: {name: '${quartz.time_zone_id.name}', type: varchar(80)}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_cron_triggers.name}', columnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.pk_qrtz_cron_triggers.name}'}
+    - addForeignKeyConstraint: {baseTableName: '${quartz.qrtz_cron_triggers.name}', baseColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', referencedTableName: '${quartz.qrtz_triggers.name}', referencedColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.fk_qrtz_cron_triggers_triggers.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_simprop_triggers.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column: {name: '${quartz.str_prop_1.name}', type: varchar(512)}
+        - column: {name: '${quartz.str_prop_2.name}', type: varchar(512)}
+        - column: {name: '${quartz.str_prop_3.name}', type: varchar(512)}
+        - column: {name: '${quartz.int_prop_1.name}', type: int}
+        - column: {name: '${quartz.int_prop_2.name}', type: int}
+        - column: {name: '${quartz.long_prop_1.name}', type: bigint}
+        - column: {name: '${quartz.long_prop_2.name}', type: bigint}
+        - column: {name: '${quartz.dec_prop_1.name}', type: 'numeric(13,4)'}
+        - column: {name: '${quartz.dec_prop_2.name}', type: 'numeric(13,4)'}
+        - column: {name: '${quartz.bool_prop_1.name}', type: bool}
+        - column: {name: '${quartz.bool_prop_2.name}', type: bool}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_simprop_triggers.name}', columnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.pk_qrtz_simprop_triggers.name}'}
+    - addForeignKeyConstraint: {baseTableName: '${quartz.qrtz_simprop_triggers.name}', baseColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', referencedTableName: '${quartz.qrtz_triggers.name}', referencedColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.fk_qrtz_simprop_triggers_triggers.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_blob_triggers.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column: {name: '${quartz.blob_data.name}', type: '${blob.type}'}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_blob_triggers.name}', columnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.pk_qrtz_blob_triggers.name}'}
+    - addForeignKeyConstraint: {baseTableName: '${quartz.qrtz_blob_triggers.name}', baseColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', referencedTableName: '${quartz.qrtz_triggers.name}', referencedColumnNames: '${quartz.sched_name.name}, ${quartz.trigger_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.fk_qrtz_blob_triggers_triggers.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_calendars.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.calendar_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.calendar.name}
+            type: ${blob.type}
+            constraints: {nullable: false}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_calendars.name}', columnNames: '${quartz.sched_name.name}, ${quartz.calendar_name.name}', constraintName: '${quartz.pk_qrtz_calendars.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_paused_trigger_grps.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_paused_trigger_grps.name}', columnNames: '${quartz.sched_name.name}, ${quartz.trigger_group.name}', constraintName: '${quartz.pk_sched_name.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_fired_triggers.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.entry_id.name}
+            type: varchar(95)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.trigger_group.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.instance_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.fired_time.name}
+            type: bigint
+            constraints: {nullable: false}
+        - column: {name: '${quartz.sched_time.name}', type: bigint}
+        - column:
+            name: ${quartz.priority.name}
+            type: integer
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.state.name}
+            type: varchar(16)
+            constraints: {nullable: false}
+        - column: {name: '${quartz.job_name.name}', type: varchar(200)}
+        - column: {name: '${quartz.job_group.name}', type: varchar(200)}
+        - column: {name: '${quartz.is_nonconcurrent.name}', type: bool}
+        - column: {name: '${quartz.requests_recovery.name}', type: bool}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_fired_triggers.name}', columnNames: '${quartz.sched_name.name}, ${quartz.entry_id.name}', constraintName: '${quartz.pk_qrtz_fired_triggers.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_scheduler_state.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.instance_name.name}
+            type: varchar(200)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.last_checkin_time.name}
+            type: bigint
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.checkin_interval.name}
+            type: bigint
+            constraints: {nullable: false}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_scheduler_state.name}', columnNames: '${quartz.sched_name.name}, ${quartz.instance_name.name}', constraintName: '${quartz.pk_qrtz_scheduler_state.name}'}
+    - createTable:
+        tableName: ${quartz.qrtz_locks.name}
+        remarks: Used for Quartz scheduler.
+        columns:
+        - column:
+            name: ${quartz.sched_name.name}
+            type: varchar(120)
+            constraints: {nullable: false}
+        - column:
+            name: ${quartz.lock_name.name}
+            type: varchar(40)
+            constraints: {nullable: false}
+    - addPrimaryKey: {tableName: '${quartz.qrtz_locks.name}', columnNames: '${quartz.sched_name.name}, ${quartz.lock_name.name}', constraintName: '${quartz.pk_qrtz_locks.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_j_req_recovery.name}
+        tableName: ${quartz.qrtz_job_details.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.requests_recovery.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_j_grp.name}
+        tableName: ${quartz.qrtz_job_details.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.job_group.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_j.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.job_name.name}'}
+        - column: {name: '${quartz.job_group.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_jg.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.job_group.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_c.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.calendar_name.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_g.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.trigger_group.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_state.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.trigger_state.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_n_state.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.trigger_name.name}'}
+        - column: {name: '${quartz.trigger_group.name}'}
+        - column: {name: '${quartz.trigger_state.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_n_g_state.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.trigger_group.name}'}
+        - column: {name: '${quartz.trigger_state.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_next_fire_time.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.next_fire_time.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_nft_st.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.trigger_state.name}'}
+        - column: {name: '${quartz.next_fire_time.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_nft_misfire.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.misfire_instr.name}'}
+        - column: {name: '${quartz.next_fire_time.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_nft_st_misfire.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.misfire_instr.name}'}
+        - column: {name: '${quartz.next_fire_time.name}'}
+        - column: {name: '${quartz.trigger_state.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_t_nft_st_misfire_grp.name}
+        tableName: ${quartz.qrtz_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.misfire_instr.name}'}
+        - column: {name: '${quartz.next_fire_time.name}'}
+        - column: {name: '${quartz.trigger_group.name}'}
+        - column: {name: '${quartz.trigger_state.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_ft_trig_inst_name.name}
+        tableName: ${quartz.qrtz_fired_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.instance_name.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_ft_inst_job_req_rcvry.name}
+        tableName: ${quartz.qrtz_fired_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.instance_name.name}'}
+        - column: {name: '${quartz.requests_recovery.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_ft_j_g.name}
+        tableName: ${quartz.qrtz_fired_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.job_name.name}'}
+        - column: {name: '${quartz.job_group.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_ft_jg.name}
+        tableName: ${quartz.qrtz_fired_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.job_group.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_ft_t_g.name}
+        tableName: ${quartz.qrtz_fired_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.trigger_name.name}'}
+        - column: {name: '${quartz.trigger_group.name}'}
+    - createIndex:
+        indexName: ${quartz.idx_qrtz_ft_tg.name}
+        tableName: ${quartz.qrtz_fired_triggers.name}
+        columns:
+        - column: {name: '${quartz.sched_name.name}'}
+        - column: {name: '${quartz.trigger_group.name}'}
+- changeSet:
+    id: 90
+    author: senior
+    comment: Added 0.30.0
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column: {name: sso_source, type: varchar(254), remarks: String to indicate the SSO backend the user is from}
+    - sql: {sql: update core_user set sso_source='saml' where saml_auth=true}
+    - dropColumn: {tableName: core_user, columnName: saml_auth}
+- changeSet:
+    id: 91
+    author: camsaul
+    comment: Added 0.30.0
+    changes:
+    - dropColumn: {tableName: metabase_table, columnName: raw_table_id}
+    - dropColumn: {tableName: metabase_field, columnName: raw_column_id}
+- changeSet:
+    id: 92
+    author: camsaul
+    comment: Added 0.31.0
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column: {name: database_id, type: integer, remarks: ID of the database this query was ran against.}
+- changeSet:
+    id: 93
+    author: camsaul
+    comment: Added 0.31.0
+    changes:
+    - addColumn:
+        tableName: query
+        columns:
+        - column: {name: query, type: text, remarks: The actual "query dictionary" for this query.}
+- changeSet:
+    id: 94
+    author: senior
+    comment: Added 0.31.0
+    changes:
+    - createTable:
+        tableName: task_history
+        remarks: Timing and metadata info about background/quartz processes
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: task
+            type: VARCHAR(254)
+            remarks: Name of the task
+            constraints: {nullable: false}
+        - column: {name: db_id, type: integer}
+        - column:
+            name: started_at
+            type: datetime
+            constraints: {nullable: false}
+        - column:
+            name: ended_at
+            type: datetime
+            constraints: {nullable: false}
+        - column:
+            name: duration
+            type: int
+            constraints: {nullable: false}
+        - column: {name: task_details, remarks: JSON string with additional info on the task, type: text}
+    - createIndex:
+        indexName: idx_task_history_end_time
+        tableName: task_history
+        columns:
+        - column: {name: ended_at}
+    - createIndex:
+        indexName: idx_task_history_db_id
+        tableName: task_history
+        columns:
+        - column: {name: db_id}
+- changeSet:
+    id: 95
+    author: senior
+    comment: Added 0.31.0
+    validCheckSum: ANY
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onUpdateSQL: IGNORE}
+    - sqlCheck: {expectedResult: 0, sql: 'SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1'}
+    changes:
+    - addUniqueConstraint: {columnNames: 'id, author, filename', constraintName: idx_databasechangelog_id_author_filename, tableName: '${databasechangelog.name}'}
+- changeSet:
+    id: 96
+    author: camsaul
+    comment: Added 0.31.0
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: settings, type: text, remarks: 'Serialized JSON FE-specific settings like formatting, etc. Scope of what is stored here may increase in future.'}
+- changeSet:
+    id: 97
+    author: senior
+    comment: Added 0.32.0
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - modifyDataType: {tableName: query_cache, columnName: results, newDataType: longblob}
+- changeSet:
+    id: 98
+    author: camsaul
+    validCheckSum: 8:f036d20a4dc86fb60ffb64ea838ed6b9
+    comment: Added 0.32.0
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onUpdateSQL: IGNORE}
+    - or:
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: 'SELECT count(*) FROM (SELECT count(*) FROM `metabase_table` GROUP BY `db_id`, `schema`, `name` HAVING count(*) > 1) t1'}
+      - and:
+        - dbms: {type: 'h2,postgresql'}
+        - sqlCheck: {expectedResult: 0, sql: 'SELECT count(*) FROM (SELECT count(*) FROM METABASE_TABLE GROUP BY DB_ID, SCHEMA, NAME HAVING count(*) > 1) t1'}
+    changes:
+    - addUniqueConstraint: {tableName: metabase_table, columnNames: 'db_id, schema, name', constraintName: idx_uniq_table_db_id_schema_name}
+    - sql: {dbms: postgresql, sql: 'CREATE UNIQUE INDEX idx_uniq_table_db_id_schema_name_2col ON "metabase_table" ("db_id", "name") WHERE "schema" IS NULL'}
+- changeSet:
+    id: 99
+    author: camsaul
+    validCheckSum: 8:274bb516dd95b76c954b26084eed1dfe
+    comment: Added 0.32.0
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onUpdateSQL: IGNORE}
+    - or:
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: 'SELECT count(*) FROM (SELECT count(*) FROM `metabase_field` GROUP BY `table_id`, `parent_id`, `name` HAVING count(*) > 1) t1'}
+      - and:
+        - dbms: {type: 'h2,postgresql'}
+        - sqlCheck: {expectedResult: 0, sql: 'SELECT count(*) FROM (SELECT count(*) FROM METABASE_FIELD GROUP BY TABLE_ID, PARENT_ID, NAME HAVING count(*) > 1) t1'}
+    changes:
+    - addUniqueConstraint: {tableName: metabase_field, columnNames: 'table_id, parent_id, name', constraintName: idx_uniq_field_table_id_parent_id_name}
+    - sql: {dbms: postgresql, sql: 'CREATE UNIQUE INDEX idx_uniq_field_table_id_parent_id_name_2col ON "metabase_field" ("table_id", "name") WHERE "parent_id" IS NULL'}
+- changeSet:
+    id: 100
+    author: camsaul
+    comment: Added 0.32.0
+    validCheckSum: ANY
+    changes:
+    - sql:
+        dbms: postgresql,h2
+        sql: |-
+          UPDATE metric SET archived = NOT archived WHERE EXISTS (
+            SELECT *
+            FROM databasechangelog dbcl
+            WHERE dbcl.id = '84'
+              AND metric.updated_at < dbcl.dateexecuted
+          )
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE metric SET archived = NOT archived WHERE EXISTS (
+            SELECT *
+            FROM `DATABASECHANGELOG` dbcl
+            WHERE dbcl.id = '84'
+              AND metric.updated_at < dbcl.dateexecuted
+          )
+- changeSet:
+    id: 101
+    author: camsaul
+    comment: Added 0.32.0
+    changes:
+    - createIndex:
+        indexName: idx_field_parent_id
+        tableName: metabase_field
+        columns:
+        - column: {name: parent_id}
+- changeSet:
+    id: 103
+    author: camsaul
+    comment: Added 0.32.10
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: auto_run_queries
+            remarks: Whether to automatically run queries when doing simple filtering and summarizing in the Query Builder.
+            type: boolean
+            constraints: {nullable: false}
+            defaultValueBoolean: true
+- changeSet:
+    id: 104
+    author: camsaul
+    comment: Added EE 1.1.6/CE 0.33.0
+    changes:
+    - addColumn:
+        tableName: core_session
+        columns:
+        - column: {name: anti_csrf_token, type: text, remarks: Anti-CSRF token for full-app embed sessions.}
+- changeSet:
+    id: 106
+    author: sb
+    comment: Added 0.33.5
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: database_type, newDataType: text}
+- changeSet:
+    id: 107
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER DATABASE CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;}
+- changeSet:
+    id: 108
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `DATABASECHANGELOG` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 109
+    author: camsaul
+    comment: Added 0.34.2, but not necessary anymore with the liquibase session lock
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: none}
+    changes:
+    - sql: {sql: ALTER TABLE `DATABASECHANGELOGLOCK` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 110
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_CALENDARS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 111
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_FIRED_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 112
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_JOB_DETAILS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 113
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_LOCKS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 114
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_PAUSED_TRIGGER_GRPS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 115
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_SCHEDULER_STATE` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 116
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `core_user` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 117
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `data_migrations` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 118
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `dependency` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 119
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `label` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 120
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `metabase_database` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 121
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `permissions_group` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 122
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `query` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 123
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `query_cache` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 124
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `query_execution` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 125
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `setting` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 126
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `task_history` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 127
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 128
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `activity` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 129
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `collection` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 130
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `collection_revision` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 131
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `computation_job` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 132
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `core_session` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 133
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `metabase_table` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 134
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `permissions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 135
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `permissions_revision` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 136
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `revision` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 137
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `view_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 138
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_BLOB_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 139
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_CRON_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 140
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_SIMPLE_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 141
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `QRTZ_SIMPROP_TRIGGERS` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 142
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `computation_job_result` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 143
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `metabase_field` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 144
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `permissions_group_membership` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 145
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `pulse` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 146
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `report_dashboard` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 147
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `dashboard_favorite` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 148
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `dimension` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 149
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `metabase_fieldvalues` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 150
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `metric` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 151
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `pulse_channel` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 152
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `segment` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 153
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `pulse_channel_recipient` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 154
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `report_card` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 155
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `metric_important_field` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 156
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `report_cardfavorite` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 157
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `card_label` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 158
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `pulse_card` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 159
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `report_dashboardcard` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 160
+    author: camsaul
+    comment: Added 0.34.2
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onSqlOutput: FAIL}
+    - or:
+      - dbms: {type: mysql}
+      - dbms: {type: mariadb}
+    changes:
+    - sql: {sql: ALTER TABLE `dashboardcard_series` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: 162
+    author: camsaul
+    comment: Added 0.23.0 as a data migration; converted to Liquibase migration in 0.35.0
+    preConditions:
+    - {onFail: MARK_RAN}
+    - tableExists: {tableName: query_queryexecution}
+    changes:
+    - dropTable: {tableName: query_queryexecution}
+- changeSet:
+    id: 163
+    author: camsaul
+    comment: Added 0.35.0
+    changes:
+    - dropColumn: {tableName: report_card, columnName: read_permissions}
+- changeSet:
+    id: 164
+    author: camsaul
+    comment: Added 0.35.0
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column: {name: locale, remarks: 'Preferred ISO locale (language/country) code, e.g "en" or "en-US", for this User. Overrides site default.', type: varchar(5)}
+- changeSet:
+    id: 165
+    author: sb
+    comment: Added field_order to Table and database_position to Field
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: database_position
+            type: int
+            defaultValueNumeric: 0
+            constraints: {nullable: false}
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: custom_position
+            type: int
+            defaultValueNumeric: 0
+            constraints: {nullable: false}
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column:
+            name: field_order
+            type: varchar(254)
+            defaultValue: database
+            constraints: {nullable: false}
+    - sql: {sql: update metabase_field set database_position = id}
+- changeSet:
+    id: 166
+    author: camsaul
+    comment: Added 0.36.0/1.35.4
+    changes:
+    - modifyDataType: {tableName: metabase_fieldvalues, columnName: updated_at, newDataType: '${timestamp_type}'}
+    - modifyDataType: {tableName: query_cache, columnName: updated_at, newDataType: '${timestamp_type}'}
+- changeSet:
+    id: 167
+    author: walterl, camsaul
+    validCheckSum: ANY
+    comment: Added 0.36.0
+    changes:
+    - sql: {sql: drop table if exists native_query_snippet}
+    - createTable:
+        tableName: native_query_snippet
+        remarks: Query snippets (raw text) to be substituted in native queries
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: name
+            type: VARCHAR(254)
+            remarks: Name of the query snippet
+            constraints: {nullable: false, unique: true}
+        - column: {name: description, type: text}
+        - column:
+            name: content
+            type: text
+            remarks: Raw query snippet
+            constraints: {nullable: false}
+        - column:
+            name: creator_id
+            type: int
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_snippet_creator_id, deleteCascade: true}
+        - column:
+            name: archived
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+    - createIndex:
+        tableName: native_query_snippet
+        indexName: idx_snippet_name
+        columns:
+        - column: {name: name}
+- changeSet:
+    id: 168
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - modifyDataType: {tableName: query_execution, columnName: started_at, newDataType: '${timestamp_type}'}
+- changeSet:
+    id: 169
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropColumn: {tableName: metabase_table, columnName: rows}
+- changeSet:
+    id: 170
+    author: sb
+    comment: Added 0.36.0
+    changes:
+    - dropColumn: {tableName: metabase_table, columnName: fields_hash}
+- changeSet:
+    id: 171
+    author: camsaul
+    validCheckSum: ANY
+    comment: Added 0.36.0
+    changes:
+    - addColumn:
+        tableName: native_query_snippet
+        columns:
+        - column:
+            name: collection_id
+            type: int
+            remarks: ID of the Snippet Folder (Collection) this Snippet is in, if any
+            constraints: {nullable: true, referencedTableName: collection, referencedColumnNames: id, foreignKeyName: fk_snippet_collection_id}
+    - createIndex:
+        tableName: native_query_snippet
+        indexName: idx_snippet_collection_id
+        columns:
+        - column: {name: collection_id}
+- changeSet:
+    id: 172
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: namespace
+            type: varchar(254)
+            remarks: The namespace (hierachy) this Collection belongs to. NULL means the Collection is in the default namespace.
+            constraints: {nullable: true}
+- changeSet:
+    id: 173
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: activity, constraintName: fk_activity_ref_user_id}
+- changeSet:
+    id: 174
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: activity, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_activity_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 175
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: card_label, constraintName: fk_card_label_ref_card_id}
+- changeSet:
+    id: 176
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: card_label, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_card_label_ref_card_id, onDelete: CASCADE}
+- changeSet:
+    id: 177
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: card_label, constraintName: fk_card_label_ref_label_id}
+- changeSet:
+    id: 178
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: card_label, baseColumnNames: label_id, referencedTableName: label, referencedColumnNames: id, constraintName: fk_card_label_ref_label_id, onDelete: CASCADE}
+- changeSet:
+    id: 179
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: collection, constraintName: fk_collection_personal_owner_id}
+- changeSet:
+    id: 180
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: collection, baseColumnNames: personal_owner_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_collection_personal_owner_id, onDelete: CASCADE}
+- changeSet:
+    id: 181
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: collection_revision, constraintName: fk_collection_revision_user_id}
+- changeSet:
+    id: 182
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: collection_revision, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_collection_revision_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 183
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: computation_job, constraintName: fk_computation_job_ref_user_id}
+- changeSet:
+    id: 184
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: computation_job, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_computation_job_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 185
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: computation_job_result, constraintName: fk_computation_result_ref_job_id}
+- changeSet:
+    id: 186
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: computation_job_result, baseColumnNames: job_id, referencedTableName: computation_job, referencedColumnNames: id, constraintName: fk_computation_result_ref_job_id, onDelete: CASCADE}
+- changeSet:
+    id: 187
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: core_session, constraintName: fk_session_ref_user_id}
+- changeSet:
+    id: 188
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: core_session, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_session_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 189
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: dashboardcard_series, constraintName: fk_dashboardcard_series_ref_card_id}
+- changeSet:
+    id: 190
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: dashboardcard_series, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_dashboardcard_series_ref_card_id, onDelete: CASCADE}
+- changeSet:
+    id: 191
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: dashboardcard_series, constraintName: fk_dashboardcard_series_ref_dashboardcard_id}
+- changeSet:
+    id: 192
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: dashboardcard_series, baseColumnNames: dashboardcard_id, referencedTableName: report_dashboardcard, referencedColumnNames: id, constraintName: fk_dashboardcard_series_ref_dashboardcard_id, onDelete: CASCADE}
+- changeSet:
+    id: 193
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: group_table_access_policy, constraintName: fk_gtap_card_id}
+- changeSet:
+    id: 194
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: group_table_access_policy, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_gtap_card_id, onDelete: CASCADE}
+- changeSet:
+    id: 195
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metabase_field, constraintName: fk_field_parent_ref_field_id}
+- changeSet:
+    id: 196
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metabase_field, baseColumnNames: parent_id, referencedTableName: metabase_field, referencedColumnNames: id, constraintName: fk_field_parent_ref_field_id, onDelete: CASCADE}
+- changeSet:
+    id: 197
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metabase_field, constraintName: fk_field_ref_table_id}
+- changeSet:
+    id: 198
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metabase_field, baseColumnNames: table_id, referencedTableName: metabase_table, referencedColumnNames: id, constraintName: fk_field_ref_table_id, onDelete: CASCADE}
+- changeSet:
+    id: 199
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metabase_fieldvalues, constraintName: fk_fieldvalues_ref_field_id}
+- changeSet:
+    id: 200
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metabase_fieldvalues, baseColumnNames: field_id, referencedTableName: metabase_field, referencedColumnNames: id, constraintName: fk_fieldvalues_ref_field_id, onDelete: CASCADE}
+- changeSet:
+    id: 201
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metabase_table, constraintName: fk_table_ref_database_id}
+- changeSet:
+    id: 202
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metabase_table, baseColumnNames: db_id, referencedTableName: metabase_database, referencedColumnNames: id, constraintName: fk_table_ref_database_id, onDelete: CASCADE}
+- changeSet:
+    id: 203
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metric, constraintName: fk_metric_ref_creator_id}
+- changeSet:
+    id: 204
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metric, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_metric_ref_creator_id, onDelete: CASCADE}
+- changeSet:
+    id: 205
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metric, constraintName: fk_metric_ref_table_id}
+- changeSet:
+    id: 206
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metric, baseColumnNames: table_id, referencedTableName: metabase_table, referencedColumnNames: id, constraintName: fk_metric_ref_table_id, onDelete: CASCADE}
+- changeSet:
+    id: 207
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metric_important_field, constraintName: fk_metric_important_field_metabase_field_id}
+- changeSet:
+    id: 208
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metric_important_field, baseColumnNames: field_id, referencedTableName: metabase_field, referencedColumnNames: id, constraintName: fk_metric_important_field_metabase_field_id, onDelete: CASCADE}
+- changeSet:
+    id: 209
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metric_important_field, constraintName: fk_metric_important_field_metric_id}
+- changeSet:
+    id: 210
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metric_important_field, baseColumnNames: metric_id, referencedTableName: metric, referencedColumnNames: id, constraintName: fk_metric_important_field_metric_id, onDelete: CASCADE}
+- changeSet:
+    id: 211
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: native_query_snippet, constraintName: fk_snippet_collection_id}
+- changeSet:
+    id: 212
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: native_query_snippet, baseColumnNames: collection_id, referencedTableName: collection, referencedColumnNames: id, constraintName: fk_snippet_collection_id, onDelete: SET NULL}
+- changeSet:
+    id: 213
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: permissions, constraintName: fk_permissions_group_id}
+- changeSet:
+    id: 214
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: permissions, baseColumnNames: group_id, referencedTableName: permissions_group, referencedColumnNames: id, constraintName: fk_permissions_group_id, onDelete: CASCADE}
+- changeSet:
+    id: 215
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: permissions_group_membership, constraintName: fk_permissions_group_group_id}
+- changeSet:
+    id: 216
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: permissions_group_membership, baseColumnNames: group_id, referencedTableName: permissions_group, referencedColumnNames: id, constraintName: fk_permissions_group_group_id, onDelete: CASCADE}
+- changeSet:
+    id: 217
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: permissions_group_membership, constraintName: fk_permissions_group_membership_user_id}
+- changeSet:
+    id: 218
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: permissions_group_membership, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_permissions_group_membership_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 219
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: permissions_revision, constraintName: fk_permissions_revision_user_id}
+- changeSet:
+    id: 220
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: permissions_revision, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_permissions_revision_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 221
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse, constraintName: fk_pulse_collection_id}
+- changeSet:
+    id: 222
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse, baseColumnNames: collection_id, referencedTableName: collection, referencedColumnNames: id, constraintName: fk_pulse_collection_id, onDelete: SET NULL}
+- changeSet:
+    id: 223
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse, constraintName: fk_pulse_ref_creator_id}
+- changeSet:
+    id: 224
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_pulse_ref_creator_id, onDelete: CASCADE}
+- changeSet:
+    id: 225
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse_card, constraintName: fk_pulse_card_ref_card_id}
+- changeSet:
+    id: 226
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse_card, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_pulse_card_ref_card_id, onDelete: CASCADE}
+- changeSet:
+    id: 227
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse_card, constraintName: fk_pulse_card_ref_pulse_id}
+- changeSet:
+    id: 228
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse_card, baseColumnNames: pulse_id, referencedTableName: pulse, referencedColumnNames: id, constraintName: fk_pulse_card_ref_pulse_id, onDelete: CASCADE}
+- changeSet:
+    id: 229
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse_channel, constraintName: fk_pulse_channel_ref_pulse_id}
+- changeSet:
+    id: 230
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse_channel, baseColumnNames: pulse_id, referencedTableName: pulse, referencedColumnNames: id, constraintName: fk_pulse_channel_ref_pulse_id, onDelete: CASCADE}
+- changeSet:
+    id: 231
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse_channel_recipient, constraintName: fk_pulse_channel_recipient_ref_pulse_channel_id}
+- changeSet:
+    id: 232
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse_channel_recipient, baseColumnNames: pulse_channel_id, referencedTableName: pulse_channel, referencedColumnNames: id, constraintName: fk_pulse_channel_recipient_ref_pulse_channel_id, onDelete: CASCADE}
+- changeSet:
+    id: 233
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse_channel_recipient, constraintName: fk_pulse_channel_recipient_ref_user_id}
+- changeSet:
+    id: 234
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse_channel_recipient, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_pulse_channel_recipient_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 235
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_card, constraintName: fk_card_collection_id}
+- changeSet:
+    id: 236
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_card, baseColumnNames: collection_id, referencedTableName: collection, referencedColumnNames: id, constraintName: fk_card_collection_id, onDelete: SET NULL}
+- changeSet:
+    id: 237
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_card, constraintName: fk_card_made_public_by_id}
+- changeSet:
+    id: 238
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_card, baseColumnNames: made_public_by_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_card_made_public_by_id, onDelete: CASCADE}
+- changeSet:
+    id: 239
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_card, constraintName: fk_card_ref_user_id}
+- changeSet:
+    id: 240
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_card, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_card_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 241
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_card, constraintName: fk_report_card_ref_database_id}
+- changeSet:
+    id: 242
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_card, baseColumnNames: database_id, referencedTableName: metabase_database, referencedColumnNames: id, constraintName: fk_report_card_ref_database_id, onDelete: CASCADE}
+- changeSet:
+    id: 243
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_card, constraintName: fk_report_card_ref_table_id}
+- changeSet:
+    id: 244
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_card, baseColumnNames: table_id, referencedTableName: metabase_table, referencedColumnNames: id, constraintName: fk_report_card_ref_table_id, onDelete: CASCADE}
+- changeSet:
+    id: 245
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_cardfavorite, constraintName: fk_cardfavorite_ref_card_id}
+- changeSet:
+    id: 246
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_cardfavorite, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_cardfavorite_ref_card_id, onDelete: CASCADE}
+- changeSet:
+    id: 247
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_cardfavorite, constraintName: fk_cardfavorite_ref_user_id}
+- changeSet:
+    id: 248
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_cardfavorite, baseColumnNames: owner_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_cardfavorite_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 249
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_dashboard, constraintName: fk_dashboard_collection_id}
+- changeSet:
+    id: 250
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_dashboard, baseColumnNames: collection_id, referencedTableName: collection, referencedColumnNames: id, constraintName: fk_dashboard_collection_id, onDelete: SET NULL}
+- changeSet:
+    id: 251
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_dashboard, constraintName: fk_dashboard_made_public_by_id}
+- changeSet:
+    id: 252
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_dashboard, baseColumnNames: made_public_by_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_dashboard_made_public_by_id, onDelete: CASCADE}
+- changeSet:
+    id: 253
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_dashboard, constraintName: fk_dashboard_ref_user_id}
+- changeSet:
+    id: 254
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_dashboard, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_dashboard_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 255
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_dashboardcard, constraintName: fk_dashboardcard_ref_card_id}
+- changeSet:
+    id: 256
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_dashboardcard, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_dashboardcard_ref_card_id, onDelete: CASCADE}
+- changeSet:
+    id: 257
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: report_dashboardcard, constraintName: fk_dashboardcard_ref_dashboard_id}
+- changeSet:
+    id: 258
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_dashboardcard, baseColumnNames: dashboard_id, referencedTableName: report_dashboard, referencedColumnNames: id, constraintName: fk_dashboardcard_ref_dashboard_id, onDelete: CASCADE}
+- changeSet:
+    id: 259
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: revision, constraintName: fk_revision_ref_user_id}
+- changeSet:
+    id: 260
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: revision, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_revision_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 261
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: segment, constraintName: fk_segment_ref_creator_id}
+- changeSet:
+    id: 262
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: segment, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_segment_ref_creator_id, onDelete: CASCADE}
+- changeSet:
+    id: 263
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: segment, constraintName: fk_segment_ref_table_id}
+- changeSet:
+    id: 264
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: segment, baseColumnNames: table_id, referencedTableName: metabase_table, referencedColumnNames: id, constraintName: fk_segment_ref_table_id, onDelete: CASCADE}
+- changeSet:
+    id: 265
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: view_log, constraintName: fk_view_log_ref_user_id}
+- changeSet:
+    id: 266
+    author: camsaul
+    comment: Added 0.36.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: view_log, baseColumnNames: user_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_view_log_ref_user_id, onDelete: CASCADE}
+- changeSet:
+    id: 268
+    author: rlotun
+    comment: Added 0.37.0
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - and:
+      - dbms: {type: postgresql}
+    validCheckSum: 8:9da2f706a7cd42b5101601e0106fa929
+    changes:
+    - createIndex:
+        columns:
+        - column: {name: lower(email), computed: true, type: varchar(254)}
+        tableName: core_user
+        indexName: idx_lower_email
+- changeSet:
+    id: 269
+    author: rlotun
+    comment: Added 0.37.0
+    changes:
+    - sql: {sql: UPDATE core_user SET email = lower(email) WHERE lower(email) NOT IN (SELECT * FROM (SELECT lower(email) FROM core_user GROUP BY lower(email) HAVING count(email) > 1) as e)}
+- changeSet:
+    id: 270
+    author: rlotun
+    comment: Added 0.37.0
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - dbms: {type: postgresql}
+    changes:
+    - sql: {sql: CREATE EXTENSION IF NOT EXISTS citext}
+- changeSet:
+    id: 271
+    author: rlotun
+    comment: Added 0.37.0
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - and:
+      - dbms: {type: postgresql}
+      - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM pg_extension WHERE extname = 'citext'}
+    changes:
+    - modifyDataType: {tableName: core_user, columnName: email, newDataType: citext}
+- changeSet:
+    id: 272
+    author: rlotun
+    comment: Added 0.37.0
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - dbms: {type: h2}
+    changes:
+    - modifyDataType: {tableName: core_user, columnName: email, newDataType: varchar_ignorecase(254)}
+- changeSet:
+    id: 273
+    author: camsaul
+    comment: Added 0.37.1
+    changes:
+    - addDefaultValue: {tableName: core_user, columnName: is_superuser, columnDataType: boolean, defaultValueBoolean: false}
+- changeSet:
+    id: 274
+    author: camsaul
+    comment: Added 0.37.1
+    changes:
+    - addDefaultValue: {tableName: core_user, columnName: is_active, columnDataType: boolean, defaultValueBoolean: true}
+- changeSet:
+    id: 275
+    author: dpsutton
+    comment: Added 0.38.0 refingerprint to Database
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: refingerprint
+            type: boolean
+            remarks: Whether or not to enable periodic refingerprinting for this Database.
+            constraints: {nullable: true}
+- changeSet:
+    id: 276
+    author: robroland
+    comment: Added 0.38.0 - Dashboard subscriptions
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: pulse_card
+        columns:
+        - column:
+            name: dashboard_card_id
+            type: int
+            remarks: If this Pulse is a Dashboard subscription, the ID of the DashboardCard that corresponds to this PulseCard.
+            constraints: {nullable: true, referencedTableName: report_dashboardcard, referencedColumnNames: id, foreignKeyName: fk_pulse_card_ref_pulse_card_id, deferrable: false, initiallyDeferred: false}
+- changeSet:
+    id: 277
+    author: tsmacdonald
+    comment: Added 0.38.0 - Dashboard subscriptions
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: pulse_card, constraintName: fk_pulse_card_ref_pulse_card_id}
+- changeSet:
+    id: 278
+    author: tsmacdonald
+    comment: Added 0.38.0 - Dashboard subscrptions
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse_card, baseColumnNames: dashboard_card_id, referencedTableName: report_dashboardcard, referencedColumnNames: id, constraintName: fk_pulse_card_ref_pulse_card_id, onDelete: CASCADE}
+- changeSet:
+    id: 279
+    author: camsaul
+    comment: Added 0.38.0 - Dashboard subscriptions
+    changes:
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column: {name: dashboard_id, type: int, remarks: ID of the Dashboard if this Pulse is a Dashboard Subscription.}
+- changeSet:
+    id: 280
+    author: camsaul
+    comment: Added 0.38.0 - Dashboard subscriptions
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse, baseColumnNames: dashboard_id, referencedTableName: report_dashboard, referencedColumnNames: id, constraintName: fk_pulse_ref_dashboard_id, onDelete: CASCADE}
+- changeSet:
+    id: 281
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - rename special_type
+    changes:
+    - renameColumn: {tableName: metabase_field, oldColumnName: special_type, newColumnName: semantic_type, columnDataType: varchar(255)}
+- changeSet:
+    id: 282
+    author: camsaul
+    validCheckSum: 8:d4b8566ee11d9f8a3d6c8c9539f6526d
+    comment: Added 0.39.0
+    changes:
+    - sql:
+        dbms: h2
+        sql: |
+          ALTER TABLE task_history
+          ALTER COLUMN started_at timestamp with time zone DEFAULT current_timestamp NOT NULL;
+    - sql:
+        dbms: postgresql
+        sql: |
+          ALTER TABLE task_history
+          ALTER COLUMN started_at TYPE timestamp with time zone,
+          ALTER COLUMN started_at SET DEFAULT current_timestamp;
+    - sql:
+        dbms: mysql,mariadb
+        sql: |
+          ALTER TABLE task_history
+          MODIFY started_at timestamp(6) DEFAULT current_timestamp(6) NOT NULL;
+- changeSet:
+    id: 283
+    author: camsaul
+    validCheckSum: 8:2220e1b1cdb57212820b96fa3107f7c3
+    comment: Added 0.39.0
+    changes:
+    - sql:
+        dbms: h2
+        sql: |
+          ALTER TABLE task_history
+          ALTER COLUMN ended_at timestamp with time zone DEFAULT current_timestamp NOT NULL;
+    - sql:
+        dbms: postgresql
+        sql: |
+          ALTER TABLE task_history
+          ALTER COLUMN ended_at TYPE timestamp with time zone,
+          ALTER COLUMN ended_at SET DEFAULT current_timestamp;
+    - sql:
+        dbms: mysql,mariadb
+        sql: |
+          ALTER TABLE task_history
+          MODIFY ended_at timestamp(6) DEFAULT current_timestamp(6) NOT NULL;
+- changeSet:
+    id: 284
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - add effective type
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: effective_type, type: varchar(255), remarks: The effective type of the field after any coercions.}
+- changeSet:
+    id: 285
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - add coercion column
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column: {name: coercion_strategy, type: varchar(255), remarks: A strategy to coerce the base_type into the effective_type.}
+- changeSet:
+    id: 286
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - set effective_type default
+    changes:
+    - sql: {sql: UPDATE metabase_field set effective_type = base_type}
+- changeSet:
+    id: 287
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - migrate ISO8601 strings
+    validCheckSum: ANY
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field SET effective_type    = (CASE semantic_type
+                                     WHEN 'type/ISO8601DateTimeString' THEN 'type/DateTime'
+                                     WHEN 'type/ISO8601TimeString'     THEN 'type/Time'
+                                     WHEN 'type/ISO8601DateString'     THEN 'type/Date'
+                                   END),
+              coercion_strategy = (CASE semantic_type
+                                    WHEN 'type/ISO8601DateTimeString' THEN 'Coercion/ISO8601->DateTime'
+                                    WHEN 'type/ISO8601TimeString'     THEN 'Coercion/ISO8601->Time'
+                                    WHEN 'type/ISO8601DateString'     THEN 'Coercion/ISO8601->Date'
+                                   END)
+          WHERE semantic_type IN ('type/ISO8601DateTimeString',
+                                  'type/ISO8601TimeString',
+                                  'type/ISO8601DateString');
+- changeSet:
+    id: 288
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - migrate unix timestamps
+    validCheckSum: ANY
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field set effective_type    = 'type/Instant',
+              coercion_strategy = (case semantic_type
+                                    WHEN 'type/UNIXTimestampSeconds'      THEN 'Coercion/UNIXSeconds->DateTime'
+                                    WHEN 'timestamp_seconds'              THEN 'Coercion/UNIXSeconds->DateTime'
+                                    WHEN 'type/UNIXTimestampMilliSeconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
+                                    WHEN 'timestamp_milliseconds'         THEN 'Coercion/UNIXMilliSeconds->DateTime'
+                                    WHEN 'type/UNIXTimestampMicroSeconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
+                                   END)
+          WHERE semantic_type IN ('type/UNIXTimestampSeconds',
+                                  'type/UNIXTimestampMilliSeconds',
+                                  'type/UNIXTimestampMicroSeconds',
+                                  'timestamp_seconds',
+                                  'timestamp_milliseconds');
+- changeSet:
+    id: 289
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - migrate unix timestamps (corrects typo- seconds was migrated correctly, not millis and micros)
+    validCheckSum: ANY
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field set effective_type    = 'type/Instant',
+              coercion_strategy = (case semantic_type
+                                    WHEN 'type/UNIXTimestampMilliseconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
+                                    WHEN 'type/UNIXTimestampMicroseconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
+                                   END)
+          WHERE semantic_type IN ('type/UNIXTimestampMilliseconds',
+                                  'type/UNIXTimestampMicroseconds')
+- changeSet:
+    id: 290
+    author: dpsutton
+    comment: Added 0.39 - Semantic type system - Clobber semantic_type where there was a coercion
+    changes:
+    - sql: {sql: UPDATE metabase_field set semantic_type = null where coercion_strategy is not null}
+- changeSet:
+    id: 291
+    author: camsaul
+    validCheckSum: ANY
+    comment: Added 0.39.0
+    changes:
+    - createTable:
+        tableName: login_history
+        remarks: Keeps track of various logins for different users and additional info such as location and device
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: timestamp
+            type: ${timestamp_type}
+            remarks: When this login occurred.
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: ID of the User that logged in.
+            constraints: {foreignKeyName: fk_login_history_user_id, referencedTableName: core_user, referencedColumnNames: id, nullable: false, deleteCascade: true}
+        - column: {name: session_id, type: varchar(254), remarks: ID of the Session created by this login if one is currently active. NULL if Session is no longer active.}
+        - column:
+            name: device_id
+            type: char(36)
+            remarks: Cookie-based unique identifier for the device/browser the user logged in from.
+            constraints: {nullable: false}
+        - column:
+            name: device_description
+            type: text
+            remarks: Description of the device that login happened from, for example a user-agent string, but this might be something different if we support alternative auth mechanisms in the future.
+            constraints: {nullable: false}
+        - column:
+            name: ip_address
+            type: text
+            remarks: IP address of the device that login happened from, so we can geocode it and determine approximate location.
+            constraints: {nullable: false}
+- changeSet:
+    id: 292
+    author: camsaul
+    comment: Added 0.39.0
+    changes:
+    - createIndex:
+        tableName: login_history
+        indexName: idx_user_id
+        columns:
+        - column: {name: user_id}
+- changeSet:
+    id: 293
+    author: camsaul
+    comment: Added 0.39.0
+    changes:
+    - addForeignKeyConstraint: {baseTableName: login_history, baseColumnNames: session_id, referencedTableName: core_session, referencedColumnNames: id, constraintName: fk_login_history_session_id, onDelete: SET NULL}
+- changeSet:
+    id: 294
+    author: camsaul
+    comment: Added 0.39.0
+    changes:
+    - createIndex:
+        tableName: login_history
+        indexName: idx_session_id
+        columns:
+        - column: {name: session_id}
+- changeSet:
+    id: 295
+    author: camsaul
+    comment: Added 0.39.0
+    changes:
+    - createIndex:
+        tableName: login_history
+        indexName: idx_timestamp
+        columns:
+        - column: {name: timestamp}
+- changeSet:
+    id: 296
+    author: camsaul
+    comment: Added 0.39.0
+    changes:
+    - createIndex:
+        tableName: login_history
+        indexName: idx_user_id_device_id
+        columns:
+        - column: {name: session_id}
+        - column: {name: device_id}
+- changeSet:
+    id: 297
+    author: camsaul
+    comment: Added 0.39.0
+    changes:
+    - createIndex:
+        tableName: login_history
+        indexName: idx_user_id_timestamp
+        columns:
+        - column: {name: user_id}
+        - column: {name: timestamp}
+- changeSet:
+    id: 298
+    author: tsmacdonald
+    comment: Added 0.39.0
+    changes:
+    - addColumn:
+        tableName: pulse
+        columns:
+        - column:
+            name: parameters
+            type: text
+            remarks: Let dashboard subscriptions have their own filters
+            constraints: {nullable: true, deferrable: false, initiallyDeferred: false}
+- changeSet:
+    id: 299
+    author: tsmacdonald
+    comment: Added 0.39.0
+    changes:
+    - addNotNullConstraint: {columnDataType: text, columnName: parameters, defaultNullValue: '[]', tableName: pulse}
+- changeSet:
+    id: 300
+    author: dpsutton
+    comment: Added 0.40.0
+    changes:
+    - renameTable: {oldTableName: collection_revision, newTableName: collection_permission_graph_revision}
+- changeSet:
+    id: 301
+    author: dpsutton
+    comment: Added 0.40.0 renaming collection_revision to collection_permission_graph_revision
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: postgresql}
+    changes:
+    - sql:
+      - {sql: ALTER SEQUENCE collection_revision_id_seq RENAME TO collection_permission_graph_revision_id_seq}
+- changeSet:
+    id: 303
+    author: tsmacdonald
+    comment: Added 0.40.0
+    changes:
+    - createTable:
+        tableName: moderation_review
+        remarks: Reviews (from moderators) for a given question/dashboard (BUCM)
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            remarks: most recent modification time
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            remarks: creation time
+            constraints: {nullable: false}
+        - column: {name: status, type: varchar(255), remarks: 'verified, misleading, confusing, not_misleading, pending'}
+        - column: {name: text, type: text, remarks: Explanation of the review}
+        - column:
+            name: moderated_item_id
+            type: int
+            remarks: either a document or question ID; the item that needs review
+            constraints: {nullable: false}
+        - column:
+            name: moderated_item_type
+            type: varchar(255)
+            remarks: whether it's a question or dashboard
+            constraints: {nullable: false}
+        - column:
+            name: moderator_id
+            type: int
+            remarks: ID of the user who did the review
+            constraints: {nullable: false}
+        - column:
+            name: most_recent
+            type: boolean
+            remarks: tag for most recent review
+            constraints: {nullable: false}
+- changeSet:
+    id: 304
+    author: camsaul
+    comment: Added 0.40.0 (replaces a data migration dating back to 0.20.0)
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field SET semantic_type = (CASE semantic_type
+                                WHEN 'avatar'    THEN 'type/AvatarURL'
+                                WHEN 'category'  THEN 'type/Category'
+                                WHEN 'city'      THEN 'type/City'
+                                WHEN 'country'   THEN 'type/Country'
+                                WHEN 'desc'      THEN 'type/Description'
+                                WHEN 'fk'        THEN 'type/FK'
+                                WHEN 'id'        THEN 'type/PK'
+                                WHEN 'image'     THEN 'type/ImageURL'
+                                WHEN 'json'      THEN 'type/SerializedJSON'
+                                WHEN 'latitude'  THEN 'type/Latitude'
+                                WHEN 'longitude' THEN 'type/Longitude'
+                                WHEN 'name'      THEN 'type/Name'
+                                WHEN 'number'    THEN 'type/Number'
+                                WHEN 'state'     THEN 'type/State'
+                                WHEN 'url'       THEN 'type/URL'
+                                WHEN 'zip_code'  THEN 'type/ZipCode'
                                END)
-              WHERE base_type IN ('ArrayField', 'BigIntegerField', 'BooleanField', 'CharField', 'DateField',
-                                  'DateTimeField', 'DecimalField', 'DictionaryField', 'FloatField', 'IntegerField',
-                                  'TextField', 'TimeField', 'UUIDField', 'UnknownField');
-  - changeSet:
-      id: 308
-      author: howonlee
-      comment: Added 0.40.0 Track cache hits in query_execution table
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: cache_hit
-                  type: boolean
-                  remarks: "Cache hit on query execution"
-                  constraints:
-                    nullable: true
-
-
-  - changeSet:
-      id: 309
-      author: dpsutton
-      comment: 'Added 0.40.0 - Add type to collections'
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: authority_level
-                  type: varchar(255)
-                  remarks: 'Nullable column to incidate collection''s authority level. Initially values are "official" and nil.'
-                  constraints:
-                    nullable: true
-
-
-  - changeSet:
-      id: 311
-      author: howonlee
-      comment: Added 0.40.0 Migrate friendly field names, not noop
-      validCheckSum: ANY # Quoting changes for H2.
-      changes:
-        - sql:
-            dbms: mariadb,mysql
-            sql: |
-                UPDATE setting SET value='simple' WHERE `key`='humanization-strategy'
-                AND value='advanced'
-        - sql:
-            dbms: postgresql
-            sql: |
-                UPDATE setting SET value='simple' WHERE key='humanization-strategy'
-                AND value='advanced'
-        - sql:
-            dbms: h2
-            sql: |
-                UPDATE setting SET "VALUE"='simple' WHERE "KEY"='humanization-strategy'
-                AND "VALUE"='advanced'
-
-  - changeSet:
-      id: 312
-      author: noahmoss
-      comment: Added 0.41.0 Backfill collection_id for dashboard subscriptions
-      validCheckSum: 8:77ef89ba2e7bc19231d9364492091764
-      changes:
-        - sql:
-            dbms: mariadb,mysql
-            sql: >-
-              UPDATE pulse p
-              INNER JOIN report_dashboard d
-              ON p.dashboard_id = d.id
-              SET p.collection_id = d.collection_id;
-        - sql:
-            dbms: postgresql
-            sql: >-
-              UPDATE pulse p
-              SET collection_id = d.collection_id
-              FROM report_dashboard d
-              WHERE p.dashboard_id = d.id
-              AND p.dashboard_id IS NOT NULL;
-        - sql:
-            dbms: h2
-            sql: >-
-              UPDATE pulse p
-              SET collection_id = (
-                SELECT d.collection_id
-                FROM report_dashboard d
-                WHERE d.id = p.dashboard_id
-              )
-              WHERE dashboard_id IS NOT NULL;
-
-  - changeSet:
-      id: 313
-      author: jeff303
-      comment: Added 0.42.0 - Secret domain object.
-      validCheckSum: ANY
-      changes:
-        - createTable:
-            tableName: secret
-            remarks: Storage for managed secrets (passwords, binary data, etc.)
-            columns:
-              - column:
-                  autoIncrement: true
-                  constraints:
-                    nullable: false
-                    primaryKey: true
-                  name: id
-                  remarks: Part of composite primary key for secret; this is the uniquely generted ID column
-                  type: int
-              - column:
-                  constraints:
-                    nullable: false
-                    primaryKey: true
-                  name: version
-                  defaultValue: 1
-                  remarks: Part of composite primary key for secret; this is the version column
-                  type: int
-              - column:
-                  constraints:
-                    deferrable: false
-                    foreignKeyName: fk_secret_ref_user_id
-                    initiallyDeferred: false
-                    nullable: true
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                  name: creator_id
-                  remarks: User ID who created this secret instance
-                  type: int
-              - column:
-                  constraints:
-                    nullable: false
-                  name: created_at
-                  remarks: Timestamp for when this secret instance was created
-                  type: ${timestamp_type}
-              - column:
-                  constraints:
-                    nullable: true
-                  name: updated_at
-                  remarks: >-
-                    Timestamp for when this secret record was updated. Only relevant when non-value field changes
-                    since a value change will result in a new version being inserted.
-                  type: ${timestamp_type}
-              - column:
-                  constraints:
-                    nullable: false
-                  name: name
-                  remarks: The name of this secret record.
-                  type: varchar(254)
-              - column:
-                  constraints:
-                    # TODO: do we want to constrain this field or leave open for extension? or separate table with FK?
-                    nullable: false
-                  name: kind
-                  remarks: >-
-                    The kind of secret this record represents; the value is interpreted as a Clojure keyword with a
-                    hierarchy. Ex: 'bytes' means generic binary data, 'jks-keystore' extends 'bytes' but has a specific
-                    meaning.
-                  type: varchar(254)
-              - column:
-                  constraints:
-                    # TODO: similar question to above?
-                    nullable: true
-                  name: source
-                  remarks: >-
-                    The source of secret record, which controls how Metabase interprets the value (ex: 'file-path'
-                    means the 'simple_value' is not the real value, but a pointer to a file that contains the value).
-                  type: varchar(254)
-              - column:
-                  constraints:
-                    nullable: false
-                  name: value
-                  remarks: The base64 encoded binary value of this secret record. If encryption is enabled, this will
-                    be the output of the encryption procedure on the plaintext. If not, it will be the base64 encoded
-                    plaintext.
-                  type: ${blob.type}
-
-  - changeSet:
-      id: 314
-      author: howonlee
-      comment: Added 0.41.0 Fine grained caching controls
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: cache_ttl
-                  type: integer
-                  remarks: "Granular cache TTL for specific database."
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: 315
-      author: howonlee
-      comment: Added 0.41.0 Fine grained caching controls, pt 2
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: cache_ttl
-                  type: integer
-                  remarks: "Granular cache TTL for specific dashboard."
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: 316
-      author: howonlee
-      comment: Added 0.41.0 Fine grained caching controls, pt 3
-      changes:
-        - addColumn:
-            tableName: view_log
-            columns:
-              - column:
-                  name: metadata
-                  type: text
-                  remarks: "Serialized JSON corresponding to metadata for view."
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: 381
-      author: camsaul
-      comment: Added 0.41.2 Add index to QueryExecution card_id to fix performance issues (#18759)
-      changes:
-        - createIndex:
-            tableName: query_execution
-            indexName: idx_query_execution_card_id
-            columns:
-              - column:
-                  name: card_id
-
-  - changeSet:
-      id: 382
-      author: camsaul
-      comment: Added 0.41.2 Add index to ModerationReview moderated_item_type + moderated_item_id to fix performance issues (#18759)
-      changes:
-        - createIndex:
-            tableName: moderation_review
-            indexName: idx_moderation_review_item_type_item_id
-            columns:
-              - column:
-                  name: moderated_item_type
-              - column:
-                  name: moderated_item_id
-
-  - changeSet:
-      id: 383
-      author: camsaul
-      comment: Added 0.41.3 -- Add index to QueryExecution card_id + started_at to fix performance issue #19053
-      changes:
-        - createIndex:
-            tableName: query_execution
-            indexName: idx_query_execution_card_id_started_at
-            columns:
-              - column:
-                  name: card_id
-              - column:
-                  name: started_at
-
-  - changeSet:
-      id: v42.00-000
-      author: camsaul
-      comment: Added 0.42.0 Remove unused column (#5240)
-      # this migration was previously numbered 317 and merged into master before we adopted the 0.42.0+ migration ID
-      # numbering scheme. See #18821 for more info.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = '317';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = '317';
-
-      changes:
-        - dropColumn:
-            tableName: metabase_table
-            columnName: entity_name
-
-
-  - changeSet:
-      id: v42.00-001
-      author: camsaul
-      comment: Added 0.42.0 Attempt to add Card.database_id (by parsing query) to rows that are missing it (#5999)
-      validCheckSum: 8:9952153cbff16147bcb47b4a26e02089
-      # If this migration fails for any reason continue with the next migration; do not fail the entire process if this one fails
-      failOnError: false
-      # Don't run for H2 -- the version of H2 we're using doesn't support JSON stuff.
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql,mysql,mariadb
-      # The basic idea below is to parse the `database_id` from the JSON string query dictionary and use it to set the
-      # database_id column as needed. We do an INNER JOIN against the Database table to make sure that Database
-      # actually exists (so we don't attempt to set an invalid database_id)
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              WITH c2 AS (
-                SELECT *, (dataset_query::json->>'database')::integer AS query_database_id
-                FROM report_card
-              )
-              UPDATE report_card c
-              SET database_id = c2.query_database_id
-              FROM c2
-              INNER JOIN metabase_database db
-                ON db.id = c2.query_database_id
-              WHERE c.database_id IS NULL
-                AND c.id = c2.id
-                AND c2.query_database_id IS NOT NULL;
-        # MySQL and MariaDB are exactly the same other than different function names: json_value (for MariaDB) vs
-        # json_extract (for MySQL)
-        - sql:
-            dbms: mariadb
-            sql: >-
-              UPDATE report_card c
-              JOIN (
-                SELECT *, cast(json_value(dataset_query, '$.database') AS signed) AS query_database_id
-                FROM report_card
-                ) c2
-                ON c.id = c2.id
-              INNER JOIN metabase_database db ON c2.query_database_id = db.id
-              SET c.database_id = c2.query_database_id
-              WHERE c.database_id IS NULL
-                AND c2.query_database_id IS NOT NULL;
-        - sql:
-            dbms: mysql
-            sql: >-
-              UPDATE report_card c
-              JOIN (
-                SELECT *, cast(json_extract(dataset_query, '$.database') AS signed) AS query_database_id
-                FROM report_card
-                ) c2
-                ON c.id = c2.id
-              INNER JOIN metabase_database db ON c2.query_database_id = db.id
-              SET c.database_id = c2.query_database_id
-              WHERE c.database_id IS NULL
-                AND c2.query_database_id IS NOT NULL;
-
-  - changeSet:
-      id: v42.00-002
-      author: camsaul
-      comment: Added 0.42.0 Added constraint we should have had all along (#5999)
-      preConditions:
-        - onFail: MARK_RAN
-        # If we're dumping the migration as a SQL file or trying to force-migrate we can't check the preconditions
-        # so just go ahead and skip the entire thing. This is a non-critical migration
-        - onUpdateSQL: IGNORE
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM report_card WHERE database_id IS NULL
-      changes:
-        - addNotNullConstraint:
-            columnDataType: int
-            tableName: report_card
-            columnName: database_id
-
-  - changeSet:
-      id: v42.00-003
-      author: dpsutton
-      comment: Added 0.42.0 Initial support for datasets based on questions
-      # this migration was previously numbered 320 and merged into master before we adopted the 0.42.0+ migration ID
-      # numbering scheme. See #18821 for more info.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = '320';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = '320';
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: dataset
-                  type: boolean
-                  remarks: "Indicate whether question is a dataset"
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-
-  - changeSet:    # this one is run unconditionally so unify the type to ${text.type} across ALL dbs
-      id: v42.00-004 # this differentiation was first done under changeSet 13 above
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of activity.details from text to ${text.type}
-      changes:
-        - modifyDataType:
-            tableName: activity
-            columnName: details
-            newDataType: ${text.type}
-
-  - changeSet:
-      id: v42.00-005
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of collection.description from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: collection
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-006
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of collection.name from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: collection
-            columnName: name
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-007
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of computation_job.context from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: computation_job
-            columnName: context
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-008
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of computation_job_result.payload from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: computation_job_result
-            columnName: payload
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-009
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of core_session.anti_csrf_token from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: core_session
-            columnName: anti_csrf_token
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-010
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of core_user.login_attributes from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: core_user
-            columnName: login_attributes
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-011
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of group_table_access_policy.attribute_remappings
-        from text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: group_table_access_policy
-            columnName: attribute_remappings
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-012
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of login_history.device_description from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: login_history
-            columnName: device_description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-013
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of login_history.ip_address from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: login_history
-            columnName: ip_address
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-014
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_database.caveats from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_database
-            columnName: caveats
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-015
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_database.description from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_database
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-016
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_database.details from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_database
-            columnName: details
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-017
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_database.options from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_database
-            columnName: options
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-018
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_database.points_of_interest from
-        text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_database
-            columnName: points_of_interest
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-019
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_field.caveats from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: caveats
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-020
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_field.database_type from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_type
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-021
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_field.description from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-022
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_field.fingerprint from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: fingerprint
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-023
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_field.has_field_values from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: has_field_values
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-024
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_field.points_of_interest from
-        text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: points_of_interest
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-025
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_field.settings from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: settings
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-026
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_fieldvalues.human_readable_values
-        from text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_fieldvalues
-            columnName: human_readable_values
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-027
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_fieldvalues.values from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_fieldvalues
-            columnName: values
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-028
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_table.caveats from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: caveats
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-029
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_table.description from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-030
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metabase_table.points_of_interest from
-        text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: points_of_interest
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-031
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metric.caveats from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metric
-            columnName: caveats
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-032
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metric.definition from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metric
-            columnName: definition
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-033
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metric.description from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metric
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-034
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metric.how_is_this_calculated from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metric
-            columnName: how_is_this_calculated
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-035
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of metric.points_of_interest from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metric
-            columnName: points_of_interest
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-036
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of moderation_review.text from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: moderation_review
-            columnName: text
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-037
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of native_query_snippet.content from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: native_query_snippet
-            columnName: content
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-038
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of native_query_snippet.description from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: native_query_snippet
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-039
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of pulse.parameters from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: pulse
-            columnName: parameters
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-040
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of pulse_channel.details from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: pulse_channel
-            columnName: details
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-041
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of query.query from text to ${text.type} on
-        mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: query
-            columnName: query
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-042
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of query_execution.error from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: query_execution
-            columnName: error
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-043
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_card.dataset_query from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: dataset_query
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-044
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_card.description from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-045
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_card.embedding_params from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: embedding_params
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-046
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_card.result_metadata from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: result_metadata
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-047
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_card.visualization_settings from
-        text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: visualization_settings
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-048
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_dashboard.caveats from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: caveats
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-049
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_dashboard.description from text
-        to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-050
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_dashboard.embedding_params from
-        text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: embedding_params
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-051
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_dashboard.parameters from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: parameters
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-052
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_dashboard.points_of_interest from
-        text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: points_of_interest
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-053
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_dashboardcard.parameter_mappings
-        from text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboardcard
-            columnName: parameter_mappings
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-054
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of report_dashboardcard.visualization_settings
-        from text to ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboardcard
-            columnName: visualization_settings
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-055
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of revision.message from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: revision
-            columnName: message
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:    # this one is run unconditionally so unify the type to ${text.type} across ALL dbs
-      id: v42.00-056 # this differentiation was first done under changeSet 10 above
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of revision.object from text to ${text.type}
-      changes:
-        - modifyDataType:
-            tableName: revision
-            columnName: object
-            newDataType: ${text.type}
-
-  - changeSet:
-      id: v42.00-057
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of segment.caveats from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: segment
-            columnName: caveats
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-058
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of segment.definition from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: segment
-            columnName: definition
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-059
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of segment.description from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: segment
-            columnName: description
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-060
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of segment.points_of_interest from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: segment
-            columnName: points_of_interest
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-061
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of setting.value from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: setting
-            columnName: value
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-062
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of task_history.task_details from text to
-        ${text.type} on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: task_history
-            columnName: task_details
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-063
-      author: jeff303
-      comment: >-
-        Added 0.42.0 - modify type of view_log.metadata from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: view_log
-            columnName: metadata
-            newDataType: ${text.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v42.00-064
-      author: jeff303
-      comment: "Added 0.42.0 - fix type of query_cache.results on upgrade (in case changeSet 97 was run before #16095)"
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: query_cache
-            columnName: results
-            newDataType: longblob
-
-  - changeSet:
-      id: v42.00-065
-      author: dpsutton
-      comment: >-
-        Added 0.42.0 - Another modal dismissed state on user. Retaining the same suffix and boolean style to ease an
-        eventual migration.
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: is_datasetnewb
-                  type: boolean
-                  remarks: "Boolean flag to indicate if the dataset info modal has been dismissed."
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v42.00-066
-      author: noahmoss
-      comment: >-
-        Added 0.42.0 - new columns for initial DB sync progress UX. Indicates whether a database has succesfully synced
-        at least one time.
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: initial_sync_status
-                  type: varchar(32)
-                  remarks: "String indicating whether a database has completed its initial sync and is ready to use"
-                  defaultValue: "complete"
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v42.00-067
-      author: noahmoss
-      comment: >-
-        Added 0.42.0 - new columns for initial DB sync progress UX. Indicates whether a table has succesfully synced
-        at least one time.
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: initial_sync_status
-                  type: varchar(32)
-                  remarks: "String indicating whether a table has completed its initial sync and is ready to use"
-                  defaultValue: "complete"
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v42.00-068
-      author: noahmoss
-      comment: >-
-        Added 0.42.0 - new columns for initial DB sync progress UX. Records the ID of the admin who added a database.
-        May be null for the sample dataset, or for databases added prior to 0.42.0.
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: creator_id
-                  type: int
-                  remarks: "ID of the admin who added the database"
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v42.00-069
-      author: noahmoss
-      comment: >-
-        Added 0.42.0 - adds FK constraint for creator_id column, containing the ID of the admin who added a database.
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_database
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_database_creator_id
-            onDelete: SET NULL
-
-  - changeSet:
-      id: v42.00-070
-      author: camsaul
-      comment: >-
-        Added 0.42.0 - add Database.settings column to implement Database-local Settings
-      # This migration was originally misnumbered, so now that it has a correct number it may get triggered a second
-      # time. That's fine
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_database
-                columnName: settings
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: settings
-                  type: ${text.type}
-                  remarks: "Serialized JSON containing Database-local Settings for this Database"
-
-  - changeSet:
-      id: v42.00-071
-      author: noahmoss
-      comment: >-
-        Added 0.42.0 - migrates the Sample Dataset to the name "Sample Database"
-      changes:
-        - sql:
-            sql: UPDATE metabase_database SET name='Sample Database' WHERE is_sample=true
-
-  - changeSet:
-      id: v43.00-001
-      author: jeff303
-      comment: >-
-        Added 0.43.0 - migrates any Database using the old bigquery driver to bigquery-cloud-sdk instead
-      changes:
-        - sql:
-            sql: UPDATE metabase_database SET engine = 'bigquery-cloud-sdk' WHERE engine = 'bigquery'
-
-
-  #
-  # The next few migrations replace metabase.db.data-migrations/add-users-to-default-permissions-groups from 0.20.0
-  #
-
-  # Create the magic Permissions Groups if they don't already exist.
-
-  # [add-users-to-default-permissions-groups 1 of 4]
-  - changeSet:
-      id: v43.00-002
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Create magic 'All Users' Permissions Group if it does not already exist.
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*) FROM permissions_group WHERE name = 'All Users';
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions_group (name)
-              VALUES
-              ('All Users')
-
-  # [add-users-to-default-permissions-groups 2 of 4]
-  - changeSet:
-      id: v43.00-003
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Create magic 'Administrators' Permissions Group if it does not already exist.
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*) FROM permissions_group WHERE name = 'Administrators';
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions_group (name)
-              VALUES
-              ('Administrators')
-
-  # Add existing Users to the magic Permissions Groups if needed.
-
-  # [add-users-to-default-permissions-groups 3 of 4]
-  - changeSet:
-      id: v43.00-004
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Add existing Users to 'All Users' magic Permissions Group if needed.
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions_group_membership (user_id, group_id)
-              SELECT
-                u.id AS user_id,
-                all_users_group.id AS group_id
-                FROM core_user u
-                LEFT JOIN (
-                  SELECT *
-                  FROM permissions_group
-                  WHERE name = 'All Users'
-                ) all_users_group
-                  ON true
-                LEFT JOIN permissions_group_membership pgm
-                       ON u.id = pgm.user_id
-                      AND all_users_group.id = pgm.group_id
-                WHERE pgm.id IS NULL;
-
-  # [add-users-to-default-permissions-groups 4 of 4]
-  - changeSet:
-      id: v43.00-005
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Add existing Users with 'is_superuser' flag to 'Administrators' magic Permissions Group if needed.
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions_group_membership (user_id, group_id)
-              SELECT
-                u.id AS user_id,
-                admin_group.id AS group_id
-                FROM core_user u
-                LEFT JOIN (
-                  SELECT *
-                  FROM permissions_group
-                  WHERE name = 'Administrators'
-                ) admin_group
-                  ON true
-                LEFT JOIN permissions_group_membership pgm
-                       ON u.id = pgm.user_id
-                      AND admin_group.id = pgm.group_id
-                WHERE u.is_superuser = true
-                  AND pgm.id IS NULL;
-
-  #
-  # This migration replaces metabase.db.data-migrations/add-admin-group-root-entry, added 0.20.0
-  #
-  # Create root permissions entry for admin magic Permissions Group. Admin Group has a single entry that lets it
-  # access to everything
-  - changeSet:
-      id: v43.00-006
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Create root '/' permissions entry for the 'Administrators' magic Permissions Group if needed.
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions (group_id, object)
-              SELECT
-                admin_group.id AS group_id,
-                '/' AS object
-              FROM (
-                SELECT id
-                FROM permissions_group
-                WHERE name = 'Administrators'
-              ) admin_group
-              LEFT JOIN permissions p
-                     ON admin_group.id = p.group_id
-                    AND p.object = '/'
-              WHERE p.object IS NULL;
-
-  #
-  # The following migration replaces metabase.db.data-migrations/add-databases-to-magic-permissions-groups, added 0.20.0
-  #
-
-  # Add permissions entries for 'All Users' for all Databases created BEFORE we created the 'All Users' Permissions
-  # Group. This replaces the old 'add-databases-to-magic-permissions-groups' Clojure-land data migration. Only run
-  # this migration if that one hasn't been run yet.
-  - changeSet:
-      id: v43.00-007
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Grant permissions for existing Databases to 'All Users' permissions group.
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*)
-              FROM data_migrations
-              WHERE id = 'add-databases-to-magic-permissions-groups';
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions (object, group_id)
-              SELECT db.object, all_users.id AS group_id
-              FROM (
-                SELECT concat('/db/', id, '/') AS object
-                FROM metabase_database
-              ) db
-              LEFT JOIN (
-                SELECT id
-                FROM permissions_group
-                WHERE name = 'All Users'
-              ) all_users
-                ON true
-              LEFT JOIN permissions p
-                     ON p.group_id = all_users.id
-                    AND db.object = p.object
-              WHERE p.object IS NULL;
-
-  #
-  # The following migration replaces metabase.db.migrations/copy-site-url-setting-and-remove-trailing-slashes, added 0.23.0
-  #
-  # Copy the value of the old setting `-site-url` to the new `site-url` if applicable. (`site-url` used to be stored
-  # internally as `-site-url`; this was confusing, see #4188 for details.) Make sure `site-url` has no trailing slashes
-  # originally fixed in #4123.
-  - changeSet:
-      id: v43.00-008
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Migrate legacy '-site-url' Setting to 'site-url'. Trim trailing slashes.
-      validCheckSum: ANY # Quoting changes in H2 don't need to be re-run
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE key = 'site-url';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'site-url';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'site-url';
-      changes:
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO setting ("KEY", "VALUE")
-              SELECT
-                'site-url' AS "KEY",
-                regexp_replace("VALUE", '/$', '') AS "VALUE"
-              FROM setting
-              WHERE "KEY" = '-site-url';
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO setting (key, value)
-              SELECT
-                'site-url' AS key,
-                regexp_replace(value, '/$', '') AS value
-              FROM setting
-              WHERE key = '-site-url';
-        - sql:
-            dbms: mysql,mariadb
-            # MySQL 5.7 doesn't support regexp_replace :(
-            # 'key' has to be quoted in MySQL
-            sql: >-
-              INSERT INTO setting (`key`, value)
-              SELECT
-                'site-url' AS `key`,
-                CASE
-                  WHEN value LIKE '%/'
-                    THEN substring(value, 1, length(value) - 1)
-                  ELSE
-                    value
-                  END
-                AS value
-              FROM setting
-              WHERE `key` = '-site-url';
-
-  #
-  # The following migration replaces metabase.db.migrations/ensure-protocol-specified-in-site-url, added in 0.25.1
-  #
-  # There's a window on in the 0.23.0 and 0.23.1 releases that the site-url could be persisted without a protocol
-  # specified. Other areas of the application expect that site-url will always include http/https. This migration
-  # ensures that if we have a site-url stored it has the current defaulting logic applied to it
-  - changeSet:
-      id: v43.00-009
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Make sure 'site-url' Setting includes protocol.
-      validCheckSum: ANY # Quoting changes in H2 don't need to be re-run
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              UPDATE setting
-              SET value = concat('http://', value)
-              WHERE key = 'site-url'
-                AND value NOT LIKE 'http%';
-        - sql:
-            dbms: h2
-            sql: >-
-              UPDATE setting
-              SET "VALUE" = concat('http://', "VALUE")
-              WHERE "KEY" = 'site-url'
-                AND "VALUE" NOT LIKE 'http%';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE setting
-              SET value = concat('http://', value)
-              WHERE `key` = 'site-url'
-                AND value NOT LIKE 'http%';
-
-  #
-  # The following migrations replace metabase.db.migrations/migrate-humanization-setting, added in 0.28.0
-  #
-  # Prior to version 0.28.0 humanization was configured using the boolean setting `enable-advanced-humanization`.
-  # `true` meant "use advanced humanization", while `false` meant "use simple humanization". In 0.28.0, this Setting
-  # was replaced by the `humanization-strategy` Setting, which (at the time of this writing) allows for a choice
-  # between three options: advanced, simple, or none. Migrate any values of the old Setting, if set, to the new one.
-
-  # [migrate-humanization-setting part 1 of 2]
-  - changeSet:
-      id: v43.00-010
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Migrates value of legacy enable-advanced-humanization Setting to humanization-strategy Setting added in 0.28.0.
-      validCheckSum: ANY # Quoting changes in H2 don't need to be re-run
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE key = 'humanization-strategy';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'humanization-strategy';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'humanization-strategy';
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO setting (key, value)
-              SELECT
-                'humanization-strategy'                                      AS key,
-                (CASE WHEN value = 'true' THEN 'advanced' ELSE 'simple' END) AS value
-              FROM setting
-              WHERE key = 'enable-advanced-humanization';
-        # key and value have to be quoted in H2
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO setting ("KEY", "VALUE")
-              SELECT
-                'humanization-strategy'                                      AS "KEY",
-                (CASE WHEN "VALUE" = 'true' THEN 'advanced' ELSE 'simple' END) AS "VALUE"
-              FROM setting
-              WHERE "KEY" = 'enable-advanced-humanization';
-        # key has to be quoted in MySQL/MariaDB
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT INTO setting (`key`, value)
-              SELECT
-                'humanization-strategy'                                      AS `key`,
-                (CASE WHEN value = 'true' THEN 'advanced' ELSE 'simple' END) AS value
-              FROM setting
-              WHERE `key` = 'enable-advanced-humanization';
-
-  # [migrate-humanization-setting part 2 of 2]
-  - changeSet:
-      id: v43.00-011
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Remove legacy enable-advanced-humanization Setting.
-      validCheckSum: ANY # Quoting changes in H2 don't need to be re-run
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              DELETE FROM setting WHERE key = 'enable-advanced-humanization';
-        # key has to be quoted in H2
-        - sql:
-            dbms: h2
-            sql: >-
-              DELETE FROM setting WHERE "KEY" = 'enable-advanced-humanization';
-        # key has to be quoted in MySQL/MariaDB
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              DELETE FROM setting WHERE `key` = 'enable-advanced-humanization';
-
-  #
-  # The following migration replaces metabase.db.migrations/mark-category-fields-as-list, added in 0.29.0
-  #
-  # Starting in version 0.29.0 we switched the way we decide which Fields should get FieldValues. Prior to 29, Fields
-  # would be marked as special type Category if they should have FieldValues. In 29+, the Category special type no
-  # longer has any meaning as far as the backend is concerned. Instead, we use the new `has_field_values` column to
-  # keep track of these things. Fields whose value for `has_field_values` is `list` is the equiavalent of the old
-  # meaning of the Category special type.
-  #
-  # Note that in 0.39.0 special type was renamed to semantic type
-  - changeSet:
-      id: v43.00-012
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Set Field.has_field_values to 'list' if semantic_type derives from :type/Category.
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*)
-              FROM data_migrations
-              WHERE id = 'mark-category-fields-as-list';
-      changes:
-        - sql:
-            # This is a snapshot of all the descendants of `:type/Category` at the time this migration was written. We
-            # don't need to worry about new types being added in the future, since the purpose of this migration is
-            # only to update old columns.
-            sql: >-
-              UPDATE metabase_field
-              SET has_field_values = 'list'
-              WHERE has_field_values IS NULL
-                AND active = true
-                AND semantic_type IN (
-                  'type/Category',
-                  'type/City',
-                  'type/Company',
-                  'type/Country',
-                  'type/Name',
-                  'type/Product',
-                  'type/Source',
-                  'type/State',
-                  'type/Subscription',
-                  'type/Title'
-                );
-
-  #
-  # The following migrations replace metabase.db.migrations/add-migrated-collections, added in 0.30.0
-  #
-  # In 0.30 dashboards and pulses will be saved in collections rather than on separate list pages. Additionally, there
-  # will no longer be any notion of saved questions existing outside of a collection (i.e. in the weird "Everything
-  # Else" area where they can currently be saved).
-  #
-  # Consequently we'll need to move existing dashboards, pulses, and questions-not-in-a-collection to a new location
-  # when users upgrade their instance to 0.30 from a previous version.
-  #
-  # The user feedback we've received points to a UX that would do the following:
-  #
-  # 1. Set permissions to the Root Collection to readwrite perms access for *all* Groups.
-  #
-  # 2. Create three new collections within the root collection: "Migrated dashboards," "Migrated pulses," and "Migrated
-  #    questions."
-  #
-  # 3. The permissions settings for these new collections should be set to No Access for all user groups except
-  #    Administrators.
-  #
-  # 4. Existing Dashboards, Pulses, and Questions from the "Everything Else" area should now be present within these
-  #    new collections.
-
-  # [add-migrated-collections part 1 of 7] Create 'Migrated Dashboards' Collection if needed
-  - changeSet:
-      id: v43.00-014
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Add 'Migrated Dashboards' Collection if needed and there are any Dashboards not in a Collection.
-      preConditions:
-        - onFail: MARK_RAN
-        - and:
-            - sqlCheck:
-                expectedResult: 0
-                sql: >-
-                  SELECT count(*)
-                  FROM data_migrations
-                  WHERE id = 'add-migrated-collections';
-            - sqlCheck:
-                expectedResult: 0
-                sql: >-
-                  SELECT count(*)
-                  FROM collection
-                  WHERE name = 'Migrated Dashboards';
-            - not:
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: >-
-                      SELECT count(*)
-                      FROM report_dashboard
-                      WHERE collection_id IS NULL;
-      changes:
-        - sql:
-            # #509ee3 is the MB brand color
-            sql: >-
-              INSERT INTO collection (name, color, slug)
-              VALUES
-              ('Migrated Dashboards', '#509ee3', 'migrated_dashboards');
-
-  # [add-migrated-collections part 2 of 7] Create 'Migrated Pulses' Collection if needed
-  - changeSet:
-      id: v43.00-015
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Add 'Migrated Pulses' Collection if needed and there are any Pulses not in a Collection.
-      preConditions:
-        - onFail: MARK_RAN
-        - and:
-            - sqlCheck:
-                expectedResult: 0
-                sql: >-
-                  SELECT count(*)
-                  FROM data_migrations
-                  WHERE id = 'add-migrated-collections';
-            - sqlCheck:
-                expectedResult: 0
-                sql: >-
-                  SELECT count(*)
-                  FROM collection
-                  WHERE name = 'Migrated Pulses';
-            - not:
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: >-
-                      SELECT count(*)
-                      FROM pulse
-                      WHERE collection_id IS NULL;
-      changes:
-        - sql:
-            # #509ee3 is the MB brand color
-            sql: >-
-              INSERT INTO collection (name, color, slug)
-              VALUES
-              ('Migrated Pulses', '#509ee3', 'migrated_pulses');
-
-  # [add-migrated-collections part 3 of 7] Create 'Migrated Questions' Collection if needed
-  - changeSet:
-      id: v43.00-016
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Add 'Migrated Questions' Collection if needed and there are any Cards not in a Collection.
-      preConditions:
-        - onFail: MARK_RAN
-        - and:
-            - sqlCheck:
-                expectedResult: 0
-                sql: >-
-                  SELECT count(*)
-                  FROM data_migrations
-                  WHERE id = 'add-migrated-collections';
-            - sqlCheck:
-                expectedResult: 0
-                sql: >-
-                  SELECT count(*)
-                  FROM collection
-                  WHERE name = 'Migrated Questions';
-            - not:
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: >-
-                      SELECT count(*)
-                      FROM report_card
-                      WHERE collection_id IS NULL;
-      changes:
-        - sql:
-            # #509ee3 is the MB brand color
-            sql: >-
-              INSERT INTO collection (name, color, slug)
-              VALUES
-              ('Migrated Questions', '#509ee3', 'migrated_questions');
-
-  # [add-migrated-collections part 4 of 7] Move Dashboards not in a Collection to 'Migrated Dashboards'
-  - changeSet:
-      id: v43.00-017
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Move Dashboards not in a Collection to 'Migrated Dashboards'.
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*)
-              FROM data_migrations
-              WHERE id = 'add-migrated-collections';
-      changes:
-        - sql:
-            sql: >-
-              UPDATE report_dashboard
-              SET collection_id = (SELECT id FROM collection WHERE name = 'Migrated Dashboards')
-              WHERE collection_id IS NULL;
-
-
-  # [add-migrated-collections part 5 of 7] Move Pulses not in a Collection to 'Migrated Pulses'
-  - changeSet:
-      id: v43.00-018
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Move Pulses not in a Collection to 'Migrated Pulses'.
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*)
-              FROM data_migrations
-              WHERE id = 'add-migrated-collections';
-      changes:
-        - sql:
-            sql: >-
-              UPDATE pulse
-              SET collection_id = (SELECT id FROM collection WHERE name = 'Migrated Pulses')
-              WHERE collection_id IS NULL;
-
-  # [add-migrated-collections part 6 of 7] Move Cards not in a Collection to 'Migrated Questions'
-  - changeSet:
-      id: v43.00-019
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Move Cards not in a Collection to 'Migrated Questions'.
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*)
-              FROM data_migrations
-              WHERE id = 'add-migrated-collections';
-      changes:
-        - sql:
-            sql: >-
-              UPDATE report_card
-              SET collection_id = (SELECT id FROM collection WHERE name = 'Migrated Questions')
-              WHERE collection_id IS NULL;
-
-  # [add-migrated-collections part 7 of 7] Grant All Users readwrite perms for the Root Collection.
-  - changeSet:
-      id: v43.00-020
-      author: camsaul
-      comment: >-
-        Added 0.43.0. Grant the 'All Users' Permissions Group readwrite perms for the Root Collection.
-      preConditions:
-        - onFail: MARK_RAN
-        - and:
-            - sqlCheck:
-                expectedResult: 0
-                sql: >-
-                  SELECT count(*)
-                  FROM data_migrations
-                  WHERE id = 'add-migrated-collections';
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions (group_id, object)
-              SELECT
-                all_users_group.id AS group_id,
-                '/collection/root/' AS object
-              FROM (
-                SELECT id
-                FROM permissions_group
-                WHERE name = 'All Users'
-              ) all_users_group
-              LEFT JOIN permissions p
-                     ON all_users_group.id = p.group_id
-                    AND p.object = '/collection/root/'
-              WHERE p.object IS NULL;
-
-  - changeSet:
-      id: v43.00-021
-      author: adam-james
-      comment: Added 0.43.0 - Timeline table for Events
-      changes:
-        - createTable:
-            tableName: timeline
-            remarks: Timeline table to organize events
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    nullable: false
-                    primaryKey: true
-              - column:
-                  remarks: Name of the timeline
-                  name: name
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: Optional description of the timeline
-                  name: description
-                  type: varchar(255)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: icon
-                  type: varchar(128)
-                  constraints:
-                    nullable: true
-                  remarks: the icon to use when displaying the event
-              - column:
-                  remarks: ID of the collection containing the timeline
-                  name: collection_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    references: collection(id)
-                    foreignKeyName: fk_timeline_collection_id
-                    deleteCascade: true
-              - column:
-                  remarks: Whether or not the timeline has been archived
-                  name: archived
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: ID of the user who created the timeline
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_timeline_creator_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the timeline was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the timeline was updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v43.00-022
-      author: adam-james
-      comment: Added 0.43.0 - Events table
-      changes:
-        - createTable:
-            tableName: timeline_event
-            remarks: Events table
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    nullable: false
-                    primaryKey: true
-              - column:
-                  remarks: ID of the timeline containing the event
-                  name: timeline_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    references: timeline(id)
-                    foreignKeyName: fk_events_timeline_id
-                    deleteCascade: true
-              - column:
-                  remarks: Name of the event
-                  name: name
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: Optional markdown description of the event
-                  name: description
-                  type: varchar(255)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: timestamp
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-                  remarks: When the event happened
-              - column:
-                  name: time_matters
-                  type: boolean
-                  constraints:
-                    nullable: false
-                  remarks: >-
-                     Indicate whether the time component matters or if the timestamp should just serve to indicate the
-                     day of the event without any time associated to it.
-              - column:
-                  name: timezone
-                  constraints:
-                    nullable: false
-                  type: varchar(255)
-                  remarks: Timezone to display the underlying UTC timestamp in for the client
-              - column:
-                  name: icon
-                  type: varchar(128)
-                  constraints:
-                    nullable: true
-                  remarks: the icon to use when displaying the event
-              - column:
-                  remarks: Whether or not the event has been archived
-                  name: archived
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: ID of the user who created the event
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_event_creator_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the event was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the event was modified
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v43.00-023
-      author: dpsutton
-      comment: Added 0.43.0 - Index on timeline collection_id
-      changes:
-        - createIndex:
-            tableName: timeline
-            indexName: idx_timeline_collection_id
-            columns:
-              - column:
-                  name: collection_id
-
-  - changeSet:
-      id: v43.00-024
-      author: dpsutton
-      comment: Added 0.43.0 - Index on timeline_event timeline_id
-      changes:
-        - createIndex:
-            tableName: timeline_event
-            indexName: idx_timeline_event_timeline_id
-            columns:
-              - column:
-                  name: timeline_id
-
-  - changeSet:
-      id: v43.00-025
-      author: dpsutton
-      comment: Added 0.43.0 - Index on timeline timestamp
-      changes:
-        - createIndex:
-            tableName: timeline_event
-            indexName: idx_timeline_event_timeline_id_timestamp
-            columns:
-              - column:
-                  name: timeline_id
-              - column:
-                  name: timestamp
-
-  - changeSet:
-      id: v43.00-026
-      author: noahmoss
-      comment: >-
-        Added 0.43.0 - adds User.settings column to implement User-local Settings
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: settings
-                  type: ${text.type}
-                  remarks: "Serialized JSON containing User-local Settings for this User"
-
-  - changeSet:
-      id: v43.00-027
-      author: camsaul
-      comment: Added 0.43.0. Drop NOT NULL constraint for core_user.password
-      changes:
-        - dropNotNullConstraint:
-            tableName: core_user
-            columnName: password
-            columnDataType: varchar(254)
-
-  - changeSet:
-      id: v43.00-028
-      author: camsaul
-      comment: Added 0.43.0. Drop NOT NULL constraint for core_user.password_salt
-      changes:
-        - dropNotNullConstraint:
-            tableName: core_user
-            columnName: password_salt
-            columnDataType: varchar(254)
-
-  #
-  # The following migration replaces metabase.db.data-migrations/clear-ldap-user-local-passwords, added 0.30.0
-  #
-  # Before 0.30.0, we were storing the LDAP user's password in the core_user table (though it wasn't used). This
-  # migration clears those passwords out, disabling password-based login.
-  - changeSet:
-      id: v43.00-029
-      author: camsaul
-      comment: Added 0.43.0. Clear local password for Users using LDAP auth.
-      changes:
-        - sql:
-            sql: >-
-              UPDATE core_user
-              SET
-                password = NULL,
-                password_salt = NULL
-              WHERE ldap_auth IS TRUE;
-
-  - changeSet:
-      id: v43.00-030
-      author: dpsutton
-      comment: Added 0.43.0 - Dashboard bookmarks table
-      changes:
-        - createTable:
-            tableName: dashboard_bookmark
-            remarks: Table holding bookmarks on dashboards
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'ID of the User who bookmarked the Dashboard'
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_dashboard_bookmark_user_id
-                    deleteCascade: true
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: 'ID of the Dashboard bookmarked by the user'
-                  constraints:
-                    nullable: false
-                    references: report_dashboard(id)
-                    foreignKeyName: fk_dashboard_bookmark_dashboard_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the bookmark was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: v43.00-031
-      author: dpsutton
-      comment: Added 0.43.0 - Dashboard bookmarks table unique constraint
-      changes:
-        - addUniqueConstraint:
-            tableName: dashboard_bookmark
-            columnNames: user_id, dashboard_id
-            constraintName: unique_dashboard_bookmark_user_id_dashboard_id
-  - changeSet:
-      id: v43.00-032
-      author: dpsutton
-      comment: Added 0.43.0 - Dashboard bookmarks table index on user_id
-      changes:
-        - createIndex:
-            tableName: dashboard_bookmark
-            columns:
-              - column:
-                  name: user_id
-            indexName: idx_dashboard_bookmark_user_id
-  - changeSet:
-      id: v43.00-033
-      author: dpsutton
-      comment: Added 0.43.0 - Dashboard bookmarks table index on dashboard_id
-      changes:
-        - createIndex:
-            tableName: dashboard_bookmark
-            columns:
-              - column:
-                  name: dashboard_id
-            indexName: idx_dashboard_bookmark_dashboard_id
-
-  - changeSet:
-      id: v43.00-034
-      author: dpsutton
-      comment: Added 0.43.0 - Card bookmarks table
-      changes:
-        - createTable:
-            tableName: card_bookmark
-            remarks: Table holding bookmarks on cards
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'ID of the User who bookmarked the Card'
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_card_bookmark_user_id
-                    deleteCascade: true
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: 'ID of the Card bookmarked by the user'
-                  constraints:
-                    nullable: false
-                    references: report_card(id)
-                    foreignKeyName: fk_card_bookmark_dashboard_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the bookmark was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: v43.00-035
-      author: dpsutton
-      comment: Added 0.43.0 - Card bookmarks table unique constraint
-      changes:
-        - addUniqueConstraint:
-            tableName: card_bookmark
-            columnNames: user_id, card_id
-            constraintName: unique_card_bookmark_user_id_card_id
-  - changeSet:
-      id: v43.00-036
-      author: dpsutton
-      comment: Added 0.43.0 - Card bookmarks table index on user_id
-      changes:
-        - createIndex:
-            tableName: card_bookmark
-            columns:
-              - column:
-                  name: user_id
-            indexName: idx_card_bookmark_user_id
-  - changeSet:
-      id: v43.00-037
-      author: dpsutton
-      comment: Added 0.43.0 - Card bookmarks table index on card_id
-      changes:
-        - createIndex:
-            tableName: card_bookmark
-            columns:
-              - column:
-                  name: card_id
-            indexName: idx_card_bookmark_card_id
-
-  - changeSet:
-      id: v43.00-038
-      author: dpsutton
-      comment: Added 0.43.0 - Collection bookmarks table
-      changes:
-        - createTable:
-            tableName: collection_bookmark
-            remarks: Table holding bookmarks on collections
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'ID of the User who bookmarked the Collection'
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_collection_bookmark_user_id
-                    deleteCascade: true
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: 'ID of the Card bookmarked by the user'
-                  constraints:
-                    nullable: false
-                    references: collection(id)
-                    foreignKeyName: fk_collection_bookmark_collection_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the bookmark was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: v43.00-039
-      author: dpsutton
-      comment: Added 0.43.0 - Collection bookmarks table unique constraint
-      changes:
-        - addUniqueConstraint:
-            tableName: collection_bookmark
-            columnNames: user_id, collection_id
-            constraintName: unique_collection_bookmark_user_id_collection_id
-  - changeSet:
-      id: v43.00-040
-      author: dpsutton
-      comment: Added 0.43.0 - Collection bookmarks table index on user_id
-      changes:
-        - createIndex:
-            tableName: collection_bookmark
-            columns:
-              - column:
-                  name: user_id
-            indexName: idx_collection_bookmark_user_id
-  - changeSet:
-      id: v43.00-041
-      author: dpsutton
-      comment: Added 0.43.0 - Collection bookmarks table index on collection_id
-      changes:
-        - createIndex:
-            tableName: collection_bookmark
-            columns:
-              - column:
-                  name: collection_id
-            indexName: idx_collection_bookmark_collection_id
-
-  - changeSet:
-      id: v43.00-042
-      author: noahmoss
-      comment: >-
-        Added 0.43.0. Grant download permissions for existing Databases to 'All Users' permissions group
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions (object, group_id)
-              SELECT db.object, all_users.id AS group_id
-              FROM (
-                SELECT concat('/download/db/', id, '/') AS object
-                FROM metabase_database
-              ) db
-              LEFT JOIN (
-                SELECT id
-                FROM permissions_group
-                WHERE name = 'All Users'
-              ) all_users
-                ON true
-              LEFT JOIN permissions p
-                     ON p.group_id = all_users.id
-                    AND db.object = p.object
-              WHERE p.object IS NULL;
-
-  - changeSet:
-      id: v43.00-043
-      author: howonlee
-      comment: Added 0.43.0 - Nested field columns in fields
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Nested field column paths, flattened
-                name: nfc_path
-                type: varchar(254)
-                constraints:
-                  nullable: true
-            tableName: metabase_field
-
-  - changeSet:
-      id: v43.00-044
-      author: noahmoss
-      comment: Added 0.43.0 - Removes MetaBot permissions group
-      changes:
-        - sql:
-            sql: DELETE FROM permissions_group WHERE name = 'MetaBot'
-
-  - changeSet:
-      id: v43.00-046
-      author: qnkhuat
-      comment: Added 0.43.0 - create General Permission Revision table
-      changes:
-        - createTable:
-            tableName: general_permissions_revision
-            remarks: 'Used to keep track of changes made to general permissions.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: before
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the permission graph before the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: after
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the changes in permission graph.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'The ID of the admin who made this set of changes.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_general_permissions_revision_user_id
-              - column:
-                  name: created_at
-                  type: datetime
-                  remarks: 'The timestamp of when these changes were made.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: remark
-                  type: ${text.type}
-                  remarks: 'Optional remarks explaining why these changes were made.'
-
-  - changeSet:
-      id: v43.00-047
-      author: qnkhuat
-      comment: Added 0.43.0. Grant the 'All Users' Group permissions to create/edit subscriptions and alerts
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions (group_id, object)
-              SELECT
-                all_users_group.id AS group_id,
-                '/general/subscription/' AS object
-              FROM (
-                SELECT id
-                FROM permissions_group
-                WHERE name = 'All Users'
-              ) all_users_group
-              LEFT JOIN permissions p
-                ON all_users_group.id = p.group_id
-                AND p.object = '/general/subscription/'
-              WHERE p.object IS NULL;
-
-  - changeSet:
-      id: v43.00-049
-      author: dpsutton
-      comment: Added 0.43.0 - Unify datatype with query_execution.started_at so comparable (see 168).
-      changes:
-        - modifyDataType:
-            tableName: view_log
-            columnName: timestamp
-            newDataType: ${timestamp_type}
-
-  - changeSet:
-        id: v43.00-050
-        author: qnkhuat
-        comment: Added 0.43.0. Add permissions_group_membership.is_group_manager
-        changes:
-          - addColumn:
-              columns:
-              - column:
-                  remarks: Boolean flag to indicate whether user is a group's manager.
-                  name: is_group_manager
-                  type: boolean
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-              tableName: permissions_group_membership
-
-  - changeSet:
-      id: v43.00-051
-      author: adam-james
-      comment: Added 0.43.0 - default boolean on timelines to indicate default timeline for a collection
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Boolean value indicating if the timeline is the default one for the containing Collection
-                name: default
-                type: boolean
-                defaultValue: false
-                constraints:
-                  nullable: false
-            tableName: timeline
-
-  - changeSet:
-      id: v43.00-052
-      author: snoe
-      comment: Added 0.43.0 - bookmark ordering
-      changes:
-        - createTable:
-            tableName: bookmark_ordering
-            remarks: Table holding ordering information for various bookmark tables
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'ID of the User who ordered bookmarks'
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_bookmark_ordering_user_id
-                    deleteCascade: true
-              - column:
-                  name: type
-                  type: varchar(255)
-                  remarks: 'type of the Bookmark'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: item_id
-                  type: int
-                  remarks: 'id of the item being bookmarked (Card, Collection, Dashboard, ...) no FK, so may no longer exist'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: ordering
-                  type: int
-                  remarks: 'order of bookmark for user'
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: v43.00-053
-      author: snoe
-      comment: Added 0.43.0 - bookmark ordering
-      changes:
-        - addUniqueConstraint:
-            tableName: bookmark_ordering
-            columnNames: user_id, type, item_id
-            constraintName: unique_bookmark_user_id_type_item_id
-  - changeSet:
-      id: v43.00-054
-      author: snoe
-      comment: Added 0.43.0 - bookmark ordering
-      changes:
-        - addUniqueConstraint:
-            tableName: bookmark_ordering
-            columnNames: user_id, ordering
-            constraintName: unique_bookmark_user_id_ordering
-  - changeSet:
-      id: v43.00-055
-      author: snoe
-      comment: Added 0.43.0 - bookmark ordering
-      changes:
-        - createIndex:
-            tableName: bookmark_ordering
-            columns:
-              - column:
-                  name: user_id
-            indexName: idx_bookmark_ordering_user_id
-
-  - changeSet:
-      id: v43.00-056
-      author: qnkhuat
-      comment: >-
-        Added 0.43.0 - Rename general permission revision table
-        It's safe to rename this table without breaking downgrades compatibility because this table was also added in 0.43.0.
-      changes:
-        - renameTable:
-            oldTableName: general_permissions_revision
-            newTableName: application_permissions_revision
-
-  - changeSet:
-      id: v43.00-057
-      author: qnkhuat
-      comment: Added 0.43.0 - Rename general_permissions_revision_id_seq
-      failOnError: false # mysql and h2 don't have this sequence
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql
-      changes:
-        - sql:
-            - sql: ALTER SEQUENCE general_permissions_revision_id_seq RENAME TO application_permissions_revision_id_seq;
-
-  - changeSet:
-      id: v43.00-058
-      author: qnkhuat
-      comment: Added 0.43.0 - Rename general permissios to application permissions
-      changes:
-        - sql:
-            sql: >-
-              UPDATE permissions
-              SET object = REPLACE(object, '/general/', '/application/')
-              WHERE object LIKE '/general/%';
-
-  - changeSet:
-      id: v43.00-059
-      author: adam-james
-      comment: Added 0.43.0 - disallow nil timeline icons
-      changes:
-        - addNotNullConstraint:
-            columnDataType: varchar(128)
-            tableName: timeline
-            columnName: icon
-            defaultNullValue: "star"
-  - changeSet:
-      id: v43.00-060
-      author: adam-james
-      comment: Added 0.43.0 - disallow nil timeline event icons
-      changes:
-        - addNotNullConstraint:
-            columnDataType: varchar(128)
-            tableName: timeline_event
-            columnName: icon
-            defaultNullValue: "star"
-
-  - changeSet:
-      id: v43.00-062
-      author: snoe
-      comment: Added 0.43.0 - Unify datatype with revision.timestamp for timezone info (see 17829).
-      changes:
-        - modifyDataType:
-            tableName: revision
-            columnName: timestamp
-            newDataType: ${timestamp_type}
-
-  - changeSet:
-      id: v44.00-000
-      author: dpsutton
-      comment: Added 0.44.0 - Persisted Info for models
-      changes:
-        - createTable:
-            tableName: persisted_info
-            remarks: Table holding information about persisted models
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: database_id
-                  type: int
-                  remarks: 'ID of the database associated to the persisted card'
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_database
-                    referencedColumnNames: id
-                    foreignKeyName: fk_persisted_info_database_id
-                    deleteCascade: true
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: 'ID of the Card model persisted'
-                  constraints:
-                    nullable: false
-                    unique: true
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_persisted_info_card_id
-                    deleteCascade: true
-              - column:
-                  remarks: Slug of the card which will form the persisted table name
-                  name: question_slug
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: Name of the table persisted
-                  name: table_name
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: JSON object that captures the state of the table when we persisted
-                  name: definition
-                  type: ${text.type}
-                  constraints:
-                    nullable: true
-              - column:
-                  remarks: Hash of the query persisted
-                  name: query_hash
-                  type: ${text.type}
-                  constraints:
-                    nullable: true
-              - column:
-                  remarks: Indicating whether the persisted table is active and can be swapped
-                  name: active
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: Persisted table state (creating, persisted, refreshing, deleted)
-                  name: state
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the most recent refresh was started
-                  name: refresh_begin
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the most recent refresh ended
-                  name: refresh_end
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: true
-              - column:
-                  remarks: The timestamp of when the most recent state changed
-                  name: state_change_at
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: true
-              - column:
-                  remarks: Error message from persisting if applicable
-                  name: error
-                  type: ${text.type}
-                  constraints:
-                    nullable: true
-              - column:
-                  remarks: The timestamp of when the model was first persisted
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: creator_id
-                  type: int
-                  remarks: The person who persisted a model
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_persisted_info_ref_creator_id
-                    deferrable: false
-                    initiallyDeferred: false
-  - changeSet:
-      id: v44.00-001
-      author: snoe
-      comment: Added 0.44.0 - Remove not null constraint from persisted_info.creator_id
-      changes:
-        - dropNotNullConstraint:
-            tableName: persisted_info
-            columnName: creator_id
-            columnDataType: int
-
-  # v44.00-002 through -011 add entity_id columns to several internal entities.
-  # These are fixed-width string fields populated with a random 21-character
-  # NanoID value, and used by the serialization system to de-duplicate entities
-  # in a portable way. See the serialization design doc in the design repo.
-  - changeSet:
-      id: v44.00-002
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: metric
-  - changeSet:
-      id: v44.00-003
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: segment
-  - changeSet:
-      id: v44.00-004
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: collection
-  - changeSet:
-      id: v44.00-005
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: report_dashboard
-  - changeSet:
-      id: v44.00-006
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: dimension
-  - changeSet:
-      id: v44.00-007
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: pulse
-  - changeSet:
-      id: v44.00-008
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: report_card
-  - changeSet:
-      id: v44.00-009
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: native_query_snippet
-  - changeSet:
-      id: v44.00-010
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: timeline
-  - changeSet:
-      id: v44.00-011
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to all internal entities
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: report_dashboardcard
-
-# Migrations v44.00-012 thru v44.00-022 have been moved to v45.00-001 thru v45.00-011
-
-  - changeSet:
-      id: v44.00-023
-      author: qnkhuat
-      comment: Added 0.44.0 - Add parameters to report_card
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: parameters
-                  type: ${text.type}
-                  remarks: List of parameter associated to a card
-                  constraints:
-                    nullable: true
-  - changeSet:
-      id: v44.00-025
-      author: qnkhuat
-      comment: Added 0.44.0 - Add parameter_mappings to report_card
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: parameter_mappings
-                  type: ${text.type}
-                  remarks: List of parameter associated to a card
-                  constraints:
-                    nullable: true
-  - changeSet:
-      id: v44.00-027
-      author: adam-james
-      comment: Added 0.44.0. Drop NOT NULL constraint for core_user.first_name
-      changes:
-        - dropNotNullConstraint:
-            tableName: core_user
-            columnName: first_name
-            columnDataType: varchar(254)
-  - changeSet:
-      id: v44.00-028
-      author: adam-james
-      comment: Added 0.44.0. Drop NOT NULL constraint for core_user.last_name
-      changes:
-        - dropNotNullConstraint:
-            tableName: core_user
-            columnName: last_name
-            columnDataType: varchar(254)
-  - changeSet:
-      id: v44.00-029
-      author: qnkhuat
-      comment: Added 0.44.0 - Add has_more_values to metabase_fieldvalues
-      changes:
-        - addColumn:
-            tableName: metabase_fieldvalues
-            columns:
-              - column:
-                  name: has_more_values
-                  type: boolean
-                  remarks: true if the stored values list is a subset of all possible values
-                  defaultValueBoolean: false
-
-  - changeSet:
-      id: v44.00-030
-      author: snoe
-      comment: Added 0.44.0 - Add database_required to metabase_field
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: database_required
-                  type: boolean
-                  remarks: Indicates this field is required by the database for new records. Usually not null and without a default.
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-
-# Migrations v44.00-031 and v44.00-032 were moved to v45.00-012 and v45.00-013 respectively
-
-  - changeSet:
-      id: v44.00-033
-      author: qnkhuat
-      comment: >-
-        Added 0.43.0. Grant the 'All Users' Permissions Group readwrite perms for the Root Snippets Collection.
-      preConditions:
-        - onFail: MARK_RAN
-          # HACK: only run this on new instances (#21940)
-        - sqlCheck:
-            expectedResult: 0
-            sql: >-
-              SELECT count(*) AS user_count FROM core_user
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO permissions (group_id, object)
-              SELECT
-                all_users_group.id AS group_id,
-                '/collection/namespace/snippets/root/' AS object
-              FROM (
-                SELECT id
-                FROM permissions_group
-                WHERE name = 'All Users'
-              ) all_users_group
-              LEFT JOIN permissions p
-                      ON all_users_group.id = p.group_id
-                    AND p.object = '/collection/namespace/snippets/root/'
-              WHERE p.object IS NULL;
-
-  - changeSet:
-      id: v44.00-035
-      author: qnkhuat
-      comment: Added 0.44.0. Add type to fieldvalues
-      validCheckSum: ANY
-      changes:
-        - addColumn:
-            tableName: metabase_fieldvalues
-            columns:
-              - column:
-                  name: type
-                  type: varchar(32)
-                  defaultValue: 'full'
-                  remarks: Type of FieldValues
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: v44.00-037
-      author: qnkhuat
-      comment: Added 0.44.0. Add type to fieldvalues
-      changes:
-        - addColumn:
-            tableName: metabase_fieldvalues
-            columns:
-              - column:
-                  name: hash_key
-                  type: ${text.type}
-                  remarks: Hash key for a cached fieldvalues
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v44.00-038
-      author: metamben
-      comment: Added 0.44.0 - Add collection_preview to report_card
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: collection_preview
-                  type: boolean
-                  remarks: Indicating whether the card should be visualized in the collection preview
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v44.00-039
-      author: qnkhuat
-      comment: Added 0.44.0 - Add template_tags to native_query_snippet
-      changes:
-        - addColumn:
-            tableName: native_query_snippet
-            columns:
-              - column:
-                  name: template_tags
-                  type: ${text.type}
-                  remarks: Template tags for a snippet
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v44.00-041
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to PulseCard, PulseChannel
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: pulse_card
-
-  - changeSet:
-      id: v44.00-042
-      author: braden
-      comment: Added 0.44.0 - add entity_id column to PulseCard, PulseChannel
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: pulse_channel
-
-  - changeSet:
-      id: v44.00-044
-      author: qnkhuat
-      comment: Added 0.44.0 - drop native_query_snippet.template_tags added in v44.00-039
-      changes:
-        - dropColumn:
-            tableName: native_query_snippet
-            columnName: template_tags
-
-# >>>>>>>>>> NEW MIGRATIONS SHOULD BE PUT IN 001_update_migrations.yaml <<<<<<<<<<
+          WHERE semantic_type IN ('avatar', 'category', 'city', 'country', 'desc', 'fk', 'id', 'image',
+                                  'json', 'latitude', 'longitude', 'name', 'number', 'state', 'url',
+                                  'zip_code');
+- changeSet:
+    id: 305
+    author: camsaul
+    comment: Added 0.40.0 (replaces a data migration dating back to 0.20.0)
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field SET base_type = (CASE base_type
+                            WHEN 'ArrayField'      THEN 'type/Array'
+                            WHEN 'BigIntegerField' THEN 'type/BigInteger'
+                            WHEN 'BooleanField'    THEN 'type/Boolean'
+                            WHEN 'CharField'       THEN 'type/Text'
+                            WHEN 'DateField'       THEN 'type/Date'
+                            WHEN 'DateTimeField'   THEN 'type/DateTime'
+                            WHEN 'DecimalField'    THEN 'type/Decimal'
+                            WHEN 'DictionaryField' THEN 'type/Dictionary'
+                            WHEN 'FloatField'      THEN 'type/Float'
+                            WHEN 'IntegerField'    THEN 'type/Integer'
+                            WHEN 'TextField'       THEN 'type/Text'
+                            WHEN 'TimeField'       THEN 'type/Time'
+                            WHEN 'UUIDField'       THEN 'type/UUID'
+                            WHEN 'UnknownField'    THEN 'type/*'
+                           END)
+          WHERE base_type IN ('ArrayField', 'BigIntegerField', 'BooleanField', 'CharField', 'DateField',
+                              'DateTimeField', 'DecimalField', 'DictionaryField', 'FloatField', 'IntegerField',
+                              'TextField', 'TimeField', 'UUIDField', 'UnknownField');
+- changeSet:
+    id: 308
+    author: howonlee
+    comment: Added 0.40.0 Track cache hits in query_execution table
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column:
+            name: cache_hit
+            type: boolean
+            remarks: Cache hit on query execution
+            constraints: {nullable: true}
+- changeSet:
+    id: 309
+    author: dpsutton
+    comment: Added 0.40.0 - Add type to collections
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: authority_level
+            type: varchar(255)
+            remarks: Nullable column to incidate collection's authority level. Initially values are "official" and nil.
+            constraints: {nullable: true}
+- changeSet:
+    id: 311
+    author: howonlee
+    comment: Added 0.40.0 Migrate friendly field names, not noop
+    validCheckSum: ANY
+    changes:
+    - sql:
+        dbms: mariadb,mysql
+        sql: |
+          UPDATE setting SET value='simple' WHERE `key`='humanization-strategy'
+          AND value='advanced'
+    - sql:
+        dbms: postgresql
+        sql: |
+          UPDATE setting SET value='simple' WHERE key='humanization-strategy'
+          AND value='advanced'
+    - sql:
+        dbms: h2
+        sql: |
+          UPDATE setting SET "VALUE"='simple' WHERE "KEY"='humanization-strategy'
+          AND "VALUE"='advanced'
+- changeSet:
+    id: 312
+    author: noahmoss
+    comment: Added 0.41.0 Backfill collection_id for dashboard subscriptions
+    validCheckSum: 8:77ef89ba2e7bc19231d9364492091764
+    changes:
+    - sql: {dbms: 'mariadb,mysql', sql: UPDATE pulse p INNER JOIN report_dashboard d ON p.dashboard_id = d.id SET p.collection_id = d.collection_id;}
+    - sql: {dbms: postgresql, sql: UPDATE pulse p SET collection_id = d.collection_id FROM report_dashboard d WHERE p.dashboard_id = d.id AND p.dashboard_id IS NOT NULL;}
+    - sql:
+        dbms: h2
+        sql: |-
+          UPDATE pulse p SET collection_id = (
+            SELECT d.collection_id
+            FROM report_dashboard d
+            WHERE d.id = p.dashboard_id
+          ) WHERE dashboard_id IS NOT NULL;
+- changeSet:
+    id: 313
+    author: jeff303
+    comment: Added 0.42.0 - Secret domain object.
+    validCheckSum: ANY
+    changes:
+    - createTable:
+        tableName: secret
+        remarks: Storage for managed secrets (passwords, binary data, etc.)
+        columns:
+        - column:
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+            name: id
+            remarks: Part of composite primary key for secret; this is the uniquely generted ID column
+            type: int
+        - column:
+            constraints: {nullable: false, primaryKey: true}
+            name: version
+            defaultValue: 1
+            remarks: Part of composite primary key for secret; this is the version column
+            type: int
+        - column:
+            constraints: {deferrable: false, foreignKeyName: fk_secret_ref_user_id, initiallyDeferred: false, nullable: true, referencedTableName: core_user, referencedColumnNames: id}
+            name: creator_id
+            remarks: User ID who created this secret instance
+            type: int
+        - column:
+            constraints: {nullable: false}
+            name: created_at
+            remarks: Timestamp for when this secret instance was created
+            type: ${timestamp_type}
+        - column:
+            constraints: {nullable: true}
+            name: updated_at
+            remarks: Timestamp for when this secret record was updated. Only relevant when non-value field changes since a value change will result in a new version being inserted.
+            type: ${timestamp_type}
+        - column:
+            constraints: {nullable: false}
+            name: name
+            remarks: The name of this secret record.
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: kind
+            remarks: 'The kind of secret this record represents; the value is interpreted as a Clojure keyword with a hierarchy. Ex: ''bytes'' means generic binary data, ''jks-keystore'' extends ''bytes'' but has a specific meaning.'
+            type: varchar(254)
+        - column:
+            constraints: {nullable: true}
+            name: source
+            remarks: 'The source of secret record, which controls how Metabase interprets the value (ex: ''file-path'' means the ''simple_value'' is not the real value, but a pointer to a file that contains the value).'
+            type: varchar(254)
+        - column:
+            constraints: {nullable: false}
+            name: value
+            remarks: The base64 encoded binary value of this secret record. If encryption is enabled, this will be the output of the encryption procedure on the plaintext. If not, it will be the base64 encoded plaintext.
+            type: ${blob.type}
+- changeSet:
+    id: 314
+    author: howonlee
+    comment: Added 0.41.0 Fine grained caching controls
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: cache_ttl
+            type: integer
+            remarks: Granular cache TTL for specific database.
+            constraints: {nullable: true}
+- changeSet:
+    id: 315
+    author: howonlee
+    comment: Added 0.41.0 Fine grained caching controls, pt 2
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: cache_ttl
+            type: integer
+            remarks: Granular cache TTL for specific dashboard.
+            constraints: {nullable: true}
+- changeSet:
+    id: 316
+    author: howonlee
+    comment: Added 0.41.0 Fine grained caching controls, pt 3
+    changes:
+    - addColumn:
+        tableName: view_log
+        columns:
+        - column:
+            name: metadata
+            type: text
+            remarks: Serialized JSON corresponding to metadata for view.
+            constraints: {nullable: true}
+- changeSet:
+    id: 381
+    author: camsaul
+    comment: Added 0.41.2 Add index to QueryExecution card_id to fix performance issues (#18759)
+    changes:
+    - createIndex:
+        tableName: query_execution
+        indexName: idx_query_execution_card_id
+        columns:
+        - column: {name: card_id}
+- changeSet:
+    id: 382
+    author: camsaul
+    comment: Added 0.41.2 Add index to ModerationReview moderated_item_type + moderated_item_id to fix performance issues (#18759)
+    changes:
+    - createIndex:
+        tableName: moderation_review
+        indexName: idx_moderation_review_item_type_item_id
+        columns:
+        - column: {name: moderated_item_type}
+        - column: {name: moderated_item_id}
+- changeSet:
+    id: 383
+    author: camsaul
+    comment: Added 0.41.3 -- Add index to QueryExecution card_id + started_at to fix performance issue
+    changes:
+    - createIndex:
+        tableName: query_execution
+        indexName: idx_query_execution_card_id_started_at
+        columns:
+        - column: {name: card_id}
+        - column: {name: started_at}
+- changeSet:
+    id: v42.00-000
+    author: camsaul
+    comment: Added 0.42.0 Remove unused column (#5240)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = '317';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = '317';}
+    changes:
+    - dropColumn: {tableName: metabase_table, columnName: entity_name}
+- changeSet:
+    id: v42.00-001
+    author: camsaul
+    comment: Added 0.42.0 Attempt to add Card.database_id (by parsing query) to rows that are missing it (#5999)
+    validCheckSum: 8:9952153cbff16147bcb47b4a26e02089
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'postgresql,mysql,mariadb'}
+    changes:
+    - sql:
+        dbms: postgresql
+        sql: |-
+          WITH c2 AS (
+            SELECT *, (dataset_query::json->>'database')::integer AS query_database_id
+            FROM report_card
+          ) UPDATE report_card c SET database_id = c2.query_database_id FROM c2 INNER JOIN metabase_database db
+            ON db.id = c2.query_database_id
+          WHERE c.database_id IS NULL
+            AND c.id = c2.id
+            AND c2.query_database_id IS NOT NULL;
+    - sql:
+        dbms: mariadb
+        sql: |-
+          UPDATE report_card c JOIN (
+            SELECT *, cast(json_value(dataset_query, '$.database') AS signed) AS query_database_id
+            FROM report_card
+            ) c2
+            ON c.id = c2.id
+          INNER JOIN metabase_database db ON c2.query_database_id = db.id SET c.database_id = c2.query_database_id WHERE c.database_id IS NULL
+            AND c2.query_database_id IS NOT NULL;
+    - sql:
+        dbms: mysql
+        sql: |-
+          UPDATE report_card c JOIN (
+            SELECT *, cast(json_extract(dataset_query, '$.database') AS signed) AS query_database_id
+            FROM report_card
+            ) c2
+            ON c.id = c2.id
+          INNER JOIN metabase_database db ON c2.query_database_id = db.id SET c.database_id = c2.query_database_id WHERE c.database_id IS NULL
+            AND c2.query_database_id IS NOT NULL;
+- changeSet:
+    id: v42.00-002
+    author: camsaul
+    comment: Added 0.42.0 Added constraint we should have had all along (#5999)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onUpdateSQL: IGNORE}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM report_card WHERE database_id IS NULL}
+    changes:
+    - addNotNullConstraint: {columnDataType: int, tableName: report_card, columnName: database_id}
+- changeSet:
+    id: v42.00-003
+    author: dpsutton
+    comment: Added 0.42.0 Initial support for datasets based on questions
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = '320';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = '320';}
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: dataset
+            type: boolean
+            remarks: Indicate whether question is a dataset
+            constraints: {nullable: false}
+            defaultValue: false
+- changeSet:
+    id: v42.00-004
+    author: jeff303
+    comment: Added 0.42.0 - modify type of activity.details from text to ${text.type}
+    changes:
+    - modifyDataType: {tableName: activity, columnName: details, newDataType: '${text.type}'}
+- changeSet:
+    id: v42.00-005
+    author: jeff303
+    comment: Added 0.42.0 - modify type of collection.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: collection, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-006
+    author: jeff303
+    comment: Added 0.42.0 - modify type of collection.name from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: collection, columnName: name, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-007
+    author: jeff303
+    comment: Added 0.42.0 - modify type of computation_job.context from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: computation_job, columnName: context, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-008
+    author: jeff303
+    comment: Added 0.42.0 - modify type of computation_job_result.payload from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: computation_job_result, columnName: payload, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-009
+    author: jeff303
+    comment: Added 0.42.0 - modify type of core_session.anti_csrf_token from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: core_session, columnName: anti_csrf_token, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-010
+    author: jeff303
+    comment: Added 0.42.0 - modify type of core_user.login_attributes from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: core_user, columnName: login_attributes, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-011
+    author: jeff303
+    comment: Added 0.42.0 - modify type of group_table_access_policy.attribute_remappings from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: group_table_access_policy, columnName: attribute_remappings, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-012
+    author: jeff303
+    comment: Added 0.42.0 - modify type of login_history.device_description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: login_history, columnName: device_description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-013
+    author: jeff303
+    comment: Added 0.42.0 - modify type of login_history.ip_address from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: login_history, columnName: ip_address, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-014
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_database.caveats from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_database, columnName: caveats, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-015
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_database.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_database, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-016
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_database.details from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_database, columnName: details, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-017
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_database.options from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_database, columnName: options, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-018
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_database.points_of_interest from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_database, columnName: points_of_interest, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-019
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_field.caveats from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: caveats, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-020
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_field.database_type from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: database_type, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-021
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_field.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-022
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_field.fingerprint from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: fingerprint, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-023
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_field.has_field_values from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: has_field_values, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-024
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_field.points_of_interest from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: points_of_interest, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-025
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_field.settings from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: settings, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-026
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_fieldvalues.human_readable_values from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_fieldvalues, columnName: human_readable_values, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-027
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_fieldvalues.values from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_fieldvalues, columnName: values, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-028
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_table.caveats from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: caveats, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-029
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_table.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-030
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metabase_table.points_of_interest from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: points_of_interest, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-031
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metric.caveats from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metric, columnName: caveats, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-032
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metric.definition from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metric, columnName: definition, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-033
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metric.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metric, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-034
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metric.how_is_this_calculated from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metric, columnName: how_is_this_calculated, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-035
+    author: jeff303
+    comment: Added 0.42.0 - modify type of metric.points_of_interest from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metric, columnName: points_of_interest, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-036
+    author: jeff303
+    comment: Added 0.42.0 - modify type of moderation_review.text from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: moderation_review, columnName: text, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-037
+    author: jeff303
+    comment: Added 0.42.0 - modify type of native_query_snippet.content from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: native_query_snippet, columnName: content, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-038
+    author: jeff303
+    comment: Added 0.42.0 - modify type of native_query_snippet.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: native_query_snippet, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-039
+    author: jeff303
+    comment: Added 0.42.0 - modify type of pulse.parameters from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: pulse, columnName: parameters, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-040
+    author: jeff303
+    comment: Added 0.42.0 - modify type of pulse_channel.details from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: pulse_channel, columnName: details, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-041
+    author: jeff303
+    comment: Added 0.42.0 - modify type of query.query from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: query, columnName: query, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-042
+    author: jeff303
+    comment: Added 0.42.0 - modify type of query_execution.error from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: query_execution, columnName: error, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-043
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_card.dataset_query from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: dataset_query, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-044
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_card.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-045
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_card.embedding_params from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: embedding_params, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-046
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_card.result_metadata from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: result_metadata, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-047
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_card.visualization_settings from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: visualization_settings, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-048
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_dashboard.caveats from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboard, columnName: caveats, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-049
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_dashboard.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboard, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-050
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_dashboard.embedding_params from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboard, columnName: embedding_params, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-051
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_dashboard.parameters from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboard, columnName: parameters, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-052
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_dashboard.points_of_interest from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboard, columnName: points_of_interest, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-053
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_dashboardcard.parameter_mappings from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboardcard, columnName: parameter_mappings, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-054
+    author: jeff303
+    comment: Added 0.42.0 - modify type of report_dashboardcard.visualization_settings from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboardcard, columnName: visualization_settings, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-055
+    author: jeff303
+    comment: Added 0.42.0 - modify type of revision.message from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: revision, columnName: message, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-056
+    author: jeff303
+    comment: Added 0.42.0 - modify type of revision.object from text to ${text.type}
+    changes:
+    - modifyDataType: {tableName: revision, columnName: object, newDataType: '${text.type}'}
+- changeSet:
+    id: v42.00-057
+    author: jeff303
+    comment: Added 0.42.0 - modify type of segment.caveats from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: segment, columnName: caveats, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-058
+    author: jeff303
+    comment: Added 0.42.0 - modify type of segment.definition from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: segment, columnName: definition, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-059
+    author: jeff303
+    comment: Added 0.42.0 - modify type of segment.description from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: segment, columnName: description, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-060
+    author: jeff303
+    comment: Added 0.42.0 - modify type of segment.points_of_interest from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: segment, columnName: points_of_interest, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-061
+    author: jeff303
+    comment: Added 0.42.0 - modify type of setting.value from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: setting, columnName: value, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-062
+    author: jeff303
+    comment: Added 0.42.0 - modify type of task_history.task_details from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: task_history, columnName: task_details, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-063
+    author: jeff303
+    comment: Added 0.42.0 - modify type of view_log.metadata from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: view_log, columnName: metadata, newDataType: '${text.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v42.00-064
+    author: jeff303
+    comment: 'Added 0.42.0 - fix type of query_cache.results on upgrade (in case changeSet 97 was run before #16095)'
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - modifyDataType: {tableName: query_cache, columnName: results, newDataType: longblob}
+- changeSet:
+    id: v42.00-065
+    author: dpsutton
+    comment: Added 0.42.0 - Another modal dismissed state on user. Retaining the same suffix and boolean style to ease an eventual migration.
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column:
+            name: is_datasetnewb
+            type: boolean
+            remarks: Boolean flag to indicate if the dataset info modal has been dismissed.
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+- changeSet:
+    id: v42.00-066
+    author: noahmoss
+    comment: Added 0.42.0 - new columns for initial DB sync progress UX. Indicates whether a database has succesfully synced at least one time.
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: initial_sync_status
+            type: varchar(32)
+            remarks: String indicating whether a database has completed its initial sync and is ready to use
+            defaultValue: complete
+            constraints: {nullable: false}
+- changeSet:
+    id: v42.00-067
+    author: noahmoss
+    comment: Added 0.42.0 - new columns for initial DB sync progress UX. Indicates whether a table has succesfully synced at least one time.
+    changes:
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column:
+            name: initial_sync_status
+            type: varchar(32)
+            remarks: String indicating whether a table has completed its initial sync and is ready to use
+            defaultValue: complete
+            constraints: {nullable: false}
+- changeSet:
+    id: v42.00-068
+    author: noahmoss
+    comment: Added 0.42.0 - new columns for initial DB sync progress UX. Records the ID of the admin who added a database. May be null for the sample dataset, or for databases added prior to 0.42.0.
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: creator_id
+            type: int
+            remarks: ID of the admin who added the database
+            constraints: {nullable: true}
+- changeSet:
+    id: v42.00-069
+    author: noahmoss
+    comment: Added 0.42.0 - adds FK constraint for creator_id column, containing the ID of the admin who added a database.
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metabase_database, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_database_creator_id, onDelete: SET NULL}
+- changeSet:
+    id: v42.00-070
+    author: camsaul
+    comment: Added 0.42.0 - add Database.settings column to implement Database-local Settings
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: metabase_database, columnName: settings}
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: settings, type: '${text.type}', remarks: Serialized JSON containing Database-local Settings for this Database}
+- changeSet:
+    id: v42.00-071
+    author: noahmoss
+    comment: Added 0.42.0 - migrates the Sample Dataset to the name "Sample Database"
+    changes:
+    - sql: {sql: UPDATE metabase_database SET name='Sample Database' WHERE is_sample=true}
+- changeSet:
+    id: v43.00-001
+    author: jeff303
+    comment: Added 0.43.0 - migrates any Database using the old bigquery driver to bigquery-cloud-sdk instead
+    changes:
+    - sql: {sql: UPDATE metabase_database SET engine = 'bigquery-cloud-sdk' WHERE engine = 'bigquery'}
+- changeSet:
+    id: v43.00-002
+    author: camsaul
+    comment: Added 0.43.0. Create magic 'All Users' Permissions Group if it does not already exist.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM permissions_group WHERE name = 'All Users';}
+    changes:
+    - sql: {sql: INSERT INTO permissions_group (name) VALUES ('All Users')}
+- changeSet:
+    id: v43.00-003
+    author: camsaul
+    comment: Added 0.43.0. Create magic 'Administrators' Permissions Group if it does not already exist.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM permissions_group WHERE name = 'Administrators';}
+    changes:
+    - sql: {sql: INSERT INTO permissions_group (name) VALUES ('Administrators')}
+- changeSet:
+    id: v43.00-004
+    author: camsaul
+    comment: Added 0.43.0. Add existing Users to 'All Users' magic Permissions Group if needed.
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions_group_membership (user_id, group_id) SELECT
+            u.id AS user_id,
+            all_users_group.id AS group_id
+            FROM core_user u
+            LEFT JOIN (
+              SELECT *
+              FROM permissions_group
+              WHERE name = 'All Users'
+            ) all_users_group
+              ON true
+            LEFT JOIN permissions_group_membership pgm
+                   ON u.id = pgm.user_id
+                  AND all_users_group.id = pgm.group_id
+            WHERE pgm.id IS NULL;
+- changeSet:
+    id: v43.00-005
+    author: camsaul
+    comment: Added 0.43.0. Add existing Users with 'is_superuser' flag to 'Administrators' magic Permissions Group if needed.
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions_group_membership (user_id, group_id) SELECT
+            u.id AS user_id,
+            admin_group.id AS group_id
+            FROM core_user u
+            LEFT JOIN (
+              SELECT *
+              FROM permissions_group
+              WHERE name = 'Administrators'
+            ) admin_group
+              ON true
+            LEFT JOIN permissions_group_membership pgm
+                   ON u.id = pgm.user_id
+                  AND admin_group.id = pgm.group_id
+            WHERE u.is_superuser = true
+              AND pgm.id IS NULL;
+- changeSet:
+    id: v43.00-006
+    author: camsaul
+    comment: Added 0.43.0. Create root '/' permissions entry for the 'Administrators' magic Permissions Group if needed.
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions (group_id, object) SELECT
+            admin_group.id AS group_id,
+            '/' AS object
+          FROM (
+            SELECT id
+            FROM permissions_group
+            WHERE name = 'Administrators'
+          ) admin_group LEFT JOIN permissions p
+                 ON admin_group.id = p.group_id
+                AND p.object = '/'
+          WHERE p.object IS NULL;
+- changeSet:
+    id: v43.00-007
+    author: camsaul
+    comment: Added 0.43.0. Grant permissions for existing Databases to 'All Users' permissions group.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-databases-to-magic-permissions-groups';}
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions (object, group_id) SELECT db.object, all_users.id AS group_id FROM (
+            SELECT concat('/db/', id, '/') AS object
+            FROM metabase_database
+          ) db LEFT JOIN (
+            SELECT id
+            FROM permissions_group
+            WHERE name = 'All Users'
+          ) all_users
+            ON true
+          LEFT JOIN permissions p
+                 ON p.group_id = all_users.id
+                AND db.object = p.object
+          WHERE p.object IS NULL;
+- changeSet:
+    id: v43.00-008
+    author: camsaul
+    comment: Added 0.43.0. Migrate legacy '-site-url' Setting to 'site-url'. Trim trailing slashes.
+    validCheckSum: ANY
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: postgresql}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE key = 'site-url';}
+      - and:
+        - dbms: {type: h2}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE "KEY" = 'site-url';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE `key` = 'site-url';}
+    changes:
+    - sql:
+        dbms: h2
+        sql: |-
+          INSERT INTO setting ("KEY", "VALUE") SELECT
+            'site-url' AS "KEY",
+            regexp_replace("VALUE", '/$', '') AS "VALUE"
+          FROM setting WHERE "KEY" = '-site-url';
+    - sql:
+        dbms: postgresql
+        sql: |-
+          INSERT INTO setting (key, value) SELECT
+            'site-url' AS key,
+            regexp_replace(value, '/$', '') AS value
+          FROM setting WHERE key = '-site-url';
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          INSERT INTO setting (`key`, value) SELECT
+            'site-url' AS `key`,
+            CASE
+              WHEN value LIKE '%/'
+                THEN substring(value, 1, length(value) - 1)
+              ELSE
+                value
+              END
+            AS value
+          FROM setting WHERE `key` = '-site-url';
+- changeSet:
+    id: v43.00-009
+    author: camsaul
+    comment: Added 0.43.0. Make sure 'site-url' Setting includes protocol.
+    validCheckSum: ANY
+    changes:
+    - sql:
+        dbms: postgresql
+        sql: |-
+          UPDATE setting SET value = concat('http://', value) WHERE key = 'site-url'
+            AND value NOT LIKE 'http%';
+    - sql:
+        dbms: h2
+        sql: |-
+          UPDATE setting SET "VALUE" = concat('http://', "VALUE") WHERE "KEY" = 'site-url'
+            AND "VALUE" NOT LIKE 'http%';
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE setting SET value = concat('http://', value) WHERE `key` = 'site-url'
+            AND value NOT LIKE 'http%';
+- changeSet:
+    id: v43.00-010
+    author: camsaul
+    comment: Added 0.43.0. Migrates value of legacy enable-advanced-humanization Setting to humanization-strategy Setting added in 0.28.0.
+    validCheckSum: ANY
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: postgresql}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE key = 'humanization-strategy';}
+      - and:
+        - dbms: {type: h2}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE "KEY" = 'humanization-strategy';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE `key` = 'humanization-strategy';}
+    changes:
+    - sql:
+        dbms: postgresql
+        sql: |-
+          INSERT INTO setting (key, value) SELECT
+            'humanization-strategy'                                      AS key,
+            (CASE WHEN value = 'true' THEN 'advanced' ELSE 'simple' END) AS value
+          FROM setting WHERE key = 'enable-advanced-humanization';
+    - sql:
+        dbms: h2
+        sql: |-
+          INSERT INTO setting ("KEY", "VALUE") SELECT
+            'humanization-strategy'                                      AS "KEY",
+            (CASE WHEN "VALUE" = 'true' THEN 'advanced' ELSE 'simple' END) AS "VALUE"
+          FROM setting WHERE "KEY" = 'enable-advanced-humanization';
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          INSERT INTO setting (`key`, value) SELECT
+            'humanization-strategy'                                      AS `key`,
+            (CASE WHEN value = 'true' THEN 'advanced' ELSE 'simple' END) AS value
+          FROM setting WHERE `key` = 'enable-advanced-humanization';
+- changeSet:
+    id: v43.00-011
+    author: camsaul
+    comment: Added 0.43.0. Remove legacy enable-advanced-humanization Setting.
+    validCheckSum: ANY
+    changes:
+    - sql: {dbms: postgresql, sql: DELETE FROM setting WHERE key = 'enable-advanced-humanization';}
+    - sql: {dbms: h2, sql: DELETE FROM setting WHERE "KEY" = 'enable-advanced-humanization';}
+    - sql: {dbms: 'mysql,mariadb', sql: DELETE FROM setting WHERE `key` = 'enable-advanced-humanization';}
+- changeSet:
+    id: v43.00-012
+    author: camsaul
+    comment: Added 0.43.0. Set Field.has_field_values to 'list' if semantic_type derives from :type/Category.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'mark-category-fields-as-list';}
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field SET has_field_values = 'list' WHERE has_field_values IS NULL
+            AND active = true
+            AND semantic_type IN (
+              'type/Category',
+              'type/City',
+              'type/Company',
+              'type/Country',
+              'type/Name',
+              'type/Product',
+              'type/Source',
+              'type/State',
+              'type/Subscription',
+              'type/Title'
+            );
+- changeSet:
+    id: v43.00-014
+    author: camsaul
+    comment: Added 0.43.0. Add 'Migrated Dashboards' Collection if needed and there are any Dashboards not in a Collection.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - and:
+      - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-migrated-collections';}
+      - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM collection WHERE name = 'Migrated Dashboards';}
+      - not:
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM report_dashboard WHERE collection_id IS NULL;}
+    changes:
+    - sql: {sql: 'INSERT INTO collection (name, color, slug) VALUES (''Migrated Dashboards'', ''#509ee3'', ''migrated_dashboards'');'}
+- changeSet:
+    id: v43.00-015
+    author: camsaul
+    comment: Added 0.43.0. Add 'Migrated Pulses' Collection if needed and there are any Pulses not in a Collection.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - and:
+      - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-migrated-collections';}
+      - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM collection WHERE name = 'Migrated Pulses';}
+      - not:
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM pulse WHERE collection_id IS NULL;}
+    changes:
+    - sql: {sql: 'INSERT INTO collection (name, color, slug) VALUES (''Migrated Pulses'', ''#509ee3'', ''migrated_pulses'');'}
+- changeSet:
+    id: v43.00-016
+    author: camsaul
+    comment: Added 0.43.0. Add 'Migrated Questions' Collection if needed and there are any Cards not in a Collection.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - and:
+      - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-migrated-collections';}
+      - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM collection WHERE name = 'Migrated Questions';}
+      - not:
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM report_card WHERE collection_id IS NULL;}
+    changes:
+    - sql: {sql: 'INSERT INTO collection (name, color, slug) VALUES (''Migrated Questions'', ''#509ee3'', ''migrated_questions'');'}
+- changeSet:
+    id: v43.00-017
+    author: camsaul
+    comment: Added 0.43.0. Move Dashboards not in a Collection to 'Migrated Dashboards'.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-migrated-collections';}
+    changes:
+    - sql: {sql: UPDATE report_dashboard SET collection_id = (SELECT id FROM collection WHERE name = 'Migrated Dashboards') WHERE collection_id IS NULL;}
+- changeSet:
+    id: v43.00-018
+    author: camsaul
+    comment: Added 0.43.0. Move Pulses not in a Collection to 'Migrated Pulses'.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-migrated-collections';}
+    changes:
+    - sql: {sql: UPDATE pulse SET collection_id = (SELECT id FROM collection WHERE name = 'Migrated Pulses') WHERE collection_id IS NULL;}
+- changeSet:
+    id: v43.00-019
+    author: camsaul
+    comment: Added 0.43.0. Move Cards not in a Collection to 'Migrated Questions'.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-migrated-collections';}
+    changes:
+    - sql: {sql: UPDATE report_card SET collection_id = (SELECT id FROM collection WHERE name = 'Migrated Questions') WHERE collection_id IS NULL;}
+- changeSet:
+    id: v43.00-020
+    author: camsaul
+    comment: Added 0.43.0. Grant the 'All Users' Permissions Group readwrite perms for the Root Collection.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - and:
+      - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'add-migrated-collections';}
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions (group_id, object) SELECT
+            all_users_group.id AS group_id,
+            '/collection/root/' AS object
+          FROM (
+            SELECT id
+            FROM permissions_group
+            WHERE name = 'All Users'
+          ) all_users_group LEFT JOIN permissions p
+                 ON all_users_group.id = p.group_id
+                AND p.object = '/collection/root/'
+          WHERE p.object IS NULL;
+- changeSet:
+    id: v43.00-021
+    author: adam-james
+    comment: Added 0.43.0 - Timeline table for Events
+    changes:
+    - createTable:
+        tableName: timeline
+        remarks: Timeline table to organize events
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+        - column:
+            remarks: Name of the timeline
+            name: name
+            type: varchar(255)
+            constraints: {nullable: false}
+        - column:
+            remarks: Optional description of the timeline
+            name: description
+            type: varchar(255)
+            constraints: {nullable: true}
+        - column:
+            name: icon
+            type: varchar(128)
+            constraints: {nullable: true}
+            remarks: the icon to use when displaying the event
+        - column:
+            remarks: ID of the collection containing the timeline
+            name: collection_id
+            type: int
+            constraints: {nullable: true, references: collection(id), foreignKeyName: fk_timeline_collection_id, deleteCascade: true}
+        - column:
+            remarks: Whether or not the timeline has been archived
+            name: archived
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        - column:
+            remarks: ID of the user who created the timeline
+            name: creator_id
+            type: int
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_timeline_creator_id, deleteCascade: true}
+        - column:
+            remarks: The timestamp of when the timeline was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the timeline was updated
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v43.00-022
+    author: adam-james
+    comment: Added 0.43.0 - Events table
+    changes:
+    - createTable:
+        tableName: timeline_event
+        remarks: Events table
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {nullable: false, primaryKey: true}
+        - column:
+            remarks: ID of the timeline containing the event
+            name: timeline_id
+            type: int
+            constraints: {nullable: false, references: timeline(id), foreignKeyName: fk_events_timeline_id, deleteCascade: true}
+        - column:
+            remarks: Name of the event
+            name: name
+            type: varchar(255)
+            constraints: {nullable: false}
+        - column:
+            remarks: Optional markdown description of the event
+            name: description
+            type: varchar(255)
+            constraints: {nullable: true}
+        - column:
+            name: timestamp
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+            remarks: When the event happened
+        - column:
+            name: time_matters
+            type: boolean
+            constraints: {nullable: false}
+            remarks: Indicate whether the time component matters or if the timestamp should just serve to indicate the day of the event without any time associated to it.
+        - column:
+            name: timezone
+            constraints: {nullable: false}
+            type: varchar(255)
+            remarks: Timezone to display the underlying UTC timestamp in for the client
+        - column:
+            name: icon
+            type: varchar(128)
+            constraints: {nullable: true}
+            remarks: the icon to use when displaying the event
+        - column:
+            remarks: Whether or not the event has been archived
+            name: archived
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        - column:
+            remarks: ID of the user who created the event
+            name: creator_id
+            type: int
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_event_creator_id, deleteCascade: true}
+        - column:
+            remarks: The timestamp of when the event was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the event was modified
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v43.00-023
+    author: dpsutton
+    comment: Added 0.43.0 - Index on timeline collection_id
+    changes:
+    - createIndex:
+        tableName: timeline
+        indexName: idx_timeline_collection_id
+        columns:
+        - column: {name: collection_id}
+- changeSet:
+    id: v43.00-024
+    author: dpsutton
+    comment: Added 0.43.0 - Index on timeline_event timeline_id
+    changes:
+    - createIndex:
+        tableName: timeline_event
+        indexName: idx_timeline_event_timeline_id
+        columns:
+        - column: {name: timeline_id}
+- changeSet:
+    id: v43.00-025
+    author: dpsutton
+    comment: Added 0.43.0 - Index on timeline timestamp
+    changes:
+    - createIndex:
+        tableName: timeline_event
+        indexName: idx_timeline_event_timeline_id_timestamp
+        columns:
+        - column: {name: timeline_id}
+        - column: {name: timestamp}
+- changeSet:
+    id: v43.00-026
+    author: noahmoss
+    comment: Added 0.43.0 - adds User.settings column to implement User-local Settings
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column: {name: settings, type: '${text.type}', remarks: Serialized JSON containing User-local Settings for this User}
+- changeSet:
+    id: v43.00-027
+    author: camsaul
+    comment: Added 0.43.0. Drop NOT NULL constraint for core_user.password
+    changes:
+    - dropNotNullConstraint: {tableName: core_user, columnName: password, columnDataType: varchar(254)}
+- changeSet:
+    id: v43.00-028
+    author: camsaul
+    comment: Added 0.43.0. Drop NOT NULL constraint for core_user.password_salt
+    changes:
+    - dropNotNullConstraint: {tableName: core_user, columnName: password_salt, columnDataType: varchar(254)}
+- changeSet:
+    id: v43.00-029
+    author: camsaul
+    comment: Added 0.43.0. Clear local password for Users using LDAP auth.
+    changes:
+    - sql:
+        sql: |-
+          UPDATE core_user SET
+            password = NULL,
+            password_salt = NULL
+          WHERE ldap_auth IS TRUE;
+- changeSet:
+    id: v43.00-030
+    author: dpsutton
+    comment: Added 0.43.0 - Dashboard bookmarks table
+    changes:
+    - createTable:
+        tableName: dashboard_bookmark
+        remarks: Table holding bookmarks on dashboards
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: ID of the User who bookmarked the Dashboard
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_dashboard_bookmark_user_id, deleteCascade: true}
+        - column:
+            name: dashboard_id
+            type: int
+            remarks: ID of the Dashboard bookmarked by the user
+            constraints: {nullable: false, references: report_dashboard(id), foreignKeyName: fk_dashboard_bookmark_dashboard_id, deleteCascade: true}
+        - column:
+            remarks: The timestamp of when the bookmark was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v43.00-031
+    author: dpsutton
+    comment: Added 0.43.0 - Dashboard bookmarks table unique constraint
+    changes:
+    - addUniqueConstraint: {tableName: dashboard_bookmark, columnNames: 'user_id, dashboard_id', constraintName: unique_dashboard_bookmark_user_id_dashboard_id}
+- changeSet:
+    id: v43.00-032
+    author: dpsutton
+    comment: Added 0.43.0 - Dashboard bookmarks table index on user_id
+    changes:
+    - createIndex:
+        tableName: dashboard_bookmark
+        columns:
+        - column: {name: user_id}
+        indexName: idx_dashboard_bookmark_user_id
+- changeSet:
+    id: v43.00-033
+    author: dpsutton
+    comment: Added 0.43.0 - Dashboard bookmarks table index on dashboard_id
+    changes:
+    - createIndex:
+        tableName: dashboard_bookmark
+        columns:
+        - column: {name: dashboard_id}
+        indexName: idx_dashboard_bookmark_dashboard_id
+- changeSet:
+    id: v43.00-034
+    author: dpsutton
+    comment: Added 0.43.0 - Card bookmarks table
+    changes:
+    - createTable:
+        tableName: card_bookmark
+        remarks: Table holding bookmarks on cards
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: ID of the User who bookmarked the Card
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_card_bookmark_user_id, deleteCascade: true}
+        - column:
+            name: card_id
+            type: int
+            remarks: ID of the Card bookmarked by the user
+            constraints: {nullable: false, references: report_card(id), foreignKeyName: fk_card_bookmark_dashboard_id, deleteCascade: true}
+        - column:
+            remarks: The timestamp of when the bookmark was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v43.00-035
+    author: dpsutton
+    comment: Added 0.43.0 - Card bookmarks table unique constraint
+    changes:
+    - addUniqueConstraint: {tableName: card_bookmark, columnNames: 'user_id, card_id', constraintName: unique_card_bookmark_user_id_card_id}
+- changeSet:
+    id: v43.00-036
+    author: dpsutton
+    comment: Added 0.43.0 - Card bookmarks table index on user_id
+    changes:
+    - createIndex:
+        tableName: card_bookmark
+        columns:
+        - column: {name: user_id}
+        indexName: idx_card_bookmark_user_id
+- changeSet:
+    id: v43.00-037
+    author: dpsutton
+    comment: Added 0.43.0 - Card bookmarks table index on card_id
+    changes:
+    - createIndex:
+        tableName: card_bookmark
+        columns:
+        - column: {name: card_id}
+        indexName: idx_card_bookmark_card_id
+- changeSet:
+    id: v43.00-038
+    author: dpsutton
+    comment: Added 0.43.0 - Collection bookmarks table
+    changes:
+    - createTable:
+        tableName: collection_bookmark
+        remarks: Table holding bookmarks on collections
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: ID of the User who bookmarked the Collection
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_collection_bookmark_user_id, deleteCascade: true}
+        - column:
+            name: collection_id
+            type: int
+            remarks: ID of the Card bookmarked by the user
+            constraints: {nullable: false, references: collection(id), foreignKeyName: fk_collection_bookmark_collection_id, deleteCascade: true}
+        - column:
+            remarks: The timestamp of when the bookmark was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v43.00-039
+    author: dpsutton
+    comment: Added 0.43.0 - Collection bookmarks table unique constraint
+    changes:
+    - addUniqueConstraint: {tableName: collection_bookmark, columnNames: 'user_id, collection_id', constraintName: unique_collection_bookmark_user_id_collection_id}
+- changeSet:
+    id: v43.00-040
+    author: dpsutton
+    comment: Added 0.43.0 - Collection bookmarks table index on user_id
+    changes:
+    - createIndex:
+        tableName: collection_bookmark
+        columns:
+        - column: {name: user_id}
+        indexName: idx_collection_bookmark_user_id
+- changeSet:
+    id: v43.00-041
+    author: dpsutton
+    comment: Added 0.43.0 - Collection bookmarks table index on collection_id
+    changes:
+    - createIndex:
+        tableName: collection_bookmark
+        columns:
+        - column: {name: collection_id}
+        indexName: idx_collection_bookmark_collection_id
+- changeSet:
+    id: v43.00-042
+    author: noahmoss
+    comment: Added 0.43.0. Grant download permissions for existing Databases to 'All Users' permissions group
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions (object, group_id) SELECT db.object, all_users.id AS group_id FROM (
+            SELECT concat('/download/db/', id, '/') AS object
+            FROM metabase_database
+          ) db LEFT JOIN (
+            SELECT id
+            FROM permissions_group
+            WHERE name = 'All Users'
+          ) all_users
+            ON true
+          LEFT JOIN permissions p
+                 ON p.group_id = all_users.id
+                AND db.object = p.object
+          WHERE p.object IS NULL;
+- changeSet:
+    id: v43.00-043
+    author: howonlee
+    comment: Added 0.43.0 - Nested field columns in fields
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Nested field column paths, flattened
+            name: nfc_path
+            type: varchar(254)
+            constraints: {nullable: true}
+        tableName: metabase_field
+- changeSet:
+    id: v43.00-044
+    author: noahmoss
+    comment: Added 0.43.0 - Removes MetaBot permissions group
+    changes:
+    - sql: {sql: DELETE FROM permissions_group WHERE name = 'MetaBot'}
+- changeSet:
+    id: v43.00-046
+    author: qnkhuat
+    comment: Added 0.43.0 - create General Permission Revision table
+    changes:
+    - createTable:
+        tableName: general_permissions_revision
+        remarks: Used to keep track of changes made to general permissions.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: before
+            type: ${text.type}
+            remarks: Serialized JSON of the permission graph before the changes.
+            constraints: {nullable: false}
+        - column:
+            name: after
+            type: ${text.type}
+            remarks: Serialized JSON of the changes in permission graph.
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The ID of the admin who made this set of changes.
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_general_permissions_revision_user_id}
+        - column:
+            name: created_at
+            type: datetime
+            remarks: The timestamp of when these changes were made.
+            constraints: {nullable: false}
+        - column: {name: remark, type: '${text.type}', remarks: Optional remarks explaining why these changes were made.}
+- changeSet:
+    id: v43.00-047
+    author: qnkhuat
+    comment: Added 0.43.0. Grant the 'All Users' Group permissions to create/edit subscriptions and alerts
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions (group_id, object) SELECT
+            all_users_group.id AS group_id,
+            '/general/subscription/' AS object
+          FROM (
+            SELECT id
+            FROM permissions_group
+            WHERE name = 'All Users'
+          ) all_users_group LEFT JOIN permissions p
+            ON all_users_group.id = p.group_id
+            AND p.object = '/general/subscription/'
+          WHERE p.object IS NULL;
+- changeSet:
+    id: v43.00-049
+    author: dpsutton
+    comment: Added 0.43.0 - Unify datatype with query_execution.started_at so comparable (see 168).
+    changes:
+    - modifyDataType: {tableName: view_log, columnName: timestamp, newDataType: '${timestamp_type}'}
+- changeSet:
+    id: v43.00-050
+    author: qnkhuat
+    comment: Added 0.43.0. Add permissions_group_membership.is_group_manager
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Boolean flag to indicate whether user is a group's manager.
+            name: is_group_manager
+            type: boolean
+            constraints: {nullable: false}
+            defaultValue: false
+        tableName: permissions_group_membership
+- changeSet:
+    id: v43.00-051
+    author: adam-james
+    comment: Added 0.43.0 - default boolean on timelines to indicate default timeline for a collection
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Boolean value indicating if the timeline is the default one for the containing Collection
+            name: default
+            type: boolean
+            defaultValue: false
+            constraints: {nullable: false}
+        tableName: timeline
+- changeSet:
+    id: v43.00-052
+    author: snoe
+    comment: Added 0.43.0 - bookmark ordering
+    changes:
+    - createTable:
+        tableName: bookmark_ordering
+        remarks: Table holding ordering information for various bookmark tables
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: ID of the User who ordered bookmarks
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_bookmark_ordering_user_id, deleteCascade: true}
+        - column:
+            name: type
+            type: varchar(255)
+            remarks: type of the Bookmark
+            constraints: {nullable: false}
+        - column:
+            name: item_id
+            type: int
+            remarks: id of the item being bookmarked (Card, Collection, Dashboard, ...) no FK, so may no longer exist
+            constraints: {nullable: false}
+        - column:
+            name: ordering
+            type: int
+            remarks: order of bookmark for user
+            constraints: {nullable: false}
+- changeSet:
+    id: v43.00-053
+    author: snoe
+    comment: Added 0.43.0 - bookmark ordering
+    changes:
+    - addUniqueConstraint: {tableName: bookmark_ordering, columnNames: 'user_id, type, item_id', constraintName: unique_bookmark_user_id_type_item_id}
+- changeSet:
+    id: v43.00-054
+    author: snoe
+    comment: Added 0.43.0 - bookmark ordering
+    changes:
+    - addUniqueConstraint: {tableName: bookmark_ordering, columnNames: 'user_id, ordering', constraintName: unique_bookmark_user_id_ordering}
+- changeSet:
+    id: v43.00-055
+    author: snoe
+    comment: Added 0.43.0 - bookmark ordering
+    changes:
+    - createIndex:
+        tableName: bookmark_ordering
+        columns:
+        - column: {name: user_id}
+        indexName: idx_bookmark_ordering_user_id
+- changeSet:
+    id: v43.00-056
+    author: qnkhuat
+    comment: Added 0.43.0 - Rename general permission revision table It's safe to rename this table without breaking downgrades compatibility because this table was also added in 0.43.0.
+    changes:
+    - renameTable: {oldTableName: general_permissions_revision, newTableName: application_permissions_revision}
+- changeSet:
+    id: v43.00-057
+    author: qnkhuat
+    comment: Added 0.43.0 - Rename general_permissions_revision_id_seq
+    failOnError: false
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: postgresql}
+    changes:
+    - sql:
+      - {sql: ALTER SEQUENCE general_permissions_revision_id_seq RENAME TO application_permissions_revision_id_seq;}
+- changeSet:
+    id: v43.00-058
+    author: qnkhuat
+    comment: Added 0.43.0 - Rename general permissios to application permissions
+    changes:
+    - sql: {sql: 'UPDATE permissions SET object = REPLACE(object, ''/general/'', ''/application/'') WHERE object LIKE ''/general/%'';'}
+- changeSet:
+    id: v43.00-059
+    author: adam-james
+    comment: Added 0.43.0 - disallow nil timeline icons
+    changes:
+    - addNotNullConstraint: {columnDataType: varchar(128), tableName: timeline, columnName: icon, defaultNullValue: star}
+- changeSet:
+    id: v43.00-060
+    author: adam-james
+    comment: Added 0.43.0 - disallow nil timeline event icons
+    changes:
+    - addNotNullConstraint: {columnDataType: varchar(128), tableName: timeline_event, columnName: icon, defaultNullValue: star}
+- changeSet:
+    id: v43.00-062
+    author: snoe
+    comment: Added 0.43.0 - Unify datatype with revision.timestamp for timezone info (see 17829).
+    changes:
+    - modifyDataType: {tableName: revision, columnName: timestamp, newDataType: '${timestamp_type}'}
+- changeSet:
+    id: v44.00-000
+    author: dpsutton
+    comment: Added 0.44.0 - Persisted Info for models
+    changes:
+    - createTable:
+        tableName: persisted_info
+        remarks: Table holding information about persisted models
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: database_id
+            type: int
+            remarks: ID of the database associated to the persisted card
+            constraints: {nullable: false, referencedTableName: metabase_database, referencedColumnNames: id, foreignKeyName: fk_persisted_info_database_id, deleteCascade: true}
+        - column:
+            name: card_id
+            type: int
+            remarks: ID of the Card model persisted
+            constraints: {nullable: false, unique: true, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_persisted_info_card_id, deleteCascade: true}
+        - column:
+            remarks: Slug of the card which will form the persisted table name
+            name: question_slug
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            remarks: Name of the table persisted
+            name: table_name
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            remarks: JSON object that captures the state of the table when we persisted
+            name: definition
+            type: ${text.type}
+            constraints: {nullable: true}
+        - column:
+            remarks: Hash of the query persisted
+            name: query_hash
+            type: ${text.type}
+            constraints: {nullable: true}
+        - column:
+            remarks: Indicating whether the persisted table is active and can be swapped
+            name: active
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        - column:
+            remarks: Persisted table state (creating, persisted, refreshing, deleted)
+            name: state
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the most recent refresh was started
+            name: refresh_begin
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the most recent refresh ended
+            name: refresh_end
+            type: ${timestamp_type}
+            constraints: {nullable: true}
+        - column:
+            remarks: The timestamp of when the most recent state changed
+            name: state_change_at
+            type: ${timestamp_type}
+            constraints: {nullable: true}
+        - column:
+            remarks: Error message from persisting if applicable
+            name: error
+            type: ${text.type}
+            constraints: {nullable: true}
+        - column:
+            remarks: The timestamp of when the model was first persisted
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: creator_id
+            type: int
+            remarks: The person who persisted a model
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_persisted_info_ref_creator_id, deferrable: false, initiallyDeferred: false}
+- changeSet:
+    id: v44.00-001
+    author: snoe
+    comment: Added 0.44.0 - Remove not null constraint from persisted_info.creator_id
+    changes:
+    - dropNotNullConstraint: {tableName: persisted_info, columnName: creator_id, columnDataType: int}
+- changeSet:
+    id: v44.00-002
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: metric
+- changeSet:
+    id: v44.00-003
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: segment
+- changeSet:
+    id: v44.00-004
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: collection
+- changeSet:
+    id: v44.00-005
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: report_dashboard
+- changeSet:
+    id: v44.00-006
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: dimension
+- changeSet:
+    id: v44.00-007
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: pulse
+- changeSet:
+    id: v44.00-008
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: report_card
+- changeSet:
+    id: v44.00-009
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: native_query_snippet
+- changeSet:
+    id: v44.00-010
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: timeline
+- changeSet:
+    id: v44.00-011
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to all internal entities
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: report_dashboardcard
+- changeSet:
+    id: v44.00-023
+    author: qnkhuat
+    comment: Added 0.44.0 - Add parameters to report_card
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: parameters
+            type: ${text.type}
+            remarks: List of parameter associated to a card
+            constraints: {nullable: true}
+- changeSet:
+    id: v44.00-025
+    author: qnkhuat
+    comment: Added 0.44.0 - Add parameter_mappings to report_card
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: parameter_mappings
+            type: ${text.type}
+            remarks: List of parameter associated to a card
+            constraints: {nullable: true}
+- changeSet:
+    id: v44.00-027
+    author: adam-james
+    comment: Added 0.44.0. Drop NOT NULL constraint for core_user.first_name
+    changes:
+    - dropNotNullConstraint: {tableName: core_user, columnName: first_name, columnDataType: varchar(254)}
+- changeSet:
+    id: v44.00-028
+    author: adam-james
+    comment: Added 0.44.0. Drop NOT NULL constraint for core_user.last_name
+    changes:
+    - dropNotNullConstraint: {tableName: core_user, columnName: last_name, columnDataType: varchar(254)}
+- changeSet:
+    id: v44.00-029
+    author: qnkhuat
+    comment: Added 0.44.0 - Add has_more_values to metabase_fieldvalues
+    changes:
+    - addColumn:
+        tableName: metabase_fieldvalues
+        columns:
+        - column: {name: has_more_values, type: boolean, remarks: true if the stored values list is a subset of all possible values, defaultValueBoolean: false}
+- changeSet:
+    id: v44.00-030
+    author: snoe
+    comment: Added 0.44.0 - Add database_required to metabase_field
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: database_required
+            type: boolean
+            remarks: Indicates this field is required by the database for new records. Usually not null and without a default.
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: v44.00-033
+    author: qnkhuat
+    comment: Added 0.43.0. Grant the 'All Users' Permissions Group readwrite perms for the Root Snippets Collection.
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) AS user_count FROM core_user}
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO permissions (group_id, object) SELECT
+            all_users_group.id AS group_id,
+            '/collection/namespace/snippets/root/' AS object
+          FROM (
+            SELECT id
+            FROM permissions_group
+            WHERE name = 'All Users'
+          ) all_users_group LEFT JOIN permissions p
+                  ON all_users_group.id = p.group_id
+                AND p.object = '/collection/namespace/snippets/root/'
+          WHERE p.object IS NULL;
+- changeSet:
+    id: v44.00-035
+    author: qnkhuat
+    comment: Added 0.44.0. Add type to fieldvalues
+    validCheckSum: ANY
+    changes:
+    - addColumn:
+        tableName: metabase_fieldvalues
+        columns:
+        - column:
+            name: type
+            type: varchar(32)
+            defaultValue: full
+            remarks: Type of FieldValues
+            constraints: {nullable: false}
+- changeSet:
+    id: v44.00-037
+    author: qnkhuat
+    comment: Added 0.44.0. Add type to fieldvalues
+    changes:
+    - addColumn:
+        tableName: metabase_fieldvalues
+        columns:
+        - column:
+            name: hash_key
+            type: ${text.type}
+            remarks: Hash key for a cached fieldvalues
+            constraints: {nullable: true}
+- changeSet:
+    id: v44.00-038
+    author: metamben
+    comment: Added 0.44.0 - Add collection_preview to report_card
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: collection_preview
+            type: boolean
+            remarks: Indicating whether the card should be visualized in the collection preview
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+- changeSet:
+    id: v44.00-039
+    author: qnkhuat
+    comment: Added 0.44.0 - Add template_tags to native_query_snippet
+    changes:
+    - addColumn:
+        tableName: native_query_snippet
+        columns:
+        - column:
+            name: template_tags
+            type: ${text.type}
+            remarks: Template tags for a snippet
+            constraints: {nullable: true}
+- changeSet:
+    id: v44.00-041
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to PulseCard, PulseChannel
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: pulse_card
+- changeSet:
+    id: v44.00-042
+    author: braden
+    comment: Added 0.44.0 - add entity_id column to PulseCard, PulseChannel
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: pulse_channel
+- changeSet:
+    id: v44.00-044
+    author: qnkhuat
+    comment: Added 0.44.0 - drop native_query_snippet.template_tags added in v44.00-039
+    changes:
+    - dropColumn: {tableName: native_query_snippet, columnName: template_tags}

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -1,11196 +1,7473 @@
 databaseChangeLog:
-  - property:
-      name: timestamp_type
-      value: timestamp with time zone
-      dbms: postgresql,h2
-  - property:
-      name: timestamp_type
-      value: timestamp(6)
-      dbms: mysql,mariadb
-  - property:
-      name: blob.type
-      value: blob
-      dbms: mysql,h2,mariadb
-  - property:
-      name: blob.type
-      value: bytea
-      dbms: postgresql
-  # In MySQL, use LONGTEXT instead of TEXT (#7006)
-  - property:
-      name: text.type
-      value: text
-      dbms: postgresql,h2
-  - property:
-      name: text.type
-      value: longtext
-      dbms: mysql,mariadb
-  # databasechangelog is uppercase in MySQL and H2 but lower-case in Postgres for reasons
-  - property:
-      name: databasechangelog.name
-      value: DATABASECHANGELOG
-      dbms: h2,mysql,mariadb
-  - property:
-      name: databasechangelog.name
-      value: databasechangelog
-      dbms: postgresql
-  # in MySQL, use bit(1) for booleans instead of tinyint
-  - property:
-      name: boolean.type
-      value: boolean
-      dbms: postgresql,h2
-  - property:
-      name: boolean.type
-      value: bit(1)
-      dbms: mysql,mariadb
-
-  - objectQuotingStrategy: QUOTE_ALL_OBJECTS
-
-  - changeSet:
-      id: v00.00-000
-      validCheckSum: 8:a59595109e74e7a2678a1b0dfd25f74a
-      author: qnkhuat
-      comment: Initialze metabase
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - tableExists:
-              tableName: core_user
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: initialization/metabase_postgres.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: initialization/metabase_mysql.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: initialization/metabase_h2.sql
-            relativeToChangelogFile: true
-
-# Note on rollback: migrations for v45 onwards should always include a rollback key unless they are supported
-# by Liquibase Auto Rollback. Most common changes are supported. See docs here:
-#
-#  https://docs.liquibase.com/workflows/liquibase-community/liquibase-auto-rollback.html
-
-  - changeSet:
-      id: v45.00-001
-      validCheckSum: 8:da99b71a4ac7eb662f6a95e69585935e
-      author: snoe
-      comment: Added 0.44.0 - writeback
-      # This migration was previously numbered v44.00-012 but ultimately was not shipped with 44.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-012';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-012';
-      changes:
-        - createTable:
-            tableName: action
-            remarks: An action is something you can do, such as run a readwrite query
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the action was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the action was updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: Type of action
-                  name: type
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v45.00-002
-      validCheckSum: 8:6da7a6285edb138c404de0eeba209570
-      author: snoe
-      comment: Added 0.44.0 - writeback
-      # This migration was previously numbered v44.00-013 but ultimately was not shipped with 44.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-013';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-013';
-      changes:
-        - createTable:
-            tableName: query_action
-            remarks: A readwrite query type of action
-            columns:
-              - column:
-                  name: action_id
-                  type: int
-                  remarks: The related action
-                  constraints:
-                    nullable: false
-                    referencedTableName: action
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_action_ref_action_id
-                    deleteCascade: true
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: The related card
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_action_ref_card_id
-                    deleteCascade: true
-
-  - changeSet:
-      id: v45.00-003
-      validCheckSum: 8:512337d6d4af38016aa79585abbe03a1
-      author: snoe
-      comment: Added 0.44.0 - writeback
-      # This migration was previously numbered v44.00-014 but ultimately was not shipped with 44.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-014';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-014';
-      changes:
-        - addPrimaryKey:
-            tableName: query_action
-            columnNames: action_id, card_id
-            constraintName: pk_query_action
-      rollback: # will be deleted when table is deleted
-
-  # note: some migrations which only added and deleted tables within v45 were removed, hence an ID gap here
-
-  - changeSet:
-      id: v45.00-011
-      validCheckSum: 8:dcf1cda9f20dca4b6ff8101b13b98c4a
-      author: snoe
-      comment: Added 0.44.0 - writeback
-      # This migration was previously numbered v44.00-022 but ultimately was not shipped with 44.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-022';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-022';
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: is_write
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: Indicates that this query will perform writes to a db
-                  constraints:
-                    nullable: false
-            tableName: report_card
-
-  - changeSet:
-      id: v45.00-012
-      validCheckSum: 8:aadf28229f585cff7c4b4c1918e558b2
-      author: snoe
-      comment: Added 0.44.0 - writeback
-      # This migration was previously numbered v44.00-031 but ultimately was not shipped with 44.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-031';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-031';
-      changes:
-        - createTable:
-            tableName: http_action
-            remarks: An http api call type of action
-            columns:
-              - column:
-                  name: action_id
-                  type: int
-                  remarks: The related action
-                  constraints:
-                    nullable: false
-                    referencedTableName: action
-                    referencedColumnNames: id
-                    foreignKeyName: fk_http_action_ref_action_id
-                    deleteCascade: true
-              - column:
-                  name: name
-                  type: varchar(254)
-                  remarks: The name of this action
-                  constraints:
-                    nullable: false
-              - column:
-                  name: description
-                  type: ${text.type}
-                  remarks: An optional description for this action
-              - column:
-                  name: template
-                  type: ${text.type}
-                  remarks: A template that defines method,url,body,headers required to make an api call
-                  constraints:
-                    nullable: false
-              - column:
-                  name: response_handle
-                  type: ${text.type}
-                  remarks: A program to take an api response and transform to an appropriate response for emitters
-              - column:
-                  name: error_handle
-                  type: ${text.type}
-                  remarks: A program to take an api response to determine if an error occurred
-
-  - changeSet:
-      id: v45.00-013
-      validCheckSum: 8:26dba276b14255d4346507a1a25d117b
-      author: snoe
-      comment: Added 0.44.0 - writeback
-      # This migration was previously numbered v44.00-032 but ultimately was not shipped with 44.
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
-            - and:
-                - dbms:
-                    type: postgresql,h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-032';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-032';
-      changes:
-        - addPrimaryKey:
-            tableName: http_action
-            columnNames: action_id
-            constraintName: pk_http_action
-      rollback: # no rollback needed, will be deleted with table
-
-
-  # note: some migrations which only added and deleted tables within v45 were removed, hence an ID gap here
-
-  - changeSet:
-      id: v45.00-022
-      validCheckSum: 8:d46fa24e4d75a11b2e92aecbf39c6ee1
-      author: snoe
-      comment: Added 0.45.0 - add app container
-      changes:
-        - createTable:
-            tableName: app
-            remarks: Defines top level concerns for App
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: entity_id
-                  type: char(21)
-                  remarks: Random NanoID tag for unique identity.
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: The associated collection
-                  constraints:
-                    nullable: false
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_app_ref_collection_id
-                    deleteCascade: true
-                    unique: true
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: The homepage of the app
-              - column:
-                  remarks: JSON for the navigation items of the app
-                  name: nav_items
-                  type: ${text.type}
-              - column:
-                  remarks: JSON for frontend related additions, such as styling
-                  name: options
-                  type: ${text.type}
-              - column:
-                  remarks: The timestamp of when the app was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the app was updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v45.00-023
-      validCheckSum: 8:c6c1ff9ca3b62d4cda3a2d782dd86f2f
-      author: snoe
-      comment: Added 0.45.0 - add app container
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: app
-            baseColumnNames: dashboard_id
-            referencedTableName: report_dashboard
-            referencedColumnNames: id
-            constraintName: fk_app_ref_dashboard_id
-            onDelete: SET NULL
-
-  - changeSet:
-      id: v45.00-025
-      validCheckSum: 8:50a43cea3123ecdb602123825f5a7dbf
-      author: metamben
-      comment: Added 0.45.0 - mark app pages
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: is_app_page
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: Indicates that this dashboard serves as a page of an app
-                  constraints:
-                    nullable: false
-            tableName: report_dashboard
-
-  - changeSet:
-      id: v45.00-026
-      validCheckSum: 8:ae77d4086998911877e3207fcf90c9c7
-      author: snoe
-      comment: Added 0.45.0 - apps add action_id to report_dashboardcard
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: action_id
-                  type: int
-                  remarks: The related action
-            tableName: report_dashboardcard
-
-  # FK constraint is added separately because deleteCascade doesn't work in addColumn -- see #14321
-  - changeSet:
-      id: v45.00-027
-      validCheckSum: 8:40c3c8391c1416a3bce09ca3c7237173
-      author: snoe
-      comment: Added 0.45.0 - apps add fk for action_id to report_dashboardcard
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboardcard
-            baseColumnNames: action_id
-            referencedTableName: action
-            referencedColumnNames: id
-            constraintName: fk_report_dashboardcard_ref_action_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v45.00-028
-      validCheckSum: 8:f8f68f80627aeb2ef7f28f2af2b5a31b
-      author: camsaul
-      comment: Added 0.45.0 -- rename DashboardCard sizeX to size_x. See https://github.com/metabase/metabase/issues/16344
-      changes:
-        - renameColumn:
-            tableName: report_dashboardcard
-            columnDataType: int
-            oldColumnName: sizeX
-            newColumnName: size_x
-
-  - changeSet:
-      id: v45.00-029
-      validCheckSum: 8:579957652133eab3ee023dd911162a1e
-      author: camsaul
-      comment: Added 0.45.0 -- rename DashboardCard size_y to size_y. See https://github.com/metabase/metabase/issues/16344
-      changes:
-        - renameColumn:
-            tableName: report_dashboardcard
-            columnDataType: int
-            oldColumnName: sizeY
-            newColumnName: size_y
-
-  - changeSet:
-      id: v45.00-030
-      validCheckSum: 8:41eda097feb034c4d01b2dbda74753c8
-      author: camsaul
-      comment: Added 0.45.0 -- add default value to DashboardCard size_x -- this was previously done by Toucan
-      changes:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_x
-            defaultValue: 2
-
-  - changeSet:
-      id: v45.00-031
-      validCheckSum: 8:6416e373e335dc1c12c7571af674dede
-      author: camsaul
-      comment: Added 0.45.0 -- add default value to DashboardCard size_y -- this was previously done by Toucan
-      changes:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_y
-            defaultValue: 2
-
-  - changeSet:
-      id: v45.00-032
-      validCheckSum: 8:d97444fe24a2dca618a2804741335f6d
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for DashboardCard created_at (Postgres/H2)
-      dbms: postgresql,h2
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql,h2
-      changes:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: created_at
-            columnDataType: ${timestamp_type}
+- property: {name: timestamp_type, value: timestamp with time zone, dbms: 'postgresql,h2'}
+- property: {name: timestamp_type, value: timestamp(6), dbms: 'mysql,mariadb'}
+- property: {name: blob.type, value: blob, dbms: 'mysql,h2,mariadb'}
+- property: {name: blob.type, value: bytea, dbms: postgresql}
+- property: {name: text.type, value: text, dbms: 'postgresql,h2'}
+- property: {name: text.type, value: longtext, dbms: 'mysql,mariadb'}
+- property: {name: databasechangelog.name, value: DATABASECHANGELOG, dbms: 'h2,mysql,mariadb'}
+- property: {name: databasechangelog.name, value: databasechangelog, dbms: postgresql}
+- property: {name: boolean.type, value: boolean, dbms: 'postgresql,h2'}
+- property: {name: boolean.type, value: bit(1), dbms: 'mysql,mariadb'}
+- {objectQuotingStrategy: QUOTE_ALL_OBJECTS}
+- changeSet:
+    id: v00.00-000
+    validCheckSum: 8:a59595109e74e7a2678a1b0dfd25f74a
+    author: qnkhuat
+    comment: Initialze metabase
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: core_user}
+    changes:
+    - sqlFile: {dbms: postgresql, path: initialization/metabase_postgres.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: initialization/metabase_mysql.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: initialization/metabase_h2.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v45.00-001
+    validCheckSum: 8:da99b71a4ac7eb662f6a95e69585935e
+    author: snoe
+    comment: Added 0.44.0 - writeback
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-012';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-012';}
+    changes:
+    - createTable:
+        tableName: action
+        remarks: An action is something you can do, such as run a readwrite query
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            remarks: The timestamp of when the action was created
+            name: created_at
+            type: ${timestamp_type}
             defaultValueComputed: current_timestamp
-
-    # addDefaultValue with defaultValueComputed doesn't work for MySQL/MariaDB so we have to do this the hard way.
-  - changeSet:
-      id: v45.00-033
-      validCheckSum: 8:34df79fc79e086ab05bb2fd79bb4e322
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for DashboardCard created_at (MySQL/MariaDB)
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - sql:
-            sql: >-
-              ALTER TABLE report_dashboardcard
-              CHANGE created_at
-              created_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
-      rollback: # nothing to do, but required for sql
-
-  - changeSet:
-      id: v45.00-034
-      validCheckSum: 8:ba0505a87ef876026759cdcb4e704f41
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for DashboardCard updated_at (Postgres/H2)
-      dbms: postgresql,h2
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql,h2
-      changes:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: updated_at
-            columnDataType: ${timestamp_type}
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the action was updated
+            name: updated_at
+            type: ${timestamp_type}
             defaultValueComputed: current_timestamp
-
-  - changeSet:
-      id: v45.00-035
-      validCheckSum: 8:dcee49781d80d9c4be5ad9dd51975a07
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for DashboardCard updated_at (MySQL/MariaDB)
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - sql:
-            sql: >-
-              ALTER TABLE report_dashboardcard
-              CHANGE updated_at
-              updated_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
-      rollback: # nothing to do
-
-  - changeSet:
-      id: v45.00-036
-      validCheckSum: 8:cd4009254bd2c56aaf281082038c1f0b
-      author: snoe
-      comment: Added 0.45.0 - add model action table
-      changes:
-        - createTable:
-            tableName: model_action
-            remarks: Ties actions to models
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: entity_id
-                  type: char(21)
-                  remarks: Random NanoID tag for unique identity.
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: slug
-                  type: varchar(254)
-                  remarks: The referenceable name for this action
-                  constraints:
-                    nullable: false
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: The associated model
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_model_action_ref_card_id
-                    deleteCascade: true
-              - column:
-                  name: action_id
-                  type: int
-                  remarks: The associated action
-                  constraints:
-                    nullable: true
-                    referencedTableName: action
-                    referencedColumnNames: id
-                    foreignKeyName: fk_model_action_ref_action_id
-                    deleteCascade: true
-              - column:
-                  name: requires_pk
-                  remarks: Indicates that the primary key(s) need to be passed in as parameters
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  name: parameter_mappings
-                  type: ${text.type}
-                  remarks: Mappings for primary keys to action parameters
-              - column:
-                  name: visualization_settings
-                  type: ${text.type}
-                  remarks: Settings for rendering the action
-
-  - changeSet:
-      id: v45.00-037
-      validCheckSum: 8:56f548cc84a53cc6d18302761ee71554
-      author: snoe
-      comment: Added 0.45.0 - model action
-      changes:
-        - addUniqueConstraint:
-            tableName: model_action
-            columnNames: card_id, slug
-            constraintName: unique_model_action_card_id_slug
-      rollback: # will be deleted with table
-
-  # The next 4 values add default values for Database `created_at` and `updated_at`; previously this was handled by
-  # Toucan but it's more convenient to do this at the application database level instead -- it facilitates stuff like
-  # schema migration tests that don't use Toucan, or other manual scripting
-  - changeSet:
-      id: v45.00-038
-      validCheckSum: 8:c38ddc295206e807c7254581ed9566c3
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for Database created_at (Postgres/H2)
-      dbms: postgresql,h2
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql,h2
-      changes:
-        - addDefaultValue:
-            tableName: metabase_database
-            columnName: created_at
-            columnDataType: ${timestamp_type}
+            constraints: {nullable: false}
+        - column:
+            remarks: Type of action
+            name: type
+            type: ${text.type}
+            constraints: {nullable: false}
+- changeSet:
+    id: v45.00-002
+    validCheckSum: 8:6da7a6285edb138c404de0eeba209570
+    author: snoe
+    comment: Added 0.44.0 - writeback
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-013';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-013';}
+    changes:
+    - createTable:
+        tableName: query_action
+        remarks: A readwrite query type of action
+        columns:
+        - column:
+            name: action_id
+            type: int
+            remarks: The related action
+            constraints: {nullable: false, referencedTableName: action, referencedColumnNames: id, foreignKeyName: fk_query_action_ref_action_id, deleteCascade: true}
+        - column:
+            name: card_id
+            type: int
+            remarks: The related card
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_query_action_ref_card_id, deleteCascade: true}
+- changeSet:
+    id: v45.00-003
+    validCheckSum: 8:512337d6d4af38016aa79585abbe03a1
+    author: snoe
+    comment: Added 0.44.0 - writeback
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-014';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-014';}
+    changes:
+    - addPrimaryKey: {tableName: query_action, columnNames: 'action_id, card_id', constraintName: pk_query_action}
+    rollback: null
+- changeSet:
+    id: v45.00-011
+    validCheckSum: 8:dcf1cda9f20dca4b6ff8101b13b98c4a
+    author: snoe
+    comment: Added 0.44.0 - writeback
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-022';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-022';}
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: is_write
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Indicates that this query will perform writes to a db
+            constraints: {nullable: false}
+        tableName: report_card
+- changeSet:
+    id: v45.00-012
+    validCheckSum: 8:aadf28229f585cff7c4b4c1918e558b2
+    author: snoe
+    comment: Added 0.44.0 - writeback
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-031';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-031';}
+    changes:
+    - createTable:
+        tableName: http_action
+        remarks: An http api call type of action
+        columns:
+        - column:
+            name: action_id
+            type: int
+            remarks: The related action
+            constraints: {nullable: false, referencedTableName: action, referencedColumnNames: id, foreignKeyName: fk_http_action_ref_action_id, deleteCascade: true}
+        - column:
+            name: name
+            type: varchar(254)
+            remarks: The name of this action
+            constraints: {nullable: false}
+        - column: {name: description, type: '${text.type}', remarks: An optional description for this action}
+        - column:
+            name: template
+            type: ${text.type}
+            remarks: A template that defines method,url,body,headers required to make an api call
+            constraints: {nullable: false}
+        - column: {name: response_handle, type: '${text.type}', remarks: A program to take an api response and transform to an appropriate response for emitters}
+        - column: {name: error_handle, type: '${text.type}', remarks: A program to take an api response to determine if an error occurred}
+- changeSet:
+    id: v45.00-013
+    validCheckSum: 8:26dba276b14255d4346507a1a25d117b
+    author: snoe
+    comment: Added 0.44.0 - writeback
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'postgresql,h2'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM databasechangelog WHERE id = 'v44.00-032';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = 'v44.00-032';}
+    changes:
+    - addPrimaryKey: {tableName: http_action, columnNames: action_id, constraintName: pk_http_action}
+    rollback: null
+- changeSet:
+    id: v45.00-022
+    validCheckSum: 8:d46fa24e4d75a11b2e92aecbf39c6ee1
+    author: snoe
+    comment: Added 0.45.0 - add app container
+    changes:
+    - createTable:
+        tableName: app
+        remarks: Defines top level concerns for App
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: entity_id
+            type: char(21)
+            remarks: Random NanoID tag for unique identity.
+            constraints: {nullable: false, unique: true}
+        - column:
+            name: collection_id
+            type: int
+            remarks: The associated collection
+            constraints: {nullable: false, referencedTableName: collection, referencedColumnNames: id, foreignKeyName: fk_app_ref_collection_id, deleteCascade: true, unique: true}
+        - column: {name: dashboard_id, type: int, remarks: The homepage of the app}
+        - column: {remarks: JSON for the navigation items of the app, name: nav_items, type: '${text.type}'}
+        - column: {remarks: 'JSON for frontend related additions, such as styling', name: options, type: '${text.type}'}
+        - column:
+            remarks: The timestamp of when the app was created
+            name: created_at
+            type: ${timestamp_type}
             defaultValueComputed: current_timestamp
-
-    # addDefaultValue with defaultValueComputed doesn't work for MySQL/MariaDB so we have to do this the hard way.
-  - changeSet:
-      id: v45.00-039
-      validCheckSum: 8:2c539d76d3aead7f7366b15333132b30
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for Database created_at (MySQL/MariaDB)
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - sql:
-            sql: >-
-              ALTER TABLE metabase_database
-              CHANGE created_at
-              created_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
-      rollback: # nothing to do
-
-  - changeSet:
-      id: v45.00-040
-      validCheckSum: 8:00ac7c24cfd3e7ea3a21f21f4e45dbcf
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for Database updated_at (Postgres/H2)
-      dbms: postgresql,h2
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql,h2
-      changes:
-        - addDefaultValue:
-            tableName: metabase_database
-            columnName: updated_at
-            columnDataType: ${timestamp_type}
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the app was updated
+            name: updated_at
+            type: ${timestamp_type}
             defaultValueComputed: current_timestamp
-
-  - changeSet:
-      id: v45.00-041
-      validCheckSum: 8:82dc368fa3e0163a06929da6e9556fe2
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for Database updated_at (MySQL/MariaDB)
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - sql:
-            sql: >-
-              ALTER TABLE metabase_database
-              CHANGE updated_at
-              updated_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
-      rollback: # nothing to do
-
-  # It was probably an oversight, but while we validated Database `details` in the API layer it was not a required/NOT
-  # NULL column in the application Database itself. No problem; let's add it now that we've noticed it.
-  #
-  # MySQL (at least 5.7) won't let us have nice things:
-  #
-  # https://dev.mysql.com/doc/refman/5.7/en/data-type-defaults.html
-  #
-  # The BLOB, TEXT, GEOMETRY, and JSON data types cannot be assigned a default value.
-  #
-  # Because of this restriction we will just have to update existing NULL values in SQL and then add a NOT NULL
-  # restriction separately; we can use Toucan `pre-insert` to set defaults values when saving things.
-  - changeSet:
-      id: v45.00-042
-      validCheckSum: 8:d04207471480e335f14094e9a7a5d293
-      author: camsaul
-      comment: Added 0.45.0 -- add default value for Database with NULL details
-      changes:
-        - sql:
-            sql: >-
-              UPDATE metabase_database SET details = '{}' WHERE details IS NULL;
-      rollback: # nothing to do, since a '{}' is okay for v44
-
-  - changeSet:
-      id: v45.00-043
-      validCheckSum: 8:1d07a5435e51abd0663458d907865a6b
-      author: camsaul
-      comment: Added 0.45.0 -- make Database details NOT NULL
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${text.type}
-            tableName: metabase_database
-            columnName: details
-
-  - changeSet:
-      id: v45.00-044
-      validCheckSum: 8:0b23976c5d2248d511ac31b244efef22
-      author: metamben
-      comment: Added 0.45.0 -- create app permission graph revision table
-      changes:
-        - createTable:
-            tableName: app_permission_graph_revision
-            remarks: 'Used to keep track of changes made to app permissions.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: before
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the apps graph before the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: after
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the apps graph after the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'The ID of the admin who made this set of changes.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_app_permission_graph_revision_user_id
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: 'The timestamp of when these changes were made.'
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: remark
-                  type: ${text.type}
-                  remarks: 'Optional remarks explaining why these changes were made.'
-
-  # note: some migrations which only added and deleted tables within v45 were removed, hence an ID gap here
-
-  # Add created_at to Collection
-  - changeSet:
-      id: v45.00-048
-      validCheckSum: 8:0aca8f157f163e62805b7202f8aa202f
-      author: camsaul
-      comment: Added 0.45.0 -- add created_at to Collection
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: Timestamp of when this Collection was created.
-                  constraints:
-                    nullable: false
-                  defaultValueComputed: current_timestamp
-
-  # Seed Collection created_at for Personal Collections with the date_joined of the User that owns them.
-  - changeSet:
-      id: v45.00-049
-      author: camsaul
-      comment: Added 0.45.0 -- set Collection.created_at to User.date_joined for Personal Collections
-      validCheckSum: 8:df2097d176fad99c142c5dd75ce8a3db
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              UPDATE collection c
-              SET created_at = u.date_joined
-              FROM core_user u
-              WHERE c.personal_owner_id = u.id;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE collection c
-              INNER JOIN core_user u
-              ON c.personal_owner_id = u.id
-              SET c.created_at = u.date_joined;
-        - sql:
-            dbms: h2
-            sql: >-
-              UPDATE collection c
-              SET created_at = (
-                SELECT u.date_joined
-                FROM core_user u
-                WHERE c.personal_owner_id = u.id
-              )
-              WHERE c.personal_owner_id IS NOT NULL;
-      rollback: # nothing to roll back, but required for sql change types
-
-  # seed Collection created_at based on the max created at of child objects
-  #
-  # At the time of this writing, the following Models can appear in a Collection:
-  #
-  # - App
-  # - Card
-  # - Dashboard
-  # - Pulse
-  # - Timeline
-  # - NativeQuerySnippet
-  - changeSet:
-      id: v45.00-050
-      author: camsaul
-      validCheckSum: ANY
-      comment: Added 0.45.0 -- seed Collection.created_at with value of oldest item for non-Personal Collections
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              UPDATE collection c
-              SET created_at = created_ats.created_at
-              FROM (
-                SELECT min(created_at) AS created_at, collection_id
-                FROM (
-                  SELECT created_at, collection_id FROM app                  UNION ALL
-                  SELECT created_at, collection_id FROM report_card          UNION ALL
-                  SELECT created_at, collection_id FROM report_dashboard     UNION ALL
-                  SELECT created_at, collection_id FROM pulse                UNION ALL
-                  SELECT created_at, collection_id FROM timeline             UNION ALL
-                  SELECT created_at, collection_id FROM native_query_snippet
-                ) created_ats
-                GROUP BY collection_id
-              ) created_ats
-              WHERE c.id = created_ats.collection_id
-                AND c.personal_owner_id IS NULL;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE collection c
-              LEFT JOIN (
-                SELECT min(created_at) AS created_at, collection_id
-                FROM (
-                  SELECT created_at, collection_id FROM app                  UNION ALL
-                  SELECT created_at, collection_id FROM report_card          UNION ALL
-                  SELECT created_at, collection_id FROM report_dashboard     UNION ALL
-                  SELECT created_at, collection_id FROM pulse                UNION ALL
-                  SELECT created_at, collection_id FROM timeline             UNION ALL
-                  SELECT created_at, collection_id FROM native_query_snippet
-                ) created_ats
-                GROUP BY collection_id
-              ) created_ats
-              ON c.id = created_ats.collection_id
-              SET c.created_at = created_ats.created_at
-              WHERE c.personal_owner_id IS NULL
-                AND created_ats.created_at IS NOT NULL;
-        - sql:
-            dbms: h2
-            # I would have preferred using MERGE ... USING instead of WHERE EXISTS ... but it's broken in 1.4.197
-            # because of https://github.com/h2database/h2database/issues/1034, which is fixed in 1.4.198. So this will
-            # have to do for now, even if it's a little ugly.
-            sql: >-
-              WITH created_ats AS (
-                SELECT min(created_at) AS created_at, collection_id
-                FROM (
-                  SELECT created_at, collection_id FROM app                  UNION ALL
-                  SELECT created_at, collection_id FROM report_card          UNION ALL
-                  SELECT created_at, collection_id FROM report_dashboard     UNION ALL
-                  SELECT created_at, collection_id FROM pulse                UNION ALL
-                  SELECT created_at, collection_id FROM timeline             UNION ALL
-                  SELECT created_at, collection_id FROM native_query_snippet
-                ) created_ats
-                GROUP BY collection_id
-              )
-              UPDATE collection c
-              SET created_at = (
-                SELECT created_ats.created_at
-                FROM created_ats
-                WHERE created_ats.collection_id = c.id
-              )
-              WHERE EXISTS (
-                SELECT created_ats.collection_id
-                FROM created_ats
-                WHERE c.id = created_ats.collection_id
-                  AND c.personal_owner_id IS NULL
-              );
-      rollback: # rollback is a no-op for most seed migrations, but required for sql change type
-
-  - changeSet:
-      id: v45.00-051
-      validCheckSum: 8:2378c7031da6871dcf1c737bf323d211
-      author: qnkhuat
-      comment: >-
-        Added 0.45.0 - modify type of collection_permission_graph_revision.after from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: collection_permission_graph_revision
-            columnName: after
-            newDataType: ${text.type}
-      rollback:
-        - modifyDataType:
-            tableName: collection_permission_graph_revision
-            columnName: after
-            newDataType: text
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v45.00-052
-      validCheckSum: 8:b7343eb9556c3e636b6f8dd70708c0b3
-      author: qnkhuat
-      comment: >-
-        Added 0.45.0 - modify type of collection_permission_graph_revision.before from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: collection_permission_graph_revision
-            columnName: before
-            newDataType: ${text.type}
-      rollback:
-        - modifyDataType:
-            tableName: collection_permission_graph_revision
-            columnName: before
-            newDataType: text
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v45.00-053
-      validCheckSum: 8:fa552605d5a587c4fa74e0c6bd358097
-      author: qnkhuat
-      comment: >-
-        Added 0.45.0 - modify type of collection_permission_graph_revision.remark from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: collection_permission_graph_revision
-            columnName: remark
-            newDataType: ${text.type}
-      rollback:
-        - modifyDataType:
-            tableName: collection_permission_graph_revision
-            columnName: remark
-            newDataType: text
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v45.00-054
-      validCheckSum: 8:60862c4ecf505727e839ac5e94f95528
-      author: qnkhuat
-      comment: >-
-        Added 0.45.0 - modify type of permissions_revision.after from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: permissions_revision
-            columnName: after
-            newDataType: ${text.type}
-      rollback:
-        - modifyDataType:
-            tableName: permissions_revision
-            columnName: after
-            newDataType: text
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v45.00-055
-      validCheckSum: 8:717f0c266da5768098a2ead6168f3b18
-      author: qnkhuat
-      comment: >-
-        Added 0.45.0 - modify type of permissions_revision.before from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: permissions_revision
-            columnName: before
-            newDataType: ${text.type}
-      rollback:
-        - modifyDataType:
-            tableName: permissions_revision
-            columnName: before
-            newDataType: text
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v45.00-056
-      validCheckSum: 8:a1f364d45a922c90b4fac741a22e66b3
-      author: qnkhuat
-      comment: >-
-        Added 0.45.0 - modify type of permissions_revision.remark from text to ${text.type}
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: permissions_revision
-            columnName: remark
-            newDataType: ${text.type}
-      rollback:
-        - modifyDataType:
-            tableName: permissions_revision
-            columnName: remark
-            newDataType: text
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v45.00-057
-      validCheckSum: 8:650a5b435f8195765a2ab1e3e4bc7b14
-      author: qnkhuat
-      comment: >-
-        Added 0.45.0 - modify type of secret.value from blob to longblob
-        on mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: secret
-            columnName: value
-            newDataType: longblob
-      rollback:
-        - modifyDataType:
-            tableName: secret
-            columnName: value
-            newDataType: ${blob.type}
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v46.00-000
-      validCheckSum: 8:97251413292221e51490e990b6f683f2
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - createTable:
-            tableName: implicit_action
-            remarks: An action with dynamic parameters based on the underlying model
-            columns:
-              - column:
-                  name: action_id
-                  type: int
-                  remarks: The associated action
-                  constraints:
-                    nullable: false
-                    referencedTableName: action
-                    referencedColumnNames: id
-                    foreignKeyName: fk_implicit_action_action_id
-                    deleteCascade: true
-              - column:
-                  name: kind
-                  type: ${text.type}
-                  remarks: The kind of implicit action create/update/delete
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v46.00-001
-      validCheckSum: 8:4a90c7523749aa7e4e4d2ea9dd6db777
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: model_id
-                  remarks: The associated model
-                  type: int
-
-  - changeSet:
-      id: v46.00-002
-      validCheckSum: 8:b2b112f0df413692631b75822f658de1
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: name
-                  remarks: The name of the action
-                  type: varchar(254)
-
-  - changeSet:
-      id: v46.00-003
-      validCheckSum: 8:45b8358f31811335aaa93032726a042b
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: description
-                  remarks: The description of the action
-                  type: ${text.type}
-
-  - changeSet:
-      id: v46.00-004
-      validCheckSum: 8:0ce8ff05beffc5c72e2348bcec581eee
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: parameters
-                  remarks: The saved parameters for this action
-                  type: ${text.type}
-
-  - changeSet:
-      id: v46.00-005
-      validCheckSum: 8:84cf1fbf435c7c3f794c973de4d62fad
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: parameter_mappings
-                  remarks: The saved parameter mappings for this action
-                  type: ${text.type}
-
-  - changeSet:
-      id: v46.00-006
-      validCheckSum: 8:df43ef08b76c33c5626dbf9b226717b5
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: visualization_settings
-                  remarks: The UI visualization_settings for this action
-                  type: ${text.type}
-
-  - changeSet:
-      id: v46.00-007
-      validCheckSum: 8:6830901cccc14ad22cdfd86bd3a2afe7
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: action
-            baseColumnNames: model_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_action_model_id
-
-  - changeSet:
-      id: v46.00-008
-      validCheckSum: 8:6e73a8683d1b757c5f9034513ec8a581
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: query_action
-            columns:
-              - column:
-                  name: database_id
-                  remarks: The associated database
-                  type: int
-
-  - changeSet:
-      id: v46.00-009
-      validCheckSum: 8:2b4fd7cee77d5ed8de22fcc2fba158bc
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addColumn:
-            tableName: query_action
-            columns:
-              - column:
-                  name: dataset_query
-                  remarks: The MBQL writeback query
-                  type: ${text.type}
-
-  - changeSet:
-      id: v46.00-010
-      validCheckSum: 8:77ca03e5a0dbe370461295da1c77cf0f
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: query_action
-            baseColumnNames: database_id
-            referencedTableName: metabase_database
-            referencedColumnNames: id
-            constraintName: fk_query_action_database_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v46.00-011
-      author: snoe
-      validCheckSum: ANY
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              ALTER TABLE query_action DROP PRIMARY KEY, ADD PRIMARY KEY pk_query_action (action_id);
-        - sql:
-            dbms: h2
-            sql: >-
-              ALTER TABLE query_action DROP PRIMARY KEY;
-              ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id);
-        - sql:
-            dbms: postgresql
-            sql: >-
-              ALTER TABLE query_action DROP CONSTRAINT pk_query_action;
-              ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id);
-      rollback:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              ALTER TABLE query_action DROP PRIMARY KEY, ADD PRIMARY KEY pk_query_action (action_id, card_id);
-        - sql:
-            dbms: h2
-            sql: >-
-              ALTER TABLE query_action DROP CONSTRAINT fk_query_action_ref_action_id;
-              ALTER TABLE query_action DROP PRIMARY KEY;
-              ALTER TABLE query_action ADD CONSTRAINT fk_query_action_ref_action_id FOREIGN KEY (action_id) REFERENCES action(id) ON DELETE CASCADE;
-              ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id, card_id);
-        - sql:
-            dbms: postgresql
-            sql: >-
-              ALTER TABLE query_action DROP CONSTRAINT pk_query_action;
-              ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id, card_id);
-
-  - changeSet:
-      id: v46.00-012
-      validCheckSum: 8:7e4dffe8bbbb740207001ead696a8557
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - dropNotNullConstraint:
-            tableName: query_action
-            columnDataType: int
-            columnName: card_id
-
-  # migration for developers and internal use of actions created in 45 during a short period.
-  - changeSet:
-      id: v46.00-013
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      validCheckSum: ANY
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO action (type, model_id, name)
-              SELECT 'implicit', card_id, slug
-              FROM model_action
-              WHERE action_id is null AND slug in ('insert','update','delete');
-
-              INSERT INTO implicit_action (action_id, kind)
-              SELECT
-                id,
-                case name
-                  when 'insert' then 'row/create'
-                  when 'update' then 'row/update'
-                  when 'delete' then 'row/delete'
-                end
-              FROM action
-              WHERE type = 'implicit';
-
-              UPDATE action
-              SET model_id = (SELECT card_id
-                              FROM model_action
-                              WHERE model_action.action_id = action.id)
-              WHERE model_id is null;
-
-              DELETE FROM action WHERE model_id is null;
-
-              UPDATE report_dashboardcard
-              SET action_id = (SELECT action.id
-                               FROM action
-                               LEFT JOIN implicit_action ON implicit_action.action_id = action.id
-                               WHERE action.model_id = report_dashboardcard.card_id
-                               AND coalesce((
-                                  CASE implicit_action.kind
-                                     WHEN 'row/create' THEN 'insert'
-                                     WHEN 'row/delete' THEN 'delete'
-                                     WHEN 'row/update' THEN 'update'
-                                  END), ('action_' || action.id)) =
+            constraints: {nullable: false}
+- changeSet:
+    id: v45.00-023
+    validCheckSum: 8:c6c1ff9ca3b62d4cda3a2d782dd86f2f
+    author: snoe
+    comment: Added 0.45.0 - add app container
+    changes:
+    - addForeignKeyConstraint: {baseTableName: app, baseColumnNames: dashboard_id, referencedTableName: report_dashboard, referencedColumnNames: id, constraintName: fk_app_ref_dashboard_id, onDelete: SET NULL}
+- changeSet:
+    id: v45.00-025
+    validCheckSum: 8:50a43cea3123ecdb602123825f5a7dbf
+    author: metamben
+    comment: Added 0.45.0 - mark app pages
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: is_app_page
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Indicates that this dashboard serves as a page of an app
+            constraints: {nullable: false}
+        tableName: report_dashboard
+- changeSet:
+    id: v45.00-026
+    validCheckSum: 8:ae77d4086998911877e3207fcf90c9c7
+    author: snoe
+    comment: Added 0.45.0 - apps add action_id to report_dashboardcard
+    changes:
+    - addColumn:
+        columns:
+        - column: {name: action_id, type: int, remarks: The related action}
+        tableName: report_dashboardcard
+- changeSet:
+    id: v45.00-027
+    validCheckSum: 8:40c3c8391c1416a3bce09ca3c7237173
+    author: snoe
+    comment: Added 0.45.0 - apps add fk for action_id to report_dashboardcard
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_dashboardcard, baseColumnNames: action_id, referencedTableName: action, referencedColumnNames: id, constraintName: fk_report_dashboardcard_ref_action_id, onDelete: CASCADE}
+- changeSet:
+    id: v45.00-028
+    validCheckSum: 8:f8f68f80627aeb2ef7f28f2af2b5a31b
+    author: camsaul
+    comment: Added 0.45.0 -- rename DashboardCard sizeX to size_x. See https://github.com/metabase/metabase/issues/16344
+    changes:
+    - renameColumn: {tableName: report_dashboardcard, columnDataType: int, oldColumnName: sizeX, newColumnName: size_x}
+- changeSet:
+    id: v45.00-029
+    validCheckSum: 8:579957652133eab3ee023dd911162a1e
+    author: camsaul
+    comment: Added 0.45.0 -- rename DashboardCard size_y to size_y. See https://github.com/metabase/metabase/issues/16344
+    changes:
+    - renameColumn: {tableName: report_dashboardcard, columnDataType: int, oldColumnName: sizeY, newColumnName: size_y}
+- changeSet:
+    id: v45.00-030
+    validCheckSum: 8:41eda097feb034c4d01b2dbda74753c8
+    author: camsaul
+    comment: Added 0.45.0 -- add default value to DashboardCard size_x -- this was previously done by Toucan
+    changes:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: size_x, defaultValue: 2}
+- changeSet:
+    id: v45.00-031
+    validCheckSum: 8:6416e373e335dc1c12c7571af674dede
+    author: camsaul
+    comment: Added 0.45.0 -- add default value to DashboardCard size_y -- this was previously done by Toucan
+    changes:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: size_y, defaultValue: 2}
+- changeSet:
+    id: v45.00-032
+    validCheckSum: 8:d97444fe24a2dca618a2804741335f6d
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for DashboardCard created_at (Postgres/H2)
+    dbms: postgresql,h2
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'postgresql,h2'}
+    changes:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: created_at, columnDataType: '${timestamp_type}', defaultValueComputed: current_timestamp}
+- changeSet:
+    id: v45.00-033
+    validCheckSum: 8:34df79fc79e086ab05bb2fd79bb4e322
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for DashboardCard created_at (MySQL/MariaDB)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - sql: {sql: ALTER TABLE report_dashboardcard CHANGE created_at created_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);}
+    rollback: null
+- changeSet:
+    id: v45.00-034
+    validCheckSum: 8:ba0505a87ef876026759cdcb4e704f41
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for DashboardCard updated_at (Postgres/H2)
+    dbms: postgresql,h2
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'postgresql,h2'}
+    changes:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: updated_at, columnDataType: '${timestamp_type}', defaultValueComputed: current_timestamp}
+- changeSet:
+    id: v45.00-035
+    validCheckSum: 8:dcee49781d80d9c4be5ad9dd51975a07
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for DashboardCard updated_at (MySQL/MariaDB)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - sql: {sql: ALTER TABLE report_dashboardcard CHANGE updated_at updated_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);}
+    rollback: null
+- changeSet:
+    id: v45.00-036
+    validCheckSum: 8:cd4009254bd2c56aaf281082038c1f0b
+    author: snoe
+    comment: Added 0.45.0 - add model action table
+    changes:
+    - createTable:
+        tableName: model_action
+        remarks: Ties actions to models
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: entity_id
+            type: char(21)
+            remarks: Random NanoID tag for unique identity.
+            constraints: {nullable: false, unique: true}
+        - column:
+            name: slug
+            type: varchar(254)
+            remarks: The referenceable name for this action
+            constraints: {nullable: false}
+        - column:
+            name: card_id
+            type: int
+            remarks: The associated model
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_model_action_ref_card_id, deleteCascade: true}
+        - column:
+            name: action_id
+            type: int
+            remarks: The associated action
+            constraints: {nullable: true, referencedTableName: action, referencedColumnNames: id, foreignKeyName: fk_model_action_ref_action_id, deleteCascade: true}
+        - column:
+            name: requires_pk
+            remarks: Indicates that the primary key(s) need to be passed in as parameters
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        - column: {name: parameter_mappings, type: '${text.type}', remarks: Mappings for primary keys to action parameters}
+        - column: {name: visualization_settings, type: '${text.type}', remarks: Settings for rendering the action}
+- changeSet:
+    id: v45.00-037
+    validCheckSum: 8:56f548cc84a53cc6d18302761ee71554
+    author: snoe
+    comment: Added 0.45.0 - model action
+    changes:
+    - addUniqueConstraint: {tableName: model_action, columnNames: 'card_id, slug', constraintName: unique_model_action_card_id_slug}
+    rollback: null
+- changeSet:
+    id: v45.00-038
+    validCheckSum: 8:c38ddc295206e807c7254581ed9566c3
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for Database created_at (Postgres/H2)
+    dbms: postgresql,h2
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'postgresql,h2'}
+    changes:
+    - addDefaultValue: {tableName: metabase_database, columnName: created_at, columnDataType: '${timestamp_type}', defaultValueComputed: current_timestamp}
+- changeSet:
+    id: v45.00-039
+    validCheckSum: 8:2c539d76d3aead7f7366b15333132b30
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for Database created_at (MySQL/MariaDB)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - sql: {sql: ALTER TABLE metabase_database CHANGE created_at created_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);}
+    rollback: null
+- changeSet:
+    id: v45.00-040
+    validCheckSum: 8:00ac7c24cfd3e7ea3a21f21f4e45dbcf
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for Database updated_at (Postgres/H2)
+    dbms: postgresql,h2
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'postgresql,h2'}
+    changes:
+    - addDefaultValue: {tableName: metabase_database, columnName: updated_at, columnDataType: '${timestamp_type}', defaultValueComputed: current_timestamp}
+- changeSet:
+    id: v45.00-041
+    validCheckSum: 8:82dc368fa3e0163a06929da6e9556fe2
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for Database updated_at (MySQL/MariaDB)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - sql: {sql: ALTER TABLE metabase_database CHANGE updated_at updated_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);}
+    rollback: null
+- changeSet:
+    id: v45.00-042
+    validCheckSum: 8:d04207471480e335f14094e9a7a5d293
+    author: camsaul
+    comment: Added 0.45.0 -- add default value for Database with NULL details
+    changes:
+    - sql: {sql: 'UPDATE metabase_database SET details = ''{}'' WHERE details IS NULL;'}
+    rollback: null
+- changeSet:
+    id: v45.00-043
+    validCheckSum: 8:1d07a5435e51abd0663458d907865a6b
+    author: camsaul
+    comment: Added 0.45.0 -- make Database details NOT NULL
+    changes:
+    - addNotNullConstraint: {columnDataType: '${text.type}', tableName: metabase_database, columnName: details}
+- changeSet:
+    id: v45.00-044
+    validCheckSum: 8:0b23976c5d2248d511ac31b244efef22
+    author: metamben
+    comment: Added 0.45.0 -- create app permission graph revision table
+    changes:
+    - createTable:
+        tableName: app_permission_graph_revision
+        remarks: Used to keep track of changes made to app permissions.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: before
+            type: ${text.type}
+            remarks: Serialized JSON of the apps graph before the changes.
+            constraints: {nullable: false}
+        - column:
+            name: after
+            type: ${text.type}
+            remarks: Serialized JSON of the apps graph after the changes.
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The ID of the admin who made this set of changes.
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_app_permission_graph_revision_user_id}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when these changes were made.
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column: {name: remark, type: '${text.type}', remarks: Optional remarks explaining why these changes were made.}
+- changeSet:
+    id: v45.00-048
+    validCheckSum: 8:0aca8f157f163e62805b7202f8aa202f
+    author: camsaul
+    comment: Added 0.45.0 -- add created_at to Collection
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: Timestamp of when this Collection was created.
+            constraints: {nullable: false}
+            defaultValueComputed: current_timestamp
+- changeSet:
+    id: v45.00-049
+    author: camsaul
+    comment: Added 0.45.0 -- set Collection.created_at to User.date_joined for Personal Collections
+    validCheckSum: 8:df2097d176fad99c142c5dd75ce8a3db
+    changes:
+    - sql: {dbms: postgresql, sql: UPDATE collection c SET created_at = u.date_joined FROM core_user u WHERE c.personal_owner_id = u.id;}
+    - sql: {dbms: 'mysql,mariadb', sql: UPDATE collection c INNER JOIN core_user u ON c.personal_owner_id = u.id SET c.created_at = u.date_joined;}
+    - sql:
+        dbms: h2
+        sql: |-
+          UPDATE collection c SET created_at = (
+            SELECT u.date_joined
+            FROM core_user u
+            WHERE c.personal_owner_id = u.id
+          ) WHERE c.personal_owner_id IS NOT NULL;
+    rollback: null
+- changeSet:
+    id: v45.00-050
+    author: camsaul
+    validCheckSum: ANY
+    comment: Added 0.45.0 -- seed Collection.created_at with value of oldest item for non-Personal Collections
+    changes:
+    - sql:
+        dbms: postgresql
+        sql: |-
+          UPDATE collection c SET created_at = created_ats.created_at FROM (
+            SELECT min(created_at) AS created_at, collection_id
+            FROM (
+              SELECT created_at, collection_id FROM app                  UNION ALL
+              SELECT created_at, collection_id FROM report_card          UNION ALL
+              SELECT created_at, collection_id FROM report_dashboard     UNION ALL
+              SELECT created_at, collection_id FROM pulse                UNION ALL
+              SELECT created_at, collection_id FROM timeline             UNION ALL
+              SELECT created_at, collection_id FROM native_query_snippet
+            ) created_ats
+            GROUP BY collection_id
+          ) created_ats WHERE c.id = created_ats.collection_id
+            AND c.personal_owner_id IS NULL;
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE collection c LEFT JOIN (
+            SELECT min(created_at) AS created_at, collection_id
+            FROM (
+              SELECT created_at, collection_id FROM app                  UNION ALL
+              SELECT created_at, collection_id FROM report_card          UNION ALL
+              SELECT created_at, collection_id FROM report_dashboard     UNION ALL
+              SELECT created_at, collection_id FROM pulse                UNION ALL
+              SELECT created_at, collection_id FROM timeline             UNION ALL
+              SELECT created_at, collection_id FROM native_query_snippet
+            ) created_ats
+            GROUP BY collection_id
+          ) created_ats ON c.id = created_ats.collection_id SET c.created_at = created_ats.created_at WHERE c.personal_owner_id IS NULL
+            AND created_ats.created_at IS NOT NULL;
+    - sql:
+        dbms: h2
+        sql: |-
+          WITH created_ats AS (
+            SELECT min(created_at) AS created_at, collection_id
+            FROM (
+              SELECT created_at, collection_id FROM app                  UNION ALL
+              SELECT created_at, collection_id FROM report_card          UNION ALL
+              SELECT created_at, collection_id FROM report_dashboard     UNION ALL
+              SELECT created_at, collection_id FROM pulse                UNION ALL
+              SELECT created_at, collection_id FROM timeline             UNION ALL
+              SELECT created_at, collection_id FROM native_query_snippet
+            ) created_ats
+            GROUP BY collection_id
+          ) UPDATE collection c SET created_at = (
+            SELECT created_ats.created_at
+            FROM created_ats
+            WHERE created_ats.collection_id = c.id
+          ) WHERE EXISTS (
+            SELECT created_ats.collection_id
+            FROM created_ats
+            WHERE c.id = created_ats.collection_id
+              AND c.personal_owner_id IS NULL
+          );
+    rollback: null
+- changeSet:
+    id: v45.00-051
+    validCheckSum: 8:2378c7031da6871dcf1c737bf323d211
+    author: qnkhuat
+    comment: Added 0.45.0 - modify type of collection_permission_graph_revision.after from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: collection_permission_graph_revision, columnName: after, newDataType: '${text.type}'}
+    rollback:
+    - modifyDataType: {tableName: collection_permission_graph_revision, columnName: after, newDataType: text}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v45.00-052
+    validCheckSum: 8:b7343eb9556c3e636b6f8dd70708c0b3
+    author: qnkhuat
+    comment: Added 0.45.0 - modify type of collection_permission_graph_revision.before from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: collection_permission_graph_revision, columnName: before, newDataType: '${text.type}'}
+    rollback:
+    - modifyDataType: {tableName: collection_permission_graph_revision, columnName: before, newDataType: text}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v45.00-053
+    validCheckSum: 8:fa552605d5a587c4fa74e0c6bd358097
+    author: qnkhuat
+    comment: Added 0.45.0 - modify type of collection_permission_graph_revision.remark from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: collection_permission_graph_revision, columnName: remark, newDataType: '${text.type}'}
+    rollback:
+    - modifyDataType: {tableName: collection_permission_graph_revision, columnName: remark, newDataType: text}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v45.00-054
+    validCheckSum: 8:60862c4ecf505727e839ac5e94f95528
+    author: qnkhuat
+    comment: Added 0.45.0 - modify type of permissions_revision.after from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: permissions_revision, columnName: after, newDataType: '${text.type}'}
+    rollback:
+    - modifyDataType: {tableName: permissions_revision, columnName: after, newDataType: text}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v45.00-055
+    validCheckSum: 8:717f0c266da5768098a2ead6168f3b18
+    author: qnkhuat
+    comment: Added 0.45.0 - modify type of permissions_revision.before from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: permissions_revision, columnName: before, newDataType: '${text.type}'}
+    rollback:
+    - modifyDataType: {tableName: permissions_revision, columnName: before, newDataType: text}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v45.00-056
+    validCheckSum: 8:a1f364d45a922c90b4fac741a22e66b3
+    author: qnkhuat
+    comment: Added 0.45.0 - modify type of permissions_revision.remark from text to ${text.type} on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: permissions_revision, columnName: remark, newDataType: '${text.type}'}
+    rollback:
+    - modifyDataType: {tableName: permissions_revision, columnName: remark, newDataType: text}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v45.00-057
+    validCheckSum: 8:650a5b435f8195765a2ab1e3e4bc7b14
+    author: qnkhuat
+    comment: Added 0.45.0 - modify type of secret.value from blob to longblob on mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: secret, columnName: value, newDataType: longblob}
+    rollback:
+    - modifyDataType: {tableName: secret, columnName: value, newDataType: '${blob.type}'}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v46.00-000
+    validCheckSum: 8:97251413292221e51490e990b6f683f2
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - createTable:
+        tableName: implicit_action
+        remarks: An action with dynamic parameters based on the underlying model
+        columns:
+        - column:
+            name: action_id
+            type: int
+            remarks: The associated action
+            constraints: {nullable: false, referencedTableName: action, referencedColumnNames: id, foreignKeyName: fk_implicit_action_action_id, deleteCascade: true}
+        - column:
+            name: kind
+            type: ${text.type}
+            remarks: The kind of implicit action create/update/delete
+            constraints: {nullable: false}
+- changeSet:
+    id: v46.00-001
+    validCheckSum: 8:4a90c7523749aa7e4e4d2ea9dd6db777
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: model_id, remarks: The associated model, type: int}
+- changeSet:
+    id: v46.00-002
+    validCheckSum: 8:b2b112f0df413692631b75822f658de1
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: name, remarks: The name of the action, type: varchar(254)}
+- changeSet:
+    id: v46.00-003
+    validCheckSum: 8:45b8358f31811335aaa93032726a042b
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: description, remarks: The description of the action, type: '${text.type}'}
+- changeSet:
+    id: v46.00-004
+    validCheckSum: 8:0ce8ff05beffc5c72e2348bcec581eee
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: parameters, remarks: The saved parameters for this action, type: '${text.type}'}
+- changeSet:
+    id: v46.00-005
+    validCheckSum: 8:84cf1fbf435c7c3f794c973de4d62fad
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: parameter_mappings, remarks: The saved parameter mappings for this action, type: '${text.type}'}
+- changeSet:
+    id: v46.00-006
+    validCheckSum: 8:df43ef08b76c33c5626dbf9b226717b5
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: visualization_settings, remarks: The UI visualization_settings for this action, type: '${text.type}'}
+- changeSet:
+    id: v46.00-007
+    validCheckSum: 8:6830901cccc14ad22cdfd86bd3a2afe7
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addForeignKeyConstraint: {baseTableName: action, baseColumnNames: model_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_action_model_id}
+- changeSet:
+    id: v46.00-008
+    validCheckSum: 8:6e73a8683d1b757c5f9034513ec8a581
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: query_action
+        columns:
+        - column: {name: database_id, remarks: The associated database, type: int}
+- changeSet:
+    id: v46.00-009
+    validCheckSum: 8:2b4fd7cee77d5ed8de22fcc2fba158bc
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addColumn:
+        tableName: query_action
+        columns:
+        - column: {name: dataset_query, remarks: The MBQL writeback query, type: '${text.type}'}
+- changeSet:
+    id: v46.00-010
+    validCheckSum: 8:77ca03e5a0dbe370461295da1c77cf0f
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addForeignKeyConstraint: {baseTableName: query_action, baseColumnNames: database_id, referencedTableName: metabase_database, referencedColumnNames: id, constraintName: fk_query_action_database_id, onDelete: CASCADE}
+- changeSet:
+    id: v46.00-011
+    author: snoe
+    validCheckSum: ANY
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - sql: {dbms: 'mysql,mariadb', sql: 'ALTER TABLE query_action DROP PRIMARY KEY, ADD PRIMARY KEY pk_query_action (action_id);'}
+    - sql: {dbms: h2, sql: ALTER TABLE query_action DROP PRIMARY KEY; ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id);}
+    - sql: {dbms: postgresql, sql: ALTER TABLE query_action DROP CONSTRAINT pk_query_action; ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id);}
+    rollback:
+    - sql: {dbms: 'mysql,mariadb', sql: 'ALTER TABLE query_action DROP PRIMARY KEY, ADD PRIMARY KEY pk_query_action (action_id, card_id);'}
+    - sql: {dbms: h2, sql: 'ALTER TABLE query_action DROP CONSTRAINT fk_query_action_ref_action_id; ALTER TABLE query_action DROP PRIMARY KEY; ALTER TABLE query_action ADD CONSTRAINT fk_query_action_ref_action_id FOREIGN KEY (action_id) REFERENCES action(id) ON DELETE CASCADE; ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id, card_id);'}
+    - sql: {dbms: postgresql, sql: 'ALTER TABLE query_action DROP CONSTRAINT pk_query_action; ALTER TABLE query_action ADD CONSTRAINT pk_query_action PRIMARY KEY (action_id, card_id);'}
+- changeSet:
+    id: v46.00-012
+    validCheckSum: 8:7e4dffe8bbbb740207001ead696a8557
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - dropNotNullConstraint: {tableName: query_action, columnDataType: int, columnName: card_id}
+- changeSet:
+    id: v46.00-013
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    validCheckSum: ANY
+    changes:
+    - sql:
+        sql: |-
+          INSERT INTO action (type, model_id, name) SELECT 'implicit', card_id, slug FROM model_action WHERE action_id is null AND slug in ('insert','update','delete');
+          INSERT INTO implicit_action (action_id, kind) SELECT
+            id,
+            case name
+              when 'insert' then 'row/create'
+              when 'update' then 'row/update'
+              when 'delete' then 'row/delete'
+            end
+          FROM action WHERE type = 'implicit';
+          UPDATE action SET model_id = (SELECT card_id
+                          FROM model_action
+                          WHERE model_action.action_id = action.id)
+          WHERE model_id is null;
+          DELETE FROM action WHERE model_id is null;
+          UPDATE report_dashboardcard SET action_id = (SELECT action.id
+                           FROM action
+                           LEFT JOIN implicit_action ON implicit_action.action_id = action.id
+                           WHERE action.model_id = report_dashboardcard.card_id
+                           AND coalesce((
+                              CASE implicit_action.kind
+                                 WHEN 'row/create' THEN 'insert'
+                                 WHEN 'row/delete' THEN 'delete'
+                                 WHEN 'row/update' THEN 'update'
+                              END), ('action_' || action.id)) =
+                              substring(report_dashboardcard.visualization_settings,
+                                position('"action_slug":"' in report_dashboardcard.visualization_settings)+15,
+                                position('"' in
                                   substring(report_dashboardcard.visualization_settings,
-                                    position('"action_slug":"' in report_dashboardcard.visualization_settings)+15,
-                                    position('"' in
-                                      substring(report_dashboardcard.visualization_settings,
-                                        position('"action_slug":"' in visualization_settings)+15)) - 1))
-              WHERE report_dashboardcard.visualization_settings like '%action_slug%';
+                                    position('"action_slug":"' in visualization_settings)+15)) - 1))
+          WHERE report_dashboardcard.visualization_settings like '%action_slug%';
+          UPDATE query_action SET
+            dataset_query = (select dataset_query from report_card where report_card.id = query_action.card_id),
+            database_id = (select database_id from report_card where report_card.id = query_action.card_id);
 
-              UPDATE query_action SET
-                dataset_query = (select dataset_query from report_card where report_card.id = query_action.card_id),
-                database_id = (select database_id from report_card where report_card.id = query_action.card_id);
-
-              UPDATE action SET
-                name = (
-                  select name
-                  from query_action
-                  inner join report_card on report_card.id = query_action.card_id
-                  where query_action.action_id = action.id),
-                description = (
-                  select description
-                  from query_action
-                  inner join report_card on report_card.id = query_action.card_id
-                  where query_action.action_id = action.id),
-                parameters = (
-                  select parameters
-                  from query_action
-                  inner join report_card on report_card.id = query_action.card_id
-                  where query_action.action_id = action.id),
-                parameter_mappings = (
-                  select parameter_mappings
-                  from query_action
-                  inner join report_card on report_card.id = query_action.card_id
-                  where query_action.action_id = action.id),
-                visualization_settings = (
-                  select visualization_settings
-                  from query_action
-                  inner join report_card on report_card.id = query_action.card_id
-                  where query_action.action_id = action.id)
-              WHERE type = 'query';
-      rollback: # no-op, we do not care to preserve actions from 46->45
-
-  - changeSet:
-      id: v46.00-014
-      validCheckSum: 8:585958ee7e90e23a9cc22ebf7e4228cb
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: query_action
-            constraintName: fk_query_action_ref_card_id
-      rollback:
-
-  - changeSet:
-      id: v46.00-015
-      validCheckSum: 8:9b57260e146618caff3f468116031008
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - dropColumn:
-            tableName: query_action
-            columnName: card_id
-
-      rollback:
-        - addColumn:
-            tableName: query_action
-            columns:
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: The related card
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_action_ref_card_id
-                    deleteCascade: true
-
-  - changeSet:
-      id: v46.00-016
-      validCheckSum: 8:cb79eef9f483e73b3d9b571f916b8598
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - sql:
-            sql: >-
-              DELETE FROM report_card
-              WHERE is_write = true;
-
-              DELETE FROM model_action;
-      rollback: # we do not care to preserve actions from 46->45
-        - sql:
-            sql: >-
-              DELETE FROM report_dashboardcard WHERE action_id is not null;
-              DELETE FROM action;
-
-  - changeSet:
-      id: v46.00-017
-      validCheckSum: 8:90525ade34e7bb883bf75cdf8a2b3340
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - dropColumn:
-            tableName: http_action
-            columnName: name
-      rollback:
-        - addColumn:
-            tableName: http_action
-            columns:
-              - column:
-                  name: name
-                  type: varchar(254)
-                  remarks: The name of this action
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v46.00-018
-      validCheckSum: 8:cf3c31a975dc86f1def6ee5d11f5f9dc
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - dropColumn:
-            tableName: http_action
-            columnName: description
-      rollback:
-        - addColumn:
-            tableName: http_action
-            columns:
-              - column:
-                  name: description
-                  type: ${text.type}
-                  remarks: An optional description for this action
-
-  - changeSet:
-      id: v46.00-019
-      validCheckSum: 8:a9f70163707cc7f798bdd0527a55854b
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - dropColumn:
-            tableName: report_card
-            columnName: is_write
-      rollback:
-        - addColumn:
-            columns:
-              - column:
-                  name: is_write
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: Indicates that this query will perform writes to a db
-                  constraints:
-                    nullable: false
-            tableName: report_card
-
-  - changeSet:
-      id: v46.00-020
-      validCheckSum: 8:2def45c139267d7424e1187764122669
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addNotNullConstraint:
-            tableName: query_action
-            columnName: database_id
-            columnDataType: int
-
-  - changeSet:
-      id: v46.00-021
-      validCheckSum: 8:52c8107f4bcc6e9889b270e0a4954921
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addNotNullConstraint:
-            tableName: query_action
-            columnName: dataset_query
-            columnDataType: ${text.type}
-
-  - changeSet:
-      id: v46.00-022
-      validCheckSum: 8:52c8107f4bcc6e9889b270e0a4954921
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addNotNullConstraint:
-            tableName: query_action
-            columnName: dataset_query
-            columnDataType: ${text.type}
-
-  - changeSet:
-      id: v46.00-023
-      validCheckSum: 8:33c91db1b039855af8bf1dc8315bd5d2
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addNotNullConstraint:
-            tableName: action
-            columnName: model_id
-            columnDataType: int
-
-  - changeSet:
-      id: v46.00-024
-      validCheckSum: 8:080ff435bae61f324535393d9e78de38
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - addNotNullConstraint:
-            tableName: action
-            columnName: name
-            columnDataType: varchar(254)
-
-  - changeSet:
-      id: v46.00-025
-      validCheckSum: 8:60016f3de98c7382602485f13bc4e04f
-      author: snoe
-      comment: Added 0.46.0 - Unify action representation
-      changes:
-        - dropTable:
-            tableName: model_action
-      rollback:
-        - createTable:
-            tableName: model_action
-            remarks: Ties actions to models
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: entity_id
-                  type: char(21)
-                  remarks: Random NanoID tag for unique identity.
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: slug
-                  type: varchar(254)
-                  remarks: The referenceable name for this action
-                  constraints:
-                    nullable: false
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: The associated model
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_model_action_ref_card_id
-                    deleteCascade: true
-              - column:
-                  name: action_id
-                  type: int
-                  remarks: The associated action
-                  constraints:
-                    nullable: true
-                    referencedTableName: action
-                    referencedColumnNames: id
-                    foreignKeyName: fk_model_action_ref_action_id
-                    deleteCascade: true
-              - column:
-                  name: requires_pk
-                  remarks: Indicates that the primary key(s) need to be passed in as parameters
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  name: parameter_mappings
-                  type: ${text.type}
-                  remarks: Mappings for primary keys to action parameters
-              - column:
-                  name: visualization_settings
-                  type: ${text.type}
-                  remarks: Settings for rendering the action
-
-  - changeSet:
-      id: v46.00-026
-      validCheckSum: 8:948b9653bfbadeb29c847ef41d053dba
-      author: metamben
-      comment: Added 0.46.0 -- add field for tracking DBMS versions
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: dbms_version
-                  type: ${text.type}
-                  remarks: 'A JSON object describing the flavor and version of the DBMS.'
-
-  - changeSet:
-      id: v46.00-027
-      validCheckSum: 8:5f7773b797a3c85a99cd35cb60cfd0b3
-      author: snoe
-      comment: Added 0.46.0 -- add last_used_at to FieldValues
-      changes:
-        - addColumn:
-            tableName: metabase_fieldvalues
-            columns:
-              - column:
-                  name: last_used_at
-                  type: ${timestamp_type}
-                  remarks: Timestamp of when these FieldValues were last used.
-                  constraints:
-                    nullable: false
-                  defaultValueComputed: current_timestamp
-
-  - changeSet:
-      id: v46.00-028
-      validCheckSum: 8:33cc1a038e926acb7dfd7cf29b4fa545
-      author: tsmacdonald
-      comment: Added 0.46.0 -- Join table connecting cards to dashboards/cards's parameters that need custom filter values from the card
-      changes:
-        - createTable:
-            tableName: parameter_card
-            remarks: "Join table connecting cards to entities (dashboards, other cards, etc.) that use the values generated by the card for filter values"
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  remarks: "most recent modification time"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  remarks: "creation time"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: "ID of the card generating the values"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: parameterized_object_type
-                  type: varchar(32)
-                  remarks: "Type of the entity consuming the values (dashboard, card, etc.)"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: parameterized_object_id
-                  type: int
-                  remarks: "ID of the entity consuming the values"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: parameter_id
-                  type: varchar(32)
-                  remarks: "The parameter ID"
-                  constraints:
-                    nullable: false
-
-  # Make Dimension <=> Field a 1t1 relationship. Replace unique field_id + name with unique field_id.
-  # See issue #27054.
-  - changeSet:
-      id: v46.00-029
-      validCheckSum: 8:96336855a4180eaf51d7be4a97f3b1a4
-      author: camsaul
-      comment: Make Dimension <=> Field a 1t1 relationship. Drop unique constraint on field_id + name. (1/3)
-      changes:
-        - dropUniqueConstraint:
-            tableName: dimension
-            constraintName: unique_dimension_field_id_name
-      rollback:
-        - addUniqueConstraint:
-            tableName: dimension
-            constraintName: unique_dimension_field_id_name
-            columnNames: field_id, name
-
-  - changeSet:
-      id: v46.00-030
-      validCheckSum: 8:e1f67579cb8dc1102445df299636cb7b
-      author: camsaul
-      comment: Make Dimension <=> Field a 1t1 relationship. Delete duplicate entries. (2/3)
-      changes:
-        - sql:
-            # Which rows to keep is not 100% clear. I decided to keep newer entries, by ID. I considered keeping new
-            # entries by `updated_at` but the SQL for doing that across the three databases was such a hairball and
-            # having duplicates in the first place was such an edge case I decided this approach is fine for now. The
-            # `row_number()` window function would have made this easier to do but we haven't merged H2 v2 yet.
-            #
-            # Writing the query with these unnecessary subselects is stupid, but MySQL 5.7 doesn't work without them.
-            # See https://metaboat.slack.com/archives/CKZEMT1MJ/p1670624514320419 for more info
-            sql: >-
-              DELETE FROM dimension
-              WHERE field_id IN (
-                SELECT field_id
-                FROM (
-                  SELECT field_id
-                  FROM dimension
-                  GROUP BY field_id
-                  HAVING COUNT(*) > 1
-                ) duplicates
+          UPDATE action SET
+            name = (
+              select name
+              from query_action
+              inner join report_card on report_card.id = query_action.card_id
+              where query_action.action_id = action.id),
+            description = (
+              select description
+              from query_action
+              inner join report_card on report_card.id = query_action.card_id
+              where query_action.action_id = action.id),
+            parameters = (
+              select parameters
+              from query_action
+              inner join report_card on report_card.id = query_action.card_id
+              where query_action.action_id = action.id),
+            parameter_mappings = (
+              select parameter_mappings
+              from query_action
+              inner join report_card on report_card.id = query_action.card_id
+              where query_action.action_id = action.id),
+            visualization_settings = (
+              select visualization_settings
+              from query_action
+              inner join report_card on report_card.id = query_action.card_id
+              where query_action.action_id = action.id)
+          WHERE type = 'query';
+    rollback: null
+- changeSet:
+    id: v46.00-014
+    validCheckSum: 8:585958ee7e90e23a9cc22ebf7e4228cb
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: query_action, constraintName: fk_query_action_ref_card_id}
+    rollback: null
+- changeSet:
+    id: v46.00-015
+    validCheckSum: 8:9b57260e146618caff3f468116031008
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - dropColumn: {tableName: query_action, columnName: card_id}
+    rollback:
+    - addColumn:
+        tableName: query_action
+        columns:
+        - column:
+            name: card_id
+            type: int
+            remarks: The related card
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_query_action_ref_card_id, deleteCascade: true}
+- changeSet:
+    id: v46.00-016
+    validCheckSum: 8:cb79eef9f483e73b3d9b571f916b8598
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - sql:
+        sql: |-
+          DELETE FROM report_card WHERE is_write = true;
+          DELETE FROM model_action;
+    rollback:
+    - sql: {sql: DELETE FROM report_dashboardcard WHERE action_id is not null; DELETE FROM action;}
+- changeSet:
+    id: v46.00-017
+    validCheckSum: 8:90525ade34e7bb883bf75cdf8a2b3340
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - dropColumn: {tableName: http_action, columnName: name}
+    rollback:
+    - addColumn:
+        tableName: http_action
+        columns:
+        - column:
+            name: name
+            type: varchar(254)
+            remarks: The name of this action
+            constraints: {nullable: false}
+- changeSet:
+    id: v46.00-018
+    validCheckSum: 8:cf3c31a975dc86f1def6ee5d11f5f9dc
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - dropColumn: {tableName: http_action, columnName: description}
+    rollback:
+    - addColumn:
+        tableName: http_action
+        columns:
+        - column: {name: description, type: '${text.type}', remarks: An optional description for this action}
+- changeSet:
+    id: v46.00-019
+    validCheckSum: 8:a9f70163707cc7f798bdd0527a55854b
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - dropColumn: {tableName: report_card, columnName: is_write}
+    rollback:
+    - addColumn:
+        columns:
+        - column:
+            name: is_write
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Indicates that this query will perform writes to a db
+            constraints: {nullable: false}
+        tableName: report_card
+- changeSet:
+    id: v46.00-020
+    validCheckSum: 8:2def45c139267d7424e1187764122669
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addNotNullConstraint: {tableName: query_action, columnName: database_id, columnDataType: int}
+- changeSet:
+    id: v46.00-021
+    validCheckSum: 8:52c8107f4bcc6e9889b270e0a4954921
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addNotNullConstraint: {tableName: query_action, columnName: dataset_query, columnDataType: '${text.type}'}
+- changeSet:
+    id: v46.00-022
+    validCheckSum: 8:52c8107f4bcc6e9889b270e0a4954921
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addNotNullConstraint: {tableName: query_action, columnName: dataset_query, columnDataType: '${text.type}'}
+- changeSet:
+    id: v46.00-023
+    validCheckSum: 8:33c91db1b039855af8bf1dc8315bd5d2
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addNotNullConstraint: {tableName: action, columnName: model_id, columnDataType: int}
+- changeSet:
+    id: v46.00-024
+    validCheckSum: 8:080ff435bae61f324535393d9e78de38
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - addNotNullConstraint: {tableName: action, columnName: name, columnDataType: varchar(254)}
+- changeSet:
+    id: v46.00-025
+    validCheckSum: 8:60016f3de98c7382602485f13bc4e04f
+    author: snoe
+    comment: Added 0.46.0 - Unify action representation
+    changes:
+    - dropTable: {tableName: model_action}
+    rollback:
+    - createTable:
+        tableName: model_action
+        remarks: Ties actions to models
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: entity_id
+            type: char(21)
+            remarks: Random NanoID tag for unique identity.
+            constraints: {nullable: false, unique: true}
+        - column:
+            name: slug
+            type: varchar(254)
+            remarks: The referenceable name for this action
+            constraints: {nullable: false}
+        - column:
+            name: card_id
+            type: int
+            remarks: The associated model
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_model_action_ref_card_id, deleteCascade: true}
+        - column:
+            name: action_id
+            type: int
+            remarks: The associated action
+            constraints: {nullable: true, referencedTableName: action, referencedColumnNames: id, foreignKeyName: fk_model_action_ref_action_id, deleteCascade: true}
+        - column:
+            name: requires_pk
+            remarks: Indicates that the primary key(s) need to be passed in as parameters
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        - column: {name: parameter_mappings, type: '${text.type}', remarks: Mappings for primary keys to action parameters}
+        - column: {name: visualization_settings, type: '${text.type}', remarks: Settings for rendering the action}
+- changeSet:
+    id: v46.00-026
+    validCheckSum: 8:948b9653bfbadeb29c847ef41d053dba
+    author: metamben
+    comment: Added 0.46.0 -- add field for tracking DBMS versions
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: dbms_version, type: '${text.type}', remarks: A JSON object describing the flavor and version of the DBMS.}
+- changeSet:
+    id: v46.00-027
+    validCheckSum: 8:5f7773b797a3c85a99cd35cb60cfd0b3
+    author: snoe
+    comment: Added 0.46.0 -- add last_used_at to FieldValues
+    changes:
+    - addColumn:
+        tableName: metabase_fieldvalues
+        columns:
+        - column:
+            name: last_used_at
+            type: ${timestamp_type}
+            remarks: Timestamp of when these FieldValues were last used.
+            constraints: {nullable: false}
+            defaultValueComputed: current_timestamp
+- changeSet:
+    id: v46.00-028
+    validCheckSum: 8:33cc1a038e926acb7dfd7cf29b4fa545
+    author: tsmacdonald
+    comment: Added 0.46.0 -- Join table connecting cards to dashboards/cards's parameters that need custom filter values from the card
+    changes:
+    - createTable:
+        tableName: parameter_card
+        remarks: Join table connecting cards to entities (dashboards, other cards, etc.) that use the values generated by the card for filter values
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            remarks: most recent modification time
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            remarks: creation time
+            constraints: {nullable: false}
+        - column:
+            name: card_id
+            type: int
+            remarks: ID of the card generating the values
+            constraints: {nullable: false}
+        - column:
+            name: parameterized_object_type
+            type: varchar(32)
+            remarks: Type of the entity consuming the values (dashboard, card, etc.)
+            constraints: {nullable: false}
+        - column:
+            name: parameterized_object_id
+            type: int
+            remarks: ID of the entity consuming the values
+            constraints: {nullable: false}
+        - column:
+            name: parameter_id
+            type: varchar(32)
+            remarks: The parameter ID
+            constraints: {nullable: false}
+- changeSet:
+    id: v46.00-029
+    validCheckSum: 8:96336855a4180eaf51d7be4a97f3b1a4
+    author: camsaul
+    comment: Make Dimension <=> Field a 1t1 relationship. Drop unique constraint on field_id + name. (1/3)
+    changes:
+    - dropUniqueConstraint: {tableName: dimension, constraintName: unique_dimension_field_id_name}
+    rollback:
+    - addUniqueConstraint: {tableName: dimension, constraintName: unique_dimension_field_id_name, columnNames: 'field_id, name'}
+- changeSet:
+    id: v46.00-030
+    validCheckSum: 8:e1f67579cb8dc1102445df299636cb7b
+    author: camsaul
+    comment: Make Dimension <=> Field a 1t1 relationship. Delete duplicate entries. (2/3)
+    changes:
+    - sql:
+        sql: |-
+          DELETE FROM dimension WHERE field_id IN (
+            SELECT field_id
+            FROM (
+              SELECT field_id
+              FROM dimension
+              GROUP BY field_id
+              HAVING COUNT(*) > 1
+            ) duplicates
+          ) AND id NOT IN (
+            SELECT id FROM (
+              SELECT max(id) AS id
+              FROM dimension
+              GROUP BY field_id
+            ) most_recents
+          );
+    rollback: null
+- changeSet:
+    id: v46.00-031
+    validCheckSum: 8:a9b4c86de880b2bc01e208d8d4d8cf64
+    author: camsaul
+    comment: Make Dimension <=> Field a 1t1 relationship. Add unique constraint on field_id. (3/3)
+    changes:
+    - addUniqueConstraint: {tableName: dimension, columnNames: field_id, constraintName: unique_dimension_field_id}
+- changeSet:
+    id: v46.00-032
+    validCheckSum: 8:2a7de9726282af199737a334395f1068
+    author: tsmacdonald
+    comment: Added 0.46.0 -- Unique parameter_card
+    changes:
+    - addUniqueConstraint: {tableName: parameter_card, columnNames: 'parameterized_object_id, parameterized_object_type, parameter_id', constraintName: unique_parameterized_object_card_parameter}
+- changeSet:
+    id: v46.00-033
+    validCheckSum: 8:25bc5b1a806d4b352d43f5b16e7e6e20
+    author: tsmacdonald
+    comment: Added 0.46.0 -- parameter_card index on connected object
+    changes:
+    - createIndex:
+        tableName: parameter_card
+        columns:
+        - column: {name: parameterized_object_id}
+        indexName: idx_parameter_card_parameterized_object_id
+- changeSet:
+    id: v46.00-034
+    validCheckSum: 8:5a6b5a2cf7160baec4f81f6675de898c
+    author: tsmacdonald
+    comment: Added 0.46.0 -- parameter_card index on connected card
+    changes:
+    - createIndex:
+        tableName: parameter_card
+        columns:
+        - column: {name: card_id}
+        indexName: idx_parameter_card_card_id
+- changeSet:
+    id: v46.00-035
+    validCheckSum: 8:0639e4c0939848b4377792290311f239
+    author: tsmacdonald
+    comment: Added 0.46.0 - parameter_card.card_id foreign key
+    changes:
+    - addForeignKeyConstraint: {baseTableName: parameter_card, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_parameter_card_ref_card_id, onDelete: CASCADE}
+- changeSet:
+    id: v46.00-036
+    validCheckSum: 8:39d440f29a481e9f0915532106079a1a
+    author: metamben
+    comment: App containers are removed in 0.46.0
+    changes:
+    - dropTable: {tableName: app_permission_graph_revision}
+    rollback:
+    - createTable:
+        tableName: app_permission_graph_revision
+        remarks: Used to keep track of changes made to app permissions.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: before
+            type: ${text.type}
+            remarks: Serialized JSON of the apps graph before the changes.
+            constraints: {nullable: false}
+        - column:
+            name: after
+            type: ${text.type}
+            remarks: Serialized JSON of the apps graph after the changes.
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The ID of the admin who made this set of changes.
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_app_permission_graph_revision_user_id}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when these changes were made.
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column: {name: remark, type: '${text.type}', remarks: Optional remarks explaining why these changes were made.}
+- changeSet:
+    id: v46.00-037
+    validCheckSum: 8:dbbe898501c554e3ee74c6b9ef9c1575
+    author: metamben
+    comment: App pages are removed in 0.46.0
+    changes:
+    - dropColumn: {tableName: report_dashboard, columnName: is_app_page}
+    rollback:
+    - addColumn:
+        columns:
+        - column:
+            name: is_app_page
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Indicates that this dashboard serves as a page of an app
+            constraints: {nullable: false}
+        tableName: report_dashboard
+- changeSet:
+    id: v46.00-038
+    validCheckSum: 8:220a27bae93423a2c9a76f611f10b87b
+    author: metamben
+    comment: App containers are removed in 0.46.0
+    changes:
+    - dropTable: {tableName: app}
+    rollback:
+    - createTable:
+        tableName: app
+        remarks: Defines top level concerns for App
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: entity_id
+            type: char(21)
+            remarks: Random NanoID tag for unique identity.
+            constraints: {nullable: false, unique: true}
+        - column:
+            name: collection_id
+            type: int
+            remarks: The associated collection
+            constraints: {nullable: false, referencedTableName: collection, referencedColumnNames: id, foreignKeyName: fk_app_ref_collection_id, deleteCascade: true, unique: true}
+        - column: {name: dashboard_id, type: int, remarks: The homepage of the app}
+        - column: {remarks: JSON for the navigation items of the app, name: nav_items, type: '${text.type}'}
+        - column: {remarks: 'JSON for frontend related additions, such as styling', name: options, type: '${text.type}'}
+        - column:
+            remarks: The timestamp of when the app was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the app was updated
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+    - addForeignKeyConstraint: {baseTableName: app, baseColumnNames: dashboard_id, referencedTableName: report_dashboard, referencedColumnNames: id, constraintName: fk_app_ref_dashboard_id, onDelete: SET NULL}
+- changeSet:
+    id: v46.00-039
+    validCheckSum: 8:7ed32de11fbe8565148d8491f908ad05
+    author: qnkhuat
+    comment: Added 0.46.0 - add entity_id to parameter_card
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: parameter_card
+- changeSet:
+    id: v46.00-040
+    validCheckSum: 8:7fec881cac598cce34b62c98fcf37563
+    author: tsmacdonald
+    comment: Added 0.46.0 -- Bump default dashcard size to 4x4
+    changes:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: size_x, defaultValue: 4}
+- changeSet:
+    id: v46.00-041
+    validCheckSum: 8:0214a8d0b94a9eb48aad75b1d50dd279
+    author: tsmacdonald
+    comment: Added 0.46.0 -- Bump default dashcard size to 4x4
+    changes:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: size_y, defaultValue: 4}
+- changeSet:
+    id: v46.00-042
+    validCheckSum: 8:7b91ad83569565517c43e9f7b9bfa29a
+    author: tsmacdonald
+    comment: Added 0.46.0 -- index query_execution.executor_id
+    changes:
+    - createIndex:
+        tableName: query_execution
+        columns:
+        - column: {name: executor_id}
+        indexName: idx_query_execution_executor_id
+- changeSet:
+    id: v46.00-043
+    validCheckSum: 8:d9cab29076035068cfc49fb9570832af
+    author: tsmacdonald
+    comment: Added 0.46.0 -- index query_execution.context
+    changes:
+    - createIndex:
+        tableName: query_execution
+        columns:
+        - column: {name: context}
+        indexName: idx_query_execution_context
+- changeSet:
+    id: v46.00-045
+    validCheckSum: 8:7a9cabf1c693de8b0c9555f7deb072a4
+    author: calherries
+    comment: Added 0.46.0 -- add public_uuid to action.
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column:
+            name: public_uuid
+            type: char(36)
+            remarks: Unique UUID used to in publically-accessible links to this Action.
+            constraints: {unique: true}
+- changeSet:
+    id: v46.00-051
+    validCheckSum: 8:74e83fc2ee7c1a06a94f07830f361773
+    author: calherries
+    comment: Added 0.46.0 -- drop defaults for dashcard's position and size
+    changes:
+    - dropDefaultValue: {tableName: report_dashboardcard, columnName: row}
+    rollback:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: row, defaultValueNumeric: 4}
+- changeSet:
+    id: v46.00-052
+    validCheckSum: 8:948c978fcb2d938d272a05b3e56808d1
+    author: calherries
+    comment: Added 0.46.0 -- drop defaults for dashcard's position and size
+    changes:
+    - dropDefaultValue: {tableName: report_dashboardcard, columnName: col}
+    rollback:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: col, defaultValueNumeric: 4}
+- changeSet:
+    id: v46.00-053
+    validCheckSum: 8:04e092dbffdfda13f28b1e3ea38299a7
+    author: calherries
+    comment: Added 0.46.0 -- drop defaults for dashcard's position and size
+    changes:
+    - dropDefaultValue: {tableName: report_dashboardcard, columnName: size_x}
+    rollback:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: size_x, defaultValueNumeric: 4}
+- changeSet:
+    id: v46.00-054
+    validCheckSum: 8:bc3abf9ab94199aeaebb2be28dea77aa
+    author: calherries
+    comment: Added 0.46.0 -- drop defaults for dashcard's position and size
+    changes:
+    - dropDefaultValue: {tableName: report_dashboardcard, columnName: size_y}
+    rollback:
+    - addDefaultValue: {tableName: report_dashboardcard, columnName: size_y, defaultValueNumeric: 4}
+- changeSet:
+    id: v46.00-055
+    validCheckSum: 8:48a516459b84a21e9edbdbfe1bffd671
+    author: calherries
+    comment: Added 0.46.0 -- add made_public_by_id
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: made_public_by_id, type: int, remarks: The ID of the User who first publically shared this Action.}
+- changeSet:
+    id: v46.00-056
+    validCheckSum: 8:af93ab591b44b5d81d8d8a496600c1bc
+    author: calherries
+    comment: Added 0.46.0 -- add public_uuid and made_public_by_id to action. public_uuid is indexed
+    changes:
+    - createIndex:
+        tableName: action
+        indexName: idx_action_public_uuid
+        columns:
+          column: {name: public_uuid}
+- changeSet:
+    id: v46.00-057
+    validCheckSum: 8:aff3b0e15dcfc36a4fd97faade0751c0
+    author: dpsutton
+    comment: Added 0.46.0 -- parameter_card.parameter_id long enough to hold a uuid
+    changes:
+    - modifyDataType: {tableName: parameter_card, columnName: parameter_id, newDataType: varchar(36)}
+    rollback: null
+- changeSet:
+    id: v46.00-058
+    validCheckSum: 8:11440c629413c7231e7f156347353761
+    author: calherries
+    comment: Added 0.46.0 -- add FK constraint for action.made_public_by_id with core_user.id
+    changes:
+    - addForeignKeyConstraint: {baseTableName: action, baseColumnNames: made_public_by_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_action_made_public_by_id, onDelete: CASCADE}
+- changeSet:
+    id: v46.00-059
+    validCheckSum: 8:6ddec7d622e9200e36bd5e2e2e0a48c2
+    author: tsmacdonald
+    comment: Added 0.46.0 -- add actions.creator_id
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column: {name: creator_id, type: int, remarks: The user who created the action}
+    rollback:
+    - dropColumn: {tableName: action, columnName: creator_id}
+- changeSet:
+    id: v46.00-060
+    validCheckSum: 8:fc1762a930726afb11131acf3a56312b
+    author: tsmacdonald
+    comment: Added 0.46.0 -- action.creator_id index
+    changes:
+    - createIndex:
+        tableName: action
+        columns:
+        - column: {name: creator_id}
+        indexName: idx_action_creator_id
+    rollback:
+    - dropIndex: {tableName: action, indexName: idx_action_creator_id}
+- changeSet:
+    id: v46.00-061
+    validCheckSum: 8:d57393ae0e96a9b1a0bd7a66597cb485
+    author: tsmacdonald
+    comment: Added 0.46.0 -- action.creator_id index
+    changes:
+    - addForeignKeyConstraint: {baseTableName: action, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_action_creator_id, nullable: false}
+- changeSet:
+    id: v46.00-062
+    validCheckSum: 8:20efdbd79df3c76cbf77318d871a9836
+    author: tsmacdonald
+    comment: Added 0.46.0 -- add actions.archived
+    changes:
+    - addColumn:
+        tableName: action
+        columns:
+        - column:
+            name: archived
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Whether or not the action has been archived
+            constraints: {nullable: false}
+    rollback:
+    - dropColumn: {tableName: action, columnName: archived}
+- changeSet:
+    id: v46.00-064
+    validCheckSum: 8:0ac10ca0d82f1bbe39737eb0a8fdcd7d
+    author: noahmoss
+    comment: Added 0.46.0 -- rename `group_table_access_policy` to `sandboxes`
+    changes:
+    - renameTable: {newTableName: sandboxes, oldTableName: group_table_access_policy}
+- changeSet:
+    id: v46.00-065
+    validCheckSum: 8:5cbb335952dd1ab7a137d80d6c1ab82e
+    author: noahmoss
+    comment: Added 0.46.0 -- add `permission_id` to `sandboxes`
+    changes:
+    - addColumn:
+        tableName: sandboxes
+        columns:
+        - column: {name: permission_id, type: int, remarks: The ID of the corresponding permissions path for this sandbox}
+- changeSet:
+    id: v46.00-070
+    validCheckSum: 8:d440a8d0aef0bbfdae24a9c70bd37605
+    author: calherries
+    comment: Added 0.46.0 - add entity_id column to action
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: action
+- changeSet:
+    id: v46.00-074
+    validCheckSum: 8:c1273a3003d82638a0a5413bf2aa6777
+    author: metamben
+    comment: Added 0.46.0 -- increase precision of updated_at of report_card
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: updated_at, newDataType: '${timestamp_type}'}
+    rollback:
+    - modifyDataType: {tableName: report_card, columnName: updated_at, newDataType: DATETIME}
+- changeSet:
+    id: v46.00-079
+    validCheckSum: 8:de167f33d3f7670246623466487d2e67
+    author: john-metabase
+    comment: Added 0.46.0 -- migrates Databases using deprecated and removed presto driver to presto-jdbc
+    changes:
+    - {sql: UPDATE metabase_database SET engine = 'presto-jdbc' WHERE engine = 'presto'}
+    rollback: null
+- changeSet:
+    id: v46.00-080
+    validCheckSum: 8:022a846feb10103f2e9fe4b58cb792d6
+    author: noahmoss
+    comment: Migrate data permission paths from v1 to v2 (splitting them into separate data and query permissions)
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.SplitDataPermissions}
+- changeSet:
+    id: v46.00-084
+    validCheckSum: 8:b4f465ca3be584028e077b907656b804
+    author: qnkhuat
+    comment: Added 0.46.0 - CASCADE delete for action.model_id
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: action, constraintName: fk_action_model_id}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: action, baseColumnNames: model_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_action_model_id, onDelete: CASCADE}
+- changeSet:
+    id: v46.00-085
+    validCheckSum: 8:17fe48c56aa457a6a09775099d44d7a5
+    author: qnkhuat
+    comment: Added 0.46.0 - CASCADE delete for action.model_id
+    changes:
+    - addForeignKeyConstraint: {baseTableName: action, baseColumnNames: model_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_action_model_id, onDelete: CASCADE}
+- changeSet:
+    id: v46.00-086
+    validCheckSum: 8:677e076d8741275d31a02e97531fd930
+    author: calherries
+    comment: Added 0.46.0 - Delete the abandonment email task
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.DeleteAbandonmentEmailTask}
+- changeSet:
+    id: v46.00-088
+    validCheckSum: 8:ff9defc19920960db55ef71e4d32b4ea
+    author: noahmoss
+    comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed verison of v46.00-066 which has been removed, since it had a bug that blocked a customer from upgrading.
+    changes:
+    - sql: |-
+        UPDATE sandboxes s SET permission_id = (
+          SELECT p.id
+          FROM permissions p
+          WHERE
+            p.object = CONCAT('/db/',
+                              (SELECT t.db_id FROM metabase_table t WHERE t.id = s.table_id),
+                              '/schema/',
+                              (SELECT t.schema FROM metabase_table t WHERE t.id = s.table_id),
+                              '/table/',
+                              s.table_id,
+                              '/query/segmented/')
+            AND p.group_id = s.group_id
+          LIMIT 1
+        ) WHERE permission_id IS NULL;
+    rollback: null
+- changeSet:
+    id: v46.00-089
+    validCheckSum: 8:e0fbd2514cc960cc74106204ac65a3ea
+    author: noahmoss
+    comment: Added 0.46.5 -- remove orphaned entries in `sandboxes`
+    changes:
+    - {sql: DELETE FROM sandboxes WHERE permission_id IS NULL;}
+    rollback: null
+- changeSet:
+    id: v46.00-090
+    validCheckSum: 8:963c0cd3a7bd2858e4dbfd4d4aad95cb
+    author: noahmoss
+    comment: Add foreign key constraint on sandboxes.permission_id
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - foreignKeyConstraintExists:
+        - {foreignKeyName: fk_sandboxes_ref_permissions}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: sandboxes, baseColumnNames: permission_id, referencedTableName: permissions, referencedColumnNames: id, constraintName: fk_sandboxes_ref_permissions, onDelete: CASCADE}
+- changeSet:
+    id: v47.00-001
+    validCheckSum: 8:14bf2732687c04256e9c036ba142aa93
+    author: calherries
+    comment: Added 0.47.0 -- set base-type to type/JSON for JSON database-types for postgres and mysql
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field f SET base_type = 'type/JSON' WHERE EXISTS (
+            SELECT *
+            FROM metabase_database d
+            JOIN metabase_table t ON t.db_id = d.id
+            WHERE f.table_id = t.id
+              AND lower(f.database_type) in ('json', 'jsonb')
+              AND d.engine in ('postgres', 'mysql')
+          )
+    rollback:
+    - sql:
+        dbms: postgresql
+        sql: |-
+          UPDATE metabase_field f SET base_type = case when d.engine = 'postgres' then 'type/Structured' else 'type/SerializedJSON' end FROM metabase_database d JOIN metabase_table t ON t.db_id = d.id WHERE f.table_id = t.id
+            AND lower(f.database_type) in ('json', 'jsonb')
+            AND d.engine in ('postgres', 'mysql')
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE metabase_field f JOIN metabase_table t ON f.table_id = t.id JOIN metabase_database d ON t.db_id = d.id SET base_type = case when d.engine = 'postgres' then 'type/Structured' else 'type/SerializedJSON' end WHERE lower(f.database_type) in ('json', 'jsonb')
+            AND d.engine in ('postgres', 'mysql')
+    - sql:
+        dbms: h2
+        sql: |-
+          MERGE INTO metabase_field f USING (
+            SELECT f.id, case when d.engine = 'postgres' then 'type/Structured' else 'type/SerializedJSON' end as base_type
+            FROM metabase_field f
+            JOIN metabase_table t ON f.table_id = t.id
+            JOIN metabase_database d ON t.db_id = d.id
+            WHERE lower(f.database_type) in ('json', 'jsonb')
+              AND d.engine in ('postgres', 'mysql')
+          ) as updates ON f.id = updates.id WHEN MATCHED THEN
+            UPDATE SET f.base_type = updates.base_type;
+- changeSet:
+    id: v47.00-002
+    validCheckSum: 8:963690f41f487b122464277c627823f6
+    author: calherries
+    comment: Added 0.47.0 - Add json_unfolding column to metabase_field
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: Enable/disable JSON unfolding for a field
+            name: json_unfolding
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        tableName: metabase_field
+- changeSet:
+    id: v47.00-003
+    validCheckSum: 8:97bccdf5e9bcdfacd1c315fa1342c167
+    author: calherries
+    comment: Added 0.47.0 - Populate metabase_field.json_unfolding based on base_type
+    changes:
+    - sql: {sql: UPDATE metabase_field SET json_unfolding = true WHERE base_type = 'type/JSON';}
+    rollback: null
+- changeSet:
+    id: v47.00-004
+    validCheckSum: 8:58ad79be7de00e413da51fab3c8beea0
+    author: qnkhuat
+    comment: Added 0.47.0 - Add auto_incremented to metabase_field
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: database_is_auto_increment
+            type: boolean
+            remarks: Indicates this field is auto incremented
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: v47.00-005
+    validCheckSum: 8:ccf53f27a551fd0799d0103bd65cca99
+    author: winlost
+    comment: Added 0.47.0 - Add auto_apply_filters to dashboard
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: auto_apply_filters
+            type: boolean
+            remarks: Whether or not to auto-apply filters on a dashboard
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+- changeSet:
+    id: v47.00-006
+    validCheckSum: 8:b63ff10d3d121bed42eece1ae3dbb177
+    author: qnkhuat
+    comment: Added 0.47.0 - Add dashboard_tab table
+    changes:
+    - createTable:
+        tableName: dashboard_tab
+        remarks: Join table connecting dashboard to dashboardcards
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: dashboard_id
+            type: int
+            remarks: The dashboard that a tab is on
+            constraints: {nullable: false, referencedTableName: report_dashboard, referencedColumnNames: id, foreignKeyName: fk_dashboard_tab_ref_dashboard_id, deleteCascade: true}
+        - column:
+            name: name
+            remarks: Displayed name of the tab
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            name: position
+            remarks: Position of the tab with respect to others tabs in dashboard
+            type: int
+            constraints: {nullable: false}
+        - column:
+            name: entity_id
+            type: char(21)
+            remarks: Random NanoID tag for unique identity.
+            constraints: {nullable: false, unique: true}
+        - column:
+            name: created_at
+            remarks: The timestamp at which the tab was created
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            remarks: The timestamp at which the tab was last updated
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v47.00-007
+    validCheckSum: 8:e9f7d6b18d65be6fde07c0b5471b8760
+    author: qnkhuat
+    comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id
+    changes:
+    - addColumn:
+        tableName: report_dashboardcard
+        columns:
+        - column:
+            name: dashboard_tab_id
+            type: int
+            remarks: The referenced tab id that dashcard is on, it's nullable for dashboard with no tab
+            constraints: {nullable: true}
+- changeSet:
+    id: v47.00-008
+    validCheckSum: 8:e37c88d202007bd3e6a72b6404d1b0e9
+    author: qnkhuat
+    comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id fk constraint
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_dashboardcard, baseColumnNames: dashboard_tab_id, referencedTableName: dashboard_tab, referencedColumnNames: id, constraintName: fk_report_dashboardcard_ref_dashboard_tab_id, deleteCascade: true}
+- changeSet:
+    id: v47.00-009
+    validCheckSum: 8:398124b0dd4dd6e117cdc1378152469b
+    author: qwef
+    comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
+    changes:
+    - sql: {sql: UPDATE core_user SET sso_source = 'google' WHERE google_auth = true;}
+    rollback:
+    - sql: {sql: 'UPDATE core_user SET google_auth = true, sso_source = NULL WHERE sso_source = ''google'';'}
+- changeSet:
+    id: v47.00-010
+    validCheckSum: 8:3c4f9fc116fbced18c50952def65b3e0
+    author: tsmacdonald
+    comment: Added 0.47.0 - Make metabase_table.name long enough for H2 names
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: name, newDataType: varchar(256)}
+    rollback: null
+- changeSet:
+    id: v47.00-011
+    validCheckSum: 8:148b982debddfa511cb45b87179b8c46
+    author: tsmacdonald
+    comment: Added 0.47.0 - Make metabase_table.display_name long enough for H2 names
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: display_name, newDataType: varchar(256)}
+    rollback: null
+- changeSet:
+    id: v47.00-012
+    validCheckSum: 8:bf19ef077bc6bc517c515dd78ca46e3b
+    author: qwef
+    comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
+    changes:
+    - dropColumn: {tableName: core_user, columnName: google_auth}
+    rollback:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column:
+            name: google_auth
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: v47.00-013
+    validCheckSum: 8:044aec6d07049e3c5a45830797189ab0
+    author: qwef
+    comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
+    changes:
+    - sql: {sql: UPDATE core_user SET sso_source = 'ldap' WHERE ldap_auth = true;}
+    rollback:
+    - sql: {sql: 'UPDATE core_user SET ldap_auth = true, sso_source = NULL WHERE sso_source = ''ldap'';'}
+- changeSet:
+    id: v47.00-014
+    validCheckSum: 8:6a973f3198ad4596ecade95e61b35991
+    author: qwef
+    comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
+    changes:
+    - dropColumn: {tableName: core_user, columnName: ldap_auth}
+    rollback:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column:
+            name: ldap_auth
+            type: boolean
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: v47.00-015
+    validCheckSum: 8:d2d5eea99db75e656709006b3a7749f0
+    author: escherize
+    comment: added 0.47.0 - Add is_audit to metabase_database
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: is_audit
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Only the app db, visible to admins via auditing should have this set true.
+            constraints: {nullable: false}
+- changeSet:
+    id: v47.00-016
+    validCheckSum: 8:62290f0389eb2a17170a9c0351ac8a85
+    author: calherres
+    comment: Added 0.47.0 - Migrate the report_card.visualization_settings.column_settings field refs from legacy format
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateLegacyColumnSettingsFieldRefs}
+- changeSet:
+    id: v47.00-018
+    validCheckSum: 8:7bacd2f60393eebd3bebcfdb0e952ecd
+    author: dpsutton
+    comment: Indexed Entities information table
+    changes:
+    - createTable:
+        tableName: model_index
+        remarks: Used to keep track of which models have indexed columns.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column: {name: model_id, type: int, remarks: The ID of the indexed model.}
+        - column:
+            name: pk_ref
+            type: ${text.type}
+            remarks: Serialized JSON of the primary key field ref.
+            constraints: {nullable: false}
+        - column:
+            name: value_ref
+            type: ${text.type}
+            remarks: Serialized JSON of the label field ref.
+            constraints: {nullable: false}
+        - column:
+            name: schedule
+            type: ${text.type}
+            remarks: The cron schedule for when value syncing should happen.
+            constraints: {nullable: false}
+        - column:
+            name: state
+            type: ${text.type}
+            remarks: 'The status of the index: initializing, indexed, error, overflow.'
+            constraints: {nullable: false}
+        - column:
+            name: indexed_at
+            type: ${timestamp_type}
+            remarks: When the status changed
+            constraints: {nullable: true}
+        - column:
+            name: error
+            type: ${text.type}
+            remarks: The error message if the status is error.
+            constraints: {nullable: true}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when these changes were made.
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            remarks: ID of the user who created the event
+            name: creator_id
+            type: int
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_model_index_creator_id, deleteCascade: true}
+    rollback:
+    - dropTable: {tableName: model_index}
+- changeSet:
+    id: v47.00-019
+    validCheckSum: 8:7a5589d70c80b3ffc99a85722f440a91
+    author: dpsutton
+    comment: Indexed Entities values table
+    changes:
+    - createTable:
+        tableName: model_index_value
+        remarks: Used to keep track of the values indexed in a model
+        columns:
+        - column: {name: model_index_id, type: int, remarks: The ID of the indexed model.}
+        - column:
+            name: model_pk
+            type: int
+            remarks: The primary key of the indexed value
+            constraints: {nullable: false}
+        - column:
+            name: name
+            type: ${text.type}
+            remarks: The label to display identifying the indexed value.
+            constraints: {nullable: false}
+    rollback:
+    - dropTable: {tableName: model_index_value}
+- changeSet:
+    id: v47.00-020
+    validCheckSum: 8:d32a4cf7b37f012a7db74628cdde48df
+    author: dpsutton
+    comment: Add unique constraint on index_id and pk
+    changes:
+    - addUniqueConstraint: {tableName: model_index_value, constraintName: unique_model_index_value_model_index_id_model_pk, columnNames: 'model_index_id, model_pk'}
+    rollback:
+    - dropUniqueConstraint: {tableName: model_index_value, constraintName: unique_model_index_value_model_index_id_model_pk}
+- changeSet:
+    id: v47.00-023
+    validCheckSum: 8:5d9e81c3e950afad66cb5e9e823b1f03
+    author: dpsutton
+    comment: Added 0.47.0 -- model_index index
+    changes:
+    - createIndex:
+        tableName: model_index
+        columns:
+        - column: {name: model_id}
+        indexName: idx_model_index_model_id
+- changeSet:
+    id: v47.00-024
+    validCheckSum: 8:3079db8d91e54ff2b41050f7dab27936
+    author: dpsutton
+    comment: Added 0.47.0 -- model_index foriegn key to report_card
+    changes:
+    - addForeignKeyConstraint: {baseTableName: model_index, baseColumnNames: model_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_model_index_model_id, nullable: false, deleteCascade: true}
+- changeSet:
+    id: v47.00-025
+    validCheckSum: 8:6889e314a2016c9bc017a358b81ed24e
+    author: dpsutton
+    comment: Added 0.47.0 -- model_index_value foriegn key to model_index
+    changes:
+    - addForeignKeyConstraint: {baseTableName: model_index_value, baseColumnNames: model_index_id, referencedTableName: model_index, referencedColumnNames: id, constraintName: fk_model_index_value_model_id, nullable: false, deleteCascade: true}
+- changeSet:
+    id: v47.00-026
+    validCheckSum: 8:acf279edf538ee29a4ea9103d809b3da
+    author: noahmoss
+    comment: Added 0.47.0 - New table for connection impersonation policies
+    changes:
+    - createTable:
+        tableName: connection_impersonations
+        remarks: Table for holding connection impersonation policies
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: db_id
+            type: int
+            remarks: ID of the database this connection impersonation policy affects
+            constraints: {nullable: false, referencedTableName: metabase_database, referencedColumnNames: id, foreignKeyName: fk_conn_impersonation_db_id, deleteCascade: true}
+        - column:
+            name: group_id
+            type: int
+            remarks: ID of the permissions group this connection impersonation policy affects
+            constraints: {nullable: false, referencedTableName: permissions_group, referencedColumnNames: id, foreignKeyName: fk_conn_impersonation_group_id, deleteCascade: true}
+        - column: {name: attribute, type: '${text.type}', remarks: User attribute associated with the database role to use for this connection impersonation policy}
+- changeSet:
+    id: v47.00-027
+    validCheckSum: 8:c720f3de8feed35e592c0ca9b9975a18
+    author: calherries
+    comment: Added 0.47.0 - Migrate field_ref in report_card.result_metadata from legacy format
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateLegacyResultMetadataFieldRefs}
+- changeSet:
+    id: v47.00-028
+    validCheckSum: 8:f38598170766acaaa8fd3b20ef683372
+    author: calherries
+    comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.AddJoinAliasToVisualizationSettingsFieldRefs}
+- changeSet:
+    id: v47.00-029
+    validCheckSum: 8:c7625e5018087e915e547f9318b2b8f5
+    author: qnkhuat
+    comment: Added 0.47.0 - Stack cards vertically for dashboard with tabs on downgrade
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.DowngradeDashboardTab}
+- changeSet:
+    id: v47.00-030
+    validCheckSum: 8:7919d959008457419a09fd3275d3ed00
+    author: escherize
+    comment: Added 0.47.0 - Type column for collections for instance-analytics
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column: {name: type, type: varchar(256), defaultValue: null, remarks: This is used to differentiate instance-analytics collections from all other collections.}
+- changeSet:
+    id: v47.00-031
+    author: qnkhuat
+    comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24
+    validCheckSum: 8:ad9bdb62df65cf26a5a9892a82779ea7
+    changes:
+    - sql: {dbms: postgresql, sql: update report_dashboardcard set size_x = size_x + floor(cast(size_x + col + 1  as decimal) / 3) - floor(cast(col + 1 as decimal) / 3); update report_dashboardcard set col    = col + floor(cast(col + 1 as decimal) / 3);}
+    - sql: {dbms: 'mysql,mariadb,h2', sql: update report_dashboardcard set size_x = size_x + floor(cast(size_x + col + 1  as decimal) / 3) - floor(cast(col + 1 as decimal) / 3); update report_dashboardcard set col    = col + floor(cast(col + 1 as decimal) / 3);}
+    rollback:
+    - sql: {dbms: postgresql, sql: update report_dashboardcard set size_x = size_x - (floor(cast(size_x + col + 1 as decimal) / 4) - floor(cast(col + 1 as decimal) / 4)) where size_x <> 1; update report_dashboardcard set col    = col - floor(cast(col + 1 as decimal) / 4);}
+    - sql: {dbms: 'mysql,mariadb,h2', sql: update report_dashboardcard set size_x = size_x - (floor(cast(size_x + col + 1 as decimal) / 4) - floor(cast(col + 1 as decimal) / 4)) where size_x <> 1; update report_dashboardcard set col    = col - floor(cast(col + 1 as decimal) / 4);}
+- changeSet:
+    id: v47.00-032
+    author: qnkhuat
+    comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24 for revisions
+    validCheckSum: ANY
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24}
+- changeSet:
+    id: v47.00-033
+    validCheckSum: 8:c4a38673bf2a702e807a2074c0d0b719
+    author: calherries
+    comment: Added 0.47.0 - Migrate field refs in visualization_settings.column_settings keys from legacy format
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.RevisionMigrateLegacyColumnSettingsFieldRefs}
+- changeSet:
+    id: v47.00-034
+    validCheckSum: 8:bb77d686c5c204e480a1da5fcfb518e2
+    author: calherries
+    comment: Added 0.47.0 - Add join-alias to the visualization_settings.column_settings field refs in card revisions
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.RevisionAddJoinAliasToColumnSettingsFieldRefs}
+- changeSet:
+    id: v47.00-035
+    validCheckSum: 8:aeafa7ff310f799eb3fb2e14640a9e06
+    author: calherries
+    comment: Added 0.47.0 - Drop foreign key constraint on implicit_action.action_id
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: implicit_action, constraintName: fk_implicit_action_action_id}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: implicit_action, baseColumnNames: action_id, referencedTableName: action, referencedColumnNames: id, constraintName: fk_implicit_action_action_id, onDelete: CASCADE}
+- changeSet:
+    id: v47.00-036
+    validCheckSum: 8:e815729b6ebfd4799743b249409558aa
+    author: calherries
+    comment: Added 0.47.0 - Set primary key to action_id for implicit_action table
+    changes:
+    - addPrimaryKey: {tableName: implicit_action, columnNames: action_id, constraintName: pk_implicit_action}
+- changeSet:
+    id: v47.00-037
+    validCheckSum: 8:58c705a18bb3441e3ed5d1167ec64fcb
+    author: calherries
+    comment: Added 0.47.0 - Add foreign key constraint on implicit_action.action_id
+    changes:
+    - addForeignKeyConstraint: {baseTableName: implicit_action, baseColumnNames: action_id, referencedTableName: action, referencedColumnNames: id, constraintName: fk_implicit_action_action_id, onDelete: CASCADE}
+- changeSet:
+    id: v47.00-043
+    validCheckSum: 8:5e030b73be03e7cd8b19a5a46f9b2a4c
+    author: calherres
+    comment: Added 0.47.0 - Migrate report_dashboardcard.visualization_settings.column_settings field refs from legacy format
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateLegacyDashboardCardColumnSettingsFieldRefs}
+- changeSet:
+    id: v47.00-044
+    validCheckSum: 8:1828d1bd8e2da6eec14ca61e6c01a56f
+    author: calherries
+    comment: Added 0.47.0 - Add join-alias to the report_dashboardcard.visualization_settings.column_settings field refs
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.AddJoinAliasToDashboardCardColumnSettingsFieldRefs}
+- changeSet:
+    id: v47.00-045
+    validCheckSum: 8:d7f479a389877010f5af9dc7ec859b51
+    author: calherres
+    comment: Added 0.47.0 - Migrate dashboard revision dashboard cards' visualization_settings.column_settings field refs from legacy format
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.RevisionMigrateLegacyDashboardCardColumnSettingsFieldRefs}
+- changeSet:
+    id: v47.00-046
+    validCheckSum: 8:1e43c8712a5b36809a3c3fa9933a523c
+    author: calherries
+    comment: Added 0.47.0 - Add join-alias to dashboard revision dashboard cards' visualization_settings.column_settings field refs
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.RevisionAddJoinAliasToDashboardCardColumnSettingsFieldRefs}
+- changeSet:
+    id: v47.00-050
+    validCheckSum: 8:a5d516f2b5ea92f401387646b49a9950
+    author: tsmacdonald
+    comment: Added 0.47.0 - table.is_upload
+    changes:
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column:
+            name: is_upload
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Was the table created from user-uploaded (i.e., from a CSV) data?
+            constraints: {nullable: false}
+- changeSet:
+    id: v47.00-051
+    validCheckSum: 8:83a8b7ad58b2deb0732e671db51fa608
+    author: noahmoss
+    comment: Added 0.47.0 - Drop foreign key constraint on connection_impersonations.db_id
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: connection_impersonations, constraintName: fk_conn_impersonation_db_id}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: connection_impersonations, baseColumnNames: db_id, referencedTableName: metabase_database, referencedColumnNames: id, constraintName: fk_conn_impersonation_db_id, onDelete: CASCADE}
+- changeSet:
+    id: v47.00-052
+    validCheckSum: 8:d170bef8f707027360cf08fb55e91452
+    author: noahmoss
+    comment: Added 0.47.0 - Drop foreign key constraint on connection_impersonations.group_id
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: connection_impersonations, constraintName: fk_conn_impersonation_group_id}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: connection_impersonations, baseColumnNames: group_id, referencedTableName: permissions_group, referencedColumnNames: id, constraintName: fk_conn_impersonation_group_id, onDelete: CASCADE}
+- changeSet:
+    id: v47.00-053
+    validCheckSum: 8:3b52631c2c82b88043b840391c7d9ef0
+    author: noahmoss
+    comment: Added 0.47.0 -- connection_impersonations index for db_id column
+    changes:
+    - createIndex:
+        tableName: connection_impersonations
+        columns:
+        - column: {name: db_id}
+        indexName: idx_conn_impersonations_db_id
+- changeSet:
+    id: v47.00-054
+    validCheckSum: 8:5404d7e3781f0dfcc984676ea434c842
+    author: noahmoss
+    comment: Added 0.47.0 -- connection_impersonations index for group_id column
+    changes:
+    - createIndex:
+        tableName: connection_impersonations
+        columns:
+        - column: {name: group_id}
+        indexName: idx_conn_impersonations_group_id
+- changeSet:
+    id: v47.00-055
+    validCheckSum: 8:295c4477995058b93eba2857090eb6f6
+    author: noahmoss
+    comment: Added 0.47.0 - unique constraint for connection impersonations
+    changes:
+    - addUniqueConstraint: {tableName: connection_impersonations, columnNames: 'group_id, db_id', constraintName: conn_impersonation_unique_group_id_db_id}
+    rollback:
+    - dropUniqueConstraint: {tableName: connection_impersonations, constraintName: conn_impersonation_unique_group_id_db_id}
+- changeSet:
+    id: v47.00-056
+    validCheckSum: 8:bd965141f770a65982ecebab51a565e9
+    author: noahmoss
+    comment: Added 0.47.0 - re-add foreign key constraint on connection_impersonations.db_id
+    changes:
+    - addForeignKeyConstraint: {baseTableName: connection_impersonations, baseColumnNames: db_id, referencedTableName: metabase_database, referencedColumnNames: id, constraintName: fk_conn_impersonation_db_id, onDelete: CASCADE}
+- changeSet:
+    id: v47.00-057
+    validCheckSum: 8:fe79acdba9db58709b6fffbb7aac2844
+    author: noahmoss
+    comment: Added 0.47.0 - re-add foreign key constraint on connection_impersonations.group_id
+    changes:
+    - addForeignKeyConstraint: {baseTableName: connection_impersonations, baseColumnNames: group_id, referencedTableName: permissions_group, referencedColumnNames: id, constraintName: fk_conn_impersonation_group_id, onDelete: CASCADE}
+- changeSet:
+    id: v47.00-058
+    validCheckSum: 8:05731b3e62deb09c64b60bc10031d206
+    author: qnkhuat
+    comment: Drop parameter_card.entity_id
+    preConditions:
+    - {onFail: MARK_RAN}
+    - columnExists: {tableName: parameter_card, columnName: entity_id}
+    changes:
+    - dropColumn: {tableName: parameter_card, columnName: entity_id}
+    rollback:
+    - addColumn:
+        tableName: parameter_card
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+- changeSet:
+    id: v47.00-059
+    validCheckSum: 8:123cf42eed168444f88418f071d2730f
+    author: piranha
+    comment: Drops not null from dashboard_tab.entity_id since it breaks drop-entity-ids command
+    changes:
+    - dropNotNullConstraint: {tableName: dashboard_tab, columnName: entity_id, columnDataType: char(21)}
+    rollback: null
+- changeSet:
+    id: v48.00-001
+    validCheckSum: 8:c38ceb502af7907aed614f17da6c3f80
+    author: qnkhuat
+    comment: Added 0.47.0 - Migrate database.options to database.settings
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateDatabaseOptionsToSettings}
+- changeSet:
+    id: v48.00-002
+    validCheckSum: 8:deceb81591f51f2d7253976f247e36cc
+    author: qnkhuat
+    comment: Added 0.47.0 - drop metabase_database.options
+    changes:
+    - dropColumn: {tableName: metabase_database, columnName: options}
+    rollback:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: options, type: '${text.type}', remarks: Serialized JSON containing various options like QB behavior.}
+- changeSet:
+    id: v48.00-003
+    validCheckSum: 8:da33cde0f1f93eed56c0f6d9ac2007df
+    author: qnkhuat
+    comment: Added 0.48.0 - drop computation_job_result table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - tableExists: {tableName: computation_job_result}
+    changes:
+    - dropTable: {tableName: computation_job_result}
+    rollback: null
+- changeSet:
+    id: v48.00-004
+    validCheckSum: 8:d0b1d7cc179c332b7e31f065325b7275
+    author: qnkhuat
+    comment: Added 0.48.0 - drop computation_job table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - tableExists: {tableName: computation_job}
+    changes:
+    - dropTable: {tableName: computation_job}
+    rollback: null
+- changeSet:
+    id: v48.00-005
+    validCheckSum: 8:a570f2e1d90a302bc207c00e3776eaaf
+    author: qnkhuat
+    comment: Added 0.48.0 - Add query_execution.action_id
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column: {name: action_id, type: integer, remarks: 'The ID of the action associated with this query execution, if any.'}
+- changeSet:
+    id: v48.00-006
+    validCheckSum: 8:cf1413241565a186bf98eece35d519bf
+    author: qnkhuat
+    comment: Added 0.48.0 - Index query_execution.action_id
+    changes:
+    - createIndex:
+        tableName: query_execution
+        indexName: idx_query_execution_action_id
+        columns:
+          column: {name: action_id}
+- changeSet:
+    id: v48.00-007
+    validCheckSum: 8:15d05ceba05e5b7d25d351fb6ec5b100
+    author: qnkhuat
+    comment: Added 0.48.0 - Add revision.most_recent
+    changes:
+    - addColumn:
+        tableName: revision
+        columns:
+        - column:
+            name: most_recent
+            type: boolean
+            defaultValueBoolean: false
+            remarks: Whether a revision is the most recent one
+            constraints: {nullable: false}
+- changeSet:
+    id: v48.00-008
+    validCheckSum: 8:c0a512701d6dfd5cc1c4a689919be074
+    author: qnkhuat
+    comment: Set revision.most_recent = true for latest revisions
+    changes:
+    - sql:
+        dbms: postgresql,h2
+        sql: |-
+          UPDATE revision r SET most_recent = true WHERE (model, model_id, timestamp) IN (
+                             SELECT model, model_id, MAX(timestamp)
+                             FROM revision
+                             GROUP BY model, model_id);
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE revision r JOIN (
+              SELECT model, model_id, MAX(timestamp) AS max_timestamp
+              FROM revision
+              GROUP BY model, model_id
+          ) AS subquery ON r.model = subquery.model AND r.model_id = subquery.model_id AND r.timestamp = subquery.max_timestamp SET r.most_recent = true;
+    rollback: null
+- changeSet:
+    id: v48.00-009
+    validCheckSum: 8:dfd90256380263274ea7f5cc0c5ed413
+    author: calherries
+    comment: Added 0.48.0 - Create table_privileges table
+    changes:
+    - createTable:
+        tableName: table_privileges
+        remarks: Table for user and role privileges by table
+        columns:
+        - column:
+            name: table_id
+            type: int
+            remarks: Table ID
+            constraints: {foreignKeyName: fk_table_privileges_table_id, nullable: false, referencedTableName: metabase_table, referencedColumnNames: id, deleteCascade: true}
+        - column: {name: role, type: varchar(255), remarks: Role name. NULL indicates the privileges are the current user's}
+        - column:
+            name: select
+            type: boolean
+            remarks: Privilege to select from the table
+            constraints: {nullable: false}
+            defaultValue: false
+        - column:
+            name: update
+            type: boolean
+            remarks: Privilege to update records in the table
+            constraints: {nullable: false}
+            defaultValue: false
+        - column:
+            name: insert
+            type: boolean
+            remarks: Privilege to insert records into the table
+            constraints: {nullable: false}
+            defaultValue: false
+        - column:
+            name: delete
+            type: boolean
+            remarks: Privilege to delete records from the table
+            constraints: {nullable: false}
+            defaultValue: false
+        uniqueConstraints:
+        - unique: {columnNames: 'table_id, role', name: uq_table_privileges_table_id_role}
+- changeSet:
+    id: v48.00-010
+    validCheckSum: 8:da6117039b6e0249b710cc3160af982d
+    author: qnkhuat
+    comment: Remove ON UPDATE for revision.timestamp on mysql, mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - sql: {sql: ALTER TABLE `revision` CHANGE `timestamp` `timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6);}
+    rollback: null
+- changeSet:
+    id: v48.00-011
+    validCheckSum: 8:65ef87949a7e9555fabaf69069806ee0
+    author: qnkhuat
+    comment: Index revision.most_recent
+    changes:
+    - createIndex:
+        tableName: revision
+        indexName: idx_revision_most_recent
+        columns:
+          column: {name: most_recent}
+- changeSet:
+    id: v48.00-013
+    validCheckSum: 8:145eb766e2d49e95f31d8a08df8ff776
+    author: qnkhuat
+    comment: Index unindexed FKs for postgres
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: postgresql}
+    changes:
+    - sql: {sql: CREATE INDEX IF NOT EXISTS idx_action_made_public_by_id ON action (made_public_by_id); CREATE INDEX IF NOT EXISTS idx_action_model_id ON action (model_id); CREATE INDEX IF NOT EXISTS idx_application_permissions_revision_user_id ON application_permissions_revision (user_id); CREATE INDEX IF NOT EXISTS idx_collection_permission_graph_revision_user_id ON collection_permission_graph_revision (user_id); CREATE INDEX IF NOT EXISTS idx_core_session_user_id ON core_session (user_id); CREATE INDEX IF NOT EXISTS idx_dashboard_tab_dashboard_id ON dashboard_tab (dashboard_id); CREATE INDEX IF NOT EXISTS idx_dimension_human_readable_field_id ON dimension (human_readable_field_id); CREATE INDEX IF NOT EXISTS idx_metabase_database_creator_id ON metabase_database (creator_id); CREATE INDEX IF NOT EXISTS idx_model_index_creator_id ON model_index (creator_id); CREATE INDEX IF NOT EXISTS idx_native_query_snippet_creator_id ON native_query_snippet (creator_id); CREATE INDEX IF NOT EXISTS idx_permissions_revision_user_id ON permissions_revision (user_id); CREATE INDEX IF NOT EXISTS idx_persisted_info_creator_id ON persisted_info (creator_id); CREATE INDEX IF NOT EXISTS idx_persisted_info_database_id ON persisted_info (database_id); CREATE INDEX IF NOT EXISTS idx_pulse_dashboard_id ON pulse (dashboard_id); CREATE INDEX IF NOT EXISTS idx_pulse_card_dashboard_card_id ON pulse_card (dashboard_card_id); CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_pulse_channel_id ON pulse_channel_recipient (pulse_channel_id); CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_user_id ON pulse_channel_recipient (user_id); CREATE INDEX IF NOT EXISTS idx_query_action_database_id ON query_action (database_id); CREATE INDEX IF NOT EXISTS idx_report_card_database_id ON report_card (database_id); CREATE INDEX IF NOT EXISTS idx_report_card_made_public_by_id ON report_card (made_public_by_id); CREATE INDEX IF NOT EXISTS idx_report_card_table_id ON report_card (table_id); CREATE INDEX IF NOT EXISTS idx_report_dashboard_made_public_by_id ON report_dashboard (made_public_by_id); CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_action_id ON report_dashboardcard (action_id); CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_dashboard_tab_id ON report_dashboardcard (dashboard_tab_id); CREATE INDEX IF NOT EXISTS idx_revision_user_id ON revision (user_id); CREATE INDEX IF NOT EXISTS idx_sandboxes_card_id ON sandboxes (card_id); CREATE INDEX IF NOT EXISTS idx_sandboxes_permission_id ON sandboxes (permission_id); CREATE INDEX IF NOT EXISTS idx_secret_creator_id ON secret (creator_id); CREATE INDEX IF NOT EXISTS idx_timeline_creator_id ON timeline (creator_id); CREATE INDEX IF NOT EXISTS idx_timeline_event_creator_id ON timeline_event (creator_id);}
+    rollback: null
+- changeSet:
+    id: v48.00-014
+    validCheckSum: 8:b2c1361f1dc14c2390a1dc25a4a86311
+    author: calherries
+    comment: Added 0.48.0 - Create table_privileges.table_id index
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: postgresql}
+    changes:
+    - createIndex:
+        indexName: idx_table_privileges_table_id
+        tableName: table_privileges
+        columns:
+        - column: {name: table_id}
+    rollback: null
+- changeSet:
+    id: v48.00-015
+    validCheckSum: 8:6f58cf60c8048bb39bbf6128058ff85e
+    author: calherries
+    comment: Added 0.48.0 - Create table_privileges.role index
+    changes:
+    - createIndex:
+        indexName: idx_table_privileges_role
+        tableName: table_privileges
+        columns:
+        - column: {name: role}
+    rollback: null
+- changeSet:
+    id: v48.00-016
+    validCheckSum: 8:ea2cb901edad5cf3a1250bdd2a9b0866
+    author: calherries
+    comment: Added 0.48.0 - Change the type of collection.slug to varchar(510)
+    changes:
+    - modifyDataType: {tableName: collection, columnName: slug, newDataType: varchar(510)}
+    rollback:
+    - modifyDataType: {tableName: collection, columnName: slug, newDataType: varchar(254)}
+- changeSet:
+    id: v48.00-018
+    validCheckSum: 8:efae52e7403f39c1458f53e885b4393d
+    author: noahmoss
+    comment: Add new recent_views table
+    changes:
+    - createTable:
+        tableName: recent_views
+        remarks: Used to store recently viewed objects for each user
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The user associated with this view
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_recent_views_ref_user_id}
+        - column:
+            name: model
+            type: varchar(16)
+            remarks: The name of the model that was viewed
+            constraints: {nullable: false}
+        - column:
+            name: model_id
+            type: int
+            remarks: The ID of the model that was viewed
+            constraints: {nullable: false}
+        - column:
+            name: timestamp
+            type: DATETIME
+            remarks: The time a view was recorded
+            constraints: {nullable: false}
+- changeSet:
+    id: v48.00-019
+    validCheckSum: 8:c3866a4b7cfbb49d4b626dc2fd750935
+    author: nemanjaglumac
+    comment: Collection color is removed in 0.48.0
+    changes:
+    - dropColumn: {tableName: collection, columnName: color}
+    rollback:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: color
+            type: char(7)
+            remarks: Seven-character hex color for this Collection, including the preceding hash sign.
+            constraints: {nullable: false}
+            defaultValue: '#31698A'
+- changeSet:
+    id: v48.00-020
+    validCheckSum: 8:2c410019e1834304131ff57278003d35
+    author: noahmoss
+    comment: Added 0.48.0 - Create recent_views.user_id index
+    changes:
+    - createIndex:
+        indexName: idx_recent_views_user_id
+        tableName: recent_views
+        columns:
+        - column: {name: user_id}
+    rollback: null
+- changeSet:
+    id: v48.00-021
+    validCheckSum: 8:a1543239e39c70dc9bab3bbc303242b1
+    author: piranha
+    comment: Cards store Metabase version used to create them
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: metabase_version, type: varchar(100), remarks: Metabase version used to create the card.}
+- changeSet:
+    id: v48.00-022
+    validCheckSum: 8:0f034d06b1ad5336c3c81b0d22cde259
+    author: johnswanson
+    comment: Migrate migrate-click-through to a custom migration
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'migrate-click-through';}
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateClickThrough}
+- changeSet:
+    id: v48.00-023
+    validCheckSum: 8:f18e5e053b508aab0bdd8c4bf1d7de4b
+    author: piranha
+    comment: Data migration migrate-remove-admin-from-group-mapping-if-needed
+    preConditions:
+    - {onFail: MARK_RAN}
+    - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM data_migrations WHERE id = 'migrate-remove-admin-from-group-mapping-if-needed';}
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateRemoveAdminFromGroupMappingIfNeeded}
+- changeSet:
+    id: v48.00-024
+    validCheckSum: 8:fab2a51d73c66cea059d55a6fea8bb2f
+    author: piranha
+    comment: All data migrations were transferred to custom_migrations!
+    changes:
+    - dropTable: {tableName: data_migrations}
+    rollback:
+    - sql:
+        sql: |-
+          CREATE TABLE data_migrations (
+            id varchar(254) primary key,
+            timestamp ${timestamp_type} not null
+          ); INSERT INTO data_migrations VALUES
+              ('set-card-database-and-table-ids', current_timestamp),
+              ('set-mongodb-databases-ssl-false', current_timestamp),
+              ('set-default-schemas', current_timestamp),
+              ('set-admin-email', current_timestamp),
+              ('remove-database-sync-activity-entries', current_timestamp),
+              ('remove-duplicate-fk-entries', current_timestamp),
+              ('update-dashboards-to-new-grid', current_timestamp),
+              ('migrate-field-visibility-type', current_timestamp),
+              ('fix-dashboard-cards-without-positions', current_timestamp),
+              ('migrate-fk-metadata', current_timestamp),
+              ('create-raw-tables', current_timestamp),
+              ('migrate-base-types', current_timestamp),
+              ('migrate-field-types', current_timestamp),
+              ('fix-invalid-field-types', current_timestamp),
+              ('add-users-to-default-permissions-groups', current_timestamp),
+              ('add-admin-group-root-entry', current_timestamp),
+              ('add-databases-to-magic-permissions-groups', current_timestamp),
+              ('fix-legacy-magic-group-names', current_timestamp),
+              ('remove-trailing-slashes-from-site-url-setting', current_timestamp),
+              ('copy-site-url-setting-and-remove-trailing-slashes', current_timestamp),
+              ('migrate-query-executions', current_timestamp),
+              ('drop-old-query-execution-table', current_timestamp),
+              ('ensure-protocol-specified-in-site-url', current_timestamp),
+              ('populate-card-database-id', current_timestamp),
+              ('migrate-humanization-setting', current_timestamp),
+              ('populate-card-read-permissions', current_timestamp),
+              ('mark-category-fields-as-list', current_timestamp),
+              ('repopulate-card-read-permissions', current_timestamp),
+              ('add-legacy-sql-directive-to-bigquery-sql-cards', current_timestamp),
+              ('clear-ldap-user-local-passwords', current_timestamp),
+              ('add-migrated-collections', current_timestamp),
+              ('migrate-map-regions', current_timestamp),
+              ('migrate-click-through', current_timestamp),
+              ('migrate-remove-admin-from-group-mapping-if-needed', current_timestamp);
+- changeSet:
+    id: v48.00-025
+    validCheckSum: 8:a2fa9ab0913b9e4b97dff91f973344d6
+    author: piranha
+    comment: Revisions store Metabase version used to create them
+    changes:
+    - addColumn:
+        tableName: revision
+        columns:
+        - column: {name: metabase_version, type: varchar(100), remarks: Metabase version used to create the revision.}
+- changeSet:
+    id: v48.00-026
+    validCheckSum: 8:7c8330e861c16997780a9b0881144b26
+    author: lbrdnk
+    comment: Set semantic_type with value type/Number to null (#18754)
+    changes:
+    - update:
+        tableName: metabase_field
+        columns:
+        - column: {name: semantic_type, value: null}
+        where: semantic_type = 'type/Number'
+    rollback: null
+- changeSet:
+    id: v48.00-027
+    author: qnkhuat
+    validCheckSum: ANY
+    comment: No op migration
+    changes:
+    - {sql: SELECT 1;}
+    rollback: null
+- changeSet:
+    id: v48.00-028
+    validCheckSum: 8:818119252c2e7877bbf46aec40fab160
+    author: noahmoss
+    comment: Add new audit_log table
+    changes:
+    - createTable:
+        tableName: audit_log
+        remarks: Used to store application events for auditing use cases
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: topic
+            type: varchar(32)
+            remarks: The topic of a given audit event
+            constraints: {nullable: false}
+        - column:
+            name: timestamp
+            type: ${timestamp_type}
+            remarks: The time an event was recorded
+            constraints: {nullable: false}
+        - column:
+            name: end_timestamp
+            type: ${timestamp_type}
+            remarks: The time an event ended, if applicable
+            constraints: {nullable: true}
+        - column:
+            name: user_id
+            type: int
+            remarks: The user who performed an action or triggered an event
+            constraints: {nullable: true}
+        - column:
+            name: model
+            type: varchar(32)
+            remarks: The name of the model this event applies to (e.g. Card, Dashboard), if applicable
+            constraints: {nullable: true}
+        - column:
+            name: model_id
+            type: int
+            remarks: The ID of the model this event applies to, if applicable
+            constraints: {nullable: true}
+        - column:
+            name: details
+            type: ${text.type}
+            remarks: A JSON map with metadata about the event
+            constraints: {nullable: false}
+- changeSet:
+    id: v48.00-029
+    validCheckSum: 8:1994760ab0950e7f591c40e887295e1a
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_audit_log
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/audit_log/v1/postgres-audit_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/audit_log/v1/mysql-audit_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/audit_log/v1/h2-audit_log.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_audit_log;}
+- changeSet:
+    id: v48.00-030
+    validCheckSum: 8:965d6479698fe55f2f6799be552b5edb
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_content
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/content/v1/postgres-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/content/v1/mysql-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/content/v1/h2-content.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_content;}
+- changeSet:
+    id: v48.00-031
+    validCheckSum: 8:721bedb0dd362793a1a216cf3e552f3b
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_dashboardcard
+    changes:
+    - sqlFile: {path: instance_analytics_views/dashboardcard/v1/dashboardcard.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_dashboardcard;}
+- changeSet:
+    id: v48.00-032
+    validCheckSum: 8:64d52462def7bb6981a3b6a40d42e67e
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_group_members
+    changes:
+    - sqlFile: {path: instance_analytics_views/group_members/v1/group_members.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_group_members;}
+- changeSet:
+    id: v48.00-033
+    validCheckSum: 8:7ac57373a0fba4bd9613c242702c863d
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_subscriptions for postgres
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/subscriptions/v1/postgres-subscriptions.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/subscriptions/v1/mysql-subscriptions.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/subscriptions/v1/h2-subscriptions.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_subscriptions;}
+- changeSet:
+    id: v48.00-034
+    validCheckSum: 8:1c268d93ce69eaee11e3ecdf9951449a
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_users
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/users/v1/postgres-users.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/users/v1/mysql-users.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/users/v1/h2-users.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_users;}
+- changeSet:
+    id: v48.00-035
+    validCheckSum: 8:c0276764af3e1b4b5b0c4e5fdc979e60
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_alerts
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/alerts/v1/postgres-alerts.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/alerts/v1/mysql-alerts.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/alerts/v1/h2-alerts.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_alerts;}
+- changeSet:
+    id: v48.00-036
+    validCheckSum: 8:8a35e1bdf0738ccac5da8062d6671dd0
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_databases
+    changes:
+    - sqlFile: {path: instance_analytics_views/databases/v1/databases.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_databases;}
+- changeSet:
+    id: v48.00-037
+    validCheckSum: 8:a4b6ebd594b4663a6a888211f36ce6c3
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_fields
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/fields/v1/postgres-fields.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/fields/v1/mysql-fields.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/fields/v1/h2-fields.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_fields;}
+- changeSet:
+    id: v48.00-038
+    validCheckSum: 8:a24f4bcd3336e79d1c8ef33ab81c0db3
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_query_log
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/query_log/v1/postgres-query_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/query_log/v1/mysql-query_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/query_log/v1/h2-query_log.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_query_log;}
+- changeSet:
+    id: v48.00-039
+    validCheckSum: 8:b43481a01df86830c4cb1adb8189d400
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_tables
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/tables/v1/postgres-tables.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/tables/v1/mysql-tables.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/tables/v1/h2-tables.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_tables;}
+- changeSet:
+    id: v48.00-040
+    validCheckSum: 8:b8842eac1c7cba6e997d4d288306e36c
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_view_log
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/view_log/v1/postgres-view_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/view_log/v1/mysql-view_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/view_log/v1/h2-view_log.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_view_log;}
+- changeSet:
+    id: v48.00-045
+    validCheckSum: 8:874f14ae26d742448d8dd2b47dc8aa3d
+    author: qwef
+    comment: Added 0.48.0 - add is_sandboxed to query_execution
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column:
+            name: is_sandboxed
+            type: boolean
+            remarks: Is query from a sandboxed user
+            constraints: {nullable: true}
+- changeSet:
+    id: v48.00-046
+    validCheckSum: 8:4bb11295621890202e066cd15de93a52
+    author: noahmoss
+    comment: Added 0.48.0 - new indexes to optimize audit v2 queries
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/indexes/v1/postgres-indexes.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: mysql, path: instance_analytics_views/indexes/v1/mysql-indexes.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: mariadb, path: instance_analytics_views/indexes/v1/mariadb-indexes.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/indexes/v1/h2-indexes.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: mysql, path: instance_analytics_views/indexes/v1/mysql-rollback.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v48.00-047
+    validCheckSum: 8:2b18bed0e1ae18dd7b26a0770dac54c0
+    author: noahmoss
+    comment: Drop foreign key on recent_views so that it can be recreated with onDelete policy
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: recent_views, constraintName: fk_recent_views_ref_user_id}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: recent_views, constraintName: fk_recent_views_ref_user_id, referencedTableName: core_user, baseColumnNames: user_id, referencedColumnNames: id, onDelete: CASCADE}
+- changeSet:
+    id: v48.00-048
+    validCheckSum: 8:872e632a8ffa42eb2969f77823e8bfc8
+    author: noahmoss
+    comment: Add foreign key on recent_views with onDelete CASCADE
+    changes:
+    - addForeignKeyConstraint: {baseTableName: recent_views, constraintName: fk_recent_views_ref_user_id, referencedTableName: core_user, baseColumnNames: user_id, referencedColumnNames: id, onDelete: CASCADE}
+    rollback:
+    - dropForeignKeyConstraint: {baseTableName: recent_views, constraintName: fk_recent_views_ref_user_id}
+- changeSet:
+    id: v48.00-049
+    validCheckSum: 8:853f2a24c53470bf2d9e85b1246bab7b
+    author: noahmoss
+    comment: Migrate data from activity to audit_log
+    changes:
+    - sql:
+        dbms: postgresql
+        sql: |-
+          INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details) SELECT
+            topic,
+            timestamp,
+            user_id,
+            model,
+            model_id,
+            details::jsonb || json_strip_nulls(json_build_object('database_id', database_id, 'table_id', table_id))::jsonb
+          FROM activity;
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details) SELECT
+              topic,
+              timestamp,
+              user_id,
+              model,
+              model_id,
+              JSON_MERGE(
+                  details,
+                  JSON_OBJECT('database_id', database_id, 'table_id', table_id)
               )
-              AND id NOT IN (
-                SELECT id FROM (
-                  SELECT max(id) AS id
-                  FROM dimension
-                  GROUP BY field_id
-                ) most_recents
-              );
-      rollback: # don't need to roll back anything, deleting duplicate entries doesn't need to be reversed.
-
-  - changeSet:
-      id: v46.00-031
-      validCheckSum: 8:a9b4c86de880b2bc01e208d8d4d8cf64
-      author: camsaul
-      comment: Make Dimension <=> Field a 1t1 relationship. Add unique constraint on field_id. (3/3)
-      changes:
-        - addUniqueConstraint:
-            tableName: dimension
-            columnNames: field_id
-            constraintName: unique_dimension_field_id
-        # this change can roll back automatically.
-
-  - changeSet:
-      id: v46.00-032
-      validCheckSum: 8:2a7de9726282af199737a334395f1068
-      author: tsmacdonald
-      comment: Added 0.46.0 -- Unique parameter_card
-      changes:
-        - addUniqueConstraint:
-            tableName: parameter_card
-            columnNames: parameterized_object_id, parameterized_object_type, parameter_id
-            constraintName: unique_parameterized_object_card_parameter
-
-  - changeSet:
-      id: v46.00-033
-      validCheckSum: 8:25bc5b1a806d4b352d43f5b16e7e6e20
-      author: tsmacdonald
-      comment: Added 0.46.0 -- parameter_card index on connected object
-      changes:
-        - createIndex:
-            tableName: parameter_card
-            columns:
-              - column:
-                  name: parameterized_object_id
-            indexName: idx_parameter_card_parameterized_object_id
-
-  - changeSet:
-      id: v46.00-034
-      validCheckSum: 8:5a6b5a2cf7160baec4f81f6675de898c
-      author: tsmacdonald
-      comment: Added 0.46.0 -- parameter_card index on connected card
-      changes:
-        - createIndex:
-            tableName: parameter_card
-            columns:
-              - column:
-                  name: card_id
-            indexName: idx_parameter_card_card_id
-
-  - changeSet:
-      id: v46.00-035
-      validCheckSum: 8:0639e4c0939848b4377792290311f239
-      author: tsmacdonald
-      comment: Added 0.46.0 - parameter_card.card_id foreign key
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: parameter_card
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_parameter_card_ref_card_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v46.00-036
-      validCheckSum: 8:39d440f29a481e9f0915532106079a1a
-      author: metamben
-      comment: App containers are removed in 0.46.0
-      changes:
-        - dropTable:
-            tableName: app_permission_graph_revision
-      rollback:
-        - createTable:
-            tableName: app_permission_graph_revision
-            remarks: 'Used to keep track of changes made to app permissions.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: before
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the apps graph before the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: after
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the apps graph after the changes.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'The ID of the admin who made this set of changes.'
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_app_permission_graph_revision_user_id
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: 'The timestamp of when these changes were made.'
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: remark
-                  type: ${text.type}
-                  remarks: 'Optional remarks explaining why these changes were made.'
-
-  - changeSet:
-      id: v46.00-037
-      validCheckSum: 8:dbbe898501c554e3ee74c6b9ef9c1575
-      author: metamben
-      comment: App pages are removed in 0.46.0
-      changes:
-        - dropColumn:
-            tableName: report_dashboard
-            columnName: is_app_page
-      rollback:
-        - addColumn:
-            columns:
-              - column:
-                  name: is_app_page
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: Indicates that this dashboard serves as a page of an app
-                  constraints:
-                    nullable: false
-            tableName: report_dashboard
-
-  - changeSet:
-      id: v46.00-038
-      validCheckSum: 8:220a27bae93423a2c9a76f611f10b87b
-      author: metamben
-      comment: App containers are removed in 0.46.0
-      changes:
-        - dropTable:
-            tableName: app
-      rollback:
-        - createTable:
-            tableName: app
-            remarks: Defines top level concerns for App
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: entity_id
-                  type: char(21)
-                  remarks: Random NanoID tag for unique identity.
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: The associated collection
-                  constraints:
-                    nullable: false
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_app_ref_collection_id
-                    deleteCascade: true
-                    unique: true
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: The homepage of the app
-              - column:
-                  remarks: JSON for the navigation items of the app
-                  name: nav_items
-                  type: ${text.type}
-              - column:
-                  remarks: JSON for frontend related additions, such as styling
-                  name: options
-                  type: ${text.type}
-              - column:
-                  remarks: The timestamp of when the app was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the app was updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-        - addForeignKeyConstraint:
-            baseTableName: app
-            baseColumnNames: dashboard_id
-            referencedTableName: report_dashboard
-            referencedColumnNames: id
-            constraintName: fk_app_ref_dashboard_id
-            onDelete: SET NULL
-
-  - changeSet:
-      id: v46.00-039
-      validCheckSum: 8:7ed32de11fbe8565148d8491f908ad05
-      author: qnkhuat
-      comment: Added 0.46.0 - add entity_id to parameter_card
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: parameter_card
-
-  - changeSet:
-      id: v46.00-040
-      validCheckSum: 8:7fec881cac598cce34b62c98fcf37563
-      author: tsmacdonald
-      comment: Added 0.46.0 -- Bump default dashcard size to 4x4
-      changes:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_x
-            defaultValue: 4
-
-  - changeSet:
-      id: v46.00-041
-      validCheckSum: 8:0214a8d0b94a9eb48aad75b1d50dd279
-      author: tsmacdonald
-      comment: Added 0.46.0 -- Bump default dashcard size to 4x4
-      changes:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_y
-            defaultValue: 4
-
-  - changeSet:
-      id: v46.00-042
-      validCheckSum: 8:7b91ad83569565517c43e9f7b9bfa29a
-      author: tsmacdonald
-      comment: Added 0.46.0 -- index query_execution.executor_id
-      changes:
-        - createIndex:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: executor_id
-            indexName: idx_query_execution_executor_id
-
-  - changeSet:
-      id: v46.00-043
-      validCheckSum: 8:d9cab29076035068cfc49fb9570832af
-      author: tsmacdonald
-      comment: Added 0.46.0 -- index query_execution.context
-      changes:
-        - createIndex:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: context
-            indexName: idx_query_execution_context
-
-  - changeSet:
-      id: v46.00-045
-      validCheckSum: 8:7a9cabf1c693de8b0c9555f7deb072a4
-      author: calherries
-      comment: Added 0.46.0 -- add public_uuid to action.
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: public_uuid
-                  type: char(36)
-                  remarks: 'Unique UUID used to in publically-accessible links to this Action.'
-                  constraints:
-                    unique: true
-
-  - changeSet:
-      id: v46.00-051
-      validCheckSum: 8:74e83fc2ee7c1a06a94f07830f361773
-      author: calherries
-      comment: Added 0.46.0 -- drop defaults for dashcard's position and size
-      changes:
-        - dropDefaultValue:
-            tableName: report_dashboardcard
-            columnName: row
-      rollback:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: row
-            defaultValueNumeric: 4
-
-  - changeSet:
-      id: v46.00-052
-      validCheckSum: 8:948c978fcb2d938d272a05b3e56808d1
-      author: calherries
-      comment: Added 0.46.0 -- drop defaults for dashcard's position and size
-      changes:
-        - dropDefaultValue:
-            tableName: report_dashboardcard
-            columnName: col
-      rollback:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: col
-            defaultValueNumeric: 4
-
-  - changeSet:
-      id: v46.00-053
-      validCheckSum: 8:04e092dbffdfda13f28b1e3ea38299a7
-      author: calherries
-      comment: Added 0.46.0 -- drop defaults for dashcard's position and size
-      changes:
-        - dropDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_x
-      rollback:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_x
-            defaultValueNumeric: 4
-
-  - changeSet:
-      id: v46.00-054
-      validCheckSum: 8:bc3abf9ab94199aeaebb2be28dea77aa
-      author: calherries
-      comment: Added 0.46.0 -- drop defaults for dashcard's position and size
-      changes:
-        - dropDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_y
-      rollback:
-        - addDefaultValue:
-            tableName: report_dashboardcard
-            columnName: size_y
-            defaultValueNumeric: 4
-
-  - changeSet:
-      id: v46.00-055
-      validCheckSum: 8:48a516459b84a21e9edbdbfe1bffd671
-      author: calherries
-      comment: Added 0.46.0 -- add made_public_by_id
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: made_public_by_id
-                  type: int
-                  remarks: 'The ID of the User who first publically shared this Action.'
-
-  - changeSet:
-      id: v46.00-056
-      validCheckSum: 8:af93ab591b44b5d81d8d8a496600c1bc
-      author: calherries
-      comment: Added 0.46.0 -- add public_uuid and made_public_by_id to action. public_uuid is indexed
-      changes:
-        - createIndex:
-            tableName: action
-            indexName: idx_action_public_uuid
-            columns:
-              column:
-                name: public_uuid
-
-  - changeSet:
-      id: v46.00-057
-      validCheckSum: 8:aff3b0e15dcfc36a4fd97faade0751c0
-      author: dpsutton
-      comment: Added 0.46.0 -- parameter_card.parameter_id long enough to hold a uuid
-      changes:
-        - modifyDataType:
-            tableName: parameter_card
-            columnName: parameter_id
-            newDataType: varchar(36)
-      rollback: #nothing to do, char(32) or char(36) are equivalent
-
-  - changeSet:
-      id: v46.00-058
-      validCheckSum: 8:11440c629413c7231e7f156347353761
-      author: calherries
-      comment: Added 0.46.0 -- add FK constraint for action.made_public_by_id with core_user.id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: action
-            baseColumnNames: made_public_by_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_action_made_public_by_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v46.00-059
-      validCheckSum: 8:6ddec7d622e9200e36bd5e2e2e0a48c2
-      author: tsmacdonald
-      comment: Added 0.46.0 -- add actions.creator_id
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: creator_id
-                  type: int
-                  remarks: 'The user who created the action'
-      rollback:
-        - dropColumn:
-            tableName: action
-            columnName: creator_id
-
-  - changeSet:
-      id: v46.00-060
-      validCheckSum: 8:fc1762a930726afb11131acf3a56312b
-      author: tsmacdonald
-      comment: Added 0.46.0 -- action.creator_id index
-      changes:
-        - createIndex:
-            tableName: action
-            columns:
-              - column:
-                  name: creator_id
-            indexName: idx_action_creator_id
-      rollback:
-        - dropIndex:
-            tableName: action
-            indexName: idx_action_creator_id
-
-  - changeSet:
-      id: v46.00-061
-      validCheckSum: 8:d57393ae0e96a9b1a0bd7a66597cb485
-      author: tsmacdonald
-      comment: Added 0.46.0 -- action.creator_id index
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: action
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_action_creator_id
-            nullable: false
-
-  - changeSet:
-      id: v46.00-062
-      validCheckSum: 8:20efdbd79df3c76cbf77318d871a9836
-      author: tsmacdonald
-      comment: Added 0.46.0 -- add actions.archived
-      changes:
-        - addColumn:
-            tableName: action
-            columns:
-              - column:
-                  name: archived
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: 'Whether or not the action has been archived'
-                  constraints:
-                    nullable: false
-      rollback:
-        - dropColumn:
-            tableName: action
-            columnName: archived
-
-  - changeSet:
-      id: v46.00-064
-      validCheckSum: 8:0ac10ca0d82f1bbe39737eb0a8fdcd7d
-      author: noahmoss
-      comment: Added 0.46.0 -- rename `group_table_access_policy` to `sandboxes`
-      changes:
-        - renameTable:
-            newTableName: sandboxes
-            oldTableName: group_table_access_policy
-
-  - changeSet:
-      id: v46.00-065
-      validCheckSum: 8:5cbb335952dd1ab7a137d80d6c1ab82e
-      author: noahmoss
-      comment: Added 0.46.0 -- add `permission_id` to `sandboxes`
-      changes:
-      - addColumn:
-          tableName: sandboxes
-          columns:
-          - column:
-              name: permission_id
-              type: int
-              remarks: The ID of the corresponding permissions path for this sandbox
-
-  - changeSet:
-      id: v46.00-070
-      validCheckSum: 8:d440a8d0aef0bbfdae24a9c70bd37605
-      author: calherries
-      comment: Added 0.46.0 - add entity_id column to action
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: action
-
-  - changeSet:
-      id: v46.00-074
-      validCheckSum: 8:c1273a3003d82638a0a5413bf2aa6777
-      author: metamben
-      comment: Added 0.46.0 -- increase precision of updated_at of report_card
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: updated_at
-            newDataType: ${timestamp_type}
-      rollback:
-        - modifyDataType:
-            tableName: report_card
-            columnName: updated_at
-            newDataType: DATETIME
-
-  - changeSet:
-      id: v46.00-079
-      validCheckSum: 8:de167f33d3f7670246623466487d2e67
-      author: john-metabase
-      comment: Added 0.46.0 -- migrates Databases using deprecated and removed presto driver to presto-jdbc
-      changes:
-        - sql: UPDATE metabase_database SET engine = 'presto-jdbc' WHERE engine = 'presto'
-      rollback: # nothing to do, since we don't know which drivers used to be presto
-
-  - changeSet:
-      id: v46.00-080
-      validCheckSum: 8:022a846feb10103f2e9fe4b58cb792d6
-      author: noahmoss
-      comment: Migrate data permission paths from v1 to v2 (splitting them into separate data and query permissions)
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.SplitDataPermissions"
-
-  - changeSet:
-      id: v46.00-084
-      validCheckSum: 8:b4f465ca3be584028e077b907656b804
-      author: qnkhuat
-      comment: Added 0.46.0 - CASCADE delete for action.model_id
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: action
-            constraintName: fk_action_model_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: action
-            baseColumnNames: model_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_action_model_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v46.00-085
-      validCheckSum: 8:17fe48c56aa457a6a09775099d44d7a5
-      author: qnkhuat
-      comment: Added 0.46.0 - CASCADE delete for action.model_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: action
-            baseColumnNames: model_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_action_model_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v46.00-086
-      validCheckSum: 8:677e076d8741275d31a02e97531fd930
-      author: calherries
-      comment: Added 0.46.0 - Delete the abandonment email task
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.DeleteAbandonmentEmailTask"
-
-  - changeSet:
-      id: v46.00-088
-      validCheckSum: 8:ff9defc19920960db55ef71e4d32b4ea
-      author: noahmoss
-      comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed verison of v46.00-066
-               which has been removed, since it had a bug that blocked a customer from upgrading.
-      changes:
-        - sql: >-
-            UPDATE sandboxes s
-            SET permission_id = (
-              SELECT p.id
-              FROM permissions p
-              WHERE
-                p.object = CONCAT('/db/',
-                                  (SELECT t.db_id FROM metabase_table t WHERE t.id = s.table_id),
-                                  '/schema/',
-                                  (SELECT t.schema FROM metabase_table t WHERE t.id = s.table_id),
-                                  '/table/',
-                                  s.table_id,
-                                  '/query/segmented/')
-                AND p.group_id = s.group_id
-              LIMIT 1
-            )
-            WHERE permission_id IS NULL;
-      rollback:
-        # not required, new values added here do not need to be dropped
-
-  - changeSet:
-      id: v46.00-089
-      validCheckSum: 8:e0fbd2514cc960cc74106204ac65a3ea
-      author: noahmoss
-      comment: Added 0.46.5 -- remove orphaned entries in `sandboxes`
-      changes:
-        - sql: >-
-            DELETE FROM sandboxes
-            WHERE permission_id IS NULL;
-      rollback: # not required, orphaned sandboxes should not be re-added to the DB
-
-  - changeSet:
-      id: v46.00-090
-      validCheckSum: 8:963c0cd3a7bd2858e4dbfd4d4aad95cb
-      author: noahmoss
-      comment: Add foreign key constraint on sandboxes.permission_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                - foreignKeyName: fk_sandboxes_ref_permissions
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: sandboxes
-            baseColumnNames: permission_id
-            referencedTableName: permissions
-            referencedColumnNames: id
-            constraintName: fk_sandboxes_ref_permissions
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v47.00-001
-      validCheckSum: 8:14bf2732687c04256e9c036ba142aa93
-      author: calherries
-      comment: Added 0.47.0 -- set base-type to type/JSON for JSON database-types for postgres and mysql
-      changes:
-        - sql:
-            sql: >-
-              UPDATE metabase_field f
-              SET base_type = 'type/JSON'
-              WHERE EXISTS (
-                SELECT *
-                FROM metabase_database d
-                JOIN metabase_table t ON t.db_id = d.id
-                WHERE f.table_id = t.id
-                  AND lower(f.database_type) in ('json', 'jsonb')
-                  AND d.engine in ('postgres', 'mysql')
+          FROM activity;
+    - sql:
+        dbms: h2
+        sql: |-
+          INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details) SELECT
+              topic,
+              timestamp,
+              user_id,
+              model,
+              model_id,
+              JSON_OBJECT(
+                'database_id': database_id,
+                'table_id': table_id
+                ABSENT ON NULL
               )
-      rollback:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              UPDATE metabase_field f
-              SET base_type = case when d.engine = 'postgres' then 'type/Structured' else 'type/SerializedJSON' end
-              FROM metabase_database d
-              JOIN metabase_table t ON t.db_id = d.id
-              WHERE f.table_id = t.id
-                AND lower(f.database_type) in ('json', 'jsonb')
-                AND d.engine in ('postgres', 'mysql')
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE metabase_field f
-              JOIN metabase_table t ON f.table_id = t.id
-              JOIN metabase_database d ON t.db_id = d.id
-              SET base_type = case when d.engine = 'postgres' then 'type/Structured' else 'type/SerializedJSON' end
-              WHERE lower(f.database_type) in ('json', 'jsonb')
-                AND d.engine in ('postgres', 'mysql')
-        - sql:
-            dbms: h2
-            sql: >-
-              MERGE INTO metabase_field f
-              USING (
-                SELECT f.id, case when d.engine = 'postgres' then 'type/Structured' else 'type/SerializedJSON' end as base_type
-                FROM metabase_field f
-                JOIN metabase_table t ON f.table_id = t.id
-                JOIN metabase_database d ON t.db_id = d.id
-                WHERE lower(f.database_type) in ('json', 'jsonb')
-                  AND d.engine in ('postgres', 'mysql')
-              ) as updates
-              ON f.id = updates.id
-              WHEN MATCHED THEN
-                UPDATE SET f.base_type = updates.base_type;
-
-  - changeSet:
-      id: v47.00-002
-      validCheckSum: 8:963690f41f487b122464277c627823f6
-      author: calherries
-      comment: Added 0.47.0 - Add json_unfolding column to metabase_field
-      changes:
-        - addColumn:
-            columns:
-            - column:
-                remarks: 'Enable/disable JSON unfolding for a field'
-                name: json_unfolding
-                type: boolean
-                defaultValueBoolean: false
-                constraints:
-                  nullable: false
-            tableName: metabase_field
-
-  - changeSet:
-      id: v47.00-003
-      validCheckSum: 8:97bccdf5e9bcdfacd1c315fa1342c167
-      author: calherries
-      comment: Added 0.47.0 - Populate metabase_field.json_unfolding based on base_type
-      changes:
-        - sql:
-            sql: >-
-              UPDATE metabase_field
-              SET json_unfolding = true
-              WHERE base_type = 'type/JSON';
-      rollback: # nothing to do, since json_unfolding is new in 47
-
-  - changeSet:
-      id: v47.00-004
-      validCheckSum: 8:58ad79be7de00e413da51fab3c8beea0
-      author: qnkhuat
-      comment: Added 0.47.0 - Add auto_incremented to metabase_field
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: database_is_auto_increment
-                  type: boolean
-                  remarks: Indicates this field is auto incremented
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v47.00-005
-      validCheckSum: 8:ccf53f27a551fd0799d0103bd65cca99
-      author: winlost
-      comment: Added 0.47.0 - Add auto_apply_filters to dashboard
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: auto_apply_filters
-                  type: boolean
-                  remarks: Whether or not to auto-apply filters on a dashboard
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v47.00-006
-      validCheckSum: 8:b63ff10d3d121bed42eece1ae3dbb177
-      author: qnkhuat
-      comment: Added 0.47.0 - Add dashboard_tab table
-      changes:
-        - createTable:
-            tableName: dashboard_tab
-            remarks: "Join table connecting dashboard to dashboardcards"
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: The dashboard that a tab is on
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_dashboard
-                    referencedColumnNames: id
-                    foreignKeyName: fk_dashboard_tab_ref_dashboard_id
-                    deleteCascade: true
-              - column:
-                  name: name
-                  remarks: Displayed name of the tab
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: position
-                  remarks: Position of the tab with respect to others tabs in dashboard
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: entity_id
-                  type: char(21)
-                  remarks: Random NanoID tag for unique identity.
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: created_at
-                  remarks: The timestamp at which the tab was created
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  remarks: The timestamp at which the tab was last updated
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v47.00-007
-      validCheckSum: 8:e9f7d6b18d65be6fde07c0b5471b8760
-      author: qnkhuat
-      comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id
-      changes:
-        - addColumn:
-            tableName: report_dashboardcard
-            columns:
-              - column:
-                  name: dashboard_tab_id
-                  type: int
-                  remarks: The referenced tab id that dashcard is on, it's nullable for dashboard with no tab
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v47.00-008
-      validCheckSum: 8:e37c88d202007bd3e6a72b6404d1b0e9
-      author: qnkhuat
-      comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id fk constraint
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboardcard
-            baseColumnNames: dashboard_tab_id
-            referencedTableName: dashboard_tab
-            referencedColumnNames: id
-            constraintName: fk_report_dashboardcard_ref_dashboard_tab_id
-            deleteCascade: true
-
-  - changeSet:
-      id: v47.00-009
-      validCheckSum: 8:398124b0dd4dd6e117cdc1378152469b
-      author: qwef
-      comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
-      changes:
-        - sql:
-            sql: UPDATE core_user SET sso_source = 'google' WHERE google_auth = true;
-      rollback:
-        - sql:
-            sql: UPDATE core_user SET google_auth = true, sso_source = NULL WHERE sso_source = 'google';
-
-  - changeSet:
-      id: v47.00-010
-      validCheckSum: 8:3c4f9fc116fbced18c50952def65b3e0
-      author: tsmacdonald
-      comment: Added 0.47.0 - Make metabase_table.name long enough for H2 names
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: name
-            newDataType: varchar(256)
-      rollback: # no rollback needed, varchar(256) is backwards compatible
-
-  - changeSet:
-      id: v47.00-011
-      validCheckSum: 8:148b982debddfa511cb45b87179b8c46
-      author: tsmacdonald
-      comment: Added 0.47.0 - Make metabase_table.display_name long enough for H2 names
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: display_name
-            newDataType: varchar(256)
-      rollback: # no rollback needed, varchar(256) is backwards compatible
-
-  - changeSet:
-      id: v47.00-012
-      validCheckSum: 8:bf19ef077bc6bc517c515dd78ca46e3b
-      author: qwef
-      comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
-      changes:
-        - dropColumn:
-            tableName: core_user
-            columnName: google_auth
-      rollback:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: google_auth
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v47.00-013
-      validCheckSum: 8:044aec6d07049e3c5a45830797189ab0
-      author: qwef
-      comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
-      changes:
-        - sql:
-            sql: UPDATE core_user SET sso_source = 'ldap' WHERE ldap_auth = true;
-      rollback:
-        - sql:
-            sql: UPDATE core_user SET ldap_auth = true, sso_source = NULL WHERE sso_source = 'ldap';
-
-  - changeSet:
-      id: v47.00-014
-      validCheckSum: 8:6a973f3198ad4596ecade95e61b35991
-      author: qwef
-      comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
-      changes:
-        - dropColumn:
-            tableName: core_user
-            columnName: ldap_auth
-      rollback:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: ldap_auth
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v47.00-015
-      validCheckSum: 8:d2d5eea99db75e656709006b3a7749f0
-      author: escherize
-      comment: added 0.47.0 - Add is_audit to metabase_database
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: is_audit
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: 'Only the app db, visible to admins via auditing should have this set true.'
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v47.00-016
-      validCheckSum: 8:62290f0389eb2a17170a9c0351ac8a85
-      author: calherres
-      comment: Added 0.47.0 - Migrate the report_card.visualization_settings.column_settings field refs from legacy format
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateLegacyColumnSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-018
-      validCheckSum: 8:7bacd2f60393eebd3bebcfdb0e952ecd
-      author: dpsutton
-      comment: Indexed Entities information table
-      changes:
-        - createTable:
-            tableName: model_index
-            remarks: 'Used to keep track of which models have indexed columns.'
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: model_id
-                  type: int
-                  remarks: 'The ID of the indexed model.'
-              - column:
-                  name: pk_ref
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the primary key field ref.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: value_ref
-                  type: ${text.type}
-                  remarks: 'Serialized JSON of the label field ref.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: schedule
-                  type: ${text.type}
-                  remarks: 'The cron schedule for when value syncing should happen.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: state
-                  type: ${text.type}
-                  remarks: 'The status of the index: initializing, indexed, error, overflow.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: indexed_at
-                  type: ${timestamp_type}
-                  remarks: 'When the status changed'
-                  constraints:
-                    nullable: true
-              - column:
-                  name: error
-                  type: ${text.type}
-                  remarks: 'The error message if the status is error.'
-                  constraints:
-                    nullable: true
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: 'The timestamp of when these changes were made.'
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: 'ID of the user who created the event'
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_model_index_creator_id
-                    deleteCascade: true
-      rollback:
-        - dropTable:
-            tableName: model_index
-
-  - changeSet:
-      id: v47.00-019
-      validCheckSum: 8:7a5589d70c80b3ffc99a85722f440a91
-      author: dpsutton
-      comment: Indexed Entities values table
-      changes:
-        - createTable:
-            tableName: model_index_value
-            remarks: 'Used to keep track of the values indexed in a model'
-            columns:
-              - column:
-                  name: model_index_id
-                  type: int
-                  remarks: 'The ID of the indexed model.'
-              - column:
-                  name: model_pk
-                  type: int
-                  remarks: 'The primary key of the indexed value'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: name
-                  type: ${text.type}
-                  remarks: 'The label to display identifying the indexed value.'
-                  constraints:
-                    nullable: false
-      rollback:
-        - dropTable:
-            tableName: model_index_value
-
-  - changeSet:
-      id: v47.00-020
-      validCheckSum: 8:d32a4cf7b37f012a7db74628cdde48df
-      author: dpsutton
-      comment: Add unique constraint on index_id and pk
-      changes:
-        - addUniqueConstraint:
-            tableName: model_index_value
-            constraintName: unique_model_index_value_model_index_id_model_pk
-            columnNames: model_index_id, model_pk
-      rollback:
-        - dropUniqueConstraint:
-            tableName: model_index_value
-            constraintName: unique_model_index_value_model_index_id_model_pk
-
-  - changeSet:
-      id: v47.00-023
-      validCheckSum: 8:5d9e81c3e950afad66cb5e9e823b1f03
-      author: dpsutton
-      comment: Added 0.47.0 -- model_index index
-      changes:
-        - createIndex:
-            tableName: model_index
-            columns:
-              - column:
-                  name: model_id
-            indexName: idx_model_index_model_id
-
-  - changeSet:
-      id: v47.00-024
-      validCheckSum: 8:3079db8d91e54ff2b41050f7dab27936
-      author: dpsutton
-      comment: Added 0.47.0 -- model_index foriegn key to report_card
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: model_index
-            baseColumnNames: model_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_model_index_model_id
-            nullable: false
-            deleteCascade: true
-
-  - changeSet:
-      id: v47.00-025
-      validCheckSum: 8:6889e314a2016c9bc017a358b81ed24e
-      author: dpsutton
-      comment: Added 0.47.0 -- model_index_value foriegn key to model_index
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: model_index_value
-            baseColumnNames: model_index_id
-            referencedTableName: model_index
-            referencedColumnNames: id
-            constraintName: fk_model_index_value_model_id
-            nullable: false
-            deleteCascade: true
-
-  - changeSet:
-      id: v47.00-026
-      validCheckSum: 8:acf279edf538ee29a4ea9103d809b3da
-      author: noahmoss
-      comment: Added 0.47.0 - New table for connection impersonation policies
-      changes:
-        - createTable:
-            tableName: connection_impersonations
-            remarks: Table for holding connection impersonation policies
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: db_id
-                  type: int
-                  remarks: 'ID of the database this connection impersonation policy affects'
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_database
-                    referencedColumnNames: id
-                    foreignKeyName: fk_conn_impersonation_db_id
-                    deleteCascade: true
-              - column:
-                  name: group_id
-                  type: int
-                  remarks: 'ID of the permissions group this connection impersonation policy affects'
-                  constraints:
-                    nullable: false
-                    referencedTableName: permissions_group
-                    referencedColumnNames: id
-                    foreignKeyName: fk_conn_impersonation_group_id
-                    deleteCascade: true
-              - column:
-                  name: attribute
-                  type: ${text.type}
-                  remarks: 'User attribute associated with the database role to use for this connection impersonation policy'
-
-  - changeSet:
-      id: v47.00-027
-      validCheckSum: 8:c720f3de8feed35e592c0ca9b9975a18
-      author: calherries
-      comment: Added 0.47.0 - Migrate field_ref in report_card.result_metadata from legacy format
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateLegacyResultMetadataFieldRefs"
-
-  - changeSet:
-      id: v47.00-028
-      validCheckSum: 8:f38598170766acaaa8fd3b20ef683372
-      author: calherries
-      comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.AddJoinAliasToVisualizationSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-029
-      validCheckSum: 8:c7625e5018087e915e547f9318b2b8f5
-      author: qnkhuat
-      comment: Added 0.47.0 - Stack cards vertically for dashboard with tabs on downgrade
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.DowngradeDashboardTab"
-
-  - changeSet:
-      id: v47.00-030
-      validCheckSum: 8:7919d959008457419a09fd3275d3ed00
-      author: escherize
-      comment: Added 0.47.0 - Type column for collections for instance-analytics
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: type
-                  type: varchar(256)
-                  defaultValue: null
-                  remarks: 'This is used to differentiate instance-analytics collections from all other collections.'
-
-  - changeSet:
-      id: v47.00-031
-      author: qnkhuat
-      comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24
-      validCheckSum: 8:ad9bdb62df65cf26a5a9892a82779ea7
-      changes:
-          # new_size_x = size_x + ((col + size_x + 1) // 3) - ((col + 1) // 3)
-          # new_col    = col + ((col + 1) // 3)
-          - sql:
-              dbms: postgresql
-              sql: >-
-                  update report_dashboardcard set size_x = size_x + floor(cast(size_x + col + 1  as decimal) / 3) - floor(cast(col + 1 as decimal) / 3);
-                  update report_dashboardcard set col    = col + floor(cast(col + 1 as decimal) / 3);
-          - sql:
-              dbms: mysql,mariadb,h2
-              sql: >-
-                  update report_dashboardcard set size_x = size_x + floor(cast(size_x + col + 1  as decimal) / 3) - floor(cast(col + 1 as decimal) / 3);
-                  update report_dashboardcard set col    = col + floor(cast(col + 1 as decimal) / 3);
-
-      rollback:
-          # new_size_x = size_x - ((size_x + col + 1) // 4 - (col + 1) // 4) for size_x > 1
-          # new_col    = col - (col + 1) // 4
-          # for size_x, we keep it as it is, because it can't be smaller right?
-          - sql:
-              dbms: postgresql
-              sql: >-
-                  update report_dashboardcard set size_x = size_x - (floor(cast(size_x + col + 1 as decimal) / 4) - floor(cast(col + 1 as decimal) / 4)) where size_x <> 1;
-                  update report_dashboardcard set col    = col - floor(cast(col + 1 as decimal) / 4);
-
-          - sql:
-              dbms: mysql,mariadb,h2
-              sql: >-
-                  update report_dashboardcard set size_x = size_x - (floor(cast(size_x + col + 1 as decimal) / 4) - floor(cast(col + 1 as decimal) / 4)) where size_x <> 1;
-                  update report_dashboardcard set col    = col - floor(cast(col + 1 as decimal) / 4);
-
-  - changeSet:
-      id: v47.00-032
-      author: qnkhuat
-      comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24 for revisions
-      validCheckSum: ANY
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24"
-
-  - changeSet:
-      id: v47.00-033
-      validCheckSum: 8:c4a38673bf2a702e807a2074c0d0b719
-      author: calherries
-      comment: Added 0.47.0 - Migrate field refs in visualization_settings.column_settings keys from legacy format
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.RevisionMigrateLegacyColumnSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-034
-      validCheckSum: 8:bb77d686c5c204e480a1da5fcfb518e2
-      author: calherries
-      comment: Added 0.47.0 - Add join-alias to the visualization_settings.column_settings field refs in card revisions
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.RevisionAddJoinAliasToColumnSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-035
-      validCheckSum: 8:aeafa7ff310f799eb3fb2e14640a9e06
-      author: calherries
-      comment: Added 0.47.0 - Drop foreign key constraint on implicit_action.action_id
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: implicit_action
-            constraintName: fk_implicit_action_action_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: implicit_action
-            baseColumnNames: action_id
-            referencedTableName: action
-            referencedColumnNames: id
-            constraintName: fk_implicit_action_action_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v47.00-036
-      validCheckSum: 8:e815729b6ebfd4799743b249409558aa
-      author: calherries
-      comment: Added 0.47.0 - Set primary key to action_id for implicit_action table
-      changes:
-        - addPrimaryKey:
-            tableName: implicit_action
-            columnNames: action_id
-            constraintName: pk_implicit_action
-
-  - changeSet:
-      id: v47.00-037
-      validCheckSum: 8:58c705a18bb3441e3ed5d1167ec64fcb
-      author: calherries
-      comment: Added 0.47.0 - Add foreign key constraint on implicit_action.action_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: implicit_action
-            baseColumnNames: action_id
-            referencedTableName: action
-            referencedColumnNames: id
-            constraintName: fk_implicit_action_action_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v47.00-043
-      validCheckSum: 8:5e030b73be03e7cd8b19a5a46f9b2a4c
-      author: calherres
-      comment: Added 0.47.0 - Migrate report_dashboardcard.visualization_settings.column_settings field refs from legacy format
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateLegacyDashboardCardColumnSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-044
-      validCheckSum: 8:1828d1bd8e2da6eec14ca61e6c01a56f
-      author: calherries
-      comment: Added 0.47.0 - Add join-alias to the report_dashboardcard.visualization_settings.column_settings field refs
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.AddJoinAliasToDashboardCardColumnSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-045
-      validCheckSum: 8:d7f479a389877010f5af9dc7ec859b51
-      author: calherres
-      comment: Added 0.47.0 - Migrate dashboard revision dashboard cards' visualization_settings.column_settings field refs from legacy format
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.RevisionMigrateLegacyDashboardCardColumnSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-046
-      validCheckSum: 8:1e43c8712a5b36809a3c3fa9933a523c
-      author: calherries
-      comment: Added 0.47.0 - Add join-alias to dashboard revision dashboard cards' visualization_settings.column_settings field refs
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.RevisionAddJoinAliasToDashboardCardColumnSettingsFieldRefs"
-
-  - changeSet:
-      id: v47.00-050
-      validCheckSum: 8:a5d516f2b5ea92f401387646b49a9950
-      author: tsmacdonald
-      comment: Added 0.47.0 - table.is_upload
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: is_upload
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: 'Was the table created from user-uploaded (i.e., from a CSV) data?'
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v47.00-051
-      validCheckSum: 8:83a8b7ad58b2deb0732e671db51fa608
-      author: noahmoss
-      comment: Added 0.47.0 - Drop foreign key constraint on connection_impersonations.db_id
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: connection_impersonations
-            constraintName: fk_conn_impersonation_db_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: connection_impersonations
-            baseColumnNames: db_id
-            referencedTableName: metabase_database
-            referencedColumnNames: id
-            constraintName: fk_conn_impersonation_db_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v47.00-052
-      validCheckSum: 8:d170bef8f707027360cf08fb55e91452
-      author: noahmoss
-      comment: Added 0.47.0 - Drop foreign key constraint on connection_impersonations.group_id
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: connection_impersonations
-            constraintName: fk_conn_impersonation_group_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: connection_impersonations
-            baseColumnNames: group_id
-            referencedTableName: permissions_group
-            referencedColumnNames: id
-            constraintName: fk_conn_impersonation_group_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v47.00-053
-      validCheckSum: 8:3b52631c2c82b88043b840391c7d9ef0
-      author: noahmoss
-      comment: Added 0.47.0 -- connection_impersonations index for db_id column
-      changes:
-        - createIndex:
-            tableName: connection_impersonations
-            columns:
-              - column:
-                  name: db_id
-            indexName: idx_conn_impersonations_db_id
-
-  - changeSet:
-      id: v47.00-054
-      validCheckSum: 8:5404d7e3781f0dfcc984676ea434c842
-      author: noahmoss
-      comment: Added 0.47.0 -- connection_impersonations index for group_id column
-      changes:
-        - createIndex:
-            tableName: connection_impersonations
-            columns:
-              - column:
-                  name: group_id
-            indexName: idx_conn_impersonations_group_id
-
-  - changeSet:
-      id: v47.00-055
-      validCheckSum: 8:295c4477995058b93eba2857090eb6f6
-      author: noahmoss
-      comment: Added 0.47.0 - unique constraint for connection impersonations
-      changes:
-        - addUniqueConstraint:
-            tableName: connection_impersonations
-            columnNames: group_id, db_id
-            constraintName: conn_impersonation_unique_group_id_db_id
-      rollback:
-        - dropUniqueConstraint:
-            tableName: connection_impersonations
-            constraintName: conn_impersonation_unique_group_id_db_id
-
-  - changeSet:
-      id: v47.00-056
-      validCheckSum: 8:bd965141f770a65982ecebab51a565e9
-      author: noahmoss
-      comment: Added 0.47.0 - re-add foreign key constraint on connection_impersonations.db_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: connection_impersonations
-            baseColumnNames: db_id
-            referencedTableName: metabase_database
-            referencedColumnNames: id
-            constraintName: fk_conn_impersonation_db_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v47.00-057
-      validCheckSum: 8:fe79acdba9db58709b6fffbb7aac2844
-      author: noahmoss
-      comment: Added 0.47.0 - re-add foreign key constraint on connection_impersonations.group_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: connection_impersonations
-            baseColumnNames: group_id
-            referencedTableName: permissions_group
-            referencedColumnNames: id
-            constraintName: fk_conn_impersonation_group_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v47.00-058
-      validCheckSum: 8:05731b3e62deb09c64b60bc10031d206
-      author: qnkhuat
-      comment: 'Drop parameter_card.entity_id'
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: parameter_card
-            columnName: entity_id
-      changes:
-        - dropColumn:
-            tableName: parameter_card
-            columnName: entity_id
-      rollback:
-        - addColumn:
-            tableName: parameter_card
-            columns:
-              - column:
-                  remarks: Random NanoID tag for unique identity.
-                  name: entity_id
-                  type: char(21)
-                  constraints:
-                    nullable: true
-                    unique: true
-
-  - changeSet:
-      id: v47.00-059
-      validCheckSum: 8:123cf42eed168444f88418f071d2730f
-      author: piranha
-      comment: 'Drops not null from dashboard_tab.entity_id since it breaks drop-entity-ids command'
-      changes:
-        - dropNotNullConstraint:
-            tableName: dashboard_tab
-            columnName: entity_id
-            columnDataType: char(21)
-      rollback: # noop, and 'drop not null' is a noop if it's dropped already
-
-  - changeSet:
-      id: v48.00-001
-      validCheckSum: 8:c38ceb502af7907aed614f17da6c3f80
-      author: qnkhuat
-      comment: Added 0.47.0 - Migrate database.options to database.settings
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateDatabaseOptionsToSettings"
-
-  - changeSet:
-      id: v48.00-002
-      validCheckSum: 8:deceb81591f51f2d7253976f247e36cc
-      author: qnkhuat
-      comment: Added 0.47.0 - drop metabase_database.options
-      changes:
-        - dropColumn:
-            tableName: metabase_database
-            columnName: options
-      rollback:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: options
-                  type: ${text.type}
-                  remarks: "Serialized JSON containing various options like QB behavior."
-
-  - changeSet:
-      id: v48.00-003
-      validCheckSum: 8:da33cde0f1f93eed56c0f6d9ac2007df
-      author: qnkhuat
-      comment: Added 0.48.0 - drop computation_job_result table
-      preConditions:
-        - onFail: MARK_RAN
-        - tableExists:
-            tableName: computation_job_result
-      changes:
-          - dropTable:
-              tableName: computation_job_result
-      rollback: # no rollback needed since this table has been unused since 2018
-
-  - changeSet:
-      id: v48.00-004
-      validCheckSum: 8:d0b1d7cc179c332b7e31f065325b7275
-      author: qnkhuat
-      comment: Added 0.48.0 - drop computation_job table
-      preConditions:
-        - onFail: MARK_RAN
-        - tableExists:
-            tableName: computation_job
-      changes:
-          - dropTable:
-              tableName: computation_job
-      rollback: # no rollback needed since this table has been unused since 2018
-
-  - changeSet:
-      id: v48.00-005
-      validCheckSum: 8:a570f2e1d90a302bc207c00e3776eaaf
-      author: qnkhuat
-      comment: Added 0.48.0 - Add query_execution.action_id
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: action_id
-                  type: integer
-                  remarks: 'The ID of the action associated with this query execution, if any.'
-
-  - changeSet:
-      id: v48.00-006
-      validCheckSum: 8:cf1413241565a186bf98eece35d519bf
-      author: qnkhuat
-      comment: Added 0.48.0 - Index query_execution.action_id
-      changes:
-        - createIndex:
-            tableName: query_execution
-            indexName: idx_query_execution_action_id
-            columns:
-              column:
-                name: action_id
-
-  - changeSet:
-      id: v48.00-007
-      validCheckSum: 8:15d05ceba05e5b7d25d351fb6ec5b100
-      author: qnkhuat
-      comment: Added 0.48.0 - Add revision.most_recent
-      changes:
-        - addColumn:
-            tableName: revision
-            columns:
-              - column:
-                  name: most_recent
-                  type: boolean
-                  defaultValueBoolean: false
-                  remarks: 'Whether a revision is the most recent one'
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v48.00-008
-      validCheckSum: 8:c0a512701d6dfd5cc1c4a689919be074
-      author: qnkhuat
-      comment: Set revision.most_recent = true for latest revisions
-      changes:
-        - sql:
-            dbms: postgresql,h2
-            sql: >-
-              UPDATE revision r
-              SET most_recent = true
-              WHERE (model, model_id, timestamp) IN (
-                                 SELECT model, model_id, MAX(timestamp)
-                                 FROM revision
-                                 GROUP BY model, model_id);
-          # mysql and mariadb does not allow update on a table that is in the select part
-          # so it we join for them
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE revision r
-              JOIN (
-                  SELECT model, model_id, MAX(timestamp) AS max_timestamp
-                  FROM revision
-                  GROUP BY model, model_id
-              ) AS subquery
-              ON r.model = subquery.model AND r.model_id = subquery.model_id AND r.timestamp = subquery.max_timestamp
-              SET r.most_recent = true;
-      rollback: # nothing to do since the most_recent will be dropped anyway
-
-  - changeSet:
-      id: v48.00-009
-      validCheckSum: 8:dfd90256380263274ea7f5cc0c5ed413
-      author: calherries
-      comment: Added 0.48.0 - Create table_privileges table
-      changes:
-        - createTable:
-            tableName: table_privileges
-            remarks: Table for user and role privileges by table
-            columns:
-              - column:
-                  name: table_id
-                  type: int
-                  remarks: 'Table ID'
-                  constraints:
-                    foreignKeyName: fk_table_privileges_table_id
-                    nullable: false
-                    referencedTableName: metabase_table
-                    referencedColumnNames: id
-                    deleteCascade: true
-              - column:
-                  name: role
-                  type: varchar(255)
-                  remarks: 'Role name. NULL indicates the privileges are the current user''s'
-              - column:
-                  name: select
-                  type: boolean
-                  remarks: 'Privilege to select from the table'
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-              - column:
-                  name: update
-                  type: boolean
-                  remarks: 'Privilege to update records in the table'
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-              - column:
-                  name: insert
-                  type: boolean
-                  remarks: 'Privilege to insert records into the table'
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-              - column:
-                  name: delete
-                  type: boolean
-                  remarks: 'Privilege to delete records from the table'
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-            uniqueConstraints:
-              - unique:
-                  columnNames: table_id, role
-                  name: uq_table_privileges_table_id_role
-
-
-  - changeSet:
-      id: v48.00-010
-      validCheckSum: 8:da6117039b6e0249b710cc3160af982d
-      author: qnkhuat
-      comment: Remove ON UPDATE for revision.timestamp on mysql, mariadb
-      preConditions:
-          # If preconditions fail (i.e., dbms is not mysql or mariadb) then mark this migration as 'ran'
-          - onFail: MARK_RAN
-          - dbms:
-              type: mysql,mariadb
-      changes:
-          - sql:
-                sql: ALTER TABLE `revision` CHANGE `timestamp` `timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6);
-      rollback: # no need
-
-  - changeSet:
-      id: v48.00-011
-      validCheckSum: 8:65ef87949a7e9555fabaf69069806ee0
-      author: qnkhuat
-      comment: Index revision.most_recent
-      changes:
-        - createIndex:
-            tableName: revision
-            indexName: idx_revision_most_recent
-            columns:
-              column:
-                name: most_recent
-
-  - changeSet:
-      id: v48.00-013
-      validCheckSum: 8:145eb766e2d49e95f31d8a08df8ff776
-      author: qnkhuat
-      comment: Index unindexed FKs for postgres
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql
-      changes:
-          - sql:
-              sql: >-
-                  CREATE INDEX IF NOT EXISTS idx_action_made_public_by_id ON action (made_public_by_id);
-                  CREATE INDEX IF NOT EXISTS idx_action_model_id ON action (model_id);
-                  CREATE INDEX IF NOT EXISTS idx_application_permissions_revision_user_id ON application_permissions_revision (user_id);
-                  CREATE INDEX IF NOT EXISTS idx_collection_permission_graph_revision_user_id ON collection_permission_graph_revision (user_id);
-                  CREATE INDEX IF NOT EXISTS idx_core_session_user_id ON core_session (user_id);
-                  CREATE INDEX IF NOT EXISTS idx_dashboard_tab_dashboard_id ON dashboard_tab (dashboard_id);
-                  CREATE INDEX IF NOT EXISTS idx_dimension_human_readable_field_id ON dimension (human_readable_field_id);
-                  CREATE INDEX IF NOT EXISTS idx_metabase_database_creator_id ON metabase_database (creator_id);
-                  CREATE INDEX IF NOT EXISTS idx_model_index_creator_id ON model_index (creator_id);
-                  CREATE INDEX IF NOT EXISTS idx_native_query_snippet_creator_id ON native_query_snippet (creator_id);
-                  CREATE INDEX IF NOT EXISTS idx_permissions_revision_user_id ON permissions_revision (user_id);
-                  CREATE INDEX IF NOT EXISTS idx_persisted_info_creator_id ON persisted_info (creator_id);
-                  CREATE INDEX IF NOT EXISTS idx_persisted_info_database_id ON persisted_info (database_id);
-                  CREATE INDEX IF NOT EXISTS idx_pulse_dashboard_id ON pulse (dashboard_id);
-                  CREATE INDEX IF NOT EXISTS idx_pulse_card_dashboard_card_id ON pulse_card (dashboard_card_id);
-                  CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_pulse_channel_id ON pulse_channel_recipient (pulse_channel_id);
-                  CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_user_id ON pulse_channel_recipient (user_id);
-                  CREATE INDEX IF NOT EXISTS idx_query_action_database_id ON query_action (database_id);
-                  CREATE INDEX IF NOT EXISTS idx_report_card_database_id ON report_card (database_id);
-                  CREATE INDEX IF NOT EXISTS idx_report_card_made_public_by_id ON report_card (made_public_by_id);
-                  CREATE INDEX IF NOT EXISTS idx_report_card_table_id ON report_card (table_id);
-                  CREATE INDEX IF NOT EXISTS idx_report_dashboard_made_public_by_id ON report_dashboard (made_public_by_id);
-                  CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_action_id ON report_dashboardcard (action_id);
-                  CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_dashboard_tab_id ON report_dashboardcard (dashboard_tab_id);
-                  CREATE INDEX IF NOT EXISTS idx_revision_user_id ON revision (user_id);
-                  CREATE INDEX IF NOT EXISTS idx_sandboxes_card_id ON sandboxes (card_id);
-                  CREATE INDEX IF NOT EXISTS idx_sandboxes_permission_id ON sandboxes (permission_id);
-                  CREATE INDEX IF NOT EXISTS idx_secret_creator_id ON secret (creator_id);
-                  CREATE INDEX IF NOT EXISTS idx_timeline_creator_id ON timeline (creator_id);
-                  CREATE INDEX IF NOT EXISTS idx_timeline_event_creator_id ON timeline_event (creator_id);
-      rollback: # no need
-
-  - changeSet:
-      id: v48.00-014
-      validCheckSum: 8:b2c1361f1dc14c2390a1dc25a4a86311
-      author: calherries
-      comment: Added 0.48.0 - Create table_privileges.table_id index
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: postgresql
-      changes:
-        - createIndex:
-            indexName: idx_table_privileges_table_id
-            tableName: table_privileges
-            columns:
-              - column:
-                  name: table_id
-      rollback: # not needed, it will be removed with the table
-
-  - changeSet:
-      id: v48.00-015
-      validCheckSum: 8:6f58cf60c8048bb39bbf6128058ff85e
-      author: calherries
-      comment: Added 0.48.0 - Create table_privileges.role index
-      changes:
-        - createIndex:
-            indexName: idx_table_privileges_role
-            tableName: table_privileges
-            columns:
-              - column:
-                  name: role
-      rollback: # not needed, it will be removed with the table
-
-  - changeSet:
-      id: v48.00-016
-      validCheckSum: 8:ea2cb901edad5cf3a1250bdd2a9b0866
-      author: calherries
-      comment: Added 0.48.0 - Change the type of collection.slug to varchar(510)
-      changes:
-        - modifyDataType:
-            tableName: collection
-            columnName: slug
-            newDataType: varchar(510)
-      rollback:
-        - modifyDataType:
-            tableName: collection
-            columnName: slug
-            newDataType: varchar(254)
-
-  - changeSet:
-      id: v48.00-018
-      validCheckSum: 8:efae52e7403f39c1458f53e885b4393d
-      author: noahmoss
-      comment: Add new recent_views table
-      changes:
-        - createTable:
-            tableName: recent_views
-            remarks: Used to store recently viewed objects for each user
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: The user associated with this view
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_recent_views_ref_user_id
-              - column:
-                  name: model
-                  type: varchar(16)
-                  remarks: The name of the model that was viewed
-                  constraints:
-                    nullable: false
-              - column:
-                  name: model_id
-                  type: int
-                  remarks: The ID of the model that was viewed
-                  constraints:
-                    nullable: false
-              - column:
-                  name: timestamp
-                  type: DATETIME
-                  remarks: The time a view was recorded
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v48.00-019
-      validCheckSum: 8:c3866a4b7cfbb49d4b626dc2fd750935
-      author: nemanjaglumac
-      comment: 'Collection color is removed in 0.48.0'
-      changes:
-        - dropColumn:
-            tableName: collection
-            columnName: color
-      rollback:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: color
-                  type: char(7)
-                  remarks: 'Seven-character hex color for this Collection, including the preceding hash sign.'
-                  constraints:
-                    nullable: false
-                  defaultValue: '#31698A'
-
-  - changeSet:
-      id: v48.00-020
-      validCheckSum: 8:2c410019e1834304131ff57278003d35
-      author: noahmoss
-      comment: Added 0.48.0 - Create recent_views.user_id index
-      changes:
-        - createIndex:
-            indexName: idx_recent_views_user_id
-            tableName: recent_views
-            columns:
-              - column:
-                  name: user_id
-      rollback: # not needed, it will be removed with the table
-
-  - changeSet:
-      id: v48.00-021
-      validCheckSum: 8:a1543239e39c70dc9bab3bbc303242b1
-      author: piranha
-      comment: 'Cards store Metabase version used to create them'
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: metabase_version
-                  type: varchar(100)
-                  remarks: 'Metabase version used to create the card.'
-
-  - changeSet:
-      id: v48.00-022
-      validCheckSum: 8:0f034d06b1ad5336c3c81b0d22cde259
-      author: johnswanson
-      comment: Migrate migrate-click-through to a custom migration
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM data_migrations WHERE id = 'migrate-click-through';
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateClickThrough"
-
-  - changeSet:
-      id: v48.00-023
-      validCheckSum: 8:f18e5e053b508aab0bdd8c4bf1d7de4b
-      author: piranha
-      comment: Data migration migrate-remove-admin-from-group-mapping-if-needed
-      preConditions:
-        - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM data_migrations WHERE id = 'migrate-remove-admin-from-group-mapping-if-needed';
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateRemoveAdminFromGroupMappingIfNeeded"
-
-  - changeSet:
-      id: v48.00-024
-      validCheckSum: 8:fab2a51d73c66cea059d55a6fea8bb2f
-      author: piranha
-      comment: All data migrations were transferred to custom_migrations!
-      changes:
-        - dropTable:
-            tableName: data_migrations
-      rollback:
-        - sql:
-            sql: >-
-              CREATE TABLE data_migrations (
-                id varchar(254) primary key,
-                timestamp ${timestamp_type} not null
-              );
-              INSERT INTO data_migrations VALUES
-                  ('set-card-database-and-table-ids', current_timestamp),
-                  ('set-mongodb-databases-ssl-false', current_timestamp),
-                  ('set-default-schemas', current_timestamp),
-                  ('set-admin-email', current_timestamp),
-                  ('remove-database-sync-activity-entries', current_timestamp),
-                  ('remove-duplicate-fk-entries', current_timestamp),
-                  ('update-dashboards-to-new-grid', current_timestamp),
-                  ('migrate-field-visibility-type', current_timestamp),
-                  ('fix-dashboard-cards-without-positions', current_timestamp),
-                  ('migrate-fk-metadata', current_timestamp),
-                  ('create-raw-tables', current_timestamp),
-                  ('migrate-base-types', current_timestamp),
-                  ('migrate-field-types', current_timestamp),
-                  ('fix-invalid-field-types', current_timestamp),
-                  ('add-users-to-default-permissions-groups', current_timestamp),
-                  ('add-admin-group-root-entry', current_timestamp),
-                  ('add-databases-to-magic-permissions-groups', current_timestamp),
-                  ('fix-legacy-magic-group-names', current_timestamp),
-                  ('remove-trailing-slashes-from-site-url-setting', current_timestamp),
-                  ('copy-site-url-setting-and-remove-trailing-slashes', current_timestamp),
-                  ('migrate-query-executions', current_timestamp),
-                  ('drop-old-query-execution-table', current_timestamp),
-                  ('ensure-protocol-specified-in-site-url', current_timestamp),
-                  ('populate-card-database-id', current_timestamp),
-                  ('migrate-humanization-setting', current_timestamp),
-                  ('populate-card-read-permissions', current_timestamp),
-                  ('mark-category-fields-as-list', current_timestamp),
-                  ('repopulate-card-read-permissions', current_timestamp),
-                  ('add-legacy-sql-directive-to-bigquery-sql-cards', current_timestamp),
-                  ('clear-ldap-user-local-passwords', current_timestamp),
-                  ('add-migrated-collections', current_timestamp),
-                  ('migrate-map-regions', current_timestamp),
-                  ('migrate-click-through', current_timestamp),
-                  ('migrate-remove-admin-from-group-mapping-if-needed', current_timestamp);
-
-  - changeSet:
-      id: v48.00-025
-      validCheckSum: 8:a2fa9ab0913b9e4b97dff91f973344d6
-      author: piranha
-      comment: 'Revisions store Metabase version used to create them'
-      changes:
-        - addColumn:
-            tableName: revision
-            columns:
-              - column:
-                  name: metabase_version
-                  type: varchar(100)
-                  remarks: 'Metabase version used to create the revision.'
-
-  - changeSet:
-      id: v48.00-026
-      validCheckSum: 8:7c8330e861c16997780a9b0881144b26
-      author: lbrdnk
-      comment: Set semantic_type with value type/Number to null (#18754)
-      changes:
-        - update:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: semantic_type
-                  value: NULL
-            where: semantic_type = 'type/Number'
-      rollback:
-
-  # this is a no op, it was previously used to Drop parameter_card.entity_id,
-  # now it's moved to v47.00-058
-  # this is still here because we want the change set id to be consistent
-  # see #35239 for details
-  - changeSet:
-      id: v48.00-027
-      author: qnkhuat
-      validCheckSum: ANY
-      comment: 'No op migration'
-      changes:
-        - sql:
-          sql: SELECT 1;
-      rollback:
-
-  - changeSet:
-      id: v48.00-028
-      validCheckSum: 8:818119252c2e7877bbf46aec40fab160
-      author: noahmoss
-      comment: Add new audit_log table
-      changes:
-        - createTable:
-            tableName: audit_log
-            remarks: Used to store application events for auditing use cases
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: topic
-                  type: varchar(32)
-                  remarks: The topic of a given audit event
-                  constraints:
-                    nullable: false
-              - column:
-                  name: timestamp
-                  type: ${timestamp_type}
-                  remarks: The time an event was recorded
-                  constraints:
-                    nullable: false
-              - column:
-                  name: end_timestamp
-                  type: ${timestamp_type}
-                  remarks: The time an event ended, if applicable
-                  constraints:
-                    nullable: true
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: The user who performed an action or triggered an event
-                  constraints:
-                    nullable: true
-              - column:
-                  name: model
-                  type: varchar(32)
-                  remarks: The name of the model this event applies to (e.g. Card, Dashboard), if applicable
-                  constraints:
-                    nullable: true
-              - column:
-                  name: model_id
-                  type: int
-                  remarks: The ID of the model this event applies to, if applicable
-                  constraints:
-                    nullable: true
-              - column:
-                  name: details
-                  type: ${text.type}
-                  remarks: A JSON map with metadata about the event
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v48.00-029
-      validCheckSum: 8:1994760ab0950e7f591c40e887295e1a
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_audit_log
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/audit_log/v1/postgres-audit_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/audit_log/v1/mysql-audit_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/audit_log/v1/h2-audit_log.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_audit_log;
-
-  - changeSet:
-      id: v48.00-030
-      validCheckSum: 8:965d6479698fe55f2f6799be552b5edb
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_content
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/content/v1/postgres-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/content/v1/mysql-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/content/v1/h2-content.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_content;
-
-  - changeSet:
-      id: v48.00-031
-      validCheckSum: 8:721bedb0dd362793a1a216cf3e552f3b
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_dashboardcard
-      changes:
-        - sqlFile:
-            path: instance_analytics_views/dashboardcard/v1/dashboardcard.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_dashboardcard;
-
-  - changeSet:
-      id: v48.00-032
-      validCheckSum: 8:64d52462def7bb6981a3b6a40d42e67e
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_group_members
-      changes:
-        - sqlFile:
-            path: instance_analytics_views/group_members/v1/group_members.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_group_members;
-
-  - changeSet:
-      id: v48.00-033
-      validCheckSum: 8:7ac57373a0fba4bd9613c242702c863d
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_subscriptions for postgres
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/subscriptions/v1/postgres-subscriptions.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/subscriptions/v1/mysql-subscriptions.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/subscriptions/v1/h2-subscriptions.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_subscriptions;
-
-  - changeSet:
-      id: v48.00-034
-      validCheckSum: 8:1c268d93ce69eaee11e3ecdf9951449a
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_users
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/users/v1/postgres-users.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/users/v1/mysql-users.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/users/v1/h2-users.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_users;
-
-  - changeSet:
-      id: v48.00-035
-      validCheckSum: 8:c0276764af3e1b4b5b0c4e5fdc979e60
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_alerts
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/alerts/v1/postgres-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/alerts/v1/mysql-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/alerts/v1/h2-alerts.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_alerts;
-
-  - changeSet:
-      id: v48.00-036
-      validCheckSum: 8:8a35e1bdf0738ccac5da8062d6671dd0
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_databases
-      changes:
-        - sqlFile:
-            path: instance_analytics_views/databases/v1/databases.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_databases;
-
-  - changeSet:
-      id: v48.00-037
-      validCheckSum: 8:a4b6ebd594b4663a6a888211f36ce6c3
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_fields
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/fields/v1/postgres-fields.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/fields/v1/mysql-fields.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/fields/v1/h2-fields.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_fields;
-
-  - changeSet:
-      id: v48.00-038
-      validCheckSum: 8:a24f4bcd3336e79d1c8ef33ab81c0db3
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_query_log
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/query_log/v1/postgres-query_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/query_log/v1/mysql-query_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/query_log/v1/h2-query_log.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_query_log;
-
-  - changeSet:
-      id: v48.00-039
-      validCheckSum: 8:b43481a01df86830c4cb1adb8189d400
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_tables
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/tables/v1/postgres-tables.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/tables/v1/mysql-tables.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/tables/v1/h2-tables.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_tables;
-
-  - changeSet:
-      id: v48.00-040
-      validCheckSum: 8:b8842eac1c7cba6e997d4d288306e36c
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_view_log
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/view_log/v1/postgres-view_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/view_log/v1/mysql-view_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/view_log/v1/h2-view_log.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_view_log;
-
-  - changeSet:
-      id: v48.00-045
-      validCheckSum: 8:874f14ae26d742448d8dd2b47dc8aa3d
-      author: qwef
-      comment: Added 0.48.0 - add is_sandboxed to query_execution
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: is_sandboxed
-                  type: boolean
-                  remarks: "Is query from a sandboxed user"
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v48.00-046
-      validCheckSum: 8:4bb11295621890202e066cd15de93a52
-      author: noahmoss
-      comment: Added 0.48.0 - new indexes to optimize audit v2 queries
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/indexes/v1/postgres-indexes.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql
-            path: instance_analytics_views/indexes/v1/mysql-indexes.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mariadb
-            path: instance_analytics_views/indexes/v1/mariadb-indexes.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/indexes/v1/h2-indexes.sql
-            relativeToChangelogFile: true
-      rollback:
-        # Only MySQL needes a rollback because all the other DBs support "CREATE INDEX IF NOT EXISTS"
-        - sqlFile:
-            dbms: mysql
-            path: instance_analytics_views/indexes/v1/mysql-rollback.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v48.00-047
-      validCheckSum: 8:2b18bed0e1ae18dd7b26a0770dac54c0
-      author: noahmoss
-      comment: Drop foreign key on recent_views so that it can be recreated with onDelete policy
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: recent_views
-            constraintName: fk_recent_views_ref_user_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: recent_views
-            constraintName: fk_recent_views_ref_user_id
-            referencedTableName: core_user
-            baseColumnNames: user_id
-            referencedColumnNames: id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v48.00-048
-      validCheckSum: 8:872e632a8ffa42eb2969f77823e8bfc8
-      author: noahmoss
-      comment: Add foreign key on recent_views with onDelete CASCADE
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: recent_views
-            constraintName: fk_recent_views_ref_user_id
-            referencedTableName: core_user
-            baseColumnNames: user_id
-            referencedColumnNames: id
-            onDelete: CASCADE
-      rollback:
-        - dropForeignKeyConstraint:
-            baseTableName: recent_views
-            constraintName: fk_recent_views_ref_user_id
-
-  - changeSet:
-      id: v48.00-049
-      validCheckSum: 8:853f2a24c53470bf2d9e85b1246bab7b
-      author: noahmoss
-      comment: Migrate data from activity to audit_log
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details)
-              SELECT
-                topic,
-                timestamp,
-                user_id,
-                model,
-                model_id,
-                details::jsonb || json_strip_nulls(json_build_object('database_id', database_id, 'table_id', table_id))::jsonb
-              FROM activity;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details)
-              SELECT
-                  topic,
-                  timestamp,
-                  user_id,
-                  model,
-                  model_id,
-                  JSON_MERGE(
-                      details,
-                      JSON_OBJECT('database_id', database_id, 'table_id', table_id)
-                  )
-              FROM activity;
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details)
-              SELECT
-                  topic,
-                  timestamp,
-                  user_id,
-                  model,
-                  model_id,
-                  JSON_OBJECT(
-                    'database_id': database_id,
-                    'table_id': table_id
-                    ABSENT ON NULL
-                  )
-              FROM activity;
-      rollback: # not necessary
-
-  - changeSet:
-      id: v48.00-050
-      validCheckSum: 8:d41d8cd98f00b204e9800998ecf8427e
-      author: noahmoss
-      comment: Added 0.48.0 - no-op migration to remove audit DB and collection on downgrade
-      changes:
-        - comment: "No operation performed for this changeset on execution."
-      rollback:
-        - sql: DELETE FROM metabase_database WHERE is_audit = TRUE;
-        - sql: DELETE FROM collection WHERE type = 'instance_analytics';
-
-  - changeSet:
-      id: v48.00-051
-      validCheckSum: 8:5f5d1fd5b6153a6613511fd8f765737d
-      author: calherries
-      comment: Migrate metabase_field when the fk target field is inactive
-      changes:
-        - sql:
-            dbms: mariadb,mysql
-            sql: >-
-              UPDATE metabase_field AS a
-              JOIN metabase_field AS b ON b.id = a.fk_target_field_id
-              SET a.fk_target_field_id = NULL,
-                  a.semantic_type = NULL
-              WHERE b.active = FALSE;
-        - sql:
-            dbms: postgresql,h2
-            sql: >-
-              UPDATE metabase_field
-              SET fk_target_field_id = NULL,
-                  semantic_type = NULL
-              WHERE fk_target_field_id IN (
-                  SELECT id
-                  FROM metabase_field
-                  WHERE active = FALSE
-              );
-      rollback: # no change
-
-  - changeSet:
-      id: v48.00-053
-      validCheckSum: 8:8b41162170f6d712871b2ee9221adc1a
-      author: johnswanson
-      comment: Increase length of `activity.model` to fit longer model names
-      changes:
-        - modifyDataType:
-            tableName: activity
-            columnName: model
-            newDataType: VARCHAR(32)
-      rollback: # not necessary
-
-  - changeSet:
-      id: v48.00-054
-      validCheckSum: 8:d41d8cd98f00b204e9800998ecf8427e
-      author: escherize
-      comment: Added 0.48.0 - no-op migration to remove Internal Metabase User on downgrade
-      changes:
-        - comment: "No operation performed for this changeset on execution."
-      rollback:
-        - sql: DELETE FROM core_user WHERE id = 13371338;
-
-  - changeSet:
-      id: v48.00-055
-      validCheckSum: 8:fd36092d50982fbf31ce16757c16e47e
-      author: noahmoss
-      comment: Added 0.48.0 - new view v_tasks
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/tasks/v1/postgres-tasks.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/tasks/v1/mysql-tasks.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/tasks/v1/h2-tasks.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: drop view if exists v_tasks;
-
-  - changeSet:
-      id: v48.00-056
-      validCheckSum: 8:229e8058cc8309053b344bbfdb042405
-      author: noahmoss
-      comment: 'Adjust view_log schema for Audit Log v2'
-      changes:
-        - addColumn:
-            tableName: view_log
-            columns:
-              - column:
-                  name: has_access
-                  type: boolean
-                  constraints:
-                    nullable: true
-                  remarks: 'Whether the user who initiated the view had read access to the item being viewed.'
-
-  - changeSet:
-      id: v48.00-057
-      validCheckSum: 8:8e32153df1031ea12005d58ce1674873
-      author: noahmoss
-      comment: 'Adjust view_log schema for Audit Log v2'
-      changes:
-        - addColumn:
-            tableName: view_log
-            columns:
-              - column:
-                  name: context
-                  type: varchar(32)
-                  constraints:
-                    nullable: true
-                  remarks: 'The context of the view, can be collection, question, or dashboard. Only for cards.'
-
-  - changeSet:
-      id: v48.00-059
-      validCheckSum: 8:fd8b5031dbbf69c4588ce2699eb20f33
-      author: qwef
-      comment: 'Update the namespace of any audit collections that are already loaded'
-      changes:
-        - sql:
-            sql: UPDATE collection SET namespace = 'analytics' WHERE entity_id = 'okNLSZKdSxaoG58JSQY54' OR entity_id = 'vG58R8k-QddHWA7_47umn'
-      rollback: # not necessary
-
-  - changeSet:
-      id: v48.00-060
-      validCheckSum: 8:a59027f5494811033ce77cd0ba05d6bd
-      author: noahmoss
-      comment: Added 0.48.0 - task_history.started_at
-      changes:
-        - createIndex:
-            indexName: idx_task_history_started_at
-            tableName: task_history
-            columns:
-              - column:
-                  name: started_at
-
-  - changeSet:
-      id: v48.00-061
-      validCheckSum: 8:9b9939aad6ca12f7cf4dfa85dae6eb1c
-      author: piranha
-      comment: 'Adds query_execution.cache_hash -> query_cache.query_hash'
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: cache_hash
-                  type: ${blob.type}
-                  constraints:
-                    nullable: true
-                  remarks: 'Hash of normalized query, calculated in middleware.cache'
-
-  # this index was added in migration 95, but during our split migration work in #34400 we didn't include this index
-  # in the sql initialization, so we need to recreate one here for new instances running 48+
-  - changeSet:
-      id: v48.00-067
-      validCheckSum: 8:e7cd8168533c58c865dacf320e819218
-      author: qnkhuat
-      comment: 'Add unique constraint idx_databasechangelog_id_author_filename'
-      preConditions:
-        - onFail: MARK_RAN
-        # If we're dumping the migration as a SQL file or trying to force-migrate we can't check the preconditions
-        # so just go ahead and skip the entire thing. This is a non-critical migration
-        - onUpdateSQL: IGNORE
+          FROM activity;
+    rollback: null
+- changeSet:
+    id: v48.00-050
+    validCheckSum: 8:d41d8cd98f00b204e9800998ecf8427e
+    author: noahmoss
+    comment: Added 0.48.0 - no-op migration to remove audit DB and collection on downgrade
+    changes:
+    - {comment: No operation performed for this changeset on execution.}
+    rollback:
+    - {sql: DELETE FROM metabase_database WHERE is_audit = TRUE;}
+    - {sql: DELETE FROM collection WHERE type = 'instance_analytics';}
+- changeSet:
+    id: v48.00-051
+    validCheckSum: 8:5f5d1fd5b6153a6613511fd8f765737d
+    author: calherries
+    comment: Migrate metabase_field when the fk target field is inactive
+    changes:
+    - sql:
+        dbms: mariadb,mysql
+        sql: |-
+          UPDATE metabase_field AS a JOIN metabase_field AS b ON b.id = a.fk_target_field_id SET a.fk_target_field_id = NULL,
+              a.semantic_type = NULL
+          WHERE b.active = FALSE;
+    - sql:
+        dbms: postgresql,h2
+        sql: |-
+          UPDATE metabase_field SET fk_target_field_id = NULL,
+              semantic_type = NULL
+          WHERE fk_target_field_id IN (
+              SELECT id
+              FROM metabase_field
+              WHERE active = FALSE
+          );
+    rollback: null
+- changeSet:
+    id: v48.00-053
+    validCheckSum: 8:8b41162170f6d712871b2ee9221adc1a
+    author: johnswanson
+    comment: Increase length of `activity.model` to fit longer model names
+    changes:
+    - modifyDataType: {tableName: activity, columnName: model, newDataType: VARCHAR(32)}
+    rollback: null
+- changeSet:
+    id: v48.00-054
+    validCheckSum: 8:d41d8cd98f00b204e9800998ecf8427e
+    author: escherize
+    comment: Added 0.48.0 - no-op migration to remove Internal Metabase User on downgrade
+    changes:
+    - {comment: No operation performed for this changeset on execution.}
+    rollback:
+    - {sql: DELETE FROM core_user WHERE id = 13371338;}
+- changeSet:
+    id: v48.00-055
+    validCheckSum: 8:fd36092d50982fbf31ce16757c16e47e
+    author: noahmoss
+    comment: Added 0.48.0 - new view v_tasks
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/tasks/v1/postgres-tasks.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/tasks/v1/mysql-tasks.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/tasks/v1/h2-tasks.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: drop view if exists v_tasks;}
+- changeSet:
+    id: v48.00-056
+    validCheckSum: 8:229e8058cc8309053b344bbfdb042405
+    author: noahmoss
+    comment: Adjust view_log schema for Audit Log v2
+    changes:
+    - addColumn:
+        tableName: view_log
+        columns:
+        - column:
+            name: has_access
+            type: boolean
+            constraints: {nullable: true}
+            remarks: Whether the user who initiated the view had read access to the item being viewed.
+- changeSet:
+    id: v48.00-057
+    validCheckSum: 8:8e32153df1031ea12005d58ce1674873
+    author: noahmoss
+    comment: Adjust view_log schema for Audit Log v2
+    changes:
+    - addColumn:
+        tableName: view_log
+        columns:
+        - column:
+            name: context
+            type: varchar(32)
+            constraints: {nullable: true}
+            remarks: The context of the view, can be collection, question, or dashboard. Only for cards.
+- changeSet:
+    id: v48.00-059
+    validCheckSum: 8:fd8b5031dbbf69c4588ce2699eb20f33
+    author: qwef
+    comment: Update the namespace of any audit collections that are already loaded
+    changes:
+    - sql: {sql: UPDATE collection SET namespace = 'analytics' WHERE entity_id = 'okNLSZKdSxaoG58JSQY54' OR entity_id = 'vG58R8k-QddHWA7_47umn'}
+    rollback: null
+- changeSet:
+    id: v48.00-060
+    validCheckSum: 8:a59027f5494811033ce77cd0ba05d6bd
+    author: noahmoss
+    comment: Added 0.48.0 - task_history.started_at
+    changes:
+    - createIndex:
+        indexName: idx_task_history_started_at
+        tableName: task_history
+        columns:
+        - column: {name: started_at}
+- changeSet:
+    id: v48.00-061
+    validCheckSum: 8:9b9939aad6ca12f7cf4dfa85dae6eb1c
+    author: piranha
+    comment: Adds query_execution.cache_hash -> query_cache.query_hash
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column:
+            name: cache_hash
+            type: ${blob.type}
+            constraints: {nullable: true}
+            remarks: Hash of normalized query, calculated in middleware.cache
+- changeSet:
+    id: v48.00-067
+    validCheckSum: 8:e7cd8168533c58c865dacf320e819218
+    author: qnkhuat
+    comment: Add unique constraint idx_databasechangelog_id_author_filename
+    preConditions:
+    - {onFail: MARK_RAN}
+    - {onUpdateSQL: IGNORE}
+    - and:
+      - sqlCheck: {expectedResult: 0, sql: 'SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1'}
+      - or:
         - and:
+          - dbms: {type: postgresql}
           - sqlCheck:
               expectedResult: 0
-              sql: SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1
-          - or:
-            - and:
-              - dbms:
-                  type: postgresql
-              - sqlCheck:
-                  expectedResult: 0
-                  sql: >-
-                    SELECT COUNT(*)
-                    FROM pg_indexes
-                    WHERE tablename = 'databasechangelog' AND
-                          indexname = 'idx_databasechangelog_id_author_filename';
-            - and:
-              - dbms:
-                  type: h2
-              - sqlCheck:
-                  expectedResult: 0
-                  sql: >-
-                    SELECT COUNT(*)
-                    FROM INFORMATION_SCHEMA.INDEXES
-                    WHERE TABLE_NAME = 'DATABASECHANGELOG' AND
-                          INDEX_NAME = 'IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME_INDEX_1';
-            - and:
-              - dbms:
-                  type: mysql,mariadb
-              - not:
-                - indexExists:
-                    tableName: ${databasechangelog.name}
-                    indexName: idx_databasechangelog_id_author_filename
-      changes:
-        - addUniqueConstraint:
-            constraintName: idx_databasechangelog_id_author_filename
-            tableName: ${databasechangelog.name}
-            columnNames: id, author, filename
-      rollback:
-        - dropUniqueConstraint:
-            tableName: ${databasechangelog.name}
-            constraintName: idx_databasechangelog_id_author_filename
-
-  - changeSet:
-      id: v49.00-000
-      author: qnkhuat
-      comment: Remove leagcy pulses
-      changes:
-        - sql: DELETE FROM pulse where dashboard_id is null and alert_condition is null;
-      # pulse has been deprecated in v38(~2.5 years ago), even the UI to view it is broken
-      # so we don't need to worry about recovering it on rollback
-      rollback:
-
-  - changeSet:
-      id: v49.00-003
-      author: johnswanson
-      comment: Add a `type` to users
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: type
-                  type: varchar(64)
-                  constraints:
-                    nullable: false
-                  defaultValue: 'personal'
-                  remarks: The type of user
-            tableName: core_user
-
-  - changeSet:
-      id: v49.00-004
-      author: johnswanson
-      comment: Add a table for API keys
-      changes:
-        - createTable:
-            tableName: api_key
-            remarks: An API Key
-            columns:
-              - column:
-                  remarks: The ID of the API Key itself
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: The ID of the user who this API Key acts as
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_api_key_user_id
-              - column:
-                  remarks: The hashed API key
-                  name: key
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The first 7 characters of the unhashed key
-                  name: key_prefix
-                  type: varchar(7)
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  remarks: The ID of the user that created this API key
-                  name: created_by
-                  type: integer
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_api_key_created_by_user_id
-              - column:
-                  remarks: The timestamp when the key was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp when the key was last updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v49.00-005
-      author: johnswanson
-      comment: Add an index on `api_key.created_by`
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: api_key
-            indexName: idx_api_key_created_by
-            columns:
-              column:
-                name: created_by
-
-  - changeSet:
-      id: v49.00-006
-      author: johnswanson
-      comment: Add an index on `api_key.user_id`
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: api_key
-            indexName: idx_api_key_user_id
-            columns:
-              column:
-                name: user_id
-
-  - changeSet:
-      id: v49.00-007
-      author: johnswanson
-      comment: Set the `type` of the internal user
-      changes:
-        - sql:
-            sql: UPDATE core_user SET type='internal' WHERE id=13371338;
-      rollback: # not necessary
-
-  - changeSet:
-      id: v49.00-008
-      author: qnkhuat
-      comment: Add metabase_field.database_indexed
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: database_indexed
-                  type: boolean
-                  constraints:
-                    nullable: true
-                  remarks: 'If the database supports indexing, this column indicate whether or not a field is indexed, or is the 1st column in a composite index'
-
-  - changeSet:
-      id: v49.00-009
-      author: adam-james
-      comment: Migrate pulse_card.include_csv to 'true' when the joined card.display is 'table'
-      changes:
-        - sql:
-            dbms: mariadb,mysql
-            sql: >-
-              UPDATE pulse_card AS pc
-              JOIN report_card AS rc ON rc.id = pc.card_id
-              SET pc.include_csv = TRUE
-              WHERE rc.display = 'table';
-        - sql:
-            dbms: postgresql,h2
-            sql: >-
-              UPDATE pulse_card pc
-              SET include_csv = TRUE
-              WHERE pc.card_id IN (
-                  SELECT rc.id
-                  FROM report_card rc
-                  WHERE rc.display = 'table'
-                  AND rc.id = pc.card_id
-              );
-      rollback: # no change
-
-  - changeSet:
-      id: v49.00-010
-      author: johnswanson
-      comment: Add a name to API Keys
-      changes:
-        - addColumn:
-            tableName: api_key
-            columns:
-              - column:
-                  name: name
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-                    unique: true
-                  remarks: 'The user-defined name of the API key.'
-
-  - changeSet:
-      id: v49.00-011
-      author: qnkhuat
-      comment: Add metabase_table.database_require_filter
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: database_require_filter
-                  type: boolean
-                  constraints:
-                    nullable: true
-                  remarks: 'If true, the table requires a filter to be able to query it'
-
-  - changeSet:
-      id: v49.00-012
-      author: qnkhuat
-      comment: Add metabase_field.database_partitioned
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: database_partitioned
-                  type: boolean
-                  constraints:
-                    nullable: true
-                  remarks: 'Whether the table is partitioned by this field'
-
-  - changeSet:
-      id: v49.00-013
-      author: johnswanson
-      comment: Add `api_key.updated_by_id`
-      rollback: # will be removed with the table
-      changes:
-        - addColumn:
-            tableName: api_key
-            columns:
-              - column:
-                  remarks: The ID of the user that last updated this API key
-                  name: updated_by_id
-                  type: integer
-                  constraints:
-                    # no default and nullable: false for a new column? yikes! But this should probably be ok, because
-                    # we don't yet have any UI for creating a new API key.
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_api_key_updated_by_id_user_id
-
-  - changeSet:
-      id: v49.00-014
-      author: johnswanson
-      comment: Add an index on `api_key.updated_by_id`
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: api_key
-            indexName: idx_api_key_updated_by_id
-            columns:
-              column:
-                name: updated_by_id
-
-  - changeSet:
-      id: v49.00-015
-      author: johnswanson
-      comment: Rename `created_by` to `creator_id`
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - renameColumn:
-            tableName: api_key
-            columnDataType: integer
-            oldColumnName: created_by
-            newColumnName: creator_id
-
-  - changeSet:
-      id: v49.00-016
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of action.archived from boolean to
-        ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: action
-            columnName: archived
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: action
-            columnName: archived
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-017
-      author: noahmoss
-      comment: Add NOT NULL constraint to action.archived
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: action
-            columnName: archived
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-018
-      author: noahmoss
-      comment: Add default value to action.archived
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: action
-            columnName: archived
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-019
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of metabase_field.json_unfolding from
-        boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: json_unfolding
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: json_unfolding
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-020
-      author: noahmoss
-      comment: Add NOT NULL constraint to metabase_field.json_unfolding
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: metabase_field
-            columnName: json_unfolding
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-021
-      author: noahmoss
-      comment: Add default value to metabase_field.json_unfolding
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: metabase_field
-            columnName: json_unfolding
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-022
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of metabase_field.database_is_auto_increment
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_is_auto_increment
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_is_auto_increment
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-023
-      author: noahmoss
-      comment: Add NOT NULL constraint to metabase_field.database_is_auto_increment
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: metabase_field
-            columnName: database_is_auto_increment
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-024
-      author: noahmoss
-      comment: Add default value to metabase_field.database_is_auto_increment
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: metabase_field
-            columnName: database_is_auto_increment
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-025
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of report_dashboard.auto_apply_filters
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: auto_apply_filters
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: auto_apply_filters
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-026
-      author: noahmoss
-      comment: Add NOT NULL constraint to report_dashboard.auto_apply_filters
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: report_dashboard
-            columnName: auto_apply_filters
-            defaultNullValue: true
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-027
-      author: noahmoss
-      comment: Add default value to report_dashboard.auto_apply_filters
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: true
-            tableName: report_dashboard
-            columnName: auto_apply_filters
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-028
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of metabase_database.is_audit
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_database
-            columnName: is_audit
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_database
-            columnName: is_audit
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-029
-      author: noahmoss
-      comment: Add NOT NULL constraint to metabase_database.is_audit
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: metabase_database
-            columnName: is_audit
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-030
-      author: noahmoss
-      comment: Add default value to metabase_database.is_audit
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: metabase_database
-            columnName: is_audit
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-031
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of metabase_table.is_upload
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: is_upload
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: is_upload
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-032
-      author: noahmoss
-      comment: Add NOT NULL constraint to metabase_table.is_upload
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: metabase_table
-            columnName: is_upload
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-033
-      author: noahmoss
-      comment: Add default value to metabase_table.is_upload
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: metabase_table
-            columnName: is_upload
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-034
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of revision.most_recent
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: revision
-            columnName: most_recent
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: revision
-            columnName: most_recent
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-035
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of revision.most_recent
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: revision
-            columnName: most_recent
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: revision
-            columnName: most_recent
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-036
-      author: noahmoss
-      comment: Add NOT NULL constraint to revision.most_recent
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: revision
-            columnName: most_recent
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-037
-      author: noahmoss
-      comment: Add default value to revision.most_recent
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: revision
-            columnName: most_recent
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-038
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of table_privileges.select
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: select
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: select
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-039
-      author: noahmoss
-      comment: Add NOT NULL constraint to table_privileges.select
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: table_privileges
-            columnName: select
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-040
-      author: noahmoss
-      comment: Add default value to table_privileges.select
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: table_privileges
-            columnName: select
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-041
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of table_privileges.update
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: update
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: update
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-042
-      author: noahmoss
-      comment: Add NOT NULL constraint to table_privileges.update
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: table_privileges
-            columnName: update
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-043
-      author: noahmoss
-      comment: Add default value to table_privileges.update
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: table_privileges
-            columnName: update
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-044
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of table_privileges.insert
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: insert
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: insert
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-045
-      author: noahmoss
-      comment: Add NOT NULL constraint to table_privileges.insert
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: table_privileges
-            columnName: insert
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-046
-      author: noahmoss
-      comment: Add default value to table_privileges.insert
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: table_privileges
-            columnName: insert
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-047
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of table_privileges.delete
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: delete
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: table_privileges
-            columnName: delete
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-048
-      author: noahmoss
-      comment: Add NOT NULL constraint to table_privileges.delete
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: table_privileges
-            columnName: delete
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-049
-      author: noahmoss
-      comment: Add default value to table_privileges.delete
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: table_privileges
-            columnName: delete
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-050
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of query_execution.is_sandboxed
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: query_execution
-            columnName: is_sandboxed
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: query_execution
-            columnName: is_sandboxed
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-051
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of view_log.has_access
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: view_log
-            columnName: has_access
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: view_log
-            columnName: has_access
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-052
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of metabase_field.database_indexed
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_indexed
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_indexed
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-053
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of metabase_table.database_require_filter
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: database_require_filter
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: database_require_filter
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.00-059
-      author: qnkhuat
-      comment: Added 0.49.0 - unify type of time columns
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.UnifyTimeColumnsType"
-
-  - changeSet:
-      id: v49.00-060
-      author: qnkhuat
-      comment: >-
-        Added 0.49.0 - modify type of metabase_field.database_partitioned
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_partitioned
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_partitioned
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2023-01-24T12:00:00
-      author: piranha
-      comment: >-
-        This significantly speeds up api.database/autocomplete-fields query
-        and is an improvement for issue 30588.
-        H2 does not support this: https://github.com/h2database/h2database/issues/3535
-        Mariadb does not support this.
-        Mysql says it does, but reports an error during migration.
-      dbms: postgresql
-      changes:
-        - createIndex:
-            tableName: metabase_field
-            indexName: idx_field_name_lower
-            columns:
-              - column:
-                  name: lower(name)
-                  computed: true
-      rollback:
-        - dropIndex:
-            tableName: metabase_field
-            indexName: idx_field_name_lower
-
-  - changeSet:
-      id: v49.2024-01-22T11:50:00
-      author: qnkhuat
-      comment: Add `report_card.type`
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  remarks: The type of card, could be 'question', 'model', 'metric'
-                  name: type
-                  type: varchar(16)
-                  defaultValue: "question"
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v49.2024-01-22T11:51:00
-      author: qnkhuat
-      comment: Backfill `report_card.type`
-      changes:
-        - sql:
-            sql: >-
-              UPDATE report_card
-              SET type = 'model'
-              WHERE dataset is true
-      rollback: # no need, the column will be dropped
-
-  - changeSet:
-      id: v49.2024-01-22T11:52:00
-      author: qnkhuat
-      comment: Backfill `report_card.type`
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.CardRevisionAddType"
-
-  - changeSet:
-      id: v49.2024-01-29T19:26:40
-      author: adam-james
-      comment: Add width setting to Dashboards
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: width
-                  type: varchar(16)
-                  defaultValue: "fixed"
-                  remarks: "The value of the dashboard's width setting can be fixed or full. New dashboards will be set to fixed"
-
-  - changeSet:
-      id: v49.2024-01-29T19:30:00
-      author: adam-james
-      comment: Update existing report_dashboard width values to full
-      changes:
-        - update:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: width
-                  value: "full"
-      rollback: []
-
-  - changeSet:
-      id: v49.2024-01-29T19:56:40
-      author: adam-james
-      comment: Dashboard width setting must have a value
-      changes:
-        - addNotNullConstraint:
-            tableName: report_dashboard
-            columnName: width
-            columnDatatype: varchar(16)
-            defaultNullvalue: "full"
-            remarks: "If for some reason an existing dashboard has null width value it is set to full"
-
-  - changeSet:
-      id: v49.2024-01-29T19:59:12
-      author: adam-james
-      comment: Add default value to report_dashboard.width for mysql and mariadb
-      changes:
-        - addDefaultValue:
-            defaultValue: "fixed"
-            tableName: report_dashboard
-            columnName: width
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-02-02T11:27:49
-      author: oisincoveney
-      comment: >-
-        Add report_card.initially_published_at
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: initially_published_at
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: true
-                  remarks: The timestamp when the card was first published in a static embed
-
-  - changeSet:
-        id: v49.2024-02-02T11:28:36
-        author: oisincoveney
-        comment: >-
-          Add report_dashboard.initially_published_at
-        changes:
-          - addColumn:
-              tableName: report_dashboard
-              columns:
-                - column:
-                    name: initially_published_at
-                    type: ${timestamp_type}
-                    constraints:
-                      nullable: true
-                    remarks: The timestamp when the dashboard was first published in a static embed
-
-  - changeSet:
-      id: v49.2024-02-07T21:52:01
-      author: noahmoss
-      comment: Added 0.49.0 - updated view v_view_log
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/view_log/v2/postgres-view_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/view_log/v2/mysql-view_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/view_log/v2/h2-view_log.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/view_log/v1/postgres-view_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/view_log/v1/mysql-view_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/view_log/v1/h2-view_log.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v49.2024-02-07T21:52:02
-      author: noahmoss
-      comment: Added 0.49.0 - updated view v_audit_log
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/audit_log/v2/postgres-audit_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/audit_log/v2/mysql-audit_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/audit_log/v2/h2-audit_log.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/audit_log/v1/postgres-audit_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/audit_log/v1/mysql-audit_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/audit_log/v1/h2-audit_log.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v49.2024-02-07T21:52:03
-      author: noahmoss
-      comment: Added 0.49.0 - updated view v_group_members
-      changes:
-        - sqlFile:
-            path: instance_analytics_views/group_members/v2/group_members.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/group_members/v1/group_members.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v49.2024-02-07T21:52:04
-      author: noahmoss
-      comment: Added 0.49.0 - updated view v_query_log
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/query_log/v2/postgres-query_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/query_log/v2/mysql-query_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/query_log/v2/h2-query_log.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/query_log/v1/postgres-query_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/query_log/v1/mysql-query_log.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/query_log/v1/h2-query_log.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v49.2024-02-07T21:52:05
-      author: noahmoss
-      comment: Added 0.49.0 - updated view v_users
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/users/v2/postgres-users.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/users/v2/mysql-users.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/users/v2/h2-users.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/users/v1/postgres-users.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/users/v1/mysql-users.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/users/v1/h2-users.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v49.2024-02-09T13:55:26
-      author: noahmoss
-      comment: Set default value for enable-public-sharing to `false` for existing instances with users, if not already set
-      preConditions:
-        - onFail: MARK_RAN
+              sql: |-
+                SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'databasechangelog' AND
+                      indexname = 'idx_databasechangelog_id_author_filename';
         - and:
-            - or:
-                - and:
-                    - dbms:
-                        type: postgresql
-                    - sqlCheck:
-                        expectedResult: 0
-                        sql: SELECT count(*) FROM setting WHERE key = 'enable-public-sharing';
-                - and:
-                    - dbms:
-                        type: h2
-                    - sqlCheck:
-                        expectedResult: 0
-                        sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-public-sharing';
-                - and:
-                    - dbms:
-                        type: mysql,mariadb
-                    - sqlCheck:
-                        expectedResult: 0
-                        sql: SELECT count(*) FROM setting WHERE `key` = 'enable-public-sharing';
-            - sqlCheck:
-                expectedResult: 1
-                sql: >
-                  SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM core_user;
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: INSERT INTO setting (key, value) VALUES ('enable-public-sharing', 'false');
-        - sql:
-            dbms: mysql,mariadb
-            sql: INSERT INTO setting (`key`, value) VALUES ('enable-public-sharing', 'false');
-        - sql:
-            dbms: h2
-            sql: INSERT INTO setting ("KEY", "VALUE") VALUES ('enable-public-sharing', 'false');
-      rollback: # not needed
-
-  - changeSet:
-      id: v49.2024-03-26T10:23:12
-      author: adam-james
-      comment: Add pulse_card.format_rows
-      changes:
-        - addColumn:
-            tableName: pulse_card
-            columns:
-              - column:
-                  name: format_rows
-                  type: ${boolean.type}
-                  defaultValue: true
-                  remarks: Whether or not to apply formatting to the rows of the export
-
-  - changeSet:
-      id: v49.2024-04-09T10:00:00
-      author: qnkhuat
-      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
-      changes:
-        - dropNotNullConstraint:
-            tableName: metabase_database
-            columnName: cache_field_values_schedule
-            columnDataType: varchar(254)
-      # nothing because it should always be like this
-      rollback:
-
-  - changeSet:
-      id: v49.2024-04-09T10:00:01
-      author: qnkhuat
-      comment: Drop default value on metabase_database.cache_field_values_schedule
-      changes:
-        - dropDefaultValue:
-            tableName: metabase_database
-            columnName: cache_field_values_schedule
-      # nothing because it should always be like this
-      rollback:
-
-  - changeSet:
-      id: v49.2024-04-09T10:00:02
-      author: qnkhuat
-      comment: Add null as default value for metabase_database.cache_field_values_schedule
-      changes:
-        - addDefaultValue:
-            defaultValue: "null"
-            tableName: metabase_database
-            columnName: cache_field_values_schedule
-      # nothing because it should always be like this
-      rollback:
-
-  - changeSet:
-      id: v49.2024-04-09T10:00:03
-      author: qnkhuat
-      comment: This clears the schedule for caching field values for databases with period scanning disabled.
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.DeleteScanFieldValuesTriggerForDBThatTurnItOff"
-
-  - changeSet:
-      id: v49.2024-05-07T10:00:00
-      author: qnkhuat
-      comment: Set revision.most_recent = true to latest revision and false to others. A redo of v48.00-008 for mysql
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE revision AS r
-              JOIN (
-                  SELECT inner_revision.id,
-                        ROW_NUMBER() OVER (PARTITION BY inner_revision.model, inner_revision.model_id ORDER BY inner_revision.timestamp DESC, inner_revision.id DESC) AS row_num
-                    FROM revision AS inner_revision
-                    JOIN (
-                          SELECT model, model_id
-                          FROM revision
-                          WHERE most_recent = true
-                          GROUP BY model, model_id
-                          HAVING count(*) > 1
-                        ) AS infected_revision ON inner_revision.model = infected_revision.model AND inner_revision.model_id = infected_revision.model_id
-              ) AS n ON r.id = n.id
-              SET r.most_recent = (n.row_num = 1);
-      rollback: # nothing
-
-  - changeSet:
-      id: v49.2024-05-20T19:10:34
-      author: johnswanson
-      comment: >-
-        Modify type of report_card.collection_preview to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: collection_preview
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: report_card
-            columnName: collection_preview
-            newDataType: boolean
-            defaultValueBoolean: true
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-05-20T20:37:55
-      author: johnswanson
-      comment: Add NOT NULL constraint to report_card.collection_preview
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: report_card
-            columnName: collection_preview
-            defaultNullValue: true
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-  - changeSet:
-      id: v49.2024-05-20T20:38:34
-      author: johnswanson
-      comment: Add default value to report_card.collection_preview
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: true
-            tableName: report_card
-            columnName: collection_preview
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-05-29T09:26:20
-      author: johnswanson
-      comment: >-
-        Modify type of report_card.dataset to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: dataset
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: report_card
-            columnName: dataset
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-05-29T09:27:15
-      author: johnswanson
-      dbms: mysql,mariadb
-      comment: Add NOT NULL constraint to report_card.dataset
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: report_card
-            columnName: dataset
-            defaultNullValue: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-05-29T09:28:25
-      author: johnswanson
-      dbms: mysql,mariadb
-      comment: Add default value to report_card.dataset
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: false
-            tableName: report_card
-            columnName: dataset
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:01:01
-      author: johnswanson
-      comment: >-
-        Modify type of core_user.is_datasetnewb to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: core_user
-            columnName: is_datasetnewb
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: core_user
-            columnName: is_datasetnewb
-            newDataType: boolean
-            defaultValueBoolean: true
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:01:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to core_user.is_datasetnewb on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: core_user
-            columnName: is_datasetnewb
-            columnDataType: ${boolean.type}
-            defaultNullValue: true
-      rollback:
-        - dropNotNullConstraint:
-            tableName: core_user
-            columnName: is_datasetnewb
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:01:03
-      author: johnswanson
-      comment: >-
-        Add default value to core_user.is_datasetnewb on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: core_user
-            columnName: is_datasetnewb
-            defaultValueBoolean: true
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:02:01
-      author: johnswanson
-      comment: >-
-        Modify type of metabase_field.database_required to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_required
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_field
-            columnName: database_required
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:02:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to metabase_field.database_required on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: metabase_field
-            columnName: database_required
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: metabase_field
-            columnName: database_required
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:02:03
-      author: johnswanson
-      comment: >-
-        Add default value to metabase_field.database_required on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: metabase_field
-            columnName: database_required
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:03:01
-      author: johnswanson
-      comment: >-
-        Modify type of metabase_fieldvalues.has_more_values to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: metabase_fieldvalues
-            columnName: has_more_values
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: metabase_fieldvalues
-            columnName: has_more_values
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:03:03
-      author: johnswanson
-      comment: >-
-        Add default value to metabase_fieldvalues.has_more_values on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: metabase_fieldvalues
-            columnName: has_more_values
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:04:01
-      author: johnswanson
-      comment: >-
-        Modify type of permissions_group_membership.is_group_manager to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: permissions_group_membership
-            columnName: is_group_manager
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: permissions_group_membership
-            columnName: is_group_manager
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:04:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to permissions_group_membership.is_group_manager on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: permissions_group_membership
-            columnName: is_group_manager
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: permissions_group_membership
-            columnName: is_group_manager
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:04:03
-      author: johnswanson
-      comment: >-
-        Add default value to permissions_group_membership.is_group_manager on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: permissions_group_membership
-            columnName: is_group_manager
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:05:01
-      author: johnswanson
-      comment: >-
-        Modify type of persisted_info.active to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: persisted_info
-            columnName: active
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: persisted_info
-            columnName: active
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:05:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to persisted_info.active on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: persisted_info
-            columnName: active
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: persisted_info
-            columnName: active
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:05:03
-      author: johnswanson
-      comment: >-
-        Add default value to persisted_info.active on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: persisted_info
-            columnName: active
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:06:01
-      author: johnswanson
-      comment: >-
-        Modify type of report_card.dataset to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: dataset
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: report_card
-            columnName: dataset
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:06:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to report_card.dataset on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: report_card
-            columnName: dataset
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: report_card
-            columnName: dataset
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:06:03
-      author: johnswanson
-      comment: >-
-        Add default value to report_card.dataset on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: report_card
-            columnName: dataset
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:07:01
-      author: johnswanson
-      comment: >-
-        Modify type of timeline.archived to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: timeline
-            columnName: archived
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: timeline
-            columnName: archived
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:07:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to timeline.archived on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: timeline
-            columnName: archived
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: timeline
-            columnName: archived
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:07:03
-      author: johnswanson
-      comment: >-
-        Add default value to timeline.archived on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: timeline
-            columnName: archived
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:08:01
-      author: johnswanson
-      comment: >-
-        Modify type of timeline.default to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: timeline
-            columnName: default
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: timeline
-            columnName: default
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:08:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to timeline.default on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: timeline
-            columnName: default
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: timeline
-            columnName: default
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:08:03
-      author: johnswanson
-      comment: >-
-        Add default value to timeline.default on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: timeline
-            columnName: default
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:09:01
-      author: johnswanson
-      comment: >-
-        Modify type of timeline_event.archived to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: timeline_event
-            columnName: archived
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: timeline_event
-            columnName: archived
-            newDataType: boolean
-            defaultValueBoolean: false
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:09:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to timeline_event.archived on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: timeline_event
-            columnName: archived
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: timeline_event
-            columnName: archived
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:09:03
-      author: johnswanson
-      comment: >-
-        Add default value to timeline_event.archived on mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: timeline_event
-            columnName: archived
-            defaultValueBoolean: false
-      dbms: mysql,mariadb
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:10:01
-      author: johnswanson
-      comment: >-
-        Modify type of timeline_event.time_matters to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: timeline_event
-            columnName: time_matters
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: timeline_event
-            columnName: time_matters
-            newDataType: boolean
-            defaultValueBoolean: NULL
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v49.2024-06-05T09:10:02
-      author: johnswanson
-      comment: >-
-        Add NOT NULL constraint to timeline_event.time_matters on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - addNotNullConstraint:
-            tableName: timeline_event
-            columnName: time_matters
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-      rollback:
-        - dropNotNullConstraint:
-            tableName: timeline_event
-            columnName: time_matters
-            columnDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  # The changesets from v49.2024-06-27T00:00:00 to v49.2024-06-27T00:00:08 prevent duplicate fields from being
-  # created on MySQL and H2. See #44866 for details. Below is an index of the changesets:
-  # - v49.2024-06-27T00:00:00: Make metabase_field.name use case-sensitive collation for MySQL
-  # - v49.2024-06-27T00:00:01: Add metabase_field.is_defective_duplicate
-  # - v49.2024-06-27T00:00:02: Populate metabase_field.is_defective_duplicate
-  # - v49.2024-06-27T00:00:03: Drop fk_field_parent_ref_field_id constraint with ON DELETE CASCADE
-  # - v49.2024-06-27T00:00:04: Add fk_field_parent_ref_field_id constraint with ON DELETE RESTRICT
-  # - v49.2024-06-27T00:00:05: Remove idx_uniq_field_table_id_parent_id_name because it is redundant with idx_unique_field
-  # - v49.2024-06-27T00:00:06: Remove the idx_uniq_field_table_id_parent_id_name_2col unique index because it blocks load-from-h2
-  # - v49.2024-06-27T00:00:07: Add unique_field_helper column to metabase_field
-  # - v49.2024-06-27T00:00:08: Add unique constraint on metabase_field's (name, table_id, unique_field_helper)
-
-  # This is necessary to make unique indexes using metabase_field.name case-sensitive for MySQL.
-  - changeSet:
-      id: v49.2024-06-27T00:00:00
-      author: calherries
-      comment: Make metabase_field.name use case-sensitive collation for MySQL
-      changes:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              ALTER TABLE metabase_field MODIFY
-              name VARCHAR(254)
-              CHARACTER SET utf8mb4
-              COLLATE utf8mb4_bin;
-      rollback:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              ALTER TABLE metabase_field MODIFY
-              name VARCHAR(254)
-              CHARACTER SET utf8mb4
-              COLLATE utf8mb4_unicode_ci;
-
-  # metabase_field.is_defective_duplicate is a new column that indicates whether a field is a defective duplicate field
-  # that should never have been created under Postgres' `idx_uniq_field_table_id_parent_id_name_2col` constraint, but
-  # was allowed to be created in MySQL or H2.
-  - changeSet:
-      id: v49.2024-06-27T00:00:01
-      author: calherries
-      comment: Add metabase_field.is_defective_duplicate
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  name: is_defective_duplicate
-                  type: ${boolean.type}
-                  remarks: "Indicates whether column is a defective duplicate field that should never have been created."
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-
-  - changeSet:
-      id: v49.2024-06-27T00:00:02
-      author: calherries
-      comment: Populate metabase_field.is_defective_duplicate
-      changes:
-        - sql:
-            # idx_uniq_field_table_id_parent_id_name_2col would prevent defective duplicates with Postgres but it
-            # can be removed by upgrading from 49 and downgrading again. We need to populate is_defective_duplicate
-            # in that case.
-            sql: >-
-              UPDATE metabase_field mf
-              SET is_defective_duplicate = TRUE
-              WHERE mf.id IN (
-                  SELECT id
-                  FROM (
-                      SELECT
-                          mf.id,
-                          ROW_NUMBER() OVER (
-                              PARTITION BY mf.table_id, mf.name, mf.parent_id
-                              ORDER BY
-                                  CASE WHEN mf.active THEN 0 ELSE 1 END,
-                                  CASE WHEN mf.nfc_path IS NULL THEN 0 ELSE 1 END,
-                                  mf.created_at
-                          ) AS rn
-                      FROM metabase_field mf
-                  ) x
-                  WHERE x.rn > 1
-              );
-      rollback: # No rollback needed since is_defective_duplicate is introduced in 49
-
-  # The next two changesets replace ON DELETE CASCADE with ON DELETE RESTRICT on fk_field_parent_ref_field_id.
-  # We need to do this for MySQL because it doesn't support ON DELETE CASCADE in a stored generated column, and we
-  # want to use parent_id in the unique_field_helper generated column. Cascading deletes are handled in the
-  # application instead.
-  - changeSet:
-      id: v49.2024-06-27T00:00:03
-      author: calherries
-      comment: Drop fk_field_parent_ref_field_id constraint with ON DELETE CASCADE
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: metabase_field
-            constraintName: fk_field_parent_ref_field_id
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_field
-            baseColumnNames: parent_id
-            referencedTableName: metabase_field
-            referencedColumnNames: id
-            constraintName: fk_field_parent_ref_field_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v49.2024-06-27T00:00:04
-      author: calherries
-      comment: Add fk_field_parent_ref_field_id constraint with ON DELETE RESTRICT
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_field
-            baseColumnNames: parent_id
-            referencedTableName: metabase_field
-            referencedColumnNames: id
-            constraintName: fk_field_parent_ref_field_id
-            onDelete: RESTRICT
-      rollback:
-        - dropForeignKeyConstraint:
-            baseTableName: metabase_field
-            constraintName: fk_field_parent_ref_field_id
-
-  - changeSet:
-      id: v49.2024-06-27T00:00:05
-      author: calherries
-      comment: Remove idx_uniq_field_table_id_parent_id_name because it is redundant with idx_unique_field
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: h2,postgresql
-                - uniqueConstraintExists:
-                    tableName: metabase_field
-                    constraintName: idx_uniq_field_table_id_parent_id_name
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: >-
-                      SELECT EXISTS (
-                        SELECT *
-                        FROM information_schema.statistics
-                        WHERE table_schema = DATABASE()
-                          AND table_name = 'metabase_field'
-                          AND index_name = 'idx_uniq_field_table_id_parent_id_name'
-                      )
-      changes:
-        - dropUniqueConstraint:
-            tableName: metabase_field
-            constraintName: idx_uniq_field_table_id_parent_id_name
-      rollback:
-        - addUniqueConstraint:
-            tableName: metabase_field
-            columnNames: table_id, parent_id, name
-            constraintName: idx_uniq_field_table_id_parent_id_name
-
-  - changeSet:
-      id: v49.2024-06-27T00:00:06
-      author: calherries
-      comment: Remove the idx_uniq_field_table_id_parent_id_name_2col unique index because it blocks load-from-h2
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: DROP INDEX IF EXISTS idx_uniq_field_table_id_parent_id_name_2col;
-      rollback: # We deliberately don't restore this constraint because otherwise it can block downgrading to 48 after load-from-h2
-
-  # Previously we had two unique constraints on metabase_field's name, table_id, and parent_id columns.
-  #
-  # 1. `idx_uniq_field_table_id_parent_id_name` is a unique constraint on (name, table_id, parent_id)
-  #    Since NULL <> NULL, it only applies to fields where parent_id IS NOT NULL.
-  #    Worse, the constraint was not case-sensitive for MySQL.
-  #
-  # 2. `idx_uniq_field_table_id_parent_id_name_2col` is a Postgres-only unique constraint on
-  #    `(name, table_id) WHERE parent_id IS NULL`. There was no equivalent constraint for H2 or MySQL because only
-  #    Postgres supports partial indexes. The following changesets introduce an equivalent constraint for H2 and
-  #    MySQL by adding a constraint that uses a generated column to handle NULL parent_id values.
-  #
-  # At the same time, we exclude fields where is_defective_duplicate=TRUE from the above constraints.
-  #
-  # The following two changesets add a new column `unique_field_helper` to `metabase_field` and a unique constraint
-  # `idx_unique_field`.
-  # The combination of `unique_field_helper` and `idx_unique_field` achieves two things:
-  # 1. It enforces the conditional constraints:
-  #   - if parent_id IS NULL, then (table_id, name) is unique. (like idx_uniq_field_table_id_parent_id_name_col2)
-  #   - if parent_id IS NOT NULL, then (table_id, name, parent_id) is unique. (like idx_uniq_field_table_id_parent_id_name)
-  # 2. It only enforces the constraints when is_defective_duplicate = FALSE
-
-  - changeSet:
-      id: v49.2024-06-27T00:00:07
-      author: calherries
-      comment: Add unique_field_helper column to metabase_field
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              ALTER TABLE metabase_field ADD COLUMN unique_field_helper INTEGER GENERATED ALWAYS AS (
-                CASE WHEN is_defective_duplicate = TRUE THEN NULL ELSE (CASE WHEN parent_id IS NULL THEN 0 ELSE parent_id END) END
-              ) STORED;
-        - sql:
-            dbms: h2
-            sql: >-
-              ALTER TABLE metabase_field ADD COLUMN unique_field_helper INTEGER GENERATED ALWAYS AS (
-                CASE WHEN is_defective_duplicate = TRUE THEN NULL ELSE (CASE WHEN parent_id IS NULL THEN 0 ELSE parent_id END) END
-              );
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              ALTER TABLE metabase_field ADD COLUMN unique_field_helper INTEGER GENERATED ALWAYS AS (
-                CASE WHEN is_defective_duplicate = TRUE THEN NULL ELSE (CASE WHEN parent_id IS NULL THEN 0 ELSE parent_id END) END
-              ) STORED;
-      rollback:
-        - sql:
-            dbms: postgresql,h2,mysql,mariadb
-            sql: ALTER TABLE metabase_field DROP COLUMN unique_field_helper;
-
-  - changeSet:
-      id: v49.2024-06-27T00:00:08
-      author: calherries
-      comment: Add unique constraint on metabase_field's (name, table_id, unique_field_helper)
-      changes:
-        - addUniqueConstraint:
-            tableName: metabase_field
-            constraintName: idx_unique_field
-            columnNames: name, table_id, unique_field_helper
-      rollback:
-        - dropUniqueConstraint:
-            tableName: metabase_field
-            constraintName: idx_unique_field
-
-  - changeSet:
-      id: v49.2024-06-27T00:00:09
-      author: calherries
-      comment: Set is_defective_duplicate=TRUE fields that shouldn't exist to have active=FALSE
-      changes:
-        - sql:
-            sql: >-
-              UPDATE metabase_field
-              SET active = false
-              WHERE is_defective_duplicate AND (nfc_path = concat('["', name, '"]') OR nfc_path IS NULL);
-      rollback: # No rollback needed since this is backward compatible
-
-  - changeSet:
-      id: v49.2024-08-21T08:33:06
-      author: johnswanson
-      comment: Add permissions.perm_value
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: permissions
-                columnName: perm_value
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: perm_value
-                  type: varchar(64)
-                  remarks: The value of the permission
-                  constraints:
-                    nullable: true
-            tableName: permissions
-
-  - changeSet:
-      id: v49.2024-08-21T08:33:07
-      author: johnswanson
-      comment: Add permissions.perm_type
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: permissions
-                columnName: perm_type
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: perm_type
-                  type: varchar(64)
-                  remarks: The type of the permission
-                  constraints:
-                    nullable: true
-            tableName: permissions
-
-  - changeSet:
-      id: v49.2024-08-21T08:33:08
-      author: johnswanson
-      comment: Add permissions.collection_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: permissions
-                columnName: collection_id
-      changes:
-        - addColumn:
-            tableName: permissions
-            columns:
-              - column:
-                  name: collection_id
-                  type: int
-                  remarks: The linked collection, if applicable
-                  constraints:
-                    nullable: true
-
-  # FK constraint is added separately because deleteCascade doesn't work in addColumn -- see #14321
-  - changeSet:
-      id: v49.2024-08-21T08:33:09
-      author: johnswanson
-      comment: Add `permissions.collection_id` foreign key constraint
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                - foreignKeyName: fk_permissions_ref_collection_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: permissions
-            baseColumnNames: collection_id
-            referencedTableName: collection
-            referencedColumnNames: id
-            constraintName: fk_permissions_ref_collection_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v49.2024-08-21T08:33:10
-      author: johnswanson
-      comment: Populate `perm_value`, `perm_type`, and `collection_id` on permissions
-      rollback: # not needed.
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: permissions/collection-access.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/collection-access-mariadb.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: permissions/collection-access-h2.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v49.2024-08-21T08:33:11
-      author: johnswanson
-      comment: Create index on `permissions.collection_id`
-      rollback: # deleted with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: permissions
-                indexName: idx_permissions_collection_id
-      changes:
-        - createIndex:
-            tableName: permissions
-            columns:
-              - column:
-                  name: collection_id
-            indexName: idx_permissions_collection_id
-
-
-  - changeSet:
-      id: v49.2024-08-21T08:33:12
-      author: johnswanson
-      comment: Index on `permissions.perm_type`
-      rollback: # deleted with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: permissions
-                indexName: idx_permissions_perm_type
-      changes:
-        - createIndex:
-            tableName: permissions
-            columns:
-              - column:
-                  name: perm_type
-            indexName: idx_permissions_perm_type
-
-  - changeSet:
-      id: v49.2024-08-21T08:33:13
-      author: johnswanson
-      comment: Index on `permissions.perm_value`
-      rollback: # deleted with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: permissions
-                indexName: idx_permissions_perm_value
-      changes:
-        - createIndex:
-            tableName: permissions
-            columns:
-              - column:
-                  name: perm_value
-            indexName: idx_permissions_perm_value
-
-  - changeSet:
-      id: v50.2024-01-04T13:52:51
-      author: noahmoss
-      comment: Data permissions table
-      changes:
-        - createTable:
-            tableName: data_permissions
-            remarks: A table to store database and table permissions
-            columns:
-              - column:
-                  remarks: The ID of the permission
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  remarks: The ID of the associated permission group
-                  name: group_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: permissions_group
-                    referencedColumnNames: id
-                    foreignKeyName: fk_data_permissions_ref_permissions_group
-                    deleteCascade: true
-              - column:
-                  remarks: The type of the permission (e.g. "data", "collection", "download"...)
-                  name: perm_type
-                  type: varchar(64)
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: A database ID, for DB and table-level permissions
-                  name: db_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_database
-                    referencedColumnNames: id
-                    foreignKeyName: fk_data_permissions_ref_db_id
-                    deleteCascade: true
-              - column:
-                  remarks: A schema name, for table-level permissions
-                  name: schema_name
-                  type: varchar(254)
-                  constraints:
-                    nullable: true
-              - column:
-                  remarks: A table ID
-                  name: table_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: metabase_table
-                    referencedColumnNames: id
-                    foreignKeyName: fk_data_permissions_ref_table_id
-                    deleteCascade: true
-              - column:
-                  remarks: The value this permission is set to.
-                  name: perm_value
-                  type: varchar(64)
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v50.2024-01-09T13:52:21
-      author: noahmoss
-      comment: Index on data_permissions.table_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: data_permissions
-            columns:
-              - column:
-                  name: table_id
-            indexName: idx_data_permissions_table_id
-
-  - changeSet:
-      id: v50.2024-01-09T13:53:50
-      author: noahmoss
-      comment: Index on data_permissions.db_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: data_permissions
-            columns:
-              - column:
-                  name: db_id
-            indexName: idx_data_permissions_db_id
-
-  - changeSet:
-      id: v50.2024-01-09T13:53:54
-      author: noahmoss
-      comment: Index on data_permissions.group_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: data_permissions
-            columns:
-              - column:
-                  name: group_id
-            indexName: idx_data_permissions_group_id
-
-  - changeSet:
-      id: v50.2024-01-10T03:27:20
-      author: noahmoss
-      comment: Analyze permissions table in preparation for subsequent migrations
-      validCheckSum: ANY
-      runInTransaction: false
-      changes:
-        - sql:
-            sql: ANALYZE permissions;
-            dbms: postgresql
-        - sql:
-            sql: ANALYZE TABLE permissions;
-            dbms: mysql,mariadb
-      rollback: # not needed
-
-  - changeSet:
-      id: v50.2024-01-10T03:27:29
-      author: noahmoss
-      comment: Drop foreign key constraint on sandboxes.permissions_id
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: sandboxes
-            constraintName: fk_sandboxes_ref_permissions
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: sandboxes
-            baseColumnNames: permission_id
-            referencedTableName: permissions
-            referencedColumnNames: id
-            constraintName: fk_sandboxes_ref_permissions
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v50.2024-01-10T03:27:30
-      author: noahmoss
-      comment: Migrate data-access permissions from `permissions` to `data_permissions`
-      validCheckSum: ANY
-      runInTransaction: false
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: permissions/data_access.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: permissions/h2_data_access.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/mysql_data_access.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql,h2
-            path: permissions/rollback/data_access.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/rollback/mysql_data_access.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-01-10T03:27:31
-      author: noahmoss
-      comment: Migrate native-query-editing permissions from `permissions` to `data_permissions`
-      changes:
-        - sqlFile:
-            path: permissions/native_query_editing.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            path: permissions/rollback/native_query_editing.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-01-10T03:27:32
-      author: noahmoss
-      comment: Migrate download-results permissions from `permissions` to `data_permissions`
-      validCheckSum: ANY
-      runInTransaction: false
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: permissions/download_results.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: permissions/h2_download_results.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/mysql_download_results.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql,h2
-            path: permissions/rollback/download_results.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/rollback/mysql_download_results.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-01-10T03:27:33
-      author: noahmoss
-      comment: Migrate manage-data-metadata permissions from `permissions` to `data_permissions`
-      validCheckSum: ANY
-      runInTransaction: false
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: permissions/manage_table_metadata.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: permissions/h2_manage_table_metadata.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/mysql_manage_table_metadata.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql,h2
-            path: permissions/rollback/manage_table_metadata.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/rollback/mysql_manage_table_metadata.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-01-10T03:27:34
-      author: noahmoss
-      comment: Migrate manage-database permissions from `permissions` to `data_permissions`
-      changes:
-        - sqlFile:
-            path: permissions/manage_database.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            path: permissions/rollback/manage_database.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-02-19T21:32:04
-      author: noahmoss
-      comment: Clear data permission paths
-      changes:
-        - sql: >-
-            DELETE FROM permissions WHERE object LIKE '%/db/%';
-      rollback: # not needed; handled by the permission migrations above
-
-  - changeSet:
-      id: v50.2024-02-20T19:21:04
-      author: camsaul
-      comment: Drop v1 version of v_content view since it references report_card.dataset which we are dropping in next migration
-      changes:
-        - sql:
-            sql: >
-              DROP VIEW IF EXISTS v_content;
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/content/v1/postgres-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/content/v1/mysql-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/content/v1/h2-content.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-02-20T19:25:40
-      author: camsaul
-      comment: Remove report_card.dataset (indicated whether Card was a Model; migrated to report_card.type in 49)
-      changes:
-        - dropColumn:
-            tableName: report_card
-            columnName: dataset
-      rollback:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: dataset
-                  type: boolean
-                  remarks: "Indicate whether question is a model"
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-        - sql:
-            sql: >-
-              UPDATE report_card
-              SET dataset = true
-              WHERE type = 'model';
-
-  - changeSet:
-      id: v50.2024-02-20T19:26:38
-      author: camsaul
-      comment: Add new v2 version of v_content view which uses report_card.type instead of report_card.dataset (removed in previous migration)
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/content/v2/postgres-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/content/v2/mysql-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/content/v2/h2-content.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sql:
-            sql: >-
-              DROP VIEW IF EXISTS v_content;
-
-  - changeSet:
-      id: v50.2024-02-26T22:15:52
-      author: noahmoss
-      comment: Add index on data_permissions(group_id, db_id, perm_value)
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: data_permissions
-                indexName: idx_data_permissions_group_id_db_id_perm_value
-      changes:
-        - createIndex:
-            tableName: data_permissions
-            indexName: idx_data_permissions_group_id_db_id_perm_value
-            columns:
-              - column:
-                  name: group_id
-              - column:
-                  name: db_id
-              - column:
-                  name: perm_value
-      rollback: # not needed
-
-  - changeSet:
-      id: v50.2024-02-26T22:15:53
-      author: noahmoss
-      comment: Add index on data_permissions(group_id, db_id, table_id, perm_value)
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: data_permissions
-                indexName: idx_data_permissions_group_id_db_id_table_id_perm_value
-      changes:
-        - createIndex:
-            tableName: data_permissions
-            indexName: idx_data_permissions_group_id_db_id_table_id_perm_value
-            columns:
-              - column:
-                  name: group_id
-              - column:
-                  name: db_id
-              - column:
-                  name: table_id
-              - column:
-                  name: perm_value
-      rollback: # not needed
-
-  - changeSet:
-      id: v50.2024-02-26T22:15:54
-      author: noahmoss
-      comment: New `view-data` permission
-      validCheckSum: ANY
-      changes:
-        - sqlFile:
-            dbms: postgresql,h2
-            path: permissions/view_data.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: permissions/mysql_view_data.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            path: permissions/rollback/view_data.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-02-26T22:15:55
-      author: noahmoss
-      comment: New `create_queries` permission
-      validCheckSum: 9:7c2bc517b6def4e3278394b0399c3d4b
-      changes:
-        - sqlFile:
-            path: permissions/create_queries.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            path: permissions/rollback/create_queries.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v50.2024-02-29T15:06:43
-      author: tsmacdonald
-      comment: Add the query_field join table
-      changes:
-        - createTable:
-            tableName: query_field
-            remarks: Fields used by a card's query
-            columns:
-              - column:
-                  name: id
-                  remarks: PK
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: card_id
-                  remarks: referenced card
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_field_card_id
-                    deleteCascade: true
-              - column:
-                  name: field_id
-                  remarks: referenced field
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_field
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_field_field_id
-                    deleteCascade: true
-
-  - changeSet:
-      id: v50.2024-02-29T15:07:43
-      author: tsmacdonald
-      comment: Index query_field.card_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: query_field
-            columns:
-              - column:
-                  name: card_id
-            indexName: idx_query_field_card_id
-
-  - changeSet:
-      id: v50.2024-02-29T15:08:43
-      author: tsmacdonald
-      comment: Index query_field.field_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: query_field
-            columns:
-              - column:
-                  name: field_id
-            indexName: idx_query_field_field_id
-
-  - changeSet:
-      id: v50.2024-03-12T17:16:38
-      author: noahmoss
-      comment: Drops the `activity` table which is now unused
-      changes:
-        - dropTable:
-            tableName: activity
-      rollback:
-        - createTable:
-            tableName: activity
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: topic
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: timestamp
-                  type: DATETIME
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_activity_ref_user_id
-                    deferrable: false
-                    initiallyDeferred: false
-              - column:
-                  name: model
-                  type: varchar(16)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: model_id
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: database_id
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: table_id
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: custom_id
-                  type: varchar(48)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: details
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-        - sql:
-            dbms: mysql
-            sql: >
-              CREATE index idx_activity_entity_qualified_id ON activity (
-                (
-                  CASE
-                    WHEN model = 'Dataset' THEN (concat('card_', model_id))
-                    WHEN model_id IS NULL THEN NULL
-                    ELSE (concat(lower(model), '_', model_id))
-                  END
-                )
-              );
-
-  - changeSet:
-      id: v50.2024-03-18T16:00:00
-      author: piranha
-      comment: 'Effective caching #36847'
-      changes:
-        - createTable:
-            tableName: cache_config
-            remarks: Cache Configuration
-            columns:
-              - column:
-                  name: id
-                  remarks: Unique ID
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: model
-                  remarks: Name of an entity model
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: model_id
-                  remarks: ID of the said entity
-                  type: int
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  remarks: Timestamp when the config was inserted
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  remarks: Timestamp when the config was updated
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: strategy
-                  remarks: caching strategy name
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: config
-                  remarks: caching strategy configuration
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: state
-                  remarks: state for strategies needing to keep some data between runs
-                  type: ${text.type}
-                  constraints:
-                    nullable: true
-              - column:
-                  name: invalidated_at
-                  remarks: indicates when a cache was invalidated last time for schedule-based strategies
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: true
-              - column:
-                  name: next_run_at
-                  remarks: keeps next time to run for schedule-based strategies
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v50.2024-03-18T16:00:01
-      author: piranha
-      comment: 'Effective caching #36847'
-      rollback: # will be removed with the table
-      changes:
-        - addUniqueConstraint:
-            remarks: Unique config for cache_config (model, model_id)
-            tableName: cache_config
-            constraintName: idx_cache_config_unique_model
-            columnNames: model, model_id
-
-  - changeSet:
-      id: v50.2024-03-21T17:41:00
-      author: qnkhuat
-      comment: Add metabase_table.estimated_row_count
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: estimated_row_count
-                  type: bigint
-                  remarks: The estimated row count
-
-  - changeSet:
-      id: v50.2024-03-22T00:38:28
-      author: qnkhuat
-      comment: Add field_usage table
-      changes:
-        - createTable:
-            tableName: field_usage
-            remarks: Used to store field usage during query execution
-            columns:
-              - column:
-                  name: id
-                  remarks: Unique ID
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: field_id
-                  remarks: ID of the field
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: metabase_field
-                    referencedColumnNames: id
-                    foreignKeyName: fk_field_usage_field_id_metabase_field_id
-                    deleteCascade: true
-              - column:
-                  name: query_execution_id
-                  remarks: referenced query execution
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: query_execution
-                    referencedColumnNames: id
-                    foreignKeyName: fk_field_usage_query_execution_id
-                    deleteCascade: true
-              - column:
-                  name: used_in
-                  remarks: which part of the query the field was used in
-                  type: varchar(25)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: filter_op
-                  remarks: filter's operator that applied to the field
-                  type: varchar(25)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: aggregation_function
-                  remarks: the aggregation function that field applied to
-                  type: varchar(25)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: breakout_temporal_unit
-                  remarks: temporal unit options of the breakout
-                  type: varchar(25)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: breakout_binning_strategy
-                  remarks: the strategy of breakout
-                  type: varchar(25)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: breakout_binning_num_bins
-                  remarks: The numbin option of breakout
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: breakout_binning_bin_width
-                  remarks: The numbin option of breakout
-                  type: int
-                  constraints:
-                    nullable: true
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: The time a field usage was recorded
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v50.2024-03-22T00:39:28
-      author: qnkhuat
-      comment: Index field_usage.field_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: field_usage
-            indexName: idx_field_usage_field_id
-            columns:
-              column:
-                name: field_id
-
-  - changeSet:
-      id: v50.2024-03-24T19:34:11
-      author: noahmoss
-      comment: Clean up deprecated view-data and native-query-editing permissions
-      rollback: # handled by the rollbacks for `v50.2024-02-26T22:15:54` and `v50.2024-02-26T22:15:55`
-      changes:
-        - sql:
-            sql: >
-              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
-
-  - changeSet:
-      id: v50.2024-03-25T14:53:00
-      author: tsmacdonald
-      comment: Add query_field.direct_reference
-      changes:
-        - addColumn:
-            tableName: query_field
-            columns:
-              - column:
-                  name: direct_reference
-                  type: ${boolean.type}
-                  remarks: "Is the Field referenced directly or via a wildcard"
-                  constraints:
-                    nullable: false
-                  defaultValue: true
-
-  - changeSet:
-      id: v50.2024-03-28T16:30:35
-      author: calherries
-      comment: Create internal user
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.CreateInternalUser"
-
-  - changeSet:
-      id: v50.2024-03-29T10:00:00
-      author: piranha
-      comment: 'Granular cache invalidation'
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: cache_invalidated_at
-                  type: ${timestamp_type}
-                  remarks: 'An invalidation time that can supersede cache_config.invalidated_at'
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v50.2024-04-09T15:55:19
-      author: calherries
-      comment: Add collection.is_sample column
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: is_sample
-                  type: ${boolean.type}
-                  remarks: "Is the collection part of the sample content?"
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-
-  - changeSet:
-      id: v50.2024-04-15T16:30:35
-      author: qnkhuat
-      comment: Add report_card.last_used_at
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: last_used_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the card is last used
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v50.2024-04-19T17:04:04
-      author: noahmoss
-      comment: Clean up deprecated view-data and native-query-editing permissions (again)
-      rollback: # handled by the rollbacks for `v50.2024-02-26T22:15:54` and `v50.2024-02-26T22:15:55`
-      changes:
-        - sql:
-            sql: >
-              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
-
-  - changeSet:
-      id: v50.2024-04-25T01:04:05
-      author: qnkhuat
-      comment: Delete the old SendPulses job and trigger
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.DeleteSendPulsesTask"
-
-  - changeSet:
-      id: v50.2024-04-25T01:04:06
-      author: qnkhuat
-      comment: Delete SendPulse Job on downgrade
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.DeleteSendPulseTaskOnDowngrade"
-
-  - changeSet:
-      id: v50.2024-04-25T01:04:07
-      author: qnkhuat
-      comment: Delete InitSendPulseTriggers Job on downgrade
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.DeleteInitSendPulseTriggersOnDowngrade"
-
-  - changeSet:
-      id: v50.2024-04-25T03:15:01
-      author: noahmoss
-      comment: Add entity_id to core_user
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  remarks: NanoID tag for each user
-                  name: entity_id
-                  type: char(21)
-                  constraints:
-                    nullable: true
-                    unique: true
-            tableName: core_user
-
-  - changeSet:
-      id: v50.2024-04-25T03:15:02
-      author: noahmoss
-      comment: Add entity_id to permissions_group
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  remarks: NanoID tag for each user
-                  name: entity_id
-                  type: char(21)
-                  constraints:
-                    nullable: true
-                    unique: true
-            tableName: permissions_group
-
-  - changeSet:
-      id: v50.2024-04-25T16:29:31
-      author: calherries
-      comment: Add report_card.view_count
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: view_count
-                  type: integer
-                  defaultValueNumeric: 0
-                  remarks: Keeps a running count of card views
-                  constraints:
-                    nullable: false
-            tableName: report_card
-
-  - changeSet:
-      id: v50.2024-04-25T16:29:32
-      author: calherries
-      comment: Populate report_card.view_count
-      changes:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE report_card c
-              SET c.view_count = (
-                  SELECT COUNT(*)
-                  FROM view_log v
-                  WHERE v.model = 'card'
-                  AND v.model_id = c.id
-              );
-        - sql:
-            dbms: postgresql,h2
-            sql: >-
-              UPDATE report_card c
-              SET view_count = (
-                  SELECT count(*)
-                  FROM view_log v
-                  WHERE v.model = 'card'
-                  AND v.model_id = c.id
-              );
-      rollback: # nothing to do, since view_count didn't exist in v49
-
-  - changeSet:
-      id: v50.2024-04-25T16:29:33
-      author: calherries
-      comment: Add report_dashboard.view_count
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: view_count
-                  type: integer
-                  defaultValueNumeric: 0
-                  remarks: Keeps a running count of dashboard views
-                  constraints:
-                    nullable: false
-            tableName: report_dashboard
-
-  - changeSet:
-      id: v50.2024-04-25T16:29:34
-      author: calherries
-      comment: Populate report_dashboard.view_count
-      changes:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE report_dashboard c
-              SET c.view_count = (
-                  SELECT COUNT(*)
-                  FROM view_log v
-                  WHERE v.model = 'dashboard'
-                  AND v.model_id = c.id
-              );
-        - sql:
-            dbms: postgresql,h2
-            sql: >-
-              UPDATE report_dashboard c
-              SET view_count = (
-                  SELECT count(*)
-                  FROM view_log v
-                  WHERE v.model = 'dashboard'
-                  AND v.model_id = c.id
-              );
-      rollback: # nothing to do, since view_count didn't exist in v49
-
-  - changeSet:
-      id: v50.2024-04-25T16:29:35
-      author: calherries
-      comment: Add metabase_table.view_count
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: view_count
-                  type: integer
-                  defaultValueNumeric: 0
-                  remarks: Keeps a running count of card views
-                  constraints:
-                    nullable: false
-            tableName: metabase_table
-
-  - changeSet:
-      id: v50.2024-04-25T16:29:36
-      author: calherries
-      comment: Populate metabase_table.view_count
-      changes:
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE metabase_table t
-              SET t.view_count = (
-                  SELECT count(*)
-                  FROM view_log v
-                  WHERE v.model = 'table'
-                  AND v.model_id = t.id
-              );
-        - sql:
-            dbms: postgresql,h2
-            sql: >-
-              UPDATE metabase_table t
-              SET view_count = (
-                  SELECT count(*)
-                  FROM view_log v
-                  WHERE v.model = 'table'
-                  AND v.model_id = t.id
-              );
-      rollback: # nothing to do, since view_count didn't exist in v49
-
-  - changeSet:
-      id: v50.2024-04-26T09:19:00
-      author: adam-james
-      comment: Added 0.50.0 - Per-user Dashboard Parameter values table
-      changes:
-        - createTable:
-            tableName: user_parameter_value
-            remarks: Table holding last set value of a parameter per user
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'ID of the User who has set the parameter value'
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_user_parameter_value_user_id
-                    deleteCascade: true
-              - column:
-                  name: parameter_id
-                  type: varchar(36)
-                  remarks: "The parameter ID"
-                  constraints:
-                    nullable: false
-              - column:
-                  name: value
-                  type: ${text.type}
-                  remarks: Value of the parameter
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v50.2024-04-26T09:25:00
-      author: adam-james
-      comment: Index user_parameter_value.user_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: user_parameter_value
-            indexName: idx_user_parameter_value_user_id
-            columns:
-              column:
-                name: user_id
-
-  - changeSet:
-      id: v50.2024-04-30T23:57:23
-      author: noahmoss
-      comment: Add `scope` column to api_key to support SCIM authentication
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: scope
-                  type: varchar(64)
-                  remarks: The scope of the API key, if applicable
-                  constraints:
-                    nullable: true
-            tableName: api_key
-
-  - changeSet:
-      id: v50.2024-04-30T23:58:24
-      author: noahmoss
-      comment: Drop NOT NULL constraint on api_key.user_id to support SCIM-scoped API keys
-      changes:
-        - dropNotNullConstraint:
-            tableName: api_key
-            columnName: user_id
-            columnDataType: integer
-      rollback: # we can't reliably add back the constraint while downgrading
-
-  - changeSet:
-      id: v50.2024-05-08T09:00:00
-      author: qnkhuat
-      comment: Add task_history.status
-      changes:
-        - addColumn:
-            tableName: task_history
-            columns:
-              - column:
-                  name: status
-                  type: varchar(21)
-                  remarks: "the status of task history, could be started, failed, success, unknown"
-                  constraints:
-                    nullable: false
-                  defaultValue: "unknown"
-
-  - changeSet:
-      id: v50.2024-05-08T09:00:01
-      author: qnkhuat
-      comment: Drop default value task_history.status
-      changes:
-        - dropDefaultValue:
-            tableName: task_history
-            columnName: status
-      # the column will be dropped
-      rollback:
-
-  - changeSet:
-      id: v50.2024-05-08T09:00:02
-      author: qnkhuat
-      comment: Add "started" as default value for task_history.status, now that backfill is done.
-      changes:
-        - addDefaultValue:
-            defaultValue: "started"
-            tableName: task_history
-            columnName: status
-      # the column will be dropped
-      rollback:
-
-  - changeSet:
-      id: v50.2024-05-08T09:00:03
-      author: qnkhuat
-      comment: Drop not null constraint for task_history.ended_at
-      changes:
-        - dropNotNullConstraint:
-            tableName: task_history
-            columnDataType: ${timestamp_type}
-            columnName: ended_at
-      rollback: # we can't reliably add back the constraint while downgrading
-
-  - changeSet:
-      id: v50.2024-05-08T09:00:04
-      author: qnkhuat
-      comment: Drop not null constraint for task_history.duration
-      changes:
-        - dropNotNullConstraint:
-            tableName: task_history
-            columnDataType: int
-            columnName: duration
-      rollback: # we can't reliably add back the constraint while downgrading
-
-  - changeSet:
-      id: v50.2024-05-08T09:00:05
-      author: qnkhuat
-      comment: Drop default value task_history.ended_at
-      changes:
-        - dropDefaultValue:
-            tableName: task_history
-            columnName: ended_at
-      rollback:
-        - addDefaultValue:
-            tableName: task_history
-            columnName: ended_at
+          - dbms: {type: h2}
+          - sqlCheck:
+              expectedResult: 0
+              sql: |-
+                SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME = 'DATABASECHANGELOG' AND
+                      INDEX_NAME = 'IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME_INDEX_1';
+        - and:
+          - dbms: {type: 'mysql,mariadb'}
+          - not:
+            - indexExists: {tableName: '${databasechangelog.name}', indexName: idx_databasechangelog_id_author_filename}
+    changes:
+    - addUniqueConstraint: {constraintName: idx_databasechangelog_id_author_filename, tableName: '${databasechangelog.name}', columnNames: 'id, author, filename'}
+    rollback:
+    - dropUniqueConstraint: {tableName: '${databasechangelog.name}', constraintName: idx_databasechangelog_id_author_filename}
+- changeSet:
+    id: v49.00-000
+    author: qnkhuat
+    comment: Remove leagcy pulses
+    changes:
+    - {sql: DELETE FROM pulse where dashboard_id is null and alert_condition is null;}
+    rollback: null
+- changeSet:
+    id: v49.00-003
+    author: johnswanson
+    comment: Add a `type` to users
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: type
+            type: varchar(64)
+            constraints: {nullable: false}
+            defaultValue: personal
+            remarks: The type of user
+        tableName: core_user
+- changeSet:
+    id: v49.00-004
+    author: johnswanson
+    comment: Add a table for API keys
+    changes:
+    - createTable:
+        tableName: api_key
+        remarks: An API Key
+        columns:
+        - column:
+            remarks: The ID of the API Key itself
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The ID of the user who this API Key acts as
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_api_key_user_id}
+        - column:
+            remarks: The hashed API key
+            name: key
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            remarks: The first 7 characters of the unhashed key
+            name: key_prefix
+            type: varchar(7)
+            constraints: {nullable: false, unique: true}
+        - column:
+            remarks: The ID of the user that created this API key
+            name: created_by
+            type: integer
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_api_key_created_by_user_id}
+        - column:
+            remarks: The timestamp when the key was created
+            name: created_at
+            type: ${timestamp_type}
             defaultValueComputed: current_timestamp
-
-  - changeSet:
-      id: v50.2024-05-08T09:00:06
-      author: qnkhuat
-      comment: Add null as default value for task_history.ended_at
-      changes:
-        - addDefaultValue:
-            defaultValue: "null"
-            tableName: task_history
-            columnName: ended_at
-      # the migration above will add one
-      rollback:
-
-  - changeSet:
-      id: v50.2024-05-13T16:00:00
-      author: filipesilva
-      comment: Create cloud migration
-      changes:
-        - createTable:
-            tableName: cloud_migration
-            remarks: Migrate to cloud directly from Metabase
-            columns:
-              - column:
-                  name: id
-                  remarks: Unique ID
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: external_id
-                  remarks: Matching ID in Cloud for this migration
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: upload_url
-                  remarks: URL where the backup will be uploaded to
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: state
-                  remarks: 'Current state of the migration: init, setup, dump, upload, done, error, cancelled'
-                  type: varchar(32)
-                  defaultValue: init
-                  constraints:
-                    nullable: false
-              - column:
-                  name: progress
-                  remarks: Number between 0 to 100 representing progress as a percentage
-                  type: int
-                  defaultValue: 0
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  remarks: Timestamp when the config was inserted
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  remarks: Timestamp when the config was updated
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v50.2024-05-14T12:42:42
-      author: johnswanson
-      comment: Create the Trash collection
-      changes:
-        - sql:
-            sql: >-
-              INSERT INTO collection (name, slug, entity_id, type) VALUES ('Trash', 'trash', 'trashtrashtrashtrasht', 'trash');
-              INSERT INTO permissions (object, group_id)
-              SELECT CONCAT('/collection/', c.id, '/'), pg.id
-              FROM collection c
-              CROSS JOIN permissions_group pg
-              WHERE c.type = 'trash' AND pg.name != 'Administrators';
-
-      rollback:
-        - sql:
-            sql: >-
-              DELETE
-              FROM permissions
-              WHERE permissions.object IN (
-                SELECT CONCAT('/collection/', collection.id, '/') FROM collection WHERE collection.type = 'trash'
-              );
-              DELETE FROM collection WHERE type = 'trash';
-
-  - changeSet:
-      id: v50.2024-05-15T13:13:13
-      author: adam-james
-      comment: Fix visualization settings for stacked area/bar/combo displays
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateStackedAreaBarComboDisplaySettings"
-
-  - changeSet:
-      id: v50.2024-05-17T19:54:23
-      author: calherries
-      comment: Add metabase_database.uploads_enabled column
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: uploads_enabled
-                  type: ${boolean.type}
-                  defaultValueBoolean: false
-                  remarks: Whether uploads are enabled for this database
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v50.2024-05-17T19:54:24
-      author: calherries
-      comment: Add metabase_database.uploads_schema_name column
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: uploads_schema_name
-                  type: ${text.type}
-                  remarks: The schema name for uploads
-
-  - changeSet:
-      id: v50.2024-05-17T19:54:25
-      author: calherries
-      comment: Add metabase_database.uploads_table_prefix column
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: uploads_table_prefix
-                  type: ${text.type}
-                  remarks: The prefix for upload table names
-
-  - changeSet:
-      id: v50.2024-05-17T19:54:26
-      author: calherries
-      comment: Update metabase_database.uploads_enabled value
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateUploadsSettings"
-
-  # This migration has been moved.
-  - changeSet:
-      id: v50.2024-05-27T15:55:22
-      author: calherries
-      comment: Create sample content
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.CreateSampleContent"
-
-  - changeSet:
-      id: v50.2024-05-29T14:04:47
-      author: johnswanson
-      comment: Add `report_dashboard.archived_directly`
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: archived_directly
-                  type: ${boolean.type}
-                  defaultValueBoolean: false
-                  remarks: "Was this thing trashed directly"
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v50.2024-05-29T14:04:53
-      author: johnswanson
-      comment: Add `report_card.archived_directly`
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: archived_directly
-                  type: ${boolean.type}
-                  remarks: "Was this thing trashed directly"
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v50.2024-05-29T14:04:58
-      author: johnswanson
-      comment: Add `collection.archive_operation_id`
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: archive_operation_id
-                  type: char(36)
-                  remarks: "The UUID of the trash operation. Each time you trash a collection subtree, you get a unique ID."
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v50.2024-05-29T14:05:01
-      author: johnswanson
-      comment: Add `collection.archived_directly`
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: archived_directly
-                  type: ${boolean.type}
-                  remarks: "Whether the item was trashed independently or as a subcollection"
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v50.2024-05-29T14:05:03
-      author: johnswanson
-      comment: Populate `archived_directly` and `archive_operation_id` (Postgres)
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: trash/postgres.sql
-            relativeToChangelogFile: true
-      rollback: # not needed, columns will be deleted
-
-  - changeSet:
-      id: v50.2024-05-29T18:42:13
-      author: johnswanson
-      comment: Populate `archived_directly` and `archive_operation_id` (H2)
-      changes:
-        - sqlFile:
-            dbms: h2
-            path: trash/h2.sql
-            relativeToChangelogFile: true
-      rollback: # not needed, columns will be deleted
-
-  - changeSet:
-      id: v50.2024-05-29T18:42:14
-      author: johnswanson
-      comment: Populate `archived_directly` and `archive_operation_id` (MySQL)
-      validCheckSum: ANY
-      changes:
-        - sqlFile:
-            dbms: mysql
-            path: trash/mysql.sql
-            relativeToChangelogFile: true
-      rollback: # not needed, columns will be deleted
-
-  - changeSet:
-      id: v50.2024-05-29T18:42:15
-      author: johnswanson
-      comment: Populate `archived_directly` and `archive_operation_id` (MariaDB)
-      changes:
-        - sqlFile:
-            dbms: mariadb
-            path: trash/mariadb.sql
-            relativeToChangelogFile: true
-      rollback: # not needed, columns will be deleted
-
-  - changeSet:
-      id: v50.2024-05-30T16:04:20
-      author: escherize
-      comment: Add context to recent views table
-      changes:
-        - addColumn:
-            tableName: recent_views
-            columns:
-              - column:
-                  name: context
-                  remarks: The contextual action that netted a recent view.
-                  type: varchar(256)
-                  defaultValue: "view"
-                  constraints:
-                    nullable: false
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: recent_views
-              columnName: context
-
-  - changeSet:
-      id: v50.2024-06-12T12:33:07
-      author: piranha
-      comment: 'Decrypt some settings so the next migration runs well'
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.DecryptCacheSettings"
-      rollback: # no rollback necessary, they'll be encrypted if you downgrade and touch them
-
-  - changeSet:
-      # this had id `v50.2024-04-12T12:33:09` before #44048
-      id: v50.2024-06-12T12:33:08
-      author: piranha
-      comment: 'Copy old cache configurations to cache_config table'
-      validCheckSum: ANY
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: custom_sql/fill_cache_config.pg.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: custom_sql/fill_cache_config.my.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: custom_sql/fill_cache_config.h2.sql
-            relativeToChangelogFile: true
-      rollback: # no rollback necessary, we're not removing the columns yet
-
-  - changeSet:
-      id: v50.2024-06-12T12:33:09
-      author: piranha
-      comment: 'Fix root cache config for mysql if it is wrong'
-      dbms: mysql,mariadb
-      validCheckSum: ANY
-      changes:
-        - sqlFile:
-            path: custom_sql/fill_cache_config_root_fix.my.sql
-            relativeToChangelogFile: true
-      rollback: # no rollback necessary here too
-
-  - changeSet:
-      id: v50.2024-06-20T13:21:30
-      author: noahmoss
-      comment: 'Drop permission_id column on sandboxes table to fix down migrations'
-      changes:
-        - dropColumn:
-            tableName: sandboxes
-            columnName: permission_id
-      rollback:
-        - addColumn:
-            tableName: sandboxes
-            columns:
-              - column:
-                  name: permission_id
-                  type: int
-                  remarks: 'The ID of the corresponding permissions path for this sandbox (deprecated)'
-                  constraints:
-                    nullable: true
-                  defaultValue: null
-
-  - changeSet:
-      id: v50.2024-06-28T12:35:50
-      author: piranha
-      comment: 'Clean databasechangelog table of migration that was once deleted'
-      changes:
-        - sql: "DELETE FROM ${databasechangelog.name} WHERE id = 'v50.2024-04-12T12:33:09'"
-      rollback: # nothing to do here
-
-  - changeSet:
-      id: v50.2024-07-02T16:48:21
-      author: adam-james
-      comment: Remove existing user_parameter_value entries as we want to add dashboard_id, and can't easily backfill
-      rollback: # none, entries already removed and are non-critical to app functionality
-      changes:
-        - delete:
-           tableName: user_parameter_value
-
-  - changeSet:
-      id: v50.2024-07-02T16:49:29
-      author: adam-james
-      comment: Add dashboard_id column to user_parameter_value to keep values unique per dashboard
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: The ID of the dashboard
-            tableName: user_parameter_value
-
-  - changeSet:
-      id: v50.2024-07-02T16:55:42
-      author: adam-james
-      comment: Add fk constraint to user_parameter_value.dashboard_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: user_parameter_value
-            baseColumnNames: dashboard_id
-            referencedTableName: report_dashboard
-            referencedColumnNames: id
-            constraintName: fk_user_parameter_value_dashboard_id
-            nullable: false
-            deleteCascade: true
-
-  - changeSet:
-      id: v50.2024-07-02T17:07:15
-      author: adam-james
-      comment: Index user_parameter_value.dashboard_id
-      rollback: # not necessary, will be removed with the table
-      changes:
-        - createIndex:
-            tableName: user_parameter_value
-            indexName: idx_user_parameter_value_dashboard_id
-            columns:
-              column:
-                name: dashboard_id
-
-  # After this migration, last_used_at becomes the lowest timestamp after which we know that
-  # the card has not been used. last_used_at will be used to determine if a report
-  # card is stale and should be cleaned up if the card is imported with serialization.
-  # Because we weren't collecting last_used_at before, we have to populate all existing cards
-  # with the current timestamp to provide a "lower bound" after which the card has not been used.
-  - changeSet:
-      id: v50.2024-07-09T20:04:00
-      author: calherries
-      comment: Populate default value for report_card.last_used_at
-      changes:
-        - sql:
-            sql: UPDATE report_card SET last_used_at = current_timestamp
-      rollback: # nothing to do, since this is backwards compatible
-
-  - changeSet:
-      id: v50.2024-07-09T20:04:02
-      author: calherries
-      comment: Add not null constraint for report_card.last_used_at
-      preConditions:
-      changes:
-        - addNotNullConstraint:
-            tableName: report_card
-            columnName: last_used_at
-            columnDataType: ${timestamp_type}
-
-  # addDefaultValue with defaultValueComputed doesn't work for MySQL/MariaDB so we have to do this the hard way.
-  - changeSet:
-      id: v50.2024-07-09T20:04:03
-      author: calherries
-      comment: Set default for report_card.last_used_at
-      preConditions:
-      changes:
-        - sql:
-            dbms: postgresql,h2
-            sql: ALTER TABLE report_card ALTER COLUMN last_used_at SET DEFAULT CURRENT_TIMESTAMP;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              ALTER TABLE report_card
-              CHANGE last_used_at
-              last_used_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
-      rollback: # nothing to do, since this is backwards compatible
-
-  - changeSet:
-      id: v50.2024-08-08T20:04:03
-      author: qnkhuat
-      comment: Added 0.50.0 - Add index on user_parameter_value(user_id, parameter_id, dashboard_id)
-      changes:
-        - createIndex:
-            tableName: user_parameter_value
-            indexName: idx_user_parameter_value_user_id_dashboard_id_parameter_id
-            columns:
-              - column:
-                  name: user_id
-              - column:
-                  name: dashboard_id
-              - column:
-                  name: parameter_id
-
-  - changeSet:
-      id: v50.2024-08-27T00:00:00
-      author: devurandom
-      comment: Add is_attached_dwh to metabase_database
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_database
-                columnName: is_attached_dwh
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: is_attached_dwh
-                  type: ${boolean.type}
-                  defaultValueBoolean: false
-                  remarks: 'This is an attached data warehouse, do not serialize it and hide its details from the UI'
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-05-13T15:30:57
-      author: metamben
-      comment: Backup of dataset_query rewritten by the metrics v2 migration
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: dataset_query_metrics_v2_migration_backup
-                  remarks: The copy of dataset_query before the metrics v2 migration
-                  type: ${text.type}
-      preConditions:
-
-  - changeSet:
-      id: v51.2024-05-13T16:00:00
-      author: metamben
-      comment: Migrate v1 metrics to v2 metrics
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateMetricsToV2"
-
-  - changeSet:
-      id: v51.2024-06-07T12:37:36
-      author: crisptrutski
-      comment: Rename query_field.direct_reference to query_field.indirect_reference
-      changes:
-        - renameColumn:
-            tableName: query_field
-            columnDataType: ${boolean.type}
-            oldColumnName: direct_reference
-            newColumnName: explicit_reference
-
-  - changeSet:
-      id: v51.2024-06-12T18:53:02
-      author: noahmoss
-      comment: Drop incorrect index on login_history
-      changes:
-        - dropIndex:
-            tableName: login_history
-            indexName: idx_user_id_device_id
-      rollback:
-        - createIndex:
-            tableName: login_history
-            indexName: idx_user_id_device_id
-            columns:
-              - column:
-                  name: session_id
-              - column:
-                  name: device_id
-      preConditions:
-
-  - changeSet:
-      id: v51.2024-06-12T18:53:03
-      author: noahmoss
-      comment: Create index on login_history (user_id, device_id)
-      changes:
-        - createIndex:
-            tableName: login_history
-            indexName: idx_user_id_device_id
-            columns:
-              - column:
-                  name: user_id
-              - column:
-                  name: device_id
-      rollback:
-        - dropIndex:
-            tableName: login_history
-            indexName: idx_user_id_device_id
-      preConditions:
-
-  - changeSet:
-      id: v51.2024-07-08T10:00:00
-      author: qnkhuat
-      comment: Create channel table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: channel
-      changes:
-        - createTable:
-            tableName: channel
-            remarks: Channel configurations
-            columns:
-              - column:
-                  name: id
-                  remarks: Unique ID
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: name
-                  remarks: channel name
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: description
-                  remarks: channel description
-                  type: ${text.type}
-                  constraints:
-                    nullable: true
-              - column:
-                  name: type
-                  remarks: Channel type
-                  type: varchar(32)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: details
-                  remarks: Channel details, used to store authentication information or channel-specific settings
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: active
-                  type: ${boolean.type}
-                  defaultValueBoolean: true
-                  remarks: whether the channel is active
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  remarks: Timestamp when the channel was inserted
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  remarks: Timestamp when the channel was updated
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-07-08T10:00:01
-      author: qnkhuat
-      comment: Create pulse_channel.channel_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: pulse_channel
-                columnName: channel_id
-      changes:
-        - addColumn:
-            tableName: pulse_channel
-            columns:
-              - column:
-                  name: channel_id
-                  type: integer
-                  remarks: The channel ID
-
-  - changeSet:
-      id: v51.2024-07-08T10:00:02
-      author: qnkhuat
-      comment: Add fk constraint to pulse_channel.channel_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_pulse_channel_channel_id
-                foreignKeyTableName: pulse_channel
-
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: pulse_channel
-            baseColumnNames: channel_id
-            referencedTableName: channel
-            referencedColumnNames: id
-            constraintName: fk_pulse_channel_channel_id
-            nullable: true
-            deleteCascade: true
-
-  - changeSet:
-      id: v51.2024-07-09T17:15:43
-      author: tsmacdonald
-      comment: Fix default boolean value for query_field.explicit_reference
-      dbms: mysql,mariadb
-      changes:
-        - addDefaultValue:
-            tableName: query_field
-            columnName: explicit_reference
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp when the key was last updated
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v49.00-005
+    author: johnswanson
+    comment: Add an index on `api_key.created_by`
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: api_key
+        indexName: idx_api_key_created_by
+        columns:
+          column: {name: created_by}
+- changeSet:
+    id: v49.00-006
+    author: johnswanson
+    comment: Add an index on `api_key.user_id`
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: api_key
+        indexName: idx_api_key_user_id
+        columns:
+          column: {name: user_id}
+- changeSet:
+    id: v49.00-007
+    author: johnswanson
+    comment: Set the `type` of the internal user
+    changes:
+    - sql: {sql: UPDATE core_user SET type='internal' WHERE id=13371338;}
+    rollback: null
+- changeSet:
+    id: v49.00-008
+    author: qnkhuat
+    comment: Add metabase_field.database_indexed
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: database_indexed
+            type: boolean
+            constraints: {nullable: true}
+            remarks: If the database supports indexing, this column indicate whether or not a field is indexed, or is the 1st column in a composite index
+- changeSet:
+    id: v49.00-009
+    author: adam-james
+    comment: Migrate pulse_card.include_csv to 'true' when the joined card.display is 'table'
+    changes:
+    - sql: {dbms: 'mariadb,mysql', sql: UPDATE pulse_card AS pc JOIN report_card AS rc ON rc.id = pc.card_id SET pc.include_csv = TRUE WHERE rc.display = 'table';}
+    - sql:
+        dbms: postgresql,h2
+        sql: |-
+          UPDATE pulse_card pc SET include_csv = TRUE WHERE pc.card_id IN (
+              SELECT rc.id
+              FROM report_card rc
+              WHERE rc.display = 'table'
+              AND rc.id = pc.card_id
+          );
+    rollback: null
+- changeSet:
+    id: v49.00-010
+    author: johnswanson
+    comment: Add a name to API Keys
+    changes:
+    - addColumn:
+        tableName: api_key
+        columns:
+        - column:
+            name: name
+            type: varchar(254)
+            constraints: {nullable: false, unique: true}
+            remarks: The user-defined name of the API key.
+- changeSet:
+    id: v49.00-011
+    author: qnkhuat
+    comment: Add metabase_table.database_require_filter
+    changes:
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column:
+            name: database_require_filter
+            type: boolean
+            constraints: {nullable: true}
+            remarks: If true, the table requires a filter to be able to query it
+- changeSet:
+    id: v49.00-012
+    author: qnkhuat
+    comment: Add metabase_field.database_partitioned
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: database_partitioned
+            type: boolean
+            constraints: {nullable: true}
+            remarks: Whether the table is partitioned by this field
+- changeSet:
+    id: v49.00-013
+    author: johnswanson
+    comment: Add `api_key.updated_by_id`
+    rollback: null
+    changes:
+    - addColumn:
+        tableName: api_key
+        columns:
+        - column:
+            remarks: The ID of the user that last updated this API key
+            name: updated_by_id
+            type: integer
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_api_key_updated_by_id_user_id}
+- changeSet:
+    id: v49.00-014
+    author: johnswanson
+    comment: Add an index on `api_key.updated_by_id`
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: api_key
+        indexName: idx_api_key_updated_by_id
+        columns:
+          column: {name: updated_by_id}
+- changeSet:
+    id: v49.00-015
+    author: johnswanson
+    comment: Rename `created_by` to `creator_id`
+    rollback: null
+    changes:
+    - renameColumn: {tableName: api_key, columnDataType: integer, oldColumnName: created_by, newColumnName: creator_id}
+- changeSet:
+    id: v49.00-016
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of action.archived from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: action, columnName: archived, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: action, columnName: archived, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-017
+    author: noahmoss
+    comment: Add NOT NULL constraint to action.archived
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: action, columnName: archived, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-018
+    author: noahmoss
+    comment: Add default value to action.archived
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: action, columnName: archived}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-019
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of metabase_field.json_unfolding from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: json_unfolding, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_field, columnName: json_unfolding, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-020
+    author: noahmoss
+    comment: Add NOT NULL constraint to metabase_field.json_unfolding
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: metabase_field, columnName: json_unfolding, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-021
+    author: noahmoss
+    comment: Add default value to metabase_field.json_unfolding
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: metabase_field, columnName: json_unfolding}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-022
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of metabase_field.database_is_auto_increment from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: database_is_auto_increment, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_field, columnName: database_is_auto_increment, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-023
+    author: noahmoss
+    comment: Add NOT NULL constraint to metabase_field.database_is_auto_increment
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: metabase_field, columnName: database_is_auto_increment, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-024
+    author: noahmoss
+    comment: Add default value to metabase_field.database_is_auto_increment
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: metabase_field, columnName: database_is_auto_increment}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-025
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of report_dashboard.auto_apply_filters from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_dashboard, columnName: auto_apply_filters, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: report_dashboard, columnName: auto_apply_filters, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-026
+    author: noahmoss
+    comment: Add NOT NULL constraint to report_dashboard.auto_apply_filters
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: report_dashboard, columnName: auto_apply_filters, defaultNullValue: true}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-027
+    author: noahmoss
+    comment: Add default value to report_dashboard.auto_apply_filters
+    changes:
+    - addDefaultValue: {defaultValueBoolean: true, tableName: report_dashboard, columnName: auto_apply_filters}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-028
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of metabase_database.is_audit from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_database, columnName: is_audit, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_database, columnName: is_audit, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-029
+    author: noahmoss
+    comment: Add NOT NULL constraint to metabase_database.is_audit
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: metabase_database, columnName: is_audit, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-030
+    author: noahmoss
+    comment: Add default value to metabase_database.is_audit
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: metabase_database, columnName: is_audit}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-031
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of metabase_table.is_upload from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: is_upload, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_table, columnName: is_upload, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-032
+    author: noahmoss
+    comment: Add NOT NULL constraint to metabase_table.is_upload
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: metabase_table, columnName: is_upload, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-033
+    author: noahmoss
+    comment: Add default value to metabase_table.is_upload
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: metabase_table, columnName: is_upload}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-034
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of revision.most_recent from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: revision, columnName: most_recent, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: revision, columnName: most_recent, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-035
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of revision.most_recent from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: revision, columnName: most_recent, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: revision, columnName: most_recent, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-036
+    author: noahmoss
+    comment: Add NOT NULL constraint to revision.most_recent
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: revision, columnName: most_recent, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-037
+    author: noahmoss
+    comment: Add default value to revision.most_recent
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: revision, columnName: most_recent}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-038
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of table_privileges.select from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: table_privileges, columnName: select, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: table_privileges, columnName: select, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-039
+    author: noahmoss
+    comment: Add NOT NULL constraint to table_privileges.select
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: table_privileges, columnName: select, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-040
+    author: noahmoss
+    comment: Add default value to table_privileges.select
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: table_privileges, columnName: select}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-041
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of table_privileges.update from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: table_privileges, columnName: update, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: table_privileges, columnName: update, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-042
+    author: noahmoss
+    comment: Add NOT NULL constraint to table_privileges.update
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: table_privileges, columnName: update, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-043
+    author: noahmoss
+    comment: Add default value to table_privileges.update
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: table_privileges, columnName: update}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-044
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of table_privileges.insert from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: table_privileges, columnName: insert, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: table_privileges, columnName: insert, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-045
+    author: noahmoss
+    comment: Add NOT NULL constraint to table_privileges.insert
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: table_privileges, columnName: insert, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-046
+    author: noahmoss
+    comment: Add default value to table_privileges.insert
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: table_privileges, columnName: insert}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-047
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of table_privileges.delete from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: table_privileges, columnName: delete, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: table_privileges, columnName: delete, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-048
+    author: noahmoss
+    comment: Add NOT NULL constraint to table_privileges.delete
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: table_privileges, columnName: delete, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-049
+    author: noahmoss
+    comment: Add default value to table_privileges.delete
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: table_privileges, columnName: delete}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-050
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of query_execution.is_sandboxed from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: query_execution, columnName: is_sandboxed, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: query_execution, columnName: is_sandboxed, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-051
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of view_log.has_access from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: view_log, columnName: has_access, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: view_log, columnName: has_access, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-052
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of metabase_field.database_indexed from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: database_indexed, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_field, columnName: database_indexed, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-053
+    author: noahmoss
+    comment: Added 0.49.0 - modify type of metabase_table.database_require_filter from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_table, columnName: database_require_filter, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_table, columnName: database_require_filter, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.00-059
+    author: qnkhuat
+    comment: Added 0.49.0 - unify type of time columns
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.UnifyTimeColumnsType}
+- changeSet:
+    id: v49.00-060
+    author: qnkhuat
+    comment: Added 0.49.0 - modify type of metabase_field.database_partitioned from boolean to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: database_partitioned, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_field, columnName: database_partitioned, newDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2023-01-24T12:00:00
+    author: piranha
+    comment: 'This significantly speeds up api.database/autocomplete-fields query and is an improvement for issue 30588. H2 does not support this: https://github.com/h2database/h2database/issues/3535 Mariadb does not support this. Mysql says it does, but reports an error during migration.'
+    dbms: postgresql
+    changes:
+    - createIndex:
+        tableName: metabase_field
+        indexName: idx_field_name_lower
+        columns:
+        - column: {name: lower(name), computed: true}
+    rollback:
+    - dropIndex: {tableName: metabase_field, indexName: idx_field_name_lower}
+- changeSet:
+    id: v49.2024-01-22T11:50:00
+    author: qnkhuat
+    comment: Add `report_card.type`
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            remarks: The type of card, could be 'question', 'model', 'metric'
+            name: type
+            type: varchar(16)
+            defaultValue: question
+            constraints: {nullable: false}
+- changeSet:
+    id: v49.2024-01-22T11:51:00
+    author: qnkhuat
+    comment: Backfill `report_card.type`
+    changes:
+    - sql: {sql: UPDATE report_card SET type = 'model' WHERE dataset is true}
+    rollback: null
+- changeSet:
+    id: v49.2024-01-22T11:52:00
+    author: qnkhuat
+    comment: Backfill `report_card.type`
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.CardRevisionAddType}
+- changeSet:
+    id: v49.2024-01-29T19:26:40
+    author: adam-james
+    comment: Add width setting to Dashboards
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column: {name: width, type: varchar(16), defaultValue: fixed, remarks: The value of the dashboard's width setting can be fixed or full. New dashboards will be set to fixed}
+- changeSet:
+    id: v49.2024-01-29T19:30:00
+    author: adam-james
+    comment: Update existing report_dashboard width values to full
+    changes:
+    - update:
+        tableName: report_dashboard
+        columns:
+        - column: {name: width, value: full}
+    rollback: []
+- changeSet:
+    id: v49.2024-01-29T19:56:40
+    author: adam-james
+    comment: Dashboard width setting must have a value
+    changes:
+    - addNotNullConstraint: {tableName: report_dashboard, columnName: width, columnDatatype: varchar(16), defaultNullvalue: full, remarks: If for some reason an existing dashboard has null width value it is set to full}
+- changeSet:
+    id: v49.2024-01-29T19:59:12
+    author: adam-james
+    comment: Add default value to report_dashboard.width for mysql and mariadb
+    changes:
+    - addDefaultValue: {defaultValue: fixed, tableName: report_dashboard, columnName: width}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-02-02T11:27:49
+    author: oisincoveney
+    comment: Add report_card.initially_published_at
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: initially_published_at
+            type: ${timestamp_type}
+            constraints: {nullable: true}
+            remarks: The timestamp when the card was first published in a static embed
+- changeSet:
+    id: v49.2024-02-02T11:28:36
+    author: oisincoveney
+    comment: Add report_dashboard.initially_published_at
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: initially_published_at
+            type: ${timestamp_type}
+            constraints: {nullable: true}
+            remarks: The timestamp when the dashboard was first published in a static embed
+- changeSet:
+    id: v49.2024-02-07T21:52:01
+    author: noahmoss
+    comment: Added 0.49.0 - updated view v_view_log
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/view_log/v2/postgres-view_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/view_log/v2/mysql-view_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/view_log/v2/h2-view_log.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/view_log/v1/postgres-view_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/view_log/v1/mysql-view_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/view_log/v1/h2-view_log.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v49.2024-02-07T21:52:02
+    author: noahmoss
+    comment: Added 0.49.0 - updated view v_audit_log
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/audit_log/v2/postgres-audit_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/audit_log/v2/mysql-audit_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/audit_log/v2/h2-audit_log.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/audit_log/v1/postgres-audit_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/audit_log/v1/mysql-audit_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/audit_log/v1/h2-audit_log.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v49.2024-02-07T21:52:03
+    author: noahmoss
+    comment: Added 0.49.0 - updated view v_group_members
+    changes:
+    - sqlFile: {path: instance_analytics_views/group_members/v2/group_members.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/group_members/v1/group_members.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v49.2024-02-07T21:52:04
+    author: noahmoss
+    comment: Added 0.49.0 - updated view v_query_log
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/query_log/v2/postgres-query_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/query_log/v2/mysql-query_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/query_log/v2/h2-query_log.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/query_log/v1/postgres-query_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/query_log/v1/mysql-query_log.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/query_log/v1/h2-query_log.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v49.2024-02-07T21:52:05
+    author: noahmoss
+    comment: Added 0.49.0 - updated view v_users
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/users/v2/postgres-users.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/users/v2/mysql-users.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/users/v2/h2-users.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/users/v1/postgres-users.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/users/v1/mysql-users.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/users/v1/h2-users.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v49.2024-02-09T13:55:26
+    author: noahmoss
+    comment: Set default value for enable-public-sharing to `false` for existing instances with users, if not already set
+    preConditions:
+    - {onFail: MARK_RAN}
+    - and:
+      - or:
+        - and:
+          - dbms: {type: postgresql}
+          - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE key = 'enable-public-sharing';}
+        - and:
+          - dbms: {type: h2}
+          - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-public-sharing';}
+        - and:
+          - dbms: {type: 'mysql,mariadb'}
+          - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE `key` = 'enable-public-sharing';}
+      - sqlCheck:
+          expectedResult: 1
+          sql: |
+            SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM core_user;
+    changes:
+    - sql: {dbms: postgresql, sql: 'INSERT INTO setting (key, value) VALUES (''enable-public-sharing'', ''false'');'}
+    - sql: {dbms: 'mysql,mariadb', sql: 'INSERT INTO setting (`key`, value) VALUES (''enable-public-sharing'', ''false'');'}
+    - sql: {dbms: h2, sql: 'INSERT INTO setting ("KEY", "VALUE") VALUES (''enable-public-sharing'', ''false'');'}
+    rollback: null
+- changeSet:
+    id: v49.2024-03-26T10:23:12
+    author: adam-james
+    comment: Add pulse_card.format_rows
+    changes:
+    - addColumn:
+        tableName: pulse_card
+        columns:
+        - column: {name: format_rows, type: '${boolean.type}', defaultValue: true, remarks: Whether or not to apply formatting to the rows of the export}
+- changeSet:
+    id: v49.2024-04-09T10:00:00
+    author: qnkhuat
+    comment: Drop not null constraint on metabase_database.cache_field_values_schedule
+    changes:
+    - dropNotNullConstraint: {tableName: metabase_database, columnName: cache_field_values_schedule, columnDataType: varchar(254)}
+    rollback: null
+- changeSet:
+    id: v49.2024-04-09T10:00:01
+    author: qnkhuat
+    comment: Drop default value on metabase_database.cache_field_values_schedule
+    changes:
+    - dropDefaultValue: {tableName: metabase_database, columnName: cache_field_values_schedule}
+    rollback: null
+- changeSet:
+    id: v49.2024-04-09T10:00:02
+    author: qnkhuat
+    comment: Add null as default value for metabase_database.cache_field_values_schedule
+    changes:
+    - addDefaultValue: {defaultValue: 'null', tableName: metabase_database, columnName: cache_field_values_schedule}
+    rollback: null
+- changeSet:
+    id: v49.2024-04-09T10:00:03
+    author: qnkhuat
+    comment: This clears the schedule for caching field values for databases with period scanning disabled.
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.DeleteScanFieldValuesTriggerForDBThatTurnItOff}
+- changeSet:
+    id: v49.2024-05-07T10:00:00
+    author: qnkhuat
+    comment: Set revision.most_recent = true to latest revision and false to others. A redo of v48.00-008 for mysql
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+    changes:
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE revision AS r JOIN (
+              SELECT inner_revision.id,
+                    ROW_NUMBER() OVER (PARTITION BY inner_revision.model, inner_revision.model_id ORDER BY inner_revision.timestamp DESC, inner_revision.id DESC) AS row_num
+                FROM revision AS inner_revision
+                JOIN (
+                      SELECT model, model_id
+                      FROM revision
+                      WHERE most_recent = true
+                      GROUP BY model, model_id
+                      HAVING count(*) > 1
+                    ) AS infected_revision ON inner_revision.model = infected_revision.model AND inner_revision.model_id = infected_revision.model_id
+          ) AS n ON r.id = n.id SET r.most_recent = (n.row_num = 1);
+    rollback: null
+- changeSet:
+    id: v49.2024-05-20T19:10:34
+    author: johnswanson
+    comment: Modify type of report_card.collection_preview to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: collection_preview, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: report_card, columnName: collection_preview, newDataType: boolean, defaultValueBoolean: true}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-05-20T20:37:55
+    author: johnswanson
+    comment: Add NOT NULL constraint to report_card.collection_preview
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: report_card, columnName: collection_preview, defaultNullValue: true}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-05-20T20:38:34
+    author: johnswanson
+    comment: Add default value to report_card.collection_preview
+    changes:
+    - addDefaultValue: {defaultValueBoolean: true, tableName: report_card, columnName: collection_preview}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-05-29T09:26:20
+    author: johnswanson
+    comment: Modify type of report_card.dataset to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: dataset, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: report_card, columnName: dataset, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-05-29T09:27:15
+    author: johnswanson
+    dbms: mysql,mariadb
+    comment: Add NOT NULL constraint to report_card.dataset
+    changes:
+    - addNotNullConstraint: {columnDataType: '${boolean.type}', tableName: report_card, columnName: dataset, defaultNullValue: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-05-29T09:28:25
+    author: johnswanson
+    dbms: mysql,mariadb
+    comment: Add default value to report_card.dataset
+    changes:
+    - addDefaultValue: {defaultValueBoolean: false, tableName: report_card, columnName: dataset}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:01:01
+    author: johnswanson
+    comment: Modify type of core_user.is_datasetnewb to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: core_user, columnName: is_datasetnewb, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: core_user, columnName: is_datasetnewb, newDataType: boolean, defaultValueBoolean: true}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:01:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to core_user.is_datasetnewb on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: core_user, columnName: is_datasetnewb, columnDataType: '${boolean.type}', defaultNullValue: true}
+    rollback:
+    - dropNotNullConstraint: {tableName: core_user, columnName: is_datasetnewb, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:01:03
+    author: johnswanson
+    comment: Add default value to core_user.is_datasetnewb on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: core_user, columnName: is_datasetnewb, defaultValueBoolean: true}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:02:01
+    author: johnswanson
+    comment: Modify type of metabase_field.database_required to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_field, columnName: database_required, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_field, columnName: database_required, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:02:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to metabase_field.database_required on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: metabase_field, columnName: database_required, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: metabase_field, columnName: database_required, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:02:03
+    author: johnswanson
+    comment: Add default value to metabase_field.database_required on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: metabase_field, columnName: database_required, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:03:01
+    author: johnswanson
+    comment: Modify type of metabase_fieldvalues.has_more_values to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: metabase_fieldvalues, columnName: has_more_values, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: metabase_fieldvalues, columnName: has_more_values, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:03:03
+    author: johnswanson
+    comment: Add default value to metabase_fieldvalues.has_more_values on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: metabase_fieldvalues, columnName: has_more_values, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:04:01
+    author: johnswanson
+    comment: Modify type of permissions_group_membership.is_group_manager to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: permissions_group_membership, columnName: is_group_manager, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: permissions_group_membership, columnName: is_group_manager, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:04:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to permissions_group_membership.is_group_manager on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: permissions_group_membership, columnName: is_group_manager, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: permissions_group_membership, columnName: is_group_manager, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:04:03
+    author: johnswanson
+    comment: Add default value to permissions_group_membership.is_group_manager on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: permissions_group_membership, columnName: is_group_manager, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:05:01
+    author: johnswanson
+    comment: Modify type of persisted_info.active to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: persisted_info, columnName: active, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: persisted_info, columnName: active, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:05:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to persisted_info.active on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: persisted_info, columnName: active, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: persisted_info, columnName: active, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:05:03
+    author: johnswanson
+    comment: Add default value to persisted_info.active on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: persisted_info, columnName: active, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:06:01
+    author: johnswanson
+    comment: Modify type of report_card.dataset to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: report_card, columnName: dataset, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: report_card, columnName: dataset, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:06:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to report_card.dataset on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: report_card, columnName: dataset, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: report_card, columnName: dataset, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:06:03
+    author: johnswanson
+    comment: Add default value to report_card.dataset on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: report_card, columnName: dataset, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:07:01
+    author: johnswanson
+    comment: Modify type of timeline.archived to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: timeline, columnName: archived, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: timeline, columnName: archived, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:07:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to timeline.archived on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: timeline, columnName: archived, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: timeline, columnName: archived, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:07:03
+    author: johnswanson
+    comment: Add default value to timeline.archived on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: timeline, columnName: archived, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:08:01
+    author: johnswanson
+    comment: Modify type of timeline.default to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: timeline, columnName: default, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: timeline, columnName: default, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:08:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to timeline.default on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: timeline, columnName: default, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: timeline, columnName: default, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:08:03
+    author: johnswanson
+    comment: Add default value to timeline.default on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: timeline, columnName: default, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:09:01
+    author: johnswanson
+    comment: Modify type of timeline_event.archived to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: timeline_event, columnName: archived, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: timeline_event, columnName: archived, newDataType: boolean, defaultValueBoolean: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:09:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to timeline_event.archived on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: timeline_event, columnName: archived, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: timeline_event, columnName: archived, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:09:03
+    author: johnswanson
+    comment: Add default value to timeline_event.archived on mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: timeline_event, columnName: archived, defaultValueBoolean: false}
+    dbms: mysql,mariadb
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:10:01
+    author: johnswanson
+    comment: Modify type of timeline_event.time_matters to ${boolean.type} on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - modifyDataType: {tableName: timeline_event, columnName: time_matters, newDataType: '${boolean.type}'}
+    rollback:
+    - modifyDataType: {tableName: timeline_event, columnName: time_matters, newDataType: boolean, defaultValueBoolean: null}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-05T09:10:02
+    author: johnswanson
+    comment: Add NOT NULL constraint to timeline_event.time_matters on mysql,mariadb
+    dbms: mysql,mariadb
+    changes:
+    - addNotNullConstraint: {tableName: timeline_event, columnName: time_matters, columnDataType: '${boolean.type}', defaultNullValue: false}
+    rollback:
+    - dropNotNullConstraint: {tableName: timeline_event, columnName: time_matters, columnDataType: boolean}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - dbms: {type: 'mysql,mariadb'}
+- changeSet:
+    id: v49.2024-06-27T00:00:00
+    author: calherries
+    comment: Make metabase_field.name use case-sensitive collation for MySQL
+    changes:
+    - sql: {dbms: 'mysql,mariadb', sql: ALTER TABLE metabase_field MODIFY name VARCHAR(254) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;}
+    rollback:
+    - sql: {dbms: 'mysql,mariadb', sql: ALTER TABLE metabase_field MODIFY name VARCHAR(254) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;}
+- changeSet:
+    id: v49.2024-06-27T00:00:01
+    author: calherries
+    comment: Add metabase_field.is_defective_duplicate
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            name: is_defective_duplicate
+            type: ${boolean.type}
+            remarks: Indicates whether column is a defective duplicate field that should never have been created.
+            constraints: {nullable: false}
+            defaultValue: false
+- changeSet:
+    id: v49.2024-06-27T00:00:02
+    author: calherries
+    comment: Populate metabase_field.is_defective_duplicate
+    changes:
+    - sql:
+        sql: |-
+          UPDATE metabase_field mf SET is_defective_duplicate = TRUE WHERE mf.id IN (
+              SELECT id
+              FROM (
+                  SELECT
+                      mf.id,
+                      ROW_NUMBER() OVER (
+                          PARTITION BY mf.table_id, mf.name, mf.parent_id
+                          ORDER BY
+                              CASE WHEN mf.active THEN 0 ELSE 1 END,
+                              CASE WHEN mf.nfc_path IS NULL THEN 0 ELSE 1 END,
+                              mf.created_at
+                      ) AS rn
+                  FROM metabase_field mf
+              ) x
+              WHERE x.rn > 1
+          );
+    rollback: null
+- changeSet:
+    id: v49.2024-06-27T00:00:03
+    author: calherries
+    comment: Drop fk_field_parent_ref_field_id constraint with ON DELETE CASCADE
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: metabase_field, constraintName: fk_field_parent_ref_field_id}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: metabase_field, baseColumnNames: parent_id, referencedTableName: metabase_field, referencedColumnNames: id, constraintName: fk_field_parent_ref_field_id, onDelete: CASCADE}
+- changeSet:
+    id: v49.2024-06-27T00:00:04
+    author: calherries
+    comment: Add fk_field_parent_ref_field_id constraint with ON DELETE RESTRICT
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metabase_field, baseColumnNames: parent_id, referencedTableName: metabase_field, referencedColumnNames: id, constraintName: fk_field_parent_ref_field_id, onDelete: RESTRICT}
+    rollback:
+    - dropForeignKeyConstraint: {baseTableName: metabase_field, constraintName: fk_field_parent_ref_field_id}
+- changeSet:
+    id: v49.2024-06-27T00:00:05
+    author: calherries
+    comment: Remove idx_uniq_field_table_id_parent_id_name because it is redundant with idx_unique_field
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: 'h2,postgresql'}
+        - uniqueConstraintExists: {tableName: metabase_field, constraintName: idx_uniq_field_table_id_parent_id_name}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck:
+            expectedResult: 1
+            sql: |-
+              SELECT EXISTS (
+                SELECT *
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'metabase_field'
+                  AND index_name = 'idx_uniq_field_table_id_parent_id_name'
+              )
+    changes:
+    - dropUniqueConstraint: {tableName: metabase_field, constraintName: idx_uniq_field_table_id_parent_id_name}
+    rollback:
+    - addUniqueConstraint: {tableName: metabase_field, columnNames: 'table_id, parent_id, name', constraintName: idx_uniq_field_table_id_parent_id_name}
+- changeSet:
+    id: v49.2024-06-27T00:00:06
+    author: calherries
+    comment: Remove the idx_uniq_field_table_id_parent_id_name_2col unique index because it blocks load-from-h2
+    changes:
+    - sql: {dbms: postgresql, sql: DROP INDEX IF EXISTS idx_uniq_field_table_id_parent_id_name_2col;}
+    rollback: null
+- changeSet:
+    id: v49.2024-06-27T00:00:07
+    author: calherries
+    comment: Add unique_field_helper column to metabase_field
+    changes:
+    - sql:
+        dbms: postgresql
+        sql: |-
+          ALTER TABLE metabase_field ADD COLUMN unique_field_helper INTEGER GENERATED ALWAYS AS (
+            CASE WHEN is_defective_duplicate = TRUE THEN NULL ELSE (CASE WHEN parent_id IS NULL THEN 0 ELSE parent_id END) END
+          ) STORED;
+    - sql:
+        dbms: h2
+        sql: |-
+          ALTER TABLE metabase_field ADD COLUMN unique_field_helper INTEGER GENERATED ALWAYS AS (
+            CASE WHEN is_defective_duplicate = TRUE THEN NULL ELSE (CASE WHEN parent_id IS NULL THEN 0 ELSE parent_id END) END
+          );
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          ALTER TABLE metabase_field ADD COLUMN unique_field_helper INTEGER GENERATED ALWAYS AS (
+            CASE WHEN is_defective_duplicate = TRUE THEN NULL ELSE (CASE WHEN parent_id IS NULL THEN 0 ELSE parent_id END) END
+          ) STORED;
+    rollback:
+    - sql: {dbms: 'postgresql,h2,mysql,mariadb', sql: ALTER TABLE metabase_field DROP COLUMN unique_field_helper;}
+- changeSet:
+    id: v49.2024-06-27T00:00:08
+    author: calherries
+    comment: Add unique constraint on metabase_field's (name, table_id, unique_field_helper)
+    changes:
+    - addUniqueConstraint: {tableName: metabase_field, constraintName: idx_unique_field, columnNames: 'name, table_id, unique_field_helper'}
+    rollback:
+    - dropUniqueConstraint: {tableName: metabase_field, constraintName: idx_unique_field}
+- changeSet:
+    id: v49.2024-06-27T00:00:09
+    author: calherries
+    comment: Set is_defective_duplicate=TRUE fields that shouldn't exist to have active=FALSE
+    changes:
+    - sql: {sql: 'UPDATE metabase_field SET active = false WHERE is_defective_duplicate AND (nfc_path = concat(''["'', name, ''"]'') OR nfc_path IS NULL);'}
+    rollback: null
+- changeSet:
+    id: v49.2024-08-21T08:33:06
+    author: johnswanson
+    comment: Add permissions.perm_value
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: permissions, columnName: perm_value}
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: perm_value
+            type: varchar(64)
+            remarks: The value of the permission
+            constraints: {nullable: true}
+        tableName: permissions
+- changeSet:
+    id: v49.2024-08-21T08:33:07
+    author: johnswanson
+    comment: Add permissions.perm_type
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: permissions, columnName: perm_type}
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: perm_type
+            type: varchar(64)
+            remarks: The type of the permission
+            constraints: {nullable: true}
+        tableName: permissions
+- changeSet:
+    id: v49.2024-08-21T08:33:08
+    author: johnswanson
+    comment: Add permissions.collection_id
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: permissions, columnName: collection_id}
+    changes:
+    - addColumn:
+        tableName: permissions
+        columns:
+        - column:
+            name: collection_id
+            type: int
+            remarks: The linked collection, if applicable
+            constraints: {nullable: true}
+- changeSet:
+    id: v49.2024-08-21T08:33:09
+    author: johnswanson
+    comment: Add `permissions.collection_id` foreign key constraint
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - foreignKeyConstraintExists:
+        - {foreignKeyName: fk_permissions_ref_collection_id}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: permissions, baseColumnNames: collection_id, referencedTableName: collection, referencedColumnNames: id, constraintName: fk_permissions_ref_collection_id, onDelete: CASCADE}
+- changeSet:
+    id: v49.2024-08-21T08:33:10
+    author: johnswanson
+    comment: Populate `perm_value`, `perm_type`, and `collection_id` on permissions
+    rollback: null
+    changes:
+    - sqlFile: {dbms: postgresql, path: permissions/collection-access.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/collection-access-mariadb.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: permissions/collection-access-h2.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v49.2024-08-21T08:33:11
+    author: johnswanson
+    comment: Create index on `permissions.collection_id`
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: permissions, indexName: idx_permissions_collection_id}
+    changes:
+    - createIndex:
+        tableName: permissions
+        columns:
+        - column: {name: collection_id}
+        indexName: idx_permissions_collection_id
+- changeSet:
+    id: v49.2024-08-21T08:33:12
+    author: johnswanson
+    comment: Index on `permissions.perm_type`
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: permissions, indexName: idx_permissions_perm_type}
+    changes:
+    - createIndex:
+        tableName: permissions
+        columns:
+        - column: {name: perm_type}
+        indexName: idx_permissions_perm_type
+- changeSet:
+    id: v49.2024-08-21T08:33:13
+    author: johnswanson
+    comment: Index on `permissions.perm_value`
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: permissions, indexName: idx_permissions_perm_value}
+    changes:
+    - createIndex:
+        tableName: permissions
+        columns:
+        - column: {name: perm_value}
+        indexName: idx_permissions_perm_value
+- changeSet:
+    id: v50.2024-01-04T13:52:51
+    author: noahmoss
+    comment: Data permissions table
+    changes:
+    - createTable:
+        tableName: data_permissions
+        remarks: A table to store database and table permissions
+        columns:
+        - column:
+            remarks: The ID of the permission
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            remarks: The ID of the associated permission group
+            name: group_id
+            type: int
+            constraints: {nullable: false, referencedTableName: permissions_group, referencedColumnNames: id, foreignKeyName: fk_data_permissions_ref_permissions_group, deleteCascade: true}
+        - column:
+            remarks: The type of the permission (e.g. "data", "collection", "download"...)
+            name: perm_type
+            type: varchar(64)
+            constraints: {nullable: false}
+        - column:
+            remarks: A database ID, for DB and table-level permissions
+            name: db_id
+            type: int
+            constraints: {nullable: false, referencedTableName: metabase_database, referencedColumnNames: id, foreignKeyName: fk_data_permissions_ref_db_id, deleteCascade: true}
+        - column:
+            remarks: A schema name, for table-level permissions
+            name: schema_name
+            type: varchar(254)
+            constraints: {nullable: true}
+        - column:
+            remarks: A table ID
+            name: table_id
+            type: int
+            constraints: {nullable: true, referencedTableName: metabase_table, referencedColumnNames: id, foreignKeyName: fk_data_permissions_ref_table_id, deleteCascade: true}
+        - column:
+            remarks: The value this permission is set to.
+            name: perm_value
+            type: varchar(64)
+            constraints: {nullable: false}
+- changeSet:
+    id: v50.2024-01-09T13:52:21
+    author: noahmoss
+    comment: Index on data_permissions.table_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: data_permissions
+        columns:
+        - column: {name: table_id}
+        indexName: idx_data_permissions_table_id
+- changeSet:
+    id: v50.2024-01-09T13:53:50
+    author: noahmoss
+    comment: Index on data_permissions.db_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: data_permissions
+        columns:
+        - column: {name: db_id}
+        indexName: idx_data_permissions_db_id
+- changeSet:
+    id: v50.2024-01-09T13:53:54
+    author: noahmoss
+    comment: Index on data_permissions.group_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: data_permissions
+        columns:
+        - column: {name: group_id}
+        indexName: idx_data_permissions_group_id
+- changeSet:
+    id: v50.2024-01-10T03:27:20
+    author: noahmoss
+    comment: Analyze permissions table in preparation for subsequent migrations
+    validCheckSum: ANY
+    runInTransaction: false
+    changes:
+    - sql: {sql: ANALYZE permissions;, dbms: postgresql}
+    - sql: {sql: ANALYZE TABLE permissions;, dbms: 'mysql,mariadb'}
+    rollback: null
+- changeSet:
+    id: v50.2024-01-10T03:27:29
+    author: noahmoss
+    comment: Drop foreign key constraint on sandboxes.permissions_id
+    changes:
+    - dropForeignKeyConstraint: {baseTableName: sandboxes, constraintName: fk_sandboxes_ref_permissions}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: sandboxes, baseColumnNames: permission_id, referencedTableName: permissions, referencedColumnNames: id, constraintName: fk_sandboxes_ref_permissions, onDelete: CASCADE}
+- changeSet:
+    id: v50.2024-01-10T03:27:30
+    author: noahmoss
+    comment: Migrate data-access permissions from `permissions` to `data_permissions`
+    validCheckSum: ANY
+    runInTransaction: false
+    changes:
+    - sqlFile: {dbms: postgresql, path: permissions/data_access.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: permissions/h2_data_access.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/mysql_data_access.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: 'postgresql,h2', path: permissions/rollback/data_access.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/rollback/mysql_data_access.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-01-10T03:27:31
+    author: noahmoss
+    comment: Migrate native-query-editing permissions from `permissions` to `data_permissions`
+    changes:
+    - sqlFile: {path: permissions/native_query_editing.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {path: permissions/rollback/native_query_editing.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-01-10T03:27:32
+    author: noahmoss
+    comment: Migrate download-results permissions from `permissions` to `data_permissions`
+    validCheckSum: ANY
+    runInTransaction: false
+    changes:
+    - sqlFile: {dbms: postgresql, path: permissions/download_results.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: permissions/h2_download_results.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/mysql_download_results.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: 'postgresql,h2', path: permissions/rollback/download_results.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/rollback/mysql_download_results.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-01-10T03:27:33
+    author: noahmoss
+    comment: Migrate manage-data-metadata permissions from `permissions` to `data_permissions`
+    validCheckSum: ANY
+    runInTransaction: false
+    changes:
+    - sqlFile: {dbms: postgresql, path: permissions/manage_table_metadata.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: permissions/h2_manage_table_metadata.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/mysql_manage_table_metadata.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: 'postgresql,h2', path: permissions/rollback/manage_table_metadata.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/rollback/mysql_manage_table_metadata.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-01-10T03:27:34
+    author: noahmoss
+    comment: Migrate manage-database permissions from `permissions` to `data_permissions`
+    changes:
+    - sqlFile: {path: permissions/manage_database.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {path: permissions/rollback/manage_database.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-02-19T21:32:04
+    author: noahmoss
+    comment: Clear data permission paths
+    changes:
+    - {sql: DELETE FROM permissions WHERE object LIKE '%/db/%';}
+    rollback: null
+- changeSet:
+    id: v50.2024-02-20T19:21:04
+    author: camsaul
+    comment: Drop v1 version of v_content view since it references report_card.dataset which we are dropping in next migration
+    changes:
+    - sql:
+        sql: |
+          DROP VIEW IF EXISTS v_content;
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/content/v1/postgres-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/content/v1/mysql-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/content/v1/h2-content.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-02-20T19:25:40
+    author: camsaul
+    comment: Remove report_card.dataset (indicated whether Card was a Model; migrated to report_card.type in 49)
+    changes:
+    - dropColumn: {tableName: report_card, columnName: dataset}
+    rollback:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: dataset
+            type: boolean
+            remarks: Indicate whether question is a model
+            constraints: {nullable: false}
+            defaultValue: false
+    - sql: {sql: UPDATE report_card SET dataset = true WHERE type = 'model';}
+- changeSet:
+    id: v50.2024-02-20T19:26:38
+    author: camsaul
+    comment: Add new v2 version of v_content view which uses report_card.type instead of report_card.dataset (removed in previous migration)
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/content/v2/postgres-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/content/v2/mysql-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/content/v2/h2-content.sql, relativeToChangelogFile: true}
+    rollback:
+    - sql: {sql: DROP VIEW IF EXISTS v_content;}
+- changeSet:
+    id: v50.2024-02-26T22:15:52
+    author: noahmoss
+    comment: Add index on data_permissions(group_id, db_id, perm_value)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: data_permissions, indexName: idx_data_permissions_group_id_db_id_perm_value}
+    changes:
+    - createIndex:
+        tableName: data_permissions
+        indexName: idx_data_permissions_group_id_db_id_perm_value
+        columns:
+        - column: {name: group_id}
+        - column: {name: db_id}
+        - column: {name: perm_value}
+    rollback: null
+- changeSet:
+    id: v50.2024-02-26T22:15:53
+    author: noahmoss
+    comment: Add index on data_permissions(group_id, db_id, table_id, perm_value)
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: data_permissions, indexName: idx_data_permissions_group_id_db_id_table_id_perm_value}
+    changes:
+    - createIndex:
+        tableName: data_permissions
+        indexName: idx_data_permissions_group_id_db_id_table_id_perm_value
+        columns:
+        - column: {name: group_id}
+        - column: {name: db_id}
+        - column: {name: table_id}
+        - column: {name: perm_value}
+    rollback: null
+- changeSet:
+    id: v50.2024-02-26T22:15:54
+    author: noahmoss
+    comment: New `view-data` permission
+    validCheckSum: ANY
+    changes:
+    - sqlFile: {dbms: 'postgresql,h2', path: permissions/view_data.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: permissions/mysql_view_data.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {path: permissions/rollback/view_data.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-02-26T22:15:55
+    author: noahmoss
+    comment: New `create_queries` permission
+    validCheckSum: 9:7c2bc517b6def4e3278394b0399c3d4b
+    changes:
+    - sqlFile: {path: permissions/create_queries.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {path: permissions/rollback/create_queries.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v50.2024-02-29T15:06:43
+    author: tsmacdonald
+    comment: Add the query_field join table
+    changes:
+    - createTable:
+        tableName: query_field
+        remarks: Fields used by a card's query
+        columns:
+        - column:
+            name: id
+            remarks: PK
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: card_id
+            remarks: referenced card
+            type: int
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_query_field_card_id, deleteCascade: true}
+        - column:
+            name: field_id
+            remarks: referenced field
+            type: int
+            constraints: {nullable: false, referencedTableName: metabase_field, referencedColumnNames: id, foreignKeyName: fk_query_field_field_id, deleteCascade: true}
+- changeSet:
+    id: v50.2024-02-29T15:07:43
+    author: tsmacdonald
+    comment: Index query_field.card_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: query_field
+        columns:
+        - column: {name: card_id}
+        indexName: idx_query_field_card_id
+- changeSet:
+    id: v50.2024-02-29T15:08:43
+    author: tsmacdonald
+    comment: Index query_field.field_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: query_field
+        columns:
+        - column: {name: field_id}
+        indexName: idx_query_field_field_id
+- changeSet:
+    id: v50.2024-03-12T17:16:38
+    author: noahmoss
+    comment: Drops the `activity` table which is now unused
+    changes:
+    - dropTable: {tableName: activity}
+    rollback:
+    - createTable:
+        tableName: activity
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: topic
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: timestamp
+            type: DATETIME
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            constraints: {nullable: true, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_activity_ref_user_id, deferrable: false, initiallyDeferred: false}
+        - column:
+            name: model
+            type: varchar(16)
+            constraints: {nullable: true}
+        - column:
+            name: model_id
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: database_id
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: table_id
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: custom_id
+            type: varchar(48)
+            constraints: {nullable: true}
+        - column:
+            name: details
+            type: ${text.type}
+            constraints: {nullable: false}
+    - sql:
+        dbms: mysql
+        sql: |
+          CREATE index idx_activity_entity_qualified_id ON activity (
+            (
+              CASE
+                WHEN model = 'Dataset' THEN (concat('card_', model_id))
+                WHEN model_id IS NULL THEN NULL
+                ELSE (concat(lower(model), '_', model_id))
+              END
+            )
+          );
+- changeSet:
+    id: v50.2024-03-18T16:00:00
+    author: piranha
+    comment: 'Effective caching #36847'
+    changes:
+    - createTable:
+        tableName: cache_config
+        remarks: Cache Configuration
+        columns:
+        - column:
+            name: id
+            remarks: Unique ID
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: model
+            remarks: Name of an entity model
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: model_id
+            remarks: ID of the said entity
+            type: int
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            remarks: Timestamp when the config was inserted
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            remarks: Timestamp when the config was updated
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: strategy
+            remarks: caching strategy name
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            name: config
+            remarks: caching strategy configuration
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            name: state
+            remarks: state for strategies needing to keep some data between runs
+            type: ${text.type}
+            constraints: {nullable: true}
+        - column:
+            name: invalidated_at
+            remarks: indicates when a cache was invalidated last time for schedule-based strategies
+            type: ${timestamp_type}
+            constraints: {nullable: true}
+        - column:
+            name: next_run_at
+            remarks: keeps next time to run for schedule-based strategies
+            type: ${timestamp_type}
+            constraints: {nullable: true}
+- changeSet:
+    id: v50.2024-03-18T16:00:01
+    author: piranha
+    comment: 'Effective caching #36847'
+    rollback: null
+    changes:
+    - addUniqueConstraint: {remarks: 'Unique config for cache_config (model, model_id)', tableName: cache_config, constraintName: idx_cache_config_unique_model, columnNames: 'model, model_id'}
+- changeSet:
+    id: v50.2024-03-21T17:41:00
+    author: qnkhuat
+    comment: Add metabase_table.estimated_row_count
+    changes:
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column: {name: estimated_row_count, type: bigint, remarks: The estimated row count}
+- changeSet:
+    id: v50.2024-03-22T00:38:28
+    author: qnkhuat
+    comment: Add field_usage table
+    changes:
+    - createTable:
+        tableName: field_usage
+        remarks: Used to store field usage during query execution
+        columns:
+        - column:
+            name: id
+            remarks: Unique ID
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: field_id
+            remarks: ID of the field
+            type: int
+            constraints: {nullable: false, referencedTableName: metabase_field, referencedColumnNames: id, foreignKeyName: fk_field_usage_field_id_metabase_field_id, deleteCascade: true}
+        - column:
+            name: query_execution_id
+            remarks: referenced query execution
+            type: int
+            constraints: {nullable: false, referencedTableName: query_execution, referencedColumnNames: id, foreignKeyName: fk_field_usage_query_execution_id, deleteCascade: true}
+        - column:
+            name: used_in
+            remarks: which part of the query the field was used in
+            type: varchar(25)
+            constraints: {nullable: false}
+        - column:
+            name: filter_op
+            remarks: filter's operator that applied to the field
+            type: varchar(25)
+            constraints: {nullable: true}
+        - column:
+            name: aggregation_function
+            remarks: the aggregation function that field applied to
+            type: varchar(25)
+            constraints: {nullable: true}
+        - column:
+            name: breakout_temporal_unit
+            remarks: temporal unit options of the breakout
+            type: varchar(25)
+            constraints: {nullable: true}
+        - column:
+            name: breakout_binning_strategy
+            remarks: the strategy of breakout
+            type: varchar(25)
+            constraints: {nullable: true}
+        - column:
+            name: breakout_binning_num_bins
+            remarks: The numbin option of breakout
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: breakout_binning_bin_width
+            remarks: The numbin option of breakout
+            type: int
+            constraints: {nullable: true}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The time a field usage was recorded
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v50.2024-03-22T00:39:28
+    author: qnkhuat
+    comment: Index field_usage.field_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: field_usage
+        indexName: idx_field_usage_field_id
+        columns:
+          column: {name: field_id}
+- changeSet:
+    id: v50.2024-03-24T19:34:11
+    author: noahmoss
+    comment: Clean up deprecated view-data and native-query-editing permissions
+    rollback: null
+    changes:
+    - sql:
+        sql: |
+          DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
+- changeSet:
+    id: v50.2024-03-25T14:53:00
+    author: tsmacdonald
+    comment: Add query_field.direct_reference
+    changes:
+    - addColumn:
+        tableName: query_field
+        columns:
+        - column:
+            name: direct_reference
+            type: ${boolean.type}
+            remarks: Is the Field referenced directly or via a wildcard
+            constraints: {nullable: false}
+            defaultValue: true
+- changeSet:
+    id: v50.2024-03-28T16:30:35
+    author: calherries
+    comment: Create internal user
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.CreateInternalUser}
+- changeSet:
+    id: v50.2024-03-29T10:00:00
+    author: piranha
+    comment: Granular cache invalidation
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: cache_invalidated_at
+            type: ${timestamp_type}
+            remarks: An invalidation time that can supersede cache_config.invalidated_at
+            constraints: {nullable: true}
+- changeSet:
+    id: v50.2024-04-09T15:55:19
+    author: calherries
+    comment: Add collection.is_sample column
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: is_sample
+            type: ${boolean.type}
+            remarks: Is the collection part of the sample content?
+            constraints: {nullable: false}
+            defaultValue: false
+- changeSet:
+    id: v50.2024-04-15T16:30:35
+    author: qnkhuat
+    comment: Add report_card.last_used_at
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: last_used_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the card is last used
+            constraints: {nullable: true}
+- changeSet:
+    id: v50.2024-04-19T17:04:04
+    author: noahmoss
+    comment: Clean up deprecated view-data and native-query-editing permissions (again)
+    rollback: null
+    changes:
+    - sql:
+        sql: |
+          DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
+- changeSet:
+    id: v50.2024-04-25T01:04:05
+    author: qnkhuat
+    comment: Delete the old SendPulses job and trigger
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.DeleteSendPulsesTask}
+- changeSet:
+    id: v50.2024-04-25T01:04:06
+    author: qnkhuat
+    comment: Delete SendPulse Job on downgrade
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.DeleteSendPulseTaskOnDowngrade}
+- changeSet:
+    id: v50.2024-04-25T01:04:07
+    author: qnkhuat
+    comment: Delete InitSendPulseTriggers Job on downgrade
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.DeleteInitSendPulseTriggersOnDowngrade}
+- changeSet:
+    id: v50.2024-04-25T03:15:01
+    author: noahmoss
+    comment: Add entity_id to core_user
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: NanoID tag for each user
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: core_user
+- changeSet:
+    id: v50.2024-04-25T03:15:02
+    author: noahmoss
+    comment: Add entity_id to permissions_group
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            remarks: NanoID tag for each user
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+        tableName: permissions_group
+- changeSet:
+    id: v50.2024-04-25T16:29:31
+    author: calherries
+    comment: Add report_card.view_count
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: view_count
+            type: integer
+            defaultValueNumeric: 0
+            remarks: Keeps a running count of card views
+            constraints: {nullable: false}
+        tableName: report_card
+- changeSet:
+    id: v50.2024-04-25T16:29:32
+    author: calherries
+    comment: Populate report_card.view_count
+    changes:
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE report_card c SET c.view_count = (
+              SELECT COUNT(*)
+              FROM view_log v
+              WHERE v.model = 'card'
+              AND v.model_id = c.id
+          );
+    - sql:
+        dbms: postgresql,h2
+        sql: |-
+          UPDATE report_card c SET view_count = (
+              SELECT count(*)
+              FROM view_log v
+              WHERE v.model = 'card'
+              AND v.model_id = c.id
+          );
+    rollback: null
+- changeSet:
+    id: v50.2024-04-25T16:29:33
+    author: calherries
+    comment: Add report_dashboard.view_count
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: view_count
+            type: integer
+            defaultValueNumeric: 0
+            remarks: Keeps a running count of dashboard views
+            constraints: {nullable: false}
+        tableName: report_dashboard
+- changeSet:
+    id: v50.2024-04-25T16:29:34
+    author: calherries
+    comment: Populate report_dashboard.view_count
+    changes:
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE report_dashboard c SET c.view_count = (
+              SELECT COUNT(*)
+              FROM view_log v
+              WHERE v.model = 'dashboard'
+              AND v.model_id = c.id
+          );
+    - sql:
+        dbms: postgresql,h2
+        sql: |-
+          UPDATE report_dashboard c SET view_count = (
+              SELECT count(*)
+              FROM view_log v
+              WHERE v.model = 'dashboard'
+              AND v.model_id = c.id
+          );
+    rollback: null
+- changeSet:
+    id: v50.2024-04-25T16:29:35
+    author: calherries
+    comment: Add metabase_table.view_count
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: view_count
+            type: integer
+            defaultValueNumeric: 0
+            remarks: Keeps a running count of card views
+            constraints: {nullable: false}
+        tableName: metabase_table
+- changeSet:
+    id: v50.2024-04-25T16:29:36
+    author: calherries
+    comment: Populate metabase_table.view_count
+    changes:
+    - sql:
+        dbms: mysql,mariadb
+        sql: |-
+          UPDATE metabase_table t SET t.view_count = (
+              SELECT count(*)
+              FROM view_log v
+              WHERE v.model = 'table'
+              AND v.model_id = t.id
+          );
+    - sql:
+        dbms: postgresql,h2
+        sql: |-
+          UPDATE metabase_table t SET view_count = (
+              SELECT count(*)
+              FROM view_log v
+              WHERE v.model = 'table'
+              AND v.model_id = t.id
+          );
+    rollback: null
+- changeSet:
+    id: v50.2024-04-26T09:19:00
+    author: adam-james
+    comment: Added 0.50.0 - Per-user Dashboard Parameter values table
+    changes:
+    - createTable:
+        tableName: user_parameter_value
+        remarks: Table holding last set value of a parameter per user
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: ID of the User who has set the parameter value
+            constraints: {nullable: false, references: core_user(id), foreignKeyName: fk_user_parameter_value_user_id, deleteCascade: true}
+        - column:
+            name: parameter_id
+            type: varchar(36)
+            remarks: The parameter ID
+            constraints: {nullable: false}
+        - column:
+            name: value
+            type: ${text.type}
+            remarks: Value of the parameter
+            constraints: {nullable: true}
+- changeSet:
+    id: v50.2024-04-26T09:25:00
+    author: adam-james
+    comment: Index user_parameter_value.user_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: user_parameter_value
+        indexName: idx_user_parameter_value_user_id
+        columns:
+          column: {name: user_id}
+- changeSet:
+    id: v50.2024-04-30T23:57:23
+    author: noahmoss
+    comment: Add `scope` column to api_key to support SCIM authentication
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: scope
+            type: varchar(64)
+            remarks: The scope of the API key, if applicable
+            constraints: {nullable: true}
+        tableName: api_key
+- changeSet:
+    id: v50.2024-04-30T23:58:24
+    author: noahmoss
+    comment: Drop NOT NULL constraint on api_key.user_id to support SCIM-scoped API keys
+    changes:
+    - dropNotNullConstraint: {tableName: api_key, columnName: user_id, columnDataType: integer}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-08T09:00:00
+    author: qnkhuat
+    comment: Add task_history.status
+    changes:
+    - addColumn:
+        tableName: task_history
+        columns:
+        - column:
+            name: status
+            type: varchar(21)
+            remarks: the status of task history, could be started, failed, success, unknown
+            constraints: {nullable: false}
+            defaultValue: unknown
+- changeSet:
+    id: v50.2024-05-08T09:00:01
+    author: qnkhuat
+    comment: Drop default value task_history.status
+    changes:
+    - dropDefaultValue: {tableName: task_history, columnName: status}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-08T09:00:02
+    author: qnkhuat
+    comment: Add "started" as default value for task_history.status, now that backfill is done.
+    changes:
+    - addDefaultValue: {defaultValue: started, tableName: task_history, columnName: status}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-08T09:00:03
+    author: qnkhuat
+    comment: Drop not null constraint for task_history.ended_at
+    changes:
+    - dropNotNullConstraint: {tableName: task_history, columnDataType: '${timestamp_type}', columnName: ended_at}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-08T09:00:04
+    author: qnkhuat
+    comment: Drop not null constraint for task_history.duration
+    changes:
+    - dropNotNullConstraint: {tableName: task_history, columnDataType: int, columnName: duration}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-08T09:00:05
+    author: qnkhuat
+    comment: Drop default value task_history.ended_at
+    changes:
+    - dropDefaultValue: {tableName: task_history, columnName: ended_at}
+    rollback:
+    - addDefaultValue: {tableName: task_history, columnName: ended_at, defaultValueComputed: current_timestamp}
+- changeSet:
+    id: v50.2024-05-08T09:00:06
+    author: qnkhuat
+    comment: Add null as default value for task_history.ended_at
+    changes:
+    - addDefaultValue: {defaultValue: 'null', tableName: task_history, columnName: ended_at}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-13T16:00:00
+    author: filipesilva
+    comment: Create cloud migration
+    changes:
+    - createTable:
+        tableName: cloud_migration
+        remarks: Migrate to cloud directly from Metabase
+        columns:
+        - column:
+            name: id
+            remarks: Unique ID
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: external_id
+            remarks: Matching ID in Cloud for this migration
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            name: upload_url
+            remarks: URL where the backup will be uploaded to
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            name: state
+            remarks: 'Current state of the migration: init, setup, dump, upload, done, error, cancelled'
+            type: varchar(32)
+            defaultValue: init
+            constraints: {nullable: false}
+        - column:
+            name: progress
+            remarks: Number between 0 to 100 representing progress as a percentage
+            type: int
+            defaultValue: 0
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            remarks: Timestamp when the config was inserted
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            remarks: Timestamp when the config was updated
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+- changeSet:
+    id: v50.2024-05-14T12:42:42
+    author: johnswanson
+    comment: Create the Trash collection
+    changes:
+    - sql: {sql: 'INSERT INTO collection (name, slug, entity_id, type) VALUES (''Trash'', ''trash'', ''trashtrashtrashtrasht'', ''trash''); INSERT INTO permissions (object, group_id) SELECT CONCAT(''/collection/'', c.id, ''/''), pg.id FROM collection c CROSS JOIN permissions_group pg WHERE c.type = ''trash'' AND pg.name != ''Administrators'';'}
+    rollback:
+    - sql:
+        sql: |-
+          DELETE FROM permissions WHERE permissions.object IN (
+            SELECT CONCAT('/collection/', collection.id, '/') FROM collection WHERE collection.type = 'trash'
+          ); DELETE FROM collection WHERE type = 'trash';
+- changeSet:
+    id: v50.2024-05-15T13:13:13
+    author: adam-james
+    comment: Fix visualization settings for stacked area/bar/combo displays
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateStackedAreaBarComboDisplaySettings}
+- changeSet:
+    id: v50.2024-05-17T19:54:23
+    author: calherries
+    comment: Add metabase_database.uploads_enabled column
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: uploads_enabled
+            type: ${boolean.type}
+            defaultValueBoolean: false
+            remarks: Whether uploads are enabled for this database
+            constraints: {nullable: false}
+- changeSet:
+    id: v50.2024-05-17T19:54:24
+    author: calherries
+    comment: Add metabase_database.uploads_schema_name column
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: uploads_schema_name, type: '${text.type}', remarks: The schema name for uploads}
+- changeSet:
+    id: v50.2024-05-17T19:54:25
+    author: calherries
+    comment: Add metabase_database.uploads_table_prefix column
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column: {name: uploads_table_prefix, type: '${text.type}', remarks: The prefix for upload table names}
+- changeSet:
+    id: v50.2024-05-17T19:54:26
+    author: calherries
+    comment: Update metabase_database.uploads_enabled value
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateUploadsSettings}
+- changeSet:
+    id: v50.2024-05-27T15:55:22
+    author: calherries
+    comment: Create sample content
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.CreateSampleContent}
+- changeSet:
+    id: v50.2024-05-29T14:04:47
+    author: johnswanson
+    comment: Add `report_dashboard.archived_directly`
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: archived_directly
+            type: ${boolean.type}
+            defaultValueBoolean: false
+            remarks: Was this thing trashed directly
+            constraints: {nullable: false}
+- changeSet:
+    id: v50.2024-05-29T14:04:53
+    author: johnswanson
+    comment: Add `report_card.archived_directly`
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: archived_directly
+            type: ${boolean.type}
+            remarks: Was this thing trashed directly
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: v50.2024-05-29T14:04:58
+    author: johnswanson
+    comment: Add `collection.archive_operation_id`
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: archive_operation_id
+            type: char(36)
+            remarks: The UUID of the trash operation. Each time you trash a collection subtree, you get a unique ID.
+            constraints: {nullable: true}
+- changeSet:
+    id: v50.2024-05-29T14:05:01
+    author: johnswanson
+    comment: Add `collection.archived_directly`
+    changes:
+    - addColumn:
+        tableName: collection
+        columns:
+        - column:
+            name: archived_directly
+            type: ${boolean.type}
+            remarks: Whether the item was trashed independently or as a subcollection
+            constraints: {nullable: true}
+- changeSet:
+    id: v50.2024-05-29T14:05:03
+    author: johnswanson
+    comment: Populate `archived_directly` and `archive_operation_id` (Postgres)
+    changes:
+    - sqlFile: {dbms: postgresql, path: trash/postgres.sql, relativeToChangelogFile: true}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-29T18:42:13
+    author: johnswanson
+    comment: Populate `archived_directly` and `archive_operation_id` (H2)
+    changes:
+    - sqlFile: {dbms: h2, path: trash/h2.sql, relativeToChangelogFile: true}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-29T18:42:14
+    author: johnswanson
+    comment: Populate `archived_directly` and `archive_operation_id` (MySQL)
+    validCheckSum: ANY
+    changes:
+    - sqlFile: {dbms: mysql, path: trash/mysql.sql, relativeToChangelogFile: true}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-29T18:42:15
+    author: johnswanson
+    comment: Populate `archived_directly` and `archive_operation_id` (MariaDB)
+    changes:
+    - sqlFile: {dbms: mariadb, path: trash/mariadb.sql, relativeToChangelogFile: true}
+    rollback: null
+- changeSet:
+    id: v50.2024-05-30T16:04:20
+    author: escherize
+    comment: Add context to recent views table
+    changes:
+    - addColumn:
+        tableName: recent_views
+        columns:
+        - column:
+            name: context
+            remarks: The contextual action that netted a recent view.
+            type: varchar(256)
+            defaultValue: view
+            constraints: {nullable: false}
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: recent_views, columnName: context}
+- changeSet:
+    id: v50.2024-06-12T12:33:07
+    author: piranha
+    comment: Decrypt some settings so the next migration runs well
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.DecryptCacheSettings}
+    rollback: null
+- changeSet:
+    id: v50.2024-06-12T12:33:08
+    author: piranha
+    comment: Copy old cache configurations to cache_config table
+    validCheckSum: ANY
+    changes:
+    - sqlFile: {dbms: postgresql, path: custom_sql/fill_cache_config.pg.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: custom_sql/fill_cache_config.my.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: custom_sql/fill_cache_config.h2.sql, relativeToChangelogFile: true}
+    rollback: null
+- changeSet:
+    id: v50.2024-06-12T12:33:09
+    author: piranha
+    comment: Fix root cache config for mysql if it is wrong
+    dbms: mysql,mariadb
+    validCheckSum: ANY
+    changes:
+    - sqlFile: {path: custom_sql/fill_cache_config_root_fix.my.sql, relativeToChangelogFile: true}
+    rollback: null
+- changeSet:
+    id: v50.2024-06-20T13:21:30
+    author: noahmoss
+    comment: Drop permission_id column on sandboxes table to fix down migrations
+    changes:
+    - dropColumn: {tableName: sandboxes, columnName: permission_id}
+    rollback:
+    - addColumn:
+        tableName: sandboxes
+        columns:
+        - column:
+            name: permission_id
+            type: int
+            remarks: The ID of the corresponding permissions path for this sandbox (deprecated)
+            constraints: {nullable: true}
+            defaultValue: null
+- changeSet:
+    id: v50.2024-06-28T12:35:50
+    author: piranha
+    comment: Clean databasechangelog table of migration that was once deleted
+    changes:
+    - {sql: 'DELETE FROM ${databasechangelog.name} WHERE id = ''v50.2024-04-12T12:33:09'''}
+    rollback: null
+- changeSet:
+    id: v50.2024-07-02T16:48:21
+    author: adam-james
+    comment: Remove existing user_parameter_value entries as we want to add dashboard_id, and can't easily backfill
+    rollback: null
+    changes:
+    - delete: {tableName: user_parameter_value}
+- changeSet:
+    id: v50.2024-07-02T16:49:29
+    author: adam-james
+    comment: Add dashboard_id column to user_parameter_value to keep values unique per dashboard
+    changes:
+    - addColumn:
+        columns:
+        - column: {name: dashboard_id, type: int, remarks: The ID of the dashboard}
+        tableName: user_parameter_value
+- changeSet:
+    id: v50.2024-07-02T16:55:42
+    author: adam-james
+    comment: Add fk constraint to user_parameter_value.dashboard_id
+    changes:
+    - addForeignKeyConstraint: {baseTableName: user_parameter_value, baseColumnNames: dashboard_id, referencedTableName: report_dashboard, referencedColumnNames: id, constraintName: fk_user_parameter_value_dashboard_id, nullable: false, deleteCascade: true}
+- changeSet:
+    id: v50.2024-07-02T17:07:15
+    author: adam-james
+    comment: Index user_parameter_value.dashboard_id
+    rollback: null
+    changes:
+    - createIndex:
+        tableName: user_parameter_value
+        indexName: idx_user_parameter_value_dashboard_id
+        columns:
+          column: {name: dashboard_id}
+- changeSet:
+    id: v50.2024-07-09T20:04:00
+    author: calherries
+    comment: Populate default value for report_card.last_used_at
+    changes:
+    - sql: {sql: UPDATE report_card SET last_used_at = current_timestamp}
+    rollback: null
+- changeSet:
+    id: v50.2024-07-09T20:04:02
+    author: calherries
+    comment: Add not null constraint for report_card.last_used_at
+    preConditions: null
+    changes:
+    - addNotNullConstraint: {tableName: report_card, columnName: last_used_at, columnDataType: '${timestamp_type}'}
+- changeSet:
+    id: v50.2024-07-09T20:04:03
+    author: calherries
+    comment: Set default for report_card.last_used_at
+    preConditions: null
+    changes:
+    - sql: {dbms: 'postgresql,h2', sql: ALTER TABLE report_card ALTER COLUMN last_used_at SET DEFAULT CURRENT_TIMESTAMP;}
+    - sql: {dbms: 'mysql,mariadb', sql: ALTER TABLE report_card CHANGE last_used_at last_used_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);}
+    rollback: null
+- changeSet:
+    id: v50.2024-08-08T20:04:03
+    author: qnkhuat
+    comment: Added 0.50.0 - Add index on user_parameter_value(user_id, parameter_id, dashboard_id)
+    changes:
+    - createIndex:
+        tableName: user_parameter_value
+        indexName: idx_user_parameter_value_user_id_dashboard_id_parameter_id
+        columns:
+        - column: {name: user_id}
+        - column: {name: dashboard_id}
+        - column: {name: parameter_id}
+- changeSet:
+    id: v50.2024-08-27T00:00:00
+    author: devurandom
+    comment: Add is_attached_dwh to metabase_database
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: metabase_database, columnName: is_attached_dwh}
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: is_attached_dwh
+            type: ${boolean.type}
+            defaultValueBoolean: false
+            remarks: This is an attached data warehouse, do not serialize it and hide its details from the UI
+            constraints: {nullable: false}
+- changeSet:
+    id: v51.2024-05-13T15:30:57
+    author: metamben
+    comment: Backup of dataset_query rewritten by the metrics v2 migration
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: dataset_query_metrics_v2_migration_backup, remarks: The copy of dataset_query before the metrics v2 migration, type: '${text.type}'}
+    preConditions: null
+- changeSet:
+    id: v51.2024-05-13T16:00:00
+    author: metamben
+    comment: Migrate v1 metrics to v2 metrics
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateMetricsToV2}
+- changeSet:
+    id: v51.2024-06-07T12:37:36
+    author: crisptrutski
+    comment: Rename query_field.direct_reference to query_field.indirect_reference
+    changes:
+    - renameColumn: {tableName: query_field, columnDataType: '${boolean.type}', oldColumnName: direct_reference, newColumnName: explicit_reference}
+- changeSet:
+    id: v51.2024-06-12T18:53:02
+    author: noahmoss
+    comment: Drop incorrect index on login_history
+    changes:
+    - dropIndex: {tableName: login_history, indexName: idx_user_id_device_id}
+    rollback:
+    - createIndex:
+        tableName: login_history
+        indexName: idx_user_id_device_id
+        columns:
+        - column: {name: session_id}
+        - column: {name: device_id}
+    preConditions: null
+- changeSet:
+    id: v51.2024-06-12T18:53:03
+    author: noahmoss
+    comment: Create index on login_history (user_id, device_id)
+    changes:
+    - createIndex:
+        tableName: login_history
+        indexName: idx_user_id_device_id
+        columns:
+        - column: {name: user_id}
+        - column: {name: device_id}
+    rollback:
+    - dropIndex: {tableName: login_history, indexName: idx_user_id_device_id}
+    preConditions: null
+- changeSet:
+    id: v51.2024-07-08T10:00:00
+    author: qnkhuat
+    comment: Create channel table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: channel}
+    changes:
+    - createTable:
+        tableName: channel
+        remarks: Channel configurations
+        columns:
+        - column:
+            name: id
+            remarks: Unique ID
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: name
+            remarks: channel name
+            type: varchar(254)
+            constraints: {nullable: false, unique: true}
+        - column:
+            name: description
+            remarks: channel description
+            type: ${text.type}
+            constraints: {nullable: true}
+        - column:
+            name: type
+            remarks: Channel type
+            type: varchar(32)
+            constraints: {nullable: false}
+        - column:
+            name: details
+            remarks: Channel details, used to store authentication information or channel-specific settings
+            type: ${text.type}
+            constraints: {nullable: false}
+        - column:
+            name: active
+            type: ${boolean.type}
             defaultValueBoolean: true
-
-  - changeSet:
-      id: v51.2024-07-10T12:28:10
-      author: johnswanson
-      comment: Add `last_viewed_at` to dashboards
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: report_dashboard
-              columnName: last_viewed_at
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: last_viewed_at
-                  type: ${timestamp_type}
-                  remarks: Timestamp of when this dashboard was last viewed
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-07-22T15:49:37
-      author: escherize
-      comment: Add embedding_client column to query_execution for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: query_execution
-              columnName: embedding_client
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: embedding_client
-                  remarks: Used by the embedding team to track SDK usage
-                  type: varchar(254)
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v51.2024-07-22T15:49:38
-      author: escherize
-      comment: Add embedding_version column to query_execution for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: query_execution
-              columnName: embedding_version
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: embedding_version
-                  remarks: Used by the embedding team to track SDK version usage
-                  type: varchar(254)
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v51.2024-07-22T15:49:39
-      author: escherize
-      comment: Add embedding_client column to view_log for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: view_log
-              columnName: embedding_client
-      changes:
-        - addColumn:
-            tableName: view_log
-            columns:
-              - column:
-                  name: embedding_client
-                  remarks: Used by the embedding team to track SDK usage
-                  type: varchar(254)
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v51.2024-07-22T15:49:40
-      author: escherize
-      comment: Add embedding_version column to view_log for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: view_log
-              columnName: embedding_version
-      changes:
-        - addColumn:
-            tableName: view_log
-            columns:
-              - column:
-                  name: embedding_version
-                  remarks: Used by the embedding team to track SDK version usage
-                  type: varchar(254)
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v51.2024-07-25T11:56:27
-      author: crisptrutski
-      comment: Wipe stale query fields, so we can add new non-nullable columns
-      rollback: # none, entries will be recreated by sweeper
-      changes:
-        - delete:
-            tableName: query_field
-            remarks: remove stale analysis, so the new fields can be non-nullable
-
-  - changeSet:
-      id: v51.2024-07-25T11:57:27
-      author: crisptrutski
-      comment: Add `column` column to query fields
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: column
-      changes:
-        - addColumn:
-            tableName: query_field
-            columns:
-              - column:
-                  name: column
-                  type: varchar(254) # matching metabase_field.name
-                  remarks: name of the table or card being referenced
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-07-25T11:58:27
-      author: crisptrutski
-      comment: Add `table` column to query fields
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: table
-      changes:
-        - addColumn:
-            tableName: query_field
-            columns:
-              - column:
-                  name: table
-                  type: varchar(254) # matching metabase_table.name
-                  remarks: name of the table or card being referenced
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-07-25T12:02:21
-      validCheckSum: ANY
-      author: crisptrutski
-      comment: Make `field_id` nullable on query fields
-      rollback:
-        - delete:
-            tableName: query_field
-            where: query_field.field_id is NULL
-            remarks: remove stale analysis, so the fields can be non-nullable
-      changes:
-        - dropNotNullConstraint:
-            tableName: query_field
-            columnDataType: int
-            columnName: field_id
-            remarks: This value is null if the field does not exist, or is created within a model
-
-  - changeSet:
-      id: v51.2024-07-26T11:56:27
-      author: crisptrutski
-      comment: Add `table_id` column to query fields
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: table_id
-      changes:
-        - addColumn:
-            tableName: query_field
-            columns:
-              - column:
-                  name: table_id
-                  type: int
-                  remarks: track the table directly, in case the field does not exist
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v51.2024-07-29T09:22:12
-      author: crisptrutski
-      comment: Add the query_analysis table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - tableExists:
-              tableName: query_analysis
-      changes:
-        - createTable:
-            tableName: query_analysis
-            remarks: Parent node for query analysis records
-            columns:
-              - column:
-                  name: id
-                  remarks: PK
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: card_id
-                  remarks: referenced card
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_analysis_card_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the analysis was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the analysis was updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-07-29T09:23:12
-      author: crisptrutski
-      comment: Index query_analysis.card_id
-      rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
-      changes:
-        - createIndex:
-            tableName: query_analysis
-            indexName: idx_query_analysis_card_id
-            columns:
-              column:
-                name: card_id
-
-  - changeSet:
-      id: v51.2024-07-29T09:24:13
-      author: crisptrutski
-      comment: Add the query_table join table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - tableExists:
-              tableName: query_table
-      changes:
-        - createTable:
-            tableName: query_table
-            remarks: Tables used by a card's query
-            columns:
-              - column:
-                  name: id
-                  remarks: PK
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: card_id
-                  remarks: referenced card
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_table_card_id
-                    deleteCascade: true
-              - column:
-                  name: analysis_id
-                  remarks: round of analysis
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: query_analysis
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_table_analysis_id
-                    deleteCascade: true
-              - column:
-                  name: table_id
-                  remarks: referenced field
-                  type: int
-                  constraints:
-                    nullable: true
-                    referencedTableName: metabase_table
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_table_table_id
-                    deleteCascade: true
-              - column:
-                  name: schema
-                  type: varchar(254) # matching metabase_table.schema
-                  remarks: name of the schema of the table being referenced
-                  constraints:
-                    nullable: true
-              - column:
-                  name: table
-                  type: varchar(254) # matching metabase_table.name
-                  remarks: name of the table or card being referenced
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-07-29T09:25:13
-      author: crisptrutski
-      comment: Index query_table.card_id
-      rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
-      changes:
-        - createIndex:
-            tableName: query_table
-            indexName: idx_query_table_card_id
-            columns:
-              column:
-                name: card_id
-
-  - changeSet:
-      id: v51.2024-07-29T09:25:14
-      author: crisptrutski
-      comment: Index query_table.analysis_id
-      rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
-      changes:
-        - createIndex:
-            tableName: query_table
-            indexName: idx_query_table_analysis_id
-            columns:
-              column:
-                name: analysis_id
-
-  - changeSet:
-      id: v51.2024-07-29T09:25:15
-      author: crisptrutski
-      comment: Index query_table.table_id
-      rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
-      changes:
-        - createIndex:
-            tableName: query_table
-            indexName: idx_query_table_table_id
-            columns:
-              column:
-                name: table_id
-
-  - changeSet:
-      id: v51.2024-07-29T10:03:27
-      author: crisptrutski
-      comment: Wipe stale query fields, so we can add new non-nullable columns
-      rollback: # none, entries will be recreated by sweeper
-      changes:
-        - delete:
-            tableName: query_field
-            remarks: remove stale analysis, so the new fields can be non-nullable
-
-  - changeSet:
-      id: v51.2024-07-29T10:04:13
-      author: crisptrutski
-      comment: Put Query Fields under a parent Query Analysis record
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: analysis_id
-      changes:
-        - addColumn:
-            tableName: query_field
-            columns:
-              - column:
-                  name: analysis_id
-                  remarks: round of analysis
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: query_analysis
-                    referencedColumnNames: id
-                    foreignKeyName: fk_query_field_analysis_id
-                    deleteCascade: true
-                    deleteCascadeForce: true # its safe as we have truncated the table
-      rollback:
-        - dropForeignKeyConstraint:
-            baseTableName: query_field
-            constraintName: fk_query_field_analysis_id
-        - dropColumn:
-            tableName: query_field
-            columnName: analysis_id
-
-  - changeSet:
-      id: v51.2024-07-29T11:25:13
-      author: crisptrutski
-      comment: Index query_field.analysis_id
-      rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
-      changes:
-        - createIndex:
-            tableName: query_field
-            indexName: idx_query_field_analysis_id
-            columns:
-              column:
-                name: analysis_id
-
-  - changeSet:
-      id: v51.2024-08-02T11:56:27
-      author: crisptrutski
-      comment: Add `schema` column to query fields
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: query_field
-                columnName: schema
-      changes:
-        - addColumn:
-            tableName: query_field
-            columns:
-              - column:
-                  name: schema
-                  type: varchar(254) # matching metabase_table.schema
-                  remarks: name of the schema of the table being referenced
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v51.2024-08-02T12:02:21
-      validCheckSum: ANY
-      author: crisptrutski
-      comment: Make `table` nullable on query fields
-      rollback: # we don't need one, the column will be dropped
-      changes:
-        - dropNotNullConstraint:
-            tableName: query_field
-            columnDataType: varchar(254) # matching metabase_table.name
-            columnName: table
-            remarks: This value is null if the field does not exist, and macaw could not determine the table
-
-  - changeSet:
-      id: v51.2024-08-05T16:00:00
-      author: metamben
-      comment: Add source card reference to report_card to support metrics based models and questions
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: report_card
-              columnName: source_card_id
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: source_card_id
-                  remarks: The ID of the model or question this card is based on
-                  type: int
-
-  - changeSet:
-      id: v51.2024-08-05T16:00:01
-      author: metamben
-      comment: Add FK constraint to report_card.source_card_id
-      preConditions:
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: source_card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_report_card_source_card_id_ref_report_card_id
-            nullable: true
-            deleteCascade: true
-
-  - changeSet:
-      id: v51.2024-08-05T16:00:02
-      author: metamben
-      comment: Index report_card.source_card_id
-      rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: report_card
-                indexName: idx_report_card_source_card_id
-      changes:
-        - createIndex:
-            tableName: report_card
-            indexName: idx_report_card_source_card_id
-            columns:
-              column:
-                name: source_card_id
-
-
-  - changeSet:
-      id: v51.2024-08-07T10:00:00
-      author: ranquild
-      comment: Remove field refs from report_card.visualization_settings.column_settings
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateLegacyColumnKeysInCardVizSettings"
-
-  - changeSet:
-      id: v51.2024-08-07T11:00:00
-      author: ranquild
-      comment: Remove field refs from report_dashboardcard.visualization_settings.column_settings
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateLegacyColumnKeysInDashboardCardVizSettings"
-
-  - changeSet:
-      id: v51.2024-08-26T08:53:46
-      author: crisptrutski
-      comment: Add a status column to track the progress and outcome of query analysis
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_analysis
-              columnName: status
-      changes:
-        - addColumn:
-            tableName: query_analysis
-            columns:
-              - column:
-                  name: status
-                  type: ${text.type}
-                  remarks: running, failed, or completed
-
-  - changeSet:
-      id: v51.2024-09-03T16:54:18
-      author: adam-james
-      comment: Add pivot_results to pulse_card
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: pulse_card
-                columnName: pivot_results
-      changes:
-        - addColumn:
-            tableName: pulse_card
-            columns:
-              - column:
-                  name: pivot_results
-                  type: ${boolean.type}
-                  defaultValue: false
-                  remarks: Whether or not to apply pivot processing to the rows of the export
-
-  - changeSet:
-      id: v51.2024-09-09T15:11:16
-      author: johnswanson
-      comment: add an index for `collection.type`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: collection
-                indexName: idx_collection_type
-      changes:
-        - createIndex:
-            tableName: collection
-            columns:
-              - column:
-                  name: type
-            indexName: idx_collection_type
-
-  - changeSet:
-      id: v51.2024-09-26T03:01:00
-      author: escherize
-      comment: iff enable-embedding is set, copy -> enable-embedding-interactive
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE key = 'enable-embedding';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'enable-embedding';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-embedding';
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO setting (key, value)
-              SELECT 'enable-embedding-interactive', value
-              FROM setting
-              WHERE key = 'enable-embedding';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT INTO setting (`key`, `value`)
-              SELECT 'enable-embedding-interactive', value
-              FROM setting
-              WHERE `key` = 'enable-embedding';
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO setting ("KEY", "VALUE")
-              SELECT 'enable-embedding-interactive', "VALUE"
-              FROM setting
-              WHERE "KEY" = 'enable-embedding';
-      rollback: # not needed
-
-  - changeSet:
-      id: v51.2024-09-26T03:02:00
-      author: escherize
-      comment: iff enable-embedding is set, copy -> enable-embedding-static
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE key = 'enable-embedding';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'enable-embedding';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-embedding';
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO setting (key, value)
-              SELECT 'enable-embedding-static', value
-              FROM setting
-              WHERE key = 'enable-embedding';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT INTO setting (`key`, `value`)
-              SELECT 'enable-embedding-static', value
-              FROM setting
-              WHERE `key` = 'enable-embedding';
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO setting ("KEY", "VALUE")
-              SELECT 'enable-embedding-static', "VALUE"
-              FROM setting
-              WHERE "KEY" = 'enable-embedding';
-      rollback: # not needed
-
-  - changeSet:
-      id: v51.2024-09-26T03:03:00
-      author: escherize
-      comment: iff enable-embedding is set, copy -> enable-embedding-sdk
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE key = 'enable-embedding';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'enable-embedding';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-embedding';
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO setting (key, value)
-              SELECT 'enable-embedding-sdk', value
-              FROM setting
-              WHERE key = 'enable-embedding';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT INTO setting (`key`, `value`)
-              SELECT 'enable-embedding-sdk', value
-              FROM setting
-              WHERE `key` = 'enable-embedding';
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO setting ("KEY", "VALUE")
-              SELECT 'enable-embedding-sdk', "VALUE"
-              FROM setting
-              WHERE "KEY" = 'enable-embedding';
-      rollback: # not needed
-
-  - changeSet:
-      id: v51.2024-09-26T03:04:00
-      author: escherize
-      comment: iff embedding-app-origin is set, copy -> embedding-app-origins-interactive
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE key = 'embedding-app-origin';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'embedding-app-origin';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'embedding-app-origin';
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              INSERT INTO setting (key, value)
-              SELECT 'embedding-app-origins-interactive', value
-              FROM setting
-              WHERE key = 'embedding-app-origin';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              INSERT INTO setting (`key`, `value`)
-              SELECT 'embedding-app-origins-interactive', value
-              FROM setting
-              WHERE `key` = 'embedding-app-origin';
-        - sql:
-            dbms: h2
-            sql: >-
-              INSERT INTO setting ("KEY", "VALUE")
-              SELECT 'embedding-app-origins-interactive', "VALUE"
-              FROM setting
-              WHERE "KEY" = 'embedding-app-origin';
-      rollback: # not needed
-
-  - changeSet:
-      id: v51.2024-10-24T14:23:58
-      author: noahmoss
-      comment: Drop not null constraint on persisted_info.card_id
-      changes:
-        - dropNotNullConstraint:
-            tableName: persisted_info
-            columnName: card_id
-            columnDataType: int
-      rollback:
-        - addNotNullConstraint:
-            tableName: persisted_info
-            columnName: card_id
-            columnDataType: int
-
-  - changeSet:
-      id: v51.2024-10-24T14:24:59
-      author: noahmoss
-      comment: Drop foreign key constraint on persisted_info.card_id
-      preConditions:
-        - foreignKeyConstraintExists:
-            foreignKeyName: fk_persisted_info_card_id
-            foreignKeyTableName: persisted_info
-      changes:
-        - dropForeignKeyConstraint:
-            constraintName: fk_persisted_info_card_id
-            baseTableName: persisted_info
-      rollback:
-        - addForeignKeyConstraint:
-            baseTableName: persisted_info
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_persisted_info_card_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v51.2024-10-24T14:25:01
-      author: noahmoss
-      comment: Re-add nullable foreign key constraint on persisted_info.card_id
-      preConditions:
-        - not:
-            - foreignKeyConstraintExists:
-              foreignKeyName: fk_persisted_info_card_id
-              foreignKeyTableName: persisted_info
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: persisted_info
-            baseColumnNames: card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_persisted_info_card_id
-            onDelete: SET NULL
-      rollback:
-        - dropForeignKeyConstraint:
-            constraintName: fk_persisted_info_card_id
-            baseTableName: persisted_info
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:00
-      author: qnkhuat
-      comment: Create the notification table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification
-      changes:
-        - createTable:
-            tableName: notification
-            remarks: join table that connect notification subscriptions and notification handlers
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: payload_type
-                  remarks: the type of the payload
-                  type: varchar(64)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: active
-                  remarks: whether the notification is active
-                  type: ${boolean.type}
-                  constraints:
-                    nullable: false
-                  defaultValueBoolean: true
-              - column:
-                  remarks: The timestamp of when the notification was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  remarks: The timestamp of when the notification was updated
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:01
-      author: qnkhuat
-      comment: Create the notification_subscription table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_subscription
-      changes:
-        - createTable:
-            remarks: which type of trigger a notification is subscribed to
-            tableName: notification_subscription
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: notification_id
-                  remarks: the notification that the subscription is connected to
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: notification
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_subscription_notification_id
-                    deleteCascade: true
-              - column:
-                  name: type
-                  remarks: the type of the subscription
-                  type: varchar(64)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: event_name
-                  remarks: the event name of subscriptions with type :notification-subscription/system-event
-                  type: varchar(64)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: created_at
-                  remarks: The timestamp of when the subscription was created
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:02
-      author: qnkhuat
-      comment: index on notification_subscription.notification_id
-      rollback: # no need, will be dropped with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_subscription
-                indexName: idx_notification_subscription_notification_id
-      changes:
-        - createIndex:
-            tableName: notification_subscription
-            columns:
-              - column:
-                  name: notification_id
-            indexName: idx_notification_subscription_notification_id
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:03
-      author: qnkhuat
-      comment: Create the channel_template table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: channel_template
-      changes:
-        - createTable:
-            tableName: channel_template
-            remarks: custom template for the channel
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: name
-                  type: varchar(64)
-                  remarks: the name of the template
-                  constraints:
-                    nullable: false
-              - column:
-                  name: channel_type
-                  type: varchar(64)
-                  remarks: the channel type of the template
-                  constraints:
-                    nullable: false
-              - column:
-                  name: details
-                  type: ${text.type}
-                  remarks: the details of the template
-                  constraints:
-                    nullable: true
-              - column:
-                  name: entity_id
-                  type: char(21)
-                  remarks: Random NanoID tag for unique identity.
-                  constraints:
-                    nullable: true
-                    unique: true
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the template was created
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the template was last updated
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:04
-      author: qnkhuat
-      comment: Create the notification_handler table
-      validCheckSum: ANY
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_handler
-      changes:
-        - createTable:
-            tableName: notification_handler
-            remarks: which channel to send the notification to
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              # TODO: can be removed once emails and slack configuration are fully migrated to be stored in channel table.
-              - column:
-                  name: channel_type
-                  type: varchar(64)
-                  remarks: the type of the channel, like :channel/email, :channel/slack
-                  constraints:
-                    nullable: false
-              - column:
-                  name: notification_id
-                  type: int
-                  remarks: the notification that the handler is connected to
-                  constraints:
-                    nullable: false
-                    referencedTableName: notification
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_handler_notification_id
-                    deleteCascade: true
-              - column:
-                  name: channel_id
-                  type: int
-                  remarks: the channel that the handler is connected to
-                  constraints:
-                    nullable: true # temporarily nullable, because we need to support email and slack channels as global configuration
-                    referencedTableName: channel
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_handler_channel_id
-                    deleteCascade: true
-              - column:
-                  name: template_id
-                  type: int
-                  remarks: the template that the handler is connected to
-                  constraints:
-                    nullable: true
-              - column:
-                  name: active
-                  type: ${boolean.type}
-                  remarks: whether the handler is active
-                  defaultValueBoolean: true
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the handler was created
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the handler was updated
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-  - changeSet:
-      id: v52.2024-09-05T08:00:05
-      author: qnkhuat
-      comment: Add fk constraint to notification_handler.template_id
-      preConditions:
-        - not:
-          - foreignKeyConstraintExists:
-              foreignKeyName: fk_notification_handler_template_id
-              foreignKeyTableName: notification_handler
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: notification_handler
-            baseColumnNames: template_id
-            referencedTableName: channel_template
-            referencedColumnNames: id
-            constraintName: fk_notification_handler_template_id
-            onDelete: SET NULL
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:06
-      author: qnkhuat
-      comment: index on notification_handler.notification_id
-      rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_handler
-                indexName: idx_notification_handler_notification_id
-      changes:
-        - createIndex:
-            tableName: notification_handler
-            columns:
-              - column:
-                  name: notification_id
-            indexName: idx_notification_handler_notification_id
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:07
-      author: qnkhuat
-      comment: index on notification_handler.channel_id
-      rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_handler
-                indexName: idx_notification_handler_channel_id
-      changes:
-        - createIndex:
-            tableName: notification_handler
-            columns:
-              - column:
-                  name: channel_id
-            indexName: idx_notification_handler_channel_id
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:08
-      author: qnkhuat
-      comment: index on notification_handler.template_id
-      rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_handler
-                indexName: idx_notification_handler_template_id
-      changes:
-        - createIndex:
-            tableName: notification_handler
-            columns:
-              - column:
-                  name: template_id
-            indexName: idx_notification_handler_template_id
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:09
-      author: qnkhuat
-      comment: Create the notification_recipient table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_recipient
-      changes:
-        - createTable:
-            tableName: notification_recipient
-            remarks: who should receive the notification
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: notification_handler_id
-                  type: int
-                  remarks: the handler that the recipient is connected to
-                  constraints:
-                    nullable: false
-                    referencedTableName: notification_handler
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_recipient_notification_handler_id
-                    deleteCascade: true
-              - column:
-                  name: type
-                  type: varchar(64)
-                  remarks: the type of the recipient
-                  constraints:
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: a user if the recipient has type user
-                  constraints:
-                    nullable: true
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_recipient_user_id
-                    deleteCascade: true
-              - column:
-                  name: permissions_group_id
-                  type: int
-                  remarks: a permissions group if the recipient has type permissions_group
-                  constraints:
-                    nullable: true
-                    referencedTableName: permissions_group
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_recipient_permissions_group_id
-                    deleteCascade: true
-              - column:
-                  name: details
-                  type: ${text.type}
-                  remarks: custom details for the recipient
-                  constraints:
-                    nullable: true
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the recipient was created
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the recipient was updated
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:10
-      author: qnkhuat
-      comment: index on notification_recipient.notification_handler_id
-      rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_recipient
-                indexName: idx_notification_recipient_notification_handler_id
-      changes:
-        - createIndex:
-            tableName: notification_recipient
-            columns:
-              - column:
-                  name: notification_handler_id
-            indexName: idx_notification_recipient_notification_handler_id
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:11
-      author: qnkhuat
-      comment: index on notification_recipient.user_id
-      rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_recipient
-                indexName: idx_notification_recipient_user_id
-      changes:
-        - createIndex:
-            tableName: notification_recipient
-            columns:
-              - column:
-                  name: user_id
-            indexName: idx_notification_recipient_user_id
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:12
-      author: qnkhuat
-      comment: index on notification_recipient.permissions_group_id
-      rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_recipient
-                indexName: idx_notification_recipient_permissions_group_id
-      changes:
-        - createIndex:
-            tableName: notification_recipient
-            columns:
-              - column:
-                  name: permissions_group_id
-            indexName: idx_notification_recipient_permissions_group_id
-
-  - changeSet:
-      id: v52.2024-09-05T08:00:13
-      author: qnkhuat
-      comment: Drop the channel_template.entity_id column
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: metabase_database
-            columnName: is_attached_dwh
-      changes:
-        - dropColumn:
-            tableName: channel_template
-            columnName: entity_id
-      rollback: # not necessary, will be removed with the table
-
-  - changeSet:
-      id: v52.2024-10-15T08:00:00
-      author: qnkhuat
-      comment: add notification_subscription.cron_schedule
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification_subscription
-              columnName: cron_schedule
-      changes:
-        - addColumn:
-            tableName: notification_subscription
-            columns:
-              - column:
-                  name: cron_schedule
-                  type: varchar(128)
-                  remarks: the cron schedule for the subscription
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v52.2024-10-26T18:42:42
-      author: metamben
-      comment: Add stage-number to dimension targets in parameter_mappings
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.AddStageNumberToParameterMappingTargets"
-
-  - changeSet:
-      id: v52.2024-11-12T15:13:18
-      author: metamben
-      comment: Add stage-number to dimension targets in visualization_settings
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.AddStageNumberToVizSettingsParameterMappingTargets"
-
-  # This migration should be changed to a no-op and a new migration inserted that does the load from edn whenever the
-  # sample content is updated, so that it matches when the version that the sample content was updated from. See
-  # metabase#50829 for an example where the content was updated.
-  - changeSet:
-      id: v52.2024-12-03T15:55:22
-      author: escherize
-      comment: Create New and improved Sample Content
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.CreateSampleContentV2"
-
-  - changeSet:
-      id: v52.2024-12-10T10:28:16
-      author: johnswanson
-      comment: Add `report_card.dashboard_id`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: report_card
-              columnName: dashboard_id
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: dashboard_id
-                  type: int
-                  remarks: The dashboard that owns the card, if it is a dashboard-internal card.
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v52.2024-12-10T10:28:21
-      author: johnswanson
-      comment: Make `report_card.dashboard_id` a foreign key
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - foreignKeyConstraintExists:
-            - foreignKeyName: fk_report_card_ref_dashboard_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_card
-            baseColumnNames: dashboard_id
-            referencedTableName: report_dashboard
-            referencedColumnNames: id
-            constraintName: fk_report_card_ref_dashboard_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v52.2024-12-10T10:28:24
-      author: johnswanson
-      comment: Add an index for `report_card.dashboard_id`
-      rollback: # will be removed with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: report_card
-                indexName: idx_report_card_dashboard_id
-      changes:
-        - createIndex:
-            indexName: idx_report_card_dashboard_id
-            tableName: report_card
-            columns:
-              - column:
-                  name: dashboard_id
-
-  - changeSet:
-      id: v52.2024-12-16T09:19:00
-      author: crisptrutski
-      comment: Metadata about search indexes
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: search_index_metadata
-      changes:
-        - createTable:
-            tableName: search_index_metadata
-            remarks: Each entry corresponds to some queryable index, and contains metadata about it.
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: engine
-                  type: varchar(64)
-                  remarks: 'The kind of search engine which this index belongs to.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: version
-                  type: varchar(254)
-                  remarks: 'Used to determine metabase compatibility. Format may depend on engine in future.'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: index_name
-                  type: varchar(254)
-                  remarks: "The name by which the given engine refers to this particular index, e.g. table name."
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: status
-                  type: varchar(32)
-                  remarks: One of 'pending', 'active', or 'retired'
-                  constraints:
-                    nullable: true
-              - column:
-                  remarks: The timestamp of when the index was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the index status was updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v52.2024-12-16T09:20:00
-      author: crisptrutski
-      comment: 'Protection against concurrent creation or promotion of indexes.'
-      rollback: # will be removed with the table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: search_index_metadata
-                indexName: idx_search_index_metadata_unique_status
-      changes:
-        - addUniqueConstraint:
-            remarks: Unique entry for each status, from any given metabase instance's perspective.
-            tableName: search_index_metadata
-            constraintName: idx_search_index_metadata_unique_status
-            columnNames: engine, version, status
-
-  - changeSet:
-      id: v52.2025-01-05T00:00:01
-      author: escherize
-      comment: set enable-embedding-sdk false when embedding-app-origins-sdk value exists
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE key = 'embedding-app-origins-sdk';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'embedding-app-origins-sdk';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'embedding-app-origins-sdk';
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              update setting set value = 'false' where key = 'enable-embedding-sdk';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE setting set `value` = 'false' where `key` = 'enable-embedding-sdk';
-        - sql:
-            dbms: h2
-            sql: >-
-              UPDATE setting set "VALUE" = 'false' where "KEY" = 'enable-embedding-sdk';
-      rollback: # not needed
-
-  - changeSet:
-      id: v53.2024-12-02T16:21:15
-      author: noahmoss
-      comment: Add cache_config.refresh_automatically column
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: cache_config
-                columnName: refresh_automatically
-      changes:
-        - addColumn:
-            tableName: cache_config
-            columns:
-              - column:
-                  name: refresh_automatically
-                  type: ${boolean.type}
-                  remarks: Whether or not we should automatically refresh cache results when a cache expires
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v53.2024-12-02T17:21:16
-      validCheckSum:
-        - 9:209a494b250a08f022114249697cbc1b
-        - 9:8adcf08936200cc74153d0c306452e0c
-      author: noahmoss
-      comment: Add query_execution.parameterized column
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: query_execution
-                columnName: parameterized
-      changes:
-        - addColumn:
-            tableName: query_execution
-            columns:
-              - column:
-                  name: parameterized
-                  type: ${boolean.type}
-                  remarks: Whether or not the query has parameters with non-nil values
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v53.2024-12-10T10:00:00
-      author: qnkhuat
-      comment: add notification.internal_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: notification
-              columnName: internal_id
-      changes:
-        - addColumn:
-            tableName: notification
-            columns:
-              - column:
-                  name: internal_id
-                  type: varchar(254)
-                  remarks: the internal id of the notification
-                  constraints:
-                    nullable: true
-                    unique: true
-
-  # Prior to this, we used to truncate then insert notifications on startup (#50127)
-  # But we can't do that anymore because pulses are migated to notification, so moving forward
-  # we'll insert/replace notifications on startup (see metabase.notification.seed)
-  # We need to do another truncate here so we have a clean slate for the new notifications
-  - changeSet:
-      id: v53.2024-12-10T10:00:10
-      author: qnkhuat
-      comment: Truncate the notification tables
-      rollback: # not needed
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              TRUNCATE TABLE notification RESTART IDENTITY CASCADE;
-              TRUNCATE TABLE notification_handler RESTART IDENTITY CASCADE;
-              TRUNCATE TABLE notification_subscription RESTART IDENTITY CASCADE;
-              TRUNCATE TABLE notification_recipient RESTART IDENTITY CASCADE;
-              TRUNCATE TABLE channel_template RESTART IDENTITY CASCADE;
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              DELETE FROM notification;
-              ALTER TABLE notification AUTO_INCREMENT = 1;
-              DELETE FROM notification_handler;
-              ALTER TABLE notification_handler AUTO_INCREMENT = 1;
-              DELETE FROM notification_subscription;
-              ALTER TABLE notification_subscription AUTO_INCREMENT = 1;
-              DELETE FROM notification_recipient;
-              ALTER TABLE notification_recipient AUTO_INCREMENT = 1;
-              DELETE FROM channel_template;
-              ALTER TABLE channel_template AUTO_INCREMENT = 1;
-
-        - sql:
-            dbms: h2
-            sql: >-
-              DELETE FROM notification;
-              DELETE FROM notification_handler;
-              DELETE FROM notification_subscription;
-              DELETE FROM notification_recipient;
-              DELETE FROM channel_template;
-              ALTER TABLE notification ALTER COLUMN id RESTART WITH 1;
-              ALTER TABLE notification_handler ALTER COLUMN id RESTART WITH 1;
-              ALTER TABLE notification_subscription ALTER COLUMN id RESTART WITH 1;
-              ALTER TABLE notification_recipient ALTER COLUMN id RESTART WITH 1;
-              ALTER TABLE channel_template ALTER COLUMN id RESTART WITH 1;
-
-  - changeSet:
-      id: v53.2024-12-20T19:53:50
-      author: johnswanson
-      comment: >
-        add a table for user-level KV. This is intended for use as a lightweight mechanism for the frontend to be able
-        to mark things as seen, unseen, dismissed, etc
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: user_key_value
-      changes:
-        - createTable:
-            tableName: user_key_value
-            remarks: A simple key value store for each user.
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: user_id
-                  type: int
-                  remarks: 'The ID of the user this KV-pair is for'
-                  constraints:
-                    nullable: false
-                    referencedTableName: core_user
-                    referencedColumnNames: id
-                    foreignKeyName: fk_user_key_value_user_id
-              - column:
-                  name: namespace
-                  type: varchar(254)
-                  remarks: 'The namespace for this KV, e.g. "dashboard-filters" or "nobody-knows"'
-                  constraints:
-                    nullable: false
-              - column:
-                  name: key
-                  remarks: 'The key'
-                  type: varchar(254)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: value
-                  remarks: 'The value, serialized JSON'
-                  type: ${text.type}
-                  constraints:
-                    nullable: true
-              - column:
-                  name: created_at
-                  remarks: 'When this row was created'
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  remarks: 'When this row was last updated'
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: expires_at
-                  remarks: 'If set, when this row expires'
-                  type: ${timestamp_type}
-                  defaultValue: null
-
-  - changeSet:
-      id: v53.2024-12-20T19:53:59
-      author: johnswanson
-      comment: Add a unique constraint for user_id,namespace,key
-      changes:
-        - addUniqueConstraint:
-            tableName: user_key_value
-            columnNames: user_id, namespace, key
-            constraintName: unique_user_key_value_user_id_namespace_key
-      rollback: # will be deleted with table
-
-  - changeSet:
-      id: v53.2024-12-27T17:33:54
-      author: nvoxland
-      comment: Adds encryption-check setting to encryption management
-      changes:
-        - insert:
-            tableName: setting
-            columns:
-              - column:
-                  name: key
-                  value: encryption-check
-              - column:
-                  name: value
-                  value: "unencrypted"
-      rollback:
-        - sql:
-            sql: "delete from setting where \"key\"='encryption-check'"
-            dbms: postgresql
-        - sql:
-            sql: "delete from setting where `key`='encryption-check'"
-            dbms: mysql,mariadb
-        - sql:
-            sql: "delete from setting where \"KEY\"='encryption-check'"
-            dbms: h2
-
-  - changeSet:
-      id: v53.2024-12-27T20:17:23
-      author: noahmoss
-      comment: Drop unnecessary NOT NULL constraint from cache_config.refresh_automatically column
-      changes:
-        - dropNotNullConstraint:
-            tableName: cache_config
-            columnName: refresh_automatically
-            columnDataType: ${boolean.type}
-      rollback:
-        - addNotNullConstraint:
-            tableName: cache_config
-            columnName: refresh_automatically
-            columnDataType: ${boolean.type}
-            defaultNullValue: false
-
-  - changeSet:
-      id: v53.2025-01-03T19:07:39
-      author: noahmoss
-      comment: Add `deactivated_at` column to the `core_user` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: core_user
-                columnName: deactivated_at
-      changes:
-        - addColumn:
-            tableName: core_user
-            columns:
-              - column:
-                  name: deactivated_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp at which a user was deactivated
-
-  - changeSet:
-      id: v53.2025-02-20T04:49:39
-      author: johnswanson
-      comment: remove unused cards in usage analytics
-      changes:
-        - sql: |
-            DELETE FROM report_card WHERE entity_id IN (
-              'Y0ZykgQ64HHwAW_MYx-dW',
-              '3CtVT_JDxNvMM5aFLtEHR',
-              'hFpp3c-7Y-CtMOrs3zeyn',
-              'PkIueKBME3DfRFwBsYjuE',
-              '4DlO-I7ry2OaVQy7-RGPU',
-              'lh0sbjKcm9BhiiHPpPxRa',
-              '9shJ0y29V5o1lOSDL4ImJ',
-              'WoQnk12nwOaJ1pcb1wsr4',
-              '-_XgVaPuz7MY8jlG0wSEC',
-              'LXu_IZa1EDg3QOhlwunGy',
-              'Fnu5Kh0gYPN6P8A_fvICu'
-            );
-      rollback: # not needed, these are created on startup using deserialization
-
-  - changeSet:
-      id: v53.2025-04-02T15:25:04
-      author: edpaget
-      comment: create new cluster lock table for instance coordination
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: metabase_cluster_lock
-      changes:
-        - createTable:
-            tableName: metabase_cluster_lock
-            remarks: A table to allow metabase instances to take locks across a cluster
-            columns:
-              - column:
-                  name: lock_name
-                  type: varchar(254)
-                  remarks: a single column that can be used to a lock across a cluster
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-
-  - changeSet:
-      id: v54.2025-01-30T16:10:55
-      author: bshepherdson
-      comment: Add `entity_id` column to the `metabase_database` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_database
-                columnName: entity_id
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  remarks: Random NanoID tag for unique identity.
-                  name: entity_id
-                  type: char(21)
-                  constraints:
-                    nullable: true
-                    unique: true
-
-  - changeSet:
-      id: v54.2025-01-30T16:13:20
-      author: bshepherdson
-      comment: Add `entity_id` column to the `metabase_table` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: entity_id
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  remarks: Random NanoID tag for unique identity.
-                  name: entity_id
-                  type: char(21)
-                  constraints:
-                    nullable: true
-                    unique: true
-
-  - changeSet:
-      id: v54.2025-01-30T16:14:02
-      author: bshepherdson
-      comment: Add `entity_id` column to the `metabase_field` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_field
-                columnName: entity_id
-      changes:
-        - addColumn:
-            tableName: metabase_field
-            columns:
-              - column:
-                  remarks: Random NanoID tag for unique identity.
-                  name: entity_id
-                  type: char(21)
-                  constraints:
-                    nullable: true
-                    unique: true
-
-  - changeSet:
-      id: v54.2025-02-14T08:00:00
-      author: qnkhuat
-      comment: add notification.payload_id
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification
-              columnName: payload_id
-      changes:
-        - addColumn:
-            tableName: notification
-            columns:
-              - column:
-                  name: payload_id
-                  type: int
-                  remarks: the internal id of the notification
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v54.2025-02-14T08:01:00
-      author: qnkhuat
-      comment: create the notification_card table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_card
-      changes:
-        - createTable:
-            tableName: notification_card
-            remarks: Card related notifications
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: card_id
-                  type: int
-                  remarks: the card that the alert is connected to
-                  constraints:
-                    nullable: true
-                    referencedTableName: report_card
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_card_card_id
-                    deleteCascade: true
-              - column:
-                  name: send_once
-                  type: ${boolean.type}
-                  remarks: whether the alert should only run once
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  name: send_condition
-                  type: varchar(32)
-                  remarks: the condition of the alert
-                  constraints:
-                    nullable: false
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the recipient was created
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  remarks: The timestamp of when the recipient was updated
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v54.2025-02-14T08:03:00
-      author: qnkhuat
-      comment: add notification.creator_id
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification
-              columnName: creator_id
-      changes:
-        - addColumn:
-            tableName: notification
-            columns:
-              - column:
-                  name: creator_id
-                  type: int
-                  remarks: the id of the creator
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v54.2025-02-14T08:04:00
-      author: qnkhuat
-      comment: add fk constraint to notification.creator_id
-      preConditions:
-        - not:
-          - foreignKeyConstraintExists:
-              foreignKeyName: fk_notification_creator_id
-              foreignKeyTableName: notification
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: notification
-            baseColumnNames: creator_id
-            referencedTableName: core_user
-            referencedColumnNames: id
-            constraintName: fk_notification_creator_id
-            onDelete: CASCADE
-            nullable: true
-
-  - changeSet:
-      id: v54.2025-02-14T08:04:01
-      author: qnkhuat
-      comment: Add an index for `notification.creator_id`
-      rollback: # will be removed with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: notification
-                indexName: idx_notification_creator_id
-      changes:
-        - createIndex:
-            indexName: idx_notification_creator_id
-            tableName: notification
-            columns:
-              - column:
-                  name: creator_id
-
-  - changeSet:
-      id: v54.2025-02-14T08:04:02
-      author: qnkhuat
-      comment: Add an index for `notification_card.card_id`
-      rollback: # will be removed with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: notification_card
-                indexName: idx_notification_card_card_id
-      changes:
-        - createIndex:
-            indexName: idx_notification_card_card_id
-            tableName: notification_card
-            columns:
-              - column:
-                  name: card_id
-
-  - changeSet:
-      id: v54.2025-02-14T08:05:00
-      author: qnkhuat
-      comment: Migrate alert to notification
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.MigrateAlertToNotification"
-
-  - changeSet:
-      id: v54.2025-02-14T08:06:00
-      author: qnkhuat
-      comment: Delete all the migrated alerts from notification table
-      changes:
-        - sql: select 1;
-      rollback:
-        # delete all migrated notification on rollback so we can re-run the migration
-        # no need to delete notification_card because the table will be dropped
-        - sql:
-            sql: >-
-              DELETE FROM notification WHERE payload_type = 'notification/card';
-
-  - changeSet:
-      id: v54.2025-02-14T08:07:00
-      author: qnkhuat
-      comment: Update view v_alerts to read from notification tables
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/alerts/v2/postgres-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/alerts/v2/mysql-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/alerts/v2/h2-alerts.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/alerts/v1/postgres-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/alerts/v1/mysql-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/alerts/v1/h2-alerts.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v54.2025-03-06T16:55:15
-      author: nvoxland
-      comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
-      preConditions:
-      changes:
-        - addColumn:
-            tableName: core_session
-            columns:
-              - column:
-                  name: key_hashed
-                  type: varchar(254)
-                  value: "upgrade placeholder"
-                  remarks: Hashed version of the session key
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v54.2025-03-06T16:55:16
-      author: nvoxland
-      comment: Creating index on the hashed session key
-      preConditions:
-      changes:
-        - createIndex:
-            tableName: core_session
-            columns:
-              - column:
-                  name: key_hashed
-            indexName: idx_core_session_key_hashed
-
-  - changeSet:
-      id: v54.2025-03-11T16:00:00
-      author: qnkhuat
-      comment: add notification_subscription.ui_display_type
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification_subscription
-              columnName: ui_display_type
-      changes:
-        - addColumn:
-            tableName: notification_subscription
-            columns:
-              - column:
-                  name: ui_display_type
-                  type: varchar(32)
-                  remarks: the display of the subscription, used for the UI only
-                  constraints:
-                    nullable: true
-
-  - changeSet:
-      id: v54.2025-03-17T18:52:44
-      author: noahmoss
-      comment: Migrating zh site locales to zh_CN
-      preConditions:
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              UPDATE setting SET value = 'zh_CN' where key = 'site-locale' AND value = 'zh';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE setting SET `value` = 'zh_CN' where `key` = 'site-locale' AND `value` = 'zh';
-        - sql:
-            dbms: h2
-            sql: >-
-              UPDATE setting SET "VALUE" = 'zh_CN' where "KEY" = 'site-locale' AND "VALUE" = 'zh';
-      rollback: # nothing to do; zh_CN is backwards compatible
-
-  - changeSet:
-      id: v54.2025-03-17T18:52:59
-      author: noahmoss
-      comment: Migrating zh user locales to zh_CN
-      preConditions:
-      changes:
-        - sql:
-            sql: >-
-              UPDATE core_user SET locale = 'zh_CN' WHERE locale = 'zh';
-      rollback: # nothing to do; zh_CN is backwards compatible
-
-  - changeSet:
-      id: v54.2025-03-25T16:34:12
-      author: edpaget
-      comment: Add index to field_usage query_execution_id column to support faster deletes
-      rollback: # cannot rollback an index on a fk in mysql
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: field_usage
-                indexName: idx_field_usage_query_execution_id
-      changes:
-        - createIndex:
-            tableName: field_usage
-            columns:
-              - column:
-                  name: query_execution_id
-            indexName: idx_field_usage_query_execution_id
-
-  - changeSet:
-      id: v54.2025-03-27T17:52:01
-      author: luizarakaki
-      comment: updating v_tasks to add new `status` field
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/tasks/v2/postgres-tasks.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/tasks/v2/mysql-tasks.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/tasks/v2/h2-tasks.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/tasks/v1/postgres-tasks.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/tasks/v1/mysql-tasks.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/tasks/v1/h2-tasks.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v54.2025-03-28T11:22:01
-      author: luizarakaki
-      comment: updating v_content to add new `is_verified` field
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/content/v3/postgres-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/content/v3/mysql-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/content/v3/h2-content.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/content/v2/postgres-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/content/v2/mysql-content.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/content/v2/h2-content.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
-      id: v55.2025-03-24T16:28:41
-      author: bshepherdson
-      comment: Add report_card.card_schema
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: report_card
-              columnName: card_schema
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: card_schema
-                  type: int
-                  remarks: Arbitrary revision number for how we store queries in report_card
-                  defaultValue: 20
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v55.2025-03-24T16:36:19
-      author: bshepherdson
-      comment: Creating index on the card_schema
-      preConditions:
-      changes:
-        - createIndex:
-            tableName: report_card
-            columns:
-              - column:
-                  name: card_schema
-            indexName: idx_report_card_card_schema
-
-  - changeSet:
-      id: v55.2025-04-01T07:17:52
-      author: johnswanson
-      comment: Add `db_router` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: db_router
-      changes:
-        - createTable:
-            tableName: db_router
-            remarks: |
-              Configuration for Database Routers. Currently just holds which user attribute each
-              configured router database should use to choose a mirror database to route to.
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: database_id
-                  type: int
-                  remarks: 'The ID of the database this is for.'
-                  constraints:
-                    unique: true
-                    nullable: false
-                    referencedTableName: metabase_database
-                    referencedColumnNames: id
-                    foreignKeyName: fk_db_router_database_id
-              - column:
-                  name: user_attribute
-                  type: varchar(254)
-                  remarks: 'The user attribute used to redirect users to a different database.'
-                  constraints:
-                    nullable: false
-
-
-  - changeSet:
-      id: v55.2025-04-01T07:18:02
-      author: johnswanson
-      comment: Add self-referential foreign key `router_database_id` to metabase_database
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_database
-                columnName: router_database_id
-      changes:
-        - addColumn:
-            tableName: metabase_database
-            columns:
-              - column:
-                  name: router_database_id
-                  type: int
-                  remarks: The ID of the primary database for this mirror database.
-                  constraints:
-                    unique: false
-                    nullable: true
-
-  - changeSet:
-      id: v55.2025-04-01T07:18:47
-      author: johnswanson
-      comment: add an index for `metabase_database.router_database_id`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: metabase_database
-                indexName: idx_unique_metabase_database_router_database_id_name
-      changes:
-        - addUniqueConstraint:
-            tableName: metabase_database
-            constraintName: idx_unique_metabase_database_router_database_id_name
-            columnNames: router_database_id, name
-
-  - changeSet:
-      id: v55.2025-04-01T07:18:52
-      author: johnswanson
-      comment: Add foreign key for `router_database_id`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - foreignKeyConstraintExists:
-            - foreignKeyName: fk_metabase_database_metabase_database_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabase_database
-            baseColumnNames: router_database_id
-            referencedTableName: metabase_database
-            referencedColumnNames: id
-            constraintName: fk_metabase_database_metabase_database_id
-            onDelete: RESTRICT
-
-
-  - changeSet:
-      id: v55.2025-04-17T08:44:39
-      author: johnswanson
-      comment: Add permissions_group.magic_group_type
-      preConditions: # Not required
-      changes:
-        - addColumn:
-            tableName: permissions_group
-            columns:
-              - column:
-                  name: magic_group_type
-                  type: varchar(254)
-                  remarks: The magic_group_type of the permissions_group
-                  constraints:
-                    unique: true
-                    nullable: true
-
-  - changeSet:
-      id: v55.2025-04-17T08:47:19
-      author: johnswanson
-      comment: Set type on existing permissions groups
-      rollback: #
-      changes:
-        - sql:
-            sql: |
-              UPDATE permissions_group SET magic_group_type='all-internal-users' WHERE name='All Users';
-              UPDATE permissions_group SET magic_group_type='admin' WHERE name='Administrators';
-
-  # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
-
-########################################################################################################################
-#
-# ADVICE:
-#
-# 1) Think through some of these points when writing a migration, learn from our past mistakes:
-#    - Do you really need a migration? Could the feature work without it? Prefer not to if possible.
-#      Data in the wild can be vastly different from what you expect, and it's hard to get right.
-#    - Make sure your migration is backward compatible: it might not be possible to add a constraint back
-#      if you drop it in a migration.
-#    - Postgres, MySQL and H2 have their differences. Make sure your migration works for all.
-#    - Database encryption is a major issue:
-#      - Fields like `metabase_database.details` or `setting.value` can be encrypted, so you need to decrypt them in
-#        your migration. See #42617, #44048.
-#      - Database could be partially encrypted, see https://www.notion.so/72575933ef2a446bafd16909e05a7387
-#    - Custom migrations:
-#      - Prefer SQL migrations when possible.
-#      - Never use application code: it can change and *will* break your migration.
-#      - Do not use Toucan models - refer table names directly.
-#      - If it's a big change, consider using Quartz, see #42279
-#      - More in `metabase.db.custom_migrations` namespace doc.
-#    - Never delete a migration: users won't be able to downgrade. If you really need to, see #44908
-#    - Migration id (`vXX.<date>`) must match its earliest released version:
-#      - Do not backport `v51....` to version 50, Metabase will try to downgrade it.
-#      - Instead, write a migration with an oldest target you plan to backport to in mind.
-#
-# 2) Run ./bin/lint-migrations-file.sh to run core.spec checks against any changes you make here. Liquibase is pretty
-#    forgiving and won't complain if you accidentally mix up things like deleteCascade and onDelete: CASCADE. CI runs
-#    this check but it's nicer to know now instead of waiting for CI.
-#
-# 3) Migration IDs should follow the format
-#
-#    vMM.TIMESTAMP
-#
-#    Where
-#
-#    M         = major version
-#    TIMESTAMP = the current timestamp with format `yyyy-MM-dd'T'HH:mm:ss`
-#                To get this timestamp, evaluate this in your REPL: `(dev/migration-timestamp)`
-#
-#    E.g: You're adding a new migration for version 49, And it's 10:30:00AM on April 1, 2023 (UTC),
-#    your migration id should be: `v49.2023-04-01T10:30:00`.
-#
-# PLEASE KEEP THIS MESSAGE AT THE BOTTOM OF THIS FILE!!!!! Add new migrations above the message.
-#
-########################################################################################################################
+            remarks: whether the channel is active
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            remarks: Timestamp when the channel was inserted
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            remarks: Timestamp when the channel was updated
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+- changeSet:
+    id: v51.2024-07-08T10:00:01
+    author: qnkhuat
+    comment: Create pulse_channel.channel_id
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: pulse_channel, columnName: channel_id}
+    changes:
+    - addColumn:
+        tableName: pulse_channel
+        columns:
+        - column: {name: channel_id, type: integer, remarks: The channel ID}
+- changeSet:
+    id: v51.2024-07-08T10:00:02
+    author: qnkhuat
+    comment: Add fk constraint to pulse_channel.channel_id
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - foreignKeyConstraintExists: {foreignKeyName: fk_pulse_channel_channel_id, foreignKeyTableName: pulse_channel}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: pulse_channel, baseColumnNames: channel_id, referencedTableName: channel, referencedColumnNames: id, constraintName: fk_pulse_channel_channel_id, nullable: true, deleteCascade: true}
+- changeSet:
+    id: v51.2024-07-09T17:15:43
+    author: tsmacdonald
+    comment: Fix default boolean value for query_field.explicit_reference
+    dbms: mysql,mariadb
+    changes:
+    - addDefaultValue: {tableName: query_field, columnName: explicit_reference, defaultValueBoolean: true}
+- changeSet:
+    id: v51.2024-07-10T12:28:10
+    author: johnswanson
+    comment: Add `last_viewed_at` to dashboards
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: report_dashboard, columnName: last_viewed_at}
+    changes:
+    - addColumn:
+        tableName: report_dashboard
+        columns:
+        - column:
+            name: last_viewed_at
+            type: ${timestamp_type}
+            remarks: Timestamp of when this dashboard was last viewed
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v51.2024-07-22T15:49:37
+    author: escherize
+    comment: Add embedding_client column to query_execution for metabase embedding SDK analytics
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: query_execution, columnName: embedding_client}
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column:
+            name: embedding_client
+            remarks: Used by the embedding team to track SDK usage
+            type: varchar(254)
+            constraints: {nullable: true}
+- changeSet:
+    id: v51.2024-07-22T15:49:38
+    author: escherize
+    comment: Add embedding_version column to query_execution for metabase embedding SDK analytics
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: query_execution, columnName: embedding_version}
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column:
+            name: embedding_version
+            remarks: Used by the embedding team to track SDK version usage
+            type: varchar(254)
+            constraints: {nullable: true}
+- changeSet:
+    id: v51.2024-07-22T15:49:39
+    author: escherize
+    comment: Add embedding_client column to view_log for metabase embedding SDK analytics
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: view_log, columnName: embedding_client}
+    changes:
+    - addColumn:
+        tableName: view_log
+        columns:
+        - column:
+            name: embedding_client
+            remarks: Used by the embedding team to track SDK usage
+            type: varchar(254)
+            constraints: {nullable: true}
+- changeSet:
+    id: v51.2024-07-22T15:49:40
+    author: escherize
+    comment: Add embedding_version column to view_log for metabase embedding SDK analytics
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: view_log, columnName: embedding_version}
+    changes:
+    - addColumn:
+        tableName: view_log
+        columns:
+        - column:
+            name: embedding_version
+            remarks: Used by the embedding team to track SDK version usage
+            type: varchar(254)
+            constraints: {nullable: true}
+- changeSet:
+    id: v51.2024-07-25T11:56:27
+    author: crisptrutski
+    comment: Wipe stale query fields, so we can add new non-nullable columns
+    rollback: null
+    changes:
+    - delete: {tableName: query_field, remarks: 'remove stale analysis, so the new fields can be non-nullable'}
+- changeSet:
+    id: v51.2024-07-25T11:57:27
+    author: crisptrutski
+    comment: Add `column` column to query fields
+    preConditions:
+    - not:
+      - columnExists: {tableName: query_field, columnName: column}
+    changes:
+    - addColumn:
+        tableName: query_field
+        columns:
+        - column:
+            name: column
+            type: varchar(254)
+            remarks: name of the table or card being referenced
+            constraints: {nullable: false}
+- changeSet:
+    id: v51.2024-07-25T11:58:27
+    author: crisptrutski
+    comment: Add `table` column to query fields
+    preConditions:
+    - not:
+      - columnExists: {tableName: query_field, columnName: table}
+    changes:
+    - addColumn:
+        tableName: query_field
+        columns:
+        - column:
+            name: table
+            type: varchar(254)
+            remarks: name of the table or card being referenced
+            constraints: {nullable: false}
+- changeSet:
+    id: v51.2024-07-25T12:02:21
+    validCheckSum: ANY
+    author: crisptrutski
+    comment: Make `field_id` nullable on query fields
+    rollback:
+    - delete: {tableName: query_field, where: query_field.field_id is NULL, remarks: 'remove stale analysis, so the fields can be non-nullable'}
+    changes:
+    - dropNotNullConstraint: {tableName: query_field, columnDataType: int, columnName: field_id, remarks: 'This value is null if the field does not exist, or is created within a model'}
+- changeSet:
+    id: v51.2024-07-26T11:56:27
+    author: crisptrutski
+    comment: Add `table_id` column to query fields
+    preConditions:
+    - not:
+      - columnExists: {tableName: query_field, columnName: table_id}
+    changes:
+    - addColumn:
+        tableName: query_field
+        columns:
+        - column:
+            name: table_id
+            type: int
+            remarks: track the table directly, in case the field does not exist
+            constraints: {nullable: true}
+- changeSet:
+    id: v51.2024-07-29T09:22:12
+    author: crisptrutski
+    comment: Add the query_analysis table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: query_analysis}
+    changes:
+    - createTable:
+        tableName: query_analysis
+        remarks: Parent node for query analysis records
+        columns:
+        - column:
+            name: id
+            remarks: PK
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: card_id
+            remarks: referenced card
+            type: int
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_query_analysis_card_id, deleteCascade: true}
+        - column:
+            remarks: The timestamp of when the analysis was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the analysis was updated
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v51.2024-07-29T09:23:12
+    author: crisptrutski
+    comment: Index query_analysis.card_id
+    rollback: null
+    preConditions: null
+    changes:
+    - createIndex:
+        tableName: query_analysis
+        indexName: idx_query_analysis_card_id
+        columns:
+          column: {name: card_id}
+- changeSet:
+    id: v51.2024-07-29T09:24:13
+    author: crisptrutski
+    comment: Add the query_table join table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: query_table}
+    changes:
+    - createTable:
+        tableName: query_table
+        remarks: Tables used by a card's query
+        columns:
+        - column:
+            name: id
+            remarks: PK
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: card_id
+            remarks: referenced card
+            type: int
+            constraints: {nullable: false, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_query_table_card_id, deleteCascade: true}
+        - column:
+            name: analysis_id
+            remarks: round of analysis
+            type: int
+            constraints: {nullable: false, referencedTableName: query_analysis, referencedColumnNames: id, foreignKeyName: fk_query_table_analysis_id, deleteCascade: true}
+        - column:
+            name: table_id
+            remarks: referenced field
+            type: int
+            constraints: {nullable: true, referencedTableName: metabase_table, referencedColumnNames: id, foreignKeyName: fk_query_table_table_id, deleteCascade: true}
+        - column:
+            name: schema
+            type: varchar(254)
+            remarks: name of the schema of the table being referenced
+            constraints: {nullable: true}
+        - column:
+            name: table
+            type: varchar(254)
+            remarks: name of the table or card being referenced
+            constraints: {nullable: false}
+- changeSet:
+    id: v51.2024-07-29T09:25:13
+    author: crisptrutski
+    comment: Index query_table.card_id
+    rollback: null
+    preConditions: null
+    changes:
+    - createIndex:
+        tableName: query_table
+        indexName: idx_query_table_card_id
+        columns:
+          column: {name: card_id}
+- changeSet:
+    id: v51.2024-07-29T09:25:14
+    author: crisptrutski
+    comment: Index query_table.analysis_id
+    rollback: null
+    preConditions: null
+    changes:
+    - createIndex:
+        tableName: query_table
+        indexName: idx_query_table_analysis_id
+        columns:
+          column: {name: analysis_id}
+- changeSet:
+    id: v51.2024-07-29T09:25:15
+    author: crisptrutski
+    comment: Index query_table.table_id
+    rollback: null
+    preConditions: null
+    changes:
+    - createIndex:
+        tableName: query_table
+        indexName: idx_query_table_table_id
+        columns:
+          column: {name: table_id}
+- changeSet:
+    id: v51.2024-07-29T10:03:27
+    author: crisptrutski
+    comment: Wipe stale query fields, so we can add new non-nullable columns
+    rollback: null
+    changes:
+    - delete: {tableName: query_field, remarks: 'remove stale analysis, so the new fields can be non-nullable'}
+- changeSet:
+    id: v51.2024-07-29T10:04:13
+    author: crisptrutski
+    comment: Put Query Fields under a parent Query Analysis record
+    preConditions:
+    - not:
+      - columnExists: {tableName: query_field, columnName: analysis_id}
+    changes:
+    - addColumn:
+        tableName: query_field
+        columns:
+        - column:
+            name: analysis_id
+            remarks: round of analysis
+            type: int
+            constraints: {nullable: false, referencedTableName: query_analysis, referencedColumnNames: id, foreignKeyName: fk_query_field_analysis_id, deleteCascade: true, deleteCascadeForce: true}
+    rollback:
+    - dropForeignKeyConstraint: {baseTableName: query_field, constraintName: fk_query_field_analysis_id}
+    - dropColumn: {tableName: query_field, columnName: analysis_id}
+- changeSet:
+    id: v51.2024-07-29T11:25:13
+    author: crisptrutski
+    comment: Index query_field.analysis_id
+    rollback: null
+    preConditions: null
+    changes:
+    - createIndex:
+        tableName: query_field
+        indexName: idx_query_field_analysis_id
+        columns:
+          column: {name: analysis_id}
+- changeSet:
+    id: v51.2024-08-02T11:56:27
+    author: crisptrutski
+    comment: Add `schema` column to query fields
+    preConditions:
+    - not:
+      - columnExists: {tableName: query_field, columnName: schema}
+    changes:
+    - addColumn:
+        tableName: query_field
+        columns:
+        - column:
+            name: schema
+            type: varchar(254)
+            remarks: name of the schema of the table being referenced
+            constraints: {nullable: true}
+- changeSet:
+    id: v51.2024-08-02T12:02:21
+    validCheckSum: ANY
+    author: crisptrutski
+    comment: Make `table` nullable on query fields
+    rollback: null
+    changes:
+    - dropNotNullConstraint: {tableName: query_field, columnDataType: varchar(254), columnName: table, remarks: 'This value is null if the field does not exist, and macaw could not determine the table'}
+- changeSet:
+    id: v51.2024-08-05T16:00:00
+    author: metamben
+    comment: Add source card reference to report_card to support metrics based models and questions
+    preConditions:
+    - not:
+      - columnExists: {tableName: report_card, columnName: source_card_id}
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column: {name: source_card_id, remarks: The ID of the model or question this card is based on, type: int}
+- changeSet:
+    id: v51.2024-08-05T16:00:01
+    author: metamben
+    comment: Add FK constraint to report_card.source_card_id
+    preConditions: null
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_card, baseColumnNames: source_card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_report_card_source_card_id_ref_report_card_id, nullable: true, deleteCascade: true}
+- changeSet:
+    id: v51.2024-08-05T16:00:02
+    author: metamben
+    comment: Index report_card.source_card_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: report_card, indexName: idx_report_card_source_card_id}
+    changes:
+    - createIndex:
+        tableName: report_card
+        indexName: idx_report_card_source_card_id
+        columns:
+          column: {name: source_card_id}
+- changeSet:
+    id: v51.2024-08-07T10:00:00
+    author: ranquild
+    comment: Remove field refs from report_card.visualization_settings.column_settings
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateLegacyColumnKeysInCardVizSettings}
+- changeSet:
+    id: v51.2024-08-07T11:00:00
+    author: ranquild
+    comment: Remove field refs from report_dashboardcard.visualization_settings.column_settings
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateLegacyColumnKeysInDashboardCardVizSettings}
+- changeSet:
+    id: v51.2024-08-26T08:53:46
+    author: crisptrutski
+    comment: Add a status column to track the progress and outcome of query analysis
+    preConditions:
+    - not:
+      - columnExists: {tableName: query_analysis, columnName: status}
+    changes:
+    - addColumn:
+        tableName: query_analysis
+        columns:
+        - column: {name: status, type: '${text.type}', remarks: 'running, failed, or completed'}
+- changeSet:
+    id: v51.2024-09-03T16:54:18
+    author: adam-james
+    comment: Add pivot_results to pulse_card
+    preConditions:
+    - not:
+      - columnExists: {tableName: pulse_card, columnName: pivot_results}
+    changes:
+    - addColumn:
+        tableName: pulse_card
+        columns:
+        - column: {name: pivot_results, type: '${boolean.type}', defaultValue: false, remarks: Whether or not to apply pivot processing to the rows of the export}
+- changeSet:
+    id: v51.2024-09-09T15:11:16
+    author: johnswanson
+    comment: add an index for `collection.type`
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: collection, indexName: idx_collection_type}
+    changes:
+    - createIndex:
+        tableName: collection
+        columns:
+        - column: {name: type}
+        indexName: idx_collection_type
+- changeSet:
+    id: v51.2024-09-26T03:01:00
+    author: escherize
+    comment: iff enable-embedding is set, copy -> enable-embedding-interactive
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: postgresql}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE key = 'enable-embedding';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE `key` = 'enable-embedding';}
+      - and:
+        - dbms: {type: h2}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-embedding';}
+    changes:
+    - sql: {dbms: postgresql, sql: 'INSERT INTO setting (key, value) SELECT ''enable-embedding-interactive'', value FROM setting WHERE key = ''enable-embedding'';'}
+    - sql: {dbms: 'mysql,mariadb', sql: 'INSERT INTO setting (`key`, `value`) SELECT ''enable-embedding-interactive'', value FROM setting WHERE `key` = ''enable-embedding'';'}
+    - sql: {dbms: h2, sql: 'INSERT INTO setting ("KEY", "VALUE") SELECT ''enable-embedding-interactive'', "VALUE" FROM setting WHERE "KEY" = ''enable-embedding'';'}
+    rollback: null
+- changeSet:
+    id: v51.2024-09-26T03:02:00
+    author: escherize
+    comment: iff enable-embedding is set, copy -> enable-embedding-static
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: postgresql}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE key = 'enable-embedding';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE `key` = 'enable-embedding';}
+      - and:
+        - dbms: {type: h2}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-embedding';}
+    changes:
+    - sql: {dbms: postgresql, sql: 'INSERT INTO setting (key, value) SELECT ''enable-embedding-static'', value FROM setting WHERE key = ''enable-embedding'';'}
+    - sql: {dbms: 'mysql,mariadb', sql: 'INSERT INTO setting (`key`, `value`) SELECT ''enable-embedding-static'', value FROM setting WHERE `key` = ''enable-embedding'';'}
+    - sql: {dbms: h2, sql: 'INSERT INTO setting ("KEY", "VALUE") SELECT ''enable-embedding-static'', "VALUE" FROM setting WHERE "KEY" = ''enable-embedding'';'}
+    rollback: null
+- changeSet:
+    id: v51.2024-09-26T03:03:00
+    author: escherize
+    comment: iff enable-embedding is set, copy -> enable-embedding-sdk
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: postgresql}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE key = 'enable-embedding';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE `key` = 'enable-embedding';}
+      - and:
+        - dbms: {type: h2}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE "KEY" = 'enable-embedding';}
+    changes:
+    - sql: {dbms: postgresql, sql: 'INSERT INTO setting (key, value) SELECT ''enable-embedding-sdk'', value FROM setting WHERE key = ''enable-embedding'';'}
+    - sql: {dbms: 'mysql,mariadb', sql: 'INSERT INTO setting (`key`, `value`) SELECT ''enable-embedding-sdk'', value FROM setting WHERE `key` = ''enable-embedding'';'}
+    - sql: {dbms: h2, sql: 'INSERT INTO setting ("KEY", "VALUE") SELECT ''enable-embedding-sdk'', "VALUE" FROM setting WHERE "KEY" = ''enable-embedding'';'}
+    rollback: null
+- changeSet:
+    id: v51.2024-09-26T03:04:00
+    author: escherize
+    comment: iff embedding-app-origin is set, copy -> embedding-app-origins-interactive
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: postgresql}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE key = 'embedding-app-origin';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE `key` = 'embedding-app-origin';}
+      - and:
+        - dbms: {type: h2}
+        - sqlCheck: {expectedResult: 1, sql: SELECT count(*) FROM setting WHERE "KEY" = 'embedding-app-origin';}
+    changes:
+    - sql: {dbms: postgresql, sql: 'INSERT INTO setting (key, value) SELECT ''embedding-app-origins-interactive'', value FROM setting WHERE key = ''embedding-app-origin'';'}
+    - sql: {dbms: 'mysql,mariadb', sql: 'INSERT INTO setting (`key`, `value`) SELECT ''embedding-app-origins-interactive'', value FROM setting WHERE `key` = ''embedding-app-origin'';'}
+    - sql: {dbms: h2, sql: 'INSERT INTO setting ("KEY", "VALUE") SELECT ''embedding-app-origins-interactive'', "VALUE" FROM setting WHERE "KEY" = ''embedding-app-origin'';'}
+    rollback: null
+- changeSet:
+    id: v51.2024-10-24T14:23:58
+    author: noahmoss
+    comment: Drop not null constraint on persisted_info.card_id
+    changes:
+    - dropNotNullConstraint: {tableName: persisted_info, columnName: card_id, columnDataType: int}
+    rollback:
+    - addNotNullConstraint: {tableName: persisted_info, columnName: card_id, columnDataType: int}
+- changeSet:
+    id: v51.2024-10-24T14:24:59
+    author: noahmoss
+    comment: Drop foreign key constraint on persisted_info.card_id
+    preConditions:
+    - foreignKeyConstraintExists: {foreignKeyName: fk_persisted_info_card_id, foreignKeyTableName: persisted_info}
+    changes:
+    - dropForeignKeyConstraint: {constraintName: fk_persisted_info_card_id, baseTableName: persisted_info}
+    rollback:
+    - addForeignKeyConstraint: {baseTableName: persisted_info, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_persisted_info_card_id, onDelete: CASCADE}
+- changeSet:
+    id: v51.2024-10-24T14:25:01
+    author: noahmoss
+    comment: Re-add nullable foreign key constraint on persisted_info.card_id
+    preConditions:
+    - not:
+      - {foreignKeyConstraintExists: null, foreignKeyName: fk_persisted_info_card_id, foreignKeyTableName: persisted_info}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: persisted_info, baseColumnNames: card_id, referencedTableName: report_card, referencedColumnNames: id, constraintName: fk_persisted_info_card_id, onDelete: SET NULL}
+    rollback:
+    - dropForeignKeyConstraint: {constraintName: fk_persisted_info_card_id, baseTableName: persisted_info}
+- changeSet:
+    id: v52.2024-09-05T08:00:00
+    author: qnkhuat
+    comment: Create the notification table
+    preConditions:
+    - not:
+      - tableExists: {tableName: notification}
+    changes:
+    - createTable:
+        tableName: notification
+        remarks: join table that connect notification subscriptions and notification handlers
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: payload_type
+            remarks: the type of the payload
+            type: varchar(64)
+            constraints: {nullable: false}
+        - column:
+            name: active
+            remarks: whether the notification is active
+            type: ${boolean.type}
+            constraints: {nullable: false}
+            defaultValueBoolean: true
+        - column:
+            remarks: The timestamp of when the notification was created
+            name: created_at
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            remarks: The timestamp of when the notification was updated
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+- changeSet:
+    id: v52.2024-09-05T08:00:01
+    author: qnkhuat
+    comment: Create the notification_subscription table
+    preConditions:
+    - not:
+      - tableExists: {tableName: notification_subscription}
+    changes:
+    - createTable:
+        remarks: which type of trigger a notification is subscribed to
+        tableName: notification_subscription
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: notification_id
+            remarks: the notification that the subscription is connected to
+            type: int
+            constraints: {nullable: false, referencedTableName: notification, referencedColumnNames: id, foreignKeyName: fk_notification_subscription_notification_id, deleteCascade: true}
+        - column:
+            name: type
+            remarks: the type of the subscription
+            type: varchar(64)
+            constraints: {nullable: false}
+        - column:
+            name: event_name
+            remarks: the event name of subscriptions with type :notification-subscription/system-event
+            type: varchar(64)
+            constraints: {nullable: true}
+        - column:
+            name: created_at
+            remarks: The timestamp of when the subscription was created
+            type: ${timestamp_type}
+            constraints: {nullable: false}
+- changeSet:
+    id: v52.2024-09-05T08:00:02
+    author: qnkhuat
+    comment: index on notification_subscription.notification_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: notification_subscription, indexName: idx_notification_subscription_notification_id}
+    changes:
+    - createIndex:
+        tableName: notification_subscription
+        columns:
+        - column: {name: notification_id}
+        indexName: idx_notification_subscription_notification_id
+- changeSet:
+    id: v52.2024-09-05T08:00:03
+    author: qnkhuat
+    comment: Create the channel_template table
+    preConditions:
+    - not:
+      - tableExists: {tableName: channel_template}
+    changes:
+    - createTable:
+        tableName: channel_template
+        remarks: custom template for the channel
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: name
+            type: varchar(64)
+            remarks: the name of the template
+            constraints: {nullable: false}
+        - column:
+            name: channel_type
+            type: varchar(64)
+            remarks: the channel type of the template
+            constraints: {nullable: false}
+        - column:
+            name: details
+            type: ${text.type}
+            remarks: the details of the template
+            constraints: {nullable: true}
+        - column:
+            name: entity_id
+            type: char(21)
+            remarks: Random NanoID tag for unique identity.
+            constraints: {nullable: true, unique: true}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the template was created
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the template was last updated
+            constraints: {nullable: false}
+- changeSet:
+    id: v52.2024-09-05T08:00:04
+    author: qnkhuat
+    comment: Create the notification_handler table
+    validCheckSum: ANY
+    preConditions:
+    - not:
+      - tableExists: {tableName: notification_handler}
+    changes:
+    - createTable:
+        tableName: notification_handler
+        remarks: which channel to send the notification to
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: channel_type
+            type: varchar(64)
+            remarks: the type of the channel, like :channel/email, :channel/slack
+            constraints: {nullable: false}
+        - column:
+            name: notification_id
+            type: int
+            remarks: the notification that the handler is connected to
+            constraints: {nullable: false, referencedTableName: notification, referencedColumnNames: id, foreignKeyName: fk_notification_handler_notification_id, deleteCascade: true}
+        - column:
+            name: channel_id
+            type: int
+            remarks: the channel that the handler is connected to
+            constraints: {nullable: true, referencedTableName: channel, referencedColumnNames: id, foreignKeyName: fk_notification_handler_channel_id, deleteCascade: true}
+        - column:
+            name: template_id
+            type: int
+            remarks: the template that the handler is connected to
+            constraints: {nullable: true}
+        - column:
+            name: active
+            type: ${boolean.type}
+            remarks: whether the handler is active
+            defaultValueBoolean: true
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the handler was created
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the handler was updated
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v52.2024-09-05T08:00:05
+    author: qnkhuat
+    comment: Add fk constraint to notification_handler.template_id
+    preConditions:
+    - not:
+      - foreignKeyConstraintExists: {foreignKeyName: fk_notification_handler_template_id, foreignKeyTableName: notification_handler}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: notification_handler, baseColumnNames: template_id, referencedTableName: channel_template, referencedColumnNames: id, constraintName: fk_notification_handler_template_id, onDelete: SET NULL}
+- changeSet:
+    id: v52.2024-09-05T08:00:06
+    author: qnkhuat
+    comment: index on notification_handler.notification_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: notification_handler, indexName: idx_notification_handler_notification_id}
+    changes:
+    - createIndex:
+        tableName: notification_handler
+        columns:
+        - column: {name: notification_id}
+        indexName: idx_notification_handler_notification_id
+- changeSet:
+    id: v52.2024-09-05T08:00:07
+    author: qnkhuat
+    comment: index on notification_handler.channel_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: notification_handler, indexName: idx_notification_handler_channel_id}
+    changes:
+    - createIndex:
+        tableName: notification_handler
+        columns:
+        - column: {name: channel_id}
+        indexName: idx_notification_handler_channel_id
+- changeSet:
+    id: v52.2024-09-05T08:00:08
+    author: qnkhuat
+    comment: index on notification_handler.template_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: notification_handler, indexName: idx_notification_handler_template_id}
+    changes:
+    - createIndex:
+        tableName: notification_handler
+        columns:
+        - column: {name: template_id}
+        indexName: idx_notification_handler_template_id
+- changeSet:
+    id: v52.2024-09-05T08:00:09
+    author: qnkhuat
+    comment: Create the notification_recipient table
+    preConditions:
+    - not:
+      - tableExists: {tableName: notification_recipient}
+    changes:
+    - createTable:
+        tableName: notification_recipient
+        remarks: who should receive the notification
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: notification_handler_id
+            type: int
+            remarks: the handler that the recipient is connected to
+            constraints: {nullable: false, referencedTableName: notification_handler, referencedColumnNames: id, foreignKeyName: fk_notification_recipient_notification_handler_id, deleteCascade: true}
+        - column:
+            name: type
+            type: varchar(64)
+            remarks: the type of the recipient
+            constraints: {nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: a user if the recipient has type user
+            constraints: {nullable: true, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_notification_recipient_user_id, deleteCascade: true}
+        - column:
+            name: permissions_group_id
+            type: int
+            remarks: a permissions group if the recipient has type permissions_group
+            constraints: {nullable: true, referencedTableName: permissions_group, referencedColumnNames: id, foreignKeyName: fk_notification_recipient_permissions_group_id, deleteCascade: true}
+        - column:
+            name: details
+            type: ${text.type}
+            remarks: custom details for the recipient
+            constraints: {nullable: true}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the recipient was created
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the recipient was updated
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v52.2024-09-05T08:00:10
+    author: qnkhuat
+    comment: index on notification_recipient.notification_handler_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: notification_recipient, indexName: idx_notification_recipient_notification_handler_id}
+    changes:
+    - createIndex:
+        tableName: notification_recipient
+        columns:
+        - column: {name: notification_handler_id}
+        indexName: idx_notification_recipient_notification_handler_id
+- changeSet:
+    id: v52.2024-09-05T08:00:11
+    author: qnkhuat
+    comment: index on notification_recipient.user_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: notification_recipient, indexName: idx_notification_recipient_user_id}
+    changes:
+    - createIndex:
+        tableName: notification_recipient
+        columns:
+        - column: {name: user_id}
+        indexName: idx_notification_recipient_user_id
+- changeSet:
+    id: v52.2024-09-05T08:00:12
+    author: qnkhuat
+    comment: index on notification_recipient.permissions_group_id
+    rollback: null
+    preConditions:
+    - not:
+      - indexExists: {tableName: notification_recipient, indexName: idx_notification_recipient_permissions_group_id}
+    changes:
+    - createIndex:
+        tableName: notification_recipient
+        columns:
+        - column: {name: permissions_group_id}
+        indexName: idx_notification_recipient_permissions_group_id
+- changeSet:
+    id: v52.2024-09-05T08:00:13
+    author: qnkhuat
+    comment: Drop the channel_template.entity_id column
+    preConditions:
+    - {onFail: MARK_RAN}
+    - columnExists: {tableName: metabase_database, columnName: is_attached_dwh}
+    changes:
+    - dropColumn: {tableName: channel_template, columnName: entity_id}
+    rollback: null
+- changeSet:
+    id: v52.2024-10-15T08:00:00
+    author: qnkhuat
+    comment: add notification_subscription.cron_schedule
+    preConditions:
+    - not:
+      - columnExists: {tableName: notification_subscription, columnName: cron_schedule}
+    changes:
+    - addColumn:
+        tableName: notification_subscription
+        columns:
+        - column:
+            name: cron_schedule
+            type: varchar(128)
+            remarks: the cron schedule for the subscription
+            constraints: {nullable: true}
+- changeSet:
+    id: v52.2024-10-26T18:42:42
+    author: metamben
+    comment: Add stage-number to dimension targets in parameter_mappings
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.AddStageNumberToParameterMappingTargets}
+- changeSet:
+    id: v52.2024-11-12T15:13:18
+    author: metamben
+    comment: Add stage-number to dimension targets in visualization_settings
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.AddStageNumberToVizSettingsParameterMappingTargets}
+- changeSet:
+    id: v52.2024-12-03T15:55:22
+    author: escherize
+    comment: Create New and improved Sample Content
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.CreateSampleContentV2}
+- changeSet:
+    id: v52.2024-12-10T10:28:16
+    author: johnswanson
+    comment: Add `report_card.dashboard_id`
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: report_card, columnName: dashboard_id}
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: dashboard_id
+            type: int
+            remarks: The dashboard that owns the card, if it is a dashboard-internal card.
+            constraints: {nullable: true}
+- changeSet:
+    id: v52.2024-12-10T10:28:21
+    author: johnswanson
+    comment: Make `report_card.dashboard_id` a foreign key
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - foreignKeyConstraintExists:
+        - {foreignKeyName: fk_report_card_ref_dashboard_id}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: report_card, baseColumnNames: dashboard_id, referencedTableName: report_dashboard, referencedColumnNames: id, constraintName: fk_report_card_ref_dashboard_id, onDelete: CASCADE}
+- changeSet:
+    id: v52.2024-12-10T10:28:24
+    author: johnswanson
+    comment: Add an index for `report_card.dashboard_id`
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: report_card, indexName: idx_report_card_dashboard_id}
+    changes:
+    - createIndex:
+        indexName: idx_report_card_dashboard_id
+        tableName: report_card
+        columns:
+        - column: {name: dashboard_id}
+- changeSet:
+    id: v52.2024-12-16T09:19:00
+    author: crisptrutski
+    comment: Metadata about search indexes
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: search_index_metadata}
+    changes:
+    - createTable:
+        tableName: search_index_metadata
+        remarks: Each entry corresponds to some queryable index, and contains metadata about it.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: engine
+            type: varchar(64)
+            remarks: The kind of search engine which this index belongs to.
+            constraints: {nullable: false}
+        - column:
+            name: version
+            type: varchar(254)
+            remarks: Used to determine metabase compatibility. Format may depend on engine in future.
+            constraints: {nullable: false}
+        - column:
+            name: index_name
+            type: varchar(254)
+            remarks: The name by which the given engine refers to this particular index, e.g. table name.
+            constraints: {nullable: false, unique: true}
+        - column:
+            name: status
+            type: varchar(32)
+            remarks: One of 'pending', 'active', or 'retired'
+            constraints: {nullable: true}
+        - column:
+            remarks: The timestamp of when the index was created
+            name: created_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            remarks: The timestamp of when the index status was updated
+            name: updated_at
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v52.2024-12-16T09:20:00
+    author: crisptrutski
+    comment: Protection against concurrent creation or promotion of indexes.
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: search_index_metadata, indexName: idx_search_index_metadata_unique_status}
+    changes:
+    - addUniqueConstraint: {remarks: 'Unique entry for each status, from any given metabase instance''s perspective.', tableName: search_index_metadata, constraintName: idx_search_index_metadata_unique_status, columnNames: 'engine, version, status'}
+- changeSet:
+    id: v52.2025-01-05T00:00:01
+    author: escherize
+    comment: set enable-embedding-sdk false when embedding-app-origins-sdk value exists
+    preConditions:
+    - {onFail: MARK_RAN}
+    - or:
+      - and:
+        - dbms: {type: postgresql}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE key = 'embedding-app-origins-sdk';}
+      - and:
+        - dbms: {type: 'mysql,mariadb'}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE `key` = 'embedding-app-origins-sdk';}
+      - and:
+        - dbms: {type: h2}
+        - sqlCheck: {expectedResult: 0, sql: SELECT count(*) FROM setting WHERE "KEY" = 'embedding-app-origins-sdk';}
+    changes:
+    - sql: {dbms: postgresql, sql: update setting set value = 'false' where key = 'enable-embedding-sdk';}
+    - sql: {dbms: 'mysql,mariadb', sql: UPDATE setting set `value` = 'false' where `key` = 'enable-embedding-sdk';}
+    - sql: {dbms: h2, sql: UPDATE setting set "VALUE" = 'false' where "KEY" = 'enable-embedding-sdk';}
+    rollback: null
+- changeSet:
+    id: v53.2024-12-02T16:21:15
+    author: noahmoss
+    comment: Add cache_config.refresh_automatically column
+    preConditions:
+    - not:
+      - columnExists: {tableName: cache_config, columnName: refresh_automatically}
+    changes:
+    - addColumn:
+        tableName: cache_config
+        columns:
+        - column:
+            name: refresh_automatically
+            type: ${boolean.type}
+            remarks: Whether or not we should automatically refresh cache results when a cache expires
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+- changeSet:
+    id: v53.2024-12-02T17:21:16
+    validCheckSum: ['9:209a494b250a08f022114249697cbc1b', '9:8adcf08936200cc74153d0c306452e0c']
+    author: noahmoss
+    comment: Add query_execution.parameterized column
+    preConditions:
+    - not:
+      - columnExists: {tableName: query_execution, columnName: parameterized}
+    changes:
+    - addColumn:
+        tableName: query_execution
+        columns:
+        - column:
+            name: parameterized
+            type: ${boolean.type}
+            remarks: Whether or not the query has parameters with non-nil values
+            constraints: {nullable: true}
+- changeSet:
+    id: v53.2024-12-10T10:00:00
+    author: qnkhuat
+    comment: add notification.internal_id
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: notification, columnName: internal_id}
+    changes:
+    - addColumn:
+        tableName: notification
+        columns:
+        - column:
+            name: internal_id
+            type: varchar(254)
+            remarks: the internal id of the notification
+            constraints: {nullable: true, unique: true}
+- changeSet:
+    id: v53.2024-12-10T10:00:10
+    author: qnkhuat
+    comment: Truncate the notification tables
+    rollback: null
+    changes:
+    - sql: {dbms: postgresql, sql: TRUNCATE TABLE notification RESTART IDENTITY CASCADE; TRUNCATE TABLE notification_handler RESTART IDENTITY CASCADE; TRUNCATE TABLE notification_subscription RESTART IDENTITY CASCADE; TRUNCATE TABLE notification_recipient RESTART IDENTITY CASCADE; TRUNCATE TABLE channel_template RESTART IDENTITY CASCADE;}
+    - sql: {dbms: 'mysql,mariadb', sql: DELETE FROM notification; ALTER TABLE notification AUTO_INCREMENT = 1; DELETE FROM notification_handler; ALTER TABLE notification_handler AUTO_INCREMENT = 1; DELETE FROM notification_subscription; ALTER TABLE notification_subscription AUTO_INCREMENT = 1; DELETE FROM notification_recipient; ALTER TABLE notification_recipient AUTO_INCREMENT = 1; DELETE FROM channel_template; ALTER TABLE channel_template AUTO_INCREMENT = 1;}
+    - sql: {dbms: h2, sql: DELETE FROM notification; DELETE FROM notification_handler; DELETE FROM notification_subscription; DELETE FROM notification_recipient; DELETE FROM channel_template; ALTER TABLE notification ALTER COLUMN id RESTART WITH 1; ALTER TABLE notification_handler ALTER COLUMN id RESTART WITH 1; ALTER TABLE notification_subscription ALTER COLUMN id RESTART WITH 1; ALTER TABLE notification_recipient ALTER COLUMN id RESTART WITH 1; ALTER TABLE channel_template ALTER COLUMN id RESTART WITH 1;}
+- changeSet:
+    id: v53.2024-12-20T19:53:50
+    author: johnswanson
+    comment: |
+      add a table for user-level KV. This is intended for use as a lightweight mechanism for the frontend to be able to mark things as seen, unseen, dismissed, etc
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: user_key_value}
+    changes:
+    - createTable:
+        tableName: user_key_value
+        remarks: A simple key value store for each user.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: user_id
+            type: int
+            remarks: The ID of the user this KV-pair is for
+            constraints: {nullable: false, referencedTableName: core_user, referencedColumnNames: id, foreignKeyName: fk_user_key_value_user_id}
+        - column:
+            name: namespace
+            type: varchar(254)
+            remarks: The namespace for this KV, e.g. "dashboard-filters" or "nobody-knows"
+            constraints: {nullable: false}
+        - column:
+            name: key
+            remarks: The key
+            type: varchar(254)
+            constraints: {nullable: false}
+        - column:
+            name: value
+            remarks: The value, serialized JSON
+            type: ${text.type}
+            constraints: {nullable: true}
+        - column:
+            name: created_at
+            remarks: When this row was created
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            remarks: When this row was last updated
+            type: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column: {name: expires_at, remarks: 'If set, when this row expires', type: '${timestamp_type}', defaultValue: null}
+- changeSet:
+    id: v53.2024-12-20T19:53:59
+    author: johnswanson
+    comment: Add a unique constraint for user_id,namespace,key
+    changes:
+    - addUniqueConstraint: {tableName: user_key_value, columnNames: 'user_id, namespace, key', constraintName: unique_user_key_value_user_id_namespace_key}
+    rollback: null
+- changeSet:
+    id: v53.2024-12-27T17:33:54
+    author: nvoxland
+    comment: Adds encryption-check setting to encryption management
+    changes:
+    - insert:
+        tableName: setting
+        columns:
+        - column: {name: key, value: encryption-check}
+        - column: {name: value, value: unencrypted}
+    rollback:
+    - sql: {sql: delete from setting where "key"='encryption-check', dbms: postgresql}
+    - sql: {sql: delete from setting where `key`='encryption-check', dbms: 'mysql,mariadb'}
+    - sql: {sql: delete from setting where "KEY"='encryption-check', dbms: h2}
+- changeSet:
+    id: v53.2024-12-27T20:17:23
+    author: noahmoss
+    comment: Drop unnecessary NOT NULL constraint from cache_config.refresh_automatically column
+    changes:
+    - dropNotNullConstraint: {tableName: cache_config, columnName: refresh_automatically, columnDataType: '${boolean.type}'}
+    rollback:
+    - addNotNullConstraint: {tableName: cache_config, columnName: refresh_automatically, columnDataType: '${boolean.type}', defaultNullValue: false}
+- changeSet:
+    id: v53.2025-01-03T19:07:39
+    author: noahmoss
+    comment: Add `deactivated_at` column to the `core_user` table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: core_user, columnName: deactivated_at}
+    changes:
+    - addColumn:
+        tableName: core_user
+        columns:
+        - column: {name: deactivated_at, type: '${timestamp_type}', remarks: The timestamp at which a user was deactivated}
+- changeSet:
+    id: v53.2025-02-20T04:49:39
+    author: johnswanson
+    comment: remove unused cards in usage analytics
+    changes:
+    - sql: |
+        DELETE FROM report_card WHERE entity_id IN (
+          'Y0ZykgQ64HHwAW_MYx-dW',
+          '3CtVT_JDxNvMM5aFLtEHR',
+          'hFpp3c-7Y-CtMOrs3zeyn',
+          'PkIueKBME3DfRFwBsYjuE',
+          '4DlO-I7ry2OaVQy7-RGPU',
+          'lh0sbjKcm9BhiiHPpPxRa',
+          '9shJ0y29V5o1lOSDL4ImJ',
+          'WoQnk12nwOaJ1pcb1wsr4',
+          '-_XgVaPuz7MY8jlG0wSEC',
+          'LXu_IZa1EDg3QOhlwunGy',
+          'Fnu5Kh0gYPN6P8A_fvICu'
+        );
+    rollback: null
+- changeSet:
+    id: v53.2025-04-02T15:25:04
+    author: edpaget
+    comment: create new cluster lock table for instance coordination
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: metabase_cluster_lock}
+    changes:
+    - createTable:
+        tableName: metabase_cluster_lock
+        remarks: A table to allow metabase instances to take locks across a cluster
+        columns:
+        - column:
+            name: lock_name
+            type: varchar(254)
+            remarks: a single column that can be used to a lock across a cluster
+            constraints: {primaryKey: true, nullable: false}
+- changeSet:
+    id: v54.2025-01-30T16:10:55
+    author: bshepherdson
+    comment: Add `entity_id` column to the `metabase_database` table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: metabase_database, columnName: entity_id}
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+- changeSet:
+    id: v54.2025-01-30T16:13:20
+    author: bshepherdson
+    comment: Add `entity_id` column to the `metabase_table` table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: metabase_table, columnName: entity_id}
+    changes:
+    - addColumn:
+        tableName: metabase_table
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+- changeSet:
+    id: v54.2025-01-30T16:14:02
+    author: bshepherdson
+    comment: Add `entity_id` column to the `metabase_field` table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: metabase_field, columnName: entity_id}
+    changes:
+    - addColumn:
+        tableName: metabase_field
+        columns:
+        - column:
+            remarks: Random NanoID tag for unique identity.
+            name: entity_id
+            type: char(21)
+            constraints: {nullable: true, unique: true}
+- changeSet:
+    id: v54.2025-02-14T08:00:00
+    author: qnkhuat
+    comment: add notification.payload_id
+    preConditions:
+    - not:
+      - columnExists: {tableName: notification, columnName: payload_id}
+    changes:
+    - addColumn:
+        tableName: notification
+        columns:
+        - column:
+            name: payload_id
+            type: int
+            remarks: the internal id of the notification
+            constraints: {nullable: true}
+- changeSet:
+    id: v54.2025-02-14T08:01:00
+    author: qnkhuat
+    comment: create the notification_card table
+    preConditions:
+    - not:
+      - tableExists: {tableName: notification_card}
+    changes:
+    - createTable:
+        tableName: notification_card
+        remarks: Card related notifications
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: card_id
+            type: int
+            remarks: the card that the alert is connected to
+            constraints: {nullable: true, referencedTableName: report_card, referencedColumnNames: id, foreignKeyName: fk_notification_card_card_id, deleteCascade: true}
+        - column:
+            name: send_once
+            type: ${boolean.type}
+            remarks: whether the alert should only run once
+            defaultValueBoolean: false
+            constraints: {nullable: false}
+        - column:
+            name: send_condition
+            type: varchar(32)
+            remarks: the condition of the alert
+            constraints: {nullable: false}
+        - column:
+            name: created_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the recipient was created
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+        - column:
+            name: updated_at
+            type: ${timestamp_type}
+            remarks: The timestamp of when the recipient was updated
+            defaultValueComputed: current_timestamp
+            constraints: {nullable: false}
+- changeSet:
+    id: v54.2025-02-14T08:03:00
+    author: qnkhuat
+    comment: add notification.creator_id
+    preConditions:
+    - not:
+      - columnExists: {tableName: notification, columnName: creator_id}
+    changes:
+    - addColumn:
+        tableName: notification
+        columns:
+        - column:
+            name: creator_id
+            type: int
+            remarks: the id of the creator
+            constraints: {nullable: true}
+- changeSet:
+    id: v54.2025-02-14T08:04:00
+    author: qnkhuat
+    comment: add fk constraint to notification.creator_id
+    preConditions:
+    - not:
+      - foreignKeyConstraintExists: {foreignKeyName: fk_notification_creator_id, foreignKeyTableName: notification}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: notification, baseColumnNames: creator_id, referencedTableName: core_user, referencedColumnNames: id, constraintName: fk_notification_creator_id, onDelete: CASCADE, nullable: true}
+- changeSet:
+    id: v54.2025-02-14T08:04:01
+    author: qnkhuat
+    comment: Add an index for `notification.creator_id`
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: notification, indexName: idx_notification_creator_id}
+    changes:
+    - createIndex:
+        indexName: idx_notification_creator_id
+        tableName: notification
+        columns:
+        - column: {name: creator_id}
+- changeSet:
+    id: v54.2025-02-14T08:04:02
+    author: qnkhuat
+    comment: Add an index for `notification_card.card_id`
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: notification_card, indexName: idx_notification_card_card_id}
+    changes:
+    - createIndex:
+        indexName: idx_notification_card_card_id
+        tableName: notification_card
+        columns:
+        - column: {name: card_id}
+- changeSet:
+    id: v54.2025-02-14T08:05:00
+    author: qnkhuat
+    comment: Migrate alert to notification
+    changes:
+    - customChange: {class: metabase.db.custom_migrations.MigrateAlertToNotification}
+- changeSet:
+    id: v54.2025-02-14T08:06:00
+    author: qnkhuat
+    comment: Delete all the migrated alerts from notification table
+    changes:
+    - {sql: select 1;}
+    rollback:
+    - sql: {sql: DELETE FROM notification WHERE payload_type = 'notification/card';}
+- changeSet:
+    id: v54.2025-02-14T08:07:00
+    author: qnkhuat
+    comment: Update view v_alerts to read from notification tables
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/alerts/v2/postgres-alerts.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/alerts/v2/mysql-alerts.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/alerts/v2/h2-alerts.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/alerts/v1/postgres-alerts.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/alerts/v1/mysql-alerts.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/alerts/v1/h2-alerts.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v54.2025-03-06T16:55:15
+    author: nvoxland
+    comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
+    preConditions: null
+    changes:
+    - addColumn:
+        tableName: core_session
+        columns:
+        - column:
+            name: key_hashed
+            type: varchar(254)
+            value: upgrade placeholder
+            remarks: Hashed version of the session key
+            constraints: {nullable: false}
+- changeSet:
+    id: v54.2025-03-06T16:55:16
+    author: nvoxland
+    comment: Creating index on the hashed session key
+    preConditions: null
+    changes:
+    - createIndex:
+        tableName: core_session
+        columns:
+        - column: {name: key_hashed}
+        indexName: idx_core_session_key_hashed
+- changeSet:
+    id: v54.2025-03-11T16:00:00
+    author: qnkhuat
+    comment: add notification_subscription.ui_display_type
+    preConditions:
+    - not:
+      - columnExists: {tableName: notification_subscription, columnName: ui_display_type}
+    changes:
+    - addColumn:
+        tableName: notification_subscription
+        columns:
+        - column:
+            name: ui_display_type
+            type: varchar(32)
+            remarks: the display of the subscription, used for the UI only
+            constraints: {nullable: true}
+- changeSet:
+    id: v54.2025-03-17T18:52:44
+    author: noahmoss
+    comment: Migrating zh site locales to zh_CN
+    preConditions: null
+    changes:
+    - sql: {dbms: postgresql, sql: UPDATE setting SET value = 'zh_CN' where key = 'site-locale' AND value = 'zh';}
+    - sql: {dbms: 'mysql,mariadb', sql: UPDATE setting SET `value` = 'zh_CN' where `key` = 'site-locale' AND `value` = 'zh';}
+    - sql: {dbms: h2, sql: UPDATE setting SET "VALUE" = 'zh_CN' where "KEY" = 'site-locale' AND "VALUE" = 'zh';}
+    rollback: null
+- changeSet:
+    id: v54.2025-03-17T18:52:59
+    author: noahmoss
+    comment: Migrating zh user locales to zh_CN
+    preConditions: null
+    changes:
+    - sql: {sql: UPDATE core_user SET locale = 'zh_CN' WHERE locale = 'zh';}
+    rollback: null
+- changeSet:
+    id: v54.2025-03-25T16:34:12
+    author: edpaget
+    comment: Add index to field_usage query_execution_id column to support faster deletes
+    rollback: null
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: field_usage, indexName: idx_field_usage_query_execution_id}
+    changes:
+    - createIndex:
+        tableName: field_usage
+        columns:
+        - column: {name: query_execution_id}
+        indexName: idx_field_usage_query_execution_id
+- changeSet:
+    id: v54.2025-03-27T17:52:01
+    author: luizarakaki
+    comment: updating v_tasks to add new `status` field
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/tasks/v2/postgres-tasks.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/tasks/v2/mysql-tasks.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/tasks/v2/h2-tasks.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/tasks/v1/postgres-tasks.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/tasks/v1/mysql-tasks.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/tasks/v1/h2-tasks.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v54.2025-03-28T11:22:01
+    author: luizarakaki
+    comment: updating v_content to add new `is_verified` field
+    changes:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/content/v3/postgres-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/content/v3/mysql-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/content/v3/h2-content.sql, relativeToChangelogFile: true}
+    rollback:
+    - sqlFile: {dbms: postgresql, path: instance_analytics_views/content/v2/postgres-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: 'mysql,mariadb', path: instance_analytics_views/content/v2/mysql-content.sql, relativeToChangelogFile: true}
+    - sqlFile: {dbms: h2, path: instance_analytics_views/content/v2/h2-content.sql, relativeToChangelogFile: true}
+- changeSet:
+    id: v55.2025-03-24T16:28:41
+    author: bshepherdson
+    comment: Add report_card.card_schema
+    preConditions:
+    - not:
+      - columnExists: {tableName: report_card, columnName: card_schema}
+    changes:
+    - addColumn:
+        tableName: report_card
+        columns:
+        - column:
+            name: card_schema
+            type: int
+            remarks: Arbitrary revision number for how we store queries in report_card
+            defaultValue: 20
+            constraints: {nullable: false}
+- changeSet:
+    id: v55.2025-03-24T16:36:19
+    author: bshepherdson
+    comment: Creating index on the card_schema
+    preConditions: null
+    changes:
+    - createIndex:
+        tableName: report_card
+        columns:
+        - column: {name: card_schema}
+        indexName: idx_report_card_card_schema
+- changeSet:
+    id: v55.2025-04-01T07:17:52
+    author: johnswanson
+    comment: Add `db_router` table
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - tableExists: {tableName: db_router}
+    changes:
+    - createTable:
+        tableName: db_router
+        remarks: |
+          Configuration for Database Routers. Currently just holds which user attribute each
+          configured router database should use to choose a mirror database to route to.
+        columns:
+        - column:
+            name: id
+            type: int
+            autoIncrement: true
+            constraints: {primaryKey: true, nullable: false}
+        - column:
+            name: database_id
+            type: int
+            remarks: The ID of the database this is for.
+            constraints: {unique: true, nullable: false, referencedTableName: metabase_database, referencedColumnNames: id, foreignKeyName: fk_db_router_database_id}
+        - column:
+            name: user_attribute
+            type: varchar(254)
+            remarks: The user attribute used to redirect users to a different database.
+            constraints: {nullable: false}
+- changeSet:
+    id: v55.2025-04-01T07:18:02
+    author: johnswanson
+    comment: Add self-referential foreign key `router_database_id` to metabase_database
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - columnExists: {tableName: metabase_database, columnName: router_database_id}
+    changes:
+    - addColumn:
+        tableName: metabase_database
+        columns:
+        - column:
+            name: router_database_id
+            type: int
+            remarks: The ID of the primary database for this mirror database.
+            constraints: {unique: false, nullable: true}
+- changeSet:
+    id: v55.2025-04-01T07:18:47
+    author: johnswanson
+    comment: add an index for `metabase_database.router_database_id`
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - indexExists: {tableName: metabase_database, indexName: idx_unique_metabase_database_router_database_id_name}
+    changes:
+    - addUniqueConstraint: {tableName: metabase_database, constraintName: idx_unique_metabase_database_router_database_id_name, columnNames: 'router_database_id, name'}
+- changeSet:
+    id: v55.2025-04-01T07:18:52
+    author: johnswanson
+    comment: Add foreign key for `router_database_id`
+    preConditions:
+    - {onFail: MARK_RAN}
+    - not:
+      - foreignKeyConstraintExists:
+        - {foreignKeyName: fk_metabase_database_metabase_database_id}
+    changes:
+    - addForeignKeyConstraint: {baseTableName: metabase_database, baseColumnNames: router_database_id, referencedTableName: metabase_database, referencedColumnNames: id, constraintName: fk_metabase_database_metabase_database_id, onDelete: RESTRICT}
+- changeSet:
+    id: v55.2025-04-17T08:44:39
+    author: johnswanson
+    comment: Add permissions_group.magic_group_type
+    preConditions: null
+    changes:
+    - addColumn:
+        tableName: permissions_group
+        columns:
+        - column:
+            name: magic_group_type
+            type: varchar(254)
+            remarks: The magic_group_type of the permissions_group
+            constraints: {unique: true, nullable: true}
+- changeSet:
+    id: v55.2025-04-17T08:47:19
+    author: johnswanson
+    comment: Set type on existing permissions groups
+    rollback: null
+    changes:
+    - sql:
+        sql: |
+          UPDATE permissions_group SET magic_group_type='all-internal-users' WHERE name='All Users';
+          UPDATE permissions_group SET magic_group_type='admin' WHERE name='Administrators';


### PR DESCRIPTION
Hypothesis is that preonditions are bad. Hoping that we can run migrations without preconditions _ON INITIAL STARTUP_. Preconditions might be necessary when upgrading, but it seems reasonable that we can setup the db without preconditions on the first run. Let's find out

```clojure
(ns nocommit.migration-experiment
  (:require
   [clj-yaml.core :as yaml]))

(defn without-preconditions [filename]
  (let [content (yaml/parse-string (slurp filename))
        modify (fn [change]
                 (if (:changeSet change)
                   (update change :changeSet dissoc :preConditions)
                   change))]
    (->> content (map modify) yaml/generate-string (spit filename))))

(comment
  (without-preconditions "/Users/dan/projects/work/metabase/resources/migrations/001_update_migrations.yaml")
  (without-preconditions "/Users/dan/projects/work/metabase/resources/migrations/000_legacy_migrations.yaml")
  )
```

just wipped this up, removing preconditions whereever they were. It is an annoyingly large diff. I wish it was more targeted in order to restore the ones we want to keep. c'est la vie