### PR TITLE
Fix snowplow e2e test helpers to be less flaky

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -153,10 +153,17 @@ export MB_SNOWPLOW_URL=http://localhost:9090
 
 We have a few helpers for dealing with tests involving snowplow
 
-1. You can use `describeWithSnowplow` (or `describeWithSnowplowEE` for EE edition) method to define tests that only run when a Snowplow instance is running
-2. Use `resetSnowplow()` test helper before each test to clear the queue of processed events.
-3. Use `expectGoodSnowPlowEvent({ ...payload})` to assert on the content of a snowplow event. Use `expectGoodSnowplowEvents(count)` to assert that events have been sent and processed correctly. Prefer the more precise assertion on the actual payload to a mere count of events.
-4. Use `expectNoBadSnowplowEvents()` after each test to assert that no invalid events have been sent.
+1. You can use `describeWithSnowplow` (or `describeWithSnowplowEE` for EE edition) method to define tests that only
+   run when a Snowplow instance is running
+1. Use `resetSnowplow()` test helper before each test to clear the queue of processed events.
+1. Use `expectSnowplowEvent({ ...payload }, count=n)` to assert that exactly `count` snowplow events match (partially)
+   the payload provided (count defaults to 1)
+1. Use `expectUnstructuredSnowplowEvent` to assert that exactly `count` snowplow events are unstructured events that
+   partial-match the payload provided. This is simply a convenience function for comparing
+   `event.unstruct_event.data.data` rather than the entire `event`. Most of our events are unstructured events, so this is handy.
+1. Use `assertNoUnstructuredSnowplowEvent({ ...eventData })` is the inverse of `expectUnstructuredSnowplowEvent`, and asserts that
+   *no* unstructured events match the payload.
+1. Use `expectNoBadSnowplowEvents()` after each test to assert that no invalid events have been sent.
 
 ### Running tests that require SMTP server
 

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -117,7 +117,7 @@ const MODEL_NAME = "Test Action Model";
             idFilter: true,
           });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "new_action_card_created",
           });
 
@@ -154,7 +154,7 @@ const MODEL_NAME = "Test Action Model";
             actionName: "Create",
           });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "new_action_card_created",
           });
 
@@ -194,7 +194,7 @@ const MODEL_NAME = "Test Action Model";
             idFilter: true,
           });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "new_action_card_created",
           });
 
@@ -251,7 +251,7 @@ const MODEL_NAME = "Test Action Model";
             actionName: "Delete",
           });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "new_action_card_created",
           });
 

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -30,7 +30,7 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
         .findAllByRole("link", { name: "Learn more" })
         .click();
       // link opens in new tab
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "upsell_viewed",
         promoted_feature: "cloud",
       });

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -931,7 +931,7 @@ H.describeWithSnowplow("add database card", () => {
 
     cy.get("@addDatabaseCard").findByText("Add a database").click();
     cy.location("pathname").should("eq", "/admin/databases/create");
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "database_add_clicked",
       triggered_from: "db-list",
     });

