### PR TITLE
Stabilize flaky Font Test

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.unit.spec.tsx
@@ -41,7 +41,7 @@ const setup = async (
 
   renderWithProviders(<FontWidget />);
   await screen.findByText("Font");
-  await waitFor(async () => {
+  return waitFor(async () => {
     const gets = await findRequests("GET");
     expect(gets).toHaveLength(2);
   });
@@ -260,7 +260,8 @@ describe("FontWidget", () => {
 });
 
 async function clickSelect(from: string, to: string) {
-  const input = (await screen.findAllByDisplayValue(from))[0];
+  const input = await screen.findByRole("textbox", { name: "Font" });
+  expect(input).toHaveValue(from);
   await userEvent.click(input);
   const option = await screen.findByText(to);
   return userEvent.click(option);


### PR DESCRIPTION
### Description

closes dev-478

For selects, mantine actually has 2 input elements, and I think selecting the first of them to interact with can be somewhat unstable

✅ [this branch stress test](https://github.com/metabase/metabase/actions/runs/14885541960/job/41804034082)