### PR TITLE
Taxanomy for alert for slack

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -260,52 +260,58 @@
                            {:args {:table_id (mt/id :orders)}})))))))))
 
 (deftest example-payload-row-create-test
-  (is (=? {:context {:event_name "event/row.created"}
-           :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :table {:id (mt/id :orders) :name "ORDERS"}
-           :settings {}
-           :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
-                                          :USER_ID :TAX :CREATED_AT}
-                                        (set (keys %)))])}
-          (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
-                                          {:payload_type :notification/system-event
-                                           :payload      {:event_name :event/row.created
-                                                          :table_id   (mt/id :orders)}
-                                           :creator_id   (mt/user->id :crowberto)})))))
+  (doseq [channel-type [:channel/slack :channel/email]]
+    (is (=? {:context {:event_name "event/row.created"}
+             :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
+             :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
+             :table {:id (mt/id :orders) :name "ORDERS"}
+             :settings {}
+             :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                            :USER_ID :TAX :CREATED_AT}
+                                          (set (keys %)))])}
+            (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
+                                            {:notification {:payload_type :notification/system-event
+                                                            :payload      {:event_name :event/row.created
+                                                                           :table_id   (mt/id :orders)}
+                                                            :creator_id   (mt/user->id :crowberto)}
+                                             :channel_type channel-type}))))))
 
 (deftest example-payload-row-update-test
-  (is (=? {:context {:event_name "event/row.updated"}
-           :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :table {:id (mt/id :orders) :name "ORDERS"}
-           :settings {}
-           :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
-                                          :USER_ID :TAX :CREATED_AT}
-                                        (set (keys %)))])
-           :changes (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
-                                           :USER_ID :TAX :CREATED_AT}
-                                         (set (keys %)))])}
-          (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
-                                          {:payload_type :notification/system-event
-                                           :payload      {:event_name :event/row.updated
-                                                          :table_id   (mt/id :orders)}
-                                           :creator_id   (mt/user->id :crowberto)})))))
+  (doseq [channel-type [:channel/slack :channel/email]]
+    (is (=? {:context {:event_name "event/row.updated"}
+             :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
+             :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
+             :table {:id (mt/id :orders) :name "ORDERS"}
+             :settings {}
+             :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                            :USER_ID :TAX :CREATED_AT}
+                                          (set (keys %)))])
+             :changes (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                             :USER_ID :TAX :CREATED_AT}
+                                           (set (keys %)))])}
+            (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
+                                            {:notification {:payload_type :notification/system-event
+                                                            :payload      {:event_name :event/row.updated
+                                                                           :table_id   (mt/id :orders)}
+                                                            :creator_id   (mt/user->id :crowberto)}
+                                             :channel_type channel-type}))))))
 
 (deftest example-payload-row-delete-test
-  (is (=? {:context {:event_name "event/row.deleted"}
-           :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
-           :table {:id (mt/id :orders) :name "ORDERS"}
-           :settings {}
-           :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
-                                          :USER_ID :TAX :CREATED_AT}
-                                        (set (keys %)))])}
-          (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
-                                          {:payload_type :notification/system-event
-                                           :payload      {:event_name :event/row.deleted
-                                                          :table_id   (mt/id :orders)}
-                                           :creator_id   (mt/user->id :crowberto)})))))
+  (doseq [channel-type [:channel/slack :channel/email]]
+    (is (=? {:context {:event_name "event/row.deleted"}
+             :creator {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
+             :editor {:first_name "Meta" :last_name "Bot" :common_name "Meta Bot" :email "bot@metabase.com"}
+             :table {:id (mt/id :orders) :name "ORDERS"}
+             :settings {}
+             :record (mt/malli=? [:fn #(= #{:ID :PRODUCT_ID :QUANTITY :SUBTOTAL :DISCOUNT :TOTAL
+                                            :USER_ID :TAX :CREATED_AT}
+                                          (set (keys %)))])}
+            (:payload (mt/user-http-request :crowberto :post 200 "notification/payload"
+                                            {:notification {:payload_type :notification/system-event
+                                                            :payload      {:event_name :event/row.deleted
+                                                                           :table_id   (mt/id :orders)}
+                                                            :creator_id   (mt/user->id :crowberto)}
+                                             :channel_type channel-type}))))))
 
 (deftest preview-notification-test
   (is (=? {:context  (mt/malli=? :map)

--- a/src/metabase/channel/core.clj
+++ b/src/metabase/channel/core.clj
@@ -34,6 +34,17 @@
   (fn [channel-type payload-type _notification-payload _template _recipients]
     [channel-type payload-type]))
 
+(defmulti template-context
+  "Transform a `notification-payload` to a context that will be used to render template."
+  {:added "0.55.0"
+   :arglists '([channel-type notification-type notification-payload])}
+  (fn [channel-type notification-type _notification-payload]
+    [channel-type notification-type]))
+
+(defmethod template-context :default
+  [_notification-type _channel-type notification-payload]
+  notification-payload)
+
 (defmulti send!
   "Send a message to a channel."
   {:added    "0.51.0"

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -146,9 +146,11 @@
   ;; for alerts, we allow users to template the url card part only
   (let [link-template (or template
                           (channel.template/default-template :notification/card nil channel-type))
-        card-url-text (markdown/process-markdown
-                       (channel.template/render-template link-template (channel/template-context channel-type payload-type notification-payload))
-                       :slack)
+        _             (assert link-template "No template found")
+        card-url-text (some->> (update-in notification-payload [:payload :card_part] channel.shared/maybe-realize-data-rows)
+                               (channel/template-context channel-type payload-type)
+                               (channel.template/render-template link-template)
+                               (#(markdown/process-markdown % :slack)))
         blocks        (concat [{:type "header"
                                 :text {:type "plain_text"
                                        :text (truncate (str "🔔 " (-> payload :card :name)) header-text-limit)

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -6,9 +6,11 @@
    [metabase.channel.shared :as channel.shared]
    [metabase.channel.slack :as slack]
    [metabase.channel.template.core :as channel.template]
+   [metabase.lib.util.match :as lib.util.match]
    [metabase.models.params.shared :as shared.params]
    [metabase.settings.deprecated-grab-bag :as public-settings]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.markdown :as markdown]
    [metabase.util.urls :as urls]))
 
@@ -111,13 +113,41 @@
 ;;                                      Notification Card                                          ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
+(mr/def ::notification.card.template.context
+  [:map {:closed true}
+   [:creator [:map {:closed true}
+              [:first_name [:maybe :string]]
+              [:last_name [:maybe :string]]
+              [:email :string]
+              [:common_name [:maybe :string]]]]
+   [:card [:map {:closed true}
+           [:id pos-int?]
+           [:name :string]]]
+   [:rows [:sequential [:map-of :string :any]]]])
+
+(mu/defmethod channel/template-context [:channel/slack :notification/card] :- ::notification.card.template.context
+  [_channel-type _notification-type notification-payload]
+  (lib.util.match/match-one
+    notification-payload
+    {:creator ?creator
+     :payload {:card_part {:card {:id   ?card_id
+                                  :name ?card_name}
+                           :result {:data {:cols ?result_cols
+                                           :rows ?result_rows}}}}}
+    {:creator  (select-keys ?creator [:first_name :last_name :email :common_name])
+     :card     {:id   ?card_id
+                :name ?card_name}
+     :rows     (let [col-names (map :display_name ?result_cols)]
+                 (for [row ?result_rows]
+                   (zipmap col-names row)))}))
+
 (mu/defmethod channel/render-notification [:channel/slack :notification/card] :- [:sequential SlackMessage]
-  [channel-type _payload-type {:keys [payload] :as notification-payload} template recipients]
+  [channel-type payload-type {:keys [payload] :as notification-payload} template recipients]
   ;; for alerts, we allow users to template the url card part only
   (let [link-template (or template
                           (channel.template/default-template :notification/card nil channel-type))
         card-url-text (markdown/process-markdown
-                       (channel.template/render-template link-template notification-payload)
+                       (channel.template/render-template link-template (channel/template-context channel-type payload-type notification-payload))
                        :slack)
         blocks        (concat [{:type "header"
                                 :text {:type "plain_text"

--- a/src/metabase/channel/template/default.clj
+++ b/src/metabase/channel/template/default.clj
@@ -50,7 +50,7 @@
                                                                                               "{{/each}}\n")}}
                    [:notification/card nil] {:channel_type :channel/slack
                                              :details      {:type :slack/handlebars-text
-                                                            :body "[{{payload.card.name}}]({{card-url payload.card.id}})"}}}
+                                                            :body "[{{card.name}}]({{card-url card.id}})"}}}
    :channel/http {[:notification/system-event :event/row.created] default-http-template
                   [:notification/system-event :event/row.updated] default-http-template
                   [:notification/system-event :event/row.deleted] default-http-template}})

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -73,18 +73,18 @@
                                  :last_name   "Bot"
                                  :common_name "Meta Bot"
                                  :email       "bot@metabase.com"}}
-              [:first_name :string]
-              [:last_name :string]
+              [:first_name [:maybe :string]]
+              [:last_name [:maybe :string]]
               [:email :string]
-              [:common_name :string]]]
+              [:common_name [:maybe :string]]]]
    [:editor [:map {:gen/return {:first_name  "Meta"
                                 :last_name   "Bot"
                                 :common_name "Meta Bot"
                                 :email       "bot@metabase.com"}}
-             [:first_name :string]
-             [:last_name :string]
+             [:first_name [:maybe :string]]
+             [:last_name [:maybe :string]]
              [:email :string]
-             [:common_name :string]]]
+             [:common_name [:maybe :string]]]]
    [:table [:map {:closed   true
                   :gen/fmap (fn [_x]
                               (if *sample-table-id*
@@ -228,10 +228,7 @@
   (or (lib.util.match/match-one
         notification-info
         {:payload    {:event_name ?event_name}
-         :creator    {:first_name  ?creator_first_name
-                      :last_name   ?creator_last_name
-                      :email       ?creator_email
-                      :common_name ?creator_common_name}
+         :creator    ?creator
          :event_info {:actor       ?actor
                       :args        {:table_id  ?table_id
                                     :db_id     ?db_id
@@ -245,14 +242,8 @@
           (merge
            {:context  {:event_name ?event_name
                        :timestamp  (u.date/format ?timestamp)}
-            :editor   {:first_name  (:first_name ?actor)
-                       :last_name   (:last_name ?actor)
-                       :email       (:email ?actor)
-                       :common_name (:common_name ?actor)}
-            :creator  {:first_name  ?creator_first_name
-                       :last_name   ?creator_last_name
-                       :email       ?creator_email
-                       :common_name ?creator_common_name}
+            :editor   (select-keys ?actor [:first_name :last_name :email :common_name])
+            :creator  (select-keys ?creator [:first_name :last_name :email :common_name])
             :table    {:id   ?table_id
                        :name ?table_name
                        :url  (urls/table-url ?db_id ?table_id)}
@@ -300,7 +291,6 @@
 
 (mu/defmethod notification.payload/notification-payload :notification/system-event :- :map
   [notification-info :- ::notification.payload/Notification]
-  (def notification-info notification-info)
   (transform-event-info notification-info))
 
 (defmethod notification.payload/notification-payload-schema :notification/system-event

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -73,21 +73,3 @@
       "abc"    "abc"
       "abcde"  "abcde"
       "abcdef" "abcd…")))
-
-(deftest card-header-truncation-test
-  (let [render-card-header
-        (fn [card-name char-limit]
-          (let [notification {:payload_type :notification/card
-                              :payload      {:card {:name card-name}
-                                             :card_part {:type :text, :text "foo"}}}
-                recipient    {:type    :notification-recipient/raw-value
-                              :details {:value "#foo"}}
-                processed    (with-redefs [channel.slack/header-text-limit char-limit]
-                               (channel/render-notification :channel/slack :notification/card notification nil [recipient]))]
-            (-> processed first :blocks first :text :text)))]
-    (are [card-name rendered-text]
-         (= rendered-text (render-card-header card-name 8))
-      ;; note java String .length counts UTF-16 characters, so (count "🔔") == 2. This may lead to overestimation of lengths (depending on how slack measures 'characters')
-      "abc"    "🔔 abc"
-      "abcde"  "🔔 abcde"
-      "abcdef" "🔔 abcd…")))

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -1075,15 +1075,34 @@
                                                    (assoc notification :handlers [notification.tu/default-slack-handler]))))))))))
 
 (deftest notification-payload-card-test
-  (mt/with-temp [:model/Card {card-id :id} {:dataset_query (mt/mbql-query categories {:limit 5})}]
-    (let [result (mt/user-http-request :crowberto :post 200 "notification/payload"
-                                       {:payload_type :notification/card
-                                        :payload      {:card_id card-id}
-                                        :creator_id   (mt/user->id :crowberto)})
-          card-result (-> result :payload :payload :card_part :result)]
-      (testing "the sample data has only 2 rows, no matter the limit"
-        (is (= 2 (:row_count card-result)))
-        (is (= [[1 "African"] [2 "American"]] (-> card-result :data :rows)))))))
+  (mt/with-temp [:model/Card {card-id :id
+                              card-name :name} {:dataset_query (mt/mbql-query categories {:limit 5})}]
+    (testing "slack has a simplified payload"
+      (let [result (mt/user-http-request :crowberto :post 200 "notification/payload"
+                                         {:notification {:payload_type :notification/card
+                                                         :payload      {:card_id card-id}
+                                                         :creator_id   (mt/user->id :crowberto)}
+                                          :channel_type :channel/slack})]
+        (testing "the sample data has only 2 rows, no matter the limit"
+          (is (= {:card    {:id card-id :name card-name}
+                  :creator {:common_name "Crowberto Corv"
+                            :email       "crowberto@metabase.com"
+                            :first_name  "Crowberto"
+                            :last_name   "Corv"}
+                  :rows [{:ID 1 :Name "African"}
+                         {:ID 2 :Name "American"}]}
+                 (:payload result))))))
+
+    (testing "email"
+      (let [result (mt/user-http-request :crowberto :post 200 "notification/payload"
+                                         {:notification {:payload_type :notification/card
+                                                         :payload      {:card_id card-id}
+                                                         :creator_id   (mt/user->id :crowberto)}
+                                          :channel_type :channel/email})
+            card-result (-> result :payload :payload :card_part :result)]
+        (testing "the sample data has only 2 rows, no matter the limit"
+          (is (= 2 (:row_count card-result)))
+          (is (= [[1 "African"] [2 "American"]] (-> card-result :data :rows))))))))
 
 (deftest default-template-notification-card-test
   (mt/with-temp [:model/Card {card-id :id} {:dataset_query (mt/mbql-query orders {:limit 5})}]

--- a/test/metabase/notification/payload/impl/card_test.clj
+++ b/test/metabase/notification/payload/impl/card_test.clj
@@ -88,7 +88,7 @@
                            (conj (default-slack-blocks card-id false)
                                  {:type "section" :text {:type "plain_text" :text "Hello world!!!"}})
                            :channel "#general"}
-                          (notification.tu/slack-message->boolean message))))
+                          message)))
 
                 :channel/http
                 (fn [[req]]
@@ -133,7 +133,7 @@
         (fn [[message]]
           (is (=? {:channel "#general"
                    :blocks (default-slack-blocks (-> notification :payload :card_id) true)}
-                  (notification.tu/slack-message->boolean message))))}))))
+                  message)))}))))
 
 (deftest card-with-rows-saved-to-disk-test
   (testing "whether the rows of a card saved to disk or in memory, all channels should work\n"
@@ -171,7 +171,7 @@
                   (fn [[message]]
                     (is (=? {:blocks  (default-slack-blocks (-> notification :payload :card_id) true)
                              :channel "#general"}
-                            (notification.tu/slack-message->boolean message))))
+                            message)))
                   :channel/http
                   (fn [[req]]
                     (is (=? {:body {:type               "alert"

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -3,7 +3,6 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [medley.core :as m]
    [metabase.channel.core :as channel]
    [metabase.channel.email :as email]
    [metabase.channel.render.js.svg :as js.svg]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -244,14 +244,6 @@
         (testing (format "chanel-type = %s" channel-type)
           (assert-fn (get channel-type->captured-message channel-type)))))))
 
-(defn slack-message->boolean [{:keys [attachments] :as result}]
-  (assoc result :attachments (for [attachment-info attachments]
-                               (if (:rendered-info attachment-info)
-                                 (update attachment-info
-                                         :rendered-info
-                                         (fn [ri] (m/map-vals some? ri)))
-                                 attachment-info))))
-
 (defn do-with-mock-inbox-email!
   "Helper function that mocks email/send-email! to capture emails in a vector and returns them."
   [thunk]


### PR DESCRIPTION
Added a translation layer that'll transform the notification payload to a template context.
This defmulti has 2 dispatches arguments: notification/card, notification/slack.

By having this we can also decouple our internal rendering with what we want to "expose" to users to use inside the template.


This is the current context that's used for alerts with slack.

```clojure
{:card       {:id card-id :name card-name}
 :creator    {:common_name "Crowberto Corv"
              :email      "crowberto@metabase.com"
              :first_name "Crowberto"
              :last_name  "Corv"}
 :rows       [{:ID 1 :Name "African"}
              {:ID 2 :Name "American"}]}
```


A side affect of this is the `POST /api/notification/payload` will now need to provide a `channel_type` because the payload now will be channel specific.