### PR TITLE
Split Dashboard Grid components

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -515,42 +515,13 @@ class DashboardGridInner extends Component<
     );
   };
 
-  renderGrid() {
-    const { width } = this.props;
-    const { layouts } = this.state;
-    const rowHeight = this.getRowHeight();
-    return (
-      <GridLayout<DashboardCard>
-        className={cx({
-          [DashboardS.DashEditing]: this.isEditingLayout,
-          [DashboardS.DashDragging]: this.state.isDragging,
-          // we use this class to hide a dashcard actions
-          // panel during dragging
-          [DashCardS.DashboardCardRootDragging]: this.state.isDragging,
-        })}
-        layouts={layouts}
-        breakpoints={GRID_BREAKPOINTS}
-        cols={GRID_COLUMNS}
-        width={width}
-        margin={{ desktop: [6, 6], mobile: [6, 10] }}
-        containerPadding={[0, 0]}
-        rowHeight={rowHeight}
-        onLayoutChange={this.onLayoutChange}
-        onDrag={this.onDrag}
-        onDragStop={this.onDragStop}
-        isEditing={this.isEditingLayout}
-        compactType="vertical"
-        items={this.getVisibleCards()}
-        itemRenderer={this.renderGridItem}
-      />
-    );
-  }
-
   render() {
     const { dashboard, width, forwardedRef } = this.props;
-    const { replaceCardModalDashCard, addSeriesModalDashCard } = this.state;
+    const { replaceCardModalDashCard, addSeriesModalDashCard, layouts } =
+      this.state;
     const isAddSeriesOpen =
       !!addSeriesModalDashCard && isQuestionDashCard(addSeriesModalDashCard);
+    const rowHeight = this.getRowHeight();
     return (
       <Flex
         align="center"
@@ -564,7 +535,31 @@ class DashboardGridInner extends Component<
           "--dashboard-fixed-width": FIXED_WIDTH,
         }}
       >
