### PR TITLE
[VISUALIZER] Fix card duplication spinning

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
@@ -13,10 +13,12 @@ import {
 } from "metabase/dashboard/selectors";
 import {
   generateTemporaryDashcardId,
+  isQuestionDashCard,
   isVirtualDashCard,
 } from "metabase/dashboard/utils";
 import { getPositionForNewDashCard } from "metabase/lib/dashboard_grid";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { isVisualizerDashboardCard } from "metabase/visualizer/utils";
 import type { Dashboard, DashboardCard } from "metabase-types/api";
 
 export function useDuplicateDashCard({
@@ -59,7 +61,28 @@ export function useDuplicateDashCard({
 
     // We don't have card (question) data for virtual dashcards (text, heading, link, action)
     if (!isVirtualDashCard(dashcard)) {
+      // Fetch data for the main card
       dispatch(fetchCardData(dashcard.card, { ...dashcard, id: newId }));
+
+      // For visualizer cards, also fetch data for all referenced data sources
+      if (isVisualizerDashboardCard(dashcard)) {
+        // Get the visualization definition
+        const visualizerDef = dashcard.visualization_settings.visualization;
+        if (visualizerDef && visualizerDef.columnValuesMapping) {
+          // Fetch data for each referenced card in the visualizer
+          const seriesCards = dashcard.series || [];
+
+          // Fetch data for all series cards
+          seriesCards.forEach((card) => {
+            dispatch(fetchCardData(card, { ...dashcard, id: newId }));
+          });
+        }
+      } else if (isQuestionDashCard(dashcard) && dashcard.series?.length > 0) {
+        // For standard multi-series cards, fetch data for each series card
+        dashcard.series.forEach((card) => {
+          dispatch(fetchCardData(card, { ...dashcard, id: newId }));
+        });
+      }
     }
 
     trackDashcardDuplicated(dashboard.id);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
@@ -77,7 +77,11 @@ export function useDuplicateDashCard({
             dispatch(fetchCardData(card, { ...dashcard, id: newId }));
           });
         }
-      } else if (isQuestionDashCard(dashcard) && dashcard.series?.length > 0) {
+      } else if (
+        isQuestionDashCard(dashcard) &&
+        dashcard.series &&
+        dashcard.series.length > 0
+      ) {
         // For standard multi-series cards, fetch data for each series card
         dashcard.series.forEach((card) => {
           dispatch(fetchCardData(card, { ...dashcard, id: newId }));


### PR DESCRIPTION
Resolves VIZ-935

  Problem

  When duplicating visualizer cards or multi-series cards on a dashboard, the duplicated card would remain in a loading state, displaying a spinner indefinitely even though the API request returned successfully. This happened because the duplication process was only fetching data for the main card and not for the additional series cards needed by visualizer cards.

  Solution

  Modified the useDuplicateDashCard hook to properly handle data fetching for all components of a card when duplicating:

  1. For standard cards: Continue fetching only the main card data
  2. For visualizer cards: Fetch data for both the main card and all series cards referenced in the visualization
  3. For multi-series cards: Fetch data for the main card and all series cards

  This ensures that after duplication, all visualizer and multi-series cards have their complete data loaded, enabling them to render properly without getting stuck in a loading state.