### PR TITLE
update chart settings types

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/types.ts
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/types.ts
@@ -1,23 +1,12 @@
-import type {
-  Dashboard,
-  DashboardCard,
-  VisualizationSettings,
-} from "metabase-types/api";
+import type { Dashboard, DashboardCard } from "metabase-types/api";
 
-import type {
-  BaseChartSettingsTestProps,
-  CommonChartSettingsProps,
-} from "../types";
+import type { CommonChartSettingsProps, Widget } from "../types";
 
 export type DashboardChartSettingsProps = {
   className?: string;
   dashboard?: Dashboard;
   dashcard?: DashboardCard;
   isDashboard?: boolean;
+  widgets?: Widget[];
   onClose?: () => void;
-} & CommonChartSettingsProps &
-  DashboardChartSettingsTestProps;
-
-export type DashboardChartSettingsTestProps = BaseChartSettingsTestProps & {
-  settings?: VisualizationSettings;
-};
+} & CommonChartSettingsProps;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/QuestionChartSettings/types.ts
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/QuestionChartSettings/types.ts
@@ -1,9 +1,7 @@
 import type { BaseChartSettingsProps } from "../BaseChartSettings/types";
-import type {
-  BaseChartSettingsTestProps,
-  CommonChartSettingsProps,
-} from "../types";
+import type { CommonChartSettingsProps, Widget } from "../types";
 
-export type QuestionChartSettingsProps = CommonChartSettingsProps &
-  Pick<BaseChartSettingsProps, "initial" | "computedSettings" | "question"> &
-  BaseChartSettingsTestProps;
+export type QuestionChartSettingsProps = {
+  widgets?: Widget[];
+} & CommonChartSettingsProps &
+  Pick<BaseChartSettingsProps, "initial" | "computedSettings" | "question">;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/types.ts
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/types.ts
@@ -8,15 +8,11 @@ export type Widget = {
   hidden?: boolean;
   props: Record<string, unknown>;
   title?: string;
-  widget: (() => JSX.Element | null) | undefined;
+  widget?: string | React.ComponentType<any>;
 };
 
 export type CommonChartSettingsProps = {
   series: Series;
+  settings?: VisualizationSettings;
   onChange?: (settings: VisualizationSettings, question?: Question) => void;
-};
-
-// Only used for the tests in ChartSettings.unit.spec.tsx
-export type BaseChartSettingsTestProps = {
-  widgets?: Widget[];
 };


### PR DESCRIPTION
### Description

`BaseChartSettingsTestProps` and its comment "Only used for the tests in ChartSettings.unit.spec.tsx" have become outdated so this PR removes it and updates settings types accordingly.

### How to verify

CI should be green

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