-        {width > 0 ? this.renderGrid() : <div />}
+        {width > 0 ? (
+          <GridLayout<DashboardCard>
+            className={cx({
+              [DashboardS.DashEditing]: this.isEditingLayout,
+              [DashboardS.DashDragging]: this.state.isDragging,
+              [DashCardS.DashboardCardRootDragging]: this.state.isDragging,
+            })}
+            layouts={layouts}
+            breakpoints={GRID_BREAKPOINTS}
+            cols={GRID_COLUMNS}
+            width={width}
+            margin={{ desktop: [6, 6], mobile: [6, 10] }}
+            containerPadding={[0, 0]}
+            rowHeight={rowHeight}
+            onLayoutChange={this.onLayoutChange}
+            onDrag={this.onDrag}
+            onDragStop={this.onDragStop}
+            isEditing={this.isEditingLayout}
+            compactType="vertical"
+            items={this.getVisibleCards()}
+            itemRenderer={this.renderGridItem}
+          />
+        ) : (
+          <div />
+        )}
         {isAddSeriesOpen && (
           <Modal
             className={cx(

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -401,65 +401,6 @@ class DashboardGridInner extends Component<
     this.setState({ replaceCardModalDashCard: dashcard });
   };
 
-  renderDashCard(
-    dashcard: DashboardCard,
-    {
-      isMobile,
-      gridItemWidth,
-      totalNumGridCols,
-      downloadsEnabled,
-      shouldAutoScrollTo,
-      reportAutoScrolledToDashcard,
-    }: {
-      isMobile: boolean;
-      gridItemWidth: number;
-      totalNumGridCols: number;
-      downloadsEnabled: boolean;
-      shouldAutoScrollTo: boolean;
-      reportAutoScrolledToDashcard?: () => void;
-    },
-  ) {
-    return (
-      <DashCard
-        className={S.Card}
-        dashcard={dashcard}
-        slowCards={this.props.slowCards}
-        gridItemWidth={gridItemWidth}
-        totalNumGridCols={totalNumGridCols}
-        markNewCardSeen={this.props.markNewCardSeen}
-        isEditing={this.props.isEditing}
-        isEditingParameter={this.props.isEditingParameter}
-        isFullscreen={this.props.isFullscreen}
-        isNightMode={this.props.isNightMode}
-        isMobile={isMobile}
-        isPublicOrEmbedded={this.props.isPublicOrEmbedded}
-        isXray={this.props.isXray}
-        withTitle={this.props.withCardTitle}
-        onRemove={this.onDashCardRemove}
-        onAddSeries={this.onDashCardAddSeries}
-        onReplaceCard={this.onReplaceCard}
-        onUpdateVisualizationSettings={
-          this.props.onUpdateDashCardVisualizationSettings
-        }
-        onReplaceAllDashCardVisualizationSettings={
-          this.props.onReplaceAllDashCardVisualizationSettings
-        }
-        getClickActionMode={this.props.getClickActionMode}
-        navigateToNewCardFromDashboard={
-          this.props.navigateToNewCardFromDashboard
-        }
-        onChangeLocation={this.props.onChangeLocation}
-        dashboard={this.props.dashboard}
-        showClickBehaviorSidebar={this.props.showClickBehaviorSidebar}
-        clickBehaviorSidebarDashcard={this.props.clickBehaviorSidebarDashcard}
-        downloadsEnabled={downloadsEnabled}
-        autoScroll={shouldAutoScrollTo}
-        isTrashedOnRemove={this.getIsLastDashboardQuestionDashcard(dashcard)}
-        reportAutoScrolledToDashcard={reportAutoScrolledToDashcard}
-      />
-    );
-  }
-
   get isEditingLayout() {
     const { isEditing, isEditingParameter, clickBehaviorSidebarDashcard } =
       this.props;
@@ -503,14 +444,43 @@ class DashboardGridInner extends Component<
           },
         )}
       >
-        {this.renderDashCard(dc, {
-          isMobile: breakpoint === "mobile",
-          gridItemWidth,
-          totalNumGridCols,
-          downloadsEnabled: this.props.downloadsEnabled,
-          shouldAutoScrollTo,
-          reportAutoScrolledToDashcard,
-        })}
+        <DashCard
+          className={S.Card}
+          dashcard={dc}
+          slowCards={this.props.slowCards}
+          gridItemWidth={gridItemWidth}
+          totalNumGridCols={totalNumGridCols}
+          markNewCardSeen={this.props.markNewCardSeen}
+          isEditing={this.props.isEditing}
+          isEditingParameter={this.props.isEditingParameter}
+          isFullscreen={this.props.isFullscreen}
+          isNightMode={this.props.isNightMode}
+          isMobile={breakpoint === "mobile"}
+          isPublicOrEmbedded={this.props.isPublicOrEmbedded}
+          isXray={this.props.isXray}
+          withTitle={this.props.withCardTitle}
+          onRemove={this.onDashCardRemove}
+          onAddSeries={this.onDashCardAddSeries}
+          onReplaceCard={this.onReplaceCard}
+          onUpdateVisualizationSettings={
+            this.props.onUpdateDashCardVisualizationSettings
+          }
+          onReplaceAllDashCardVisualizationSettings={
+            this.props.onReplaceAllDashCardVisualizationSettings
+          }
+          getClickActionMode={this.props.getClickActionMode}
+          navigateToNewCardFromDashboard={
+            this.props.navigateToNewCardFromDashboard
+          }
+          onChangeLocation={this.props.onChangeLocation}
+          dashboard={this.props.dashboard}
+          showClickBehaviorSidebar={this.props.showClickBehaviorSidebar}
+          clickBehaviorSidebarDashcard={this.props.clickBehaviorSidebarDashcard}
+          downloadsEnabled={this.props.downloadsEnabled}
+          autoScroll={shouldAutoScrollTo}
+          isTrashedOnRemove={this.getIsLastDashboardQuestionDashcard(dc)}
+          reportAutoScrolledToDashcard={reportAutoScrolledToDashcard}
+        />
       </Box>
     );
   };

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -367,35 +367,6 @@ class DashboardGridInner extends Component<
     return hasScroll ? Math.ceil(actualHeight) : Math.floor(actualHeight);
   }
 
