### PR TITLE
Speed up notification tests

### DIFF
--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -63,12 +63,13 @@
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn do-with-captured-channel-send!
   [thunk]
-  (with-send-notification-sync
-    (let [channel-messages (atom {})]
-      (with-redefs [channel/send! (fn [channel message]
-                                    (swap! channel-messages update (:type channel) u/conjv message))]
-        (thunk)
-        @channel-messages))))
+  (with-javascript-visualization-stub
+    (with-send-notification-sync
+      (let [channel-messages (atom {})]
+        (with-redefs [channel/send! (fn [channel message]
+                                      (swap! channel-messages update (:type channel) u/conjv message))]
+          (thunk)
+          @channel-messages)))))
 
 (defmacro with-captured-channel-send!
   "Macro that captures all messages sent to channels in the body of the macro.


### PR DESCRIPTION
Use the `with-javascript-visualization-stub` added in https://github.com/metabase/metabase/pull/56336 for notification tests.

This speed up notification tests from 29s to 23s on my m4.

```
clj -X:dev:ee:ee-dev:test:test/notification
{:test 244, :pass 812, :fail 0, :error 0, :type :summary, :duration 23101.613334, :single-threaded 214, :parallel 30}
```