### PR TITLE
a transformation layer for event info before evaluating the condition

### DIFF
--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -31,18 +31,17 @@
       ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user
       (str (user/form-password-reset-url reset-token) "#new"))))
 
-(defn- dispatch-on-event-info
-  [{notification-system-event :payload :as _notification-info}]
-  (let [{:keys [action event_name]} notification-system-event]
-    (if action
-      [event_name action]
-      event_name)))
-
 (defmulti transform-event-info
   "Transform the event info to a format that is easier to work with in the templates.
   This is a multi-method because we want to be able to add more event types in the future."
   {:arglists '([notification-info])}
-  dispatch-on-event-info)
+  :event_name)
+
+(defmulti event-info->condition-context
+  "Transformed the published event info to an intermediate datastructure that's used for evaluating the condition"
+  {:arglists '([event-topic event-info])}
+  (fn [event-topic _event-info]
+    event-topic))
 
 (defn- sample-for-table
   [table-id changes?]
@@ -269,6 +268,7 @@
 
 (mu/defmethod transform-event-info :event/row.created :- ::row.created
   [notification-info]
+  (def notification-info notification-info)
   (bulk-row-transformation notification-info))
 
 (mu/defmethod transform-event-info :event/row.updated :- ::row.updated
@@ -302,17 +302,41 @@
 (defmethod notification.payload/notification-payload-schema :notification/system-event
   [notification-info]
   (when-let [[op _arg-schema return-schema] (some->> notification-info
-                                                     dispatch-on-event-info
+                                                     :payload
+                                                     :event_name
                                                      (get-method transform-event-info)
                                                      meta
                                                      :schema)]
     (assert (= op :=>))
     (mr/resolve-schema return-schema)))
 
+(defn- default-row-action-transformation
+  [event-info]
+  (lib.util.match/match-one
+    event-info
+    {:row_change {:before ?before
+                  :after  ?after}
+     :args       {:table_id ?table-id}}
+    {:record   (or ?after ?before)
+     :table_id ?table-id}))
+
+(defmethod event-info->condition-context :event/row.created
+  [_event-topic event-info]
+  (default-row-action-transformation event-info))
+
+(defmethod event-info->condition-context :event/row.updated
+  [_event-topic event-info]
+  (default-row-action-transformation event-info))
+
+(defmethod event-info->condition-context :event/row.deleted
+  [_event-topic event-info]
+  (default-row-action-transformation event-info))
+
 (defmethod notification.send/should-queue-notification? :notification/system-event
   [notification-info]
   (if-let [condition (not-empty (:condition notification-info))]
-    (notification.condition/evaluate-expression condition (:event_info notification-info))
+    (->> (event-info->condition-context (get-in notification-info [:payload :event_name]) (:event_info notification-info))
+         (notification.condition/evaluate-expression condition))
     true))
 
 (defn sample-payload

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -7,7 +7,6 @@
    [metabase.models.table :as table]
    [metabase.models.user :as user]
    [metabase.notification.condition :as notification.condition]
-   [metabase.notification.events.notification :as notification.events]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.payload.sample :as payload.sample]
    [metabase.notification.send :as notification.send]
@@ -36,7 +35,7 @@
   "Transform the event info to a format that is easier to work with in the templates.
   This is a multi-method because we want to be able to add more event types in the future."
   {:arglists '([notification-info])}
-  :event_name)
+  (comp :event_name :payload))
 
 (defmulti event-info->condition-context
   "Transformed the published event info to an intermediate datastructure that's used for evaluating the condition"
@@ -269,7 +268,6 @@
 
 (mu/defmethod transform-event-info :event/row.created :- ::row.created
   [notification-info]
-  (def notification-info notification-info)
   (bulk-row-transformation notification-info))
 
 (mu/defmethod transform-event-info :event/row.updated :- ::row.updated
@@ -298,6 +296,7 @@
 
 (mu/defmethod notification.payload/notification-payload :notification/system-event :- :map
   [notification-info :- ::notification.payload/Notification]
+  (def notification-info notification-info)
   (transform-event-info notification-info))
 
 (defmethod notification.payload/notification-payload-schema :notification/system-event
@@ -312,31 +311,33 @@
     (mr/resolve-schema return-schema)))
 
 (defn- default-row-action-transformation
-  [event-info]
+  [event-topic event-info]
   (lib.util.match/match-one
     event-info
     {:row_change {:before ?before
                   :after  ?after}
      :args       {:table_id ?table-id}}
-    {:record   (or ?after ?before)
-     :table_id ?table-id}))
+    {:record     (or ?after ?before)
+     :table_id   ?table-id
+     :event_name event-topic}))
 
 (mr/def ::condition.row.mutated
   [:map {:closed true}
    [:record :map]
-   [:table_id pos-int?]])
+   [:table_id pos-int?]
+   [:event_name :keyword]])
 
 (mu/defmethod event-info->condition-context :event/row.created :- ::condition.row.mutated
-  [_event-topic event-info]
-  (default-row-action-transformation event-info))
+  [event-topic event-info]
+  (default-row-action-transformation event-topic event-info))
 
 (mu/defmethod event-info->condition-context :event/row.updated :- ::condition.row.mutated
-  [_event-topic event-info]
-  (default-row-action-transformation event-info))
+  [event-topic event-info]
+  (default-row-action-transformation event-topic event-info))
 
 (mu/defmethod event-info->condition-context :event/row.deleted :- ::condition.row.mutated
-  [_event-topic event-info]
-  (default-row-action-transformation event-info))
+  [event-topic event-info]
+  (default-row-action-transformation event-topic event-info))
 
 (defmethod notification.send/should-queue-notification? :notification/system-event
   [notification-info]

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -7,6 +7,7 @@
    [metabase.models.table :as table]
    [metabase.models.user :as user]
    [metabase.notification.condition :as notification.condition]
+   [metabase.notification.events.notification :as notification.events]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.payload.sample :as payload.sample]
    [metabase.notification.send :as notification.send]
