### PR TITLE
Migrate hacked semantic type fields to use coercion

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11184,12 +11184,16 @@ databaseChangeLog:
   - changeSet:
       id: v55.2025-05-02T08:21:44
       author: lbrdnk
-      comment: |
-        Migrate "hacked" semantic types
-        Context: Using semantic type that is descendant of :type/Number enabled eg. use of numeric
-        filter widgets on string columns. That is legal eg. in Mysql and considered a hack applicationwise.
-        Addition of String->Float coercion strategy enabled its "legalization".
+      comment: Migrate hacked semantic types
       rollback:
+        - update:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: coercion_strategy
+              - column:
+                  name: effective_type
+            where: coercion_strategy = 'Coercion/String->Float'
       changes:
         - update:
             tableName: metabase_field
@@ -11229,7 +11233,8 @@ databaseChangeLog:
                 'type/Share',
                 'type/Price',
                 'type/Income',
-                'type/Score'
+                'type/Score',
+                'type/Number'
               )
 
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11188,6 +11188,7 @@ databaseChangeLog:
       rollback:
         - update:
             tableName: metabase_field
+            # set columns to NULL
             columns:
               - column:
                   name: coercion_strategy

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11181,6 +11181,56 @@ databaseChangeLog:
                     unique: false
                     nullable: true
 
+  - changeSet:
+      id: v55.2025-05-02T08:21:44
+      author: lbrdnk
+      comment: |
+        Migrate "hacked" semantic types
+        Context: Using semantic type that is descendant of :type/Number enabled eg. use of numeric
+        filter widgets on string columns. That is legal eg. in Mysql and considered a hack applicationwise.
+        Addition of String->Float coercion strategy enabled its "legalization".
+      changes:
+        - update:
+          columns:
+            - column:
+              name: coercion_strategy
+              value: 'Coercion/String->Float'
+            - column:
+              name: effective_type
+              value: 'type/Float'
+          where: |
+            (
+              select metabase_database.engine
+              from metabase_table
+              where metabase_field.table_id = metabase_table.id
+              join metabase_database on metabase_table.db_id = metabase_database.id
+            ) in (
+              'mysql',
+              'sqlite',
+              'sqlserver',
+              'snowflake',
+              'h2',
+              'oracle'
+            )
+            AND base_type = 'type/Text'
+            AND semantic_type in (
+              'type/Longitude',
+              'type/Discount',
+              'type/Currency',
+              'type/Cost',
+              'type/Quantity',
+              'type/Duration',
+              'type/Latitude',
+              'type/Coordinate',
+              'type/GrossMargin',
+              'type/Percentage',
+              'type/Share',
+              'type/Price',
+              'type/Income',
+              'type/Score',
+            )
+      rollback:
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11189,47 +11189,35 @@ databaseChangeLog:
         Context: Using semantic type that is descendant of :type/Number enabled eg. use of numeric
         filter widgets on string columns. That is legal eg. in Mysql and considered a hack applicationwise.
         Addition of String->Float coercion strategy enabled its "legalization".
+      rollback:
       changes:
         - update:
-          columns:
-            - column:
-              name: coercion_strategy
-              value: 'Coercion/String->Float'
-            - column:
-              name: effective_type
-              value: 'type/Float'
-          where: |
-            (
-              select metabase_database.engine
-              from metabase_table
-              where metabase_field.table_id = metabase_table.id
-              join metabase_database on metabase_table.db_id = metabase_database.id
-            ) in (
-              'mysql',
-              'sqlite',
-              'sqlserver',
-              'snowflake',
-              'h2',
-              'oracle'
-            )
-            AND base_type = 'type/Text'
-            AND semantic_type in (
-              'type/Longitude',
-              'type/Discount',
-              'type/Currency',
-              'type/Cost',
-              'type/Quantity',
-              'type/Duration',
-              'type/Latitude',
-              'type/Coordinate',
-              'type/GrossMargin',
-              'type/Percentage',
-              'type/Share',
-              'type/Price',
-              'type/Income',
-              'type/Score',
-            )
-      rollback:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: coercion_strategy
+                  value: 'Coercion/String->Float'
+              - column:
+                  name: effective_type
+                  value: 'type/Float'
+            where: |
+              base_type = 'type/Text'
+              AND semantic_type in (
+                'type/Longitude',
+                'type/Discount',
+                'type/Currency',
+                'type/Cost',
+                'type/Quantity',
+                'type/Duration',
+                'type/Latitude',
+                'type/Coordinate',
+                'type/GrossMargin',
+                'type/Percentage',
+                'type/Share',
+                'type/Price',
+                'type/Income',
+                'type/Score'
+              )
 
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11201,7 +11201,20 @@ databaseChangeLog:
                   name: effective_type
                   value: 'type/Float'
             where: |
-              base_type = 'type/Text'
+              (
+                select metabase_database.engine
+                from metabase_table
+                join metabase_database on metabase_table.db_id = metabase_database.id
+                where metabase_field.table_id = metabase_table.id
+              ) in (
+                'mysql',
+                'sqlite',
+                'sqlserver',
+                'snowflake',
+                'h2',
+                'oracle'
+              )
+              AND base_type = 'type/Text'
               AND semantic_type in (
                 'type/Longitude',
                 'type/Discount',


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-162/migrate-hacked-number-semantic-types-used-to-cast-string-in-some

### Description

This PR migrates "hacked" fields to use new coercion strategy. Rationale can be found in [this tech doc](https://www.notion.so/metabase/Tech-Migration-of-hacked-semantic-types-1e569354c9018079b9c3fdd655904604).

### How to verify

Follow the steps from [this thread](https://metaboat.slack.com/archives/CKZEMT1MJ/p1746464896704159).

### Checklist

- ~~[ ] Tests have been added/updated to cover changes in this PR~~ The change has been tested manually for available appdb types.
