### PR TITLE
feat(sdk): theme-dependent default question toolbar colors

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -100,10 +100,8 @@ describe(
             haveBackgroundColor($el, lighten(theme.colors?.background, 0.4)),
           );
 
-        cy.findByTestId("interactive-question-result-toolbar").should(
-          "have.css",
-          "background-color",
-          lighten(theme.colors?.background, 0.15),
+        cy.findByTestId("interactive-question-result-toolbar").should(($el) =>
+          haveBackgroundColor($el, lighten(theme.colors?.background, 0.5)),
         );
       });
     });
@@ -147,10 +145,8 @@ describe(
             haveBackgroundColor($el, darken(theme.colors?.background, 0.1)),
           );
 
-        cy.findByTestId("interactive-question-result-toolbar").should(
-          "have.css",
-          "background-color",
-          darken(theme.colors?.background, 0.04),
+        cy.findByTestId("interactive-question-result-toolbar").should(($el) =>
+          haveBackgroundColor($el, darken(theme.colors?.background, 0.04)),
         );
       });
     });
@@ -181,10 +177,8 @@ describe(
       getSdkRoot().within(() => {
         cy.findByText("Product ID").should("be.visible");
         // Should use the toolbar backgroundColor override, not the default background
-        cy.findByTestId("interactive-question-result-toolbar").should(
-          "have.css",
-          "background-color",
-          "rgb(100, 150, 200)",
+        cy.findByTestId("interactive-question-result-toolbar").should(($el) =>
+          haveBackgroundColor($el, "rgb(100, 150, 200)"),
         );
       });
     });

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -154,6 +154,40 @@ describe(
         );
       });
     });
+
+    it("overrides the question toolbar's default background color", () => {
+      const theme: MetabaseTheme = {
+        colors: {
+          background: "rgb(255, 255, 255)",
+          "text-primary": "rgb(51, 51, 51)",
+          brand: "rgb(253, 121, 168)",
+        },
+        components: {
+          question: {
+            toolbar: { backgroundColor: "rgb(100, 150, 200)" },
+          },
+        },
+      };
+
+      cy.get<number>("@questionId").then((questionId) => {
+        mountSdkContent(
+          <Box bg={theme.colors?.background} h="100vh">
+            <InteractiveQuestion questionId={questionId} />
+          </Box>,
+          { sdkProviderProps: { theme } },
+        );
+      });
+
+      getSdkRoot().within(() => {
+        cy.findByText("Product ID").should("be.visible");
+        // Should use the toolbar backgroundColor override, not the default background
+        cy.findByTestId("interactive-question-result-toolbar").should(
+          "have.css",
+          "background-color",
+          "rgb(100, 150, 200)",
+        );
+      });
+    });
   },
 );
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -62,7 +62,7 @@ describe(
           <Box bg={theme.colors?.background} h="100vh">
             <InteractiveQuestion questionId={questionId} />
           </Box>,
-          { theme },
+          { sdkProviderProps: { theme } },
         );
       });
 
@@ -99,6 +99,12 @@ describe(
           .should(($el) =>
             haveBackgroundColor($el, lighten(theme.colors?.background, 0.4)),
           );
+
+        cy.findByTestId("interactive-question-result-toolbar").should(
+          "have.css",
+          "background-color",
+          lighten(theme.colors?.background, 0.15),
+        );
       });
     });
 
@@ -117,7 +123,7 @@ describe(
           <Box bg={theme.colors?.background} h="100vh">
             <InteractiveQuestion questionId={questionId} />
           </Box>,
-          { theme },
+          { sdkProviderProps: { theme } },
         );
       });
 
