### PR TITLE
fix: failing kondos on master

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -91,7 +91,6 @@
      metabase.test.data.users/with-group-for-user
      metabase.test.data/with-empty-h2-app-db
      metabase.test.util.log/with-log-level
-     metabase.test.util.misc/with-single-admin-user
      metabase.test.util/with-all-users-permission
      metabase.test.util/with-discarded-collections-perms-changes
      metabase.test.util/with-env-keys-renamed-by
@@ -123,7 +122,6 @@
      metabase.test/with-model-cleanup
      metabase.test/with-non-admin-groups-no-root-collection-for-namespace-perms
      metabase.test/with-non-admin-groups-no-root-collection-perms
-     metabase.test/with-single-admin-user
      metabase.test/with-temp-env-var-value
      metabase.test/with-temp-vals-in-db
      metabase.test/with-temporary-raw-setting-values
@@ -579,7 +577,7 @@
   metabase.test/with-actions                                                            clojure.core/let
   metabase.test/with-grouper-batches!                                                   clojure.core/fn
   metabase.test/with-open-channels                                                      clojure.core/let
-  metabase.test/with-single-admin-user                                                  clojure.core/fn
+  metabase.test/with-single-admin-user!                                                 clojure.core/fn
   metabase.test/with-temp-dir                                                           clojure.core/let
   metabase.test/with-temp-empty-app-db                                                  clojure.core/let
   metabase.test/with-temp-file                                                          clojure.core/let
@@ -773,7 +771,7 @@
    metabase.lib.filter/deffilter                                                           macros.metabase.lib.filter/deffilter
    metabase.models.params.chain-filter-test/chain-filter                                   macros.metabase.models.params.chain-filter-test/chain-filter
    metabase.models.params.chain-filter-test/chain-filter-search                            macros.metabase.models.params.chain-filter-test/chain-filter
-   metabase.models.user-test/with-groups                                                   macros.metabase.models.user-test/with-groups
+   metabase.models.user-test/with-groups!                                                  macros.metabase.models.user-test/with-groups!
    metabase.public-sharing.api-test/with-sharing-enabled-and-temp-card-referencing!        macros.metabase.public-sharing.api-test/with-sharing-enabled-and-temp-card-referencing!
    metabase.public-sharing.api-test/with-sharing-enabled-and-temp-dashcard-referencing!    macros.metabase.public-sharing.api-test/with-sharing-enabled-and-temp-dashcard-referencing!
    metabase.query-analysis.models.query-analysis-test/with-test-setup                      macros.metabase.query-analysis.models.query-analysis-test/with-test-setup

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -473,7 +473,6 @@
            metabase.permissions.models.data-permissions
            metabase.permissions.models.permissions
            metabase.permissions.models.permissions-group
-           metabase.permissions.models.permissions-group-membership
            metabase.permissions.util}
    :uses #{api audit config db models plugins premium-features request server settings util}}
 

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -473,6 +473,7 @@
            metabase.permissions.models.data-permissions
            metabase.permissions.models.permissions
            metabase.permissions.models.permissions-group
+           metabase.permissions.models.permissions-group-membership
            metabase.permissions.util}
    :uses #{api audit config db models plugins premium-features request server settings util}}
 

--- a/.clj-kondo/macros/metabase/models/user_test.clj
+++ b/.clj-kondo/macros/metabase/models/user_test.clj
@@ -1,9 +1,9 @@
 (ns macros.metabase.models.user-test)
 
