### PR TITLE
Limit data selected out to what will be eventually indexed

### DIFF
--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1369,7 +1369,7 @@
                   :database-id         true
                   :entity-id           true
                   :last-viewed-at      :last_used_at
-                  :native-query        [:case [:= "native" :query_type] :dataset_query]
+                  :native-query        (search/searchable-value-trim-sql [:case [:= "native" :query_type] :dataset_query])
                   :official-collection [:= "official" :collection.authority_level]
                   :last-edited-at      :r.timestamp
                   :last-editor-id      :r.user_id

--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [metabase.db :as mdb]
    [metabase.search.appdb.specialization.api :as specialization]
+   [metabase.search.ingestion :as search.ingestion]
    [metabase.search.settings :as search.settings]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
@@ -156,7 +157,7 @@
 
 (defn- weighted-tsvector [weight text]
   ;; tsvector has a max value size of 1048575 bytes, limit to less than that because the multiple values get concatenated together
-  [:setweight [:to_tsvector [:inline (tsv-language)] [:cast (u.str/limit-bytes text 500000) :text]] [:inline weight]])
+  [:setweight [:to_tsvector [:inline (tsv-language)] [:cast (u.str/limit-bytes text search.ingestion/max-searchable-value-length) :text]] [:inline weight]])
 
 (defmethod specialization/extra-entry-fields :postgres [entity]
   {:search_vector

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -73,27 +73,30 @@
 (defn init-index!
   "Ensure there is an index ready to be populated."
   [& {:as opts}]
-  (log/info "Initializing search indexes")
-  ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
-  (reduce (partial merge-with max)
-          nil
-          (for [e (search.engine/active-engines)]
-            (search.engine/init! e opts))))
+  (when (supports-index?)
+    (log/info "Initializing search indexes")
+    ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
+    (reduce (partial merge-with max)
+            nil
+            (for [e (search.engine/active-engines)]
+              (search.engine/init! e opts)))))
 
 (defn reindex!
   "Populate a new index, and make it active. Simultaneously updates the current index."
   [& {:as opts}]
   ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
-  (reduce (partial merge-with max)
-          nil
-          (for [e (search.engine/active-engines)]
-            (search.engine/reindex! e opts))))
+  (when (supports-index?)
+    (reduce (partial merge-with max)
+            nil
+            (for [e (search.engine/active-engines)]
+              (search.engine/reindex! e opts)))))
 
 (defn reset-tracking!
   "Stop tracking the current indexes. Used when resetting the appdb."
   []
-  (doseq [e (search.engine/active-engines)]
-    (search.engine/reset-tracking! e)))
+  (when (supports-index?)
+    (doseq [e (search.engine/active-engines)]
+      (search.engine/reset-tracking! e))))
 
 (defn update!
   "Given a new or updated instance, put all the corresponding search entries if needed in the queue."
@@ -108,8 +111,9 @@
 (defn delete!
   "Given a model and a list of model's ids, remove corresponding search entries."
   [model ids]
-  (doseq [e            (search.engine/active-engines)
-          search-model (->> (vals (search.spec/specifications))
-                            (filter (comp #{model} :model))
-                            (map :name))]
-    (search.engine/delete! e search-model ids)))
+  (when (supports-index?)
+    (doseq [e            (search.engine/active-engines)
+            search-model (->> (vals (search.spec/specifications))
+                              (filter (comp #{model} :model))
+                              (map :name))]
+      (search.engine/delete! e search-model ids))))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -37,7 +37,8 @@
   search-context]
 
  [search.ingestion
-  bulk-ingest!]
+  bulk-ingest!
+  searchable-value-trim-sql]
 
  [search.spec
   define-spec])

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -34,7 +34,7 @@
 
 (def max-searchable-value-length
   "The maximum length of a searchable value. This is mostly driven by postgresql max-lengths on tsvector columns.
-  And is about half of postgresql's max, since we concat two values together often"
+  And is about half of postgresql's max, since we concat two values together often. That is likely aggressive, but being safe until we can better understand normal data shapes"
   500000)
 
 (defn searchable-value-trim-sql [column]

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.analytics.core :as analytics]
    [metabase.analytics.prometheus :as prometheus]
+   [metabase.db :as mdb]
    [metabase.search.engine :as search.engine]
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
@@ -42,9 +43,11 @@
   The passed column should be a keyword that is qualified as needed.
   Uses a slightly larger value that what will be stored in the db so we can better use word boundaries on the actual end"
   [column]
-  [:left
-   column
-   [:cast (+ max-searchable-value-length 100) :integer]])
+  (if (#{:postgres :h2} (mdb/db-type))
+    [:left
+     column
+     [:cast (+ max-searchable-value-length 100) :integer]]
+    column))
 
 (defn- searchable-text [m]
   ;; For now, we never index the native query content

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -69,7 +69,12 @@
     (u/remove-nils
      {:select    (search.spec/qualify-columns :this
                                               (concat
-                                               (map (fn [term] [[:left (keyword (str "this." (name term))) [:cast max-searchable-value-length :integer]] term]) (:search-terms spec))
+                                               (map (fn [term] [[:left
+                                                                 (keyword (str "this." (name term)))
+                                                                 ;; Select lightly more than the max length
+                                                                 ;; so we can better determine the word boundaries when we actually trim
+                                                                 [:cast (+ max-searchable-value-length 100) :integer]] term])
+                                                    (:search-terms spec))
                                                (mapcat (fn [k] (attrs->select-items (get spec k) (:search-terms spec)))
                                                        [:attrs :render-terms])))
       :from      [[(t2/table-name (:model spec)) :this]]

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -37,10 +37,11 @@
   And is about half of postgresql's max, since we concat two values together often. That is likely aggressive, but being safe until we can better understand normal data shapes"
   500000)
 
-(defn searchable-value-trim-sql [column]
+(defn searchable-value-trim-sql
   "Returns the honeysql expression to trim a searchable value to the max length.
   The passed column should be a keyword that is qualified as needed.
   Uses a slightly larger value that what will be stored in the db so we can better use word boundaries on the actual end"
+  [column]
   [:left
    column
    [:cast (+ max-searchable-value-length 100) :integer]])

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -170,21 +170,23 @@
 (defn bulk-ingest!
   "Process the given search model updates. Returns the number of search index entries that get updated as a result."
   [updates]
-  (let [documents (->> (for [[search-model where-clauses] (u/group-by first second updates)]
-                         (spec-index-reducible search-model (into [:or] (distinct where-clauses))))
-                       ;; init collection is only for clj-kondo, as we know that the list is non-empty
-                       (reduce u/rconcat [])
-                       query->documents)
-        passed-documents (map extract-model-and-id updates)
-        indexed-documents (map (juxt :model (comp str :id)) (into [] documents))
-        ;; TODO: The list of documents to delete is not completely accurate.
-        ;; We are attempting to figure it out based on the ids that are passed in to be indexed vs. the ids of the rows that were actually indexed.
-        ;; This will not work for cases like indexed-entries with compound PKs,
-        ;; but it's fine for now because that model doesn't have a where clause so never needs to be purged during an update.
-        ;; Long-term, we should find a better approach to knowing what to purge.
-        to-delete (remove (set indexed-documents) passed-documents)]
+  (if (seq (search.engine/active-engines))
+    (let [documents (->> (for [[search-model where-clauses] (u/group-by first second updates)]
+                           (spec-index-reducible search-model (into [:or] (distinct where-clauses))))
+                         ;; init collection is only for clj-kondo, as we know that the list is non-empty
+                         (reduce u/rconcat [])
+                         query->documents)
+          passed-documents (map extract-model-and-id updates)
+          indexed-documents (map (juxt :model (comp str :id)) (into [] documents))
+          ;; TODO: The list of documents to delete is not completely accurate.
+          ;; We are attempting to figure it out based on the ids that are passed in to be indexed vs. the ids of the rows that were actually indexed.
+          ;; This will not work for cases like indexed-entries with compound PKs,
+          ;; but it's fine for now because that model doesn't have a where clause so never needs to be purged during an update.
+          ;; Long-term, we should find a better approach to knowing what to purge.
+          to-delete (remove (set indexed-documents) passed-documents)]
 
-    (update! documents to-delete)))
+      (update! documents to-delete))
+    {}))
 
 (defn- track-queue-size! []
   (analytics/set! :metabase-search/queue-size (.size queue)))


### PR DESCRIPTION
### Description

Related to #57514: Since we're only going to index a max number of bytes anyway, when reindexing content don't select out more than we will use

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
