### PR TITLE
SEM-229 Hide numerical semantic types on string-based fields

### DIFF
--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.unit.spec.tsx
@@ -203,22 +203,20 @@ describe("SemanticTypePicker", () => {
     );
   });
 
-  describe("hack: allow casting text types to numerical types", () => {
-    it("also shows semantic types derived from text/Number when field's effective_type is derived from $display_name", async () => {
-      setup({ fieldId: TEXT_FIELD.id });
+  it("does not show semantic types derived from type/Number when field's effective_type is derived from type/Text", async () => {
+    setup({ fieldId: TEXT_FIELD.id });
 
-      await assertSemanticTypesVisibility({
-        visibleTypes: [
-          "Latitude",
-          "Longitude",
-          "Currency",
-          "Discount",
-          "Income",
-          "Quantity",
-          "Score",
-          "Percentage",
-        ],
-      });
+    await assertSemanticTypesVisibility({
+      hiddenTypes: [
+        "Latitude",
+        "Longitude",
+        "Currency",
+        "Discount",
+        "Income",
+        "Quantity",
+        "Score",
+        "Percentage",
+      ],
     });
   });
 

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/utils.ts
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/utils.ts
@@ -46,17 +46,6 @@ export function getCompatibleSemanticTypes(
       return isa(option.id, type);
     });
 
-    /**
-     * Hack: allow "casting" text types to numerical types
-     * @see https://metaboat.slack.com/archives/C08E17FN206/p1741960345351799?thread_ts=1741957848.897889&cid=C08E17FN206
-     *
-     * If Field’s effective_type is derived from "type/Text"
-     * additionally show semantic types derived from "type/Number".
-     */
-    if (isFieldText) {
-      return isDerivedFromAnyLevelOneType || isa(option.id, TYPE.Number);
-    }
-
     // Limit the choice to types derived from level-one data type of Field’s effective_type
     return isDerivedFromAnyLevelOneType;
   });


### PR DESCRIPTION
Closes [SEM-229](https://linear.app/metabase/issue/SEM-229/hide-numerical-semantic-types-on-string-base-type-fields)

### Description

We no longer allow string-based fields to be "casted" to numeric types with semantic types because we now have an explicit String -> Float coercion strategy (i.e. "casting" strategy) for that.
Existing hacks (i.e. casting with semantic type) are being migrated to use coercion strategy in #57518.

### How to verify

1. Admin > Table Metadata > Sample DB > People
2. Open semantic type picker for the "Address" field
3. The should be no numeric types in the dropdown (currency, discount, income, quantity, score, percentage)

If you want to cast the field to numeric, you'll have to go to field settings (cog button) and then "Cast to a specific data type".
