### PR TITLE
Add a new model button to browse models page

### DIFF
--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -1,4 +1,5 @@
 const { H } = cy;
+import { USERS } from "e2e/support/cypress_data";
 import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "A name";
@@ -81,6 +82,61 @@ describe("scenarios > models > create", () => {
         "have.text",
         "Third collection",
       );
+    });
+  });
+
+  // This covers creating a GUI model from the browse page + nocollection permissions (2 in 1)
+  it("user without a collection access should still be able to create and save a model in his own personal collection", () => {
+    cy.intercept("POST", "/api/card").as("createModel");
+
+    cy.signIn("nocollection");
+    cy.visit("/browse/models");
+
+    cy.findByLabelText("Create a new model").click();
+    cy.findByTestId("new-model-options")
+      .findByText("Use the notebook editor")
+      .click();
+    H.entityPickerModal().findByText("People").click();
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
+    cy.findByTestId("save-question-modal")
+      .should("contain", "Save model")
+      .and("contain", H.getPersonalCollectionName(USERS["nocollection"]))
+      .button("Save")
+      .click();
+    cy.wait("@createModel");
+    cy.location("pathname").should("match", /^\/model\/\d+-.*$/);
+  });
+
+  it("should be able to create a new native model from the browse page", () => {
+    cy.intercept("POST", "/api/dataset").as("previewModel");
+    cy.intercept("POST", "/api/card").as("createModel");
+
+    cy.visit("/browse/models");
+    cy.findByLabelText("Create a new model").click();
+    cy.findByTestId("new-model-options")
+      .findByText("Use a native query")
+      .click();
+    H.NativeEditor.focus().type("select 42");
+    cy.findByTestId("native-query-editor-sidebar")
+      .findByLabelText("Get Answer")
+      .click();
+    cy.wait("@previewModel");
+    cy.findByTestId("visualization-root").should("contain", "42");
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
+    cy.findByTestId("save-question-modal").within(() => {
+      cy.findByLabelText("Name").type("m42");
+      cy.button("Save").click();
+    });
+    cy.wait("@createModel");
+    cy.location("pathname").should("match", /^\/model\/\d+-.*$/);
+  });
+
+  it("should not be possible to initiate a new model creation without native permissions", () => {
+    cy.signIn("nosql");
+    cy.visit("/browse/models");
+    cy.findByTestId("browse-models-header").within(() => {
+      cy.findByRole("heading").should("contain", "Models").and("be.visible");
+      cy.findByLabelText("Create a new model").should("not.exist");
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/browse/models/BrowseModels.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/browse/models/BrowseModels.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
+  setupDatabasesEndpoints,
   setupRecentViewsEndpoints,
   setupSearchEndpoints,
   setupSettingsEndpoints,
@@ -14,11 +15,13 @@ import {
 import type { RecentCollectionItem } from "metabase-types/api";
 import {
   createMockCollection,
+  createMockDatabase,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 import { createMockSetupState } from "metabase-types/store/mocks";
 
 const setup = (modelCount: number, recentModelCount = 5) => {
+  const databases = [createMockDatabase()];
   const models = mockModels.slice(0, modelCount);
 
   // Add some instance analytics models to ensure they don't affect the page
@@ -30,7 +33,7 @@ const setup = (modelCount: number, recentModelCount = 5) => {
       createMockRecentModel(model as unknown as RecentCollectionItem),
     );
   setupRecentViewsEndpoints(mockRecentModels);
-
+  setupDatabasesEndpoints(databases);
   setupSearchEndpoints(models);
   setupSettingsEndpoints([]);
   setupEnterprisePlugins();

--- a/frontend/src/metabase/browse/models/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.tsx
@@ -2,17 +2,25 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { skipToken, useListRecentsQuery } from "metabase/api";
+import {
+  skipToken,
+  useListDatabasesQuery,
+  useListRecentsQuery,
+} from "metabase/api";
 import { useDocsUrl } from "metabase/common/hooks";
 import { useFetchModels } from "metabase/common/hooks/use-fetch-models";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import ExternalLink from "metabase/core/components/ExternalLink";
+import { ForwardRefLink } from "metabase/core/components/Link";
 import { useSelector } from "metabase/lib/redux";
 import {
   PLUGIN_COLLECTIONS,
   PLUGIN_CONTENT_VERIFICATION,
 } from "metabase/plugins";
+import { getHasDataAccess, getHasNativeWrite } from "metabase/selectors/data";
+import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import {
+  ActionIcon,
   Box,
   Button,
   Flex,
@@ -21,6 +29,7 @@ import {
   Stack,
   Text,
   Title,
+  Tooltip,
 } from "metabase/ui";
 
 import {
@@ -44,6 +53,7 @@ const {
 } = PLUGIN_CONTENT_VERIFICATION;
 
 export const BrowseModels = () => {
+  const { data } = useListDatabasesQuery();
   const [modelFilters, setModelFilters] = useModelFilterSettings();
   const { isLoading, error, models, recentModels, hasVerifiedModels } =
     useFilteredModels(modelFilters);
@@ -52,6 +62,14 @@ export const BrowseModels = () => {
 
   const isEmpty = !isLoading && !error && models.length === 0;
   const titleId = useMemo(() => _.uniqueId("browse-models"), []);
+
+  const databases = data?.data ?? [];
+  const hasDataAccess = getHasDataAccess(databases);
+  const hasNativeWrite = getHasNativeWrite(databases);
+  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
+
+  const canCreateNewModel =
+    !isEmbeddingIframe && hasDataAccess && hasNativeWrite;
 
   return (
     <BrowseContainer aria-labelledby={titleId}>
@@ -74,12 +92,27 @@ export const BrowseModels = () => {
                 {t`Models`}
               </Group>
             </Title>
-            {hasVerifiedModels && (
-              <ModelFilterControls
-                modelFilters={modelFilters}
-                setModelFilters={setModelFilters}
-              />
-            )}
+            <Group gap="xs">
+              {canCreateNewModel && (
+                <Tooltip label={t`Create a new model`} position="bottom">
+                  <ActionIcon
+                    aria-label={t`Create a new model`}
+                    size={32}
+                    variant="viewHeader"
+                    component={ForwardRefLink}
+                    to="/model/new"
+                  >
+                    <Icon name="add" />
+                  </ActionIcon>
+                </Tooltip>
+              )}
+              {hasVerifiedModels && (
+                <ModelFilterControls
+                  modelFilters={modelFilters}
+                  setModelFilters={setModelFilters}
+                />
+              )}
+            </Group>
           </Flex>
         </BrowseSection>
       </BrowseHeader>

--- a/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  setupDatabasesEndpoints,
   setupRecentViewsEndpoints,
   setupSearchEndpoints,
   setupSettingsEndpoints,
@@ -8,6 +9,7 @@ import {
 import { renderWithProviders, screen, within } from "__support__/ui";
 import {
   createMockCollection,
+  createMockDatabase,
   createMockSearchResult,
 } from "metabase-types/api/mocks";
 import { createMockSetupState } from "metabase-types/store/mocks";
@@ -21,6 +23,7 @@ const defaultRootCollection = createMockCollection({
 });
 
 const setup = (modelCount: number, recentModelCount = 5) => {
+  const database = createMockDatabase();
   const mockModelResults = mockModels.map((model) =>
     createMockModelResult(model),
   );
@@ -28,6 +31,7 @@ const setup = (modelCount: number, recentModelCount = 5) => {
     .slice(0, recentModelCount)
     .map((model) => createMockRecentModel(model));
   const models = mockModelResults.slice(0, modelCount);
+  setupDatabasesEndpoints([database]);
   setupSearchEndpoints(models.map((model) => createMockSearchResult(model)));
   setupSettingsEndpoints([]);
   setupRecentViewsEndpoints(mockRecentModels);

--- a/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
@@ -328,6 +328,20 @@ describe("BrowseModels", () => {
       expect(src).toContain("youtube.com");
       expect(src).toContain("autoplay=0");
     });
+
+    it("should display a new model button in the header along when in empty state", async () => {
+      setup({ modelCount: 0, hasDataPermissions: true });
+      const newModelButton = await screen.findByLabelText("Create a new model");
+      expect(newModelButton).toBeInTheDocument();
+    });
+
+    it("should not display a new model button in the header when in empty state if the user lacks data permissions", async () => {
+      setup({ modelCount: 0, hasDataPermissions: false });
+      const header = await screen.findByTestId("browse-models-header");
+      expect(
+        within(header).queryByLabelText("Create a new model"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("Models explanation banner", () => {
@@ -380,6 +394,20 @@ describe("BrowseModels", () => {
       const src = youtubeVideo.getAttribute("src");
       expect(src).toContain("youtube.com");
       expect(src).toContain("autoplay=1");
+    });
+
+    it("should display a new model button in the header along when a model explanation banner", async () => {
+      setup({ modelCount: 1, hasDataPermissions: true });
+      const newModelButton = await screen.findByLabelText("Create a new model");
+      expect(newModelButton).toBeInTheDocument();
+    });
+
+    it("should not display a new model button in the header along the model explanation banner if the user lacks data permission", async () => {
+      setup({ modelCount: 1, hasDataPermissions: false });
+      const header = await screen.findByTestId("browse-models-header");
+      expect(
+        within(header).queryByLabelText("Create a new model"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
@@ -22,7 +22,12 @@ const defaultRootCollection = createMockCollection({
   name: "Our analytics",
 });
 
-const setup = (modelCount: number, recentModelCount = 5) => {
+interface SetupOptions {
+  modelCount: number;
+  recentModelCount?: number;
+}
+
+const setup = ({ modelCount, recentModelCount = 5 }: SetupOptions) => {
   const database = createMockDatabase();
   const mockModelResults = mockModels.map((model) =>
     createMockModelResult(model),
@@ -283,7 +288,7 @@ const mockModels = [
 describe("BrowseModels", () => {
   describe("Empty state", () => {
     it("displays an explanation about how to use models when no models exist", async () => {
-      setup(0);
+      setup({ modelCount: 0 });
 
       const emptyState = await screen.findByTestId("empty-state");
       const title =
@@ -305,7 +310,7 @@ describe("BrowseModels", () => {
     });
 
     it("should display embedded YouTube video (that doesn't auto play) when no models exist", async () => {
-      setup(0);
+      setup({ modelCount: 0 });
 
       const emptyState = await screen.findByTestId("empty-state");
       const youtubeVideo = await within(emptyState).findByTitle(
@@ -322,7 +327,7 @@ describe("BrowseModels", () => {
 
   describe("Models explanation banner", () => {
     it("displays an explanation banner when there is at least one model", async () => {
-      setup(1);
+      setup({ modelCount: 1 });
 
       const banner = await screen.findByRole("complementary");
       const title =
@@ -347,7 +352,7 @@ describe("BrowseModels", () => {
     });
 
     it("explanation banner can open an autoplaying embedded YouTube video in a modal", async () => {
-      setup(1);
+      setup({ modelCount: 1 });
 
       const banner = await screen.findByRole("complementary");
       const videoThumbnail = await within(banner).findByTestId(
@@ -374,7 +379,7 @@ describe("BrowseModels", () => {
   });
 
   it("displays the Our Analytics collection if it has a model", async () => {
-    setup(25);
+    setup({ modelCount: 25 });
     const modelsTable = await screen.findByRole("table", {
       name: /Table of models/,
     });
@@ -396,7 +401,7 @@ describe("BrowseModels", () => {
   });
 
   it("displays collection breadcrumbs", async () => {
-    setup(25);
+    setup({ modelCount: 25 });
     const modelsTable = await screen.findByRole("table", {
       name: /Table of models/,
     });
@@ -407,7 +412,7 @@ describe("BrowseModels", () => {
   });
 
   it("displays recently viewed models", async () => {
-    setup(25);
+    setup({ modelCount: 25 });
     const recentModelsGrid = await screen.findByRole("grid", {
       name: /Recents/,
     });
@@ -430,7 +435,7 @@ describe("BrowseModels", () => {
   });
 
   it("displays no recently viewed models when there are fewer than 9 models - but instance analytics models do not count", async () => {
-    setup(8);
+    setup({ modelCount: 8 });
     const recentModelsGrid = screen.queryByRole("grid", {
       name: /Recents/,
     });

--- a/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.unit.spec.tsx
@@ -25,10 +25,15 @@ const defaultRootCollection = createMockCollection({
 interface SetupOptions {
   modelCount: number;
   recentModelCount?: number;
+  hasDataPermissions?: boolean;
 }
 
-const setup = ({ modelCount, recentModelCount = 5 }: SetupOptions) => {
-  const database = createMockDatabase();
+const setup = ({
+  modelCount,
+  recentModelCount = 5,
+  hasDataPermissions = true,
+}: SetupOptions) => {
+  const databases = hasDataPermissions ? [createMockDatabase()] : [];
   const mockModelResults = mockModels.map((model) =>
     createMockModelResult(model),
   );
@@ -36,7 +41,7 @@ const setup = ({ modelCount, recentModelCount = 5 }: SetupOptions) => {
     .slice(0, recentModelCount)
     .map((model) => createMockRecentModel(model));
   const models = mockModelResults.slice(0, modelCount);
-  setupDatabasesEndpoints([database]);
+  setupDatabasesEndpoints(databases);
   setupSearchEndpoints(models.map((model) => createMockSearchResult(model)));
   setupSettingsEndpoints([]);
   setupRecentViewsEndpoints(mockRecentModels);


### PR DESCRIPTION
Resolves PRG-21 by adding a new model button to the header of the `/browse/models` page.

The layout with an empty state
![image](https://github.com/user-attachments/assets/09d0e136-4d40-4742-a8b4-a3dfe2d5bbc7)

The layout when there are models + the models edu content
![image](https://github.com/user-attachments/assets/5e0d1fef-30a6-45b7-8240-33d9d5f00db1)

Here's how the layout looks when there is a "verified models" filter
![image](https://github.com/user-attachments/assets/a43ff03b-6375-47e9-a0bf-743f8dfa8bc3)


### Testing
- Expanded the existing unit tests
- Added new E2E test

> [!IMPORTANT]
> The logic to create a new model used in the main "New" menu is kept intact. That means that the user needs to have native permissions on top of the data/query permissions in order to initiate a new model creation from this page.
