### PR TITLE
docs: link to help page

### DIFF
--- a/docs/configuring-metabase/config-template.md
+++ b/docs/configuring-metabase/config-template.md
@@ -12,7 +12,6 @@ clojure -M:doc:ee config-template
 
 The template lists example `database`, `user`, and `settings` sections for the [config file](./config-file.md).
 
-
 ```yaml
 # A config file template for Metabase.
 # You'll need to update (or remove) the `users` and `databases` sections.
@@ -27,45 +26,45 @@ The template lists example `database`, `user`, and `settings` sections for the [
 version: 1
 config:
   users:
-  - first_name: First
-    last_name: Person
-    password: metabot1
-    email: first@example.com
-  - first_name: Normal
-    last_name: Person
-    password: metabot1
-    email: normal@example.com
-  - first_name: Admin
-    last_name: Person
-    password: metabot1
-    is_superuser: true
-    email: admin@example.com
+    - first_name: First
+      last_name: Person
+      password: metabot1
+      email: first@example.com
+    - first_name: Normal
+      last_name: Person
+      password: metabot1
+      email: normal@example.com
+    - first_name: Admin
+      last_name: Person
+      password: metabot1
+      is_superuser: true
+      email: admin@example.com
   databases:
-  - name: Sample PostgreSQL
-    engine: postgres
-    details:
-      host: postgres-data
-      port: 5432
-      user: metabase
-      password: metasample123
-      dbname: sample
-  - name: Sample MySQL
-    engine: mysql
-    details:
-      host: mysql-data
-      port: 3306
-      user: metabase
-      password: metasample123
-      dbname: sample
+    - name: Sample PostgreSQL
+      engine: postgres
+      details:
+        host: postgres-data
+        port: 5432
+        user: metabase
+        password: metasample123
+        dbname: sample
+    - name: Sample MySQL
+      engine: mysql
+      details:
+        host: mysql-data
+        port: 3306
+        user: metabase
+        password: metasample123
+        dbname: sample
   api-keys:
-  - name: Admin API key
-    group: admin
-    creator: first@example.com
-    key: mb_firsttestapikey123
-  - name: All Users API key
-    group: all-users
-    creator: first@example.com
-    key: mb_secondtestapikey456
+    - name: Admin API key
+      group: admin
+      creator: first@example.com
+      key: mb_firsttestapikey123
+    - name: All Users API key
+      group: all-users
+      creator: first@example.com
+      key: mb_secondtestapikey456
   settings:
     admin-email: null
     aggregated-query-row-limit: null
@@ -149,7 +148,7 @@ config:
     gsheets: null
     health-check-logging-enabled: true
     help-link: metabase
-    help-link-custom-destination: https://www.metabase.com/help/premium
+    help-link-custom-destination: https://www.metabase.com/help-premium
     humanization-strategy: simple
     jdbc-data-warehouse-max-connection-pool-size: 15
     jwt-attribute-email: email
@@ -162,7 +161,7 @@ config:
     jwt-identity-provider-uri: null
     jwt-shared-secret: null
     jwt-user-provisioning-enabled: true
-    landing-page: ''
+    landing-page: ""
     landing-page-illustration: default
     landing-page-illustration-custom: null
     ldap-attribute-email: mail

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -45,7 +45,7 @@ docker run -d -p 3000:3000 -e MB_SITE_NAME="Awesome Company" --name metabase met
 
 ## Environment variables on Metabase Cloud
 
-If you're running Metabase Cloud, you can [contact support](https://www.metabase.com/help/premium) to adjust environment variables for your Metabase.
+If you're running Metabase Cloud, you can [contact support](https://www.metabase.com/help-premium) to adjust environment variables for your Metabase.
 
 ---
 
@@ -690,7 +690,7 @@ Keyword setting to control whitelabeling of the help link. Valid values are `:me
 > Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.
 
 - Type: string
-- Default: `https://www.metabase.com/help/premium`
+- Default: `https://www.metabase.com/help-premium`
 - [Configuration file name](./config-file.md): `help-link-custom-destination`
 
 Custom URL for the help link.

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -80,7 +80,7 @@ If you check this box, Metabase will drop any visualization settings applied to 
 
 Here you can specify which questions Metabase should attach results for.
 
