### PR TITLE
Closes VIZ-933 a replaced dataset no longer appears as collapsed

### DIFF
--- a/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/ColumnsList/ColumnsList.tsx
@@ -17,21 +17,28 @@ import {
   removeColumn,
   removeDataSource,
 } from "metabase/visualizer/visualizer.slice";
-import type { DatasetColumn, VisualizerDataSource } from "metabase-types/api";
-
-import { useVisualizerUi } from "../../VisualizerUiContext";
+import type {
+  DatasetColumn,
+  VisualizerDataSource,
+  VisualizerDataSourceId,
+} from "metabase-types/api";
 
 import S from "./ColumnsList.module.css";
 import { ColumnsListItem, type ColumnsListItemProps } from "./ColumnsListItem";
 
-export const ColumnsList = () => {
+export interface ColumnListProps {
+  collapsedDataSources: Record<string, boolean>;
+  toggleDataSource: (sourceId: VisualizerDataSourceId) => void;
+}
+
+export const ColumnsList = (props: ColumnListProps) => {
+  const { collapsedDataSources, toggleDataSource } = props;
+
   const dataSources = useSelector(getDataSources);
   const datasets = useSelector(getDatasets);
   const loadingDatasets = useSelector(getLoadingDatasets);
   const referencedColumns = useSelector(getReferencedColumns);
   const dispatch = useDispatch();
-
-  const { expandedDataSources, toggleDataSourceExpanded } = useVisualizerUi();
 
   const handleAddColumn = (
     dataSource: VisualizerDataSource,
@@ -55,7 +62,7 @@ export const ColumnsList = () => {
       {dataSources.map((source) => {
         const dataset = datasets[source.id];
         const isLoading = loadingDatasets[source.id];
-        const isExpanded = expandedDataSources[source.id];
+        const isCollapsed = collapsedDataSources[source.id];
 
         return (
           <Box key={source.id} mb={4} data-testid="data-source-list-item">
@@ -63,12 +70,12 @@ export const ColumnsList = () => {
               {!isLoading ? (
                 <Icon
                   style={{ flexShrink: 0 }}
-                  name={isExpanded ? "chevronup" : "chevrondown"}
+                  name={isCollapsed ? "chevrondown" : "chevronup"}
                   aria-label={t`Expand`}
                   size={12}
                   mr={6}
                   cursor="pointer"
-                  onClick={() => toggleDataSourceExpanded(source.id)}
+                  onClick={() => toggleDataSource(source.id)}
                 />
               ) : (
                 <Loader size={12} mr={6} />
@@ -89,7 +96,7 @@ export const ColumnsList = () => {
                 />
               )}
             </Flex>
-            {isExpanded && dataset && dataset.data.cols && (
+            {!isCollapsed && dataset && dataset.data.cols && (
               <Box ml={12} mt={2}>
                 {dataset.data.cols.map((column) => {
                   if (isPivotGroupColumn(column)) {

--- a/frontend/src/metabase/visualizer/components/DataImporter/DataImporter.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DataImporter.tsx
@@ -15,6 +15,7 @@ import {
   TextInput,
   Title,
 } from "metabase/ui";
+import { useBooleanMap } from "metabase/visualizer/hooks/use-boolean-map";
 import { getDataSources } from "metabase/visualizer/selectors";
 
 import { ColumnsList } from "./ColumnsList/ColumnsList";
@@ -26,6 +27,12 @@ export const DataImporter = ({ className }: { className?: string }) => {
   const [showDatasets, handlers] = useDisclosure(false);
 
   const dataSources = useSelector(getDataSources);
+
+  const {
+    values: collapsedDataSources,
+    toggle: toggleDataSource,
+    setValue: setDataSourceCollapsed,
+  } = useBooleanMap();
 
   const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_DURATION);
 
@@ -81,7 +88,10 @@ export const DataImporter = ({ className }: { className?: string }) => {
               overflowY: "auto",
             }}
           >
-            <DatasetsList search={debouncedSearch} />
+            <DatasetsList
+              search={debouncedSearch}
+              setDataSourceCollapsed={setDataSourceCollapsed}
+            />
           </Flex>
         </Flex>
       ) : (
@@ -96,7 +106,10 @@ export const DataImporter = ({ className }: { className?: string }) => {
           }}
         >
           {dataSources.length > 0 ? (
-            <ColumnsList />
+            <ColumnsList
+              collapsedDataSources={collapsedDataSources}
+              toggleDataSource={toggleDataSource}
+            />
           ) : (
             <Center h="100%" w="100%" mx="auto">
               <Text>{t`Pick a dataset first`}</Text>

--- a/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DatasetsList/DatasetsList.tsx
@@ -18,8 +18,6 @@ import type {
   VisualizerDataSourceId,
 } from "metabase-types/api";
 
-import { useVisualizerUi } from "../../VisualizerUiContext";
-
 import { DatasetsListItem } from "./DatasetsListItem";
 
 function shouldIncludeDashboardQuestion(
@@ -31,10 +29,16 @@ function shouldIncludeDashboardQuestion(
 
 interface DatasetsListProps {
   search: string;
+  setDataSourceCollapsed: (
+    sourceId: VisualizerDataSourceId,
+    collapsed: boolean,
+  ) => void;
 }
 
-export function DatasetsList({ search }: DatasetsListProps) {
-  const { setDataSourceExpanded } = useVisualizerUi();
+export function DatasetsList({
+  search,
+  setDataSourceCollapsed,
+}: DatasetsListProps) {
   const dashboardId = useSelector(getDashboard)?.id;
   const dispatch = useDispatch();
   const dataSources = useSelector(getDataSources);
@@ -46,17 +50,17 @@ export function DatasetsList({ search }: DatasetsListProps) {
   const handleAddDataSource = useCallback(
     (id: VisualizerDataSourceId) => {
       dispatch(addDataSource(id));
-      setDataSourceExpanded(id, true);
+      setDataSourceCollapsed(id, false);
     },
-    [dispatch, setDataSourceExpanded],
+    [dispatch, setDataSourceCollapsed],
   );
 
   const handleRemoveDataSource = useCallback(
     (source: VisualizerDataSource) => {
       dispatch(removeDataSource(source));
-      setDataSourceExpanded(source.id, false);
+      setDataSourceCollapsed(source.id, true);
     },
-    [dispatch, setDataSourceExpanded],
+    [dispatch, setDataSourceCollapsed],
   );
 
   const handleToggleDataSource = useCallback(

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -23,10 +23,7 @@ import {
   resetVisualizer,
   setDraggedItem,
 } from "metabase/visualizer/visualizer.slice";
-import type {
-  VisualizerDataSourceId,
-  VisualizerVizDefinition,
-} from "metabase-types/api";
+import type { VisualizerVizDefinition } from "metabase-types/api";
 import type { DraggedItem } from "metabase-types/store/visualizer";
 
 import { DataImporter } from "../DataImporter";
@@ -64,7 +61,6 @@ const isVerticalDraggedItem = (draggedItem: DraggedItem | null) => {
 
 interface VisualizerProps {
   className?: string;
-  initialDataSources?: VisualizerDataSourceId[];
   onSave: (visualization: VisualizerVizDefinition) => void;
   onClose: () => void;
   saveLabel?: string;
@@ -194,12 +190,9 @@ const VisualizerInner = (props: VisualizerProps) => {
   );
 };
 
-export const Visualizer = ({
-  initialDataSources,
-  ...props
-}: VisualizerProps) => {
+export const Visualizer = ({ ...props }: VisualizerProps) => {
   return (
-    <VisualizerUiProvider initialDataSources={initialDataSources}>
+    <VisualizerUiProvider>
       <VisualizerInner {...props} />
     </VisualizerUiProvider>
   );

--- a/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, useCallback, useEffect, useMemo } from "react";
+import { type ComponentProps, useCallback, useEffect } from "react";
 import { usePrevious } from "react-use";
 import { t } from "ttag";
 
@@ -7,13 +7,8 @@ import { useModalOpen } from "metabase/hooks/use-modal-open";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { Modal } from "metabase/ui";
 import { getIsDirty } from "metabase/visualizer/selectors";
-import { getDataSourceIdsFromColumnValueMappings } from "metabase/visualizer/utils";
 import { initializeVisualizer } from "metabase/visualizer/visualizer.slice";
-import type {
-  CardId,
-  VisualizerDataSourceId,
-  VisualizerVizDefinition,
-} from "metabase-types/api";
+import type { CardId, VisualizerVizDefinition } from "metabase-types/api";
 
 import { Visualizer } from "../Visualizer";
 
@@ -60,22 +55,6 @@ export function VisualizerModal({
     }
   }, [open, wasOpen, initialState, dispatch]);
 
-  const initialDataSources = useMemo(() => {
-    if (!initialState) {
-      return;
-    }
-    if ("cardId" in initialState) {
-      const id: VisualizerDataSourceId = `card:${initialState.cardId}`;
-      return [id];
-    }
-    if (initialState?.state?.columnValuesMapping) {
-      return getDataSourceIdsFromColumnValueMappings(
-        initialState.state.columnValuesMapping,
-      );
-    }
-    return;
-  }, [initialState]);
-
   return (
     <>
       <Modal
@@ -90,7 +69,6 @@ export function VisualizerModal({
           <Visualizer
             className={S.VisualizerRoot}
             {...otherProps}
-            initialDataSources={initialDataSources}
             onClose={onModalClose}
           />
         )}

--- a/frontend/src/metabase/visualizer/components/VisualizerUiContext/VisualizerUiContext.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizerUiContext/VisualizerUiContext.tsx
@@ -3,7 +3,6 @@ import {
   type ReactNode,
   type SetStateAction,
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -14,51 +13,34 @@ import _ from "underscore";
 
 import { useSelector } from "metabase/lib/redux";
 import { getDatasets } from "metabase/visualizer/selectors";
-import type { VisualizerDataSourceId } from "metabase-types/api";
 
 type VisualizerUiState = {
   isDataSidebarOpen: boolean;
   isVizSettingsSidebarOpen: boolean;
   isSwapAffordanceVisible: boolean;
-  expandedDataSources: Record<VisualizerDataSourceId, boolean>;
 
   setDataSidebarOpen: Dispatch<SetStateAction<boolean>>;
   setVizSettingsSidebarOpen: Dispatch<SetStateAction<boolean>>;
   setSwapAffordanceVisible: Dispatch<SetStateAction<boolean>>;
-  setDataSourceExpanded: (
-    sourceId: VisualizerDataSourceId,
-    isExpanded: boolean,
-  ) => void;
-  toggleDataSourceExpanded: (sourceId: VisualizerDataSourceId) => void;
 };
 
 const VisualizerUiContext = createContext<VisualizerUiState>({
   isDataSidebarOpen: false,
   isVizSettingsSidebarOpen: false,
   isSwapAffordanceVisible: false,
-  expandedDataSources: {},
   setDataSidebarOpen: _.noop,
   setVizSettingsSidebarOpen: _.noop,
   setSwapAffordanceVisible: _.noop,
-  setDataSourceExpanded: _.noop,
-  toggleDataSourceExpanded: _.noop,
 });
 
 interface VisualizerUiProviderProps {
-  initialDataSources?: VisualizerDataSourceId[];
   children: ReactNode;
 }
 
-export function VisualizerUiProvider({
-  initialDataSources = [],
-  children,
-}: VisualizerUiProviderProps) {
+export function VisualizerUiProvider({ children }: VisualizerUiProviderProps) {
   const [isDataSidebarOpen, setDataSidebarOpen] = useState(true);
   const [isVizSettingsSidebarOpen, setVizSettingsSidebarOpen] = useState(false);
   const [isSwapAffordanceVisible, setSwapAffordanceVisible] = useState(false);
-  const [expandedDataSources, setExpandedDataSources] = useState(
-    getInitiallyExpandedDataSources(initialDataSources),
-  );
 
   const dataSourceCount = useSelector(
     (state) => Object.keys(getDatasets(state)).length,
@@ -69,54 +51,19 @@ export function VisualizerUiProvider({
     if (dataSourceCount === 0 && previousDataSourceCount > 0) {
       setVizSettingsSidebarOpen(false);
       setSwapAffordanceVisible(false);
-      setExpandedDataSources({});
     }
   }, [dataSourceCount, previousDataSourceCount]);
-
-  const setDataSourceExpanded = useCallback(
-    (sourceId: VisualizerDataSourceId, isExpanded: boolean) => {
-      setExpandedDataSources((expandedDataSources) => {
-        return {
-          ...expandedDataSources,
-          [sourceId]: isExpanded,
-        };
-      });
-    },
-    [],
-  );
-
-  const toggleDataSourceExpanded = useCallback(
-    (sourceId: VisualizerDataSourceId) => {
-      setExpandedDataSources((expandedDataSources) => {
-        return {
-          ...expandedDataSources,
-          [sourceId]: !expandedDataSources[sourceId],
-        };
-      });
-    },
-    [],
-  );
 
   const value = useMemo(
     () => ({
       isDataSidebarOpen,
       isVizSettingsSidebarOpen,
       isSwapAffordanceVisible,
-      expandedDataSources,
       setDataSidebarOpen,
       setVizSettingsSidebarOpen,
       setSwapAffordanceVisible,
-      setDataSourceExpanded,
-      toggleDataSourceExpanded,
     }),
-    [
-      expandedDataSources,
-      isDataSidebarOpen,
-      isSwapAffordanceVisible,
-      isVizSettingsSidebarOpen,
-      setDataSourceExpanded,
-      toggleDataSourceExpanded,
-    ],
+    [isDataSidebarOpen, isSwapAffordanceVisible, isVizSettingsSidebarOpen],
   );
 
   return (
@@ -128,16 +75,4 @@ export function VisualizerUiProvider({
 
 export function useVisualizerUi() {
   return useContext(VisualizerUiContext);
-}
-
-function getInitiallyExpandedDataSources(
-  initialDataSources: VisualizerDataSourceId[],
-) {
-  return initialDataSources.reduce(
-    (acc, sourceId) => {
-      acc[sourceId] = true;
-      return acc;
-    },
-    {} as Record<VisualizerDataSourceId, boolean>,
-  );
 }

--- a/frontend/src/metabase/visualizer/hooks/use-boolean-map.ts
+++ b/frontend/src/metabase/visualizer/hooks/use-boolean-map.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+/**
+ * A hook to manage one boolean state per key in an object.
+ */
+export const useBooleanMap = () => {
+  const [values, setValues] = useState<Record<string, boolean>>({});
+
+  const toggle = useCallback(
+    (key: string) => {
+      setValues((prev) => ({
+        ...prev,
+        [key]: !prev[key],
+      }));
+    },
+    [setValues],
+  );
+
+  const setValue = useCallback(
+    (key: string, value: boolean) => {
+      setValues((prev) => ({
+        ...prev,
+        [key]: value,
+      }));
+    },
+    [setValues],
+  );
+  return { values, toggle, setValue };
+};


### PR DESCRIPTION
Closes [VIZ-933: When replacing a dataset, it appears as collapsed in the columns list](https://linear.app/metabase/issue/VIZ-933/when-replacing-a-dataset-it-appears-as-collapsed-in-the-columns-list)

### Description

Replacing a dataset no longer makes it collapsed. This was due to a `useEffect` overriding recent changes made through redux. I've removed this part of the store in favor of a simpler state in the DataImporter. Also, I've reversed the state. Instead of keeping track of expanded datasources, it now keeps track of collasped datasources. It's mroe natural since the default state for a datasource is expanded, hence it saves on initialization.