### PR TITLE
WRK-336 temporary primitive action support

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -324,7 +324,7 @@
    _]
   (api/check-superuser)
   (let [databases          (t2/select [:model/Database :id :settings])
-        editable-database? #(-> % :settings :database-enable-table-editing boolean)
+        editable-database? (comp boolean :database-enable-table-editing :settings)
         editable-databases (filter editable-database? databases)
 
         editable-tables

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -319,6 +319,7 @@
     (actions/execute-action! action (merge row-params provided))))
 
 (api.macros/defendpoint :get "/tmp-action"
+  "Returns all actions across all tables and models"
   [_
    _
    _]

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -318,33 +318,6 @@
         provided    (update-keys params #(api/check-400 (param-id (name %)) "Unexpected parameter provided"))]
     (actions/execute-action! action (merge row-params provided))))
 
-(defn- table-action-id [table-id action-type]
-  (format "%d.%s" table-id (name action-type)))
-
-(defn- parse-table-action-id [id]
-  (when-some [[_ table-id-part type-part] (re-find #"(\d+)(\.+)" id)]
-    (when-some [action-type ({"create" :create
-                              "update" :update
-                              "delete" :delete}
-                             type-part)]
-      {:table-id    (parse-long table-id-part)
-       :action-type action-type})))
-
-(def ^:private table-action->int {:create 0 :update 1 :delete 2})
-(def ^:private int->table-action (set/map-invert table-action->int))
-
-(defn- table-action-id ^long [^long table-id op]
-  (let [action-bits (table-action->int op)
-        encoded (bit-or (bit-shift-left action-bits 32) (bit-and table-id 0xFFFFFFFF))
-        negative-id (- (bit-or encoded 0x800000000))] ; force negative via high bit
-    negative-id))
-
-(defn- unpack-table-action-id [^long encoded-id]
-  (let [pos-id (bit-and (Math/abs encoded-id) 0xFFFFFFFFFF)
-        table-id (bit-and pos-id 0xFFFFFFFF)
-        action-bits (bit-and (bit-shift-right pos-id 32) 0x3)]
-    {:table-id table-id :op (int->table-action action-bits)}))
-
 (api.macros/defendpoint :get "/tmp-action"
   [_
    _
@@ -356,67 +329,31 @@
 
         editable-tables
         (when (seq editable-databases)
-          (t2/select :model/Table :database_id [:in (map :id editable-databases)]))
+          (t2/select :model/Table :db_id [:in (map :id editable-databases)]))
 
         fields
         (when (seq editable-tables)
-          (t2/select :model/Field [:in (map :id editable-tables)]))
+          (t2/select :model/Field :table_id [:in (map :id editable-tables)]))
 
         fields-by-table
         (group-by :table_id fields)
 
         table-actions
         (for [t editable-tables
-              action-type [:create :update :delete]]
-          {:database_id (:database_id t)
-           :name        (name action-type)
-           :kind        "table"
-           :table_id (:id t)
-           :id (table-action-id (:it t) action-type)
-           :visualization_settings
-           {:name ""
-            :type "button"
-            :description ""
-            :fields (->> (for [field (fields-by-table (:id t))
-                               :let [field-name (:name field)]]
-                           [field-name
-                            {:description ""
-                             :placeholder ""
-                             :name        field-name
-                             :width       "medium"
-                             :title       field-name
-                             :hidden      false
-                             :id          field-name
-                             :order       999
-                             :inputType   "string"
-                             :required    (:database_required field)
-                             :fieldType   nil}])
-                         (into {}))}
-           :parameters
-           (->> (for [field (fields-by-table (:id t))
-                      :let [field-name (:name field)]]
-                  [field-name
-                   {:value nil
-                    :id    field-name
-                    :type  :string/=
-                    :target [:variable [:template-tag field-name]]
-                    :name  field-name
-                    :slug  field-name
-                    :hasVariableTemplateTagTarget true}])
-                (into {}))})
+              op [:table.row/create :table.row/update :table.row/delete]
+              :let [fields (fields-by-table (:id t))]]
+          (actions/table-primitive-action t fields op))
 
         model-actions
