### PR TITLE
Content translation: validate uploads

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -265,6 +265,10 @@
            task
            util}}
 
+  content-translation
+  {:api  #{metabase.content-translation.api}
+   :uses #{api}}
+
   content-verification
   {:api  #{metabase.content-verification.core
            metabase.content-verification.init}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1445,7 +1445,7 @@
            util}}
 
   enterprise/content-translation
-  {:api  #{metabase-enterprise.content-translation.api.routes}
+  {:api  #{metabase-enterprise.content-translation.routes}
    :uses #{api
            content-translation
            util

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1440,6 +1440,13 @@
            task
            util}}
 
+  enterprise/content-translation
+  {:api  #{metabase-enterprise.content-translation.api.routes}
+   :uses #{api
+           content-translation
+           util
+           enterprise/api}}
+
   enterprise/content-verification
   {:api  #{metabase-enterprise.content-verification.api.routes}
    :uses #{api

--- a/e2e/test/scenarios/admin/i18n/content-translation/constants.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/constants.ts
@@ -46,6 +46,13 @@ export const nonAsciiFieldNames: DictionaryArray = [
 
 export const columnNamesWithTypeText = ["Title", "Category", "Vendor"];
 
+export const invalidLocaleXX = structuredClone(germanFieldNames);
+invalidLocaleXX[0].locale = "xx";
+
+export const multipleInvalidLocales = structuredClone(germanFieldNames);
+multipleInvalidLocales[0].locale = "ze";
+multipleInvalidLocales[3].locale = "qe";
+
 export const stringTranslatedTwice = structuredClone(germanFieldNames);
 stringTranslatedTwice.push({
   locale: "de",

--- a/e2e/test/scenarios/admin/i18n/content-translation/constants.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/constants.ts
@@ -45,3 +45,10 @@ export const nonAsciiFieldNames: DictionaryArray = [
 ];
 
 export const columnNamesWithTypeText = ["Title", "Category", "Vendor"];
+
+export const stringTranslatedTwice = structuredClone(germanFieldNames);
+stringTranslatedTwice.push({
+  locale: "de",
+  msgid: "Title",
+  msgstr: "Überschrift",
+});

--- a/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
@@ -46,3 +46,17 @@ export const interceptContentTranslationRoutes = () => {
     "uploadDictionary",
   );
 };
+
+export const generateLargeCSV = ({
+  sizeInMebibytes,
+}: {
+  sizeInMebibytes: number;
+}) => {
+  const oneMebibyte = 2 ** 20;
+  const charsPerRow = 100;
+  const totalRows = Math.floor((sizeInMebibytes * oneMebibyte) / charsPerRow);
+  const header = "locale,string,translation\n";
+  const row = "de,data2,data3\n";
+  const largeCSV = header + row.repeat(totalRows);
+  return largeCSV;
+};

--- a/e2e/test/scenarios/admin/i18n/content-translation/upload.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload.cy.spec.ts
@@ -1,9 +1,15 @@
 import {
   germanFieldNames,
+  invalidLocaleAndInvalidRow,
+  invalidLocaleXX,
+  longCSVCell,
+  multipleInvalidLocales,
   nonAsciiFieldNames,
   portugueseFieldNames,
+  stringTranslatedTwice,
 } from "./constants";
 import {
+  assertAdminSummarizesTranslations,
   assertOnlyTheseTranslationsAreStored,
   uploadTranslationDictionary,
 } from "./helpers/e2e-content-translation-helpers";
@@ -43,6 +49,7 @@ describe("scenarios > admin > localization > content translation", () => {
           "Dictionary uploaded",
         );
         assertOnlyTheseTranslationsAreStored(germanFieldNames);
+        assertAdminSummarizesTranslations({ German: germanFieldNames.length });
       });
 
       it("accepts a CSV upload with non-ASCII characters", () => {
@@ -51,6 +58,18 @@ describe("scenarios > admin > localization > content translation", () => {
           "Dictionary uploaded",
         );
         assertOnlyTheseTranslationsAreStored(nonAsciiFieldNames);
+        assertAdminSummarizesTranslations({
+          Arabic: 1,
+          Hebrew: 1,
+          Japanese: 1,
+          Korean: 1,
+          Russian: 1,
+          Turkish: 1,
+          Ukrainian: 1,
+          Vietnamese: 1,
+          "Chinese (Taiwan)": 1,
+          English: 1,
+        });
       });
 
       it("accepts a CSV upload with a hyphenated locale", () => {
@@ -60,6 +79,9 @@ describe("scenarios > admin > localization > content translation", () => {
         );
         cy.signInAsNormalUser();
         assertOnlyTheseTranslationsAreStored(portugueseFieldNames);
+        assertAdminSummarizesTranslations({
+          "Portuguese (Brazil)": portugueseFieldNames.length,
+        });
       });
 
       it("does not store rows with translations made of only whitespace and/or semicolons", () => {
@@ -90,11 +112,72 @@ describe("scenarios > admin > localization > content translation", () => {
         assertOnlyTheseTranslationsAreStored(germanFieldNames);
       });
 
+      it("rejects a CSV upload that provides two translations for the same string", () => {
+        uploadTranslationDictionary(stringTranslatedTwice);
+        cy.findByTestId("content-localization-setting").within(() => {
+          cy.findByText(/We couldn't upload the file/);
+          cy.findByText(
+            new RegExp(
+              `Row ${stringTranslatedTwice.length + 1}.*earlier in the file`,
+            ),
+          );
+        });
+      });
+
+      it("rejects a CSV upload with invalid locale in one row", () => {
+        uploadTranslationDictionary(invalidLocaleXX);
+        cy.findByTestId("content-localization-setting").within(() => {
+          cy.findByText(/We couldn't upload the file/);
+          cy.log("The error is in row 2 (the first row is the header)");
+          cy.findByText(/Row 2: Invalid locale: xx/);
+        });
+      });
+
       it("erases previously stored translations when a new CSV is uploaded", () => {
         uploadTranslationDictionary(germanFieldNames);
         assertOnlyTheseTranslationsAreStored(germanFieldNames);
         uploadTranslationDictionary(nonAsciiFieldNames);
         assertOnlyTheseTranslationsAreStored(nonAsciiFieldNames);
+      });
+
+      it("does not erase previously stored translations when an upload fails", () => {
+        uploadTranslationDictionary(germanFieldNames);
+        assertOnlyTheseTranslationsAreStored(germanFieldNames);
+        uploadTranslationDictionary(invalidLocaleXX);
+        assertOnlyTheseTranslationsAreStored(germanFieldNames);
+      });
+
+      it("rejects a CSV upload with invalid locales in multiple rows", () => {
+        uploadTranslationDictionary(multipleInvalidLocales);
+        cy.findByTestId("content-localization-setting").within(() => {
+          cy.findByText(/We couldn't upload the file/);
+          cy.log("The first error is in row 2 (the first row is the header)");
+          cy.findByText(/Row 2: Invalid locale: ze/);
+          cy.findByText(/Row 5: Invalid locale: qe/);
+        });
+      });
+
+      it("rejects a CSV upload with different kinds of errors", () => {
+        uploadTranslationDictionary(invalidLocaleAndInvalidRow);
+        cy.findByTestId("content-localization-setting").within(() => {
+          cy.findByText(/We couldn't upload the file/);
+          cy.findByText(/Row 2: Invalid locale: ze/);
+          cy.findByText(/Row 5: Translation exceeds maximum length/);
+        });
+      });
+
+      (["msgid", "msgstr"] as const).forEach((column) => {
+        it(`rejects a CSV upload containing a row with a ${column} that is too long`, () => {
+          const rows = structuredClone(germanFieldNames);
+          rows[3][column] = longCSVCell;
+          uploadTranslationDictionary(rows);
+          // Index 3 in the rows array corresponds to the 4th row of data. The
+          // 4th row of data is the 5th row in the CSV file, because the file
+          // has a header row
+          cy.findByTestId("content-localization-setting").findByText(
+            /Row 5.*exceeds maximum length/,
+          );
+        });
       });
     });
   });

--- a/e2e/test/scenarios/admin/i18n/content-translation/upload.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload.cy.spec.ts
@@ -9,7 +9,6 @@ import {
   stringTranslatedTwice,
 } from "./constants";
 import {
-  assertAdminSummarizesTranslations,
   assertOnlyTheseTranslationsAreStored,
   uploadTranslationDictionary,
 } from "./helpers/e2e-content-translation-helpers";
@@ -49,7 +48,6 @@ describe("scenarios > admin > localization > content translation", () => {
           "Dictionary uploaded",
         );
         assertOnlyTheseTranslationsAreStored(germanFieldNames);
-        assertAdminSummarizesTranslations({ German: germanFieldNames.length });
       });
 
       it("accepts a CSV upload with non-ASCII characters", () => {
@@ -58,18 +56,6 @@ describe("scenarios > admin > localization > content translation", () => {
           "Dictionary uploaded",
         );
         assertOnlyTheseTranslationsAreStored(nonAsciiFieldNames);
-        assertAdminSummarizesTranslations({
-          Arabic: 1,
-          Hebrew: 1,
-          Japanese: 1,
-          Korean: 1,
-          Russian: 1,
-          Turkish: 1,
-          Ukrainian: 1,
-          Vietnamese: 1,
-          "Chinese (Taiwan)": 1,
-          English: 1,
-        });
       });
 
       it("accepts a CSV upload with a hyphenated locale", () => {
@@ -79,9 +65,6 @@ describe("scenarios > admin > localization > content translation", () => {
         );
         cy.signInAsNormalUser();
         assertOnlyTheseTranslationsAreStored(portugueseFieldNames);
-        assertAdminSummarizesTranslations({
-          "Portuguese (Brazil)": portugueseFieldNames.length,
-        });
       });
 
       it("does not store rows with translations made of only whitespace and/or semicolons", () => {

--- a/e2e/test/scenarios/admin/i18n/content-translation/upload.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload.cy.spec.ts
@@ -1,8 +1,6 @@
 import {
   germanFieldNames,
-  invalidLocaleAndInvalidRow,
   invalidLocaleXX,
-  longCSVCell,
   multipleInvalidLocales,
   nonAsciiFieldNames,
   portugueseFieldNames,
@@ -137,29 +135,6 @@ describe("scenarios > admin > localization > content translation", () => {
           cy.log("The first error is in row 2 (the first row is the header)");
           cy.findByText(/Row 2: Invalid locale: ze/);
           cy.findByText(/Row 5: Invalid locale: qe/);
-        });
-      });
-
-      it("rejects a CSV upload with different kinds of errors", () => {
-        uploadTranslationDictionary(invalidLocaleAndInvalidRow);
-        cy.findByTestId("content-localization-setting").within(() => {
-          cy.findByText(/We couldn't upload the file/);
-          cy.findByText(/Row 2: Invalid locale: ze/);
-          cy.findByText(/Row 5: Translation exceeds maximum length/);
-        });
-      });
-
-      (["msgid", "msgstr"] as const).forEach((column) => {
-        it(`rejects a CSV upload containing a row with a ${column} that is too long`, () => {
-          const rows = structuredClone(germanFieldNames);
-          rows[3][column] = longCSVCell;
-          uploadTranslationDictionary(rows);
-          // Index 3 in the rows array corresponds to the 4th row of data. The
-          // 4th row of data is the 5th row in the CSV file, because the file
-          // has a header row
-          cy.findByTestId("content-localization-setting").findByText(
-            /Row 5.*exceeds maximum length/,
-          );
         });
       });
     });

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -13,7 +13,7 @@
    [metabase-enterprise.api.routes.common :as ee.api.common]
    [metabase-enterprise.audit-app.api.routes]
    [metabase-enterprise.billing.api.routes]
-   [metabase-enterprise.content-translation.api.routes]
+   [metabase-enterprise.content-translation.routes]
    [metabase-enterprise.content-verification.api.routes]
    [metabase-enterprise.data-editing.api]
    [metabase-enterprise.database-routing.api]
@@ -80,7 +80,7 @@
    "/autodescribe"               (premium-handler 'metabase-enterprise.llm.api :llm-autodescription)
    "/billing"                    metabase-enterprise.billing.api.routes/routes
    "/data-editing"               (premium-handler metabase-enterprise.data-editing.api/routes :table-data-editing)
-   "/content-translation"        (premium-handler metabase-enterprise.content-translation.api.routes/routes :content-translation)
+   "/content-translation"        (premium-handler metabase-enterprise.content-translation.routes/routes :content-translation)
    "/gsheets"                    (-> gsheets.api/routes ;; gsheets requires both features.
                                      (premium-handler :attached-dwh)
                                      (premium-handler :etl-connections))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/api/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/api/dictionary.clj
@@ -10,6 +10,43 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private http-status-unprocessable 422)
+
+(def ^:private max-string-length 255)
+
+(defn- row-has-correct-number-of-fields
+  "Checks if a row has the expected format with exactly 3 columns."
+  [row]
+  (and (vector? row) (= (count row) 3)))
+
+(defn- collect-row-format-error
+  "Returns an error message if a row does not have the expected format."
+  [row-index row]
+  (when-not (row-has-correct-number-of-fields row)
+    (tru "Row {0}: Invalid format. Expected exactly 3 columns (Language, String, Translation)" (+ row-index 2))))
+
+(defn- collect-locale-error
+  "Returns an error message if a row does not have a valid locale."
+  [row-index locale]
+  (when (and (not (str/blank? locale))
+             (not (i18n/available-locale? locale)))
+    (tru "Row {0}: Invalid locale: {1}" (+ row-index 2) locale)))
+
+(defn- collect-duplication-error
+  "Returns an error message if this translation key has already been seen in the file. A translation key is a string like 'de,Category'"
+  [seen-keys translation-key row-index locale trimmed-msgid]
+  (when (contains? seen-keys translation-key)
+    (tru "Row {0}: The string \"{1}\" is translated into locale \"{2}\" earlier in the file"
+         (+ row-index 2) trimmed-msgid locale)))
+
+(defn- collect-string-length-error
+  "Checks if a string is within length limits and returns an error message if not."
+  [row-index field-name string-value]
+  (when (and (not (str/blank? string-value))
+             (> (count string-value) max-string-length))
+    (tru "Row {0}: {1} exceeds maximum length of {2} characters"
+         (+ row-index 2) field-name max-string-length)))
+
 (defn- read-csv-file
   "Read CSV file content, skipping the header row. Throws a formatted exception if parsing fails."
   [reader]
@@ -18,7 +55,7 @@
     (catch Exception e
       (log/error e "Error parsing CSV file")
       (throw (ex-info (tru "Please upload a valid CSV file.")
-                      {:status-code 422
+                      {:status-code http-status-unprocessable
                        :errors [(tru "Invalid CSV format: {0}" (.getMessage e))]})))))
 
 (defn is-msgstr-usable
@@ -29,19 +66,61 @@
     (str/blank? msgstr)
     (re-matches #"^[,;\s]*$" msgstr))))
 
+(defn- validate-row
+  "Validate a single row of CSV data, recording errors and updating the set of seen translation keys."
+  [row-index row seen-keys]
+  (let [errors (transient [])
+        [locale msgid msgstr] row
+        trimmed-msgid (str/trim msgid)
+        trimmed-msgstr (str/trim msgstr)
+        translation-key (str locale "," trimmed-msgid)]
+    (when-let [format-error (collect-row-format-error row-index row)]
+      (conj! errors format-error))
+
+    (when (row-has-correct-number-of-fields row)
+      (when-let [duplication-error (collect-duplication-error seen-keys translation-key row-index locale trimmed-msgid)]
+        (conj! errors duplication-error))
+      (when-let [locale-error (collect-locale-error row-index locale)]
+        (conj! errors locale-error))
+      (when-let [msgid-error (collect-string-length-error row-index "Original string" trimmed-msgid)]
+        (conj! errors msgid-error))
+      (when-let [msgstr-error (collect-string-length-error row-index "Translation" trimmed-msgstr)]
+        (conj! errors msgstr-error)))
+
+    {:errors (persistent! errors) :seen-keys (conj seen-keys translation-key)}))
+
 (defn import-translations!
   "Import translations from CSV and insert or update rows in the content_translation table."
   [{:keys [file]}]
   (with-open [reader (io/reader file)]
-    (let [csv-data (read-csv-file reader)
-          usable-rows (for [[locale msgid msgstr] csv-data
-                            :let [trimmed-msgid (str/trim msgid)
-                                  trimmed-msgstr (str/trim msgstr)]
-                            :when (is-msgstr-usable trimmed-msgstr)]
-                        {:locale locale :msgid trimmed-msgid :msgstr trimmed-msgstr})]
-      (t2/with-transaction [_tx]
-        ;; Replace all existing entries
-        (t2/delete! :model/ContentTranslation)
-        ;; Insert all usable rows at once
-        (when-not (empty? usable-rows)
-          (t2/insert! :model/ContentTranslation usable-rows))))))
+    (let [csv-data (read-csv-file reader)]
+
+      ; Validate all rows before proceeding
+      (loop [rows (map-indexed vector csv-data)
+             errors (transient [])
+             seen-keys #{}]
+        (if (seq rows)
+          (let [[row-index row] (first rows)
+                {row-errors :errors updated-seen-keys :seen-keys}
+                (validate-row row-index row seen-keys)]
+            (recur (rest rows)
+                   (reduce conj! errors row-errors)
+                   updated-seen-keys))
+
+          (let [all-errors (persistent! errors)]
+            (when (seq all-errors)
+              (throw (ex-info (tru "The file could not be uploaded due to the following error(s):")
+                              {:status-code http-status-unprocessable
+                               :errors all-errors}))))))
+
+      (let [usable-rows (for [[locale msgid msgstr] csv-data
+                              :let [trimmed-msgid (str/trim msgid)
+                                    trimmed-msgstr (str/trim msgstr)]
+                              :when (is-msgstr-usable trimmed-msgstr)]
+                          {:locale locale :msgid trimmed-msgid :msgstr trimmed-msgstr})]
+        (t2/with-transaction [_tx]
+          ;; Replace all existing entries
+          (t2/delete! :model/ContentTranslation)
+          ;; Insert all usable rows at once
+          (when-not (empty? usable-rows)
+            (t2/insert! :model/ContentTranslation usable-rows)))))))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/api/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/api/dictionary.clj
@@ -4,7 +4,7 @@
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [metabase.util.i18n :refer [tru]]
+   [metabase.util.i18n :as i18n :refer [tru]]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 

--- a/enterprise/backend/src/metabase_enterprise/content_translation/api/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/api/dictionary.clj
@@ -12,24 +12,16 @@
 
 (def ^:private http-status-unprocessable 422)
 
-(def ^:private max-string-length 255)
-
-(defn- row-has-correct-number-of-fields
-  "Checks if a row has the expected format with exactly 3 columns."
-  [row]
-  (and (vector? row) (= (count row) 3)))
-
 (defn- collect-row-format-error
   "Returns an error message if a row does not have the expected format."
   [row-index row]
-  (when-not (row-has-correct-number-of-fields row)
+  (when-not (= (count row) 3)
     (tru "Row {0}: Invalid format. Expected exactly 3 columns (Language, String, Translation)" (+ row-index 2))))
 
 (defn- collect-locale-error
   "Returns an error message if a row does not have a valid locale."
   [row-index locale]
-  (when (and (not (str/blank? locale))
-             (not (i18n/available-locale? locale)))
+  (when (not (i18n/available-locale? locale))
     (tru "Row {0}: Invalid locale: {1}" (+ row-index 2) locale)))
 
 (defn- collect-duplication-error
@@ -38,14 +30,6 @@
   (when (contains? seen-keys translation-key)
     (tru "Row {0}: The string \"{1}\" is translated into locale \"{2}\" earlier in the file"
          (+ row-index 2) trimmed-msgid locale)))
-
-(defn- collect-string-length-error
-  "Checks if a string is within length limits and returns an error message if not."
-  [row-index field-name string-value]
-  (when (and (not (str/blank? string-value))
-             (> (count string-value) max-string-length))
-    (tru "Row {0}: {1} exceeds maximum length of {2} characters"
-         (+ row-index 2) field-name max-string-length)))
 
 (defn- read-csv-file
   "Read CSV file content, skipping the header row. Throws a formatted exception if parsing fails."
@@ -66,61 +50,53 @@
     (str/blank? msgstr)
     (re-matches #"^[,;\s]*$" msgstr))))
 
+(defn- row-has-correct-number-of-fields
+  "Checks if a row has the expected format with exactly 3 columns."
+  [row]
+  (= (count row) 3))
+
 (defn- validate-row
-  "Validate a single row of CSV data, recording errors and updating the set of seen translation keys."
+  "Validate a single row of CSV data, returning errors and the updated set of seen translation keys."
   [row-index row seen-keys]
-  (let [errors (transient [])
-        [locale msgid msgstr] row
+  (let [[locale msgid _msgstr] row
         trimmed-msgid (str/trim msgid)
-        trimmed-msgstr (str/trim msgstr)
         translation-key (str locale "," trimmed-msgid)]
-    (when-let [format-error (collect-row-format-error row-index row)]
-      (conj! errors format-error))
-
-    (when (row-has-correct-number-of-fields row)
-      (when-let [duplication-error (collect-duplication-error seen-keys translation-key row-index locale trimmed-msgid)]
-        (conj! errors duplication-error))
-      (when-let [locale-error (collect-locale-error row-index locale)]
-        (conj! errors locale-error))
-      (when-let [msgid-error (collect-string-length-error row-index "Original string" trimmed-msgid)]
-        (conj! errors msgid-error))
-      (when-let [msgstr-error (collect-string-length-error row-index "Translation" trimmed-msgstr)]
-        (conj! errors msgstr-error)))
-
-    {:errors (persistent! errors) :seen-keys (conj seen-keys translation-key)}))
+    (if-let [format-error (collect-row-format-error row-index row)]
+      ;; If the row format is invalid, just return that error
+      {:errors [format-error] :seen-keys (conj seen-keys translation-key)}
+      ;; Otherwise check for other potential errors
+      (let [errors (remove nil?
+                           [(collect-duplication-error seen-keys translation-key row-index locale trimmed-msgid)
+                            (collect-locale-error row-index locale)])]
+        {:errors errors :seen-keys (conj seen-keys translation-key)}))))
 
 (defn import-translations!
   "Import translations from CSV and insert or update rows in the content_translation table."
   [{:keys [file]}]
   (with-open [reader (io/reader file)]
-    (let [csv-data (read-csv-file reader)]
-
-      ; Validate all rows before proceeding
-      (loop [rows (map-indexed vector csv-data)
-             errors (transient [])
-             seen-keys #{}]
-        (if (seq rows)
-          (let [[row-index row] (first rows)
-                {row-errors :errors updated-seen-keys :seen-keys}
-                (validate-row row-index row seen-keys)]
-            (recur (rest rows)
-                   (reduce conj! errors row-errors)
-                   updated-seen-keys))
-
-          (let [all-errors (persistent! errors)]
-            (when (seq all-errors)
+    ; Validate all rows before proceeding
+    (let [csv-data (read-csv-file reader)
+          errors (seq
+                  (:errors (reduce (fn [{:keys [seen-keys] :as m} [row-index row]]
+                                     (let [{row-errors :errors updated-seen-keys :seen-keys} (validate-row row-index row seen-keys)]
+                                       (-> m
+                                           (update :seen-keys #(apply conj %1 %2) updated-seen-keys)
+                                           (update :errors #(apply conj %1 %2) row-errors))))
+                                   {:seen-keys #{}
+                                    :errors []}
+                                   (map-indexed vector csv-data))))
+          _ (when (seq errors)
               (throw (ex-info (tru "The file could not be uploaded due to the following error(s):")
                               {:status-code http-status-unprocessable
-                               :errors all-errors}))))))
-
-      (let [usable-rows (for [[locale msgid msgstr] csv-data
-                              :let [trimmed-msgid (str/trim msgid)
-                                    trimmed-msgstr (str/trim msgstr)]
-                              :when (is-msgstr-usable trimmed-msgstr)]
-                          {:locale locale :msgid trimmed-msgid :msgstr trimmed-msgstr})]
-        (t2/with-transaction [_tx]
-          ;; Replace all existing entries
-          (t2/delete! :model/ContentTranslation)
-          ;; Insert all usable rows at once
-          (when-not (empty? usable-rows)
-            (t2/insert! :model/ContentTranslation usable-rows)))))))
+                               :errors errors})))
+          usable-rows (for [[locale msgid msgstr] csv-data
+                            :let [trimmed-msgid (str/trim msgid)
+                                  trimmed-msgstr (str/trim msgstr)]
+                            :when (is-msgstr-usable trimmed-msgstr)]
+                        {:locale locale :msgid trimmed-msgid :msgstr trimmed-msgstr})]
+      (t2/with-transaction [_tx]
+        ;; Replace all existing entries
+        (t2/delete! :model/ContentTranslation)
+        ;; Insert all usable rows at once
+        (when-not (empty? usable-rows)
+          (t2/insert! :model/ContentTranslation usable-rows))))))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
@@ -46,7 +46,6 @@
         ; For other types of exceptions, rethrow
         (throw e)))))
 
-
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/content-translation` routes."
   (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
@@ -9,7 +9,10 @@
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private http-status-ok 200)
+(def ^:private http-status-unprocessable 422)
 
 (api.macros/defendpoint :post
   "/upload-dictionary"
@@ -25,11 +28,24 @@
                                                    [:map
                                                     [:filename :string]
                                                     [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
-  (dictionary/import-translations! {:filename (get-in multipart-params ["file" :filename])
-                                    :file     (get-in multipart-params ["file" :tempfile])})
-  {:status http-status-ok
-   :headers {"Content-Type" "application/json"}
-   :body (json/encode {:success true})})
+  (try
+    (dictionary/import-translations! {:filename (get-in multipart-params ["file" :filename])
+                                      :file     (get-in multipart-params ["file" :tempfile])})
+    {:status http-status-ok
+     :headers {"Content-Type" "application/json"}
+     :body (json/encode {:success true
+                         :message (tru "Import was successful")})}
+    (catch clojure.lang.ExceptionInfo e
+      ; If the exception contains a list of validation errors, return them properly formatted
+      (if-let [errors (get (ex-data e) :errors)]
+        {:status (or (:status-code (ex-data e)) http-status-unprocessable)
+         :headers {"Content-Type" "application/json"}
+         :body (json/encode {:success false
+                             :message (.getMessage e)
+                             :errors errors})}
+        ; For other types of exceptions, rethrow
+        (throw e)))))
+
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/content-translation` routes."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
@@ -1,10 +1,9 @@
 (ns metabase-enterprise.content-translation.api.routes
   "Endpoints relating to the translation of user-generated content"
   (:require
-   [metabase-enterprise.content-translation.api.dictionary :as dictionary]
-   [metabase-enterprise.content-translation.models :as ct]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
+   [metabase.content-translation.api.dictionary :as dictionary]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -7,6 +7,8 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private http-status-unprocessable 422)
+
 (defn- translation-key
   "The identity of a translation. It's locale and source string so we can identify if the same translation is present
   multiple times."
@@ -79,7 +81,7 @@
   (let [{:keys [translations errors]} (process-rows rows)]
     (when (seq errors)
       (throw (ex-info (tru "The file could not be uploaded due to the following error(s):")
-                      {:status-code 422
+                      {:status-code http-status-unprocessable
                        :errors errors})))
     ;; remove bad msgstrs after error generator for line number reporting reasons
     (let [usable-rows (filter (comp is-msgstr-usable :msgstr) translations)]

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.content-translation.api.dictionary
+(ns metabase-enterprise.content-translation.dictionary
   "Implementation of dictionary upload and retrieval logic for content translations"
   (:require
    [clojure.data.csv :as csv]

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -50,11 +50,6 @@
     (str/blank? msgstr)
     (re-matches #"^[,;\s]*$" msgstr))))
 
-(defn- row-has-correct-number-of-fields
-  "Checks if a row has the expected format with exactly 3 columns."
-  [row]
-  (= (count row) 3))
-
 (defn- validate-row
   "Validate a single row of CSV data, returning errors and the updated set of seen translation keys."
   [row-index row seen-keys]

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -1,48 +1,39 @@
 (ns metabase-enterprise.content-translation.dictionary
   "Implementation of dictionary upload and retrieval logic for content translations"
   (:require
-   [clojure.data.csv :as csv]
-   [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase.util.i18n :as i18n :refer [tru]]
-   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
-(def ^:private http-status-unprocessable 422)
+(defn- translation-key
+  "The identity of a translation. It's locale and source string so we can identify if the same translation is present
+  multiple times."
+  [t]
+  (select-keys t [:locale :msgid]))
 
-(defn- collect-row-format-error
-  "Returns an error message if a row does not have the expected format."
-  [row-index row]
-  (when-not (= (count row) 3)
-    (tru "Row {0}: Invalid format. Expected exactly 3 columns (Language, String, Translation)" (+ row-index 2))))
+(defn- adjust-index
+  "Adjust index: increment once for the header row that was chopped off and again to go to 1-based indexing for human
+  consumption."
+  [i]
+  (+ i 2))
 
 (defn- collect-locale-error
   "Returns an error message if a row does not have a valid locale."
-  [row-index locale]
+  [_state index {:keys [locale]}]
   (when (not (i18n/available-locale? locale))
-    (tru "Row {0}: Invalid locale: {1}" (+ row-index 2) locale)))
+    (tru "Row {0}: Invalid locale: {1}" (adjust-index index) locale)))
 
 (defn- collect-duplication-error
-  "Returns an error message if this translation key has already been seen in the file. A translation key is a string like 'de,Category'"
-  [seen-keys translation-key row-index locale trimmed-msgid]
-  (when (contains? seen-keys translation-key)
+  "Returns an error message if this translation key has already been seen in the file. A translation key is a string
+  like 'de,Category'"
+  [{:keys [seen] :as _state} index {:keys [msgid locale] :as translation}]
+  (when (-> translation translation-key seen)
     (tru "Row {0}: The string \"{1}\" is translated into locale \"{2}\" earlier in the file"
-         (+ row-index 2) trimmed-msgid locale)))
+         (adjust-index index) msgid locale)))
 
-(defn- read-csv-file
-  "Read CSV file content, skipping the header row. Throws a formatted exception if parsing fails."
-  [reader]
-  (try
-    (rest (csv/read-csv reader))
-    (catch Exception e
-      (log/error e "Error parsing CSV file")
-      (throw (ex-info (tru "Please upload a valid CSV file.")
-                      {:status-code http-status-unprocessable
-                       :errors [(tru "Invalid CSV format: {0}" (.getMessage e))]})))))
-
-(defn is-msgstr-usable
+(defn- is-msgstr-usable
   "Check if the translation string is usable. It should not be blank or contain only commas, whitespace, or semicolons."
   [msgstr]
   (not
@@ -50,45 +41,48 @@
     (str/blank? msgstr)
     (re-matches #"^[,;\s]*$" msgstr))))
 
-(defn- validate-row
-  "Validate a single row of CSV data, returning errors and the updated set of seen translation keys."
-  [row-index row seen-keys]
-  (let [[locale msgid _msgstr] row
-        trimmed-msgid (str/trim msgid)
-        translation-key (str locale "," trimmed-msgid)]
-    (if-let [format-error (collect-row-format-error row-index row)]
-      ;; If the row format is invalid, just return that error
-      {:errors [format-error] :seen-keys (conj seen-keys translation-key)}
-      ;; Otherwise check for other potential errors
-      (let [errors (remove nil?
-                           [(collect-duplication-error seen-keys translation-key row-index locale trimmed-msgid)
-                            (collect-locale-error row-index locale)])]
-        {:errors errors :seen-keys (conj seen-keys translation-key)}))))
+(defn- row-errors
+  [state index translation]
+  (keep (fn [f] (f state index translation))
+        [collect-duplication-error collect-locale-error]))
+
+(defn- wrong-row-shape
+  [index]
+  (tru "Row {0}: Invalid format. Expected exactly 3 columns (Language, String, Translation)"
+       (adjust-index index)))
+
+(defn- process-rows
+  "Format, trim, validate rows. Takes the vectors from a csv and returns a map with the shape
+  {:translations [{:locale :msgid :msgstr}]
+   :errors       [string]}.
+  The :seen set is returned but not meant for consumption."
+  [rows]
+  (reduce (fn [state [index row]]
+            (let [[locale msgid msgstr & extra] row
+                  translation                   {:locale locale
+                                                 :msgid  (str/trim msgid)
+                                                 :msgstr (str/trim msgstr)}
+                  errors                        (cond-> (row-errors state index translation)
+                                                  (seq extra) (conj (wrong-row-shape index)))]
+              (cond-> (-> state
+                          (update :seen conj (dissoc translation :msgstr))
+                          (update :translations conj translation))
+                (seq errors) (update :errors into errors))))
+          {:seen         #{}
+           :errors       []
+           :translations []}
+          (map-indexed vector rows)))
 
 (defn import-translations!
   "Import translations from CSV and insert or update rows in the content_translation table."
-  [{:keys [file]}]
-  (with-open [reader (io/reader file)]
-    ; Validate all rows before proceeding
-    (let [csv-data (read-csv-file reader)
-          errors (seq
-                  (:errors (reduce (fn [{:keys [seen-keys] :as m} [row-index row]]
-                                     (let [{row-errors :errors updated-seen-keys :seen-keys} (validate-row row-index row seen-keys)]
-                                       (-> m
-                                           (update :seen-keys #(apply conj %1 %2) updated-seen-keys)
-                                           (update :errors #(apply conj %1 %2) row-errors))))
-                                   {:seen-keys #{}
-                                    :errors []}
-                                   (map-indexed vector csv-data))))
-          _ (when (seq errors)
-              (throw (ex-info (tru "The file could not be uploaded due to the following error(s):")
-                              {:status-code http-status-unprocessable
-                               :errors errors})))
-          usable-rows (for [[locale msgid msgstr] csv-data
-                            :let [trimmed-msgid (str/trim msgid)
-                                  trimmed-msgstr (str/trim msgstr)]
-                            :when (is-msgstr-usable trimmed-msgstr)]
-                        {:locale locale :msgid trimmed-msgid :msgstr trimmed-msgstr})]
+  [rows]
+  (let [{:keys [translations errors]} (process-rows rows)]
+    (when (seq errors)
+      (throw (ex-info (tru "The file could not be uploaded due to the following error(s):")
+                      {:status-code 422
+                       :errors errors})))
+    ;; remove bad msgstrs after error generator for line number reporting reasons
+    (let [usable-rows (filter (comp is-msgstr-usable :msgstr) translations)]
       (t2/with-transaction [_tx]
         ;; Replace all existing entries
         (t2/delete! :model/ContentTranslation)

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -1,17 +1,13 @@
 (ns metabase-enterprise.content-translation.api.routes
   "Endpoints relating to the translation of user-generated content"
   (:require
+   [metabase-enterprise.content-translation.dictionary :as dictionary]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
-   [metabase.content-translation.api.dictionary :as dictionary]
-   [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]))
 
-(set! *warn-on-reflection* true)
-
 (def ^:private http-status-ok 200)
-(def ^:private http-status-unprocessable 422)
 
 (api.macros/defendpoint :post
   "/upload-dictionary"
@@ -27,23 +23,11 @@
                                                    [:map
                                                     [:filename :string]
                                                     [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
-  (try
-    (dictionary/import-translations! {:filename (get-in multipart-params ["file" :filename])
-                                      :file     (get-in multipart-params ["file" :tempfile])})
-    {:status http-status-ok
-     :headers {"Content-Type" "application/json"}
-     :body (json/encode {:success true
-                         :message (tru "Import was successful")})}
-    (catch clojure.lang.ExceptionInfo e
-      ; If the exception contains a list of validation errors, return them properly formatted
-      (if-let [errors (get (ex-data e) :errors)]
-        {:status (or (:status-code (ex-data e)) http-status-unprocessable)
-         :headers {"Content-Type" "application/json"}
-         :body (json/encode {:success false
-                             :message (.getMessage e)
-                             :errors errors})}
-        ; For other types of exceptions, rethrow
-        (throw e)))))
+  (dictionary/import-translations! {:filename (get-in multipart-params ["file" :filename])
+                                    :file     (get-in multipart-params ["file" :tempfile])})
+  {:status http-status-ok
+   :headers {"Content-Type" "application/json"}
+   :body (json/encode {:success true})})
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/content-translation` routes."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -7,7 +7,17 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli.schema :as ms]))
+   [metabase.util.malli.schema :as ms])
+  (:import
+   (java.io File)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private http-status-content-too-large 413)
+
+;; The maximum size of a content translation dictionary is 1.5MiB
+;; This should equal the maxContentDictionarySizeInMiB variable in the frontend
+(def ^:private max-content-translation-dictionary-size (* 1.5 1024 1024))
 
 (api.macros/defendpoint :post
   "/upload-dictionary"
@@ -24,12 +34,15 @@
                                                     [:filename :string]
                                                     [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
   (let [file (get-in multipart-params ["file" :tempfile])]
+    (when (> (get-in multipart-params ["file" :size]) max-content-translation-dictionary-size)
+      (throw (ex-info (tru "The dictionary should be less than {0}MB." (/ max-content-translation-dictionary-size (* 1024 1024)))
+                      {:status-code http-status-content-too-large})))
     (when-not (instance? java.io.File file)
       (throw (ex-info (tru "No file provided") {:status-code 400})))
     (with-open [rdr (io/reader file)]
       (let [[_header & rows] (csv/read-csv rdr)]
-        (dictionary/import-translations! rows))))
-  {:success true})
+        (dictionary/import-translations! rows)))
+    {:success true}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/content-translation` routes."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.content-translation.api.routes
+(ns metabase-enterprise.content-translation.routes
   "Endpoints relating to the translation of user-generated content"
   (:require
    [metabase-enterprise.content-translation.dictionary :as dictionary]

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
@@ -1,5 +1,12 @@
-import { type ChangeEvent, type ReactNode, useCallback, useRef } from "react";
-import { useState, Dispatch, SetStateAction } from "react";
+import {
+  type ChangeEvent,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { t } from "ttag";
 
 import { useDocsUrl } from "metabase/common/hooks";
@@ -12,7 +19,7 @@ import {
   FormSubmitButton,
   useFormContext,
 } from "metabase/forms";
-import { List, Group, Icon, Loader, Stack, Text } from "metabase/ui";
+import { Group, Icon, List, Loader, Stack, Text } from "metabase/ui";
 import { useUploadContentTranslationDictionaryMutation } from "metabase-enterprise/api";
 
 export const ContentTranslationConfiguration = () => {

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import { useDocsUrl } from "metabase/common/hooks";
 import { UploadInput } from "metabase/components/upload";
@@ -21,6 +21,19 @@ import {
 } from "metabase/forms";
 import { Group, Icon, List, Loader, Stack, Text } from "metabase/ui";
 import { useUploadContentTranslationDictionaryMutation } from "metabase-enterprise/api";
+
+/** Maximum file size for uploaded content-translation dictionaries, expressed
+ * in mebibytes. */
+const maxContentDictionarySizeInMiB = 1.5;
+
+/** The maximum file size is 1.5 mebibytes (which equals 1.57 metabytes).
+ * For simplicity, though, let's express this as 1.5 megabytes, which is
+ * approximately right. */
+const approxMaxContentDictionarySizeInMB = 1.5;
+
+/** This should equal the max-content-translation-dictionary-size variable in the backend */
+const maxContentDictionarySizeInBytes =
+  maxContentDictionarySizeInMiB * 1024 * 1024;
 
 export const ContentTranslationConfiguration = () => {
   // eslint-disable-next-line no-unconditional-metabase-links-render -- This is used in admin settings
@@ -87,6 +100,16 @@ const UploadForm = ({
   const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.files?.length) {
       const file = event.target.files[0];
+
+      if (file.size > maxContentDictionarySizeInBytes) {
+        setErrorMessages([
+          c("{0} is a number")
+            .t`Upload a dictionary smaller than ${approxMaxContentDictionarySizeInMB} MB`,
+        ]);
+        setStatus("rejected");
+        return;
+      }
+
       await uploadFile(file);
       resetInput();
     }

--- a/src/metabase/content_translation/api.clj
+++ b/src/metabase/content_translation/api.clj
@@ -1,7 +1,7 @@
 (ns metabase.content-translation.api
   (:require
-   [metabase-enterprise.content-translation.models :as ct]
-   [metabase.api.macros :as api.macros]))
+   [metabase.api.macros :as api.macros]
+   [metabase.content-translation.models :as ct]))
 
 (api.macros/defendpoint :get "/dictionary"
   "Provides translations of user-generated content. This is a public route so that logged-out viewers of static-embedded questions and dashboards can retrieve translations"

--- a/src/metabase/content_translation/models.clj
+++ b/src/metabase/content_translation/models.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.content-translation.models
+(ns metabase.content-translation.models
   "A model representing dictionary entries for translations."
   (:require
    [methodical.core :as methodical]

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -27,7 +27,7 @@
     :model/CollectionBookmark                metabase.bookmarks.models.bookmark
     :model/CollectionPermissionGraphRevision metabase.permissions.models.collection-permission-graph-revision
     :model/ConnectionImpersonation           metabase-enterprise.impersonation.model
-    :model/ContentTranslation                metabase-enterprise.content-translation.models
+    :model/ContentTranslation                metabase.content-translation.models
     :model/Dashboard                         metabase.dashboards.models.dashboard
     :model/DashboardBookmark                 metabase.bookmarks.models.bookmark
     :model/DashboardCard                     metabase.dashboards.models.dashboard-card


### PR DESCRIPTION
This PR adds logic to validate content translation dictionary uploads and display errors to the user.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/c0813eb0-67a4-4b20-b746-0c3c780d08bb.png)

A valid dictionary must have:

* Three fields per row
* A valid locale in the first column
* One translation per string per locale (for example, you can only provide one translation of "Category" into German - you can't have two rows that begin "de,Category,")
* Cells containing strings no longer than 255 characters