-The attached files will include up to 2000 rows by default. If you're self-hosting Metabase, you can adjust this row limit by setting the environment variable [MB_UNAGGREGATED_QUERY_ROW_LIMIT](../configuring-metabase/environment-variables.md#mb_unaggregated_query_row_limit). To change this row limit on your Metabase Cloud instance, you can [contact us](https://www.metabase.com/help/premium) and request a different row limit.
+The attached files will include up to 2000 rows by default. If you're self-hosting Metabase, you can adjust this row limit by setting the environment variable [MB_UNAGGREGATED_QUERY_ROW_LIMIT](../configuring-metabase/environment-variables.md#mb_unaggregated_query_row_limit). To change this row limit on your Metabase Cloud instance, you can [contact us](https://www.metabase.com/help-premium) and request a different row limit.
 
 ## Slack subscription options
 

--- a/docs/installation-and-operation/activating-the-enterprise-edition.md
+++ b/docs/installation-and-operation/activating-the-enterprise-edition.md
@@ -57,7 +57,7 @@ Assuming you've been using a [production application database](../installation-a
 
 Migrating to the Enterprise Edition will keep all of your questions, dashboards, people, settings — everything in your existing Metabase.
 
-And don't stress. You won't lose any of your work, and if you get stuck, we're [here to help](https://www.metabase.com/help/premium).
+And don't stress. You won't lose any of your work, and if you get stuck, we're [here to help](https://www.metabase.com/help-premium).
 
 ## Validating your token
 
@@ -99,12 +99,12 @@ If you're hosting Metabase behind a firewall that blocks outgoing connections, *
 44.212.138.188
 ```
 
-To verify your license with a token check to `token-check.metabase.com`, your Metabase will make GET HTTP requests to these IP addresses and parse their responses. If you can't allow outbound connections for security reasons, please [contact us](https://www.metabase.com/help/premium).
+To verify your license with a token check to `token-check.metabase.com`, your Metabase will make GET HTTP requests to these IP addresses and parse their responses. If you can't allow outbound connections for security reasons, please [contact us](https://www.metabase.com/help-premium).
 
 ## Note about Zscaler deployments
 
 When Metabase is deployed inside infrastructure that uses Zscaler, you should do the following:
 
-1. Contact your networking team and let them know that Metabase will need to perform token checks in order for paid features to work. If you need an air-gapped version of Metabase, [contact us](https://www.metabase.com/help/premium).
+1. Contact your networking team and let them know that Metabase will need to perform token checks in order for paid features to work. If you need an air-gapped version of Metabase, [contact us](https://www.metabase.com/help-premium).
 2. Make sure Zscaler isn't acting as a proxy or DNS for the server where Metabase is running. Metabase needs a direct connection to the token check service without any gateway acting as a proxy.
 3. Make sure the server where Metabase is running isn't using Zscaler root CA certificates for all websites. Otherwise, the Java virtual machine where Metabase runs will determine that the certificate authority is incorrect.

--- a/docs/people-and-groups/user-provisioning.md
+++ b/docs/people-and-groups/user-provisioning.md
@@ -11,7 +11,7 @@ Metabase supports user provisioning via the System for Cross-domain Identity Man
 - **Decouple authentication from provisioning**. Even though anyone could authenticate with SSO, you may only want some people to be able to create an account in Metabase.
 - **Support deprovisioning user accounts**. If you deactivate someone from your SSO, SCIM can let Metabase know to deactivate their Metabase account as well.
 
-> For now, Metabase officially supports SCIM for [Okta](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_scim.htm?cshid=ext_Apps_App_Integration_Wizard-scim) and [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/configure-automatic-user-provisioning-portal). Other SCIM providers may work, but we haven't tested them. If you're having issues with another identity provider, please [reach out to us](https://www.metabase.com/help/premium).
+> For now, Metabase officially supports SCIM for [Okta](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_scim.htm?cshid=ext_Apps_App_Integration_Wizard-scim) and [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/configure-automatic-user-provisioning-portal). Other SCIM providers may work, but we haven't tested them. If you're having issues with another identity provider, please [reach out to us](https://www.metabase.com/help-premium).
 
 ## Setting up user provisioning
 

--- a/src/metabase/cmd/resources/env-var-intro.md
+++ b/src/metabase/cmd/resources/env-var-intro.md
@@ -45,7 +45,7 @@ docker run -d -p 3000:3000 -e MB_SITE_NAME="Awesome Company" --name metabase met
 
 ## Environment variables on Metabase Cloud
 
-If you're running Metabase Cloud, you can [contact support](https://www.metabase.com/help/premium) to adjust environment variables for your Metabase.
+If you're running Metabase Cloud, you can [contact support](https://www.metabase.com/help-premium) to adjust environment variables for your Metabase.
 
 ---
 


### PR DESCRIPTION
Change link to the help page, see [Slack](https://metaboat.slack.com/archives/C021BPRNNBT/p1746455031224639)

my prettier didn't like the indentation in the config file, and I defer to our computer overlords 🤷🏼‍♂️ 