### PR TITLE
Cast booleans literals in :fields clause to bit for sqlserver

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -552,7 +552,7 @@
 ;; SQLServer doesn't support `TRUE`/`FALSE`; it uses `1`/`0`, respectively; convert these booleans to numbers.
 (defmethod sql.qp/->honeysql [:sqlserver Boolean]
   [_ bool]
-  (if bool 1 0))
+  [:inline (if bool 1 0)])
 
 (defmethod sql.qp/->honeysql [:sqlserver :and]
   [driver clause]

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -506,21 +506,16 @@
       (update new-hsql :group-by distinct))))
 
 (defmethod sql.qp/apply-top-level-clause [:sqlserver :fields]
-  [driver _ honeysql-form {fields :fields :as query}]
+  [driver _ honeysql-form query]
   (let [parent-method (get-method sql.qp/apply-top-level-clause [:sql-jdbc :fields])
-        boolean-expression-clause? sql.qp.boolean-to-comparison/boolean-expression-clause?
-        maybe-cast-honeysql-field (fn [honeysql-field]
-                                    ;; honeysql-field is a vector [[field-or-value] [optional-alias]]
-                                    (update honeysql-field 0 #(h2x/maybe-cast :bit %)))]
-    (-> (parent-method driver :fields honeysql-form query)
-        ;; Insert a cast to :bit for boolean expressions. This ensures the :type/Boolean is preserved in results
-        ;; metadata, so downstream questions and query stages can use the column in contexts where a boolean is
-        ;; required; otherwise, SQL Server returns a value of type int for `SELECT 1 AS MyBool ...`.
-        (update :select (fn [honeysql-fields]
-                          (mapv #(cond-> %1
-                                   (boolean-expression-clause? %2) maybe-cast-honeysql-field)
-                                honeysql-fields
-                                fields))))))
+        ;; Tell [[sql.qp/as]] to insert a cast to :bit for boolean expressions. This ensures the :type/Boolean is
+        ;; preserved in results metadata, so downstream questions and query stages can use the column in contexts
+        ;; where a boolean is required; otherwise, SQL Server returns a value of type int for `SELECT 1 AS MyBool`.
+        maybe-add-cast #(cond-> %
+                          (sql.qp.boolean-to-comparison/boolean-expression-clause? %)
+                          (mbql.u/assoc-field-options ::sql.qp/add-cast :bit))]
+    (->> (update query :fields #(mapv maybe-add-cast %))
+         (parent-method driver :fields honeysql-form))))
 
 (defn- optimize-order-by-subclauses
   "Optimize `:order-by` `subclauses` using [[optimized-temporal-buckets]], if possible."
@@ -546,8 +541,9 @@
 
 (defmethod sql.qp/apply-top-level-clause [:sqlserver :filter]
   [driver _ honeysql-form query]
-  (->> (update query :filter sql.qp.boolean-to-comparison/boolean->comparison)
-       ((get-method sql.qp/apply-top-level-clause [:sql-jdbc :filter]) driver :filter honeysql-form)))
+  (let [parent-method (get-method sql.qp/apply-top-level-clause [:sql-jdbc :filter])]
+    (->> (update query :filter sql.qp.boolean-to-comparison/boolean->comparison)
+         (parent-method driver :filter honeysql-form))))
 
 ;; SQLServer doesn't support `TRUE`/`FALSE`; it uses `1`/`0`, respectively; convert these booleans to numbers.
 (defmethod sql.qp/->honeysql [:sqlserver Boolean]

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -537,46 +537,43 @@
                          :fields      [[:expression "MyTrue"]]
                          :limit       1})
                       (update :query merge args)))]