--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -235,7 +235,7 @@ describe("scenarios > collections > clean up", () => {
           moveToTrash();
           assertNoPagination();
 
-          H.expectGoodSnowplowEvent(
+          H.expectUnstructuredSnowplowEvent(
             (event) =>
               isMatching(
                 {
@@ -254,7 +254,7 @@ describe("scenarios > collections > clean up", () => {
           // Because cutoff_date will be relative to the current date, we simply check
           // that it exists and is a string. Snowplow will assert that it is in the correct
           // format
-          H.expectGoodSnowplowEvent(
+          H.expectUnstructuredSnowplowEvent(
             (event) =>
               event &&
               event.event === "stale_items_archived" &&
@@ -303,7 +303,7 @@ describe("scenarios > collections > clean up", () => {
           closeCleanUpModal();
 
           // Ensure that stale items in Our Analytics are maked with a null collection id
-          H.expectGoodSnowplowEvent(
+          H.expectUnstructuredSnowplowEvent(
             (event) =>
               event &&
               event.event === "stale_items_archived" &&

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -51,7 +51,7 @@ describe("scenarios > collection defaults", () => {
         .click();
 
       cy.log("Track the collection initiation from the header");
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "plus_button_clicked",
         triggered_from: "collection-header",
       });
@@ -77,7 +77,7 @@ describe("scenarios > collection defaults", () => {
       cy.log("Track the collection initiation from the main navbar");
       H.navigationSidebar().findByLabelText("Create a new collection").click();
       cy.findByTestId("new-collection-modal").should("be.visible");
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "plus_button_clicked",
         triggered_from: "collection-nav",
       });

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -131,7 +131,7 @@ describe("scenarios > collections > trash", () => {
       cy.log("should be able to move to trash from collection view");
       toggleEllipsisMenuFor(/Collection A/);
       H.popover().findByText("Move to trash").click();
-      H.expectGoodSnowplowEvent((event) =>
+      H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -147,7 +147,7 @@ describe("scenarios > collections > trash", () => {
 
       toggleEllipsisMenuFor("Dashboard A");
       H.popover().findByText("Move to trash").click();
-      H.expectGoodSnowplowEvent((event) =>
+      H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -163,7 +163,7 @@ describe("scenarios > collections > trash", () => {
 
       toggleEllipsisMenuFor("Question A");
       H.popover().findByText("Move to trash").click();
-      H.expectGoodSnowplowEvent((event) =>
+      H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -207,7 +207,7 @@ describe("scenarios > collections > trash", () => {
         cy.findByText("Move this collection to trash?");
         cy.findByText("Move to trash").click();
       });
-      H.expectGoodSnowplowEvent((event) =>
+      H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -233,7 +233,7 @@ describe("scenarios > collections > trash", () => {
         cy.findByText("Move this dashboard to trash?");
         cy.findByText("Move to trash").click();
       });
-      H.expectGoodSnowplowEvent((event) =>
+      H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -263,7 +263,7 @@ describe("scenarios > collections > trash", () => {
         cy.findByText("Move this question to trash?");
         cy.findByText("Move to trash").click();
       });
-      H.expectGoodSnowplowEvent((event) =>
+      H.expectUnstructuredSnowplowEvent((event) =>
         isMatching(
           {
             event: "moved-to-trash",

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -119,7 +119,7 @@ H.describeWithSnowplow(
           it(`Can upload ${testFile.fileName} to a collection`, () => {
             uploadFileToCollection(testFile);
 
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "csv_upload_successful",
             });
 
@@ -145,7 +145,7 @@ H.describeWithSnowplow(
           it(`Cannot upload ${testFile.fileName} to a collection`, () => {
             uploadFileToCollection(testFile);
 
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "csv_upload_failed",
             });
 

--- a/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
@@ -148,7 +148,7 @@ H.describeWithSnowplow(
 
       H.expressionEditorWidget().button("Done").click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "column_combine_via_shortcut",
         custom_expressions_used: ["concat"],
         database_id: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
@@ -214,7 +214,7 @@ H.describeWithSnowplow(
 
       H.popover().findAllByRole("button").contains("Hour of day").click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "column_extract_via_shortcut",
         custom_expressions_used: ["get-hour"],
         database_id: SAMPLE_DB_ID,
@@ -357,7 +357,7 @@ H.describeWithSnowplow(
 
       H.expressionEditorWidget().button("Done").click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "column_combine_via_shortcut",
         custom_expressions_used: ["concat"],
         database_id: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -36,7 +36,7 @@ H.describeWithSnowplow("scenarios > dashboard cards > sections", () => {
     H.getDashboardCards().should("have.length", 1);
     addSection("KPIs w/ large chart below");
     H.getDashboardCards().should("have.length", 7);
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "dashboard_section_added",
       section_layout: "kpi_chart_below",
     });
@@ -48,7 +48,7 @@ H.describeWithSnowplow("scenarios > dashboard cards > sections", () => {
     H.getDashboardCards().should("have.length", 0);
     addSection("KPI grid");
     H.getDashboardCards().should("have.length", 5);
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "dashboard_section_added",
       section_layout: "kpi_grid",
     });

--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -139,7 +139,7 @@ H.describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
     replaceQuestion(findTargetDashcard(), {
       nextQuestionName: "Orders",
     });
-    H.expectGoodSnowplowEvent({ event: "dashboard_card_replaced" });
+    H.expectUnstructuredSnowplowEvent({ event: "dashboard_card_replaced" });
     findTargetDashcard().within(() => {
       assertDashCardTitle("Orders");
       cy.findByText("Product ID").should("exist");

--- a/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
@@ -80,7 +80,7 @@ H.describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
     cy.findByLabelText("Edit dashboard").click();
 
     H.findDashCardAction(H.getDashboardCard(0), "Duplicate").click();
-    H.expectGoodSnowplowEvent(EVENTS.duplicateDashcard);
+    H.expectUnstructuredSnowplowEvent(EVENTS.duplicateDashcard);
 
     // check that the new card loads _before_ saving
     cy.findAllByText("Products").should("have.length", 2);
@@ -88,7 +88,7 @@ H.describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
     cy.findAllByText("Small Marble Shoes").should("have.length", 2);
 
     H.saveDashboard();
-    H.expectGoodSnowplowEvent(EVENTS.saveDashboard);
+    H.expectUnstructuredSnowplowEvent(EVENTS.saveDashboard);
 
     // 2. Confirm filter still works
     H.filterWidget().click();
@@ -106,14 +106,14 @@ H.describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
     cy.findByLabelText("Edit dashboard").click();
 
     H.duplicateTab("Tab 1");
-    H.expectGoodSnowplowEvent(EVENTS.duplicateTab);
+    H.expectUnstructuredSnowplowEvent(EVENTS.duplicateTab);
     H.getDashboardCard().within(() => {
       cy.findByText("Products").should("exist");
       cy.findByText("Category").should("exist");
       cy.findByText(/(Problem|Error)/i).should("not.exist");
     });
     H.saveDashboard();
-    H.expectGoodSnowplowEvent(EVENTS.saveDashboard);
+    H.expectUnstructuredSnowplowEvent(EVENTS.saveDashboard);
 
     H.dashboardCards().within(() => {
       cy.findByText("Products");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -624,8 +624,6 @@ describe(
 );
 
 H.describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
-  const NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS = 2;
-
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -645,15 +643,12 @@ H.describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
 
     H.openDashboardSettingsSidebar();
     H.sidesheet().within(() => {
-      H.expectGoodSnowplowEvents(
-        NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
-      );
       cy.findByText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
       cy.findByLabelText(filterToggleLabel).should("not.be.checked");
-      H.expectGoodSnowplowEvents(
-        NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS + 1,
-      );
+      H.expectUnstructuredSnowplowEvent({
+        event: "auto_apply_filters_disabled",
+      });
     });
   });
 
@@ -664,15 +659,12 @@ H.describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
 
     H.openDashboardSettingsSidebar();
     H.sidesheet().within(() => {
-      H.expectGoodSnowplowEvents(
-        NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
-      );
       cy.findByText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
       cy.findByLabelText(filterToggleLabel).should("be.checked");
-      H.expectGoodSnowplowEvents(
-        NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
-      );
+      H.assertNoUnstructuredSnowplowEvent({
+        event: "auto_apply_filters_disabled",
+      });
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1359,7 +1359,7 @@ H.describeWithSnowplow("scenarios > dashboard", () => {
       H.saveDashboard();
       validateIFrame("https://example.com");
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "new_iframe_card_created",
         target_id: id,
         event_detail: "example.com",
@@ -1373,7 +1373,7 @@ H.describeWithSnowplow("scenarios > dashboard", () => {
     const newTitle = "New title";
     cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();
     H.saveDashboard();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "dashboard_saved",
     });
   });
@@ -1405,7 +1405,7 @@ H.describeWithSnowplow("scenarios > dashboard", () => {
       /orders in a dashboard/i,
     );
 
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "new_link_card_created",
     });
   });
@@ -1426,7 +1426,7 @@ H.describeWithSnowplow("scenarios > dashboard", () => {
         .click({ force: true }) // disable
         .click({ force: true }); // enable
 
-      H.expectGoodSnowplowEvent(
+      H.expectUnstructuredSnowplowEvent(
         {
           event: "card_set_to_hide_when_no_results",
           dashboard_id: ORDERS_DASHBOARD_ID,
@@ -1488,7 +1488,7 @@ H.describeWithSnowplow("scenarios > dashboard", () => {
     cy.findByLabelText("Toggle width").click();
     H.popover().findByText("Full width").click();
     H.assertDashboardFullWidth();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "dashboard_width_toggled",
       full_width: true,
     });
@@ -1503,7 +1503,7 @@ H.describeWithSnowplow("scenarios > dashboard", () => {
     cy.findByLabelText("Toggle width").click();
     H.popover().findByText("Full width").click();
     H.assertDashboardFixedWidth();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "dashboard_width_toggled",
       full_width: false,
     });

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -742,8 +742,6 @@ describe("scenarios > dashboard > tabs", () => {
 });
 
 H.describeWithSnowplow("scenarios > dashboard > tabs", () => {
-  const PAGE_VIEW_EVENT = 1;
-
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -757,19 +755,18 @@ H.describeWithSnowplow("scenarios > dashboard > tabs", () => {
 
   it("should send snowplow events when dashboard tabs are created and deleted", () => {
     H.visitDashboard(ORDERS_DASHBOARD_ID);
-    H.expectGoodSnowplowEvents(PAGE_VIEW_EVENT);
 
     H.editDashboard();
     H.createNewTab();
     H.saveDashboard();
-    H.expectGoodSnowplowEvent({ event: "dashboard_saved" }, 1);
-    H.expectGoodSnowplowEvent({ event: "dashboard_tab_created" }, 1);
+    H.expectUnstructuredSnowplowEvent({ event: "dashboard_saved" });
+    H.expectUnstructuredSnowplowEvent({ event: "dashboard_tab_created" });
 
     H.editDashboard();
     H.deleteTab("Tab 2");
     H.saveDashboard();
-    H.expectGoodSnowplowEvent({ event: "dashboard_saved" }, 2);
-    H.expectGoodSnowplowEvent({ event: "dashboard_tab_deleted" }, 1);
+    H.expectUnstructuredSnowplowEvent({ event: "dashboard_saved" }, 2);
+    H.expectUnstructuredSnowplowEvent({ event: "dashboard_tab_deleted" });
   });
 
   it("should send snowplow events when cards are moved between tabs", () => {
@@ -777,12 +774,7 @@ H.describeWithSnowplow("scenarios > dashboard > tabs", () => {
 
     H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    H.expectGoodSnowplowEvent(
-      {
-        event: cardMovedEventName,
-      },
-      0,
-    );
+    H.assertNoUnstructuredSnowplowEvent({ event: cardMovedEventName });
 
     H.editDashboard();
     H.createNewTab();
@@ -790,12 +782,7 @@ H.describeWithSnowplow("scenarios > dashboard > tabs", () => {
 
     H.moveDashCardToTab({ tabName: "Tab 2" });
 
-    H.expectGoodSnowplowEvent(
-      {
-        event: cardMovedEventName,
-      },
-      1,
-    );
+    H.expectUnstructuredSnowplowEvent({ event: cardMovedEventName });
   });
 });
 

--- a/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
@@ -28,7 +28,7 @@ describe("scenarios > dashboard > text and headings", () => {
       cy.findByLabelText("Add a heading or text box").click();
       H.popover().findByText("Text").click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "new_text_card_created",
       });
 
@@ -115,7 +115,7 @@ describe("scenarios > dashboard > text and headings", () => {
         { delay: 0.5 },
       );
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "new_text_card_created",
       });
 
@@ -160,7 +160,7 @@ describe("scenarios > dashboard > text and headings", () => {
       cy.findByLabelText("Add a heading or text box").click();
       H.popover().findByText("Heading").click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "new_heading_card_created",
       });
 

--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -82,7 +82,7 @@ H.describeWithSnowplowEE(
 
         cy.verifyDownload("Orders in a dashboard.pdf");
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "dashboard_pdf_exported",
           dashboard_id: 0,
           dashboard_accessed_via: "static-embed",
@@ -108,7 +108,7 @@ H.describeWithSnowplowEE(
         H.exportFromDashcard(".csv");
         cy.verifyDownload(".csv", { contains: true });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "dashcard",
           accessed_via: "static-embed",
@@ -189,7 +189,7 @@ H.describeWithSnowplowEE(
           H.exportFromDashcard(".csv");
           cy.verifyDownload(".csv", { contains: true });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "download_results_clicked",
             resource_type: "dashcard",
             accessed_via: "static-embed",
@@ -256,7 +256,7 @@ H.describeWithSnowplowEE(
 
         cy.verifyDownload(".png", { contains: true });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "static-embed",
@@ -288,7 +288,7 @@ H.describeWithSnowplowEE(
 
         cy.verifyDownload(".csv", { contains: true });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "static-embed",
@@ -373,7 +373,7 @@ H.describeWithSnowplowEE(
 
           cy.verifyDownload(".csv", { contains: true });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "download_results_clicked",
             resource_type: "question",
             accessed_via: "static-embed",

--- a/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
@@ -31,12 +31,12 @@ H.describeWithSnowplow(
 
           H.uploadFile("#dwh-upload-csv-input", "Our analytics", testFile);
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "csv_upload_clicked",
             triggered_from: "left-nav",
           });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: testFile.valid
               ? "csv_upload_successful"
               : "csv_upload_failed",
@@ -58,7 +58,7 @@ H.describeWithSnowplow(
         cy.visit("/");
         cy.findByTestId("main-navbar-root").findByText("Add database").click();
         cy.location("pathname").should("eq", "/admin/databases/create");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "database_add_clicked",
           triggered_from: "left-nav",
         });

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -431,7 +431,7 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("c").realPress("f");
     cy.findByRole("dialog", { name: /collection/i }).should("exist");
     cy.realPress("Escape");
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "keyboard_shortcut_performed",
       event_detail: "create-new-collection",
     });
@@ -442,7 +442,7 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
 
     // Using a command palette action registered as a shortcut should only
     // emit snowplow events when using keyboard shortcuts, not command palette
-    H.expectGoodSnowplowEvent(
+    H.expectUnstructuredSnowplowEvent(
       {
         event: "keyboard_shortcut_performed",
         event_detail: "create-new-dashboard",
@@ -453,7 +453,7 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("c").realPress("d");
     cy.findByRole("dialog", { name: /dashboard/i }).should("exist");
     cy.realPress("Escape");
-    H.expectGoodSnowplowEvent(
+    H.expectUnstructuredSnowplowEvent(
       {
         event: "keyboard_shortcut_performed",
         event_detail: "create-new-dashboard",
@@ -471,7 +471,7 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     H.navigationSidebar().should("not.be.visible");
     cy.realPress("[");
     H.navigationSidebar().should("be.visible");
-    H.expectGoodSnowplowEvent(
+    H.expectUnstructuredSnowplowEvent(
       {
         event: "keyboard_shortcut_performed",
         event_detail: "toggle-navbar",
@@ -484,7 +484,7 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
       "equal",
       `/collection/${ADMIN_PERSONAL_COLLECTION_ID}`,
     );
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "keyboard_shortcut_performed",
       event_detail: "navigate-personal-collection",
     });
@@ -492,7 +492,7 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("g").realPress("t");
     cy.location("pathname").should("equal", "/trash");
 
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "keyboard_shortcut_performed",
       event_detail: "navigate-trash",
     });

--- a/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
@@ -28,7 +28,7 @@ H.describeWithSnowplow(
       // the example-dashboard-id is mocked, it's normal that we'll get to a permision error page
       H.main().findByText("Embed an example dashboard").click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "embedding_homepage_example_dashboard_click",
       });
     });
@@ -39,7 +39,7 @@ H.describeWithSnowplow(
       H.main().findByText("Hide these").click();
       H.popover().findByText("Embedding done, all good").click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "embedding_homepage_dismissed",
         dismiss_reason: "dismissed-done",
       });

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -82,7 +82,7 @@ H.describeWithSnowplow("scenarios > browse", () => {
     cy.findByRole("heading", { name: "Orders Model" }).click();
     cy.url().should("include", `/model/${ORDERS_MODEL_ID}-`);
     H.expectNoBadSnowplowEvents();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "browse_data_model_clicked",
       model_id: ORDERS_MODEL_ID,
     });
@@ -96,7 +96,7 @@ H.describeWithSnowplow("scenarios > browse", () => {
     cy.findByRole("button", { name: /Summarize/ });
     cy.findByRole("link", { name: /Sample Database/ }).click();
     H.expectNoBadSnowplowEvents();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "browse_data_table_clicked",
       table_id: PRODUCTS_ID,
     });
@@ -110,7 +110,7 @@ H.describeWithSnowplow("scenarios > browse", () => {
       .click();
     cy.location("pathname").should("eq", "/model/new");
     H.expectNoBadSnowplowEvents();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "plus_button_clicked",
       triggered_from: "model",
     });
@@ -125,7 +125,7 @@ H.describeWithSnowplow("scenarios > browse", () => {
     cy.findByTestId("entity-picker-modal").should("be.visible");
 
     H.expectNoBadSnowplowEvents();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "plus_button_clicked",
       triggered_from: "metric",
     });

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -583,7 +583,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
 
     H.undoToast().findByText("Changes saved").should("be.visible");
 
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "homepage_dashboard_enabled",
       source: "admin",
     });
@@ -598,7 +598,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
 
     H.entityPickerModal().findByText("Orders in a dashboard").click();
     H.modal().findByText("Save").click();
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "homepage_dashboard_enabled",
       source: "homepage",
     });
@@ -610,7 +610,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
     cy.log("From the app bar");
     H.newButton().should("be.visible").click();
     cy.findByRole("dialog").should("be.visible");
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "new_button_clicked",
       triggered_from: "app-bar",
     });
@@ -618,7 +618,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
     cy.log("Track closing the button as well");
     H.newButton().should("be.visible").click();
     cy.findByRole("dialog").should("not.exist");
-    H.expectGoodSnowplowEvent(
+    H.expectUnstructuredSnowplowEvent(
       {
         event: "new_button_clicked",
         triggered_from: "app-bar",
@@ -634,7 +634,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
     });
 
     cy.findByRole("dialog").should("be.visible");
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "new_button_clicked",
       triggered_from: "empty-collection",
     });
@@ -650,7 +650,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
     H.newButton().should("be.visible").click();
     cy.findByRole("dialog").findByText("Dashboard").click();
     cy.findByTestId("new-dashboard-modal").should("be.visible");
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "new_button_item_clicked",
       triggered_from: "dashboard",
     });
@@ -665,7 +665,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
     });
     cy.findByRole("dialog").findByText("Dashboard").click();
     cy.findByTestId("new-dashboard-modal").should("be.visible");
-    H.expectGoodSnowplowEvent(
+    H.expectUnstructuredSnowplowEvent(
       {
         event: "new_button_item_clicked",
         triggered_from: "dashboard",

--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -134,14 +134,13 @@ H.describeWithSnowplow("Onboarding checklist events", () => {
       .findByRole("listitem", { name: "How to use Metabase" })
       .click();
     cy.location("pathname").should("eq", "/getting-started");
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "onboarding_checklist_opened",
     });
   });
 
   describe("Onboarding checklist page", () => {
     it("should track each item when expanded", () => {
-      const PAGE_VIEW = 1;
       const items: ChecklistItemValue[] = [
         "invite",
         "database",
@@ -154,14 +153,10 @@ H.describeWithSnowplow("Onboarding checklist events", () => {
       ];
 
       cy.visit("/getting-started");
-      cy.log(
-        "The default open accordion item is not tracked - only the page view is",
-      );
-      H.expectGoodSnowplowEvents(PAGE_VIEW);
 
       items.forEach((i) => {
         cy.findByTestId(`${i}-item`).click();
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "onboarding_checklist_item_expanded",
           triggered_from: i,
         });
@@ -178,7 +173,7 @@ H.describeWithSnowplow("Onboarding checklist events", () => {
         .should("have.attr", "aria-selected", "true");
 
       cy.findByTestId("database-cta").button("Add Database").click();
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "onboarding_checklist_cta_clicked",
         triggered_from: "database",
         event_detail: "primary",
@@ -188,7 +183,7 @@ H.describeWithSnowplow("Onboarding checklist events", () => {
 
       cy.findByTestId("invite-item").click();
       cy.findByTestId("invite-cta").button("Invite people").click();
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "onboarding_checklist_cta_clicked",
         triggered_from: "invite",
         event_detail: "primary",
@@ -197,7 +192,7 @@ H.describeWithSnowplow("Onboarding checklist events", () => {
       cy.go("back");
 
       cy.findByTestId("invite-cta").button("Set up Single Sign-on").click();
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "onboarding_checklist_cta_clicked",
         triggered_from: "invite",
         event_detail: "secondary",

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -451,31 +451,24 @@ H.describeWithSnowplow("scenarios > setup", () => {
     H.expectNoBadSnowplowEvents();
   });
 
-  it("should send snowplow events", { tags: "@flaky" }, () => {
-    let goodEvents = 0;
-
-    goodEvents++; // 1 - new_instance_created
-    goodEvents++; // 2 - pageview
+  it("should send snowplow events", () => {
     cy.visit("/setup");
 
-    goodEvents++; // 3 - setup/step_seen "welcome"
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "step_seen",
       step_number: 0,
       step: "welcome",
     });
     skipWelcomePage();
 
-    goodEvents++; // 4 - setup/step_seen  "language"
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "step_seen",
       step_number: 1,
       step: "language",
     });
     selectPreferredLanguageAndContinue();
 
-    goodEvents++; // 5 - setup/step_seen "user_info"
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "step_seen",
       step_number: 2,
       step: "user_info",
@@ -488,74 +481,63 @@ H.describeWithSnowplow("scenarios > setup", () => {
       });
 
       cy.findByText("What will you use Metabase for?").should("exist");
-      goodEvents++; // 6 - setup/step_seen "usage_question"
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
         step_number: 3,
         step: "usage_question",
       });
       cy.button("Next").click();
 
-      goodEvents++; // 7 - setup/usage_reason_selected
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "usage_reason_selected",
         usage_reason: "self-service-analytics",
       });
 
-      goodEvents++; // 8 - setup/step_seen "db_connection"
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
         step_number: 4,
         step: "db_connection",
       });
       cy.findByText("I'll add my data later").click();
 
-      goodEvents++; // 9/10 - setup/add_data_later_clicked
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "add_data_later_clicked",
       });
 
       // This step is only visile on EE builds
       if (IS_ENTERPRISE) {
-        goodEvents++; // 10/11 - setup/step_seen "commercial_license"
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "step_seen",
           step_number: 5,
           step: "license_token",
         });
 
         cy.button("Skip").click();
-        goodEvents++; // 11/12 - setup/step_seen "commercial_license"
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "license_token_step_submitted",
           valid_token_present: false,
         });
       }
 
-      goodEvents++; // 11/12 - setup/step_seen "data_usage"
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
         step_number: IS_ENTERPRISE ? 6 : 5,
         step: "data_usage",
       });
 
       cy.findByRole("button", { name: "Finish" }).click();
-      goodEvents++; // 12/13- - new_user_created (from BE)
 
-      goodEvents++; // 13/14- setup/step_seen "completed"
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
         step_number: IS_ENTERPRISE ? 7 : 6,
         step: "completed",
       });
 
-      H.expectGoodSnowplowEvents(goodEvents);
-
       cy.findByText(
         "Get infrequent emails about new releases and feature updates.",
       ).click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "newsletter-toggle-clicked",
         triggered_from: "setup",
         event_detail: "opted-in",
@@ -565,7 +547,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
         "Get infrequent emails about new releases and feature updates.",
       ).click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "newsletter-toggle-clicked",
         triggered_from: "setup",
         event_detail: "opted-out",
@@ -573,18 +555,15 @@ H.describeWithSnowplow("scenarios > setup", () => {
     });
   });
 
-  it(
-    "should ignore snowplow failures and work as normal",
-    { tags: "@flaky" },
-    () => {
-      H.blockSnowplow();
-      cy.visit("/setup");
-      skipWelcomePage();
-
-      // 1 event is sent from the BE, which isn't blocked by blockSnowplow()
-      H.expectGoodSnowplowEvents(1);
-    },
-  );
+  it("should ignore snowplow failures and work as normal", () => {
+    H.blockSnowplow();
+    cy.visit("/setup");
+    skipWelcomePage();
+    selectPreferredLanguageAndContinue();
+    H.assertNoUnstructuredSnowplowEvent({
+      event: "step_seen",
+    });
+  });
 });
 
 const skipWelcomePage = () => {

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -710,23 +710,55 @@ H.describeWithSnowplow("scenarios > collections > timelines", () => {
   });
 
   it("should send snowplow events when creating a timeline event", () => {
-    // 1 - new_instance_created
-    // 2 - pageview
     cy.visit("/collection/root");
+    H.expectSnowplowEvent({
+      eventType: "page_view",
+      event: {
+        page_urlpath: "/collection/root",
+      },
+    });
 
-    // 3 - pageview
     cy.icon("calendar").click();
+    H.expectSnowplowEvent({
+      eventType: "page_view",
+      event: {
+        page_urlpath: "/collection/root/timelines",
+      },
+    });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Create event").click();
     cy.findByLabelText("Event name").type("Event");
     cy.findByLabelText("Date").type("10/20/2026");
+    H.expectSnowplowEvent({
+      eventType: "page_view",
+      event: {
+        page_urlpath: "/collection/root/timelines/new/events/new",
+      },
+    });
 
-    // 4 - new_event_created
-    // 5 - pageview
     cy.button("Create").click();
+    H.expectSnowplowEvent({
+      event: {
+        unstruct_event: {
+          data: {
+            data: {
+              event: "new_event_created",
+            },
+          },
+        },
+      },
+    });
 
-    H.expectGoodSnowplowEvents(5);
+    H.expectSnowplowEvent(
+      {
+        eventType: "page_view",
+        event: {
+          page_urlpath: "/collection/root/timelines",
+        },
+      },
+      2,
+    ); // we viewed this page twice
   });
 });
 

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -394,7 +394,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -449,7 +449,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -509,7 +509,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -575,7 +575,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -636,7 +636,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -692,7 +692,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -749,7 +749,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -812,7 +812,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -875,7 +875,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -930,7 +930,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -987,7 +987,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -1044,7 +1044,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -1150,7 +1150,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1212,7 +1212,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1274,7 +1274,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1345,7 +1345,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1402,7 +1402,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1460,7 +1460,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1523,7 +1523,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1587,7 +1587,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1649,7 +1649,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1707,7 +1707,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1766,7 +1766,7 @@ describe.skip("scenarios > question", () => {
           H.popover().button("Done").click();
 
           cy.get("@questionId").then((questionId) => {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -468,24 +468,21 @@ H.describeWithSnowplow(
     it("should track `notebook_native_preview_shown|hidden` events", () => {
       cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
       H.openReviewsTable({ mode: "notebook", limit: 1 });
-      H.expectGoodSnowplowEvents(1); // page view
 
       cy.findByLabelText("View SQL").click();
       cy.wait("@nativeDataset");
       cy.findByTestId("native-query-preview-sidebar").should("exist");
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "notebook_native_preview_shown",
       });
 
       cy.findByLabelText("Hide SQL").click();
       cy.findByTestId("native-query-preview-sidebar").should("not.exist");
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "notebook_native_preview_hidden",
       });
-
-      H.expectGoodSnowplowEvents(3);
     });
   },
 );

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -425,8 +425,6 @@ describe(
 );
 
 H.describeWithSnowplow("send snowplow question events", () => {
-  const NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_MODEL_CONVERSION = 2;
-
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -441,15 +439,10 @@ H.describeWithSnowplow("send snowplow question events", () => {
   it("should send event when clicking `Turn into a model`", () => {
     H.visitQuestion(ORDERS_QUESTION_ID);
     H.openQuestionActions();
-    H.expectGoodSnowplowEvents(
-      NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_MODEL_CONVERSION,
-    );
     H.popover().within(() => {
       cy.findByText("Turn into a model").click();
     });
-    H.expectGoodSnowplowEvents(
-      NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_MODEL_CONVERSION + 1,
-    );
+    H.expectUnstructuredSnowplowEvent({ event: "turn_into_model_clicked" });
   });
 });
 

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -24,7 +24,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       H.commandPaletteSearch("Orders", false);
 
       //Passing a function to ensure that runtime_milliseconds is populated as a number
-      H.expectGoodSnowplowEvent((data) => {
+      H.expectUnstructuredSnowplowEvent((data) => {
         if (!data) {
           return false;
         }
@@ -36,7 +36,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       });
 
       H.commandPalette().findByRole("option", { name: "Orders Model" }).click();
-      H.expectGoodSnowplowEvent(
+      H.expectUnstructuredSnowplowEvent(
         {
           event: SEARCH_CLICK,
           context: "command-palette",
@@ -51,7 +51,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       H.commandPaletteSearch("Orders", false);
 
       //Passing a function to ensure that runtime_milliseconds is populated as a number
-      H.expectGoodSnowplowEvent((data) => {
+      H.expectUnstructuredSnowplowEvent((data) => {
         if (!data) {
           return false;
         }
@@ -69,7 +69,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
         delay: 200,
       });
 
-      H.expectGoodSnowplowEvent(
+      H.expectUnstructuredSnowplowEvent(
         {
           event: SEARCH_CLICK,
           context: "command-palette",
@@ -89,7 +89,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
 
       H.entityPickerModal().findByPlaceholderText("Search…").type("second");
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: NEW_SEARCH_QUERY_EVENT_NAME,
         context: "entity-picker",
         content_type: ["collection"],
@@ -99,7 +99,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
         .findByRole("button", { name: /Second/ })
         .click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: SEARCH_CLICK,
         context: "entity-picker",
         position: 0,
@@ -116,7 +116,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       cy.findByPlaceholderText("Search…").type("coun");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: NEW_SEARCH_QUERY_EVENT_NAME,
         context: "search-bar",
       });
@@ -125,7 +125,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
         .findByRole("heading", { name: "People" })
         .click();
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: SEARCH_CLICK,
         context: "search-bar",
         position: 2,
@@ -138,13 +138,13 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a new_search_query snowplow event", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
         });
 
         cy.findByRole("heading", { name: "Orders in a dashboard" }).click();
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: SEARCH_CLICK,
           context: "search-app",
           position: 0,
@@ -157,7 +157,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
         cy.visit("/search?q=orders&type=card");
         cy.wait("@search");
 
-        H.expectGoodSnowplowEvent(
+        H.expectUnstructuredSnowplowEvent(
           {
             event: NEW_SEARCH_QUERY_EVENT_NAME,
 
@@ -171,7 +171,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
         });
@@ -184,7 +184,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           cy.findByText("Apply").click();
         });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
 
           context: "search-app",
@@ -203,7 +203,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&type=card");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -214,7 +214,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -227,7 +227,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&created_by=1");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -238,7 +238,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
           creator: false,
@@ -250,7 +250,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           cy.findByText("Apply").click();
         });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -261,7 +261,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&created_by=1");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -272,7 +272,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -285,7 +285,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&last_edited_by=1");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -296,7 +296,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -309,7 +309,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           cy.findByText("Apply").click();
         });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -320,7 +320,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&last_edited_by=1");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -331,7 +331,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -344,7 +344,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&created_at=thisday");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -355,7 +355,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -367,7 +367,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           cy.findByText("Today").click();
         });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -378,7 +378,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&created_at=thisday");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -389,7 +389,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -402,7 +402,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&last_edited_at=thisday");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -413,7 +413,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -425,7 +425,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           cy.findByText("Today").click();
         });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -436,7 +436,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&last_edited_at=thisday");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -447,7 +447,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -464,7 +464,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&verified=true");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -475,7 +475,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -486,7 +486,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Verified items only")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -497,7 +497,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&verified=true");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -508,7 +508,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Verified items only")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -521,7 +521,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&search_native_query=true");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -532,7 +532,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -543,7 +543,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search the contents of native queries")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -554,7 +554,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&search_native_query=true");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -565,7 +565,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search the contents of native queries")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -578,7 +578,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&archived=true");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -589,7 +589,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -600,7 +600,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search items in trash")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -611,7 +611,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&archived=true");
         cy.wait("@search");
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -622,7 +622,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search items in trash")
           .click();
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -66,7 +66,7 @@ describe("scenarios > question > download", () => {
           expect(sheet["A2"].v).to.eq(18760);
         });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "ad-hoc-question",
           accessed_via: "internal",
@@ -568,7 +568,7 @@ H.describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
       H.visitDashboard(dashboard.id);
       H.openSharingMenu("Export as PDF");
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "dashboard_pdf_exported",
         dashboard_id: dashboard.id,
         dashboard_accessed_via: "internal",
@@ -590,7 +590,7 @@ H.describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
 
     H.exportFromDashcard(".png");
 
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "download_results_clicked",
       resource_type: "dashcard",
       accessed_via: "internal",

--- a/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
@@ -136,7 +136,7 @@ H.describeWithSnowplowEE(
 
         cy.verifyDownload("Orders in a dashboard.pdf");
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "dashboard_pdf_exported",
           dashboard_id: 0,
           dashboard_accessed_via: "public-link",
@@ -161,7 +161,7 @@ H.describeWithSnowplowEE(
           H.assertNotEmptyObject,
         );
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "dashcard",
           accessed_via: "public-link",
@@ -225,7 +225,7 @@ H.describeWithSnowplowEE(
 
         cy.verifyDownload(".png", { contains: true });
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "public-link",
@@ -255,7 +255,7 @@ H.describeWithSnowplowEE(
           H.assertNotEmptyObject,
         );
 
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "public-link",

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -289,7 +289,7 @@ describe("#39152 sharing an unsaved question", () => {
           H.openSharingMenu(/public link/i);
           cy.findByTestId("copy-button").realClick();
           if (resource === "dashboard") {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "public_link_copied",
               artifact: "dashboard",
               format: null,
@@ -297,7 +297,7 @@ describe("#39152 sharing an unsaved question", () => {
           }
 
           if (resource === "question") {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "html",
@@ -305,7 +305,7 @@ describe("#39152 sharing an unsaved question", () => {
 
             H.popover().findByText("csv").click();
             cy.findByTestId("copy-button").realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "csv",
@@ -313,7 +313,7 @@ describe("#39152 sharing an unsaved question", () => {
 
             H.popover().findByText("xlsx").click();
             cy.findByTestId("copy-button").realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "xlsx",
@@ -321,7 +321,7 @@ describe("#39152 sharing an unsaved question", () => {
 
             H.popover().findByText("json").click();
             cy.findByTestId("copy-button").realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "json",
@@ -336,7 +336,7 @@ describe("#39152 sharing an unsaved question", () => {
 
           H.openSharingMenu(/public link/i);
           H.popover().button("Remove public link").click();
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "public_link_removed",
             artifact: resource,
             source: "public-share",
@@ -365,7 +365,7 @@ describe("#39152 sharing an unsaved question", () => {
 
           H.popover().findByTestId("copy-button").click();
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "public_embed_code_copied",
             artifact: resource,
             source: "public-embed",
@@ -382,7 +382,7 @@ describe("#39152 sharing an unsaved question", () => {
 
           H.popover().findByText("Remove public link").click();
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "public_link_removed",
             artifact: resource,
             source: "public-embed",
@@ -401,7 +401,7 @@ describe("#39152 sharing an unsaved question", () => {
           cy.findByTestId("embed-backend")
             .findByTestId("copy-button")
             .realClick();
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "node",
@@ -420,7 +420,7 @@ describe("#39152 sharing an unsaved question", () => {
           cy.findByTestId("embed-frontend")
             .findByTestId("copy-button")
             .realClick();
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "pug",
@@ -446,7 +446,7 @@ describe("#39152 sharing an unsaved question", () => {
           cy.findByTestId("embed-backend")
             .findByTestId("copy-button")
             .realClick();
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "ruby",
@@ -486,7 +486,7 @@ describe("#39152 sharing an unsaved question", () => {
           cy.findByTestId("embed-backend")
             .findByTestId("copy-button")
             .realClick();
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "python",
@@ -509,7 +509,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "python",
@@ -542,7 +542,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "node",
@@ -561,7 +561,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByTestId("embed-frontend")
               .findByTestId("copy-button")
               .realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "pug",
@@ -587,7 +587,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "ruby",
@@ -646,7 +646,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "python",
@@ -686,7 +686,7 @@ describe("#39152 sharing an unsaved question", () => {
                 .findByTestId("copy-button")
                 .realClick();
 
-              H.expectGoodSnowplowEvent({
+              H.expectUnstructuredSnowplowEvent({
                 event: "static_embed_code_copied",
                 artifact: resource,
                 language: "node",
@@ -720,7 +720,7 @@ describe("#39152 sharing an unsaved question", () => {
                 .findByTestId("copy-button")
                 .realClick();
 
-              H.expectGoodSnowplowEvent({
+              H.expectUnstructuredSnowplowEvent({
                 event: "static_embed_code_copied",
                 artifact: resource,
                 language: "node",
@@ -754,7 +754,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByText("Discard changes").click();
           });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "static_embed_discarded",
             artifact: resource,
           });
@@ -774,7 +774,7 @@ describe("#39152 sharing an unsaved question", () => {
             .click();
 
           cy.then(function () {
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "static_embed_published",
               artifact: resource,
               new_embed: true,
@@ -812,7 +812,7 @@ describe("#39152 sharing an unsaved question", () => {
               .button("Publish")
               .click();
 
-            H.expectGoodSnowplowEvent({
+            H.expectUnstructuredSnowplowEvent({
               event: "static_embed_published",
               artifact: resource,
               new_embed: false,
@@ -840,7 +840,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByText("Unpublish").click();
           });
 
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "static_embed_unpublished",
             artifact: resource,
             time_since_creation: closeTo(toSecond(HOUR), 10),

--- a/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
@@ -13,13 +13,17 @@ H.describeWithSnowplow("scenarios > stats > snowplow", () => {
     { tags: "@OSS" },
     () => {
       cy.request("POST", "api/testing/stats");
-      H.expectGoodSnowplowEvents(1);
+      H.expectSnowplowEvent({
+        event: { event_name: "instance_stats" },
+      });
     },
   );
 
   it("should send a snowplow event when the stats ping is triggered on EE", () => {
     cy.request("POST", "api/testing/stats");
-    H.expectGoodSnowplowEvents(1);
+    H.expectSnowplowEvent({
+      event: { event_name: "instance_stats" },
+    });
   });
 
   afterEach(() => {

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
@@ -104,7 +104,7 @@ H.describeWithSnowplow("extract shortcut", () => {
             value,
             example,
           });
-          H.expectGoodSnowplowEvent({
+          H.expectUnstructuredSnowplowEvent({
             event: "column_extract_via_plus_modal",
             custom_expressions_used: expressions,
             database_id: SAMPLE_DB_ID,
@@ -173,7 +173,7 @@ H.describeWithSnowplow("extract shortcut", () => {
           value,
           example,
         });
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "column_extract_via_plus_modal",
           custom_expressions_used: expressions,
           database_id: SAMPLE_DB_ID,
@@ -213,7 +213,7 @@ H.describeWithSnowplow("extract shortcut", () => {
           value,
           example,
         });
-        H.expectGoodSnowplowEvent({
+        H.expectUnstructuredSnowplowEvent({
           event: "column_extract_via_plus_modal",
           custom_expressions_used: expressions,
           database_id: SAMPLE_DB_ID,
@@ -428,7 +428,7 @@ H.describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
       newValue: "borer-hudson@yahoo.com1",
     });
 
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "column_combine_via_plus_modal",
       custom_expressions_used: ["concat"],
       database_id: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
@@ -417,7 +417,7 @@ H.describeWithSnowplow("extract action", () => {
       extraction: "Extract day, month…",
     });
 
-    H.expectGoodSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "column_extract_via_column_header",
       custom_expressions_used: ["get-year"],
       database_id: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
@@ -82,7 +82,7 @@ H.describeWithSnowplow(
         .last()
         .should("have.text", "Combined Email, Name, ID");
 
-      H.expectGoodSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "column_combine_via_column_header",
         custom_expressions_used: ["concat"],
         database_id: SAMPLE_DB_ID,


### PR DESCRIPTION
Remove `expectGoodSnowplowEvents` entirely - doing assertions based on the count wasn't a good idea (changes that added a new snowplow event could cause your tests to stop testing what you think they're testing).

Replace it with a good set of snowplow helper functions that actually
accomplish what we want:

- `expectSnowplowEvent`, which matches on the *entire* event rather than
assuming the event is an unstructured event (most of ours are, but some
are not).

- `expectUnstructuredSnowplowEvent`, which behaves the same as
  `expectGoodSnowplowEvent` used to, except I removed an unused behavior
  where it took a function instead of a partial-match object.

- `assertNoUnstructuredSnowplowEvent`, which asserts the inverse of
  `expectGoodSnowplowEvent` - there are zero matching snowplow events.

I removed `Good` from all these names as I think that's implied - if you
want to make an assertion that a bad event is being received you can
write your own helper :)
