### PR TITLE
Patch the metabot-v3 merge

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -1,20 +1,14 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { METAKEY } from "metabase/lib/browser";
 import type { PaletteAction } from "metabase/palette/types";
-import {
-  PLUGIN_GO_MENU,
-  PLUGIN_METABOT,
-  PLUGIN_REDUCERS,
-} from "metabase/plugins";
-import { Flex, Text } from "metabase/ui";
+import { PLUGIN_METABOT, PLUGIN_REDUCERS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { Metabot } from "./components/Metabot";
 import { MetabotContext, MetabotProvider, defaultContext } from "./context";
 import { useMetabotAgent } from "./hooks";
-import { metabotReducer, setVisible } from "./state";
+import { metabotReducer } from "./state";
 
 if (hasPremiumFeature("metabot_v3")) {
   PLUGIN_METABOT.Metabot = Metabot;
@@ -48,21 +42,6 @@ if (hasPremiumFeature("metabot_v3")) {
   };
 
   PLUGIN_REDUCERS.metabotPlugin = metabotReducer;
-
-  PLUGIN_GO_MENU.getMenuItems = (dispatch) => [
-    {
-      title: (
-        <Flex align="center" justify="space-between" gap="md">
-          <div>{t`Metabot request`}</div>
-          <Text fz="sm" c="text-light">
-            {METAKEY} + B
-          </Text>
-        </Flex>
-      ),
-      icon: "metabot",
-      action: () => dispatch(setVisible(true)),
-    },
-  ];
 }
 
 /**

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -25,12 +25,9 @@ export interface NewItemMenuProps {
   trigger?: ReactNode;
   triggerIcon?: string;
   triggerTooltip?: string;
-  appendMenuItems?: NewMenuItem[];
-  hasModels: boolean;
   hasDataAccess: boolean;
   hasNativeWrite: boolean;
   hasDatabaseWithJsonEngine: boolean;
-  hasDatabaseWithActionsEnabled: boolean;
   onCloseNavbar: () => void;
   onChangeLocation: (nextLocation: LocationDescriptor) => void;
 }

--- a/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
+++ b/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
@@ -1,8 +1,6 @@
 import { t } from "ttag";
 
 import NewItemMenu from "metabase/containers/NewItemMenu";
-import { useDispatch } from "metabase/lib/redux";
-import { PLUGIN_GO_MENU } from "metabase/plugins";
 import type { CollectionId } from "metabase-types/api";
 
 import { NewButton, NewButtonText } from "./NewItemButton.styled";
@@ -12,8 +10,6 @@ export interface NewItemButtonProps {
 }
 
 const NewItemButton = ({ collectionId }: NewItemButtonProps) => {
-  const dispatch = useDispatch();
-
   return (
     <NewItemMenu
       trigger={
@@ -21,7 +17,6 @@ const NewItemButton = ({ collectionId }: NewItemButtonProps) => {
           <NewButtonText>{t`New`}</NewButtonText>
         </NewButton>
       }
-      appendMenuItems={PLUGIN_GO_MENU.getMenuItems(dispatch)}
       collectionId={collectionId}
     />
   );

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -716,10 +716,6 @@ export const PLUGIN_METABOT = {
     useMemo(() => [] as PaletteAction[], []),
 };
 
-export const PLUGIN_GO_MENU = {
-  getMenuItems: (_dispatch: any) => [] as Array<any>,
-};
-
 type DashCardMenuItemGetter = (
   question: Question,
   dashcardId: DashCardId | undefined,


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/52436 had a merge-conflict-resolution that left some superfluous bits in the New menu.

tl;dr
The new "metabot" menu item does not render.

This PR patches the merge (d3fafe9cf214660506de2ad2619f7d64e6d76b64) by removing these extra bits.
It also removes the `PLUGIN_GO_MENU` that was used in the new menu component.