-          (doseq [{:keys [desc query expected-sql expected-rows]}
+          (doseq [{:keys [desc query expected-sql expected-types expected-rows]}
                   [{:desc "true filter"
                     :query
                     (orders-query {:filter true-value})
                     :expected-sql
-                    {:query ["SELECT"
-                             "  TOP(1) CAST(? AS bit) AS MyTrue"
-                             "FROM"
-                             "  dbo.orders"
-                             "WHERE"
-                             "  ? = ?"]
-                     :params [1 1 1]}
-                    :expected-rows
-                    [[true]]}
+                    ["SELECT"
+                     "  TOP(1) CAST(1 AS bit) AS MyTrue"
+                     "FROM"
+                     "  dbo.orders"
+                     "WHERE"
+                     "  1 = 1"]
+                    :expected-types [:type/Boolean]
+                    :expected-rows  [[true]]}
                    {:desc "false filter"
                     :query
                     (orders-query {:filter false-value})
                     :expected-sql
-                    {:query ["SELECT"
-                             "  TOP(1) CAST(? AS bit) AS MyTrue"
-                             "FROM"
-                             "  dbo.orders"
-                             "WHERE"
-                             "  ? = ?"]
-                     :params [1 0 1]}
-                    :expected-rows
-                    []}
+                    ["SELECT"
+                     "  TOP(1) CAST(1 AS bit) AS MyTrue"
+                     "FROM"
+                     "  dbo.orders"
+                     "WHERE"
+                     "  0 = 1"]
+                    :expected-types [:type/Boolean]
+                    :expected-rows  []}
                    {:desc "not filter"
                     :query
                     (orders-query {:filter [:not false-value]})
                     :expected-sql
-                    {:query ["SELECT"
-                             "  TOP(1) CAST(? AS bit) AS MyTrue"
-                             "FROM"
-                             "  dbo.orders"
-                             "WHERE"
-                             "  NOT (? = ?)"]
-                     :params [1 0 1]}
-                    :expected-rows
-                    [[true]]}
+                    ["SELECT"
+                     "  TOP(1) CAST(1 AS bit) AS MyTrue"
+                     "FROM"
+                     "  dbo.orders"
+                     "WHERE"
+                     "  NOT (0 = 1)"]
+                    :expected-types [:type/Boolean]
+                    :expected-rows  [[true]]}
                    {:desc "nested logical operators"
                     :query
                     (orders-query {:filter [:and
@@ -585,19 +582,18 @@
                                              [:expression "MyFalse"]
                                              [:expression "MyTrue"]]]})
                     :expected-sql
-                    {:query ["SELECT"
-                             "  TOP(1) CAST(? AS bit) AS MyTrue"
-                             "FROM"
-                             "  dbo.orders"
-                             "WHERE"
-                             "  NOT (? = ?)"
-                             "  AND ("
-                             "    (? = ?)"
-                             "    OR (? = ?)"
-                             "  )"]
-                     :params [1 0 1 0 1 1 1]}
-                    :expected-rows
-                    [[true]]}
+                    ["SELECT"
+                     "  TOP(1) CAST(1 AS bit) AS MyTrue"
+                     "FROM"
+                     "  dbo.orders"
+                     "WHERE"
+                     "  NOT (0 = 1)"
+                     "  AND ("
+                     "    (0 = 1)"
+                     "    OR (1 = 1)"
+                     "  )"]
+                    :expected-types [:type/Boolean]
+                    :expected-rows  [[true]]}
                    {:desc "case expression"
                     :query
                     (orders-query {:expressions {"MyTrue"  true-value
@@ -606,42 +602,44 @@
                                                                    [[:expression "MyTrue"]  true-value]]]}
                                    :fields [[:expression "MyCase"]]})
                     :expected-sql
