### PR TITLE
Content translation: impose maximum size on upload

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
@@ -46,3 +46,17 @@ export const interceptContentTranslationRoutes = () => {
     "uploadDictionary",
   );
 };
+
+export const generateLargeCSV = ({
+  sizeInMebibytes,
+}: {
+  sizeInMebibytes: number;
+}) => {
+  const oneMebibyte = 2 ** 20;
+  const charsPerRow = 100;
+  const totalRows = Math.floor((sizeInMebibytes * oneMebibyte) / charsPerRow);
+  const header = "locale,string,translation\n";
+  const row = "de,data2,data3\n";
+  const largeCSV = header + row.repeat(totalRows);
+  return largeCSV;
+};

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -15,11 +15,6 @@
   [t]
   (select-keys t [:locale :msgid]))
 
-;; Maximum file size: 1.5MB
-;; This should equal the maxFileSizeInMiB variable in
-;; enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
-(def ^:private max-file-size (* 1.5 1024 1024))
-
 (defn- adjust-index
   "Adjust index: increment once for the header row that was chopped off and again to go to 1-based indexing for human
   consumption."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -7,7 +7,27 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli.schema :as ms]))
+   [metabase.util.malli.schema :as ms])
+  (:import
+   (java.io File)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private http-status-content-too-large 413)
+
+;; The maximum size of a content translation dictionary is 1.5MiB
+;; This should equal the maxContentDictionarySizeInMiB variable in the frontend
+(def ^:private max-content-translation-dictionary-size (* 1.5 1024 1024))
+
+(defn- check-file-size
+  "Throws an error message if the file is too large. Note that frontend will also refuse to upload a file that's too large."
+  [^File file]
+  (let [file-size (.length file)]
+    (when (> file-size max-content-translation-dictionary-size)
+      (throw (ex-info (tru "Upload a dictionary smaller than {0}MB." (/ max-content-translation-dictionary-size (* 1024 1024)))
+                      {:status-code http-status-content-too-large
+                       :file-size file-size
+                       :max-size max-content-translation-dictionary-size})))))
 
 (api.macros/defendpoint :post
   "/upload-dictionary"
@@ -26,6 +46,7 @@
   (let [file (get-in multipart-params ["file" :tempfile])]
     (when-not (instance? java.io.File file)
       (throw (ex-info (tru "No file provided") {:status-code 400})))
+    (check-file-size file)
     (with-open [rdr (io/reader file)]
       (let [[_header & rows] (csv/read-csv rdr)]
         (dictionary/import-translations! rows))))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -35,7 +35,7 @@
                                                     [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
   (let [file (get-in multipart-params ["file" :tempfile])]
     (when (> (get-in multipart-params ["file" :size]) max-content-translation-dictionary-size)
-      (throw (ex-info (tru "Dictionary is larger than {0}MB." (/ max-content-translation-dictionary-size (* 1024 1024)))
+      (throw (ex-info (tru "The dictionary should be less than {0}MB." (/ max-content-translation-dictionary-size (* 1024 1024)))
                       {:status-code http-status-content-too-large})))
     (when-not (instance? java.io.File file)
       (throw (ex-info (tru "No file provided") {:status-code 400})))

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
@@ -106,6 +106,7 @@ const UploadForm = ({
           c("{0} is a number")
             .t`Upload a dictionary smaller than ${approxMaxContentDictionarySizeInMB} MB`,
         ]);
+        setStatus("rejected");
         return;
       }
 

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import { useDocsUrl } from "metabase/common/hooks";
 import { UploadInput } from "metabase/components/upload";
@@ -21,6 +21,19 @@ import {
 } from "metabase/forms";
 import { Group, Icon, List, Loader, Stack, Text } from "metabase/ui";
 import { useUploadContentTranslationDictionaryMutation } from "metabase-enterprise/api";
+
+/** Maximum file size for uploaded content-translation dictionaries, expressed
+ * in mebibytes. */
+const maxContentDictionarySizeInMiB = 1.5;
+
+/** The maximum file size is 1.5 mebibytes (which equals 1.57 metabytes).
+ * For simplicity, though, let's express this as 1.5 megabytes, which is
+ * approximately right. */
+const approxMaxContentDictionarySizeInMB = 1.5;
+
+/** This should equal the max-content-translation-dictionary-size variable in the backend */
+const maxContentDictionarySizeInBytes =
+  maxContentDictionarySizeInMiB * 1024 * 1024;
 
 export const ContentTranslationConfiguration = () => {
   // eslint-disable-next-line no-unconditional-metabase-links-render -- This is used in admin settings
@@ -87,6 +100,15 @@ const UploadForm = ({
   const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.files?.length) {
       const file = event.target.files[0];
+
+      if (file.size > maxContentDictionarySizeInBytes) {
+        setErrorMessages([
+          c("{0} is a number")
+            .t`Upload a dictionary smaller than ${approxMaxContentDictionarySizeInMB} MB`,
+        ]);
+        return;
+      }
+
       await uploadFile(file);
       resetInput();
     }


### PR DESCRIPTION
This contribution to the content translation project imposes a maximum size on uploaded dictionaries

To test, go to Admin / Settings / Localization and upload a file larger than 1.6MB

<img width="765" alt="image" src="https://github.com/user-attachments/assets/4e0bff63-fa06-4a0f-b163-0a96a59c0d35" />
