### PR TITLE
Remove "Model" and "Action" from the "New" button menu

### DIFF
--- a/e2e/support/helpers/e2e-action-helpers.js
+++ b/e2e/support/helpers/e2e-action-helpers.js
@@ -1,5 +1,10 @@
 import { capitalize } from "inflection";
 
+import {
+  commandPalette,
+  commandPaletteButton,
+  commandPaletteInput,
+} from "./e2e-command-palette-helpers";
 import { NativeEditor } from "./e2e-native-editor-helpers";
 
 export function setActionsEnabledForDB(dbId, enabled = true) {
@@ -47,4 +52,14 @@ export function createImplicitActions({ modelId }) {
   createImplicitAction({ model_id: modelId, kind: "create" });
   createImplicitAction({ model_id: modelId, kind: "update" });
   createImplicitAction({ model_id: modelId, kind: "delete" });
+}
+
+export function startNewAction() {
+  commandPaletteButton().click();
+  commandPalette().within(() => {
+    commandPaletteInput().type("Ac");
+    cy.findByLabelText("New action").click();
+  });
+  commandPalette().should("not.exist");
+  cy.findByTestId("action-creator").should("be.visible");
 }

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -454,22 +454,6 @@ describe("issue 32840", () => {
   });
 });
 
-describe("issue 41831", () => {
-  beforeEach(() => {
-    H.restore("without-models");
-    cy.signInAsAdmin();
-    H.setActionsEnabledForDB(SAMPLE_DB_ID);
-    cy.visit("/");
-  });
-
-  it("new action button is hidden without models", () => {
-    cy.findByRole("button", { name: "New" }).click();
-    cy.findByRole("dialog").within(() => {
-      cy.findByText("Action").should("not.exist");
-    });
-  });
-});
-
 describe("issue 32750", () => {
   beforeEach(() => {
     H.restore();

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -331,8 +331,7 @@ describe("issue 51020", () => {
       createTemporaryTable();
       H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "foo" });
 
-      cy.visit("/");
-      H.newButton("Model").click();
+      cy.visit("/model/new");
       cy.findByTestId("new-model-options")
         .findByText("Use the notebook editor")
         .click();

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -479,12 +479,7 @@ describe("issue 32750", () => {
   });
 
   it("modal do not dissapear on viewport change", () => {
-    cy.findByRole("button", { name: "New" }).click();
-    cy.findByRole("dialog").within(() => {
-      cy.findByText("Action").click();
-    });
-
-    cy.findByTestId("action-creator").should("be.visible");
+    H.startNewAction();
     cy.viewport(320, 800);
     cy.findByTestId("action-creator").should("be.visible");
     cy.viewport(1440, 800);

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -155,36 +155,6 @@ describe(
       });
     });
 
-    it("should allow to create an action with the New button", () => {
-      const QUERY = "UPDATE orders SET discount = {{ discount }}";
-      cy.visit("/");
-
-      cy.findByTestId("app-bar").findByText("New").click();
-      H.popover().findByText("Action").click();
-
-      cy.wait("@getDatabase");
-      H.fillActionQuery(QUERY);
-
-      cy.findByRole("dialog").within(() => {
-        cy.findByText(/New Action/)
-          .clear()
-          .type("Discount order");
-
-        cy.findByRole("button", { name: "Save" }).click();
-      });
-
-      H.modal().eq(1).findByText("Select a model").click();
-      H.entityPickerModal().within(() => {
-        cy.findByText("Order").click();
-      });
-
-      cy.findByRole("button", { name: "Create" }).click();
-
-      cy.get("@modelId").then((modelId) => {
-        cy.url().should("include", `/model/${modelId}/detail/actions`);
-      });
-    });
-
     it("should respect permissions", () => {
       // Enabling actions for sample database as well
       // to test database picker behavior in the action editor

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -236,8 +236,7 @@ describe(
 
     it("should display parameters for variable template tags only", () => {
       cy.visit("/");
-      cy.findByTestId("app-bar").findByText("New").click();
-      H.popover().findByText("Action").click();
+      H.startNewAction();
 
       H.fillActionQuery("{{#1-orders-model}}");
       cy.findByLabelText("#1-orders-model").should("not.exist");

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1797,7 +1797,6 @@ describe("issue 48878", () => {
     // Create a dummy model so that GET /api/search does not return the model want to test.
     // If we don't do this, GET /api/search will return and put card object with dataset_query
     // attribute in the redux store (entity framework) which would prevent the issue from happening.
-    cy.visit("/model/new");
     createModel({
       name: "Dummy model",
       query: "select 1",
@@ -1805,8 +1804,6 @@ describe("issue 48878", () => {
 
     cy.log("create model");
 
-    cy.button("New").click();
-    H.popover().findByText("Model").click();
     createModel({
       name: "SQL Model",
       query: "select * from orders limit 5",
@@ -1863,6 +1860,7 @@ describe("issue 48878", () => {
   }
 
   function createModel({ name, query }) {
+    cy.visit("/model/new");
     cy.findByTestId("new-model-options")
       .findByText("Use a native query")
       .click();

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -1,6 +1,5 @@
 const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
-import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "A name";
 
@@ -42,47 +41,6 @@ describe("scenarios > models > create", () => {
     cy.findByText("Summarize");
 
     checkIfPinned();
-  });
-
-  it("suggest the currently viewed collection when saving a new native query", () => {
-    H.visitCollection(THIRD_COLLECTION_ID);
-
-    navigateToNewModelPage();
-    H.NativeEditor.focus().type("select 1");
-    cy.findByTestId("native-query-editor-container").icon("play").click();
-    cy.wait("@dataset");
-
-    cy.findByTestId("dataset-edit-bar").within(() => {
-      cy.contains("button", "Save").click();
-    });
-    cy.findByTestId("save-question-modal").within(() => {
-      cy.findByLabelText(/Where do you want to save this/).should(
-        "have.text",
-        "Third collection",
-      );
-    });
-  });
-
-  it("suggest the last accessed collection when saving a new structured query model", () => {
-    H.visitCollection(THIRD_COLLECTION_ID);
-
-    navigateToNewModelPage("structured");
-
-    H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Tables").click();
-      cy.findByText("Orders").click();
-    });
-
-    cy.findByTestId("dataset-edit-bar").within(() => {
-      cy.contains("button", "Save").click();
-    });
-
-    cy.findByTestId("save-question-modal").within(() => {
-      cy.findByLabelText(/Where do you want to save this/).should(
-        "have.text",
-        "Third collection",
-      );
-    });
   });
 
   // This covers creating a GUI model from the browse page + nocollection permissions (2 in 1)

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -142,7 +142,7 @@ describe("scenarios > models > create", () => {
 });
 
 function navigateToNewModelPage(queryType = "native") {
-  H.newButton("Model").click();
+  cy.visit("/model/new");
   if (queryType === "structured") {
     cy.findByText("Use the notebook editor").click();
   } else {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -965,46 +965,6 @@ describe("issue 28971", () => {
   });
 });
 
-describe("issue 28971", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsNormalUser();
-    cy.intercept("POST", "/api/card").as("createCard");
-    cy.intercept("POST", "/api/dataset").as("dataset");
-  });
-
-  it("should be able to filter a newly created model (metabase#28971)", () => {
-    cy.visit("/");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-    H.popover().findByText("Model").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Use the notebook editor").click();
-    H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Tables").click();
-      cy.findByText("Orders").click();
-    });
-    cy.button("Save").click();
-    cy.findByTestId("save-question-modal").within((modal) => {
-      cy.findByText("Save").click();
-    });
-    cy.wait("@createCard");
-
-    H.filter();
-    H.popover().within(() => {
-      cy.findByText("Quantity").click();
-      cy.findByText("20").click();
-      cy.button("Apply filter").click();
-    });
-    cy.wait("@dataset");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Quantity is equal to 20").should("exist");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing 4 rows").should("exist");
-  });
-});
-
 describe("issue 29378", () => {
   const ACTION_DETAILS = {
     name: "Update orders quantity",

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -929,27 +929,22 @@ describe("issue 28971", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
-    cy.intercept("POST", "/api/card").as("createCard");
+    cy.intercept("POST", "/api/card").as("createModel");
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should be able to filter a newly created model (metabase#28971)", () => {
-    cy.visit("/");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-    H.popover().findByText("Model").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Use the notebook editor").click();
+    H.startNewModel();
     H.entityPickerModal().within(() => {
       H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
-    cy.button("Save").click();
-    cy.findByTestId("save-question-modal").within((modal) => {
-      cy.findByText("Save").click();
-    });
-    cy.wait("@createCard");
+    cy.findByTestId("run-button").click();
+    cy.wait("@dataset");
+
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
+    cy.findByTestId("save-question-modal").button("Save").click();
+    cy.wait("@createModel");
 
     H.filter();
     H.popover().within(() => {
@@ -958,10 +953,12 @@ describe("issue 28971", () => {
       cy.button("Apply filter").click();
     });
     cy.wait("@dataset");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Quantity is equal to 20").should("exist");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing 4 rows").should("exist");
+
+    cy.findByTestId("filter-pill").should(
+      "have.text",
+      "Quantity is equal to 20",
+    );
+    cy.findByTestId("question-row-count").should("have.text", "Showing 4 rows");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -783,8 +783,7 @@ describe("issue 33844", () => {
   }
 
   it("should show hidden PKs in model metadata editor and object details after creating a model (metabase#33844)", () => {
-    cy.visit("/");
-    H.newButton("Model").click();
+    cy.visit("/model/new");
     cy.findByTestId("new-model-options")
       .findByText("Use the notebook editor")
       .click();
@@ -1058,10 +1057,9 @@ describe("issue 34514", () => {
     cy.intercept("GET", "/api/database/*/schema/*").as("fetchTables");
     cy.intercept("GET", "/api/database/*").as("fetchDatabase");
 
-    cy.visit("/");
     // It's important to navigate via UI so that there are
     // enough entries in the browser history to go back to.
-    H.newButton("Model").click();
+    cy.visit("/model/new");
     cy.findByTestId("new-model-options")
       .findByText("Use the notebook editor")
       .click();

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -115,7 +115,8 @@ describe(
     it("selecting a database in native editor for model actions should not persist the database", () => {
       [SAMPLE_DB_ID, PG_DB_ID].forEach(enableModelActionsForDatabase);
 
-      startNewAction();
+      cy.visit("/");
+      H.startNewAction();
       assertNoDatabaseSelected();
 
       selectDatabase("Sample Database");
@@ -129,7 +130,8 @@ describe(
       selectDatabase(postgresName);
       cy.wait("@persistDatabase");
 
-      startNewAction();
+      cy.visit("/");
+      H.startNewAction();
       assertNoDatabaseSelected();
     });
 
@@ -365,12 +367,6 @@ function startNativeQuestion() {
 function startNativeModel() {
   cy.visit("/model/new");
   cy.findByRole("heading", { name: "Use a native query" }).click();
-}
-
-function startNewAction() {
-  cy.visit("/");
-  cy.findByTestId("app-bar").findByText("New").click();
-  H.popover().findByTextEnsureVisible("Action").click();
 }
 
 function assertNoDatabaseSelected() {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -518,7 +518,8 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("Escape");
     // Legacy Modals
 
-    H.newButton("Action").click();
+    H.startNewAction();
+
     // Remove focus
     H.modal()
       .findByText(/Build custom forms/)

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -183,9 +183,7 @@ describe("issue 25144", { tags: "@OSS" }, () => {
   });
 
   it("should show Models tab after creation the first model (metabase#24878)", () => {
-    cy.visit("/");
-
-    H.newButton("Model").click();
+    cy.visit("/model/new");
     cy.findByTestId("new-model-options")
       .findByText(/use the notebook/i)
       .click();

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -140,7 +140,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.get("@updatePreviewStateSpy").should("have.callCount", 1);
     cy.findByTestId("native-query-preview-sidebar").should("be.visible");
 
-    H.newButton("Model").click();
+    cy.visit("/model/new");
     cy.findByTestId("new-model-options").should("be.visible");
 
     resizeScreen("small");

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1015,8 +1015,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should let the user navigate back (metabase#50971)", () => {
-    cy.visit("/");
-    H.newButton("Model").click();
+    cy.visit("/model/new");
     cy.findByTestId("new-model-options")
       .findByText("Use the notebook editor")
       .click();

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -7,10 +7,6 @@ import EntityMenu from "metabase/components/EntityMenu";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { setOpenModal } from "metabase/redux/ui";
-import {
-  getEmbedOptions,
-  getIsEmbeddingIframe,
-} from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
 import type { CollectionId } from "metabase-types/api";
 
@@ -20,11 +16,9 @@ export interface NewItemMenuProps {
   trigger?: ReactNode;
   triggerIcon?: string;
   triggerTooltip?: string;
-  hasModels: boolean;
   hasDataAccess: boolean;
   hasNativeWrite: boolean;
   hasDatabaseWithJsonEngine: boolean;
-  hasDatabaseWithActionsEnabled: boolean;
   onCloseNavbar: () => void;
   onChangeLocation: (nextLocation: LocationDescriptor) => void;
 }
@@ -44,18 +38,12 @@ const NewItemMenu = ({
   trigger,
   triggerIcon,
   triggerTooltip,
-  hasModels,
   hasDataAccess,
   hasNativeWrite,
   hasDatabaseWithJsonEngine,
-  hasDatabaseWithActionsEnabled,
   onCloseNavbar,
 }: NewItemMenuProps) => {
   const dispatch = useDispatch();
-  const entityTypes = useSelector(
-    (state) => getEmbedOptions(state).entity_types,
-  );
-  const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
 
   const lastUsedDatabaseId = useSelector((state) =>
     getSetting(state, "last-used-native-database-id"),
@@ -99,43 +87,10 @@ const NewItemMenu = ({
       action: () => dispatch(setOpenModal("dashboard")),
     });
 
-    if (
-      hasNativeWrite &&
-      (!isEmbeddingIframe || entityTypes.includes("model"))
-    ) {
-      const collectionQuery = collectionId
-        ? `?collectionId=${collectionId}`
-        : "";
-
-      items.push({
-        title: t`Model`,
-        icon: "model",
-        link: `/model/new${collectionQuery}`,
-        onClose: onCloseNavbar,
-      });
-    }
-
-    if (
-      hasModels &&
-      hasDatabaseWithActionsEnabled &&
-      hasNativeWrite &&
-      !isEmbeddingIframe
-    ) {
-      items.push({
-        title: t`Action`,
-        icon: "bolt",
-        action: () => dispatch(setOpenModal("action")),
-      });
-    }
-
     return items;
   }, [
     hasDataAccess,
     hasNativeWrite,
-    isEmbeddingIframe,
-    entityTypes,
-    hasModels,
-    hasDatabaseWithActionsEnabled,
     collectionId,
     onCloseNavbar,
     hasDatabaseWithJsonEngine,

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
@@ -3,33 +3,27 @@ import _ from "underscore";
 
 import NewItemMenu from "metabase/components/NewItemMenu";
 import Databases from "metabase/entities/databases";
-import Search from "metabase/entities/search";
 import { connect } from "metabase/lib/redux";
 import { closeNavbar } from "metabase/redux/app";
 import {
   getHasDataAccess,
-  getHasDatabaseWithActionsEnabled,
   getHasDatabaseWithJsonEngine,
   getHasNativeWrite,
 } from "metabase/selectors/data";
 import type Database from "metabase-lib/v1/metadata/Database";
-import type { CollectionItem } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 interface MenuDatabaseProps {
   databases?: Database[];
-  models?: CollectionItem[];
 }
 
 const mapStateToProps = (
   state: State,
-  { databases = [], models = [] }: MenuDatabaseProps,
+  { databases = [] }: MenuDatabaseProps,
 ) => ({
-  hasModels: models.length > 0,
   hasDataAccess: getHasDataAccess(databases),
   hasNativeWrite: getHasNativeWrite(databases),
   hasDatabaseWithJsonEngine: getHasDatabaseWithJsonEngine(databases),
-  hasDatabaseWithActionsEnabled: getHasDatabaseWithActionsEnabled(databases),
 });
 
 const mapDispatchToProps = {
@@ -41,13 +35,6 @@ const mapDispatchToProps = {
 export default _.compose(
   Databases.loadList({
     loadingAndErrorWrapper: false,
-  }),
-  Search.loadList({
-    // Checking if there is at least one model,
-    // so we can decide if "Action" option should be shown
-    query: { models: ["dataset"], limit: 1 },
-    loadingAndErrorWrapper: false,
-    listName: "models",
   }),
   connect(mapStateToProps, mapDispatchToProps),
 )(NewItemMenu);

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -5,17 +5,10 @@ import {
   setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import type { EmbeddingEntityType } from "metabase/embedding-sdk/store";
-import * as domUtils from "metabase/lib/dom";
 import { NewModals } from "metabase/new/components/NewModals/NewModals";
 import type { Database } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import {
-  createMockEmbedOptions,
-  createMockEmbedState,
-  createMockState,
-} from "metabase-types/store/mocks";
 
 import NewItemMenu from "./NewItemMenu";
 
@@ -25,43 +18,22 @@ console.error = jest.fn();
 type SetupOpts = {
   databases?: Database[];
   hasModels?: boolean;
-  isEmbeddingIframe?: boolean;
-  entityTypes?: EmbeddingEntityType[];
 };
 
 const SAMPLE_DATABASE = createSampleDatabase();
 const COLLECTION = createMockCollection();
 
-async function setup({
-  databases = [SAMPLE_DATABASE],
-  isEmbeddingIframe,
-  entityTypes,
-}: SetupOpts = {}) {
+async function setup({ databases = [SAMPLE_DATABASE] }: SetupOpts = {}) {
   setupDatabasesEndpoints(databases);
   setupCollectionByIdEndpoint({
     collections: [COLLECTION],
   });
-
-  if (isEmbeddingIframe) {
-    jest.spyOn(domUtils, "isWithinIframe").mockReturnValue(true);
-  }
 
   renderWithProviders(
     <>
       <NewItemMenu trigger={<button>New</button>} />
       <NewModals />
     </>,
-    entityTypes
-      ? {
-          storeInitialState: createMockState({
-            embed: createMockEmbedState({
-              options: createMockEmbedOptions({
-                entity_types: entityTypes,
-              }),
-            }),
-          }),
-        }
-      : undefined,
   );
   await userEvent.click(screen.getByText("New"));
 }

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
 
 import {
   setupCollectionByIdEndpoint,
@@ -10,11 +9,7 @@ import type { EmbeddingEntityType } from "metabase/embedding-sdk/store";
 import * as domUtils from "metabase/lib/dom";
 import { NewModals } from "metabase/new/components/NewModals/NewModals";
 import type { Database } from "metabase-types/api";
-import {
-  createMockCard,
-  createMockCollection,
-  createMockDatabase,
-} from "metabase-types/api/mocks";
+import { createMockCollection } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 import {
   createMockEmbedOptions,
@@ -23,14 +18,6 @@ import {
 } from "metabase-types/store/mocks";
 
 import NewItemMenu from "./NewItemMenu";
-
-jest.mock(
-  "metabase/actions/containers/ActionCreator",
-  () =>
-    function ActionCreator() {
-      return <div data-testid="mock-action-editor" />;
-    },
-);
 
 console.warn = jest.fn();
 console.error = jest.fn();
@@ -43,47 +30,17 @@ type SetupOpts = {
 };
 
 const SAMPLE_DATABASE = createSampleDatabase();
-
-const DB_WITH_ACTIONS = createMockDatabase({
-  id: 2,
-  name: "Postgres with actions",
-  engine: "postgres",
-  native_permissions: "write",
-  settings: { "database-enable-actions": true },
-});
-
-const DB_WITHOUT_WRITE_ACCESS = createMockDatabase({
-  ...DB_WITH_ACTIONS,
-  id: 3,
-  native_permissions: "none",
-});
-
 const COLLECTION = createMockCollection();
 
 async function setup({
-  databases = [SAMPLE_DATABASE, DB_WITH_ACTIONS],
-  hasModels = true,
+  databases = [SAMPLE_DATABASE],
   isEmbeddingIframe,
   entityTypes,
 }: SetupOpts = {}) {
-  const models = hasModels ? [createMockCard({ type: "model" })] : [];
-
   setupDatabasesEndpoints(databases);
   setupCollectionByIdEndpoint({
     collections: [COLLECTION],
   });
-
-  fetchMock.get(
-    {
-      url: "path:/api/search",
-    },
-    {
-      available_models: ["dataset"],
-      models: ["dataset"],
-      data: models,
-      total: models.length,
-    },
-  );
 
   if (isEmbeddingIframe) {
     jest.spyOn(domUtils, "isWithinIframe").mockReturnValue(true);
@@ -119,10 +76,10 @@ describe("NewItemMenu", () => {
     expect(await screen.findByText("Question")).toBeInTheDocument();
     expect(await screen.findByText("SQL query")).toBeInTheDocument();
     expect(await screen.findByText("Dashboard")).toBeInTheDocument();
-    expect(await screen.findByText("Model")).toBeInTheDocument();
-    expect(await screen.findByText("Action")).toBeInTheDocument();
     expect(screen.queryByText("Metric")).not.toBeInTheDocument();
     expect(screen.queryByText("Collection")).not.toBeInTheDocument();
+    expect(screen.queryByText("Model")).not.toBeInTheDocument();
+    expect(screen.queryByText("Action")).not.toBeInTheDocument();
   });
 
   describe("New Dashboard", () => {
@@ -131,128 +88,6 @@ describe("NewItemMenu", () => {
       await userEvent.click(await screen.findByText("Dashboard"));
       const modal = await screen.findByRole("dialog");
       expect(modal).toHaveTextContent("New dashboard");
-    });
-  });
-
-  describe("New Action", () => {
-    it("should open action editor on click", async () => {
-      await setup();
-
-      await userEvent.click(await screen.findByText("Action"));
-      const modal = screen.getByRole("dialog");
-
-      expect(modal).toBeVisible();
-    });
-
-    it("should not be visible if there are no databases with actions enabled", async () => {
-      await setup({ databases: [SAMPLE_DATABASE] });
-      expect(screen.queryByText("Action")).not.toBeInTheDocument();
-    });
-
-    it("should not be visible if user has no models", async () => {
-      await setup({ hasModels: false });
-      expect(screen.queryByText("Action")).not.toBeInTheDocument();
-    });
-
-    it("should not be visible if user has no write data access", async () => {
-      await setup({ databases: [DB_WITHOUT_WRITE_ACCESS] });
-      expect(screen.queryByText("Action")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("interactive embedding with `entity_types` (EMB-230)", () => {
-    it("should show models when no `entity_types` is provided", async () => {
-      await setup({ isEmbeddingIframe: true });
-      expect(
-        screen.getByRole("listitem", { name: "Question" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "SQL query" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Dashboard" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Model" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Action" }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Metric" }),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should show models when `entity_types` is `["model", "table"]`', async () => {
-      await setup({ isEmbeddingIframe: true, entityTypes: ["model", "table"] });
-      expect(
-        screen.getByRole("listitem", { name: "Question" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "SQL query" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Dashboard" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Model" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Action" }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Metric" }),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should show models when `entity_types` is `["model"]`', async () => {
-      await setup({
-        isEmbeddingIframe: true,
-        entityTypes: ["model"],
-      });
-      expect(
-        screen.getByRole("listitem", { name: "Question" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "SQL query" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Dashboard" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Model" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Action" }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Metric" }),
-      ).not.toBeInTheDocument();
-    });
-
-    it('should not show models when `entity_types` is `["table"]` (does not contain "model")', async () => {
-      await setup({
-        isEmbeddingIframe: true,
-        entityTypes: ["table"],
-      });
-      expect(
-        screen.getByRole("listitem", { name: "Question" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "SQL query" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Dashboard" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Model" }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Action" }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("listitem", { name: "Metric" }),
-      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Resolves PRG-28 by removing the "Model" and "Action" entries from the main "New" menu.

<img width="217" alt="image" src="https://github.com/user-attachments/assets/95864f4c-dbe4-4d1a-94b5-dd48a029b40f" />


### Testing
A lot of tests needed to be updated, while others had to be removed as they are not valid anymore.