### PR TITLE
fix(sdk): updating collection's entity id crashes InteractiveQuestion and CollectionBrowser

### DIFF
--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -94,6 +94,11 @@ export const SECOND_COLLECTION_ID = _.findWhere(
   { name: "Second collection" },
 ).id;
 
+export const SECOND_COLLECTION_ENTITY_ID = _.findWhere(
+  SAMPLE_INSTANCE_DATA.collections,
+  { name: "Second collection" },
+).entity_id;
+
 export const THIRD_COLLECTION_ID = _.findWhere(
   SAMPLE_INSTANCE_DATA.collections,
   { name: "Third collection" },

--- a/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
@@ -1,6 +1,10 @@
 import { CollectionBrowser } from "@metabase/embedding-sdk-react";
+import { useState } from "react";
 
-import { FIRST_COLLECTION_ENTITY_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  FIRST_COLLECTION_ENTITY_ID,
+  SECOND_COLLECTION_ENTITY_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/component-testing-sdk";
 import {
   mockAuthProviderAndJwtSignIn,
@@ -76,19 +80,40 @@ describe("scenarios > embedding-sdk > collection browser", () => {
       mockAuthProviderAndJwtSignIn();
     });
 
-    it("should not crash when using entity ids in the collection browser", () => {
+    it("can change collection to a different entity id without crashing (metabase#57438)", () => {
+      const TestComponent = () => {
+        const [collectionId, setCollectionId] = useState<string | null>(
+          FIRST_COLLECTION_ENTITY_ID!,
+        );
+
+        return (
+          <div>
+            <div>id = {collectionId}</div>
+            <CollectionBrowser collectionId={collectionId} />
+
+            <div onClick={() => setCollectionId(SECOND_COLLECTION_ENTITY_ID!)}>
+              use second collection
+            </div>
+          </div>
+        );
+      };
+
       cy.intercept("GET", "/api/collection/*").as("getCollection");
 
-      mountSdkContent(
-        <CollectionBrowser collectionId={FIRST_COLLECTION_ENTITY_ID} />,
-      );
+      mountSdkContent(<TestComponent />);
 
       getSdkRoot().within(() => {
+        cy.findByText(`id = ${FIRST_COLLECTION_ENTITY_ID}`).should("exist");
         cy.findByText("Our analytics").should("not.exist");
+        cy.findByText("Second collection").should("not.exist");
         cy.findByText("First collection").should("exist");
-        cy.findByTestId("collection-entry")
-          .findByText("Second collection")
-          .should("exist");
+
+        cy.findByText("use second collection").click();
+
+        cy.log("ensure that the collection id is updated and does not crash");
+        cy.findByText(`id = ${SECOND_COLLECTION_ENTITY_ID}`).should("exist");
+        cy.findByText("First collection").should("not.exist");
+        cy.findByText("Second collection").should("exist");
       });
     });
   });

--- a/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/collection-browser.cy.spec.tsx
@@ -1,5 +1,6 @@
 import { CollectionBrowser } from "@metabase/embedding-sdk-react";
 
+import { FIRST_COLLECTION_ENTITY_ID } from "e2e/support/cypress_sample_instance_data";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/component-testing-sdk";
 import {
   mockAuthProviderAndJwtSignIn,
@@ -65,6 +66,30 @@ describe("scenarios > embedding-sdk > collection browser", () => {
       cy.wait("@getRootCollection");
 
       getSdkRoot().findByText("Our analytics").should("exist");
+    });
+  });
+
+  describe("collection using entity ids", () => {
+    beforeEach(() => {
+      signInAsAdminAndEnableEmbeddingSdk();
+      cy.signOut();
+      mockAuthProviderAndJwtSignIn();
+    });
+
+    it("should not crash when using entity ids in the collection browser", () => {
+      cy.intercept("GET", "/api/collection/*").as("getCollection");
+
+      mountSdkContent(
+        <CollectionBrowser collectionId={FIRST_COLLECTION_ENTITY_ID} />,
+      );
+
+      getSdkRoot().within(() => {
+        cy.findByText("Our analytics").should("not.exist");
+        cy.findByText("First collection").should("exist");
+        cy.findByTestId("collection-entry")
+          .findByText("Second collection")
+          .should("exist");
+      });
     });
   });
 });

--- a/frontend/src/metabase/lib/entity-id/hooks/use-validated-entity-id.ts
+++ b/frontend/src/metabase/lib/entity-id/hooks/use-validated-entity-id.ts
@@ -37,7 +37,7 @@ export const useValidatedEntityId = <
   const {
     data: entity_ids,
     isError,
-    isLoading,
+    isFetching,
   } = useTranslateEntityIdQuery(
     id && isEntityId
       ? {
@@ -56,7 +56,7 @@ export const useValidatedEntityId = <
       } as const;
     }
 
-    if (isLoading) {
+    if (isFetching) {
       return {
         id: null,
         isLoading: true,
@@ -82,5 +82,5 @@ export const useValidatedEntityId = <
 
     // something went wrong, either entity_ids is empty or the translation failed
     return { id: null, isLoading: false, isError: true } as const;
-  }, [isEntityId, isLoading, isError, entity_ids, id]);
+  }, [isEntityId, isFetching, isError, entity_ids, id]);
 };


### PR DESCRIPTION
Closes #57438
Closes EMB-368

### Description

If we load either `InteractiveQuestion` or `CollectionBrowser` with one entity id, then change the prop at runtime to another entity id, the app crashes with `Error: Invalid collection id, expected number | 'root' | 'personal'`. Using the `isFetching` state instead of `isLoading` fixes the issue.

### How to verify

Use the snippet from the e2e tests to verify, which tries to update the target collection to another entity id. e.g:

```tsx
const TestComponent = () => {
  const [targetCollection, setTargetCollection] = useState<string | null>(
    FIRST_COLLECTION_ENTITY_ID!,
  );

  return (
    <div>
      <div>id = {targetCollection}</div>

      <InteractiveQuestion
        questionId="new"
        targetCollection={targetCollection}
        onSave={() => {}}
        isSaveEnabled
      />

      <div
        onClick={() => setTargetCollection(SECOND_COLLECTION_ENTITY_ID!)}
      >
        use second collection
      </div>
    </div>
  );
};
```

Verify on Shoppy:
- Build the bundle with `yarn embedding-sdk:dev`
- Do `rm -rf node_modules/.vite && rm -rf node_modules/@metabase/ && yarn add file:../metabase/resources/embedding-sdk && env NODE_OPTIONS=--max-old-space-size=7000 yarn dev` on Shoppy
- Start Shoppy and their API: `yarn dev` and `cd api && yarn dev`
- Click "New Custom Exploration > From Scratch"
- Switch the site to Site 2
- The InteractiveQuestion should be shown without crashing

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
