### PR TITLE
Giving system event notifications its own queue

### DIFF
--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -16,7 +16,7 @@
    [toucan2.core :as t2])
   (:import
    (java.time ZonedDateTime)
-   (java.util.concurrent Callable Executors ThreadPoolExecutor)
+   (java.util.concurrent ArrayBlockingQueue Callable Executors ThreadPoolExecutor)
    (org.apache.commons.lang3.concurrent BasicThreadFactory$Builder)
    (org.quartz CronExpression)))
 
@@ -31,6 +31,13 @@
 (setting/defsetting notification-thread-pool-size
   "The size of the thread pool used to send notifications."
   :default    3
+  :export?    false
+  :type       :integer
+  :visibility :internal)
+
+(setting/defsetting notification-system-event-thread-pool-size
+  "The size of the thread pool used to send system event notifications."
+  :default    5
   :export?    false
   :type       :integer
   :visibility :internal)
@@ -284,7 +291,8 @@
   (put-notification!  [this notification] "Add a notification to the queue. If a notification with the same id is already in the queue, replace it.")
   (take-notification! [this]              "Take the next notification from the queue, blocking if none available."))
 
-(deftype ^:private NotificationQueue
+;; A priority queue that deduplicates notifications by id
+(deftype ^:private DedupPriorityQueue
          [^java.util.PriorityQueue                  items-list
           ^java.util.concurrent.ConcurrentHashMap   id->notification
           ^java.util.concurrent.locks.ReentrantLock queue-lock
@@ -315,7 +323,7 @@
       (finally
         (.unlock queue-lock)))))
 
-(defn- create-notification-queue
+(defn- create-dedup-priority-queue
   "A thread-safe, prioritized notification queue with the following properties:
   - Notifications are identified by unique IDs
   - Prioritized by deadline
@@ -325,10 +333,23 @@
   []
   (let [queue-lock     (java.util.concurrent.locks.ReentrantLock.)
         not-empty-cond (.newCondition queue-lock)]
-    (->NotificationQueue (java.util.PriorityQueue. ^java.util.Comparator deadline-comparator)
-                         (java.util.concurrent.ConcurrentHashMap.)
-                         queue-lock
-                         not-empty-cond)))
+    (->DedupPriorityQueue (java.util.PriorityQueue. ^java.util.Comparator deadline-comparator)
+                          (java.util.concurrent.ConcurrentHashMap.)
+                          queue-lock
+                          not-empty-cond)))
+
+;; A simple array blocking queue for notification
+(deftype BlockingQueue [^java.util.concurrent.ArrayBlockingQueue items-list]
+  NotificationQueueProtocol
+  (put-notification! [_ notification]
+    (.put items-list notification))
+  (take-notification! [_]
+    (.take items-list)))
+
+(defn- create-blocking-queue
+  "Create a blocking queue for notifications."
+  []
+  (BlockingQueue. (ArrayBlockingQueue. 1000)))
 
 (defn- create-notification-dispatcher
   "Create a thread pool for sending notifications.
@@ -377,17 +398,25 @@
       (ensure-enough-workers!)
       (put-notification! queue notification))))
 
-(defonce ^{:private true
-           :doc "Do not use this queue directly, use the dispatcher instead."}
-  notification-queue (delay (create-notification-queue)))
+(defonce ^:private dedup-priority-dispatcher
+  (delay (create-notification-dispatcher (notification-thread-pool-size) (create-dedup-priority-queue))))
 
