### PR TITLE
fix: display values of FK fields when it is outside of search results

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
@@ -14,6 +14,7 @@ import {
   TextInput,
   useCombobox,
 } from "metabase/ui";
+import type { RemappingHydratedDatasetColumn } from "metabase/visualizations/types";
 import type { FieldValue } from "metabase-types/api";
 
 import type { EditingBodyPrimitiveProps } from "./types";
@@ -101,11 +102,30 @@ export const EditingBodyCellCategorySelect = ({
     }
 
     if (value) {
-      // Type safety, should always be present
+      // Lookup ad-hoc search results (e.g. might be different from the initial value)
       if (value in optionValueToOptionMap) {
         return getSelectedLabelText(optionValueToOptionMap[value]);
       }
 
+      // Lookup column remapped values (usually when FK value is not presented in the current search results)
+      const maybeHydratedDatasetColumn =
+        datasetColumn as RemappingHydratedDatasetColumn;
+      const intValue = parseInt(value, 10);
+      if (
+        maybeHydratedDatasetColumn.remapping?.has(value) ||
+        maybeHydratedDatasetColumn.remapping?.has(intValue)
+      ) {
+        const remappedValue =
+          maybeHydratedDatasetColumn.remapping.get(value) ??
+          maybeHydratedDatasetColumn.remapping.get(intValue);
+
+        return getSelectedLabelText({
+          value: value,
+          label: remappedValue,
+        });
+      }
+
+      // Fallback to the raw value instead of a label
       return value;
     }
 
@@ -116,6 +136,7 @@ export const EditingBodyCellCategorySelect = ({
     optionValueToOptionMap,
     inputProps?.placeholder,
     getSelectedLabelText,
+    datasetColumn,
   ]);
 
   const isNullable = field?.database_is_nullable;


### PR DESCRIPTION
Resolves [WRK-354](https://linear.app/metabase/issue/WRK-354/fk-is-displayed-instead-of-a-value-per-table-metadatafield-display)