@@ -320,15 +321,20 @@
     {:record   (or ?after ?before)
      :table_id ?table-id}))
 
-(defmethod event-info->condition-context :event/row.created
+(mr/def ::condition.row.mutated
+  [:map {:closed true}
+   [:record :map]
+   [:table_id pos-int?]])
+
+(mu/defmethod event-info->condition-context :event/row.created :- ::condition.row.mutated
   [_event-topic event-info]
   (default-row-action-transformation event-info))
 
-(defmethod event-info->condition-context :event/row.updated
+(mu/defmethod event-info->condition-context :event/row.updated :- ::condition.row.mutated
   [_event-topic event-info]
   (default-row-action-transformation event-info))
 
-(defmethod event-info->condition-context :event/row.deleted
+(mu/defmethod event-info->condition-context :event/row.deleted :- ::condition.row.mutated
   [_event-topic event-info]
   (default-row-action-transformation event-info))
 

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -43,6 +43,10 @@
   (fn [event-topic _event-info]
     event-topic))
 
+(defmethod event-info->condition-context :default
+  [_event-topic event-info]
+  event-info)
+
 (defn- sample-for-table
   [table-id changes?]
   (let [order-field    (t2/select-one-fn :field_order :model/Table table-id)

--- a/test/metabase/notification/events/notification_test.clj
+++ b/test/metabase/notification/events/notification_test.clj
@@ -5,42 +5,44 @@
    [metabase.notification.core :as notification]
    [metabase.notification.events.notification :as events.notification]
    [metabase.notification.models :as models.notification]
+   [metabase.notification.send :as notification.send]
    [metabase.notification.test-util :as notification.tu]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
 (deftest supported-events-with-notification-will-be-sent-test
-  (mt/with-model-cleanup [:model/Notification]
-    (notification.tu/with-temporary-event-topics! #{:event/test-notification}
-      (let [topic      :event/test-notification
-            n-1        (models.notification/create-notification!
-                        {:payload_type :notification/system-event
-                         :active       true
-                         :payload      {:event_name topic}}
-                        nil
-                        [])
-            n-2         (models.notification/create-notification!
-                         {:payload_type :notification/system-event
-                          :active       true
-                          :payload      {:event_name topic}}
-                         nil
-                         [])
-            _inactive  (models.notification/create-notification!
-                        {:payload_type :notification/system-event
-                         :active       false
-                         :payload      {:event_name topic}}
-                        []
-                        nil)
-            sent-notis (atom [])]
-        (testing "publishing event will send all the actively subscribed notifciations"
-          (with-redefs [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
-                        events.notification/supported-topics #{:event/test-notification}]
-            (events/publish-event! topic {::hi true})
-            (is (=? [[(:id n-1) {::hi true}]
-                     [(:id n-2) {::hi true}]]
-                    (->> @sent-notis
-                         (map (juxt :id :event_info))
-                         (sort-by first))))))))))
+  (notification.tu/with-send-notification-sync
+    (mt/with-model-cleanup [:model/Notification]
+      (notification.tu/with-temporary-event-topics! #{:event/test-notification}
+        (let [topic      :event/test-notification
+              n-1        (models.notification/create-notification!
+                          {:payload_type :notification/system-event
+                           :active       true
+                           :payload      {:event_name topic}}
+                          nil
+                          [])
+              n-2         (models.notification/create-notification!
+                           {:payload_type :notification/system-event
+                            :active       true
+                            :payload      {:event_name topic}}
+                           nil
+                           [])
+              _inactive  (models.notification/create-notification!
+                          {:payload_type :notification/system-event
+                           :active       false
+                           :payload      {:event_name topic}}
+                          []
+                          nil)
+              sent-notis (atom [])]
+          (testing "publishing event will send all the actively subscribed notifciations"
+            (with-redefs [notification.send/send-notification!      (fn [notification] (swap! sent-notis conj notification))
+                          events.notification/supported-topics #{:event/test-notification}]
+              (events/publish-event! topic {::hi true})
+              (is (=? [[(:id n-1) {::hi true}]
+                       [(:id n-2) {::hi true}]]
+                      (->> @sent-notis
+                           (map (juxt :id :event_info))
+                           (sort-by first)))))))))))
 
 (deftest unsupported-events-will-not-send-notification-test
   (mt/with-model-cleanup [:model/Notification]


### PR DESCRIPTION
Add a transformation step to translate the event info published to a format that'll be used for evaluate the condition.

The schema of the event info that'll be used for evaluate the condition will looks like

```json
{"table_id": 1,
 "record": {"ID": 1, "NAME": "Ngoc"},
  "event_name": "event/row.created"}
```