### PR TITLE
Update logger presets

### DIFF
--- a/src/metabase/api/logger.clj
+++ b/src/metabase/api/logger.clj
@@ -49,13 +49,54 @@
   []
   (let [namespace-names (all-namespace-names)]
     [{:id :sync
-      :display_name (tru "Sync issue troubleshooting")
+      :display_name (tru "Info") ; to be decided
       :loggers (->> (-> [(logger "metabase.driver")]
                         (into (loggers-under "metabase.sync" namespace-names))
                         (into (comp (map #(str "metabase.driver." %))
                                     (mapcat #(loggers-under % namespace-names)))
                               (sort (loaded-drivers))))
-                    (sort-by :name))}]))
+                    (sort-by :name))}
+     {:id :sync
+      :display_name (tru "Sync issue troubleshooting")
+      :loggers [{:name "metabase.sync.util" :level :debug}
+                {:name "metabase.sync.sync_metadata" :level :debug}
+                {:name "metabase.sync.analyze" :level :debug}
+                {:name "metabase.sync.analyze.fingerprint" :level :debug}
+                {:name "metabase.sync.field_values" :level :debug}
+                {:name "metabase.driver" :level :debug}
+                {:name "metabase.sync.task.sync_databases" :level :debug}]}
+     {:id :linkedfilters
+      :display_name (tru "Linked filters troubleshooting")
+      :loggers [{:name "metabase" :level :info}
+                {:name "metabase-enterprise" :level :info}
+                {:name "metabase.metabot" :level :info}
+                {:name "metabase.plugins" :level :info}
+                {:name "metabase.server.middleware" :level :info}
+                {:name "metabase.server.middleware.log" :level :debug}
+                {:name "metabase.query-processor.async" :level :info}
+                {:name "metabase.driver.sql.query-processor" :level :info}
+                {:name "metabase.query-processor.middleware.escape-join-aliases" :level :info}
+                {:name "com.mchange" :level :error}
+                {:name "org.quartz" :level :info}
+                {:name "liquibase" :level :error}
+                {:name "metabase.models.params.chain-filter" :level :debug}]}
+     {:id :linkedfilters
+      :display_name (tru "Serialization troubleshooting")
+      :loggers [{:name "metabase" :level :info}
+                {:name "metabase-enterprise" :level :info}
+                {:name "metabase.metabot" :level :info}
+                {:name "metabase.plugins" :level :info}
+                {:name "metabase.server.middleware" :level :info}
+                {:name "metabase.server.middleware.log" :level :debug}
+                {:name "metabase.query-processor.async" :level :info}
+                {:name "metabase.driver.sql.query-processor" :level :info}
+                {:name "metabase.query-processor.middleware.escape-join-aliases" :level :info}
+                {:name "com.mchange" :level :error}
+                {:name "org.quartz" :level :info}
+                {:name "liquibase" :level :error}
+                {:name "net.snowflake.client.jdbc.SnowflakeConnectString" :level :error}
+                {:name "metabase-enterprise.serialization" :level :debug}
+                {:name "metabase.models.serialization" :level :debug}]}]))
 
 (api.macros/defendpoint :get "/presets" :- [:sequential
                                             [:map

--- a/src/metabase/api/logger.clj
+++ b/src/metabase/api/logger.clj
@@ -49,7 +49,7 @@
                         (map #(assoc % :level :debug))
                         (sort-by :name)
                         (vec))
-               (as-> $ (when (empty? $) (log/error "Serialization preset is empty"))))}
+               (as-> $ (when (empty? $) (log/error "Sync preset is empty"))))}
    {:id :linkedfilters
     :display_name (tru "Linked filters troubleshooting")
     :loggers (doto (->> (loggers-under "metabase.models.params.chain-filter")
@@ -57,7 +57,7 @@
                         (map #(assoc % :level :debug))
                         (sort-by :name)
                         (vec))
-               (as-> $ (when (empty? $) (log/error "Serialization preset is empty"))))}
+               (as-> $ (when (empty? $) (log/error "Linked filters preset is empty"))))}
    {:id :serialization
     :display_name (tru "Serialization troubleshooting")
     :loggers (doto (->> (cons (logger "metabase.models.serialization")

--- a/src/metabase/api/logger.clj
+++ b/src/metabase/api/logger.clj
@@ -5,9 +5,9 @@
    [flatland.ordered.map :as ordered-map]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.driver :as driver]
    [metabase.logger :as logger]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr])
   (:import
@@ -15,12 +15,6 @@
    (java.util.concurrent.atomic AtomicInteger)))
 
 (set! *warn-on-reflection* true)
