### PR TITLE
remove add visualization button from empty dashcards

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
@@ -173,13 +173,13 @@ describe("scenarios > dashboard > visualizer > funnels", () => {
     H.visitDashboard(ORDERS_DASHBOARD_ID);
     H.editDashboard();
 
-    cy.findByLabelText("Add section").click();
-    H.menu().findByLabelText("KPI grid").click();
-    H.getDashboardCard(2).button("Visualize").click();
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(LANDING_PAGE_VIEWS.name);
 
     H.modal().within(() => {
+      cy.findByText(LANDING_PAGE_VIEWS.name).realHover();
+      cy.findAllByLabelText("Remove").eq(0).click();
       cy.findByText("Funnel").click();
-
       H.switchToAddMoreData();
       H.selectDataset(LANDING_PAGE_VIEWS.name);
       H.addDataset(CHECKOUT_PAGE_VIEWS.name);

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -5,18 +5,10 @@ import {
   QuestionPickerModal,
   type QuestionPickerValueItem,
 } from "metabase/common/components/QuestionPicker";
-import {
-  replaceCard,
-  replaceCardWithVisualization,
-} from "metabase/dashboard/actions";
+import { replaceCard } from "metabase/dashboard/actions";
 import { useDispatch } from "metabase/lib/redux";
 import { Button, Flex } from "metabase/ui";
-import { VisualizerModal } from "metabase/visualizer/components/VisualizerModal";
-import type {
-  Dashboard,
-  VirtualDashboardCard,
-  VisualizerVizDefinition,
-} from "metabase-types/api";
+import type { Dashboard, VirtualDashboardCard } from "metabase-types/api";
 
 import type { VisualizationProps } from "../types";
 
@@ -34,21 +26,11 @@ function DashCardPlaceholderInner({
   isEditingParameter,
 }: Props) {
   const [isQuestionPickerOpen, setQuestionPickerOpen] = useState(false);
-  const [isVisualizerModalOpen, setVisualizerModalOpen] = useState(false);
   const dispatch = useDispatch();
 
   const handleSelectQuestion = (nextCard: QuestionPickerValueItem) => {
     dispatch(replaceCard({ dashcardId: dashcard.id, nextCardId: nextCard.id }));
     setQuestionPickerOpen(false);
-  };
-
-  const handleSelectVisualization = (
-    visualization: VisualizerVizDefinition,
-  ) => {
-    dispatch(
-      replaceCardWithVisualization({ dashcardId: dashcard.id, visualization }),
-    );
-    setVisualizerModalOpen(false);
   };
 
   if (!isDashboard) {
@@ -77,11 +59,6 @@ function DashCardPlaceholderInner({
               onMouseDown={preventDragging}
               style={{ pointerEvents }}
             >{t`Select question`}</Button>
-            <Button
-              onClick={() => setVisualizerModalOpen(true)}
-              onMouseDown={preventDragging}
-              style={{ pointerEvents }}
-            >{t`Visualize`}</Button>
           </Flex>
         )}
       </Flex>
@@ -99,12 +76,6 @@ function DashCardPlaceholderInner({
           models={["card", "dataset", "metric"]}
           onChange={handleSelectQuestion}
           onClose={() => setQuestionPickerOpen(false)}
-        />
-      )}
-      {isVisualizerModalOpen && (
-        <VisualizerModal
-          onSave={handleSelectVisualization}
-          onClose={() => setVisualizerModalOpen(false)}
         />
       )}
     </>


### PR DESCRIPTION
Closes [VIZ-928](https://linear.app/metabase/issue/VIZ-928/remove-the-add-visualization-cta-from-sections-for-now) 

### Description

Removes the "Visualize" button from empty dashcards.

### Demo

<img width="1069" alt="Screenshot 2025-05-02 at 9 01 50 PM" src="https://github.com/user-attachments/assets/a59e9976-a4c3-4c87-8784-250575315d62" />

