### PR TITLE
Fix #47301: Ensure consistent bookmark tooltip placement in sidebar

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.styled.tsx
@@ -2,6 +2,7 @@
 import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
+import { Tooltip } from "metabase/ui";
 
 import { DraggableSidebarLink } from "../../SidebarItems";
 
@@ -33,4 +34,8 @@ export const SidebarBookmarkItem = styled(DraggableSidebarLink)`
       outline: none;
     }
   }
+`;
+
+export const BookmarkTooltip = styled(Tooltip)`
+  margin-top: -8.5px;
 `;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -19,13 +19,13 @@ import Bookmarks from "metabase/entities/bookmarks";
 import { connect } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { Icon, Tooltip } from "metabase/ui";
+import { Icon } from "metabase/ui";
 import type { Bookmark } from "metabase-types/api";
 
 import { SidebarHeading } from "../../MainNavbar.styled";
 import type { SelectedItem } from "../../types";
 
-import { SidebarBookmarkItem } from "./BookmarkList.styled";
+import { BookmarkTooltip, SidebarBookmarkItem } from "./BookmarkList.styled";
 
 const mapDispatchToProps = {
   onDeleteBookmark: ({ item_id, type }: Bookmark) =>
@@ -95,11 +95,11 @@ const BookmarkItem = ({
         hasDefaultIconStyle={!isIrregularCollection}
         onClick={onSelect}
         right={
-          <button onClick={onRemove}>
-            <Tooltip label={t`Remove bookmark`} position="bottom">
+          <BookmarkTooltip label={t`Remove bookmark`} position="top">
+            <button onClick={onRemove} className="bookmark-remove-button">
               <Icon name={iconName} />
-            </Tooltip>
-          </button>
+            </button>
+          </BookmarkTooltip>
         }
       >
         {bookmark.name}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47301

### Description

Changed BookmarkTooltip position from bottom to top.

Moved BookmarkTooltip to BookmarkList.styled.tsx to simplify styling.

### How to verify

1.Bookmark a question with a very long name
2.Open sidebar
3.Hover bookmark title
     tooltip goes down

### Demo

Before:
![Screenshot 2025-05-07 110643](https://github.com/user-attachments/assets/5fdaba9f-00cf-43e6-b026-c176a2926e9c)
After:
![Screenshot 2025-05-07 110408](https://github.com/user-attachments/assets/27a71f8f-261b-4efd-8ec0-2aa87a217a35)

