### PR TITLE
feat: handle data urls when getting a setting key

### DIFF
--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -12,6 +12,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.server.auth-wrapper :as auth-wrapper]
    [metabase.server.routes.index :as index]
+   [metabase.settings.core :as setting]
    [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -72,6 +73,7 @@
   ;; ^/app/ -> static files under frontend_client/app
   (context "/app" []
     (route/resources "/" {:root "frontend_client/app"})
+    (GET "/img/:key" [key] (setting/image-response key))
     ;; return 404 for anything else starting with ^/app/ that doesn't exist
     (route/not-found {:status 404, :body "Not found."}))
   ;; ^/public/ -> Public frontend and download routes

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -87,6 +87,7 @@
 
 (p/import-vars
  [metabase.settings.models.setting
+  as-binary
   admin-writable-site-wide-settings
   can-read-setting?
   current-user-readable-visibilities
@@ -119,7 +120,8 @@
   define-multi-setting
   define-multi-setting-impl]
  [metabase.settings.settings
-  application-name-for-setting-descriptions])
+  application-name-for-setting-descriptions
+  image-response])
 
 (defn database-local-values
   "Database-local Settings values (as a map of Setting name -> already-deserialized value). This comes from the value of

--- a/test/metabase/server/routes_test.clj
+++ b/test/metabase/server/routes_test.clj
@@ -2,7 +2,11 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.http-client :as client]))
+   [metabase.http-client :as client]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
 
 (deftest test-public-routes
   (binding [client/*url-prefix* ""]
@@ -25,3 +29,21 @@
                             :headers
                             (get "Location"))
                         "/api/embed/card/token-string/query/csv?"))))
+
+(deftest test-app-img-route
+  (testing "GET /app/img/:key"
+    (binding [client/*url-prefix* ""]
+      (testing "should return 404 if the setting key does not correspond to a valid image setting"
+        (let [response (client/client-full-response :get 404 "app/img/this-is-not-a-valid-image-setting-key" {})]
+          (is (str/includes? (:body response) "Not found."))))
+      (testing "should return 200 with image data if the setting is a valid image"
+        (let [base64-data  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" ; 1x1 black PNG
+              content-type "image/png"
+              image-setting-value (str "data:" content-type ";base64," base64-data)
+              expected-bytes (u/decode-base64 base64-data)]
+          (mt/with-temporary-setting-values [no-data-illustration-custom image-setting-value]
+            (let [response (client/client-full-response :get 200 "app/img/no-data-illustration-custom" {})]
+              (is (= content-type
+                     (get-in response [:headers "content-type"])))
+              (is (= expected-bytes (:body response))
+                  "Response body should match the expected image bytes"))))))))

--- a/test/metabase/settings/api_test.clj
+++ b/test/metabase/settings/api_test.clj
@@ -37,6 +37,12 @@
   :visibility :settings-manager
   :encryption :when-encryption-key-set)
 
+(defsetting test-api-setting-data-url
+  (deferred-tru "Test setting for data URL handling in API")
+  :visibility :public
+  :type :string
+  :encryption :no)
+
 ;; ## Helper Fns
 (defn- fetch-test-settings
   "Fetch the provided settings using the API. Settings not present in the response are ignored."


### PR DESCRIPTION
### Description

Converts data urls with base64 encoded data (such as images in whitelabelled metabase) to bytes and sets the content type to the type given in the data URL.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
