### PR TITLE
fix: add table-level sql based permission query

### DIFF
--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -172,7 +172,15 @@
 
 (mu/defn- user-in-group-half-join
   [user-id :- pos-int?]
-  [:exists ])
+  [:exists {:select [1]
+            :from   [[:permissions_group :pg]]
+            :where  [:and
+                     [:= :pg.id :dp.group_id]
+                     [:exists {:select [1]
+                               :from [[:permissions_group_membership :pgm]]
+                               :where [:and
+                                       [:= :pgm.group_id :pg.id]
+                                       [:= :pgm.user_id [:inline user-id]]]}]]}])
 
 (mu/defn- has-perms-for-table-as-honey-sql?
   [user-id :- pos-int?

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -290,7 +290,7 @@
 
 (mi/define-batched-hydration-method with-segments
   :segments
-  "Efficientsly hydrate the Segments for a collection of `tables`."
+  "Efficiently hydrate the Segments for a collection of `tables`."
   [tables]
   (with-objects :segments
     (fn [table-ids]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -154,7 +154,7 @@
    This lets us write SQL statements to compare permissions values by their index position in the same way we do in the
    `data-perms/at-least-as-permissive?` function"
   [perm-type :- data-perms/PermissionType
-   column-or-perm-value :- [:or :keyword [:tuple [:= ::h2x/literal] :string]]]
+   column-or-perm-value :- [:or :keyword h2x/Literal]]
   (into [:case]
         (apply concat
                (map-indexed (fn [idx perm-value] [[:= column-or-perm-value (h2x/literal perm-value)] [:inline idx]])
@@ -172,15 +172,7 @@
 
 (mu/defn- user-in-group-half-join
   [user-id :- pos-int?]
-  [:exists {:select [1]
-            :from   [[:permissions_group :pg]]
-            :where  [:and
-                     [:= :pg.id :dp.group_id]
-                     [:exists {:select [1]
-                               :from [[:permissions_group_membership :pgm]]
-                               :where [:and
-                                       [:= :pgm.group_id :pg.id]
-                                       [:= :pgm.user_id [:inline user-id]]]}]]}])
+  [:exists ])
 
 (mu/defn- has-perms-for-table-as-honey-sql?
   [user-id :- pos-int?

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -69,6 +69,17 @@
       (update :updated_at parse-datetime)
       (update :last_edited_at parse-datetime)))
 
+(defn add-table-where-clauses
+  "Add a `WHERE` caluse to the query to only return tables the current user has access to"
+  [search-ctx qry]
+  (sql.helpers/where qry
+                     [:or
+                      [:= :search_index.model nil]
+                      [:!= :search_index.model [:inline "table"]]
+                      [:and
+                       [:= :search_index.model [:inline "table"]]
+                       (search.permissions/permitted-tables-caluse search-ctx :search_index.model_id)]]))
+
 (defn add-collection-join-and-where-clauses
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,
   so we can return its `:name`."
@@ -123,6 +134,7 @@
           scorers (search.scoring/scorers search-ctx)]
       (->> (search.index/search-query search-string search-ctx [:legacy_input])
            (add-collection-join-and-where-clauses search-ctx)
+           (add-table-where-clauses search-ctx)
            (search.scoring/with-scores search-ctx scorers)
            (search.filter/with-filters search-ctx)
            t2/query

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -70,7 +70,7 @@
       (update :last_edited_at parse-datetime)))
 
 (defn add-table-where-clauses
-  "Add a `WHERE` caluse to the query to only return tables the current user has access to"
+  "Add a `WHERE` clause to the query to only return tables the current user has access to"
   [search-ctx qry]
   (sql.helpers/where qry
                      [:or
@@ -78,7 +78,7 @@
                       [:!= :search_index.model [:inline "table"]]
                       [:and
                        [:= :search_index.model [:inline "table"]]
-                       (search.permissions/permitted-tables-caluse search-ctx :search_index.model_id)]]))
+                       (search.permissions/permitted-tables-clause search-ctx :search_index.model_id)]]))
 
 (defn add-collection-join-and-where-clauses
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -55,14 +55,9 @@
     true))
 
 (defmethod check-permissions-for-model :table
-  [search-ctx instance]
-  ;; we've already filtered out tables w/o collection permissions in the query itself.
-  (let [instance-id (:id instance)
-        user-id     (:current-user-id search-ctx)
-        db-id       (database/table-id->database-id instance-id)]
-    (and
-     (perms/user-has-permission-for-table? user-id :perms/view-data :unrestricted db-id instance-id)
-     (perms/user-has-permission-for-table? user-id :perms/create-queries :query-builder db-id instance-id))))
+  [_search-ctx _instance]
+  ;; we've already filtered out tables the user doesn't have access do and don't want to use the default
+  true)
 
 (defmethod check-permissions-for-model :indexed-entity
   [search-ctx instance]

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -161,16 +161,16 @@
     query))
 
 (defn add-table-where-clauses
-  "Add a `WHERE` caluse to the query to only return tables the current user has access to"
+  "Add a `WHERE` clause to the query to only return tables the current user has access to"
   [qry model search-ctx]
   (sql.helpers/where qry (case model
-                           "table" (search.permissions/permitted-tables-caluse search-ctx :table.id)
+                           "table" (search.permissions/permitted-tables-clause search-ctx :table.id)
                            "search-index" [:or
                                            [:= :search_index.model nil]
                                            [:!= :search_index.model [:inline "table"]]
                                            [:and
                                             [:= :search_index.model [:inline "table"]]
-                                            (search.permissions/permitted-tables-caluse search-ctx :search_index.model_id)]])))
+                                            (search.permissions/permitted-tables-clause search-ctx :search_index.model_id)]])))
 
 (mu/defn add-collection-join-and-where-clauses
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -160,6 +160,18 @@
     (sql.helpers/where query [:= id :database_id])
     query))
 
