### PR TITLE
Closes VIZ-693 adding more than two datasets

### DIFF
--- a/e2e/support/test-visualizer-data.ts
+++ b/e2e/support/test-visualizer-data.ts
@@ -102,6 +102,21 @@ export const PRODUCTS_COUNT_BY_CREATED_AT: StructuredQuestionDetailsWithName = {
   },
 };
 
+export const PRODUCTS_AVERAGE_BY_CREATED_AT: StructuredQuestionDetailsWithName =
+  {
+    display: "bar",
+    name: "Products average by Created At (Month)",
+    query: {
+      "source-table": PRODUCTS_ID,
+      aggregation: [["avg", ["field", PRODUCTS.PRICE, null]]],
+      breakout: [["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }]],
+    },
+    visualization_settings: {
+      "graph.dimensions": ["CREATED_AT"],
+      "graph.metrics": ["count"],
+    },
+  };
+
 export const PRODUCTS_COUNT_BY_CATEGORY: StructuredQuestionDetailsWithName = {
   display: "bar",
   name: "Products by Category",

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -39,7 +39,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       wrapId: true,
     });
     H.createQuestion(PRODUCTS_AVERAGE_BY_CREATED_AT, {
-      idAlias: "productsCountByCreatedAtQuestionId",
+      idAlias: "productsAvgByCreatedAtQuestionId",
       wrapId: true,
     });
     H.createQuestion(PRODUCTS_COUNT_BY_CATEGORY, {
@@ -467,17 +467,13 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.openQuestionsSidebar();
     H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
 
+    H.modal().within(() => {
+      H.switchToAddMoreData();
+      H.addDataset(PRODUCTS_AVERAGE_BY_CREATED_AT.name);
+      H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
+    });
+
     H.saveDashcardVisualizerModal("create");
-    H.saveDashboard();
-
-    H.editDashboard();
-    H.showDashcardVisualizerModal(0);
-
-    H.switchToAddMoreData();
-    H.addDataset(PRODUCTS_AVERAGE_BY_CREATED_AT.name);
-    H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
-
-    H.saveDashcardVisualizerModal();
     H.saveDashboard();
 
     // Making sure the card renders

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -4,7 +4,6 @@ import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   ORDERS_COUNT_BY_CREATED_AT,
   ORDERS_COUNT_BY_PRODUCT_CATEGORY,
-  PRODUCTS_AVERAGE_BY_CREATED_AT,
   PRODUCTS_COUNT_BY_CATEGORY,
   PRODUCTS_COUNT_BY_CATEGORY_PIE,
   PRODUCTS_COUNT_BY_CREATED_AT,
@@ -36,10 +35,6 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     });
     H.createQuestion(PRODUCTS_COUNT_BY_CREATED_AT, {
       idAlias: "productsCountByCreatedAtQuestionId",
-      wrapId: true,
-    });
-    H.createQuestion(PRODUCTS_AVERAGE_BY_CREATED_AT, {
-      idAlias: "productsAvgByCreatedAtQuestionId",
       wrapId: true,
     });
     H.createQuestion(PRODUCTS_COUNT_BY_CATEGORY, {
@@ -446,34 +441,6 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.switchToAddMoreData();
     H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
     H.saveDashcardVisualizerModal();
-    H.saveDashboard();
-
-    // Making sure the card renders
-    H.getDashboardCard(0).within(() => {
-      cy.findByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
-        "exist",
-      );
-      cy.findByText("Created At: Month").should("exist");
-    });
-  });
-
-  it("should work with more than two datasets (VIZ-693)", () => {
-    H.createDashboard().then(({ body: { id: dashboardId } }) => {
-      H.visitDashboard(dashboardId);
-    });
-
-    H.editDashboard();
-
-    H.openQuestionsSidebar();
-    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
-
-    H.modal().within(() => {
-      H.switchToAddMoreData();
-      H.addDataset(PRODUCTS_AVERAGE_BY_CREATED_AT.name);
-      H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
-    });
-
-    H.saveDashcardVisualizerModal("create");
     H.saveDashboard();
 
     // Making sure the card renders

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -4,6 +4,7 @@ import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   ORDERS_COUNT_BY_CREATED_AT,
   ORDERS_COUNT_BY_PRODUCT_CATEGORY,
+  PRODUCTS_AVERAGE_BY_CREATED_AT,
   PRODUCTS_COUNT_BY_CATEGORY,
   PRODUCTS_COUNT_BY_CATEGORY_PIE,
   PRODUCTS_COUNT_BY_CREATED_AT,
@@ -34,6 +35,10 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       wrapId: true,
     });
     H.createQuestion(PRODUCTS_COUNT_BY_CREATED_AT, {
+      idAlias: "productsCountByCreatedAtQuestionId",
+      wrapId: true,
+    });
+    H.createQuestion(PRODUCTS_AVERAGE_BY_CREATED_AT, {
       idAlias: "productsCountByCreatedAtQuestionId",
       wrapId: true,
     });
