### PR TITLE
hide metric and dimension columns from scalar funnel

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
@@ -191,15 +191,14 @@ describe("scenarios > dashboard > visualizer > funnels", () => {
       H.assertDataSourceColumnSelected(PAYMENT_DONE_PAGE_VIEWS.name, "views");
 
       H.verticalWell().within(() => {
-        cy.findByText("METRIC").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 1);
+        cy.findByText("METRIC").should("not.exist");
       });
       H.horizontalWell().within(() => {
-        cy.findByText("DIMENSION").should("exist");
+        cy.findByText("DIMENSION").should("not.exist");
         cy.findByText(LANDING_PAGE_VIEWS.name).should("exist");
         cy.findByText(CHECKOUT_PAGE_VIEWS.name).should("exist");
         cy.findByText(PAYMENT_DONE_PAGE_VIEWS.name).should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 4);
+        cy.findAllByTestId("well-item").should("have.length", 3);
       });
 
       // Remove a column from the data manager
@@ -210,43 +209,27 @@ describe("scenarios > dashboard > visualizer > funnels", () => {
         false,
       );
       H.verticalWell().within(() => {
-        cy.findByText("METRIC").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 1);
+        cy.findByText("METRIC").should("not.exist");
       });
       H.horizontalWell().within(() => {
-        cy.findByText("DIMENSION").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 3);
+        cy.findByText("DIMENSION").should("not.exist");
+        cy.findAllByTestId("well-item").should("have.length", 2);
       });
 
       // Add a column back
       H.selectColumnFromColumnsList(CHECKOUT_PAGE_VIEWS.name, "views");
       H.assertDataSourceColumnSelected(CHECKOUT_PAGE_VIEWS.name, "views");
       H.verticalWell().within(() => {
-        cy.findByText("METRIC").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 1);
+        cy.findByText("METRIC").should("not.exist");
       });
       H.horizontalWell().within(() => {
-        cy.findByText("DIMENSION").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 4);
+        cy.findByText("DIMENSION").should("not.exist");
+        cy.findAllByTestId("well-item").should("have.length", 3);
       });
 
-      // Remove the metric column from the well
-      H.verticalWell()
-        .findByTestId("well-item")
-        .findByLabelText("Remove")
-        .click();
-
-      H.assertDataSourceColumnSelected(LANDING_PAGE_VIEWS.name, "views", false);
-      H.assertDataSourceColumnSelected(
-        CHECKOUT_PAGE_VIEWS.name,
-        "views",
-        false,
-      );
-      H.assertDataSourceColumnSelected(
-        PAYMENT_DONE_PAGE_VIEWS.name,
-        "views",
-        false,
-      );
+      H.deselectColumnFromColumnsList(LANDING_PAGE_VIEWS.name, "views");
+      H.deselectColumnFromColumnsList(CHECKOUT_PAGE_VIEWS.name, "views");
+      H.deselectColumnFromColumnsList(PAYMENT_DONE_PAGE_VIEWS.name, "views");
 
       H.verticalWell().findAllByTestId("well-item").should("have.length", 0);
       H.horizontalWell().findAllByTestId("well-item").should("have.length", 0);
@@ -261,35 +244,12 @@ describe("scenarios > dashboard > visualizer > funnels", () => {
       H.assertDataSourceColumnSelected(PAYMENT_DONE_PAGE_VIEWS.name, "views");
 
       H.verticalWell().within(() => {
-        cy.findByText("METRIC").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 1);
+        cy.findByText("METRIC").should("not.exist");
       });
       H.horizontalWell().within(() => {
-        cy.findByText("DIMENSION").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 4);
+        cy.findByText("DIMENSION").should("not.exist");
+        cy.findAllByTestId("well-item").should("have.length", 3);
       });
-
-      // Remove the dimension column from the well
-      H.horizontalWell()
-        .findAllByTestId("well-item")
-        .first()
-        .findByLabelText("Remove")
-        .click();
-
-      H.assertDataSourceColumnSelected(LANDING_PAGE_VIEWS.name, "views", false);
-      H.assertDataSourceColumnSelected(
-        CHECKOUT_PAGE_VIEWS.name,
-        "views",
-        false,
-      );
-      H.assertDataSourceColumnSelected(
-        PAYMENT_DONE_PAGE_VIEWS.name,
-        "views",
-        false,
-      );
-
-      H.verticalWell().findAllByTestId("well-item").should("have.length", 0);
-      H.horizontalWell().findAllByTestId("well-item").should("have.length", 0);
     });
   });
 
