### PR TITLE
fix(sdk): custom GeoJSON maps does not load due to wrong domain

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -116,20 +116,20 @@ const connector = connect(mapStateToProps, null);
 const ensureTrailingSlash = (url) => (url.endsWith("/") ? url : url + "/");
 
 export function getMapUrl(details, props) {
-  if (details.builtin) {
-    if (props?.isSdk && props?.sdkMetabaseInstanceUrl) {
-      const baseUrl = new URL(
-        props.sdkMetabaseInstanceUrl,
-        window.location.origin,
-      ).href;
+  const mapUrl = details.builtin
+    ? details.url
+    : "api/geojson/" + props.settings["map.region"];
 
-      // if the second parameter ends with a slash, it will join them together
-      // new URL("/sub-path", "http://example.org/proxy/") => "http://example.org/proxy/sub-path"
-      return new URL(details.url, ensureTrailingSlash(baseUrl)).href;
-    }
-    return details.url;
+  if (!props?.isSdk || !props?.sdkMetabaseInstanceUrl) {
+    return mapUrl;
   }
-  return "api/geojson/" + props.settings["map.region"];
+
+  const baseUrl = new URL(props.sdkMetabaseInstanceUrl, window.location.origin)
+    .href;
+
+  // if the second parameter ends with a slash, it will join them together
+  // new URL("/sub-path", "http://example.org/proxy/") => "http://example.org/proxy/sub-path"
+  return new URL(mapUrl, ensureTrailingSlash(baseUrl)).href;
 }
 
 class ChoroplethMapInner extends Component {

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
@@ -74,6 +74,21 @@ describe("getLegendTitles", () => {
           "http://mb-instance.example.com/sub-path/api/geojson/world.json",
         );
       });
+
+      it("supports custom GeoJSON maps", () => {
+        const url = getMapUrl(
+          { builtin: false },
+          {
+            isSdk: true,
+            sdkMetabaseInstanceUrl: "http://mb-instance.example.com",
+            settings: { "map.region": "foobarbaz" },
+          },
+        );
+
+        expect(url).toBe(
+          "http://mb-instance.example.com/api/geojson/foobarbaz",
+        );
+      });
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
@@ -81,12 +81,12 @@ describe("getLegendTitles", () => {
           {
             isSdk: true,
             sdkMetabaseInstanceUrl: "http://mb-instance.example.com",
-            settings: { "map.region": "foobarbaz.geojson" },
+            settings: { "map.region": "f3b71a29-5e4b-4d6c-8a1f-9c0e2d3a4b5c" },
           },
         );
 
         expect(url).toBe(
-          "http://mb-instance.example.com/api/geojson/foobarbaz.geojson",
+          "http://mb-instance.example.com/api/geojson/f3b71a29-5e4b-4d6c-8a1f-9c0e2d3a4b5c",
         );
       });
     });

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
@@ -81,12 +81,12 @@ describe("getLegendTitles", () => {
           {
             isSdk: true,
             sdkMetabaseInstanceUrl: "http://mb-instance.example.com",
-            settings: { "map.region": "foobarbaz" },
+            settings: { "map.region": "foobarbaz.geojson" },
           },
         );
 
         expect(url).toBe(
-          "http://mb-instance.example.com/api/geojson/foobarbaz",
+          "http://mb-instance.example.com/api/geojson/foobarbaz.geojson",
         );
       });
     });


### PR DESCRIPTION
Closes EMB-369
Closes #57439

### Description

Map visualizations using custom GeoJSON files from the "Custom Maps" admin settings does not load on the Embedding SDK because of how the wrong domain is being used.

### How to verify

- Add a custom GeoJSON file to the "Custom Maps" admin settings
- Add a question using the Map visualization, and apply the GeoJSON map
- Render that question on the SDK
- We do not get a network error indicating the wrong domain is applied
- The custom GeoJSON map renders successfully

### Demo

Before fix: Map does not load and gets stuck on the loading indicator

![CleanShot 2568-05-02 at 23 08 58@2x](https://github.com/user-attachments/assets/348006fa-3049-484b-98da-2809b4963cd9)

After fix: Custom GeoJSON map loads fine on the SDK

![CleanShot 2568-05-02 at 23 07 28@2x](https://github.com/user-attachments/assets/b5949371-11f0-45de-aaa8-426fc50458d3)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - Unit