@@ -440,6 +445,38 @@ describe("scenarios > dashboard > visualizer > basics", () => {
 
     H.switchToAddMoreData();
     H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
+    H.saveDashcardVisualizerModal();
+    H.saveDashboard();
+
+    // Making sure the card renders
+    H.getDashboardCard(0).within(() => {
+      cy.findByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
+        "exist",
+      );
+      cy.findByText("Created At: Month").should("exist");
+    });
+  });
+
+  it("should work with more than two datasets (VIZ-693)", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+    });
+
+    H.editDashboard();
+
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
+
+    H.saveDashcardVisualizerModal("create");
+    H.saveDashboard();
+
+    H.editDashboard();
+    H.showDashcardVisualizerModal(0);
+
+    H.switchToAddMoreData();
+    H.addDataset(PRODUCTS_AVERAGE_BY_CREATED_AT.name);
+    H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
+
     H.saveDashcardVisualizerModal();
     H.saveDashboard();
 

--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -5,6 +5,7 @@ import {
   ORDERS_COUNT_BY_CREATED_AT,
   ORDERS_COUNT_BY_PRODUCT_CATEGORY,
   PIVOT_TABLE_CARD,
+  PRODUCTS_AVERAGE_BY_CREATED_AT,
   PRODUCTS_COUNT_BY_CATEGORY,
   PRODUCTS_COUNT_BY_CATEGORY_PIE,
   PRODUCTS_COUNT_BY_CREATED_AT,
@@ -36,6 +37,10 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
     });
     H.createQuestion(PRODUCTS_COUNT_BY_CREATED_AT, {
       idAlias: "productsCountByCreatedAtQuestionId",
+      wrapId: true,
+    });
+    H.createQuestion(PRODUCTS_AVERAGE_BY_CREATED_AT, {
+      idAlias: "productsAvgByCreatedAtQuestionId",
       wrapId: true,
     });
     H.createQuestion(PRODUCTS_COUNT_BY_CATEGORY, {
@@ -159,6 +164,34 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
       });
 
       H.chartLegendItems().should("have.length", 2);
+    });
+  });
+
+  it("should work with more than two datasets (VIZ-693)", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+    });
+
+    H.editDashboard();
+
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
+
+    H.modal().within(() => {
+      H.switchToAddMoreData();
+      H.addDataset(PRODUCTS_AVERAGE_BY_CREATED_AT.name);
+      H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
+    });
+
+    H.saveDashcardVisualizerModal("create");
+    H.saveDashboard();
+
+    // Making sure the card renders
+    H.getDashboardCard(0).within(() => {
+      cy.findByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
+        "exist",
+      );
+      cy.findByText("Created At: Month").should("exist");
     });
   });
 

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -194,12 +194,19 @@ export const getVisualizerTransformedSeries = createSelector(
     const { series } = getVisualizationTransformed(
       extractRemappings(rawSeries),
     );
+
     return series;
   },
 );
 
 export const getVisualizerComputedSettings = createSelector(
   [getVisualizerTransformedSeries],
+  (series): ComputedVisualizationSettings =>
+    series.length > 0 ? getComputedSettingsForSeries(series) : {},
+);
+
+export const getVisualizerComputedSettingsForFlatSeries = createSelector(
+  [getVisualizerFlatRawSeries],
   (series): ComputedVisualizationSettings =>
     series.length > 0 ? getComputedSettingsForSeries(series) : {},
 );

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -30,7 +30,7 @@ import type {
 
 import {
   getCurrentVisualizerState,
-  getVisualizerComputedSettings,
+  getVisualizerComputedSettingsForFlatSeries,
 } from "./selectors";
 import {
   copyColumn,
@@ -191,7 +191,8 @@ export const addDataSource = createAsyncThunk(
       throw new Error(`Could not get data source or dataset for: ${sourceId}`);
     }
 
-    const computedSettings = getVisualizerComputedSettings(getState());
+    const computedSettings =
+      getVisualizerComputedSettingsForFlatSeries(getState());
 
     return maybeCombineDataset(
       {


### PR DESCRIPTION
Closes [VIZ-693: Combining more than 2 charts causes a mapping issue](https://linear.app/metabase/issue/VIZ-693/combining-more-than-2-charts-causes-a-mapping-issue)

### Description

This fixes an issue introduced in #56670 where we use transformed series instead of flat series to compute the settings when adding a data source.