@@ -313,15 +273,14 @@ describe("scenarios > dashboard > visualizer > funnels", () => {
       H.addDataset(PAYMENT_DONE_PAGE_VIEWS.name);
 
       H.verticalWell().within(() => {
-        cy.findByText("METRIC").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 1);
+        cy.findByText("METRIC").should("not.exist");
       });
       H.horizontalWell().within(() => {
-        cy.findByText("DIMENSION").should("exist");
+        cy.findByText("DIMENSION").should("not.exist");
         cy.findByText(LANDING_PAGE_VIEWS.name).should("exist");
         cy.findByText(CHECKOUT_PAGE_VIEWS.name).should("exist");
         cy.findByText(PAYMENT_DONE_PAGE_VIEWS.name).should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 4);
+        cy.findAllByTestId("well-item").should("have.length", 3);
       });
     });
   });

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/HorizontalWell/FunnelHorizontalWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/HorizontalWell/FunnelHorizontalWell.tsx
@@ -24,7 +24,10 @@ import {
   getVisualizerComputedSettings,
   getVisualizerDatasetColumns,
 } from "metabase/visualizer/selectors";
-import { isDraggedColumnItem } from "metabase/visualizer/utils";
+import {
+  isArtificialColumn,
+  isDraggedColumnItem,
+} from "metabase/visualizer/utils";
 import {
   removeColumn,
   updateSettings,
@@ -47,7 +50,9 @@ export function FunnelHorizontalWell({ style, ...props }: FlexProps) {
   });
 
   const dimension = columns.find(
-    (column) => column.name === settings["funnel.dimension"],
+    (column) =>
+      column.name === settings["funnel.dimension"] &&
+      !isArtificialColumn(column),
   );
 
   const rows = settings?.["funnel.rows"] ?? [];

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/FunnelVerticalWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VerticalWell/FunnelVerticalWell.tsx
@@ -8,7 +8,10 @@ import {
   getVisualizerComputedSettings,
   getVisualizerDatasetColumns,
 } from "metabase/visualizer/selectors";
-import { isDraggedColumnItem } from "metabase/visualizer/utils";
+import {
+  isArtificialColumn,
+  isDraggedColumnItem,
+} from "metabase/visualizer/utils";
 import { removeColumn } from "metabase/visualizer/visualizer.slice";
 import { isMetric } from "metabase-lib/v1/types/utils/isa";
 
@@ -42,6 +45,10 @@ export function FunnelVerticalWell() {
       dispatch(removeColumn({ name: metric.name }));
     }
   };
+
+  if (metric && isArtificialColumn(metric)) {
+    return null;
+  }
 
   return (
     <SimpleVerticalWell

--- a/frontend/src/metabase/visualizer/utils/column.ts
+++ b/frontend/src/metabase/visualizer/utils/column.ts
@@ -101,3 +101,7 @@ export function extractReferencedColumns(
       typeof valueSource !== "string",
   );
 }
+
+export function isArtificialColumn(column: DatasetColumn) {
+  return column.source === "artificial";
+}


### PR DESCRIPTION
Closes [VIZ-679](https://linear.app/metabase/issue/VIZ-679/hide-metric-dimension-placeholders-for-scalar-funnels)

### Description

Removes hardcoded `METRIC` and `DIMENSION` columns from wells of visualizer when creating a funnel from scalars. As vertical well becomes empty I hid it entirely for this case.

### How to verify

- Create a visualizer entity from N scalars
- Ensure there are no `METRIC` and `DIMENSION` columns

### Demo

Before
<img width="1266" alt="Screenshot 2025-05-08 at 5 35 50 PM" src="https://github.com/user-attachments/assets/30bed5cd-329c-4b7d-b926-f6de42e365ac" />

After
<img width="1359" alt="Screenshot 2025-05-08 at 5 34 28 PM" src="https://github.com/user-attachments/assets/b301bb9e-9cc0-40ab-b684-65df3d856342" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