-(defmacro with-groups [bindings & body]
+(defmacro with-groups! [bindings & body]
   `(let ~(into []
-              (comp (partition-all 3)
-                    (mapcat (fn [[group-binding properties members]]
-                              [group-binding [properties members]])))
-              bindings)
+               (comp (partition-all 3)
+                     (mapcat (fn [[group-binding properties members]]
+                               [group-binding [properties members]])))
+               bindings)
      ~@body))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/group_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/group_manager.clj
@@ -3,7 +3,7 @@
    [clojure.data :as data]
    [clojure.set :as set]
    [metabase.api.common :as api]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
+   [metabase.permissions.core :as perms]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [toucan2.core :as t2]))
@@ -56,6 +56,6 @@
           (throw (ex-info (tru "Not allowed to edit group memberships")
                           {:status-code 403}))))
       (t2/with-transaction [_conn]
-        (perms-group-membership/remove-user-from-groups! user-id to-remove-group-ids)
+        (perms/remove-user-from-groups! user-id to-remove-group-ids)
         (doseq [group-id to-add-group-ids]
-          (perms-group-membership/add-user-to-group! user-id group-id (:is_group_manager (new-group-id->membership-info group-id))))))))
+          (perms/add-user-to-group! user-id group-id (:is_group_manager (new-group-id->membership-info group-id))))))))

--- a/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
@@ -9,8 +9,8 @@
    [metabase.api.macros :as api.macros]
    [metabase.models.interface :as mi]
    [metabase.models.user :as user]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
@@ -414,7 +414,7 @@
                             (fn [user-id] {:group group-id :user user-id})
                             user-ids)]
       (t2/delete! :model/PermissionsGroupMembership :group_id group-id)
-      (perms-group-membership/add-users-to-groups! memberships))))
+      (perms/add-users-to-groups! memberships))))
 
 (api.macros/defendpoint :post "/Groups"
   "Create a single group, and populates it if necessary."

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -5,8 +5,8 @@
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-permissions.models.permissions.group-manager :as gm]
    [metabase.models.user :as user]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -333,7 +333,7 @@
                   (remove-user-from-group! [req-user status group-to-remove]
                     (u/ignore-exceptions
                      ;; ensure `user-to-update` is in `group-to-remove`
-                      (perms-group-membership/add-user-to-group! user-to-update group-to-remove))
+                      (perms/add-user-to-group! user-to-update group-to-remove))
                     (let [current-user-group-membership (gm/user-group-memberships user-to-update)
                           new-user-group-membership     (into [] (filter #(not= (:id group-to-remove)
                                                                                 (:id %))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -12,7 +12,6 @@
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.test :as mt]
    [metabase.test.data.sql :as sql.tx]
    [metabase.test.fixtures :as fixtures]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -2,11 +2,10 @@
   (:require
    [clojure.test :refer :all]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.data-permissions.graph :as data-perms.graph]
-   [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.test :as mt]
@@ -160,7 +159,7 @@
                      :model/Card                       {card-id :id} {:collection_id collection-id
                                                                       :dataset_query query}
                      :model/Permissions                _ {:group_id group-id :object (perms/collection-read-path collection-id)}]
-        (perms-group-membership/add-user-to-group! user-id group-id)
+        (perms/add-user-to-group! user-id group-id)
         (mt/with-premium-features #{:advanced-permissions}
           (mt/with-no-data-perms-for-all-users!
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
@@ -218,7 +217,7 @@
                             :limit        1}}]
       (mt/with-temp [:model/User                       {user-id :id} {}
                      :model/PermissionsGroup           {group-id :id} {}]
-        (perms-group-membership/add-user-to-group! user-id group-id)
+        (perms/add-user-to-group! user-id group-id)
         (mt/with-premium-features #{:advanced-permissions}
           (mt/with-no-data-perms-for-all-users!
             (testing "legacy-no-self-service does not override block perms for a table"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -3,9 +3,8 @@
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]
    [metabase.api.card-test :as api.card-test]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
-   [metabase.permissions.models.permissions :as perms]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]))
@@ -21,7 +20,7 @@
                        :model/PermissionsGroup           group {}
                        :model/GroupTableAccessPolicy     _ {:group_id (u/the-id group)
                                                             :table_id (u/the-id table)}]
-          (perms-group-membership/add-user-to-group! (mt/user->id :rasta) group)
+          (perms/add-user-to-group! (mt/user->id :rasta) group)
           (mt/with-db db
             (mt/with-no-data-perms-for-all-users!
               (data-perms/set-database-permission! group db :perms/view-data :unrestricted)
@@ -42,7 +41,7 @@
                                                                :collection_id (u/the-id collection)}
                        :model/GroupTableAccessPolicy     _    {:group_id (u/the-id group)
                                                                :table_id (u/the-id table)}]
-          (perms-group-membership/add-user-to-group! (mt/user->id :rasta) group)
+          (perms/add-user-to-group! (mt/user->id :rasta) group)
           (mt/with-db db
             (mt/with-no-data-perms-for-all-users!
               (data-perms/set-database-permission! group db :perms/view-data :unrestricted)
@@ -65,7 +64,7 @@
                                                                :collection_id (u/the-id collection)}
                        :model/GroupTableAccessPolicy     _    {:group_id (u/the-id group)
                                                                :table_id (u/the-id table)}]
-          (perms-group-membership/add-user-to-group! (mt/user->id :rasta) group)
+          (perms/add-user-to-group! (mt/user->id :rasta) group)
           (mt/with-db db
             (mt/with-no-data-perms-for-all-users!
               (data-perms/set-database-permission! group db :perms/view-data :unrestricted)
@@ -86,7 +85,7 @@
                          :model/PermissionsGroup           group {}
                          :model/GroupTableAccessPolicy     _    {:group_id (u/the-id group)
                                                                  :table_id (u/the-id table)}]
-            (perms-group-membership/add-user-to-group! (mt/user->id :rasta) group)
+            (perms/add-user-to-group! (mt/user->id :rasta) group)
             (mt/with-db db
               (mt/with-no-data-perms-for-all-users!
                 (data-perms/set-database-permission! group db :perms/view-data :unrestricted)
@@ -107,7 +106,7 @@
                                                                                                       :query {:source-table (mt/id :venues)
                                                                                                               :limit 1}}}]
 
-      (perms-group-membership/add-user-to-group! user-id group)
+      (perms/add-user-to-group! user-id group)
       (let [cases [[:unrestricted           :query-builder-and-native true]
                    [:unrestricted           :query-builder            true]
                    [:unrestricted           :no                       true]

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -11,7 +11,6 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.premium-features.core :as premium-features]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.settings.deprecated-grab-bag :as public-settings]
@@ -121,8 +120,8 @@
     (let [groups (filter some? [(when-not (:tenant_id user) (perms/all-users-group))
                                 (when superuser? (perms/admin-group))])]
       (perms/allow-changing-all-users-group-members
-        (perms-group-membership/without-is-superuser-sync-on-add-to-admin-group
-         (perms-group-membership/add-user-to-groups! user-id (map u/the-id groups)))))))
+        (perms/without-is-superuser-sync-on-add-to-admin-group
+         (perms/add-user-to-groups! user-id (map u/the-id groups)))))))
 
 (t2/define-before-update :model/User
   [{:keys [id] :as user}]
@@ -142,14 +141,14 @@
       (cond
         (and superuser?
              (not in-admin-group?))
-        (perms-group-membership/without-is-superuser-sync-on-add-to-admin-group
-         (perms-group-membership/add-user-to-group! id (u/the-id (perms/admin-group))))
+        (perms/without-is-superuser-sync-on-add-to-admin-group
+         (perms/add-user-to-group! id (u/the-id (perms/admin-group))))
         ;; don't use [[t2/delete!]] here because that does the opposite and tries to update this user which leads to a
         ;; stack overflow of calls between the two. TODO - could we fix this issue by using a `post-delete` method?
         (and (not superuser?)
              in-admin-group?)
-        (perms-group-membership/without-is-superuser-sync-on-add-to-admin-group
-         (perms-group-membership/remove-user-from-group! id (u/the-id (perms/admin-group))))))
+        (perms/without-is-superuser-sync-on-add-to-admin-group
+         (perms/remove-user-from-group! id (u/the-id (perms/admin-group))))))
     ;; make sure email and locale are valid if set
     (when email
       (assert (u/email? email)))
@@ -413,8 +412,8 @@
         [to-remove to-add] (data/diff old-group-ids new-group-ids)]
     (when (seq (concat to-remove to-add))
       (t2/with-transaction [_conn]
-        (perms-group-membership/remove-user-from-groups! user-id to-remove)
-        (perms-group-membership/add-user-to-groups! user-id to-add)))
+        (perms/remove-user-from-groups! user-id to-remove)
+        (perms/add-user-to-groups! user-id to-add)))
     true))
 
 ;;; ## ---------------------------------------- USER SETTINGS ----------------------------------------

--- a/src/metabase/permissions/api.clj
+++ b/src/metabase/permissions/api.clj
@@ -13,9 +13,9 @@
    [metabase.db.query :as mdb.query]
    [metabase.models.interface :as mi]
    [metabase.permissions.api.permission-graph :as api.permission-graph]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.permissions.models.permissions-revision :as perms-revision]
    [metabase.permissions.util :as perms.u]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
@@ -321,7 +321,7 @@
       (api/check
        (t2/exists? :model/User :id user_id :is_superuser false)
        [400 (tru "Admin cant be a group manager.")]))
-    (perms-group-membership/add-user-to-group! user_id group_id is_group_manager)
+    (perms/add-user-to-group! user_id group_id is_group_manager)
     ;; TODO - it's a bit silly to return the entire list of members for the group, just return the newly created one and
     ;; let the frontend add it as appropriate
     (:members (t2/hydrate (t2/instance :model/PermissionsGroup {:id group_id})

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -50,6 +50,11 @@
  [metabase.permissions.models.permissions-group
   non-magic-groups]
  [metabase.permissions.models.permissions-group-membership
+  add-users-to-groups!
+  add-user-to-groups!
+  add-user-to-group!
+  remove-user-from-group!
+  remove-user-from-groups!
   allow-changing-all-users-group-members
   fail-to-remove-last-admin-msg
   throw-if-last-admin!]

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -53,11 +53,12 @@
   add-users-to-groups!
   add-user-to-groups!
   add-user-to-group!
-  remove-user-from-group!
-  remove-user-from-groups!
   allow-changing-all-users-group-members
   fail-to-remove-last-admin-msg
-  throw-if-last-admin!]
+  remove-user-from-group!
+  remove-user-from-groups!
+  throw-if-last-admin!
+  without-is-superuser-sync-on-add-to-admin-group]
  [metabase.permissions.util
   PathSchema
   check-revision-numbers

--- a/src/metabase/permissions/models/permissions_group_membership.clj
+++ b/src/metabase/permissions/models/permissions_group_membership.clj
@@ -1,7 +1,6 @@
 (ns metabase.permissions.models.permissions-group-membership
   (:require
    [medley.core :as m]
-   [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.util :as u]
@@ -112,6 +111,7 @@
                                                      [:not= :u.tenant_id nil]]]))]}]}))
 
 (mu/defn add-users-to-groups!
+  "Creates permission group memberships from aa sequence of maps of users, groups and is-group-manager?."
   [pgms :- [:sequential
             [:map
              [:group [:or
@@ -124,7 +124,7 @@
               :boolean]]]]
   (when (seq pgms)
     (let [pgms (->> pgms
-                    (map (fn [{:keys [user group is-group-manager?] :as pgm}]
+                    (map (fn [{:keys [user group is-group-manager?]}]
                            {:user-id (u/the-id user)
                             :group-id (u/the-id group)
                             :is-group-manager? is-group-manager?})))

--- a/src/metabase/permissions/models/permissions_group_membership.clj
+++ b/src/metabase/permissions/models/permissions_group_membership.clj
@@ -86,7 +86,7 @@
     (dissoc membership
             :__test-only-sigil-allowing-direct-insertion-of-permissions-group-memberships)))
 
-(mu/defn add-users-to-groups-sql
+(mu/defn- add-users-to-groups-sql
   "Generates SQL for adding users to groups"
   [user-id-group-id->is-group-manager? :- [:map-of
                                            [:tuple pos-int? pos-int?]

--- a/src/metabase/sso/common.clj
+++ b/src/metabase/sso/common.clj
@@ -4,7 +4,6 @@
    [clojure.data :as data]
    [clojure.set :as set]
    [metabase.permissions.core :as perms]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
@@ -47,6 +46,6 @@
       ;; if adding membership fails for one reason or another (i.e. if the group doesn't exist) log the error add the
       ;; user to the other groups rather than failing entirely
       (try
-        (perms-group-membership/add-user-to-group! user-id id)
+        (perms/add-user-to-group! user-id id)
         (catch Throwable e
           (log/errorf e "Error adding User %s to Group %s" user-id id))))))

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.actions.api-test
   (:require
-   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.actions.api :as api.action]
    [metabase.analytics.snowplow-test :as snowplow-test]
@@ -106,7 +105,7 @@
                                     :model_id   card-id
                                     :kind       "row/create"
                                     :parameters [{:id "x" :type "number"}]}
-                          archived {:name                   "Archived example"
+                          _        {:name                   "Archived example"
                                     :type                   :query
                                     :model_id               card-id
                                     :dataset_query          (update (mt/native-query {:query "update venues set name = 'foo' where id = {{x}}"})

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -16,7 +16,6 @@
    [metabase.notification.test-util :as notification.tu]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.revisions.models.revision :as revision]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -10,7 +10,6 @@
    [metabase.models.user :as user]
    [metabase.models.user-test :as user-test]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.permissions.util :as perms-util]
    [metabase.request.core :as request]
    [metabase.test :as mt]
@@ -1230,12 +1229,12 @@
                (mt/derecordize (t2/select-one [:model/User :is_active] :id (:id user)))))))
 
     (testing "Check that the last superuser cannot deactivate themselves"
-      (mt/with-single-admin-user [{id :id}]
+      (mt/with-single-admin-user! [{id :id}]
         (is (= "You cannot remove the last member of the 'Admin' group!"
                (mt/user-http-request id :delete 400 (format "user/%d" id))))))
 
     (testing "Check that the last non-archived superuser cannot deactivate themselves"
-      (mt/with-single-admin-user [{id :id}]
+      (mt/with-single-admin-user! [{id :id}]
         (mt/with-temp [:model/User _ {:is_active    false
                                       :is_superuser true}]
           (is (= "You cannot remove the last member of the 'Admin' group!"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -33,9 +33,8 @@
    [metabase.db.schema-migrations-test.impl :as impl]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
-   [metabase.permissions.models.permissions :as perms]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -2425,7 +2424,7 @@
                                                    :created_at #t "2020"
                                                    :updated_at #t "2020"})
           group-id     (t2/insert-returning-pk! :permissions_group {:name "Test Group"})]
-      (perms-group-membership/add-user-to-group! user-id group-id)
+      (perms/add-user-to-group! user-id group-id)
       (migrate!)
       (clear-permissions!)
       ;; set one table to be unrestricted

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -12,9 +12,8 @@
    [metabase.models.serialization :as serdes]
    [metabase.models.user :as user]
    [metabase.notification.test-util :as notification.tu]
-   [metabase.permissions.models.permissions :as perms]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.permissions.models.permissions-test :as perms-test]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
@@ -239,11 +238,11 @@
 
 (defn- do-with-group! [group-properties group-members f]
   (mt/with-temp [:model/PermissionsGroup group group-properties]
-    (perms-group-membership/add-users-to-groups! (for [member group-members]
-                                                   {:user (if (keyword? member)
-                                                            (mt/user->id member)
-                                                            (u/the-id member))
-                                                    :group group}))
+    (perms/add-users-to-groups! (for [member group-members]
+                                  {:user (if (keyword? member)
+                                           (mt/user->id member)
+                                           (u/the-id member))
+                                   :group group}))
     (f group)))
 
 (defmacro ^:private with-groups! [[group-binding group-properties members & more-groups] & body]

--- a/test/metabase/permissions/models/permissions_group_membership_test.clj
+++ b/test/metabase/permissions/models/permissions_group_membership_test.clj
@@ -24,12 +24,12 @@
              (t2/select-one-fn :is_superuser :model/User :id (u/the-id user))))))
 
   (testing "it should not let you remove the last admin"
-    (mt/with-single-admin-user [{id :id}]
+    (mt/with-single-admin-user! [{id :id}]
       (is (thrown? Exception
                    (t2/delete! :model/PermissionsGroupMembership :user_id id, :group_id (u/the-id (perms-group/admin)))))))
 
   (testing "it should not let you remove the last non-archived admin"
-    (mt/with-single-admin-user [{id :id}]
+    (mt/with-single-admin-user! [{id :id}]
       (mt/with-temp [:model/User _ {:is_active    false
                                     :is_superuser true}]
         (is (thrown? Exception

--- a/test/metabase/permissions/models/permissions_group_membership_test.clj
+++ b/test/metabase/permissions/models/permissions_group_membership_test.clj
@@ -1,8 +1,8 @@
 (ns metabase.permissions.models.permissions-group-membership-test
   (:require
    [clojure.test :refer :all]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -13,7 +13,7 @@
 (deftest set-is-superuser-test
   (testing "when you create a PermissionsGroupMembership for a User in the admin group, it should set their `is_superuser` flag"
     (mt/with-temp [:model/User user]
-      (perms-group-membership/add-user-to-group! user (perms-group/admin))
+      (perms/add-user-to-group! user (perms-group/admin))
       (is (true? (t2/select-one-fn :is_superuser :model/User :id (u/the-id user)))))))
 
 (deftest remove-is-superuser-test
@@ -46,13 +46,13 @@
       (testing "cannot be added to a normal group"
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"Cannot add non-tenant user to tenant-group or vice versa"
-                              (perms-group-membership/add-user-to-group! tenant-user normal-group))))
+                              (perms/add-user-to-group! tenant-user normal-group))))
       (testing "can be added to tenant groups"
-        (perms-group-membership/add-user-to-group! tenant-user tenant-group)))
+        (perms/add-user-to-group! tenant-user tenant-group)))
     (testing "A normal user"
       (testing "cannot be added to a tenant group"
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"Cannot add non-tenant user to tenant-group or vice versa"
-                              (perms-group-membership/add-user-to-group! normal-user tenant-group))))
+                              (perms/add-user-to-group! normal-user tenant-group))))
       (testing "can be added to a normal group"
-        (perms-group-membership/add-user-to-group! normal-user normal-group)))))
+        (perms/add-user-to-group! normal-user normal-group)))))

--- a/test/metabase/permissions/models/permissions_group_test.clj
+++ b/test/metabase/permissions/models/permissions_group_test.clj
@@ -4,10 +4,10 @@
    [metabase.config :as config]
    [metabase.models.interface :as mi]
    [metabase.permissions.api-test-util :as perm-test-util]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -94,7 +94,7 @@
   (testing "flipping the is_superuser bit should add/remove user from Admin group as appropriate"
     (testing "adding user to Admin should set is_superuser -> true"
       (mt/with-temp [:model/User {user-id :id}]
-        (perms-group-membership/add-user-to-group! user-id (u/the-id (perms-group/admin)))
+        (perms/add-user-to-group! user-id (u/the-id (perms-group/admin)))
         (is (true? (t2/select-one-fn :is_superuser :model/User, :id user-id)))))))
 
 (deftest add-remove-from-admin-group-test-2

--- a/test/metabase/sso/common_test.clj
+++ b/test/metabase/sso/common_test.clj
@@ -3,8 +3,8 @@
    [clojure.test :refer :all]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.sso.common :as integrations.common]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -138,7 +138,7 @@
           (with-redefs [t2/delete!
                         (fn [model & _args]
                           (when (= model :model/PermissionsGroupMembership)
-                            (throw (ex-info (str perms-group-membership/fail-to-remove-last-admin-msg)
+                            (throw (ex-info (str perms/fail-to-remove-last-admin-msg)
                                             {:status-code 400}))))
                         clojure.tools.logging/log*
                         (fn [_logger level _throwable msg]

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -310,7 +310,7 @@
  [tu.misc
   object-defaults
   with-clock
-  with-single-admin-user]
+  with-single-admin-user!]
 
  [u.random
   random-name

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -5,7 +5,6 @@
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.http-client :as client]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
    [metabase.test.initialize :as initialize]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -22,7 +22,6 @@
    [metabase.permissions.models.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.plugins.classloader :as classloader]
    [metabase.premium-features.test-util :as premium-features.test-util]

--- a/test/metabase/test/util/misc.clj
+++ b/test/metabase/test/util/misc.clj
@@ -35,7 +35,7 @@
   [clock & body]
   `(do-with-clock ~clock (fn [] ~@body)))
 
-(defn do-with-single-admin-user
+(defn do-with-single-admin-user!
   [attributes thunk]
   (let [existing-admin-memberships (t2/select :model/PermissionsGroupMembership :group_id (:id (perms-group/admin)))
         _                          (t2/delete! (t2/table-name :model/PermissionsGroupMembership) :group_id (:id (perms-group/admin)))
@@ -54,19 +54,19 @@
         (perms-group-membership/add-users-to-groups! (for [{:keys [user_id group_id is_group_manager]} existing-admin-memberships]
                                                        {:user user_id :group group_id :is-group-manager? is_group_manager}))))))
 
-(defmacro with-single-admin-user
+(defmacro with-single-admin-user!
   "Creates an admin user (with details described in the `options-map`) and (temporarily) removes the administrative
   powers of all other users in the database.
 
   Example:
 
   (testing \"Check that the last superuser cannot deactivate themselves\"
-    (mt/with-single-admin-user [{id :id}]
+    (mt/with-single-admin-user! [{id :id}]
       (is (= \"You cannot remove the last member of the 'Admin' group!\"
              (mt/user-http-request :crowberto :delete 400 (format \"user/%d\" id))))))"
   [[binding-form & [options-map]] & body]
-  `(do-with-single-admin-user ~options-map (fn [~binding-form]
-                                             ~@body)))
+  `(do-with-single-admin-user! ~options-map (fn [~binding-form]
+                                              ~@body)))
 
 (def ^{:arglists '([toucan-model])} object-defaults
   "Return the default values for columns in an instance of a `toucan-model`, excluding ones that differ between

--- a/test/metabase/test/util/misc.clj
+++ b/test/metabase/test/util/misc.clj
@@ -5,8 +5,8 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [mb.hawk.init]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
    [metabase.test.initialize :as initialize]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]
@@ -51,8 +51,8 @@
         (t2/delete! :model/User (:id temp-admin))
         (when (seq existing-admin-ids)
           (t2/update! (t2/table-name :model/User) {:id [:in existing-admin-ids]} {:is_superuser true}))
-        (perms-group-membership/add-users-to-groups! (for [{:keys [user_id group_id is_group_manager]} existing-admin-memberships]
-                                                       {:user user_id :group group_id :is-group-manager? is_group_manager}))))))
+        (perms/add-users-to-groups! (for [{:keys [user_id group_id is_group_manager]} existing-admin-memberships]
+                                      {:user user_id :group group_id :is-group-manager? is_group_manager}))))))
 
 (defmacro with-single-admin-user!
   "Creates an admin user (with details described in the `options-map`) and (temporarily) removes the administrative


### PR DESCRIPTION
### Description

Fixes failing kondos. Most of these are around the permissions-group-membership namespace not being included in our module config. 

