### PR TITLE
Closes VIZ-638: better type comparison for compatibility check

### DIFF
--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.ts
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.ts
@@ -1,3 +1,4 @@
+import * as Lib from "metabase-lib";
 import { isDate, isNumber, isString } from "metabase-lib/v1/types/utils/isa";
 import type {
   DatasetColumn,
@@ -16,15 +17,15 @@ function compareIdAndName(
   return column.name === field.name && column.id === field.id;
 }
 
-function compareTypeAndName(
-  column: DatasetColumn | undefined,
-  field: Field,
-): boolean {
+function compareType(column: DatasetColumn | undefined, field: Field): boolean {
   if (!column) {
     return false;
   }
 
-  return column.semantic_type === field.semantic_type;
+  return Lib.isAssignableType(
+    Lib.legacyColumnTypeInfo(column),
+    Lib.legacyColumnTypeInfo(field as any), // TODO: Fix this type
+  );
 }
 
 function comparedId(column: DatasetColumn | undefined, field: Field): boolean {
@@ -66,7 +67,7 @@ export function getIsCompatible(parameters: CompatibilityParameters) {
 
   const idAndNameMatcher = (f: Field) => compareIdAndName(primaryColumn, f);
   const idMatcher = (f: Field) => comparedId(primaryColumn, f);
-  const typeMatcher = (f: Field) => compareTypeAndName(primaryColumn, f);
+  const typeMatcher = (f: Field) => compareType(primaryColumn, f);
 
   if (currentDisplay === "scalar") {
     return (

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/getIsCompatible.unit.spec.ts
@@ -3,6 +3,7 @@ import {
   NumberColumn,
   StringColumn,
 } from "__support__/visualizations";
+import { TYPE } from "cljs/metabase.types";
 import type { Field } from "metabase-types/api";
 import { createMockColumn, createMockField } from "metabase-types/api/mocks";
 
@@ -257,6 +258,38 @@ describe("getIsCompatible", () => {
           display: "line",
           fields: [anotherFieldWithSameType, anotherField],
         },
+      }),
+    ).toBe(true);
+  });
+
+  it("should accept a target with an assignable type to the primary column, regardless of the semantic type (VIZ-638)", () => {
+    const primaryColumn = createMockColumn(
+      DateTimeColumn({
+        id: 1,
+        name: "the column",
+        semantic_type: TYPE.Temporal, // <-- this needs to be set to something
+      }),
+    );
+
+    const field = createMockField(
+      StringColumn({
+        id: 2,
+        name: "the column",
+      }),
+    );
+
+    // No semantic type here, it shouldn't matter
+    const anotherField = createMockField(
+      DateTimeColumn({
+        id: 3,
+        name: "another column",
+      }),
+    );
+
+    expect(
+      getIsCompatible({
+        currentDataset: { display: "line", primaryColumn },
+        targetDataset: { display: "line", fields: [field, anotherField] },
       }),
     ).toBe(true);
   });


### PR DESCRIPTION
Closes [VIZ-638: Weird compatibility behavior when date fields are named differently](https://linear.app/metabase/issue/VIZ-638/weird-compatibility-behavior-when-date-fields-are-named-differently)

### Description

Now using `Lib.isAssignableType` to compare types.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
