### PR TITLE
Remove zh from the list of supported translations

### DIFF
--- a/docs/configuring-metabase/localization.md
+++ b/docs/configuring-metabase/localization.md
@@ -26,9 +26,9 @@ Supported languages include:
 | Arabic (Saudi Arabia)  | `ar-SA` |
 | Bulgarian              | `bg`    |
 | Catalan                | `ca`    |
-| Chinese (Taiwanese)    | `zh-TW` |
 | Chinese (Hong Kong)    | `zh-HK` |
 | Chinese (Simplified)   | `zh-CN` |
+| Chinese (Taiwanese)    | `zh-TW` |
 | Czech                  | `cs`    |
 | Dutch                  | `nl`    |
 | Farsi/Persian          | `fa`    |
@@ -38,11 +38,11 @@ Supported languages include:
 | Hebrew                 | `he`    |
 | Hungarian              | `hu`    |
 | Indonesian             | `id`    |
-| Malay                  | `ms`    |
 | Italian                | `it`    |
 | Japanese               | `ja`    |
 | Korean                 | `ko`    |
 | Latvian                | `lv`    |
+| Malay                  | `ms`    |
 | Norwegian Bokmål       | `nb`    |
 | Polish                 | `pl`    |
 | Portuguese (Brazilian) | `pt-BR` |

--- a/docs/configuring-metabase/localization.md
+++ b/docs/configuring-metabase/localization.md
@@ -26,7 +26,6 @@ Supported languages include:
 | Arabic (Saudi Arabia)  | `ar-SA` |
 | Bulgarian              | `bg`    |
 | Catalan                | `ca`    |
-| Chinese (Traditional)  | `zh`    |
 | Chinese (Taiwanese)    | `zh-TW` |
 | Chinese (Hong Kong)    | `zh-HK` |
 | Chinese (Simplified)   | `zh-CN` |


### PR DESCRIPTION
We don't support the `zh` (Traditional Chinese) locale anymore – only `zh-CN` (Simplified Chinese), and `zh-HK` (Hong Kong), and `zh-TW` (Taiwan). Here's a [Slack discussion](https://metaboat.slack.com/archives/C6UBFU9GW/p1741983889165599).

So let's remove `zh` from the list of supported translations.

For some reason the list wasn't sorted alphabetically by language name - this PR fixes that too.