### PR TITLE
Visualizer cleanup

### DIFF
--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
@@ -241,7 +241,6 @@ export function PublicOrEmbeddedDashboardView({
                 downloadsEnabled={downloadsEnabled.results}
                 autoScrollToDashcardId={undefined}
                 reportAutoScrolledToDashcard={_.noop}
-                handleSetEditing={_.noop}
               />
             </FullWidthContainer>
           );

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 
@@ -196,7 +197,7 @@ export const BaseChartSettings = ({
         data-testid="chartsettings-sidebar"
         h="100%"
         gap={0}
-        className={`${CS.overflowHidden} ${className}`}
+        className={cx(CS.overflowHidden, className)}
         {...stackProps}
       >
         {showSectionPicker && (


### PR DESCRIPTION
### Description

Addresses two small nits:
- Removes unnecessary handleSetEditing prop from PublicOrEmbeddedDashboardView
- uses classnames to combine css classes instead of a template string

Please merge on approval