-  renderAddSeriesModal() {
-    // can't use PopoverWithTrigger due to strange interaction with ReactGridLayout
-    const { addSeriesModalDashCard } = this.state;
-
-    const isOpen =
-      !!addSeriesModalDashCard && isQuestionDashCard(addSeriesModalDashCard);
-    return (
-      <Modal
-        className={cx(
-          ModalS.Modal,
-          DashboardS.Modal,
-          DashboardS.AddSeriesModal,
-        )}
-        data-testid="add-series-modal"
-        isOpen={isOpen}
-      >
-        {isOpen && (
-          <AddSeriesModal
-            dashcard={addSeriesModalDashCard}
-            dashcardData={this.props.dashcardData}
-            fetchCardData={this.props.fetchCardData}
-            setDashCardAttributes={this.props.setDashCardAttributes}
-            onClose={() => this.setState({ addSeriesModalDashCard: null })}
-          />
-        )}
-      </Modal>
-    );
-  }
-
   onDrag = () => {
     if (!this.state.isDragging) {
       this.setState({ isDragging: true });
@@ -577,7 +548,9 @@ class DashboardGridInner extends Component<
 
   render() {
     const { dashboard, width, forwardedRef } = this.props;
-    const { replaceCardModalDashCard } = this.state;
+    const { replaceCardModalDashCard, addSeriesModalDashCard } = this.state;
+    const isAddSeriesOpen =
+      !!addSeriesModalDashCard && isQuestionDashCard(addSeriesModalDashCard);
     return (
       <Flex
         align="center"
@@ -592,7 +565,25 @@ class DashboardGridInner extends Component<
         }}
       >
         {width > 0 ? this.renderGrid() : <div />}
-        {this.renderAddSeriesModal()}
+        {isAddSeriesOpen && (
+          <Modal
+            className={cx(
+              ModalS.Modal,
+              DashboardS.Modal,
+              DashboardS.AddSeriesModal,
+            )}
+            data-testid="add-series-modal"
+            isOpen={isAddSeriesOpen}
+          >
+            <AddSeriesModal
+              dashcard={addSeriesModalDashCard}
+              dashcardData={this.props.dashcardData}
+              fetchCardData={this.props.fetchCardData}
+              setDashCardAttributes={this.props.setDashCardAttributes}
+              onClose={() => this.setState({ addSeriesModalDashCard: null })}
+            />
+          </Modal>
+        )}
         <ReplaceCardModal
           isOpen={
             !!replaceCardModalDashCard &&

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -409,82 +409,6 @@ class DashboardGridInner extends Component<
     );
   }
 
-  renderGridItem = ({
-    item: dc,
-    breakpoint,
-    gridItemWidth,
-    totalNumGridCols,
-  }: {
-    item: DashboardCard;
-    breakpoint: GridBreakpoint;
-    gridItemWidth: number;
-    totalNumGridCols: number;
-  }) => {
-    const { isEditing, autoScrollToDashcardId, reportAutoScrolledToDashcard } =
-      this.props;
-    const shouldAutoScrollTo = autoScrollToDashcardId === dc.id;
-
-    const shouldChangeResizeHandle = isEditingTextOrHeadingCard(
-      dc.card.display,
-      isEditing,
-    );
-
-    return (
-      <Box
-        key={String(dc.id)}
-        data-testid="dashcard-container"
-        className={cx(
-          DashboardS.DashCard,
-          EmbedFrameS.DashCard,
-          LegendS.DashCard,
-          S.DashboardCardContainer,
-          {
-            [DashboardS.BrandColorResizeHandle]: shouldChangeResizeHandle,
-            [S.isAnimationDisabled]: this.state.isAnimationPaused,
-          },
-        )}
-      >
-        <DashCard
-          className={S.Card}
-          dashcard={dc}
-          slowCards={this.props.slowCards}
-          gridItemWidth={gridItemWidth}
-          totalNumGridCols={totalNumGridCols}
-          markNewCardSeen={this.props.markNewCardSeen}
-          isEditing={this.props.isEditing}
-          isEditingParameter={this.props.isEditingParameter}
-          isFullscreen={this.props.isFullscreen}
-          isNightMode={this.props.isNightMode}
-          isMobile={breakpoint === "mobile"}
-          isPublicOrEmbedded={this.props.isPublicOrEmbedded}
-          isXray={this.props.isXray}
-          withTitle={this.props.withCardTitle}
-          onRemove={this.onDashCardRemove}
-          onAddSeries={this.onDashCardAddSeries}
-          onReplaceCard={this.onReplaceCard}
-          onUpdateVisualizationSettings={
-            this.props.onUpdateDashCardVisualizationSettings
-          }
-          onReplaceAllDashCardVisualizationSettings={
-            this.props.onReplaceAllDashCardVisualizationSettings
-          }
-          getClickActionMode={this.props.getClickActionMode}
-          navigateToNewCardFromDashboard={
-            this.props.navigateToNewCardFromDashboard
-          }
-          onChangeLocation={this.props.onChangeLocation}
-          dashboard={this.props.dashboard}
-          showClickBehaviorSidebar={this.props.showClickBehaviorSidebar}
-          clickBehaviorSidebarDashcard={this.props.clickBehaviorSidebarDashcard}
-          downloadsEnabled={this.props.downloadsEnabled}
-          autoScroll={shouldAutoScrollTo}
-          isTrashedOnRemove={this.getIsLastDashboardQuestionDashcard(dc)}
-          reportAutoScrolledToDashcard={reportAutoScrolledToDashcard}
-        />
-      </Box>
-    );
-  };
-
   render() {
     const { dashboard, width, forwardedRef } = this.props;
     const { replaceCardModalDashCard, addSeriesModalDashCard, layouts } =
@@ -525,7 +449,84 @@ class DashboardGridInner extends Component<
             isEditing={this.isEditingLayout}
             compactType="vertical"
             items={this.getVisibleCards()}
-            itemRenderer={this.renderGridItem}
+            itemRenderer={({
+              item: dc,
+              breakpoint,
+              gridItemWidth,
+              totalNumGridCols,
+            }) => {
+              const {
+                isEditing,
+                autoScrollToDashcardId,
+                reportAutoScrolledToDashcard,
+              } = this.props;
+              const shouldAutoScrollTo = autoScrollToDashcardId === dc.id;
+              const shouldChangeResizeHandle = isEditingTextOrHeadingCard(
+                dc.card.display,
+                isEditing,
+              );
+              return (
+                <Box
+                  key={String(dc.id)}
+                  data-testid="dashcard-container"
+                  className={cx(
+                    DashboardS.DashCard,
+                    EmbedFrameS.DashCard,
+                    LegendS.DashCard,
+                    S.DashboardCardContainer,
+                    {
+                      [DashboardS.BrandColorResizeHandle]:
+                        shouldChangeResizeHandle,
+                      [S.isAnimationDisabled]: this.state.isAnimationPaused,
+                    },
+                  )}
+                >
+                  <DashCard
+                    className={S.Card}
+                    dashcard={dc}
+                    slowCards={this.props.slowCards}
+                    gridItemWidth={gridItemWidth}
+                    totalNumGridCols={totalNumGridCols}
+                    markNewCardSeen={this.props.markNewCardSeen}
+                    isEditing={this.props.isEditing}
+                    isEditingParameter={this.props.isEditingParameter}
+                    isFullscreen={this.props.isFullscreen}
+                    isNightMode={this.props.isNightMode}
+                    isMobile={breakpoint === "mobile"}
+                    isPublicOrEmbedded={this.props.isPublicOrEmbedded}
+                    isXray={this.props.isXray}
+                    withTitle={this.props.withCardTitle}
+                    onRemove={this.onDashCardRemove}
+                    onAddSeries={this.onDashCardAddSeries}
+                    onReplaceCard={this.onReplaceCard}
+                    onUpdateVisualizationSettings={
+                      this.props.onUpdateDashCardVisualizationSettings
+                    }
+                    onReplaceAllDashCardVisualizationSettings={
+                      this.props.onReplaceAllDashCardVisualizationSettings
+                    }
+                    getClickActionMode={this.props.getClickActionMode}
+                    navigateToNewCardFromDashboard={
+                      this.props.navigateToNewCardFromDashboard
+                    }
+                    onChangeLocation={this.props.onChangeLocation}
+                    dashboard={this.props.dashboard}
+                    showClickBehaviorSidebar={
+                      this.props.showClickBehaviorSidebar
+                    }
+                    clickBehaviorSidebarDashcard={
+                      this.props.clickBehaviorSidebarDashcard
+                    }
+                    downloadsEnabled={this.props.downloadsEnabled}
+                    autoScroll={shouldAutoScrollTo}
+                    isTrashedOnRemove={this.getIsLastDashboardQuestionDashcard(
+                      dc,
+                    )}
+                    reportAutoScrolledToDashcard={reportAutoScrolledToDashcard}
+                  />
+                </Box>
+              );
+            }}
           />
         ) : (
           <div />

--- a/frontend/src/metabase/dashboard/components/ReplaceCardModal.tsx
+++ b/frontend/src/metabase/dashboard/components/ReplaceCardModal.tsx
@@ -1,0 +1,107 @@
+import type React from "react";
+import { t } from "ttag";
+import type { QuestionPickerValueItem } from "metabase/common/components/QuestionPicker";
+import {
+  QuestionPickerModal,
+  getQuestionPickerValue,
+} from "metabase/common/components/QuestionPicker";
+
+import type {
+  BaseDashboardCard,
+  Card,
+  Dashboard,
+  RecentItem,
+} from "metabase-types/api";
+import { isRecentCollectionItem } from "metabase-types/api";
+
+// Helper for undo message
+const getUndoReplaceCardMessage = ({ type }: Pick<Card, "type">) => {
+  if (type === "model") {
+    return t`Model replaced`;
+  }
+  if (type === "metric") {
+    return t`Metric replaced`;
+  }
+  if (type === "question") {
+    return t`Question replaced`;
+  }
+  throw new Error(`Unknown card.type: ${type}`);
+};
+
+export type ReplaceCardModalProps = {
+  isOpen: boolean;
+  dashcard: BaseDashboardCard | null;
+  dashboard: Dashboard;
+  onClose: () => void;
+  onReplace: (opts: { dashcardId: number; nextCardId: number }) => void;
+  onUndo: (opts: {
+    message: string;
+    undo: boolean;
+    action: () => void;
+  }) => void;
+  setDashCardAttributes: (opts: { id: number; attributes: any }) => void;
+};
+
+export const ReplaceCardModal: React.FC<ReplaceCardModalProps> = ({
+  isOpen,
+  dashcard,
+  dashboard,
+  onClose,
+  onReplace,
+  onUndo,
+  setDashCardAttributes,
+}) => {
+  const hasValidDashCard = !!dashcard && dashcard.card && dashcard.card.id;
+
+  const handleSelect = (nextCard: QuestionPickerValueItem) => {
+    if (!hasValidDashCard || !dashcard) {
+      return;
+    }
+    onReplace({ dashcardId: dashcard.id, nextCardId: nextCard.id });
+    if (dashcard.card && dashcard.card.type) {
+      onUndo({
+        message: getUndoReplaceCardMessage({ type: dashcard.card.type }),
+        undo: true,
+        action: () =>
+          setDashCardAttributes({
+            id: dashcard.id,
+            attributes: dashcard,
+          }),
+      });
+    }
+    onClose();
+  };
+
+  const replaceCardModalRecentFilter = (items: RecentItem[]) => {
+    return items.filter((item) => {
+      if (isRecentCollectionItem(item) && item.dashboard) {
+        if (item.dashboard.id !== dashboard.id) {
+          return false;
+        }
+      }
+      return true;
+    });
+  };
+
+  if (!isOpen || !hasValidDashCard || !dashcard) {
+    return null;
+  }
+
+  let questionPickerValue:
+    | ReturnType<typeof getQuestionPickerValue>
+    | undefined = undefined;
+  if (dashcard.card && dashcard.card.id && dashcard.card.type) {
+    questionPickerValue = getQuestionPickerValue(dashcard.card as Card);
+  }
+
+  return (
+    <QuestionPickerModal
+      title={t`Pick what you want to replace this with`}
+      value={questionPickerValue}
+      models={["card", "dataset", "metric"]}
+      onChange={handleSelect}
+      onClose={onClose}
+      recentFilter={replaceCardModalRecentFilter}
+    />
+  );
+};


### PR DESCRIPTION
Splits the Dashboard Grid into multiple components and inlines the render functions. Also moves the state that isn’t used in the lifecycle methods into the functional part of the component as well. This will help simplify things (and hopefully allow us to move the DashboardGrid to a functional component more easily) and make it easier for me to add context to the component as I want to do in EMB-357.