-        (for [a (actions/select-actions :archived false)]
-          (merge
-           {:kind "model"}
-           (select-keys a [:name
-                           :model_id
-                           :type
-                           :database_id
-                           :id
-                           :visualization_settings
-                           :parameters])))]
-    {:actions (concat model-actions table-actions)}))
+        (for [a (actions/select-actions nil :archived false)]
+          (select-keys a [:name
+                          :model_id
+                          :type
+                          :database_id
+                          :id
+                          :visualization_settings
+                          :parameters]))]
+    {:actions (vec (concat model-actions table-actions))}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -774,7 +774,8 @@
                     dashcards]
 
                 (testing "create"
-                  (is (= {} (prefill-values create-card {})))
+                  (testing "prefill does not crash"
+                    (is (= {} (prefill-values create-card {}))))
                   (execute! create-card
                             {:text      "hello, world!"
                              :int       42
@@ -788,9 +789,9 @@
                               (sort-by first)))))
 
                 (testing "update"
-                  (is (= {} (prefill-values update-card {})))
-                  ;; todo should this do something
-                  (is (= {} (prefill-values update-card {:id 1})))
+                  (testing "prefill does not crash"
+                    (is (= {} (prefill-values update-card {})))
+                    (is (= {} (prefill-values update-card {:id 1}))))
                   (execute! update-card
                             {:id 1
                              :int 43})
@@ -800,7 +801,9 @@
                               (sort-by first)))))
 
                 (testing "delete"
-                  (is (= {} (prefill-values delete-card {})))
+                  (testing "prefill does not crash"
+                    (is (= {} (prefill-values delete-card {})))
+                    (is (= {} (prefill-values delete-card {:id 2}))))
                   (execute! delete-card {:id 2})
                   (is (= [[1 "hello, world!" 43 "2025-05-12T14:32:16Z" "2025-05-12T00:00:00Z"]]
                          (->> (table-rows @test-table)

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -720,21 +720,21 @@
                                                                  {:primary-key [:id]})]
           (let [{:keys [status body]}
                 (list-req {})
-                all-actions  (:actions body)
-                crud-actions (filter #(= @test-table (:table_id %)) all-actions)]
+                all-actions   (:actions body)
+                table-actions (filter #(= @test-table (:table_id %)) all-actions)]
             (is (= 200 status))
             (testing "table actions have neg ids"
-              (is (every? neg? (map :id crud-actions))))
+              (is (every? neg? (map :id table-actions))))
             (testing "one action for each crud op"
               (is (= {"table.row/create" 1
                       "table.row/update" 1
                       "table.row/delete" 1}
-                     (frequencies (map :kind crud-actions)))))
+                     (frequencies (map :kind table-actions)))))
             (mt/with-temp [:model/Dashboard dash {}]
               (let [{create-action "table.row/create"
                      update-action "table.row/update"
                      delete-action "table.row/delete"}
-                    (u/index-by :kind crud-actions)
+                    (u/index-by :kind table-actions)
                     dashboard-url (str "dashboard/" (:id dash))
                     card-counter (atom 0)
                     card-input (fn [action]

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -721,11 +721,7 @@
           (let [{:keys [status body]}
                 (list-req {})
                 all-actions  (:actions body)
-                crud-actions (filter #(= @test-table (:table_id %)) all-actions)
-                {create-action "table.row/create"
-                 update-action "table.row/update"
-                 delete-action "table.row/delete"}
-                (u/index-by :kind crud-actions)]
+                crud-actions (filter #(= @test-table (:table_id %)) all-actions)]
             (is (= 200 status))
             (testing "table actions have neg ids"
               (is (every? neg? (map :id crud-actions))))
@@ -735,7 +731,11 @@
                       "table.row/delete" 1}
                      (frequencies (map :kind crud-actions)))))
             (mt/with-temp [:model/Dashboard dash {}]
-              (let [dashboard-url (str "dashboard/" (:id dash))
+              (let [{create-action "table.row/create"
+                     update-action "table.row/update"
+                     delete-action "table.row/delete"}
+                    (u/index-by :kind crud-actions)
+                    dashboard-url (str "dashboard/" (:id dash))
                     card-counter (atom 0)
                     card-input (fn [action]
                                  {:id (swap! card-counter dec)

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -736,9 +736,8 @@
                      delete-action "table.row/delete"}
                     (u/index-by :kind table-actions)
                     dashboard-url (str "dashboard/" (:id dash))
-                    card-counter (atom 0)
-                    card-input (fn [action]
-                                 {:id (swap! card-counter dec)
+                    card-input (fn [id action]
+                                 {:id id
                                   :size_x 1
                                   :size_y 1
                                   :row 0
@@ -749,9 +748,9 @@
                      :crowberto
                      :put
                      dashboard-url
-                     {:dashcards [(card-input create-action)
-                                  (card-input update-action)
-                                  (card-input delete-action)]})
+                     {:dashcards [(card-input -1 create-action)
+                                  (card-input -2 update-action)
+                                  (card-input -3 delete-action)]})
 
                     exec-url #(str dashboard-url "/dashcard/" (:id %) "/execute")
 

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -42,6 +42,6 @@
   select-action
   select-actions
   table-primitive-action
-  unpack-primitive-action-id]
+  unpack-table-primitive-action-id]
  [metabase.actions.events
   publish-action-success!])

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -39,6 +39,7 @@
   apply-json-query]
  [metabase.actions.models
   dashcard->action
-  select-action]
+  select-action
+  select-actions]
  [metabase.actions.events
   publish-action-success!])

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -40,6 +40,8 @@
  [metabase.actions.models
   dashcard->action
   select-action
-  select-actions]
+  select-actions
+  table-primitive-action
+  unpack-primitive-action-id]
  [metabase.actions.events
   publish-action-success!])

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -229,6 +229,7 @@
     (api/check-404 (or action-id table-action))
     (if table-action
       (let [{:keys [kind table_id]} table-action]
+        ;; avoiding snowplow for now, to avoid adding new actions into schema
         (execute-table-action! (keyword kind) table_id request-parameters))
       (let [action (api/check-404 (action/select-action :id action-id))]
         (analytics/track-event! :snowplow/action

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -208,10 +208,7 @@
 (defn- execute-table-action!
   [kind table-id request-parameters]
   (let [args
-        {:type     :query
-         :query    {:source-table table-id}
-         :database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
-         :table-id table-id
+        {:table-id table-id
          :arg      [request-parameters]}
 
         opts

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -205,22 +205,41 @@
       (execute-custom-action! action request-parameters)
       (throw (ex-info (tru "Unknown action type {0}." (name (:type action))) action)))))
 
+(defn- execute-table-action!
+  [kind table-id request-parameters]
+  (let [args
+        {:type     :query
+         :query    {:source-table table-id}
+         :database (api/check-404 (t2/select-one-fn :db_id [:model/Table :db_id] table-id))
+         :table-id table-id
+         :arg      [request-parameters]}
+
+        opts
+        {:policy :data-editing}]
+    (actions/perform-action-with-single-input-and-output kind args opts)))
+
 (mu/defn execute-dashcard!
   "Execute the given action in the dashboard/dashcard context with the given parameters
    of shape `{<parameter-id> <value>}."
   [dashboard-id       :- ::lib.schema.id/dashboard
    dashcard-id        :- ::lib.schema.id/dashcard
    request-parameters :- [:maybe [:map-of :string :any]]]
-  (let [dashcard (api/check-404 (t2/select-one :model/DashboardCard
-                                               :id dashcard-id
-                                               :dashboard_id dashboard-id))
-        action (api/check-404 (action/select-action :id (:action_id dashcard)))]
-    (analytics/track-event! :snowplow/action
-                            {:event     :action-executed
-                             :source    :dashboard
-                             :type      (:type action)
-                             :action_id (:id action)})
-    (execute-action! action request-parameters)))
+  (let [dashcard     (api/check-404 (t2/select-one :model/DashboardCard
+                                                   :id dashcard-id
+                                                   :dashboard_id dashboard-id))
+        action-id    (:action_id dashcard)
+        table-action (-> dashcard :visualization_settings :table_action)]
+    (api/check-404 (or action-id table-action))
+    (if table-action
+      (let [{:keys [kind table_id]} table-action]
+        (execute-table-action! (keyword kind) table_id request-parameters))
+      (let [action (api/check-404 (action/select-action :id (:action_id dashcard)))]
+        (analytics/track-event! :snowplow/action
+                                {:event     :action-executed
+                                 :source    :dashboard
+                                 :type      (:type action)
+                                 :action_id (:id action)})
+        (execute-action! action request-parameters)))))
 
 (defn- fetch-implicit-action-values
   [action request-parameters]

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -209,7 +209,8 @@
   [kind table-id request-parameters]
   (let [args
         {:table-id table-id
-         :arg      [request-parameters]}
+         :database (t2/select-one-fn :db_id [:model/Table :db_id] table-id)
+         :arg      request-parameters}
 
         opts
         {:policy :data-editing}]

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -230,7 +230,7 @@
     (if table-action
       (let [{:keys [kind table_id]} table-action]
         (execute-table-action! (keyword kind) table_id request-parameters))
-      (let [action (api/check-404 (action/select-action :id (:action_id dashcard)))]
+      (let [action (api/check-404 (action/select-action :id action-id))]
         (analytics/track-event! :snowplow/action
                                 {:event     :action-executed
                                  :source    :dashboard

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -405,10 +405,10 @@
 
 (defn dashcard->action
   "Get the action associated with a dashcard if exists, return `nil` otherwise."
-  [dashcard-or-dashcard-id]
+  [dashcard-id]
   (let [{:keys [action_id
                 visualization_settings]}
-        (t2/select-one [:model/DashboardCard :action_id :visualization_settings] (u/the-id dashcard-or-dashcard-id))
+        (t2/select-one [:model/DashboardCard :action_id :visualization_settings] dashcard-id)
         {:keys [table_action]}
         visualization_settings]
     (cond

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -391,7 +391,6 @@
              :type (:base_type field)
              :target [:variable [:template-tag field-name]]
              :slug  field-name
-             ;; todo
              :required (or (= :type/PK (:semantic_type field))
                            (:database_required field))
              :is-auto-increment (:database_is_auto_increment field)})

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -367,7 +367,7 @@
                           (sort-by :position))]
     {:database_id (:database_id table)
      :name        (name kind)
-     :kind        (str (namespace kind) "/" (name kind))
+     :kind        (u/qualified-name kind)
      :table_id    (:id table)
      :id          (primitive-action-id kind (:id table))
      ;; true for all databases with data_editing_enabled

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -433,8 +433,7 @@
              distinct)
         table-by-id
         (when (seq table-ids)
-          (->> (t2/select :model/Table :id [:in table-ids])
-               (u/index-by :id)))
+          (t2/select-fn->fn :id identity :model/Table :id [:in table-ids]))
         fields-by-id
         (when (seq table-ids)
           (->> (t2/select :model/Field :table_id [:in table-ids])

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -378,12 +378,11 @@
       :type "button"
       :description ""
       :fields
-      (->> (for [field field-params
-                 :let [field-name (:name field)]]
-             [field-name
-              {:hidden      false
-               :id          field-name}])
-           (into {}))}
+      (u/for-map [field field-params
+                  :let [field-name (:name field)]]
+        [field-name
+         {:hidden      false
+          :id          field-name}])}
      :parameters
      (->> (for [field field-params
                 :let [field-name (:name field)]]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -1017,11 +1017,11 @@
                                                                         (pos-int? (:action_id dashcard))
                                                                         (u/update-if-exists dashcard :visualization_settings dissoc :table_action)
                                                                         (neg-int? (:action_id dashcard))
-                                                                        (let [[op param] (actions/unpack-primitive-action-id (:action_id dashcard))]
+                                                                        (let [[op table-id] (actions/unpack-table-primitive-action-id (:action_id dashcard))]
                                                                           (-> dashcard
                                                                               (assoc-in [:visualization_settings :table_action]
                                                                                         {:kind (u/qualified-name op)
-                                                                                         :table_id param})
+                                                                                         :table_id table-id})
                                                                               (dissoc :action_id)))
                                                                         :else
                                                                         dashcard))))


### PR DESCRIPTION
Closes WRK-336 

Adds primitive table action support to dashboards. These actions are not associated with a model, and are available implicitly for all database tables where data editing is enabled.

Care has been taken to provide as much compatibility with the existing frontend components/flows as possible (in particular, dashboards), so these new actions should work pretty much the same as 'old school' implicit actions.

- A new (temporary) listing API is provided @ `ee/data-editing/tmp-action` for finding all table actions, for the current picker.
- Table actions are listed with a `table_id` attribute (for frontend joins in the picker), and a negative `action_id`. To add the action to the dashboard, the picker ought to be able to work by providing this negative action_id when creating the dashcard (the same as a normal action).
