### PR TITLE
[VISUALIZER] Add fallback to assoc-attachment-booleans

### DIFF
--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -109,7 +109,7 @@
         :let [result-dashboard-card-id (:id (:dashcard result))
               is-visualizer-part (render.util/is-visualizer-dashcard? (:dashcard result))
               ;; For visualizer dashcards we match on both card_id and dashboard_card_id
-              ;; To disambiguate between regulard cards and regular cards that were turned into visualizer dashcards
+              ;; To disambiguate between regular cards and regular cards that were turned into visualizer dashcards
               noti-dashcard (or (and is-visualizer-part
                                      (m/find-first (fn [config]
                                                      (and (= (:card_id config) result-card-id)

--- a/test/metabase/channel/impl/email_test.clj
+++ b/test/metabase/channel/impl/email_test.clj
@@ -3,6 +3,8 @@
    [clojure.test :refer :all]
    [metabase.channel.core :as channel]
    [metabase.channel.email :as email]
+   [metabase.channel.impl.email :as email.impl]
+   [metabase.channel.render.util :as render.util]
    [metabase.test :as mt]))
 
 (deftest bcc-enabled-test
@@ -20,3 +22,46 @@
                                                  :message      "Test message"})
           (is (=? {:to ["ngoc@metabase.com"]}
                   @sent-message)))))))
+
+(deftest assoc-attachment-booleans-test
+  (testing "assoc-attachment-booleans function"
+    (testing "handles visualizer dashcards by matching on both card_id and dashboard_card_id"
+      (let [;; Create a visualizer dashcard
+            visualizer-dashcard {:id 100
+                                 :visualization_settings {:visualization {}}}
+            ;; Create a part with visualizer dashcard
+            visualizer-part {:card {:id 1 :name "Visualizer Card"}
+                             :dashcard visualizer-dashcard}
+            ;; Create a part config that matches on both card_id and dashboard_card_id
+            matching-part-config {:card_id 1
+                                  :dashboard_card_id 100
+                                  :include_csv true
+                                  :include_xls true}
+            ;; Call the function
+            ;; Use with-redefs to mock is-visualizer-dashcard? to return true
+            result (with-redefs [render.util/is-visualizer-dashcard? (constantly true)]
+                     (#'email.impl/assoc-attachment-booleans [matching-part-config] [visualizer-part]))]
+
+        (is (= true (-> result first :card :include_csv))
+            "Should include CSV attachment setting from matching part config")
+        (is (= true (-> result first :card :include_xls))
+            "Should include XLS attachment setting from matching part config")))
+
+    (testing "falls back to matching on card_id only when no perfect visualizer match is found"
+      (let [;; Create a regular dashcard (not a visualizer)
+            regular-dashcard {:id 200}
+            ;; Create a part with regular dashcard
+            regular-part {:card {:id 2 :name "Regular Card"}
+                          :dashcard regular-dashcard}
+            ;; Create a part config that matches on card_id only
+            matching-part-config {:card_id 2
+                                  :dashboard_card_id 999 ;; Different from the dashcard.id
+                                  :include_csv true
+                                  :format_rows true}
+            ;; Call the function
+            result (#'email.impl/assoc-attachment-booleans [matching-part-config] [regular-part])]
+
+        (is (= true (-> result first :card :include_csv))
+            "Should include CSV attachment setting using the fallback match")
+        (is (= true (-> result first :card :format_rows))
+            "Should include format_rows setting using the fallback match")))))

--- a/test/metabase/channel/impl/email_test.clj
+++ b/test/metabase/channel/impl/email_test.clj
@@ -26,19 +26,14 @@
 (deftest assoc-attachment-booleans-test
   (testing "assoc-attachment-booleans function"
     (testing "handles visualizer dashcards by matching on both card_id and dashboard_card_id"
-      (let [;; Create a visualizer dashcard
-            visualizer-dashcard {:id 100
+      (let [visualizer-dashcard {:id 100
                                  :visualization_settings {:visualization {}}}
-            ;; Create a part with visualizer dashcard
             visualizer-part {:card {:id 1 :name "Visualizer Card"}
                              :dashcard visualizer-dashcard}
-            ;; Create a part config that matches on both card_id and dashboard_card_id
             matching-part-config {:card_id 1
                                   :dashboard_card_id 100
                                   :include_csv true
                                   :include_xls true}
-            ;; Call the function
-            ;; Use with-redefs to mock is-visualizer-dashcard? to return true
             result (with-redefs [render.util/is-visualizer-dashcard? (constantly true)]
                      (#'email.impl/assoc-attachment-booleans [matching-part-config] [visualizer-part]))]
 
@@ -48,17 +43,13 @@
             "Should include XLS attachment setting from matching part config")))
 
     (testing "falls back to matching on card_id only when no perfect visualizer match is found"
-      (let [;; Create a regular dashcard (not a visualizer)
-            regular-dashcard {:id 200}
-            ;; Create a part with regular dashcard
+      (let [regular-dashcard {:id 200}
             regular-part {:card {:id 2 :name "Regular Card"}
                           :dashcard regular-dashcard}
-            ;; Create a part config that matches on card_id only
             matching-part-config {:card_id 2
                                   :dashboard_card_id 999 ;; Different from the dashcard.id
                                   :include_csv true
                                   :format_rows true}
-            ;; Call the function
             result (#'email.impl/assoc-attachment-booleans [matching-part-config] [regular-part])]
 
         (is (= true (-> result first :card :include_csv))


### PR DESCRIPTION
### Problem

  Dashboard subscriptions were failing to include CSV/Excel attachments in some cases.

### Solution
  Modified the `assoc-attachment-booleans` function to use a more flexible matching strategy:
  1. First, try to match on both `card_id` and `dashboard_card_id` if both are present
  2. If no match is found, fall back to matching just on `card_id`

We added the dashboard_card_id match criteria to `assoc-attachment-booleans` as part of adding file attachment support in subscriptions for dashboards containing visualizer cards.