### PR TITLE
Add analytics for new entity creation being initiated

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -102,6 +102,20 @@ H.describeWithSnowplow("scenarios > browse", () => {
     });
   });
 
+  it("tracks when a new model creation is initiated", () => {
+    cy.visit("/browse/models");
+    cy.findByTestId("browse-models-header")
+      .findByLabelText("Create a new model")
+      .should("be.visible")
+      .click();
+    cy.location("pathname").should("eq", "/model/new");
+    H.expectNoBadSnowplowEvents();
+    H.expectGoodSnowplowEvent({
+      event: "plus_button_clicked",
+      triggered_from: "model",
+    });
+  });
+
   it("browsing to a database only triggers a request for schemas for that specific database", () => {
     cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/schemas`).as(
       "schemasForSampleDatabase",

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -116,6 +116,21 @@ H.describeWithSnowplow("scenarios > browse", () => {
     });
   });
 
+  it("tracks when a new metric creation is initiated", () => {
+    cy.visit("/browse/metrics");
+    cy.findByTestId("browse-metrics-header")
+      .findByLabelText("Create a new metric")
+      .should("be.visible")
+      .click();
+    cy.findByTestId("entity-picker-modal").should("be.visible");
+
+    H.expectNoBadSnowplowEvents();
+    H.expectGoodSnowplowEvent({
+      event: "plus_button_clicked",
+      triggered_from: "metric",
+    });
+  });
+
   it("browsing to a database only triggers a request for schemas for that specific database", () => {
     cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/schemas`).as(
       "schemasForSampleDatabase",

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -639,6 +639,37 @@ H.describeWithSnowplow("scenarios > setup", () => {
       triggered_from: "empty-collection",
     });
   });
+
+  /**
+   * Until we refactor the NewItem menu component and drop EntityMenu from it,
+   * the only menu item that can have onClick handler is a "dashboard".
+   */
+  it("should track when a 'New' button's menu item is clicked", () => {
+    cy.visit("/");
+
+    H.newButton().should("be.visible").click();
+    cy.findByRole("dialog").findByText("Dashboard").click();
+    cy.findByTestId("new-dashboard-modal").should("be.visible");
+    H.expectGoodSnowplowEvent({
+      event: "new_button_item_clicked",
+      triggered_from: "dashboard",
+    });
+
+    cy.findByTestId("new-dashboard-modal").button("Cancel").click();
+    cy.findByTestId("new-dashboard-modal").should("not.exist");
+
+    H.navigationSidebar().findByText("Your personal collection").click();
+    cy.findByTestId("collection-empty-state").within(() => {
+      cy.findByText("This collection is empty").should("be.visible");
+      cy.findByText("New").click();
+    });
+    cy.findByRole("dialog").findByText("Dashboard").click();
+    cy.findByTestId("new-dashboard-modal").should("be.visible");
+    H.expectGoodSnowplowEvent({
+      event: "new_button_item_clicked",
+      triggered_from: "dashboard",
+    });
+  });
 });
 
 const pinItem = (name) => {

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -603,6 +603,42 @@ H.describeWithSnowplow("scenarios > setup", () => {
       source: "homepage",
     });
   });
+
+  it("should track when 'New' button is clicked", () => {
+    cy.visit("/");
+
+    cy.log("From the app bar");
+    H.newButton().should("be.visible").click();
+    cy.findByRole("dialog").should("be.visible");
+    H.expectGoodSnowplowEvent({
+      event: "new_button_clicked",
+      triggered_from: "app-bar",
+    });
+
+    cy.log("Track closing the button as well");
+    H.newButton().should("be.visible").click();
+    cy.findByRole("dialog").should("not.exist");
+    H.expectGoodSnowplowEvent(
+      {
+        event: "new_button_clicked",
+        triggered_from: "app-bar",
+      },
+      2,
+    );
+
+    cy.log("From the empty collection");
+    H.navigationSidebar().findByText("Your personal collection").click();
+    cy.findByTestId("collection-empty-state").within(() => {
+      cy.findByText("This collection is empty").should("be.visible");
+      cy.findByText("New").click();
+    });
+
+    cy.findByRole("dialog").should("be.visible");
+    H.expectGoodSnowplowEvent({
+      event: "new_button_clicked",
+      triggered_from: "empty-collection",
+    });
+  });
 });
 
 const pinItem = (name) => {

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -665,10 +665,13 @@ H.describeWithSnowplow("scenarios > setup", () => {
     });
     cy.findByRole("dialog").findByText("Dashboard").click();
     cy.findByTestId("new-dashboard-modal").should("be.visible");
-    H.expectGoodSnowplowEvent({
-      event: "new_button_item_clicked",
-      triggered_from: "dashboard",
-    });
+    H.expectGoodSnowplowEvent(
+      {
+        event: "new_button_item_clicked",
+        triggered_from: "dashboard",
+      },
+      2,
+    );
   });
 });
 

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -97,6 +97,22 @@ export type KeyboardShortcutPerformEvent = ValidateEvent<{
   event_detail: KeyboardShortcutId;
 }>;
 
