### PR TITLE
Content translation: localize dashcard parameter dropdown

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/column-names.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/column-names.cy.spec.ts
@@ -1,8 +1,11 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
 
-import { germanFieldNames } from "./constants";
-import { uploadTranslationDictionary } from "./helpers/e2e-content-translation-helpers";
+import { columnNamesWithTypeText, germanFieldNames } from "./constants";
+import {
+  openDashCardCardParameterMapper,
+  uploadTranslationDictionary,
+} from "./helpers/e2e-content-translation-helpers";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -13,12 +16,10 @@ describe("scenarios > admin > localization > content translation of column names
     before(() => {
       H.restore();
     });
-
     beforeEach(() => {
       cy.signInAsAdmin();
       H.setTokenFeatures("all");
     });
-
     describe("after uploading related German translations", () => {
       before(() => {
         cy.signInAsAdmin();
@@ -55,7 +56,7 @@ describe("scenarios > admin > localization > content translation of column names
             cy.signInAsNormalUser();
           });
 
-          it("column headers", () => {
+          it.only("column headers", () => {
             H.visitQuestion(productsQuestionId);
             cy.findByTestId("table-header").within(() => {
               germanFieldNames.forEach((row) => {
@@ -95,6 +96,19 @@ describe("scenarios > admin > localization > content translation of column names
                 cy.findByText(row.msgstr).should("not.exist");
                 cy.findByText(row.msgid).should("be.visible");
               });
+            });
+          });
+
+          it("dashcard parameter mapper", () => {
+            openDashCardCardParameterMapper();
+
+            H.popover().within(() => {
+              Object.values(usedGermanFieldNames)
+                .filter((tr) => columnNamesWithTypeText.includes(tr.msgid))
+                .forEach((row) => {
+                  cy.findByText(row.msgstr).should("not.exist");
+                  cy.findByText(row.msgid).should("be.visible");
+                });
             });
           });
         });
@@ -172,6 +186,19 @@ describe("scenarios > admin > localization > content translation of column names
               cy.findByPlaceholderText(/Finden/).type("kat");
               cy.findByText("Erstellt am").should("not.exist");
               cy.findByText("Kategorie").should("be.visible");
+            });
+          });
+
+          it("dashcard parameter mapper", () => {
+            openDashCardCardParameterMapper();
+
+            H.popover().within(() => {
+              Object.values(usedGermanFieldNames)
+                .filter((tr) => columnNamesWithTypeText.includes(tr.msgid))
+                .forEach((row) => {
+                  cy.findByText(row.msgid).should("not.exist");
+                  cy.findByText(row.msgstr).should("be.visible");
+                });
             });
           });
         });

--- a/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
@@ -1,4 +1,44 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import type { DictionaryArray, DictionaryResponse } from "metabase/i18n/types";
+
+const { H } = cy;
+
+/** Opens the parameter mapper. Works whether the current locale is English or German */
+export const openDashCardCardParameterMapper = () => {
+  const questionDetails: StructuredQuestionDetails = {
+    query: { "source-table": SAMPLE_DATABASE.PRODUCTS_ID },
+  };
+  H.createQuestionAndDashboard({
+    questionDetails,
+  }).then(({ body: { id, card_id, dashboard_id } }) => {
+    cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+      dashcards: [
+        {
+          id,
+          card_id,
+          row: 0,
+          col: 0,
+          size_x: 11,
+          size_y: 6,
+        },
+      ],
+    });
+
+    H.visitDashboard(dashboard_id);
+
+    cy.findByLabelText(/Edit dashboard|Ändere das Dashboard/).click();
+
+    cy.icon("filter").click();
+    H.popover()
+      .findByText(/Text or Category|Text oder Kategorie/)
+      .click();
+
+    H.getDashboardCard()
+      .findByText(/Select|Wähle/)
+      .click();
+  });
+};
 
 export const getCSVWithHeaderRow = (dictionary: DictionaryArray) => {
   const header = ["Language", "String", "Translation"];

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { t } from "ttag";
 
 import { isActionDashCard } from "metabase/actions/utils";
@@ -8,6 +9,7 @@ import {
   getQuestionByCard,
 } from "metabase/dashboard/selectors";
 import { isNativeDashCard, isQuestionDashCard } from "metabase/dashboard/utils";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { connect } from "metabase/lib/redux";
 import {
   type ParameterMappingOption,
@@ -71,14 +73,24 @@ export function DashCardCardParameterMapper({
   mappingOptions,
   isRecentlyAutoConnected,
 }: DashcardCardParameterMapperProps) {
+  const tc = useTranslateContent();
   const isQuestion = isQuestionDashCard(dashcard);
   const hasSeries = isQuestion && dashcard.series && dashcard.series.length > 0;
   const isAction = isActionDashCard(dashcard);
   const isDisabled = mappingOptions.length === 0 || isAction;
   const isNative = isQuestion && isNativeDashCard(dashcard);
 
+  const translatedMappingOptions = useMemo(
+    () =>
+      mappingOptions.map((opt) => ({
+        ...opt,
+        name: tc(opt.name),
+      })),
+    [mappingOptions, tc],
+  );
+
   const selectedMappingOption = getMappingOptionByTarget(
-    mappingOptions,
+    translatedMappingOptions,
     target,
     question,
     editingParameter ?? undefined,
@@ -112,7 +124,7 @@ export function DashCardCardParameterMapper({
         dashcard={dashcard}
         question={question}
         editingParameter={editingParameter}
-        mappingOptions={mappingOptions}
+        mappingOptions={translatedMappingOptions}
         isQuestion={isQuestion}
         card={card}
         selectedMappingOption={selectedMappingOption}

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -4,6 +4,7 @@ import _ from "underscore";
 import { tag_names } from "cljs/metabase.models.params.shared";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import { isActionDashCard, isVirtualDashCard } from "metabase/dashboard/utils";
+import type { ContentTranslationFunction } from "metabase/i18n/types";
 import { getGroupName } from "metabase/querying/filters/utils/groups";
 import { getAllowedIframeAttributes } from "metabase/visualizations/visualizations/IFrameViz/utils";
 import * as Lib from "metabase-lib";
@@ -49,11 +50,12 @@ function buildStructuredQuerySectionOptions(
   stageIndex: number,
   group: Lib.ColumnGroup,
   columns: Lib.ColumnMetadata[],
+  tc?: ContentTranslationFunction,
 ): StructuredQuerySectionOption[] {
   const groupInfo = Lib.displayInfo(query, stageIndex, group);
 
   return columns.map((column) => {
-    const columnInfo = Lib.displayInfo(query, stageIndex, column);
+    const columnInfo = Lib.displayInfo(query, stageIndex, column, tc);
 
     return {
       sectionName: getGroupName(groupInfo, stageIndex) ?? t`Summaries`,
@@ -131,6 +133,7 @@ export function getParameterMappingOptions(
   parameter: Parameter | null | undefined = null,
   card: Card,
   dashcard: BaseDashboardCard | null | undefined = null,
+  tc?: ContentTranslationFunction,
 ): ParameterMappingOption[] {
   if (dashcard && isVirtualDashCard(dashcard)) {
     if (["heading", "text"].includes(card.display)) {
@@ -185,6 +188,7 @@ export function getParameterMappingOptions(
             stageIndex,
             group,
             Lib.getColumnsFromColumnGroup(group),
+            tc,
           ),
         );
       },


### PR DESCRIPTION
This PR localizes column names in the parameter mapper dropdown:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/c709e411-a12f-41c2-b12f-ddd9c6aba2e5" />