### PR TITLE
Fix columns removed when changing cartesian viz types

### DIFF
--- a/e2e/support/test-visualizer-data.ts
+++ b/e2e/support/test-visualizer-data.ts
@@ -88,6 +88,24 @@ export const ORDERS_COUNT_BY_PRODUCT_CATEGORY: StructuredQuestionDetailsWithName
     },
   };
 
+export const ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY: StructuredQuestionDetailsWithName =
+  {
+    display: "line",
+    name: "Orders by Created At (Month) & Category",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+        ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+      ],
+    },
+    visualization_settings: {
+      "graph.dimensions": ["CREATED_AT", "CATEGORY"],
+      "graph.metrics": ["count"],
+    },
+  };
+
 export const PRODUCTS_COUNT_BY_CREATED_AT: StructuredQuestionDetailsWithName = {
   display: "bar",
   name: "Products by Created At (Month)",

--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -3,6 +3,7 @@ const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   ORDERS_COUNT_BY_CREATED_AT,
+  ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY,
   ORDERS_COUNT_BY_PRODUCT_CATEGORY,
   PIVOT_TABLE_CARD,
   PRODUCTS_AVERAGE_BY_CREATED_AT,
@@ -33,6 +34,10 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
     });
     H.createQuestion(ORDERS_COUNT_BY_PRODUCT_CATEGORY, {
       idAlias: "ordersCountByProductCategoryQuestionId",
+      wrapId: true,
+    });
+    H.createQuestion(ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY, {
+      idAlias: "ordersCountByCreatedAtAndProductCategoryQuestionId",
       wrapId: true,
     });
     H.createQuestion(PRODUCTS_COUNT_BY_CREATED_AT, {
@@ -192,6 +197,46 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
         "exist",
       );
       cy.findByText("Created At: Month").should("exist");
+    });
+  });
+
+  it("should not drop dimensions when changing viz type to another cartesian chart (VIZ-648)", () => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.openQuestionsSidebar();
+
+    H.clickVisualizeAnotherWay(
+      ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY.name,
+    );
+
+    H.modal().within(() => {
+      H.switchToAddMoreData();
+      H.addDataset(PRODUCTS_COUNT_BY_CREATED_AT.name);
+      H.switchToColumnsList();
+
+      H.selectVisualization("area");
+
+      H.assertDataSourceColumnSelected(
+        ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY.name,
+        "Count",
+      );
+      H.assertDataSourceColumnSelected(
+        ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY.name,
+        "Created At: Month",
+      );
+      H.assertDataSourceColumnSelected(
+        ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY.name,
+        "Product → Category",
+      );
+
+      H.assertDataSourceColumnSelected(
+        PRODUCTS_COUNT_BY_CREATED_AT.name,
+        "Count",
+      );
+      H.assertDataSourceColumnSelected(
+        PRODUCTS_COUNT_BY_CREATED_AT.name,
+        "Created At: Month",
+      );
     });
   });
 

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -3,7 +3,6 @@ import _ from "underscore";
 import { isNotNull } from "metabase/lib/types";
 import {
   getMaxDimensionsSupported,
-  getMaxMetricsSupported,
   isCartesianChart,
 } from "metabase/visualizations";
 import type {
@@ -39,12 +38,7 @@ export function getUpdatedSettingsForDisplay(
 
   if (sourceIsCartesian) {
     if (targetIsCartesian) {
-      return cartesianToCartesian(
-        columnValuesMapping,
-        columns,
-        settings,
-        targetDisplay,
-      );
+      return;
     }
     if (targetDisplay === "pie") {
       return cartesianToPie(columnValuesMapping, columns, settings);
@@ -84,40 +78,6 @@ export function getUpdatedSettingsForDisplay(
     settings: _.pick(settings, "card.title"),
   };
 }
-
-const cartesianToCartesian = (
-  columnValuesMapping: ColumnValuesMapping,
-  columns: DatasetColumn[],
-  settings: VisualizationSettings,
-  targetDisplay: VisualizationDisplay,
-) => {
-  const maxMetrics = getMaxMetricsSupported(targetDisplay);
-  const maxDimensions = getMaxDimensionsSupported(targetDisplay);
-
-  const {
-    "graph.metrics": metrics = [],
-    "graph.dimensions": dimensions = [],
-    ...otherSettings
-  } = settings;
-
-  const nextMetrics = metrics.slice(0, maxMetrics);
-  const removedMetrics = metrics.slice(maxMetrics);
-
-  const nextDimensions = dimensions.slice(0, maxDimensions);
-  const removedDimensions = dimensions.slice(maxDimensions);
-
-  const removedColumns = [...removedMetrics, ...removedDimensions];
-
-  return {
-    columns: columns.filter((column) => !removedColumns.includes(column.name)),
-    columnValuesMapping: _.omit(columnValuesMapping, removedColumns),
-    settings: {
-      ...otherSettings,
-      "graph.metrics": nextMetrics,
-      "graph.dimensions": nextDimensions,
-    },
-  };
-};
 
 const cartesianToPie = (
   columnValuesMapping: ColumnValuesMapping,

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -75,11 +75,7 @@ describe("updateSettingsForDisplay", () => {
       "bar",
       "line",
     );
-    expect(result).toStrictEqual({
-      columnValuesMapping,
-      columns,
-      settings: { "graph.dimensions": [], "graph.metrics": [] },
-    });
+    expect(result).toBeUndefined();
   });
 
   describe("cartesian → cartesian", () => {
@@ -94,14 +90,7 @@ describe("updateSettingsForDisplay", () => {
         "line",
         "bar",
       );
-      expect(result).toEqual({
-        columnValuesMapping,
-        columns,
-        settings: {
-          "graph.metrics": ["COLUMN_1", "COLUMN_3"],
-          "graph.dimensions": ["COLUMN_2"],
-        },
-      });
+      expect(result).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Based on #57650

Fixes an issue when the visualizer would unmap some columns when changing between cartesian charts. The issue was around the `cartesianToCartesian` handler in `getUpdatedSettingsForDisplay` that was added when we still wanted to support waterfall charts, but it doesn't seem helpful now after we decided to exclude them from v1