### PR TITLE
Add build-args to uberjar job

### DIFF
--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -16,6 +16,8 @@ on:
       release:
         type: string
         default: 'true'
+      build-args:
+        type: string
   workflow_dispatch:
     inputs:
       artifact-name:
@@ -87,6 +89,7 @@ jobs:
         tags: ${{ inputs.repo }}:${{ inputs.tag }}
         no-cache: true
         push: true
+        build-args: ${{ inputs.build-args }}
 
     # we need to do this to get the nice fallback behavior of the legacy manifest file
     - name: Build container (x86 only)

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -142,7 +142,7 @@ jobs:
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
       release: "false"
       build-args: |
-        GIT_COMMIT_SHA=${{ github.sha }}
+        GIT_COMMIT_SHA=${{ github.event.inputs.commit || github.sha }}
 
   run-trivy:
     needs: [get-container-info, containerize]

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -141,6 +141,8 @@ jobs:
       repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
       tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
       release: "false"
+      build-args: |
+        GIT_COMMIT_SHA=${{ github.sha }}
 
   run-trivy:
     needs: [get-container-info, containerize]


### PR DESCRIPTION

### Description

Follow up to #57298, allows passing build-args to the containerization job, and in the uberjar build job, adds the github sha as a build arg

*Not entirely sure what it will do with an empty string for build args*
