### PR TITLE
Add label to `CodeEditor` in `LogLevelsForm`

### DIFF
--- a/frontend/src/metabase/admin/tasks/components/LogLevelsModal/DurationInput.tsx
+++ b/frontend/src/metabase/admin/tasks/components/LogLevelsModal/DurationInput.tsx
@@ -15,7 +15,6 @@ export const DurationInput = () => {
         label={t`Duration`}
         name="duration"
         placeholder={t`Duration`}
-        required
         w={80}
       />
 

--- a/frontend/src/metabase/admin/tasks/components/LogLevelsModal/LogLevelsForm.tsx
+++ b/frontend/src/metabase/admin/tasks/components/LogLevelsModal/LogLevelsForm.tsx
@@ -1,5 +1,5 @@
 import { useField } from "formik";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 import { t } from "ttag";
 
 import { CodeEditor } from "metabase/components/CodeEditor";
@@ -17,6 +17,7 @@ interface Props {
 }
 
 export const LogLevelsForm = ({ presets }: Props) => {
+  const codeId = useId();
   const [{ value }, { error: jsonError }, { setValue }] = useField("json");
   const [, { error: durationError }] = useField("duration");
   const error = durationError || jsonError;
@@ -45,6 +46,10 @@ export const LogLevelsForm = ({ presets }: Props) => {
         )}
       </Flex>
 
+      <Text component="label" fw="bold" htmlFor={codeId} size="sm">
+        {t`Override log configuration using`}
+      </Text>
+
       <Box
         className={S.codeContainer}
         // Using h + mah + mih to make the CodeEditor fill its parent vertically
@@ -54,6 +59,7 @@ export const LogLevelsForm = ({ presets }: Props) => {
       >
         <CodeEditor
           className={S.code}
+          id={codeId}
           language="json"
           value={value}
           onChange={setValue}

--- a/frontend/src/metabase/components/CodeEditor/CodeEditor.tsx
+++ b/frontend/src/metabase/components/CodeEditor/CodeEditor.tsx
@@ -18,6 +18,7 @@ import {
 type Props = {
   className?: string;
   highlightRanges?: { start: number; end: number }[];
+  id?: string;
   language: CodeLanguage;
   lineNumbers?: boolean;
   readOnly?: boolean;
@@ -28,6 +29,7 @@ type Props = {
 export function CodeEditor({
   className,
   highlightRanges,
+  id,
   language,
   lineNumbers = true,
   readOnly,
@@ -58,6 +60,7 @@ export function CodeEditor({
       }}
       className={cx(S.codeEditor, className)}
       extensions={extensions}
+      id={id}
       readOnly={readOnly}
       ref={ref}
       value={value}


### PR DESCRIPTION
See [Slack](https://metaboat.slack.com/archives/C08E17FN206/p1746187299946939).

### Description

Adds a label above `CodeEditor` in `LogLevelsForm`.
Also removes `required` from duration input for visual consistency (no red asterisk now). The input is still validated.

### How to verify

1. Admin > Troubleshooting > Logs
2. Adjust log levels

There should be a "Override log configuration using" label above the code editor.

### Demo

![image](https://github.com/user-attachments/assets/ec517e2d-674c-425b-819a-cb899eb918aa)