-(defonce ^:private dispatcher
-  (delay (create-notification-dispatcher (notification-thread-pool-size) @notification-queue)))
+(defonce ^:private simple-blocking-dispatcher
+  (delay (create-notification-dispatcher (notification-thread-pool-size) (create-blocking-queue))))
+
+(defn- dispatcher
+  [notification]
+  (let [the-dispatcher (case (:payload_type notification)
+                         :notification/system-event
+                         @simple-blocking-dispatcher
+                         ;; notification/card, notification/dashboard
+                         @dedup-priority-dispatcher)]
+    (the-dispatcher notification)))
 
 (mu/defn ^:private send-notification-async!
   "Send a notification asynchronously."
   [notification :- ::notification.payload/Notification]
-  (@dispatcher notification)
+  (dispatcher notification)
   nil)
 
 (def ^:private Options

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -472,8 +472,8 @@
                           (sort @#'notification.send/deadline-comparator))]
       (is (= [1 2 3] (map #(.id %) items))))))
 
-(deftest notification-dispatcher-test
-  (testing "notification dispatcher"
+(deftest notification-dedup-dispatcher-test
+  (testing "notification dedup dispatcher"
     (let [sent-notifications  (atom [])
           wait-for-processing #(u/poll {:thunk       (fn [] (count @sent-notifications))
                                         :done?       (fn [cnt] (= cnt %))
@@ -483,7 +483,7 @@
                                                                 ;; fake latency
                                                                 (Thread/sleep 20)
                                                                 (swap! sent-notifications conj notification))]
-        (let [queue           (#'notification.send/create-notification-queue)
+        (let [queue           (#'notification.send/create-dedup-priority-queue)
               test-dispatcher (#'notification.send/create-notification-dispatcher 2 queue)]
           (testing "basic processing"
             (reset! sent-notifications [])
@@ -533,7 +533,7 @@
 
 (deftest notification-priority-test
   (testing "notifications are processed in priority order (by deadline)"
-    (let [queue (#'notification.send/create-notification-queue)
+    (let [queue (#'notification.send/create-dedup-priority-queue)
           low-priority    {:id "low-priority"
                            :triggering_subscription {:type :notification-subscription/cron
                                                      :cron_schedule "0 0 0 * * ? *"}} ; daily schedule
@@ -553,7 +553,7 @@
 
 (deftest notification-queue-preserves-deadline-on-replacement-test
   (testing "notifications with same ID are replaced in queue while preserving original deadline"
-    (let [queue (#'notification.send/create-notification-queue)
+    (let [queue (#'notification.send/create-dedup-priority-queue)
           ;; Create a notification with a daily schedule (lower priority)
           notification-v1 {:id "same-id"
                            :version 1
@@ -577,8 +577,8 @@
              (for [_ (range 2)]
                (#'notification.send/take-notification! queue)))))))
 
-(deftest notification-queue-test
-  (let [queue (#'notification.send/create-notification-queue)]
+(deftest notification-dedup-priority-test
+  (let [queue (#'notification.send/create-dedup-priority-queue)]
 
     (testing "put and take operations work correctly"
       (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "A"})
@@ -586,14 +586,14 @@
              (#'notification.send/take-notification! queue))))
 
     (testing "notifications with same ID are replaced in queue"
-      (let [queue (#'notification.send/create-notification-queue)]
+      (let [queue (#'notification.send/create-dedup-priority-queue)]
         (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "A"})
         (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "B"})
         (is (= {:id 1 :payload_type :notification/testing :test-value "B"}
                (#'notification.send/take-notification! queue)))))
 
     (testing "multiple notifications are processed in order"
-      (let [queue (#'notification.send/create-notification-queue)]
+      (let [queue (#'notification.send/create-dedup-priority-queue)]
         (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "A"})
         (#'notification.send/put-notification! queue {:id 2 :payload_type :notification/testing :test-value "B"})
         (#'notification.send/put-notification! queue {:id 3 :payload_type :notification/testing :test-value "C"})
@@ -606,7 +606,7 @@
                (#'notification.send/take-notification! queue)))))
 
     (testing "take blocks until notification is available"
-      (let [queue (#'notification.send/create-notification-queue)
+      (let [queue (#'notification.send/create-dedup-priority-queue)
             result (atom nil)
             latch (java.util.concurrent.CountDownLatch. 1)
             thread (Thread. (fn []
@@ -626,7 +626,7 @@
 
 (deftest blocking-queue-concurrency-test
   (testing "blocking queue handles concurrent operations correctly"
-    (let [queue                  (#'notification.send/create-notification-queue)
+    (let [queue                  (#'notification.send/create-dedup-priority-queue)
           num-producers          5
           num-consumers          3
           num-items-per-producer 20


### PR DESCRIPTION
Currently our dedup queue is processing all notification types, including system events.

We don't want to share this queue with system events because:
- we don't want de-duplication
- the pool size is too small (currently 3)
- system event notifications are quite light weight and we expect them to be delivered _instantly_.

So this PRs make sending systemevent notification will have its own queue that's backed by a simple ArrayBlockingQueue