+export type NewEntityInitiatedEvent = ValidateEvent<{
+  event: "plus_button_clicked";
+  triggered_from: "model" | "metric" | "collection-header" | "collection-nav";
+}>;
+
+export type NewButtonClickedEvent = ValidateEvent<{
+  event: "new_button_clicked";
+  triggered_from: "app-bar" | "empty-collection";
+}>;
+
+export type NewButtonItemClickedEvent = ValidateEvent<{
+  event: "new_button_item_clicked";
+  triggered_from: "question" | "native-query" | "dashboard" | "metabot";
+  event_detail: "app-bar" | "empty-collection";
+}>;
+
 export type SimpleEvent =
   | CSVUploadClickedEvent
   | DatabaseAddClickedEvent
@@ -110,4 +126,7 @@ export type SimpleEvent =
   | ErrorDiagnosticModalSubmittedEvent
   | GsheetsConnectionClickedEvent
   | GsheetsImportClickedEvent
-  | KeyboardShortcutPerformEvent;
+  | KeyboardShortcutPerformEvent
+  | NewEntityInitiatedEvent
+  | NewButtonClickedEvent
+  | NewButtonItemClickedEvent;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -109,7 +109,7 @@ export type NewButtonClickedEvent = ValidateEvent<{
 
 export type NewButtonItemClickedEvent = ValidateEvent<{
   event: "new_button_item_clicked";
-  triggered_from: "question" | "native-query" | "dashboard" | "metabot";
+  triggered_from: "question" | "native-query" | "dashboard";
   event_detail: "app-bar" | "empty-collection";
 }>;
 

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -110,7 +110,6 @@ export type NewButtonClickedEvent = ValidateEvent<{
 export type NewButtonItemClickedEvent = ValidateEvent<{
   event: "new_button_item_clicked";
   triggered_from: "question" | "native-query" | "dashboard";
-  event_detail: "app-bar" | "empty-collection";
 }>;
 
 export type SimpleEvent =

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -35,6 +35,7 @@ import {
 } from "../components/BrowseContainer.styled";
 
 import { MetricsTable } from "./MetricsTable";
+import { trackNewMetricInitiated } from "./analytics";
 import type { MetricFilterSettings, MetricResult } from "./types";
 
 const {
@@ -93,6 +94,7 @@ export function BrowseMetrics() {
                     variant="viewHeader"
                     component={ForwardRefLink}
                     to={newMetricLink}
+                    onClick={() => trackNewMetricInitiated()}
                   >
                     <Icon name="add" />
                   </ActionIcon>

--- a/frontend/src/metabase/browse/metrics/analytics.ts
+++ b/frontend/src/metabase/browse/metrics/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackNewMetricInitiated = () =>
+  trackSimpleEvent({
+    event: "plus_button_clicked",
+    triggered_from: "metric",
+  });

--- a/frontend/src/metabase/browse/models/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.tsx
@@ -43,6 +43,7 @@ import { ModelsVideo } from "./EmptyStates";
 import { ModelExplanationBanner } from "./ModelExplanationBanner";
 import { ModelsTable } from "./ModelsTable";
 import { RecentModels } from "./RecentModels";
+import { trackNewModelInitiated } from "./analytics";
 import type { ModelFilterSettings, ModelResult } from "./types";
 import { getMaxRecentModelCount, isRecentModel } from "./utils";
 
@@ -101,6 +102,7 @@ export const BrowseModels = () => {
                     variant="viewHeader"
                     component={ForwardRefLink}
                     to="/model/new"
+                    onClick={() => trackNewModelInitiated()}
                   >
                     <Icon name="add" />
                   </ActionIcon>

--- a/frontend/src/metabase/browse/models/analytics.ts
+++ b/frontend/src/metabase/browse/models/analytics.ts
@@ -1,8 +1,14 @@
-import { trackSchemaEvent } from "metabase/lib/analytics";
+import { trackSchemaEvent, trackSimpleEvent } from "metabase/lib/analytics";
 import type { CardId } from "metabase-types/api";
 
 export const trackModelClick = (modelId: CardId) =>
   trackSchemaEvent("browse_data", {
     event: "browse_data_model_clicked",
     model_id: modelId,
+  });
+
+export const trackNewModelInitiated = () =>
+  trackSimpleEvent({
+    event: "plus_button_clicked",
+    triggered_from: "model",
   });

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
@@ -8,6 +8,8 @@ import { color } from "metabase/lib/colors";
 import { Box, Button, Icon, Stack, Text, useMantineTheme } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
+import { trackCollectionNewButtonClicked } from "./analytics";
+
 export interface CollectionEmptyStateProps {
   collection?: Collection;
 }
@@ -67,6 +69,7 @@ const DefaultCollectionEmptyState = ({
               variant="outline"
               leftSection={<Icon name="add" />}
               w="12.5rem"
+              onClick={() => trackCollectionNewButtonClicked()}
             >{t`New`}</Button>
           }
           collectionId={collection?.id}

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/analytics.ts
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackCollectionNewButtonClicked = () =>
+  trackSimpleEvent({
+    event: "new_button_clicked",
+    triggered_from: "empty-collection",
+  });

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionNewButton.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionNewButton.tsx
@@ -5,7 +5,7 @@ import { setOpenModal } from "metabase/redux/ui";
 import { Tooltip } from "metabase/ui";
 
 import { CollectionHeaderButton } from "./CollectionHeader.styled";
-import { trackNewCollectionInitiated } from "./analytics";
+import { trackNewCollectionFromHeaderInitiated } from "./analytics";
 
 export const CollectionNewButton = () => {
   const dispatch = useDispatch();
@@ -17,7 +17,7 @@ export const CollectionNewButton = () => {
           aria-label={t`Create a new collection`}
           icon="add_folder"
           onClick={() => {
-            trackNewCollectionInitiated();
+            trackNewCollectionFromHeaderInitiated();
             dispatch(setOpenModal("collection"));
           }}
         />

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionNewButton.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionNewButton.tsx
@@ -5,6 +5,7 @@ import { setOpenModal } from "metabase/redux/ui";
 import { Tooltip } from "metabase/ui";
 
 import { CollectionHeaderButton } from "./CollectionHeader.styled";
+import { trackNewCollectionInitiated } from "./analytics";
 
 export const CollectionNewButton = () => {
   const dispatch = useDispatch();
@@ -15,7 +16,10 @@ export const CollectionNewButton = () => {
         <CollectionHeaderButton
           aria-label={t`Create a new collection`}
           icon="add_folder"
-          onClick={() => dispatch(setOpenModal("collection"))}
+          onClick={() => {
+            trackNewCollectionInitiated();
+            dispatch(setOpenModal("collection"));
+          }}
         />
       </div>
     </Tooltip>

--- a/frontend/src/metabase/collections/components/CollectionHeader/analytics.ts
+++ b/frontend/src/metabase/collections/components/CollectionHeader/analytics.ts
@@ -1,7 +1,7 @@
 import { trackSimpleEvent } from "metabase/lib/analytics";
 
-export const trackNewCollectionInitiated = () =>
+export const trackNewCollectionFromHeaderInitiated = () =>
   trackSimpleEvent({
     event: "plus_button_clicked",
-    triggered_from: "collection",
+    triggered_from: "collection-header",
   });

--- a/frontend/src/metabase/collections/components/CollectionHeader/analytics.ts
+++ b/frontend/src/metabase/collections/components/CollectionHeader/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackNewCollectionInitiated = () =>
+  trackSimpleEvent({
+    event: "plus_button_clicked",
+    triggered_from: "collection",
+  });

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -10,6 +10,8 @@ import { setOpenModal } from "metabase/redux/ui";
 import { getSetting } from "metabase/selectors/settings";
 import type { CollectionId } from "metabase-types/api";
 
+import { trackNewMenuItemClicked } from "./analytics";
+
 type NewMenuItem = {
   title: string;
   icon: string;
@@ -53,6 +55,7 @@ const NewItemMenu = ({
     const items: NewMenuItem[] = [];
 
     if (hasDataAccess) {
+      // TODO: Add anon tracking once we enable onClick
       items.push({
         title: t`Question`,
         icon: "insight",
@@ -67,6 +70,7 @@ const NewItemMenu = ({
     }
 
     if (hasNativeWrite) {
+      // TODO: Add anon tracking once we enable onClick
       items.push({
         title: hasDatabaseWithJsonEngine ? t`Native query` : t`SQL query`,
         icon: "sql",
@@ -84,7 +88,10 @@ const NewItemMenu = ({
     items.push({
       title: t`Dashboard`,
       icon: "dashboard",
-      action: () => dispatch(setOpenModal("dashboard")),
+      action: () => {
+        trackNewMenuItemClicked("dashboard");
+        dispatch(setOpenModal("dashboard"));
+      },
     });
 
     return items;
@@ -101,6 +108,8 @@ const NewItemMenu = ({
   return (
     <EntityMenu
       className={className}
+      // To the best of my knowledge, entity menu items with a `link` prop
+      // do not have `onClick`handlers. Hence, we cannot track their clicks.
       items={menuItems}
       trigger={trigger}
       triggerIcon={triggerIcon}

--- a/frontend/src/metabase/components/NewItemMenu/analytics.ts
+++ b/frontend/src/metabase/components/NewItemMenu/analytics.ts
@@ -1,0 +1,9 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackNewMenuItemClicked = (
+  item: "question" | "native-query" | "dashboard",
+) =>
+  trackSimpleEvent({
+    event: "new_button_item_clicked",
+    triggered_from: item,
+  });

--- a/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
+++ b/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
@@ -4,6 +4,7 @@ import NewItemMenu from "metabase/containers/NewItemMenu";
 import type { CollectionId } from "metabase-types/api";
 
 import { NewButton, NewButtonText } from "./NewItemButton.styled";
+import { trackAppNewButtonClicked } from "./analytics";
 
 export interface NewItemButtonProps {
   collectionId?: CollectionId;
@@ -13,7 +14,12 @@ const NewItemButton = ({ collectionId }: NewItemButtonProps) => {
   return (
     <NewItemMenu
       trigger={
-        <NewButton primary icon="add" aria-label={t`New`}>
+        <NewButton
+          primary
+          icon="add"
+          aria-label={t`New`}
+          onClick={() => trackAppNewButtonClicked()}
+        >
           <NewButtonText>{t`New`}</NewButtonText>
         </NewButton>
       }

--- a/frontend/src/metabase/nav/components/NewItemButton/analytics.ts
+++ b/frontend/src/metabase/nav/components/NewItemButton/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackAppNewButtonClicked = () =>
+  trackSimpleEvent({
+    event: "new_button_clicked",
+    triggered_from: "app-bar",
+  });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -42,7 +42,10 @@ import {
 import { SidebarCollectionLink } from "../SidebarItems";
 import { AddDatabase } from "../SidebarItems/AddDatabase";
 import { DwhUploadMenu } from "../SidebarItems/DwhUpload";
-import { trackOnboardingChecklistOpened } from "../analytics";
+import {
+  trackNewCollectionFromNavInitiated,
+  trackOnboardingChecklistOpened,
+} from "../analytics";
 import type { SelectedItem } from "../types";
 
 import BookmarkList from "./BookmarkList";
@@ -300,6 +303,7 @@ function CollectionSectionHeading({
           aria-label={t`Create a new collection`}
           color="var(--mb-color-text-medium)"
           onClick={() => {
+            trackNewCollectionFromNavInitiated();
             handleCreateNewCollection();
           }}
         >

--- a/frontend/src/metabase/nav/containers/MainNavbar/analytics.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/analytics.ts
@@ -5,3 +5,9 @@ export const trackOnboardingChecklistOpened = () => {
     event: "onboarding_checklist_opened",
   });
 };
+
+export const trackNewCollectionFromNavInitiated = () =>
+  trackSimpleEvent({
+    event: "plus_button_clicked",
+    triggered_from: "collection-nav",
+  });


### PR DESCRIPTION
Resolves PRG-30

This PR adds analytics to the:
1. New button being clicked
    - In the top app bar
    - From the empty collection
2. New menu individual items being clicked:
    - Dashboard
    - ~Question~ (not possible at the moment)
    - ~Native query~ (not possible at the moment)
3. An entity creation being initiated
    - Model from the `/browse/models` page
    - Metric from the `/browse/metrics` page
    - Collection from the collection header
    - Collection from the main nav sidebar

> [!IMPORTANT]
> The product doc states that we need to add analytics to the individual "New" menu item clicks. That component is using the deprecated `EntityMenu` component which doesn't have the notion of `onClick` when the menu item is a link (which both question and native query are). Implementing analytics for these individual items requires a significant refactor of `frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx` component. It should not be a part of this PR.
>
> I have prepared the schema for those events, though.
>
> Outstanding issue tracked in PRG-32