### PR TITLE
wrap strings in t in EditSandboxingModal

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import type * as React from "react";
 import { useState } from "react";
 import { useAsyncFn } from "react-use";
-import { jt, t } from "ttag";
+import { c, jt, t } from "ttag";
 import _ from "underscore";
 
 import { skipToken, useGetCardQuery, useGetTableQuery } from "metabase/api";
@@ -397,7 +397,8 @@ const TargetName = ({ policy, policyTable, target }: TargetNameProps) => {
     ) {
       return (
         <span>
-          <strong>{target[1][1]}</strong> variable
+          {c("{0} is a name of a variable being used by sandboxing")
+            .jt`${(<strong>{target[1][1]}</strong>)} variable`}
         </span>
       );
     } else if (target[0] === "dimension") {
@@ -435,7 +436,8 @@ const TargetName = ({ policy, policyTable, target }: TargetNameProps) => {
             const columnInfo = Lib.displayInfo(query, stageIndex, column);
             return (
               <span>
-                <strong>{columnInfo.displayName}</strong> field
+                {c("{0} is a name of a field being used by sandboxing")
+                  .jt`${(<strong>{columnInfo.displayName}</strong>)} field`}
               </span>
             );
           }}


### PR DESCRIPTION
Found these with [adds i18next/no-literal-string](https://github.com/metabase/metabase/pull/57785)

I hope the context I added is correct, it took me a while to reach the page and I only verified the `field` one.

Are maybe missing a "the" before that?

<img width="1001" alt="image" src="https://github.com/user-attachments/assets/0495a1b6-6a46-473f-9508-d3606eccf1a1" />