-                    {:query ["SELECT"
-                             "  TOP(1) CASE"
-                             "    WHEN ? = ? THEN ?"
-                             "    WHEN ? = ? THEN ?"
-                             "  END AS MyCase"
-                             "FROM"
-                             "  dbo.orders"]
-                     :params [0 1 0 1 1 1]}
-                    :expected-rows
-                    [[1]]}
+                    ["SELECT"
+                     "  TOP(1) CASE"
+                     "    WHEN 0 = 1 THEN 0"
+                     "    WHEN 1 = 1 THEN 1"
+                     "  END AS MyCase"
+                     "FROM"
+                     "  dbo.orders"]
+                    :expected-types [:type/Integer]
+                    :expected-rows  [[1]]}
                    ;; only top-level booleans should be transformed; otherwise an expression like 1 = 1 gets compiled
                    ;; to (1 = 1) = (1 = 1)
                    {:desc "non-top-level booleans"
                     :query
                     (orders-query {:filter [:= true-value true-value]})
                     :expected-sql
-                    {:query ["SELECT"
-                             "  TOP(1) CAST(? AS bit) AS MyTrue"
-                             "FROM"
-                             "  dbo.orders"
-                             "WHERE"
-                             "  ? = ?"]
-                     :params [1 1 1]}
-                    :expected-rows
-                    [[true]]}]]
+                    ["SELECT"
+                     "  TOP(1) CAST(1 AS bit) AS MyTrue"
+                     "FROM"
+                     "  dbo.orders"
+                     "WHERE"
+                     "  1 = 1"]
+                    :expected-types [:type/Boolean]
+                    :expected-rows  [[true]]}]]
             (testing (format "\n%s\nMBQL query = %s\n" desc query)
               (testing "Should generate the correct SQL query"
                 (is (= expected-sql
-                       (-> query
-                           qp.compile/compile
-                           (update :query pretty-sql)))))
+                       (pretty-sql (:query (qp.compile/compile query))))))
               (testing "Should return correct results"
-                (is (= expected-rows
-                       (->> query
-                            qp/process-query
-                            mt/rows)))))))))))
+                (let [result (qp/process-query query)
+                      rows (mt/rows result)
+                      cols (mt/cols result)
+                      results-metadata-cols (-> result :data :results_metadata :columns)]
+                  (is (= expected-rows
+                         rows))
+                  (is (= expected-types
+                         (map :base_type cols)))
+                  (is (= expected-types
+                         (map :base_type results-metadata-cols))))))))))))
 
 (deftest filter-by-datetime-fields-test
   (mt/test-driver :sqlserver

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -543,20 +543,20 @@
                     (orders-query {:filter true-value})
                     :expected-sql
                     {:query ["SELECT"
-                             "  TOP(1) ? AS MyTrue"
+                             "  TOP(1) CAST(? AS bit) AS MyTrue"
                              "FROM"
                              "  dbo.orders"
                              "WHERE"
                              "  ? = ?"]
                      :params [1 1 1]}
                     :expected-rows
-                    [[1]]}
+                    [[true]]}
                    {:desc "false filter"
                     :query
                     (orders-query {:filter false-value})
                     :expected-sql
                     {:query ["SELECT"
-                             "  TOP(1) ? AS MyTrue"
+                             "  TOP(1) CAST(? AS bit) AS MyTrue"
                              "FROM"
                              "  dbo.orders"
                              "WHERE"
@@ -569,14 +569,14 @@
                     (orders-query {:filter [:not false-value]})
                     :expected-sql
                     {:query ["SELECT"
-                             "  TOP(1) ? AS MyTrue"
+                             "  TOP(1) CAST(? AS bit) AS MyTrue"
                              "FROM"
                              "  dbo.orders"
                              "WHERE"
                              "  NOT (? = ?)"]
                      :params [1 0 1]}
                     :expected-rows
-                    [[1]]}
+                    [[true]]}
                    {:desc "nested logical operators"
                     :query
                     (orders-query {:filter [:and
@@ -586,7 +586,7 @@
                                              [:expression "MyTrue"]]]})
                     :expected-sql
                     {:query ["SELECT"
-                             "  TOP(1) ? AS MyTrue"
+                             "  TOP(1) CAST(? AS bit) AS MyTrue"
                              "FROM"
                              "  dbo.orders"
                              "WHERE"
@@ -597,7 +597,7 @@
                              "  )"]
                      :params [1 0 1 0 1 1 1]}
                     :expected-rows
-                    [[1]]}
+                    [[true]]}
                    {:desc "case expression"
                     :query
                     (orders-query {:expressions {"MyTrue"  true-value
@@ -623,14 +623,14 @@
                     (orders-query {:filter [:= true-value true-value]})
                     :expected-sql
                     {:query ["SELECT"
-                             "  TOP(1) ? AS MyTrue"
+                             "  TOP(1) CAST(? AS bit) AS MyTrue"
                              "FROM"
                              "  dbo.orders"
                              "WHERE"
                              "  ? = ?"]
                      :params [1 1 1]}
                     :expected-rows
-                    [[1]]}]]
+                    [[true]]}]]
             (testing (format "\n%s\nMBQL query = %s\n" desc query)
               (testing "Should generate the correct SQL query"
                 (is (= expected-sql

--- a/src/metabase/driver/sql/query_processor/boolean_to_comparison.clj
+++ b/src/metabase/driver/sql/query_processor/boolean_to_comparison.clj
@@ -70,7 +70,9 @@
        (or (boolean? (second clause))
            (boolean-typed-clause? clause))))
 
-(defn- boolean-expression-clause? [clause]
+(defn boolean-expression-clause?
+  "Is `clause` an :expression clause with :type/Boolean or a literal boolean :value?"
+  [clause]
   (and (mbql.u/is-clause? :expression clause)
        (or (boolean-typed-clause? clause)
            (boolean-value-clause? (mbql.u/expression-with-name sql.qp/*inner-query* (second clause))))))

--- a/src/metabase/driver/sql/query_processor/boolean_to_comparison.clj
+++ b/src/metabase/driver/sql/query_processor/boolean_to_comparison.clj
@@ -71,7 +71,10 @@
            (boolean-typed-clause? clause))))
 
 (defn boolean-expression-clause?
-  "Is `clause` an :expression clause with :type/Boolean or a literal boolean :value?"
+  "Is `clause` an :expression clause with :type/Boolean or a literal boolean :value?
+
+  This function expects to be called in a context where sql.qp/*inner-query* is bound, so that it can lookup
+  expression refs by name, if necessary, to determine whether their value is a boolean literal."
   [clause]
   (and (mbql.u/is-clause? :expression clause)
        (or (boolean-typed-clause? clause)

--- a/test/metabase/driver/sql/query_processor/boolean_to_comparison_test.clj
+++ b/test/metabase/driver/sql/query_processor/boolean_to_comparison_test.clj
@@ -7,25 +7,40 @@
 
 (def ^:private true-value  [:value true  {:base_type :type/Boolean}])
 (def ^:private false-value [:value false {:base_type :type/Boolean}])
+(def ^:private int-value   [:value 1     {:base_type :type/Integer}])
 
 (defn- basic-filter-query [expression]
   (mt/mbql-query venues
-    {:expressions {"T" true-value, "F" false-value}
-     :fields      [[:expression "T"] [:expression "F"]]
+    {:expressions {"T" true-value, "F" false-value, "I" int-value}
+     :fields      [[:expression "T"] [:expression "F"] [:expression "I"]]
      :filter      expression}))
 
 (deftest ^:parallel boolean->comparison-test
-  (are [expression] (binding [sql.qp/*inner-query* (:query (basic-filter-query expression))]
-                      (= [:= expression true]
-                         (sql.qp.boolean-to-comparison/boolean->comparison expression)))
-    false
-    true
-    true-value
-    false-value
-    [:expression "T"]
-    [:expression "F"]
-    [:field "some-bool" {:base-type :type/Boolean}]
-    [:field 123 {:base-type :type/Boolean}]))
+  (testing "boolean expressions"
+    (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
+                    (= [:= clause true]
+                       (sql.qp.boolean-to-comparison/boolean->comparison clause)))
+      false
+      true
+      true-value
+      false-value
+      [:value true nil]
+      [:expression "T"]
+      [:expression "F"]
+      [:field "some-bool" {:base-type :type/Boolean}]
+      [:field 123 {:base-type :type/Boolean}]))
+
+  (testing "non-boolean expressions"
+    (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
+                    (= clause
+                       (sql.qp.boolean-to-comparison/boolean->comparison clause)))
+      0
+      1
+      "not a boolean"
+      [:value 1 nil]
+      [:expression "I"]
+      [:field "some-int" {:base-type :type/Integer}]
+      [:field 123 {:base-type :type/Integer}])))
 
 (deftest ^:parallel case-boolean->comparison
   (are [clause expected] (= expected
@@ -34,9 +49,13 @@
      [[true true]
       [true-value true]
       [false false]
-      [false-value false]]]
+      [false-value false]
+      [[:= true false] false]
+      [[:= 1 2] false]]]
     [:case
      [[[:= true true] true]
       [[:= true-value true] true]
       [[:= false true] false]
-      [[:= false-value true] false]]]))
+      [[:= false-value true] false]
+      [[:= true false] false]
+      [[:= 1 2] false]]]))

--- a/test/metabase/driver/sql/query_processor/boolean_to_comparison_test.clj
+++ b/test/metabase/driver/sql/query_processor/boolean_to_comparison_test.clj
@@ -19,57 +19,55 @@
   (mt/nest-query (basic-filter-query expression) 4))
 
 (deftest ^:parallel boolean->comparison-test
-  (testing "boolean expressions"
-    (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
-                    (= [:= clause true]
-                       (sql.qp.boolean-to-comparison/boolean->comparison clause)))
-      false
-      true
-      true-value
-      false-value
-      [:value true nil]
-      [:expression "T"]
-      [:expression "F"]
-      [:field "some-bool" {:base-type :type/Boolean}]
-      [:field 123 {:base-type :type/Boolean}]))
+  (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
+                  (= [:= clause true]
+                     (sql.qp.boolean-to-comparison/boolean->comparison clause)))
+    false
+    true
+    true-value
+    false-value
+    [:value true nil]
+    [:expression "T"]
+    [:expression "F"]
+    [:field "some-bool" {:base-type :type/Boolean}]
+    [:field 123 {:base-type :type/Boolean}]))
 
-  (testing "non-boolean expressions"
-    (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
-                    (= clause
-                       (sql.qp.boolean-to-comparison/boolean->comparison clause)))
-      0
-      1
-      "not a boolean"
-      [:value 1 nil]
-      [:expression "I"]
-      [:field "some-int" {:base-type :type/Integer}]
-      [:field 123 {:base-type :type/Integer}])))
+(deftest ^:parallel non-boolean->comparison-test
+  (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
+                  (= clause
+                     (sql.qp.boolean-to-comparison/boolean->comparison clause)))
+    0
+    1
+    "not a boolean"
+    [:value 1 nil]
+    [:expression "I"]
+    [:field "some-int" {:base-type :type/Integer}]
+    [:field 123 {:base-type :type/Integer}]))
 
 (deftest ^:parallel boolean-expression-clause?-test
-  (testing "boolean expressions"
-    (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
-                    (sql.qp.boolean-to-comparison/boolean-expression-clause? clause))
-      [:expression "T"]
-      [:expression "F"]))
+  (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
+                  (sql.qp.boolean-to-comparison/boolean-expression-clause? clause))
+    [:expression "T"]
+    [:expression "F"]))
 
-  (testing "nested boolean expressions"
-    (are [clause] (binding [sql.qp/*inner-query* (:query (nested-filter-query clause))]
-                    (sql.qp.boolean-to-comparison/boolean-expression-clause? clause))
-      [:expression "T"]
-      [:expression "F"]))
+(deftest ^:parallel nested-boolean-expression-clause?-test
+  (are [clause] (binding [sql.qp/*inner-query* (:query (nested-filter-query clause))]
+                  (sql.qp.boolean-to-comparison/boolean-expression-clause? clause))
+    [:expression "T"]
+    [:expression "F"]))
 
-  (testing "non-boolean expressions"
-    (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
-                    (not (sql.qp.boolean-to-comparison/boolean-expression-clause? clause)))
-      0
-      1
-      "not a boolean"
-      [:value 1 nil]
-      [:expression "I"]
-      [:field "some-int" {:base-type :type/Integer}]
-      [:field "some-bool" {:base-type :type/Boolean}]
-      [:field 123 {:base-type :type/Integer}]
-      [:field 234 {:base-type :type/Boolean}])))
+(deftest ^:parallel non-boolean-expression-clause?-test
+  (are [clause] (binding [sql.qp/*inner-query* (:query (basic-filter-query clause))]
+                  (not (sql.qp.boolean-to-comparison/boolean-expression-clause? clause)))
+    0
+    1
+    "not a boolean"
+    [:value 1 nil]
+    [:expression "I"]
+    [:field "some-int" {:base-type :type/Integer}]
+    [:field "some-bool" {:base-type :type/Boolean}]
+    [:field 123 {:base-type :type/Integer}]
+    [:field 234 {:base-type :type/Boolean}]))
 
 (deftest ^:parallel case-boolean->comparison
   (are [clause expected] (= expected


### PR DESCRIPTION
Closes QUE-1169

### Description

Insert a cast to bit for boolean expressions in `:fields` clauses on sqlserver. Without the cast, we generate code like `SELECT 1 AS MyBool ...` and the return type of that column is `int`. After the cast, we generate `SELECT CAST(1 AS bit) AS MyBool ...` which enables us to detect that column should be `:type/Boolean` in the results metadata. This enables you to use the custom column in contexts that expect a boolean, e.g. to use it in a filter expression in the custom expression editor.

Also, compile boolean literals `:inline` to prevent turning them into statement parameters.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Attach sqlserver db
2. New question -> Sample Dataset for SQL Server -> Orders
3. Custom column > name: `T`, value: `True`
4. Custom column > name: `F`, value: `False`
5. Save question as Q1
6. New question > Q1
7. Filter > Custom expression > `[T] OR [F]`
8. Visualize

Prior to this change, attempting to use `[T]` or `[F]` in the Filter expression would result in a type check error in the custom expression editor.

Also note that results for boolean literal columns will now display as `true`/`false` rather than `1`/`0`.

### Demo

**before**
![Screenshot 2025-05-09 at 12 41 02 PM](https://github.com/user-attachments/assets/97b94979-dc35-46c7-9b16-9ee9adf37279)
![Screenshot 2025-05-09 at 12 40 34 PM](https://github.com/user-attachments/assets/7fde1796-9e34-4896-a229-1d2d0d3bb827)

**after**
![Screenshot 2025-05-09 at 12 42 17 PM](https://github.com/user-attachments/assets/b00ded19-3fce-4811-a0c9-121b77ed61d1)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
