### PR TITLE
Fix funnel mapping issues

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
@@ -292,4 +292,37 @@ describe("scenarios > dashboard > visualizer > funnels", () => {
       H.horizontalWell().findAllByTestId("well-item").should("have.length", 0);
     });
   });
+
+  it("should initialize a scalar funnel when opening a scalar card (VIZ-678)", () => {
+    const { LANDING_PAGE_VIEWS, CHECKOUT_PAGE_VIEWS, PAYMENT_DONE_PAGE_VIEWS } =
+      SCALAR_CARD;
+
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(LANDING_PAGE_VIEWS.name);
+
+    H.modal().within(() => {
+      cy.findByText(LANDING_PAGE_VIEWS.name).realHover();
+      cy.findAllByLabelText("Remove").eq(0).click();
+      cy.findByText("Funnel").click();
+      H.switchToAddMoreData();
+      H.selectDataset(LANDING_PAGE_VIEWS.name);
+      H.addDataset(CHECKOUT_PAGE_VIEWS.name);
+      H.addDataset(PAYMENT_DONE_PAGE_VIEWS.name);
+
+      H.verticalWell().within(() => {
+        cy.findByText("METRIC").should("exist");
+        cy.findAllByTestId("well-item").should("have.length", 1);
+      });
+      H.horizontalWell().within(() => {
+        cy.findByText("DIMENSION").should("exist");
+        cy.findByText(LANDING_PAGE_VIEWS.name).should("exist");
+        cy.findByText(CHECKOUT_PAGE_VIEWS.name).should("exist");
+        cy.findByText(PAYMENT_DONE_PAGE_VIEWS.name).should("exist");
+        cy.findAllByTestId("well-item").should("have.length", 4);
+      });
+    });
+  });
 });

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -9,6 +9,7 @@ import {
   createMockDashboardCard,
   createMockDataset,
   createMockDatasetData,
+  createMockNumericColumn,
 } from "metabase-types/api/mocks";
 
 import { getInitialStateForCardDataSource } from "./get-initial-state-for-card-data-source";
@@ -38,7 +39,7 @@ describe("getInitialStateForCardDataSource", () => {
   const dataset = createMockDataset({
     data: createMockDatasetData({
       cols: [
-        createMockColumn({ name: "Foo" }),
+        createMockNumericColumn({ name: "Foo" }),
         createMockColumn({ name: "Bar" }),
       ],
     }),
@@ -101,12 +102,46 @@ describe("getInitialStateForCardDataSource", () => {
     });
   });
 
-  it("should pick funnel as the display if the original card is a scalar", () => {
+  it("should return scalar funnel initial state if the original card is a scalar", () => {
     const initialState = getInitialStateForCardDataSource(
       createMockCard({ display: "scalar" }),
       dataset,
     );
 
-    expect(initialState.display).toEqual("funnel");
+    expect(initialState).toEqual({
+      display: "funnel",
+      columns: [
+        {
+          name: "METRIC",
+          display_name: "METRIC",
+          base_type: "type/Integer",
+          effective_type: "type/Integer",
+          field_ref: ["field", "METRIC", { "base-type": "type/Integer" }],
+          source: "artificial",
+        },
+        {
+          name: "DIMENSION",
+          display_name: "DIMENSION",
+          base_type: "type/Text",
+          effective_type: "type/Text",
+          field_ref: ["field", "DIMENSION", { "base-type": "type/Text" }],
+          source: "artificial",
+        },
+      ],
+      columnValuesMapping: {
+        METRIC: [
+          {
+            name: "COLUMN_1",
+            originalName: "Foo",
+            sourceId: "card:1",
+          },
+        ],
+        DIMENSION: ["$_card:1_name"],
+      },
+      settings: {
+        "funnel.metric": "METRIC",
+        "funnel.dimension": "DIMENSION",
+      },
+    });
   });
 });

--- a/frontend/src/metabase/visualizer/visualizations/funnel.ts
+++ b/frontend/src/metabase/visualizer/visualizations/funnel.ts
@@ -46,7 +46,11 @@ export const funnelDropHandler = (
     extractReferencedColumns(state.columnValuesMapping),
   );
 
-  if (over.id === DROPPABLE_ID.X_AXIS_WELL) {
+  if (
+    over.id === DROPPABLE_ID.X_AXIS_WELL &&
+    isDimension(column) &&
+    !isMetric(column)
+  ) {
     let dimensionColumnName = state.settings["funnel.dimension"];
     if (!dimensionColumnName) {
       dimensionColumnName = columnRef.name;
@@ -74,7 +78,7 @@ export const funnelDropHandler = (
     }
   }
 
-  if (over.id === DROPPABLE_ID.Y_AXIS_WELL && isNumeric(column)) {
+  if (over.id === DROPPABLE_ID.Y_AXIS_WELL && isMetric(column)) {
     let metricColumnName = state.settings["funnel.metric"];
     if (!metricColumnName) {
       metricColumnName = columnRef.name;


### PR DESCRIPTION
Fixes two bugs around funnels in visualizer:

1. Visualizer didn't initialize properly when starting a new chart from a scalar card. It'd correctly set the display to "funnel", but it won't pre-create artificial metric and dimension columns, so nothing happened after adding more scalar datasets. Fixed by updating `getInitialStateForCardDataSource`
2. X-axis well for funnels could accept a metric column, which could break a chart, fixed by adding more strict checks to the DND drop handler + updating the well so it doesn't highlight in this case