### PR TITLE
Closes VIZ-926: combining existing dashcards causes them to crash

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -142,9 +142,11 @@ export function showDashcardVisualizerModalSettings(index = 0) {
   });
 }
 
-export function saveDashcardVisualizerModal(isCreation = false) {
+export function saveDashcardVisualizerModal(
+  mode: "create" | "update" = "update",
+) {
   modal().within(() => {
-    cy.findByText(isCreation ? "Add to dashboard" : "Save").click();
+    cy.findByText(mode === "create" ? "Add to dashboard" : "Save").click();
   });
 }
 

--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -142,9 +142,9 @@ export function showDashcardVisualizerModalSettings(index = 0) {
   });
 }
 
-export function saveDashcardVisualizerModal() {
+export function saveDashcardVisualizerModal(isCreation = false) {
   modal().within(() => {
-    cy.findByText("Save").click();
+    cy.findByText(isCreation ? "Add to dashboard" : "Save").click();
   });
 }
 

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -421,4 +421,34 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       cy.findByText(ORDERS_COUNT_BY_CREATED_AT.name).should("exist");
     });
   });
+
+  it("should allow adding a dataset after a card is created (VIZ-926)", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+    });
+
+    H.editDashboard();
+
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
+
+    H.saveDashcardVisualizerModal(true);
+    H.saveDashboard();
+
+    H.editDashboard();
+    H.showDashcardVisualizerModal(0);
+
+    H.switchToAddMoreData();
+    H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
+    H.saveDashcardVisualizerModal();
+    H.saveDashboard();
+
+    // Making sure the card renders
+    H.getDashboardCard(0).within(() => {
+      cy.findByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
+        "exist",
+      );
+      cy.findByText("Created At: Month").should("exist");
+    });
+  });
 });

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -432,7 +432,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.openQuestionsSidebar();
     H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
 
-    H.saveDashcardVisualizerModal(true);
+    H.saveDashcardVisualizerModal("create");
     H.saveDashboard();
 
     H.editDashboard();

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -106,8 +106,11 @@ function isNewAdditionalSeriesCard(
   dashcardBeforeEditing?: DashboardCard,
 ) {
   if (isVisualizerDashboardCard(dashcard)) {
-    const prevSeries =
-      (dashcardBeforeEditing as QuestionDashboardCard)?.series ?? [];
+    if (!dashcardBeforeEditing || !("series" in dashcardBeforeEditing)) {
+      return false;
+    }
+
+    const prevSeries = dashcardBeforeEditing.series ?? [];
     const newSeries = dashcard.series ?? [];
 
     return (
@@ -371,7 +374,6 @@ export const fetchCardDataAction = createAsyncThunk<
       const shouldUseCardQueryEndpoint =
         isNewDashcard(dashcard) ||
         (isQuestionDashCard(dashcard) &&
-          !isVisualizerDashboardCard(dashcard) &&
           isNewAdditionalSeriesCard(card, dashcard, dashcardBeforeEditing)) ||
         hasReplacedCard;
 


### PR DESCRIPTION
Closes [VIZ-926: Combining existing dashcards can cause them to crash](https://linear.app/metabase/issue/VIZ-926/combining-existing-dashcards-can-cause-them-to-crash)

### Description

The fix for [VIZ-657: Categorical dashboard filters only filtering the first source](https://linear.app/metabase/issue/VIZ-657/categorical-dashboard-filters-only-filtering-the-first-source) (https://github.com/metabase/metabase/commit/4f4bdabe3c1ebc96cd782e37c9d46d90b5d5c18e) was wrong, it would entirely bypass the card query endpoint, leading to using the dashboard endpoint even before the card is actually saved and in the end crashing the card.
This is now fixed by being slightly smarter in determining what endpoint to use. Only downside is, filters won't be applied to secondary datasets before the dashboard is saved, but that's acceptable because 1°) it doesn't crash anything 2°) that's how "add series" used to work anyway.

### How to verify

There are e2e tests for both scenarios (the one about [VIZ-657: Categorical dashboard filters only filtering the first source](https://linear.app/metabase/issue/VIZ-657/categorical-dashboard-filters-only-filtering-the-first-source) and this one).

[VIZ-657: Categorical dashboard filters only filtering the first source](https://linear.app/metabase/issue/VIZ-657/categorical-dashboard-filters-only-filtering-the-first-source):
 1. Create a dashcard with two datasources, and apply a categorical filter to bothe datasources in the card.
 2. Save the dasboad, set the filter to whatever value
 3. Both datasets in the dashcard should be affected by this filter

[VIZ-926: Combining existing dashcards can cause them to crash](https://linear.app/metabase/issue/VIZ-926/combining-existing-dashcards-can-cause-them-to-crash)
 1. Create a dashcard with a single dataset
 2. Save the dashboard
 3. Edit the dashboard again
 4. Add another dataset to the dashcard
 5. Save the dashcard
 6. The dashcard should render just fine and not crash. Crashes are uncool.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
