### PR TITLE
Improved database rollback logic logic

### DIFF
--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -3,6 +3,8 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
+   [honey.sql :as sql]
+   [honey.sql.helpers :as sql.helpers]
    [metabase.config :as config]
    [metabase.db.connection :as mdb.connection]
    [metabase.db.custom-migrations]
@@ -19,13 +21,14 @@
   (:import
    (java.io StringWriter)
    (java.sql Connection)
-   (java.util List Map)
+   (java.util ArrayList List Map)
    (javax.sql DataSource)
    (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
-   (liquibase.changelog.filter ChangeSetFilter)
+   (liquibase.changelog.filter AlreadyRanChangeSetFilter ChangeSetFilter ChangeSetFilterResult DbmsChangeSetFilter IgnoreChangeSetFilter)
    (liquibase.changelog.visitor AbstractChangeExecListener ChangeExecListener UpdateVisitor)
+   (liquibase.command.core AbstractRollbackCommandStep)
    (liquibase.database Database DatabaseFactory)
    (liquibase.database.jvm JdbcConnection)
    (liquibase.exception LockException)
@@ -516,17 +519,47 @@
    (with-scope-locked liquibase
     ;; count and rollback only the applied change set ids which come after the target version (only the "v..." IDs need
     ;; to be considered)
-     (let [changeset-query (format "SELECT id FROM %s WHERE id LIKE 'v%%' ORDER BY ID ASC" (changelog-table-name liquibase))
+     (let [changeset-query (format "SELECT id FROM %s WHERE id LIKE 'v%%'" (changelog-table-name liquibase))
            changeset-ids   (map :id (jdbc/query {:connection conn} [changeset-query]))
            ;; IDs in changesets do not include the leading 0/1 digit, so the major version is the first number
-           ids-to-drop     (drop-while #(not= (inc target-version) (first (extract-numbers %))) changeset-ids)
+           ids-to-drop     (set (filter #(< target-version (first (extract-numbers %))) changeset-ids))
            latest-available (latest-available-major-version liquibase)
-           latest-applied   (latest-applied-major-version conn (.getDatabase liquibase))]
+           latest-applied   (latest-applied-major-version conn (.getDatabase liquibase))
+           lb-db (.getDatabase liquibase)
+           ran-changesets   (.getRanChangeSetList lb-db)
+           changelog (.getDatabaseChangeLog liquibase)
+           changeset-filter (proxy [ChangeSetFilter] []
+                              (accepts [^ChangeSet changeSet]
+                                (let [id (.getId changeSet)
+                                      result (contains? ids-to-drop id)]
+                                  (ChangeSetFilterResult. result (if result
+                                                                   (do
+                                                                     (log/infof "Going to roll back changeset %s" id)
+                                                                     (str "Changeset ID '" id "' is in target list"))
+                                                                   (str "Changeset ID '" id "' is not in target list")) nil))))
+           changelog-iterator (ChangeLogIterator. ran-changesets changelog
+                                                  (doto (ArrayList.)
+                                                    (.addAll
+                                                     [(AlreadyRanChangeSetFilter. ran-changesets)
+                                                      (IgnoreChangeSetFilter.)
+                                                      (DbmsChangeSetFilter. lb-db)
+                                                      changeset-filter])))]
        (when (and (not force) (> latest-applied latest-available))
          (throw (ex-info
                  (format "Cannot downgrade a database at version %d from Metabase version %d. You must run 'migrate down' from Metabase version >= %d."
                          latest-applied latest-available latest-applied)
                  {:latest-available latest-available
                   :latest-applied   latest-applied})))
+
        (log/infof "Rolling back app database schema to version %d" target-version)
-       (.rollback liquibase (count ids-to-drop) "")))))
+       (if (empty? ids-to-drop)
+         (log/info "No changesets to roll back")
+         (do
+           (AbstractRollbackCommandStep/doRollback lb-db update-migrations-file nil changelog-iterator (.getChangeLogParameters liquibase) changelog nil nil)
+           (let [remaining-query (-> (sql.helpers/select :id)
+                                     (sql.helpers/from (keyword (changelog-table-name liquibase)))
+                                     (sql.helpers/where [:in :id ids-to-drop]))
+                 formatted-sql (sql/format remaining-query)
+                 remaining-ids   (map :id (t2/query conn formatted-sql))]
+             (when (seq remaining-ids)
+               (log/warnf "The following changesets were not rolled back. Likely because they are not in the changelog file: %s" (str/join ", " remaining-ids))))))))))


### PR DESCRIPTION
### Description

The current "migrate down" logic counts the number of changesets that were executed against the database in the versions to downgrade from and then rolls back that number of changesets.

While that will generally work because the "rollback count" reverts the last X executed changesets and normally the new version changesets are the last ones executed, there are edge cases where that is not the case.

For example, if someone:

1. Installed v53.0 which ran changesets `[v53.a, v53.b, v53.c] `
1. Upgraded to v53.1 which ran changesets `[v52.x, v53.d]` 
    1. backported 53.1 included a v52-backported  changest
1. Rolled back to v52

Then the old logic would have seen the count of v53 changes as`[v53.d, v53.c, v53.b v53.a]`, but the 4 changesets rolled back would be `[v53.d, v52.x, v53.c, v53.b]`

This fixes the logic by using the liquibase rollback logic more directly so we can do a custom "roll back the changeset ids that are in this list" logic instead.

It also includes a warn-level message if there are changesets that were expected to roll back but were not. The main reason this should happen is because liquibase will only try to roll back changests that are in the databasechangelog file. Reasons previously-executed changelogs may not be there would include us removing changesets that are no longer needed or the user doing a rollback with an earlier patch release than they had previously ran.

I didn't want to block the rollback for either of those reasons, but wanted to at least warn the case since the changeset is (correctly) still marked as executed. 


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
