### PR TITLE
Omit model metadata when compiling Editable cards

### DIFF
--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -306,7 +306,7 @@
                             :dashboard-id           dashboard-id
                             :visualization-settings merged-viz}
                      (and (= (:type card) :model)
-                          (not (:editable? merged-viz))
+                          (not= :table-editable (:display card))
                           (seq (:result_metadata card)))
                      (assoc :metadata/model-metadata (:result_metadata card)))]
     (when (seq parameters)

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -305,7 +305,9 @@
                             :card-name              (:name card)
                             :dashboard-id           dashboard-id
                             :visualization-settings merged-viz}
-                     (and (= (:type card) :model) (seq (:result_metadata card)))
+                     (and (= (:type card) :model)
+                          (not (:editable? merged-viz))
+                          (seq (:result_metadata card)))
                      (assoc :metadata/model-metadata (:result_metadata card)))]
     (when (seq parameters)
       (validate-card-parameters card-id (mbql.normalize/normalize-fragment [:parameters] parameters)))


### PR DESCRIPTION
Closes WRK-356

This change compiles the MBQL for editables *without* passing the result metadata into QP.

This works around https://github.com/metabase/metabase/issues/57596, which affects all models.

I've left non-editable models working as is, at this metadata is probably necessary for most complex cases. Luckily our Editables are currently always trivial queries, and we don't cache or build up upon them with other questions.