### PR TITLE
Remove unused code in embedding data picker

### DIFF
--- a/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
@@ -106,7 +106,6 @@ export class UnconnectedDataSelector extends Component {
     containerClassName: PropTypes.string,
     canSelectModel: PropTypes.bool,
     canSelectTable: PropTypes.bool,
-    canSelectSavedQuestion: PropTypes.bool,
 
     // from search entity list loader
     allError: PropTypes.bool,
@@ -137,7 +136,6 @@ export class UnconnectedDataSelector extends Component {
     isMantine: false,
     canSelectModel: true,
     canSelectTable: true,
-    canSelectSavedQuestion: true,
   };
 
   isPopoverOpen() {
@@ -402,36 +400,17 @@ export class UnconnectedDataSelector extends Component {
     return this.hasModels() && this.props.hasNestedQueriesEnabled;
   };
 
-  hasSavedQuestions = () => {
-    const { canSelectSavedQuestion } = this.props;
-    return (
-      this.state.databases.some((database) => database.is_saved_questions) &&
-      canSelectSavedQuestion
-    );
-  };
-
   getDatabases = () => {
     const { databases } = this.state;
 
-    // When there is at least one dataset,
-    // "Saved Questions" are presented in a different picker step
-    // So it should be excluded from a regular databases list
-    const shouldRemoveSavedQuestionDatabaseFromList =
-      !this.props.hasNestedQueriesEnabled ||
-      this.hasUsableModels() ||
-      !this.props.canSelectSavedQuestion;
-
-    return shouldRemoveSavedQuestionDatabaseFromList
-      ? databases.filter((db) => !db.is_saved_questions)
-      : databases;
+    return databases.filter((db) => !db.is_saved_questions);
   };
 
   async hydrateActiveStep() {
     const { steps } = this.props;
     if (
       this.isSavedEntitySelected() ||
-      this.state.selectedDataBucketId === DATA_BUCKET.MODELS ||
-      this.state.selectedDataBucketId === DATA_BUCKET.SAVED_QUESTIONS
+      this.state.selectedDataBucketId === DATA_BUCKET.MODELS
     ) {
       await this.switchToStep(DATABASE_STEP);
     } else if (this.state.selectedTableId && steps.includes(FIELD_STEP)) {
@@ -824,7 +803,6 @@ export class UnconnectedDataSelector extends Component {
                 hasModels: this.hasModels(),
                 hasTables: this.props.canSelectTable,
                 hasNestedQueriesEnabled,
-                hasSavedQuestions: this.hasSavedQuestions(),
               })}
               {...props}
             />

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
@@ -571,22 +571,13 @@ export class UnconnectedDataSelector extends Component {
     const loadersForSteps = {
       // NOTE: make sure to return the action's resulting promise
       [DATA_BUCKET_STEP]: () => {
-        return Promise.all([
-          this.props.fetchDatabases(this.props.databaseQuery),
-          this.props.fetchDatabases({ saved: true }),
-        ]);
+        return this.props.fetchDatabases();
       },
       [DATABASE_STEP]: () => {
-        return Promise.all([
-          this.props.fetchDatabases(this.props.databaseQuery),
-          this.props.fetchDatabases({ saved: true }),
-        ]);
+        return this.props.fetchDatabases();
       },
       [SCHEMA_STEP]: () => {
-        return Promise.all([
-          this.props.fetchDatabases(this.props.databaseQuery),
-          this.props.fetchSchemas(this.state.selectedDatabaseId),
-        ]);
+        return this.props.fetchSchemas(this.state.selectedDatabaseId);
       },
       [TABLE_STEP]: () => {
         if (this.state.selectedSchemaId != null) {
@@ -959,7 +950,7 @@ const DataSelector = _.compose(
       databases:
         ownProps.databases ||
         Databases.selectors.getList(state, {
-          entityQuery: ownProps.databaseQuery,
+          entityQuery: { saved: true },
         }) ||
         [],
       hasLoadedDatabasesWithTablesSaved: Databases.selectors.getLoaded(state, {
@@ -978,8 +969,7 @@ const DataSelector = _.compose(
       }),
     }),
     {
-      fetchDatabases: (databaseQuery) =>
-        Databases.actions.fetchList(databaseQuery),
+      fetchDatabases: () => Databases.actions.fetchList({ saved: true }),
       fetchSchemas: (databaseId) =>
         Schemas.actions.fetchList({ dbId: databaseId }),
       fetchSchemaTables: (schemaId) => Schemas.actions.fetch({ id: schemaId }),

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
@@ -379,17 +379,6 @@ export class UnconnectedDataSelector extends Component {
     return this.props.loading;
   };
 
-  getCardType() {
-    const { selectedDataBucketId, savedEntityType } = this.state;
-    switch (true) {
-      case selectedDataBucketId === DATA_BUCKET.MODELS ||
-        savedEntityType === "model":
-        return "model";
-      default:
-        return "question";
-    }
-  }
-
   hasModels = () => {
     const { availableModels, canSelectModel, loaded } = this.props;
     return loaded && canSelectModel && availableModels.includes("dataset");
@@ -871,7 +860,6 @@ export class UnconnectedDataSelector extends Component {
         return (
           <SavedEntityPicker
             collectionId={selectedCollectionId}
-            type={this.getCardType()}
             tableId={selectedTable?.id}
             databaseId={currentDatabaseId}
             onSelect={this.handleSavedEntitySelect}

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector.jsx
@@ -30,12 +30,7 @@ import DatabaseSchemaPicker from "./DataSelectorDatabaseSchemaPicker";
 import FieldPicker from "./DataSelectorFieldPicker";
 import SchemaPicker from "./DataSelectorSchemaPicker";
 import TablePicker from "./DataSelectorTablePicker";
-import {
-  DatabaseTrigger,
-  FieldTrigger,
-  TableTrigger,
-  Trigger,
-} from "./TriggerComponents";
+import { TableTrigger, Trigger } from "./TriggerComponents";
 import { CONTAINER_WIDTH, DATA_BUCKET } from "./constants";
 import SavedEntityPicker from "./saved-entity-picker/SavedEntityPicker";
 import { getDataTypes } from "./utils";
@@ -62,59 +57,6 @@ export function DataSourceSelector(props) {
       steps={[DATA_BUCKET_STEP, DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
       combineDatabaseSchemaSteps
       getTriggerElementContent={TableTrigger}
-      {...props}
-    />
-  );
-}
-
-export function DatabaseDataSelector(props) {
-  return (
-    <DataSelector
-      steps={[DATABASE_STEP]}
-      getTriggerElementContent={DatabaseTrigger}
-      {...props}
-    />
-  );
-}
-
-export function DatabaseSchemaAndTableDataSelector(props) {
-  return (
-    <DataSelector
-      steps={[DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
-      combineDatabaseSchemaSteps
-      getTriggerElementContent={TableTrigger}
-      {...props}
-    />
-  );
-}
-
-export function SchemaAndTableDataSelector(props) {
-  return (
-    <DataSelector
-      steps={[SCHEMA_STEP, TABLE_STEP]}
-      getTriggerElementContent={TableTrigger}
-      {...props}
-    />
-  );
-}
-
-export function SchemaTableAndFieldDataSelector(props) {
-  return (
-    <DataSelector
-      steps={[SCHEMA_STEP, TABLE_STEP, FIELD_STEP]}
-      getTriggerElementContent={FieldTrigger}
-      // We don't want to change styles when there's a different trigger element
-      isMantine={!props.getTriggerElementContent}
-      {...props}
-    />
-  );
-}
-
-export function FieldDataSelector(props) {
-  return (
-    <DataSelector
-      steps={[FIELD_STEP]}
-      getTriggerElementContent={FieldTrigger}
       {...props}
     />
   );

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector.unit.spec.js
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector.unit.spec.js
@@ -1,21 +1,13 @@
 import userEvent from "@testing-library/user-event";
 
 import { createMockMetadata } from "__support__/metadata";
-import { getIcon, render, renderWithProviders, screen } from "__support__/ui";
+import { getIcon, render, screen } from "__support__/ui";
 import { delay } from "__support__/utils";
-import {
-  createMockDatabase,
-  createMockSavedQuestionsDatabase,
-  createMockTable,
-} from "metabase-types/api/mocks";
+import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 import {
   SAMPLE_DB_ID,
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
-import {
-  createMockSettingsState,
-  createMockState,
-} from "metabase-types/store/mocks";
 
 import { UnconnectedDataSelector as DataSelector } from "./DataSelector";
 
@@ -75,11 +67,6 @@ describe("DataSelector", () => {
 
   const metadata = createMockMetadata({ databases });
   const emptyMetadata = createMockMetadata({});
-  const storeInitialState = createMockState({
-    settings: createMockSettingsState({
-      "enable-nested-queries": true,
-    }),
-  });
 
   const SAMPLE_DATABASE = metadata.database(SAMPLE_DB_ID);
   const ANOTHER_DATABASE = metadata.database(EMPTY_DB_ID);
@@ -87,7 +74,6 @@ describe("DataSelector", () => {
   const OTHER_MULTI_SCHEMA_DATABASE = metadata.database(
     OTHER_MULTI_SCHEMA_DB_ID,
   );
-  const SAVED_QUESTIONS_DATABASE = createMockSavedQuestionsDatabase();
 
   it("should allow selecting db, schema, and table", async () => {
     const setTable = jest.fn();
@@ -458,43 +444,5 @@ describe("DataSelector", () => {
     expect(
       screen.getByText("To pick some data, you'll need to add some first"),
     ).toBeInTheDocument();
-  });
-
-  it("should show 'Saved Questions' option when there are saved questions", async () => {
-    renderWithProviders(
-      <DataSelector
-        availableModels={[]}
-        steps={["BUCKET", "DATABASE", "SCHEMA", "TABLE"]}
-        combineDatabaseSchemaSteps
-        databases={[SAMPLE_DATABASE, SAVED_QUESTIONS_DATABASE]}
-        hasNestedQueriesEnabled
-        loaded
-        search={[{}]}
-        triggerElement={<div />}
-        isOpen
-      />,
-      { storeInitialState },
-    );
-
-    expect(screen.getByText("Saved Questions")).toBeInTheDocument();
-  });
-
-  it("should not show 'Saved Questions' option when there are no saved questions (metabase#29760)", () => {
-    renderWithProviders(
-      <DataSelector
-        availableModels={[]}
-        steps={["BUCKET", "DATABASE", "SCHEMA", "TABLE"]}
-        combineDatabaseSchemaSteps
-        databases={[SAMPLE_DATABASE]}
-        hasNestedQueriesEnabled
-        loaded
-        search={[{}]}
-        triggerElement={<div />}
-        isOpen
-      />,
-      { storeInitialState },
-    );
-
-    expect(screen.queryByText("Saved Questions")).not.toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
@@ -25,7 +25,6 @@ describe("DataSelectorDataBucketPicker", () => {
 
     expect(screen.getByText("Models")).toBeInTheDocument();
     expect(screen.getByText("Raw Data")).toBeInTheDocument();
-    expect(screen.getByText("Saved Questions")).toBeInTheDocument();
     expect(screen.queryAllByTestId("data-bucket-list-item").length).toBe(
       dataTypes.length,
     );
@@ -37,7 +36,6 @@ describe("DataSelectorDataBucketPicker", () => {
 
     expect(screen.queryByText("Models")).not.toBeInTheDocument();
     expect(screen.queryByText("Raw Data")).not.toBeInTheDocument();
-    expect(screen.queryByText("Saved Questions")).not.toBeInTheDocument();
     expect(screen.queryAllByTestId("data-bucket-list-item").length).toBe(
       dataTypes.length,
     );

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
@@ -19,7 +19,6 @@ describe("DataSelectorDataBucketPicker", () => {
     const dataTypes = getDataTypes({
       hasModels: true,
       hasTables: true,
-      hasMetrics: false,
       hasSavedQuestions: true,
       hasNestedQueriesEnabled: true,
     });

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
@@ -19,7 +19,6 @@ describe("DataSelectorDataBucketPicker", () => {
     const dataTypes = getDataTypes({
       hasModels: true,
       hasTables: true,
-      hasSavedQuestions: true,
       hasNestedQueriesEnabled: true,
     });
     setup(dataTypes);

--- a/enterprise/frontend/src/embedding/data-picker/constants.ts
+++ b/enterprise/frontend/src/embedding/data-picker/constants.ts
@@ -7,7 +7,6 @@ export const CONTAINER_WIDTH = 300;
 export const DATA_BUCKET: Record<string, DataPickerDataType> = {
   MODELS: "models",
   RAW_DATA: "raw-data",
-  SAVED_QUESTIONS: "questions",
 } as const;
 
 export const MODELS_INFO_ITEM: DataTypeInfoItem = {
@@ -29,16 +28,5 @@ export const RAW_DATA_INFO_ITEM: DataTypeInfoItem = {
   },
   get description() {
     return t`Unaltered tables in connected databases.`;
-  },
-};
-
-export const SAVED_QUESTIONS_INFO_ITEM: DataTypeInfoItem = {
-  id: DATA_BUCKET.SAVED_QUESTIONS,
-  icon: "folder",
-  get name() {
-    return t`Saved Questions`;
-  },
-  get description() {
-    return t`Use any question’s results to start a new question.`;
   },
 };

--- a/enterprise/frontend/src/embedding/data-picker/constants.ts
+++ b/enterprise/frontend/src/embedding/data-picker/constants.ts
@@ -8,7 +8,6 @@ export const DATA_BUCKET: Record<string, DataPickerDataType> = {
   MODELS: "models",
   RAW_DATA: "raw-data",
   SAVED_QUESTIONS: "questions",
-  METRICS: "metrics",
 } as const;
 
 export const MODELS_INFO_ITEM: DataTypeInfoItem = {
@@ -41,16 +40,5 @@ export const SAVED_QUESTIONS_INFO_ITEM: DataTypeInfoItem = {
   },
   get description() {
     return t`Use any question’s results to start a new question.`;
-  },
-};
-
-export const METRICS_INFO_ITEM: DataTypeInfoItem = {
-  id: DATA_BUCKET.METRICS,
-  icon: "metric",
-  get name() {
-    return t`Metrics`;
-  },
-  get description() {
-    return t`Trustworthy definitions to start from.`;
   },
 };

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityList.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityList.tsx
@@ -9,14 +9,13 @@ import { PERSONAL_COLLECTIONS } from "metabase/entities/collections/constants";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { Box } from "metabase/ui";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type { CardType, Collection, DatabaseId } from "metabase-types/api";
+import type { Collection, DatabaseId } from "metabase-types/api";
 import { SortDirection } from "metabase-types/api/sorting";
 
 import SavedEntityListS from "./SavedEntityList.module.css";
 import { CARD_INFO } from "./constants";
 
 interface SavedEntityListProps {
-  type: CardType;
   selectedId: string;
   databaseId: DatabaseId;
   collection?: Collection;
@@ -24,7 +23,6 @@ interface SavedEntityListProps {
 }
 
 const SavedEntityList = ({
-  type,
   selectedId,
   databaseId,
   collection,
@@ -42,7 +40,7 @@ const SavedEntityList = ({
     collection && !isVirtualCollection
       ? {
           id: collection.id,
-          models: [CARD_INFO[type].model],
+          models: [CARD_INFO.model.model],
           sort_column: "name",
           sort_direction: SortDirection.Asc,
         }
@@ -79,7 +77,7 @@ const SavedEntityList = ({
                   size="small"
                   name={name}
                   icon={{
-                    name: CARD_INFO[type].icon,
+                    name: CARD_INFO.model.icon,
                     size: 16,
                   }}
                   onSelect={() => onSelect(virtualTableId)}

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.jsx
@@ -46,7 +46,6 @@ const ALL_PERSONAL_COLLECTIONS_ROOT = {
 };
 
 function SavedEntityPicker({
-  type,
   onBack,
   onSelect,
   collections,
@@ -57,7 +56,7 @@ function SavedEntityPicker({
   rootCollection,
 }) {
   const collectionTree = useMemo(() => {
-    const modelFilter = (model) => CARD_INFO[type].model === model;
+    const modelFilter = (model) => CARD_INFO.model.model === model;
 
     const preparedCollections = [];
     const userPersonalCollections = currentUserPersonalCollections(
@@ -90,7 +89,7 @@ function SavedEntityPicker({
       ...(rootCollection ? [getOurAnalyticsCollection(rootCollection)] : []),
       ...buildCollectionTree(preparedCollections, modelFilter),
     ];
-  }, [collections, rootCollection, currentUser, type]);
+  }, [collections, rootCollection, currentUser]);
 
   const initialCollection = useMemo(
     () => findCollectionById(collectionTree, collectionId) ?? collectionTree[0],
@@ -117,7 +116,7 @@ function SavedEntityPicker({
           data-testid="saved-entity-back-navigation"
         >
           <Icon name="chevronleft" className={CS.mr1} />
-          {CARD_INFO[type].title}
+          {CARD_INFO.model.title}
         </a>
         <Box m="0.5rem 0" data-testid="saved-entity-collection-tree">
           <Tree
@@ -128,7 +127,6 @@ function SavedEntityPicker({
         </Box>
       </Box>
       <SavedEntityList
-        type={type}
         collection={selectedCollection}
         selectedId={tableId}
         databaseId={databaseId}

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.jsx
@@ -73,11 +73,7 @@ async function setup() {
   mockCollectionItemsEndpoint();
 
   renderWithProviders(
-    <SavedEntityPicker
-      type="question"
-      onSelect={jest.fn()}
-      onBack={jest.fn()}
-    />,
+    <SavedEntityPicker onSelect={jest.fn()} onBack={jest.fn()} />,
   );
   await waitForLoaderToBeRemoved();
 }

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/SavedEntityPicker.unit.spec.jsx
@@ -24,12 +24,12 @@ const COLLECTIONS = {
     id: CURRENT_USER.personal_collection_id,
     name: "My personal collection",
     personal_owner_id: CURRENT_USER.id,
-    here: ["card"],
+    here: ["dataset"],
   }),
   REGULAR: createMockCollection({
     id: 1,
     name: "Regular collection",
-    here: ["card"],
+    here: ["dataset"],
   }),
 };
 
@@ -48,17 +48,20 @@ function mockCollectionItemsEndpoint() {
         createMockCollectionItem({
           id: 2,
           name: "a",
+          model: "dataset",
         }),
         createMockCollectionItem({
           id: 3,
           name: "A",
+          model: "dataset",
         }),
         createMockCollectionItem({
           id: 1,
           name: "B",
+          model: "dataset",
         }),
       ],
-      models: ["card"],
+      models: ["dataset"],
       limit: null,
       offset: null,
     },

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/constants.ts
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/constants.ts
@@ -1,25 +1,11 @@
 import { t } from "ttag";
 
 export const CARD_INFO = {
-  question: {
-    get title() {
-      return t`Saved Questions`;
-    },
-    model: "card",
-    icon: "table2",
-  },
   model: {
     get title() {
       return t`Models`;
     },
     model: "dataset",
     icon: "model",
-  },
-  metric: {
-    get title() {
-      return t`Metrics`;
-    },
-    model: "metric",
-    icon: "metric",
   },
 } as const;

--- a/enterprise/frontend/src/embedding/data-picker/types.ts
+++ b/enterprise/frontend/src/embedding/data-picker/types.ts
@@ -1,10 +1,6 @@
 import type { IconName } from "metabase/ui";
 
-export type DataPickerDataType =
-  | "models"
-  | "raw-data"
-  | "questions"
-  | "metrics";
+export type DataPickerDataType = "models" | "raw-data" | "questions";
 
 export type DataTypeInfoItem = {
   id: DataPickerDataType;

--- a/enterprise/frontend/src/embedding/data-picker/types.ts
+++ b/enterprise/frontend/src/embedding/data-picker/types.ts
@@ -1,6 +1,6 @@
 import type { IconName } from "metabase/ui";
 
-export type DataPickerDataType = "models" | "raw-data" | "questions";
+export type DataPickerDataType = "models" | "raw-data";
 
 export type DataTypeInfoItem = {
   id: DataPickerDataType;

--- a/enterprise/frontend/src/embedding/data-picker/utils.ts
+++ b/enterprise/frontend/src/embedding/data-picker/utils.ts
@@ -1,5 +1,4 @@
 import {
-  METRICS_INFO_ITEM,
   MODELS_INFO_ITEM,
   RAW_DATA_INFO_ITEM,
   SAVED_QUESTIONS_INFO_ITEM,
@@ -11,13 +10,11 @@ export function getDataTypes({
   hasTables,
   hasNestedQueriesEnabled,
   hasSavedQuestions,
-  hasMetrics,
 }: {
   hasTables: boolean;
   hasModels: boolean;
   hasNestedQueriesEnabled: boolean;
   hasSavedQuestions: boolean;
-  hasMetrics: boolean;
 }): DataTypeInfoItem[] {
   const dataTypes: DataTypeInfoItem[] = [];
 
@@ -31,10 +28,6 @@ export function getDataTypes({
 
   if (hasNestedQueriesEnabled && hasSavedQuestions) {
     dataTypes.push(SAVED_QUESTIONS_INFO_ITEM);
-  }
-
-  if (hasNestedQueriesEnabled && hasMetrics) {
-    dataTypes.push(METRICS_INFO_ITEM);
   }
 
   return dataTypes;

--- a/enterprise/frontend/src/embedding/data-picker/utils.ts
+++ b/enterprise/frontend/src/embedding/data-picker/utils.ts
@@ -1,20 +1,14 @@
-import {
-  MODELS_INFO_ITEM,
-  RAW_DATA_INFO_ITEM,
-  SAVED_QUESTIONS_INFO_ITEM,
-} from "./constants";
+import { MODELS_INFO_ITEM, RAW_DATA_INFO_ITEM } from "./constants";
 import type { DataTypeInfoItem } from "./types";
 
 export function getDataTypes({
   hasModels,
   hasTables,
   hasNestedQueriesEnabled,
-  hasSavedQuestions,
 }: {
   hasTables: boolean;
   hasModels: boolean;
   hasNestedQueriesEnabled: boolean;
-  hasSavedQuestions: boolean;
 }): DataTypeInfoItem[] {
   const dataTypes: DataTypeInfoItem[] = [];
 
@@ -24,10 +18,6 @@ export function getDataTypes({
 
   if (hasTables) {
     dataTypes.push(RAW_DATA_INFO_ITEM);
-  }
-
-  if (hasNestedQueriesEnabled && hasSavedQuestions) {
-    dataTypes.push(SAVED_QUESTIONS_INFO_ITEM);
   }
 
   return dataTypes;

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -1,9 +1,7 @@
-import type Database from "metabase-lib/v1/metadata/Database";
 import type { TableId } from "metabase-types/api";
 
 export interface DataSourceSelectorProps {
   isInitiallyOpen: boolean;
-  databases: Database[] | undefined;
   canChangeDatabase: boolean;
   selectedDatabaseId: number | null;
   selectedTableId: TableId | undefined;

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -11,7 +11,6 @@ export interface DataSourceSelectorProps {
   databaseQuery: { saved: boolean };
   canSelectModel: boolean;
   canSelectTable: boolean;
-  canSelectSavedQuestion: boolean;
   triggerElement: JSX.Element;
   setSourceTableFn: (tableId: TableId) => void;
 }

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -11,7 +11,6 @@ export interface DataSourceSelectorProps {
   databaseQuery: { saved: boolean };
   canSelectModel: boolean;
   canSelectTable: boolean;
-  canSelectMetric: boolean;
   canSelectSavedQuestion: boolean;
   triggerElement: JSX.Element;
   setSourceTableFn: (tableId: TableId) => void;

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -8,7 +8,6 @@ export interface DataSourceSelectorProps {
   selectedDatabaseId: number | null;
   selectedTableId: TableId | undefined;
   selectedCollectionId: number | null | undefined;
-  databaseQuery: { saved: boolean };
   canSelectModel: boolean;
   canSelectTable: boolean;
   triggerElement: JSX.Element;

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -1,12 +1,8 @@
-import { useMemo } from "react";
-
 import { skipToken, useGetCardQuery, useSearchQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING } from "metabase/plugins";
 import { getEmbedOptions } from "metabase/selectors/embed";
-import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
-import type Database from "metabase-lib/v1/metadata/Database";
 import type { TableId } from "metabase-types/api";
 
 import { DataPickerTarget } from "../DataPickerTarget";
@@ -42,24 +38,6 @@ export function EmbeddingDataPicker({
   const { data: card } = useGetCardQuery(
     pickerInfo?.cardId != null ? { id: pickerInfo.cardId } : skipToken,
   );
-
-  const metadata = useSelector(getMetadata);
-  const databases = useMemo(() => {
-    // We're joining data
-    if (!canChangeDatabase) {
-      return [
-        metadata.database(databaseId),
-        metadata.savedQuestionsDatabase(),
-      ].filter(Boolean) as Database[];
-    }
-
-    /**
-     * When not joining data, we want to use all databases loaded inside `DataSourceSelector`
-     *
-     * @see https://github.com/metabase/metabase/blob/fb25682fe8dbafe2062e37bce832f62440872ab7/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx#L1163-L1168
-     */
-    return undefined;
-  }, [canChangeDatabase, databaseId, metadata]);
 
   const entityTypes = useSelector(
     (state) => getEmbedOptions(state).entity_types,
@@ -100,7 +78,6 @@ export function EmbeddingDataPicker({
     <PLUGIN_EMBEDDING.DataSourceSelector
       key={pickerInfo?.tableId}
       isInitiallyOpen={!table}
-      databases={databases}
       canChangeDatabase={canChangeDatabase}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -108,7 +108,6 @@ export function EmbeddingDataPicker({
       databaseQuery={{ saved: true }}
       canSelectModel={entityTypes.includes("model")}
       canSelectTable={entityTypes.includes("table")}
-      canSelectSavedQuestion={false}
       triggerElement={
         <DataPickerTarget
           tableInfo={tableInfo}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -108,7 +108,6 @@ export function EmbeddingDataPicker({
       databaseQuery={{ saved: true }}
       canSelectModel={entityTypes.includes("model")}
       canSelectTable={entityTypes.includes("table")}
-      canSelectMetric={false}
       canSelectSavedQuestion={false}
       triggerElement={
         <DataPickerTarget

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -105,7 +105,6 @@ export function EmbeddingDataPicker({
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}
       selectedCollectionId={card?.collection_id}
-      databaseQuery={{ saved: true }}
       canSelectModel={entityTypes.includes("model")}
       canSelectTable={entityTypes.includes("table")}
       triggerElement={


### PR DESCRIPTION
Closes EMB-366

### Backport reason
It's a refactor, so backporting should be super safe.

### Description

This PR strips the embedding multi-stage data picker code by removing what's not used in the embedding use case. I only could remove references to metrics and saved questions for now. There might be more, but they don't look safe to be removed. I think this gives us a leaner version of the embedding data picker now.

### How to verify
- All tests pass.
- Or play around with the multi-stage data picker
    - run `yarn storybook-embedding-sdk`
    - Change this line to `false` to force multi-stage data picker to show up regardless of the number of models and tables.
        https://github.com/metabase/metabase/blob/34992d3d5c6450ad40f723e7eadec6fa3299d324/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx#L74
    - Thest the multi-stage data picker in http://localhost:6006/?path=/story/embeddingsdk-interactivequestion--create-question&globals=locale:en

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ New tests will be added in [EMB-367: Add additional tests for completeness.](https://linear.app/metabase/issue/EMB-367/add-additional-tests-for-completeness)
