### PR TITLE
Drop `-v2` suffix from new metadata editing pages

### DIFF
--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -78,7 +78,12 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
           {PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes(IsAdmin)}
         </Route>
       </Route>
-      <Route path="datamodel" component={createAdminRouteGuard("data-model")}>
+      {/* TODO: remove this at the end of Milestone 1 */}
+      {/* https://linear.app/metabase/project/up-level-admin-metadata-editing-0399213bee40 */}
+      <Route
+        path="datamodel-v1"
+        component={createAdminRouteGuard("data-model")}
+      >
         <Route title={t`Table Metadata`} component={DataModelApp}>
           {getMetadataRoutes()}
           <Route path="segments" component={SegmentListApp} />
@@ -87,12 +92,7 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
           <Route path="segment/:id/revisions" component={RevisionHistoryApp} />
         </Route>
       </Route>
-      {/* TODO: replace this at the end of Milestone 1 */}
-      {/* https://linear.app/metabase/project/up-level-admin-metadata-editing-0399213bee40 */}
-      <Route
-        path="datamodel-v2"
-        component={createAdminRouteGuard("data-model")}
-      >
+      <Route path="datamodel" component={createAdminRouteGuard("data-model")}>
         <Route title={t`Table Metadata`} component={DataModelApp}>
           <IndexRedirect to="database" />
           <Route path="database" component={DataModel} />

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import EmptyDashboardBot from "assets/img/dashboard-empty.svg";
-import { useGetTableQueryMetadataQuery } from "metabase/api";
+import { skipToken, useGetTableQueryMetadataQuery } from "metabase/api";
 import EmptyState from "metabase/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
@@ -31,11 +31,15 @@ export const DataModel = ({ params }: Props) => {
     data: table,
     error,
     isLoading,
-  } = useGetTableQueryMetadataQuery({
-    id: tableId,
-    include_sensitive_fields: true,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-  });
+  } = useGetTableQueryMetadataQuery(
+    tableId == null
+      ? skipToken
+      : {
+          id: tableId,
+          include_sensitive_fields: true,
+          ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+        },
+  );
   const field = table?.fields?.find((field) => field.id === fieldId);
 
   return (

--- a/frontend/src/metabase/metadata/pages/DataModel/utils.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/utils.ts
@@ -20,20 +20,20 @@ export function getUrl(params: ParsedRouteParams): string {
     tableId != null &&
     fieldId != null
   ) {
-    return `/admin/datamodel-v2/database/${databaseId}/schema/${schemaId}/table/${tableId}/field/${fieldId}`;
+    return `/admin/datamodel/database/${databaseId}/schema/${encodeURIComponent(schemaId)}/table/${tableId}/field/${fieldId}`;
   }
 
   if (databaseId != null && schemaId != null && tableId != null) {
-    return `/admin/datamodel-v2/database/${databaseId}/schema/${schemaId}/table/${tableId}`;
+    return `/admin/datamodel/database/${databaseId}/schema/${encodeURIComponent(schemaId)}/table/${tableId}`;
   }
 
   if (databaseId != null && schemaId != null) {
-    return `/admin/datamodel-v2/database/${databaseId}/schema/${schemaId}`;
+    return `/admin/datamodel/database/${databaseId}/schema/${encodeURIComponent(schemaId)}`;
   }
 
   if (databaseId != null) {
-    return `/admin/datamodel-v2/database/${databaseId}`;
+    return `/admin/datamodel/database/${databaseId}`;
   }
 
-  return `/admin/datamodel-v2`;
+  return `/admin/datamodel`;
 }

--- a/frontend/src/metabase/metadata/pages/DataModel/utils.unit.spec.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/utils.unit.spec.ts
@@ -58,7 +58,7 @@ describe("getUrl", () => {
     };
 
     expect(getUrl(params)).toBe(
-      "/admin/datamodel-v2/database/1/schema/public/table/2/field/3",
+      "/admin/datamodel/database/1/schema/public/table/2/field/3",
     );
   });
 
@@ -71,7 +71,7 @@ describe("getUrl", () => {
     };
 
     expect(getUrl(params)).toBe(
-      "/admin/datamodel-v2/database/1/schema/public/table/2",
+      "/admin/datamodel/database/1/schema/public/table/2",
     );
   });
 
@@ -83,7 +83,7 @@ describe("getUrl", () => {
       fieldId: undefined,
     };
 
-    expect(getUrl(params)).toBe("/admin/datamodel-v2/database/1/schema/public");
+    expect(getUrl(params)).toBe("/admin/datamodel/database/1/schema/public");
   });
 
   it("should generate URL with database", () => {
@@ -94,7 +94,7 @@ describe("getUrl", () => {
       fieldId: undefined,
     };
 
-    expect(getUrl(params)).toBe("/admin/datamodel-v2/database/1");
+    expect(getUrl(params)).toBe("/admin/datamodel/database/1");
   });
 
   it("should generate base URL when no params are provided", () => {
@@ -105,7 +105,7 @@ describe("getUrl", () => {
       fieldId: undefined,
     };
 
-    expect(getUrl(params)).toBe("/admin/datamodel-v2");
+    expect(getUrl(params)).toBe("/admin/datamodel");
   });
 
   it("should not include field param when there is no table param", () => {
@@ -116,7 +116,7 @@ describe("getUrl", () => {
       fieldId: 3,
     };
 
-    expect(getUrl(params)).toBe("/admin/datamodel-v2/database/1/schema/public");
+    expect(getUrl(params)).toBe("/admin/datamodel/database/1/schema/public");
   });
 
   it("should not include schema, table, and field params when there is no database param", () => {
@@ -127,6 +127,6 @@ describe("getUrl", () => {
       fieldId: 3,
     };
 
-    expect(getUrl(params)).toBe("/admin/datamodel-v2");
+    expect(getUrl(params)).toBe("/admin/datamodel");
   });
 });

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -80,14 +80,6 @@ export const AdminNavbar = ({
 
       <MobileHide>
         <AdminNavbarItems data-testid="admin-navbar-items">
-          {/* TODO: remove this at the end of Milestone 1 */}
-          {/* https://linear.app/metabase/project/up-level-admin-metadata-editing-0399213bee40 */}
-          <AdminNavItem
-            name="Table Metadata v2"
-            path="/admin/datamodel-v2"
-            currentPath={currentPath}
-          />
-
           {adminPaths.map(({ name, key, path }) => (
             <AdminNavItem
               name={name}


### PR DESCRIPTION
### Description

- Removes link to old pages from admin nav
- Uses `/admin/datamodel` for new pages (instead of `/admin/datamodel-v2`)
- Old pages are still accessible via URL (`/admin/datamodel-v1`) for reference
- Fixes schema id not being encoded in the URL
- Fixes table being fetched when `tableId` is `undefined`

This will make lots of tests fail.
