### PR TITLE
do not store all computed settings values in viz definitions

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -451,4 +451,37 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       cy.findByText("Created At: Month").should("exist");
     });
   });
+
+  it("should not store all computed settings in visualizer settings (VIZ-905)", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+
+      H.editDashboard();
+
+      H.openQuestionsSidebar();
+      H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
+      H.modal().within(() => {
+        H.switchToAddMoreData();
+        H.addDataset("Products by Created At (Month)");
+      });
+      H.saveDashcardVisualizerModal("create");
+      H.saveDashboard();
+
+      cy.intercept("GET", `/api/dashboard/${dashboardId}*`).as("dashboardLoad");
+      cy.reload();
+
+      cy.wait("@dashboardLoad").then(({ response }) => {
+        const visualizerSettings =
+          response?.body?.dashcards[0]?.visualization_settings?.visualization
+            ?.settings;
+
+        expect(Object.keys(visualizerSettings)).to.have.length(3);
+        expect(visualizerSettings).to.eql({
+          "card.title": "Orders by Created At (Month)",
+          "graph.dimensions": ["COLUMN_1", "COLUMN_4"],
+          "graph.metrics": ["COLUMN_2", "COLUMN_3"],
+        });
+      });
+    });
+  });
 });

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -445,8 +445,9 @@ describe("scenarios > dashboard > visualizer > basics", () => {
 
     // Making sure the card renders
     H.getDashboardCard(0).within(() => {
-      cy.findByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
-        "exist",
+      cy.findAllByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
+        "have.length",
+        2,
       );
       cy.findByText("Created At: Month").should("exist");
     });

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -31,6 +31,7 @@ import type {
 import {
   getCurrentVisualizerState,
   getVisualizerComputedSettingsForFlatSeries,
+  getVisualizerTransformedSeries,
 } from "./selectors";
 import {
   copyColumn,
@@ -191,13 +192,25 @@ export const addDataSource = createAsyncThunk(
       throw new Error(`Could not get data source or dataset for: ${sourceId}`);
     }
 
+    // Computed settings include all settings with their default values, including derived settings
     const computedSettings =
       getVisualizerComputedSettingsForFlatSeries(getState());
+
+    // When we add a new data source and we want to understand whether it can be combined with the existing data source
+    // we only need to look at the data settings such as metrics and dimensions: 'graph.dimensions' and 'graph.metrics' for cartesian charts,
+    // 'funnel.metric' and 'funnel.dimension' for funnel charts, etc. If we use full computed settings here, when saving the state
+    // we will store all settings with their default values, including derived settings.
+    const dataSettings = getColumnVizSettings(state.display);
+    const transformedSeries = getVisualizerTransformedSeries(getState());
+    const settings = {
+      ...transformedSeries[0].card.visualization_settings,
+      ..._.pick(computedSettings, dataSettings),
+    };
 
     return maybeCombineDataset(
       {
         ...copy(state),
-        settings: computedSettings,
+        settings,
       },
       dataSource,
       dataset,


### PR DESCRIPTION
Closes [VIZ-905](https://linear.app/metabase/issue/VIZ-905/do-not-store-computed-visualization-settings-in-the-visualizer-entity)

### Description

Before this PR we stored all computed visualization settings in viz definitions. They include computed defaults and even only derived settings that should never be stored. This PR ensures only changed by user settings are stored in addition to data settings such as metrics, dimensions that are crucial for rendering a chart.

### How to verify

- Create a visualizer card from multiple datasets
- Save a dashboard
- Inspect settings got saved and ensure there are only changed values and data (dimensions, metrics) settings

### Demo

Stores only changed settings:

<img width="975" alt="Screenshot 2025-05-06 at 6 34 14 PM" src="https://github.com/user-attachments/assets/05f34cd2-6e7b-4422-bb6c-4c3466da08f8" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