-
-(defn- loaded-drivers
-  "Returns the names of all loaded drivers"
-  []
-  (into [] (comp (filter simple-keyword?) (map name))
-        (sort (descendants driver/hierarchy ::driver/driver))))
 
 (defn- all-namespace-names
   []
@@ -47,56 +41,32 @@
 
 (defn- presets
   []
-  (let [namespace-names (all-namespace-names)]
-    [{:id :sync
-      :display_name (tru "Info") ; to be decided
-      :loggers (->> (-> [(logger "metabase.driver")]
-                        (into (loggers-under "metabase.sync" namespace-names))
-                        (into (comp (map #(str "metabase.driver." %))
-                                    (mapcat #(loggers-under % namespace-names)))
-                              (sort (loaded-drivers))))
-                    (sort-by :name))}
-     {:id :sync
-      :display_name (tru "Sync issue troubleshooting")
-      :loggers [{:name "metabase.sync.util" :level :debug}
-                {:name "metabase.sync.sync_metadata" :level :debug}
-                {:name "metabase.sync.analyze" :level :debug}
-                {:name "metabase.sync.analyze.fingerprint" :level :debug}
-                {:name "metabase.sync.field_values" :level :debug}
-                {:name "metabase.driver" :level :debug}
-                {:name "metabase.sync.task.sync_databases" :level :debug}]}
-     {:id :linkedfilters
-      :display_name (tru "Linked filters troubleshooting")
-      :loggers [{:name "metabase" :level :info}
-                {:name "metabase-enterprise" :level :info}
-                {:name "metabase.metabot" :level :info}
-                {:name "metabase.plugins" :level :info}
-                {:name "metabase.server.middleware" :level :info}
-                {:name "metabase.server.middleware.log" :level :debug}
-                {:name "metabase.query-processor.async" :level :info}
-                {:name "metabase.driver.sql.query-processor" :level :info}
-                {:name "metabase.query-processor.middleware.escape-join-aliases" :level :info}
-                {:name "com.mchange" :level :error}
-                {:name "org.quartz" :level :info}
-                {:name "liquibase" :level :error}
-                {:name "metabase.models.params.chain-filter" :level :debug}]}
-     {:id :linkedfilters
-      :display_name (tru "Serialization troubleshooting")
-      :loggers [{:name "metabase" :level :info}
-                {:name "metabase-enterprise" :level :info}
-                {:name "metabase.metabot" :level :info}
-                {:name "metabase.plugins" :level :info}
-                {:name "metabase.server.middleware" :level :info}
-                {:name "metabase.server.middleware.log" :level :debug}
-                {:name "metabase.query-processor.async" :level :info}
-                {:name "metabase.driver.sql.query-processor" :level :info}
-                {:name "metabase.query-processor.middleware.escape-join-aliases" :level :info}
-                {:name "com.mchange" :level :error}
-                {:name "org.quartz" :level :info}
-                {:name "liquibase" :level :error}
-                {:name "net.snowflake.client.jdbc.SnowflakeConnectString" :level :error}
-                {:name "metabase-enterprise.serialization" :level :debug}
-                {:name "metabase.models.serialization" :level :debug}]}]))
+  [{:id :sync
+    :display_name (tru "Sync issue troubleshooting")
+    :loggers (doto (->> (concat (loggers-under "metabase.sync")
+                                (loggers-under "metabase.driver.sql-jdbc.sync"))
+                        (filter map?)
+                        (map #(assoc % :level :debug))
+                        (sort-by :name)
+                        (vec))
+               (as-> $ (when (empty? $) (log/error "Serialization preset is empty"))))}
+   {:id :linkedfilters
+    :display_name (tru "Linked filters troubleshooting")
+    :loggers (doto (->> (loggers-under "metabase.models.params.chain-filter")
+                        (filter map?)
+                        (map #(assoc % :level :debug))
+                        (sort-by :name)
+                        (vec))
+               (as-> $ (when (empty? $) (log/error "Serialization preset is empty"))))}
+   {:id :serialization
+    :display_name (tru "Serialization troubleshooting")
+    :loggers (doto (->> (cons (logger "metabase.models.serialization")
+                              (loggers-under "metabase-enterprise.serialization"))
+                        (filter map?)
+                        (map #(assoc % :level :debug))
+                        (sort-by :name)
+                        (vec))
+               (as-> $ (when (empty? $) (log/error "Serialization preset is empty"))))}])
 
 (api.macros/defendpoint :get "/presets" :- [:sequential
                                             [:map

--- a/test/metabase/api/logger_test.clj
+++ b/test/metabase/api/logger_test.clj
@@ -12,7 +12,13 @@
   (testing "admins have access"
     (is (=? [{:id "sync"
               :display_name "Sync issue troubleshooting"
-              :loggers #(every? (every-pred :name :level) %)}]
+              :loggers #(every? (every-pred :name (comp #{"debug"} :level)) %)}
+             {:id "linkedfilters"
+              :display_name "Linked filters troubleshooting"
+              :loggers #(every? (every-pred :name (comp #{"debug"} :level)) %)}
+             {:id "serialization"
+              :display_name "Serialization troubleshooting"
+              :loggers #(every? (every-pred :name (comp #{"debug"} :level)) %)}]
             (mt/user-http-request :crowberto :get 200 "logger/presets")))))
 
 (deftest ^:parallel adjust-invocation-error-test


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-292/adjust-the-sync-issue-troubleshooting-preset-configuration
Closes https://linear.app/metabase/issue/SEM-296/add-another-preset-to-ease-troubleshooting-linked-filters
Closes https://linear.app/metabase/issue/SEM-298/add-preset-for-troubleshooting-serialization

### Description

Context for choosing loggers for presets can be found in [this thread](https://metaboat.slack.com/archives/C08E17FN206/p1746557785208179).

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