+(defn add-table-where-clauses
+  "Add a `WHERE` caluse to the query to only return tables the current user has access to"
+  [qry model search-ctx]
+  (sql.helpers/where qry (case model
+                           "table" (search.permissions/permitted-tables-caluse search-ctx :table.id)
+                           "search-index" [:or
+                                           [:= :search_index.model nil]
+                                           [:!= :search_index.model [:inline "table"]]
+                                           [:and
+                                            [:= :search_index.model [:inline "table"]]
+                                            (search.permissions/permitted-tables-caluse search-ctx :search_index.model_id)]])))
+
 (mu/defn add-collection-join-and-where-clauses
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,
   so we can return its `:name`."
@@ -168,7 +180,7 @@
    search-ctx     :- SearchContext]
   (let [collection-id-col      (case model
                                  "collection"    :collection.id
-                                 "search-index" :search_index.collection_id
+                                 "search-index"  :search_index.collection_id
                                  :collection_id)
         permitted-clause       (search.permissions/permitted-collections-clause search-ctx collection-id-col)
         personal-clause        (search.filter/personal-collections-where-clause search-ctx collection-id-col)]
@@ -542,6 +554,7 @@
   (when (seq current-user-perms)
     (-> (base-query-for-model model search-ctx)
         (add-table-db-id-clause table-db-id)
+        (add-table-where-clauses model search-ctx)
         (sql.helpers/left-join :metabase_database [:= :table.db_id :metabase_database.id]))))
 
 (defmethod search.engine/model-set :search.engine/in-place

--- a/src/metabase/search/permissions.clj
+++ b/src/metabase/search/permissions.clj
@@ -42,7 +42,7 @@
      :is-superuser?   is-superuser?})
    (perms/audit-namespace-clause :collection.namespace nil)])
 
-(mu/defn permitted-tables-caluse
+(mu/defn permitted-tables-clause
   "Build the WHERE clause corresponding to which tables the given user has access to."
   [{:keys [current-user-id is-superuser?]} :- SearchContext table-id-col :- :keyword]
   (table/visible-tables-filter-clause

--- a/src/metabase/search/permissions.clj
+++ b/src/metabase/search/permissions.clj
@@ -1,6 +1,7 @@
 (ns metabase.search.permissions
   (:require
    [metabase.models.collection :as collection]
+   [metabase.models.table :as table]
    [metabase.permissions.core :as perms]
    [metabase.search.config :refer [SearchContext]]
    [metabase.util.malli :as mu]))
@@ -40,3 +41,13 @@
     {:current-user-id current-user-id
      :is-superuser?   is-superuser?})
    (perms/audit-namespace-clause :collection.namespace nil)])
+
+(mu/defn permitted-tables-caluse
+  "Build the WHERE clause corresponding to which tables the given user has access to."
+  [{:keys [current-user-id is-superuser?]} :- SearchContext table-id-col :- :keyword]
+  (table/visible-tables-filter-clause
+   table-id-col
+   {:user-id current-user-id
+    :is-superuser? is-superuser?
+    :view-data-permission-level :unrestricted
+    :create-queries-permission-level :query-builder}))

--- a/src/metabase/util/honey_sql_2.clj
+++ b/src/metabase/util/honey_sql_2.clj
@@ -180,7 +180,9 @@
 
 (sql/register-fn! ::literal #'format-literal)
 
-(defn literal
+(def Literal "A `literal` tagged string or keyword" [:tuple [:= ::literal] :string])
+
+(mu/defn literal :- Literal
   "Wrap keyword or string `s` in single quotes and a HoneySQL `raw` form.
 
   We'll try to escape single quotes in the literal, unless they're already escaped (either as `''` or as `\\`, but

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -921,6 +921,15 @@
                (binding [*search-request-results-database-id* db-id]
                  (search-request-data :rasta :q (:name table)))))))))
 
+(deftest table-test-8
+  (testing "you should be able to see a Table when the current user is a superuser"
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/Table    table {:db_id db-id}]
+      (mt/with-no-data-perms-for-all-users!
+        (is (= 1
+               (binding [*search-request-results-database-id* db-id]
+                 (count (search-request-data :crowberto :q (:name table))))))))))
+
 (deftest all-users-no-perms-table-test
   (testing (str "If the All Users group doesn't have perms to view a Table, but the current User is in a group that "
                 "does have perms, they should still be able to see it (#12332)")

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -143,7 +143,7 @@
 (deftest phrase-test
   (with-index
     (with-fulltext-filtering
-    ;; Less matches without an english dictionary
+      ;; Less matches without an english dictionary
       (is (= #_2 3 (index-hits "projected")))
       (is (= 2 (index-hits "revenue")))
       (is (= #_1 2 (index-hits "projected revenue")))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57413

### Description

Some places in our code we may be returning fewer tables than a user has access to because we load a limited number of models from the database then apply permissions filters to those. This provides a subquery based check for table permissions that we can use in other queries to do the same kind of test for table access that we would do on the clojure-side.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
