### PR TITLE
Remove "Collection" option from the "New" button menu

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.ts
+++ b/e2e/support/helpers/e2e-collection-helpers.ts
@@ -3,9 +3,17 @@ import {
   entityPickerModalLevel,
   entityPickerModalTab,
   getFullName,
+  navigationSidebar,
   popover,
 } from "e2e/support/helpers";
 import type { CollectionId } from "metabase-types/api";
+
+export function startNewCollectionFromSidebar() {
+  return navigationSidebar()
+    .findByLabelText("Create a new collection")
+    .should("be.visible")
+    .click();
+}
 
 export function getCollectionActions() {
   return cy.findByTestId("collection-menu");

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -112,11 +112,7 @@ describe("scenarios > collection defaults", () => {
 
       cy.viewport(800, 500);
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("New").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Collection").click();
-
+      H.startNewCollectionFromSidebar();
       cy.findByTestId("new-collection-modal").then((modal) => {
         cy.findByPlaceholderText("My new fantastic collection").type(
           "Test collection",
@@ -923,11 +919,7 @@ describe("scenarios > collection defaults", () => {
 
     it("should create new collections within the current collection", () => {
       H.visitCollection(THIRD_COLLECTION_ID);
-      cy.findByTestId("app-bar").findByText("New").click();
-
-      H.popover().within(() => {
-        cy.findByText("Collection").click();
-      });
+      H.startNewCollectionFromSidebar();
 
       cy.findByTestId("new-collection-modal").then((modal) => {
         cy.findByText("Collection it's saved in").should("be.visible");

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -142,8 +142,7 @@ describe("personal collections", () => {
           cy.signIn(user);
 
           cy.visit("/collection/root");
-          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("Your personal collection").click();
+          H.navigationSidebar().findByText("Your personal collection").click();
 
           // Create initial collection inside the personal collection and navigate to it
           addNewCollection("Foo");
@@ -165,11 +164,9 @@ describe("personal collections", () => {
           );
 
           H.openCollectionMenu();
-          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          H.popover().within(() => cy.findByText("Move to trash").click());
-          H.modal().findByRole("button", { name: "Move to trash" }).click();
-          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("Trashed collection");
+          H.popover().findByText("Move to trash").click();
+          H.modal().button("Move to trash").click();
+          cy.findByTestId("toast-undo").should("contain", "Trashed collection");
           cy.get("@sidebar").findByText("Foo").should("not.exist");
         });
       });
@@ -178,7 +175,7 @@ describe("personal collections", () => {
 });
 
 function addNewCollection(name) {
-  H.newButton("Collection").click();
+  H.startNewCollectionFromSidebar();
   cy.findByPlaceholderText("My new fantastic collection").type(name, {
     delay: 0,
   });

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -501,9 +501,9 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
 
     H.navigationSidebar().should("be.visible");
     // Mantine Modals
-    H.newButton("Collection").click();
+    H.startNewCollectionFromSidebar();
 
-    H.modal()
+    cy.findByTestId("new-collection-modal")
       .findByLabelText(/collection it's saved in/i)
       .click();
 

--- a/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
@@ -26,26 +26,4 @@ describe("metabase > scenarios > navbar > new menu", () => {
     cy.url("should.contain", "/question#");
     H.NativeEditor.get().should("be.visible");
   });
-
-  it("collection opens modal and redirects to a created collection after saving", () => {
-    H.popover().within(() => {
-      cy.findByText("Collection").click();
-    });
-
-    cy.findByTestId("new-collection-modal").then((modal) => {
-      cy.findByTestId("collection-picker-button").findByText("Our analytics");
-
-      cy.findByPlaceholderText("My new fantastic collection").type(
-        "Test collection",
-      );
-      cy.findByLabelText("Description").type("Test collection description");
-
-      cy.findByText("Create").click();
-    });
-
-    cy.findByTestId("collection-name-heading").should(
-      "have.text",
-      "Test collection",
-    );
-  });
 });

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -10,12 +10,16 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import type {
+  DashboardDetails,
+  StructuredQuestionDetails,
+} from "e2e/support/helpers";
 import type { DashboardCard } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-const cardDetails: H.StructuredQuestionDetails = {
+const cardDetails: StructuredQuestionDetails = {
   name: "Question",
   type: "question",
   query: {
@@ -1032,8 +1036,8 @@ describe("scenarios > organization > entity picker", () => {
       cy.visit("/");
 
       // New Collection Flow
-      H.newButton("Collection").click();
-      H.modal()
+      H.startNewCollectionFromSidebar();
+      cy.findByTestId("new-collection-modal")
         .findByLabelText(/Collection it's saved in/)
         .click();
 
@@ -1123,8 +1127,8 @@ describe("scenarios > organization > entity picker", () => {
       cy.visit("/");
 
       // New Collection Flow
-      H.newButton("Collection").click();
-      H.modal()
+      H.startNewCollectionFromSidebar();
+      cy.findByTestId("new-collection-modal")
         .findByLabelText(/Collection it's saved in/)
         .click();
       H.entityPickerModalTab("Collections").click();
@@ -1253,7 +1257,7 @@ function createTestDashboards() {
 }
 
 function createTestDashboardWithEmptyCard(
-  dashboardDetails: H.DashboardDetails = {},
+  dashboardDetails: DashboardDetails = {},
 ) {
   const dashcardDetails: Partial<DashboardCard>[] = [
     {
@@ -1285,7 +1289,7 @@ function createTestDashboardWithEmptyCard(
   });
 }
 
-function selectQuestionFromDashboard(dashboardDetails?: H.DashboardDetails) {
+function selectQuestionFromDashboard(dashboardDetails?: DashboardDetails) {
   createTestDashboardWithEmptyCard(dashboardDetails).then((dashboard) => {
     H.visitDashboard(dashboard.id);
     H.editDashboard();

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -39,7 +39,7 @@ describe("official collections", () => {
       // Gate the UI
       cy.visit("/collection/root");
 
-      startNewCollectionCreation();
+      H.startNewCollectionFromSidebar();
       cy.findByTestId("new-collection-modal").then((modal) => {
         assertNoCollectionTypeInput();
         cy.findByLabelText("Close").click();
@@ -84,7 +84,7 @@ describe("official collections", () => {
 
       openCollection("First collection");
 
-      startNewCollectionCreation();
+      H.startNewCollectionFromSidebar();
       cy.findByTestId("new-collection-modal").then((modal) => {
         assertNoCollectionTypeInput();
         cy.findByLabelText("Close").click();
@@ -107,7 +107,7 @@ describe("official collections", () => {
 
       H.popover().findByText("Make collection official").should("exist");
 
-      startNewCollectionCreation();
+      H.startNewCollectionFromSidebar();
       cy.findByTestId("new-collection-modal").then((modal) => {
         assertHasCollectionTypeInput();
         cy.findByPlaceholderText("My new fantastic collection").type(
@@ -124,7 +124,7 @@ describe("official collections", () => {
       });
       H.popover().findByText("Make collection official").should("exist");
 
-      startNewCollectionCreation();
+      H.startNewCollectionFromSidebar();
       cy.findByTestId("new-collection-modal").then((modal) => {
         assertHasCollectionTypeInput();
         cy.findByLabelText("Close").click();
@@ -236,7 +236,7 @@ function openCollection(collectionName) {
 }
 
 function createAndOpenOfficialCollection({ name }) {
-  startNewCollectionCreation();
+  H.startNewCollectionFromSidebar();
   cy.findByTestId("new-collection-modal").then((modal) => {
     cy.findByPlaceholderText("My new fantastic collection").type(name);
     cy.findByText("Official").click();
@@ -310,5 +310,3 @@ const assertHasCollectionBadgeInNavbar = (expectBadge = true) => {
       }
     });
 };
-
-const startNewCollectionCreation = () => H.newButton("Collection").click();

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -306,14 +306,8 @@ describe("UI elements that make no sense for users without data permissions (met
       cy.icon("refresh").should("not.exist");
     });
 
-    cy.visit("/collection/root");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-
-    H.popover()
-      .should("contain", "Dashboard")
-      .and("contain", "Collection")
-      .and("not.contain", "Question");
+    H.newButton().click();
+    H.popover().should("contain", "Dashboard").and("not.contain", "Question");
   });
 
   it("should not show visualization or question settings to users with block data permissions", () => {
@@ -341,14 +335,9 @@ describe("UI elements that make no sense for users without data permissions (met
     cy.findByTestId("qb-header-action-panel").within(() => {
       cy.icon("refresh").should("not.exist");
     });
-    cy.visit("/collection/root");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
 
-    H.popover()
-      .should("contain", "Dashboard")
-      .and("contain", "Collection")
-      .and("not.contain", "Question");
+    H.newButton().click();
+    H.popover().should("contain", "Dashboard").and("not.contain", "Question");
   });
 });
 

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -93,18 +93,11 @@ const NewItemMenu = ({
       });
     }
 
-    items.push(
-      {
-        title: t`Dashboard`,
-        icon: "dashboard",
-        action: () => dispatch(setOpenModal("dashboard")),
-      },
-      {
-        title: t`Collection`,
-        icon: "folder",
-        action: () => dispatch(setOpenModal("collection")),
-      },
-    );
+    items.push({
+      title: t`Dashboard`,
+      icon: "dashboard",
+      action: () => dispatch(setOpenModal("dashboard")),
+    });
 
     if (
       hasNativeWrite &&

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -3,7 +3,6 @@ import fetchMock from "fetch-mock";
 
 import {
   setupCollectionByIdEndpoint,
-  setupCollectionsEndpoints,
   setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
@@ -70,9 +69,6 @@ async function setup({
   const models = hasModels ? [createMockCard({ type: "model" })] : [];
 
   setupDatabasesEndpoints(databases);
-  setupCollectionsEndpoints({
-    collections: [COLLECTION],
-  });
   setupCollectionByIdEndpoint({
     collections: [COLLECTION],
   });
@@ -123,21 +119,10 @@ describe("NewItemMenu", () => {
     expect(await screen.findByText("Question")).toBeInTheDocument();
     expect(await screen.findByText("SQL query")).toBeInTheDocument();
     expect(await screen.findByText("Dashboard")).toBeInTheDocument();
-    expect(await screen.findByText("Collection")).toBeInTheDocument();
     expect(await screen.findByText("Model")).toBeInTheDocument();
     expect(await screen.findByText("Action")).toBeInTheDocument();
     expect(screen.queryByText("Metric")).not.toBeInTheDocument();
-  });
-
-  describe("New Collection", () => {
-    it("should open new collection modal on click", async () => {
-      setup();
-      await userEvent.click(await screen.findByText("Collection"));
-      const modal = await screen.findByRole("dialog", {
-        name: /new collection/i,
-      });
-      expect(modal).toBeVisible();
-    });
+    expect(screen.queryByText("Collection")).not.toBeInTheDocument();
   });
 
   describe("New Dashboard", () => {
@@ -188,9 +173,6 @@ describe("NewItemMenu", () => {
         screen.getByRole("listitem", { name: "Dashboard" }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("listitem", { name: "Collection" }),
-      ).toBeInTheDocument();
-      expect(
         screen.getByRole("listitem", { name: "Model" }),
       ).toBeInTheDocument();
       expect(
@@ -211,9 +193,6 @@ describe("NewItemMenu", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByRole("listitem", { name: "Dashboard" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Collection" }),
       ).toBeInTheDocument();
       expect(
         screen.getByRole("listitem", { name: "Model" }),
@@ -241,9 +220,6 @@ describe("NewItemMenu", () => {
         screen.getByRole("listitem", { name: "Dashboard" }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("listitem", { name: "Collection" }),
-      ).toBeInTheDocument();
-      expect(
         screen.getByRole("listitem", { name: "Model" }),
       ).toBeInTheDocument();
       expect(
@@ -267,9 +243,6 @@ describe("NewItemMenu", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByRole("listitem", { name: "Dashboard" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("listitem", { name: "Collection" }),
       ).toBeInTheDocument();
       expect(
         screen.queryByRole("listitem", { name: "Model" }),


### PR DESCRIPTION
Resolves PRG-29 by removing the "Collection" entry from the main "New" menu.

![image](https://github.com/user-attachments/assets/438080e2-43ae-49ca-9cdf-424def10efbb)

### Testing
- Updated unit tests
- Used this opportunity to create a new helper `startNewCollectionFromSidebar` that replaces all-over-the-place logic to start creating a new collection.
- Got rid of some linter warnings as a bonus
