### PR TITLE
Add more input label spacing

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.module.css
@@ -62,12 +62,14 @@
   font-size: var(--mantine-font-size-sm);
   font-weight: bold;
   line-height: var(--mantine-line-height-sm);
+  margin-bottom: var(--mantine-spacing-xs);
 }
 
 .description {
   color: var(--mb-color-text-dark);
   font-size: var(--mantine-font-size-xs);
   line-height: var(--mantine-line-height-sm);
+  margin-bottom: var(--mantine-spacing-xs);
 }
 
 .error {


### PR DESCRIPTION
### Description

Our Mantine inputs are too tight. let's loosen em up a bit.

Before | After
--- | ---
![Screenshot 2025-05-06 at 1 22 06 PM](https://github.com/user-attachments/assets/b156fc0e-3790-436d-9502-d225617fba0a) | ![Screenshot 2025-05-06 at 1 22 18 PM](https://github.com/user-attachments/assets/c5851abe-b394-4820-98f8-c6fbdd2499f8)
![Screenshot 2025-05-06 at 1 21 56 PM](https://github.com/user-attachments/assets/30ebc051-e0da-4ed4-9059-9ef76dda6568) | ![Screenshot 2025-05-06 at 1 21 42 PM](https://github.com/user-attachments/assets/e3d24729-9db8-434e-86df-b2519d762a3d)

