### PR TITLE
Add a "new collection" button to the main sidebar

### DIFF
--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -416,6 +416,43 @@ describe("collection permissions", () => {
     );
     cy.findByTestId("permission-table");
   });
+
+  it("should show the new collection button in a sidebar even to users without collection access", () => {
+    cy.intercept("POST", "/api/collection").as("createCollection");
+
+    cy.signIn("nocollection");
+    cy.visit("/");
+    H.navigationSidebar()
+      .findByLabelText("Create a new collection")
+      .should("be.visible")
+      .click();
+
+    cy.findByTestId("new-collection-modal").within(() => {
+      cy.findByLabelText("Name").type("Foo");
+      cy.log(
+        "The only possible location to save the new collection is this user's personal collection",
+      );
+      cy.findByTestId("collection-picker-button").should(
+        "contain",
+        "No Collection Tableton's Personal Collection",
+      );
+      cy.button("Create").click();
+      cy.wait("@createCollection");
+      cy.location("pathname").should("match", /^\/collection\/\d+-foo/);
+    });
+
+    H.navigationSidebar()
+      .findByLabelText("Create a new collection")
+      .should("be.visible")
+      .click();
+
+    cy.log(
+      "Should offer the current collection as a parent for the new sub-collection",
+    );
+    cy.findByTestId("new-collection-modal").within(() => {
+      cy.findByTestId("collection-picker-button").should("contain", "Foo");
+    });
+  });
 });
 
 function clickButton(name) {

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -438,20 +438,8 @@ describe("collection permissions", () => {
       );
       cy.button("Create").click();
       cy.wait("@createCollection");
-      cy.location("pathname").should("match", /^\/collection\/\d+-foo/);
     });