@@ -140,6 +146,12 @@ describe(
           .should(($el) =>
             haveBackgroundColor($el, darken(theme.colors?.background, 0.1)),
           );
+
+        cy.findByTestId("interactive-question-result-toolbar").should(
+          "have.css",
+          "background-color",
+          darken(theme.colors?.background, 0.04),
+        );
       });
     });
   },

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -52,7 +52,6 @@ describe(
         colors: {
           background: "rgb(22, 26, 29)",
           "background-hover": "rgb(14, 17, 20)",
-          "background-disabled": "rgb(45, 45, 48)",
           "text-primary": "rgb(255, 255, 255)",
           brand: "rgb(253, 121, 168)",
         },
@@ -108,7 +107,6 @@ describe(
         colors: {
           background: "rgb(255, 255, 255)",
           "background-hover": "rgb(245, 245, 245)",
-          "background-disabled": "rgb(230, 230, 230)",
           "text-primary": "rgb(51, 51, 51)",
           brand: "rgb(253, 121, 168)",
         },

--- a/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
@@ -64,10 +64,6 @@ export const DEFAULT_METABASE_COMPONENT_THEME: MetabaseComponentTheme = {
   },
   question: {
     backgroundColor: "transparent",
-
-    toolbar: {
-      backgroundColor: "var(--mb-color-background-disabled)",
-    },
   },
 
   table: {

--- a/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
@@ -4,6 +4,10 @@ import type { DynamicCssVarConfig } from "../types/private/css-variables";
  * These CSS variables are dynamically generated based on the theme.
  */
 export const DYNAMIC_CSS_VARIABLES: DynamicCssVarConfig = {
+  "--mb-color-bg-sdk-question-toolbar": {
+    light: { source: "bg-white", darken: 0.04 },
+    dark: { source: "bg-white", lighten: 0.12 },
+  },
   "--mb-color-notebook-step-bg": {
     light: { source: "bg-white", darken: 0.05 },
     dark: { source: "bg-white", lighten: 0.5 },

--- a/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
@@ -6,7 +6,7 @@ import type { DynamicCssVarConfig } from "../types/private/css-variables";
 export const DYNAMIC_CSS_VARIABLES: DynamicCssVarConfig = {
   "--mb-color-bg-sdk-question-toolbar": {
     light: { source: "bg-white", darken: 0.04 },
-    dark: { source: "bg-white", lighten: 0.15 },
+    dark: { source: "bg-white", lighten: 0.5 },
   },
   "--mb-color-notebook-step-bg": {
     light: { source: "bg-white", darken: 0.05 },

--- a/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
@@ -6,7 +6,7 @@ import type { DynamicCssVarConfig } from "../types/private/css-variables";
 export const DYNAMIC_CSS_VARIABLES: DynamicCssVarConfig = {
   "--mb-color-bg-sdk-question-toolbar": {
     light: { source: "bg-white", darken: 0.04 },
-    dark: { source: "bg-white", lighten: 0.12 },
+    dark: { source: "bg-white", lighten: 0.15 },
   },
   "--mb-color-notebook-step-bg": {
     light: { source: "bg-white", darken: 0.05 },

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -31,8 +31,8 @@ export function getMetabaseSdkCssVariables(theme: MantineTheme, font: string) {
     :root {
       --mb-default-font-family: ${font};
       ${getSdkDesignSystemCssVariables(theme)}
-      ${getThemeSpecificCssVariables(theme)}
       ${getDynamicCssVariables(theme)}
+      ${getThemeSpecificCssVariables(theme)}
     }
   `;
 }


### PR DESCRIPTION
Closes EMB-380

### Description

We currently default the toolbar color to background-disabled which means yet another color for the user to define. The embed should look good with just a few colors defined. We darken or lighten the background color dynamically depending on the color scheme of the user.

### How to verify

- Set the background color and text color for the theme. You should try it with a light theme and also a dark theme. Example for a dark theme:

```tsx
colors: {
  background: "#2d2d3d",
  "text-primary": "#fff",
  "text-secondary": "#b3b3b3",
  "text-tertiary": "#8a8a8a",
  brand: "#ff9900",
}
```

- Render an InteractiveQuestion.
- The toolbar should be 4% darkened on light mode, and 15% lightened on dark mode.

### Demo

Light theme

![image](https://github.com/user-attachments/assets/6384aa4f-b511-46ed-a30d-7c3a60d84684)

Dark theme

![image](https://github.com/user-attachments/assets/08f4bebe-8a44-4eff-87aa-cb352d66ce35)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