-
-    H.navigationSidebar()
-      .findByLabelText("Create a new collection")
-      .should("be.visible")
-      .click();
-
-    cy.log(
-      "Should offer the current collection as a parent for the new sub-collection",
-    );
-    cy.findByTestId("new-collection-modal").within(() => {
-      cy.findByTestId("collection-picker-button").should("contain", "Foo");
-    });
+    cy.location("pathname").should("match", /^\/collection\/\d+-foo/);
   });
 });
 

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -56,10 +56,9 @@ describe("personal collections", () => {
       cy.findAllByRole("tree")
         .contains("Your personal collection")
         .should("be.visible");
-      H.navigationSidebar().within(() => {
-        cy.icon("ellipsis").click();
-      });
-      H.popover().findByText("Other users' personal collections").click();
+      H.navigationSidebar()
+        .findByLabelText("Other users' personal collections")
+        .click();
       cy.location("pathname").should("eq", "/collection/users");
       cy.findByTestId("browsercrumbs").findByText(/All personal collections/i);
       Object.values(USERS).forEach((user) => {

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -74,12 +74,13 @@ describe("personal collections", () => {
         parent_id: ADMIN_PERSONAL_COLLECTION_ID,
       });
 
-      // Go to admin's personal collection
-      cy.visit("/collection/root");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Your personal collection").click();
+      H.visitCollection(ADMIN_PERSONAL_COLLECTION_ID);
 
+      cy.log(
+        "Make sure it's not possible to edit personal collection's permissions",
+      );
       H.getCollectionActions().within(() => {
+        cy.icon("info").should("exist");
         cy.icon("ellipsis").should("not.exist");
       });
 
@@ -95,11 +96,14 @@ describe("personal collections", () => {
 
       // Go to the newly created sub-collection "Foo"
       H.navigationSidebar().findByText("Foo").click();
-
-      // It should be possible to edit sub-collections' details, but not its permissions
       cy.findByDisplayValue("Foo").should("be.enabled");
+
+      cy.log(
+        "Other menu options exist, but editing permissions is not possible",
+      );
       H.openCollectionMenu();
       H.popover().within(() => {
+        cy.findByText("Move to trash").should("be.visible");
         cy.findByText("Edit permissions").should("not.exist");
       });
 
@@ -111,9 +115,10 @@ describe("personal collections", () => {
       // });
 
       // Go to random user's personal collection
-      cy.visit(`/collection/${NO_DATA_PERSONAL_COLLECTION_ID}`);
+      H.visitCollection(NO_DATA_PERSONAL_COLLECTION_ID);
 
       H.getCollectionActions().within(() => {
+        cy.icon("info").should("exist");
         cy.icon("ellipsis").should("not.exist");
       });
     });

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -90,13 +90,11 @@ describe("URLs", () => {
     });
 
     it("should not slugify users' collections page URL", () => {
-      cy.visit("/collection/root");
-      H.navigationSidebar().within(() => {
-        cy.icon("ellipsis").click();
-      });
-      H.popover().findByText("Other users' personal collections").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("All personal collections");
+      cy.visit("/collection/users");
+      cy.findByTestId("browsercrumbs").should(
+        "contain",
+        /All personal collections/i,
+      );
       cy.location("pathname").should("eq", "/collection/users");
     });
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -7,7 +7,7 @@ import {
   breakpointMinSmall,
   space,
 } from "metabase/styled-components/theme";
-import { Box, type BoxProps, Icon } from "metabase/ui";
+import { Box, type BoxProps } from "metabase/ui";
 
 import { SidebarLink } from "./SidebarItems";
 import { ExpandToggleButton } from "./SidebarItems/SidebarItems.styled";
@@ -71,12 +71,6 @@ export const TrashSidebarSection = styled(SidebarSection)`
   }
 ` as unknown as typeof Box;
 
-export const SidebarHeadingWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: ${space(1)};
-`;
-
 export const SidebarHeading = styled.h4`
   color: var(--mb-color-text-medium);
   font-weight: 700;
@@ -84,20 +78,6 @@ export const SidebarHeading = styled.h4`
   text-transform: uppercase;
   letter-spacing: 0.45px;
   padding-inline-start: ${space(2)};
-`;
-
-export const CollectionsMoreIconContainer = styled.button`
-  margin-inline-start: auto;
-  margin-inline-end: ${space(1)};
-  cursor: pointer;
-`;
-
-export const CollectionsMoreIcon = styled(Icon)`
-  color: var(--mb-color-text-medium);
-`;
-
-export const CollectionMenuList = styled.ul`
-  padding: 0.5rem;
 `;
 
 export const LoadingAndErrorContainer = styled.div`

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -187,7 +187,6 @@ function MainNavbarContainer({
         bookmarks={bookmarks}
         isAdmin={isAdmin}
         isOpen={isOpen}
-        currentUser={currentUser}
         collections={collectionTree}
         selectedItems={selectedItems}
         hasDataAccess={hasDataAccess}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -33,7 +33,7 @@ import {
   Tooltip,
 } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
-import type { Bookmark, Collection, User } from "metabase-types/api";
+import type { Bookmark, Collection } from "metabase-types/api";
 
 import {
   PaddedSidebarLink,
@@ -59,7 +59,6 @@ interface CollectionTreeItem extends Collection {
 type Props = {
   isAdmin: boolean;
   isOpen: boolean;
-  currentUser: User;
   bookmarks: Bookmark[];
   hasDataAccess: boolean;
   collections: CollectionTreeItem[];
@@ -80,7 +79,6 @@ const OTHER_USERS_COLLECTIONS_URL = Urls.otherUsersPersonalCollections();
 
 export function MainNavbarView({
   isAdmin,
-  currentUser,
   bookmarks,
   collections,
   databases,
@@ -235,7 +233,7 @@ export function MainNavbarView({
               <CollectionSectionHeading
                 handleCreateNewCollection={handleCreateNewCollection}
               />
-              {currentUser.is_superuser && (
+              {isAdmin && (
                 <PaddedSidebarLink
                   icon={
                     getCollectionIcon(

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -8,6 +8,10 @@ import ErrorBoundary from "metabase/ErrorBoundary";
 import { useHasTokenFeature, useUserSetting } from "metabase/common/hooks";
 import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
 import { Tree } from "metabase/components/tree";
+import {
+  PERSONAL_COLLECTIONS,
+  getCollectionIcon,
+} from "metabase/entities/collections";
 import { OnboardingDismissedToast } from "metabase/home/components/Onboarding";
 import {
   getCanAccessOnboardingPage,
@@ -15,6 +19,7 @@ import {
 } from "metabase/home/selectors";
 import { isSmallScreen } from "metabase/lib/dom";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
 import { WhatsNewNotification } from "metabase/nav/components/WhatsNewNotification";
 import { addUndo } from "metabase/redux/undo";
 import { getHasOwnDatabase } from "metabase/selectors/data";
@@ -71,9 +76,11 @@ type Props = {
     oldIndex: number;
   }) => Promise<any>;
 };
+const OTHER_USERS_COLLECTIONS_URL = Urls.otherUsersPersonalCollections();
 
 export function MainNavbarView({
   isAdmin,
+  currentUser,
   bookmarks,
   collections,
   databases,
@@ -228,6 +235,18 @@ export function MainNavbarView({
               <CollectionSectionHeading
                 handleCreateNewCollection={handleCreateNewCollection}
               />
+              {currentUser.is_superuser && (
+                <PaddedSidebarLink
+                  icon={
+                    getCollectionIcon(
+                      PERSONAL_COLLECTIONS as Collection,
+                    ) as unknown as IconName
+                  }
+                  url={OTHER_USERS_COLLECTIONS_URL}
+                >
+                  {t`Other users' personal collections`}
+                </PaddedSidebarLink>
+              )}
               <Tree
                 data={collectionsWithoutTrash}
                 selectedId={collectionItem?.id}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -7,12 +7,7 @@ import _ from "underscore";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { useHasTokenFeature, useUserSetting } from "metabase/common/hooks";
 import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { Tree } from "metabase/components/tree";
-import {
-  PERSONAL_COLLECTIONS,
-  getCollectionIcon,
-} from "metabase/entities/collections";
 import { OnboardingDismissedToast } from "metabase/home/components/Onboarding";
 import {
   getCanAccessOnboardingPage,
@@ -20,28 +15,30 @@ import {
 } from "metabase/home/selectors";
 import { isSmallScreen } from "metabase/lib/dom";
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import * as Urls from "metabase/lib/urls";
 import { WhatsNewNotification } from "metabase/nav/components/WhatsNewNotification";
 import { addUndo } from "metabase/redux/undo";
 import { getHasOwnDatabase } from "metabase/selectors/data";
 import { getSetting } from "metabase/selectors/settings";
-import { Icon, type IconName, type IconProps, Tooltip } from "metabase/ui";
+import {
+  ActionIcon,
+  Flex,
+  Icon,
+  type IconName,
+  type IconProps,
+  Tooltip,
+} from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, User } from "metabase-types/api";
 
 import {
-  CollectionMenuList,
-  CollectionsMoreIcon,
-  CollectionsMoreIconContainer,
   PaddedSidebarLink,
   PaddedSidebarLinkDismissible,
   SidebarContentRoot,
   SidebarHeading,
-  SidebarHeadingWrapper,
   SidebarSection,
   TrashSidebarSection,
 } from "../MainNavbar.styled";
-import { SidebarCollectionLink, SidebarLink } from "../SidebarItems";
+import { SidebarCollectionLink } from "../SidebarItems";
 import { AddDatabase } from "../SidebarItems/AddDatabase";
 import { DwhUploadMenu } from "../SidebarItems/DwhUpload";
 import { trackOnboardingChecklistOpened } from "../analytics";
@@ -74,11 +71,9 @@ type Props = {
     oldIndex: number;
   }) => Promise<any>;
 };
-const OTHER_USERS_COLLECTIONS_URL = Urls.otherUsersPersonalCollections();
 
 export function MainNavbarView({
   isAdmin,
-  currentUser,
   bookmarks,
   collections,
   databases,
@@ -231,7 +226,6 @@ export function MainNavbarView({
           <SidebarSection>
             <ErrorBoundary>
               <CollectionSectionHeading
-                currentUser={currentUser}
                 handleCreateNewCollection={handleCreateNewCollection}
               />
               <Tree
@@ -282,54 +276,26 @@ export function MainNavbarView({
   );
 }
 interface CollectionSectionHeadingProps {
-  currentUser: User;
   handleCreateNewCollection: () => void;
 }
+
 function CollectionSectionHeading({
-  currentUser,
   handleCreateNewCollection,
 }: CollectionSectionHeadingProps) {
-  const renderMenu = useCallback(
-    ({ closePopover }: { closePopover: () => void }) => (
-      <CollectionMenuList>
-        <SidebarLink
-          icon="add"
+  return (
+    <Flex align="center" justify="space-between">
+      <SidebarHeading>{t`Collections`}</SidebarHeading>
+      <Tooltip label={t`Create a new collection`}>
+        <ActionIcon
+          aria-label={t`Create a new collection`}
+          color="var(--mb-color-text-medium)"
           onClick={() => {
-            closePopover();
             handleCreateNewCollection();
           }}
         >
-          {t`New collection`}
-        </SidebarLink>
-        {currentUser.is_superuser && (
-          <SidebarLink
-            icon={
-              getCollectionIcon(
-                PERSONAL_COLLECTIONS as Collection,
-              ) as unknown as IconName
-            }
-            url={OTHER_USERS_COLLECTIONS_URL}
-            onClick={closePopover}
-          >
-            {t`Other users' personal collections`}
-          </SidebarLink>
-        )}
-      </CollectionMenuList>
-    ),
-    [currentUser, handleCreateNewCollection],
-  );
-
-  return (
-    <SidebarHeadingWrapper>
-      <SidebarHeading>{t`Collections`}</SidebarHeading>
-      <CollectionsMoreIconContainer>
-        <TippyPopoverWithTrigger
-          renderTrigger={({ onClick }) => (
-            <CollectionsMoreIcon name="ellipsis" onClick={onClick} />
-          )}
-          popoverContent={renderMenu}
-        />
-      </CollectionsMoreIconContainer>
-    </SidebarHeadingWrapper>
+          <Icon name="add" />
+        </ActionIcon>
+      </Tooltip>
+    </Flex>
   );
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -233,6 +233,15 @@ export function MainNavbarView({
               <CollectionSectionHeading
                 handleCreateNewCollection={handleCreateNewCollection}
               />
+
+              <Tree
+                data={collectionsWithoutTrash}
+                selectedId={collectionItem?.id}
+                onSelect={onItemSelect}
+                TreeNode={SidebarCollectionLink}
+                role="tree"
+                aria-label="collection-tree"
+              />
               {isAdmin && (
                 <PaddedSidebarLink
                   icon={
@@ -245,14 +254,6 @@ export function MainNavbarView({
                   {t`Other users' personal collections`}
                 </PaddedSidebarLink>
               )}
-              <Tree
-                data={collectionsWithoutTrash}
-                selectedId={collectionItem?.id}
-                onSelect={onItemSelect}
-                TreeNode={SidebarCollectionLink}
-                role="tree"
-                aria-label="collection-tree"
-              />
             </ErrorBoundary>
           </SidebarSection>
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -8,10 +8,6 @@ import ErrorBoundary from "metabase/ErrorBoundary";
 import { useHasTokenFeature, useUserSetting } from "metabase/common/hooks";
 import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
 import { Tree } from "metabase/components/tree";
-import {
-  PERSONAL_COLLECTIONS,
-  getCollectionIcon,
-} from "metabase/entities/collections";
 import { OnboardingDismissedToast } from "metabase/home/components/Onboarding";
 import {
   getCanAccessOnboardingPage,
@@ -244,11 +240,7 @@ export function MainNavbarView({
               />
               {isAdmin && (
                 <PaddedSidebarLink
-                  icon={
-                    getCollectionIcon(
-                      PERSONAL_COLLECTIONS as Collection,
-                    ) as unknown as IconName
-                  }
+                  icon="group"
                   url={OTHER_USERS_COLLECTIONS_URL}
                 >
                   {t`Other users' personal collections`}


### PR DESCRIPTION
Resolves PRG-20

This PR replaces the old `...` menu next to the "Collections" sidebar header. As a reminder, this menu was previously triggering a popup with two items:
1. New collection
2. Other users' personal collections (in case the user is an admin)

![Kapture 2025-05-05 at 21 13 25](https://github.com/user-attachments/assets/f568e2cb-e0d8-45c1-9280-228adf62c7e5)

We're now improving the UX and replacing this menu with two distinct items:
1. The `+` icon that creates a new collection directly
2. The new individual sidebar link that leads to other users' personal collections (again, only if admin)

> [!IMPORTANT]
> The decision has been made to add this link after the collection tree! See the conversation [here](https://metaboat.slack.com/archives/C08N6CX5EMQ/p1746453808559909).

![Kapture 2025-05-05 at 21 21 16](https://github.com/user-attachments/assets/1406c457-b056-4731-bdba-5a9f43f68ce4)
