### PR TITLE
standardize on ToolbarButton for main view header actions

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionInfoSidebarToggle.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionInfoSidebarToggle.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
+import { t } from "ttag";
 
-import { FixedSizeIcon as Icon } from "metabase/ui";
+import { ToolbarButton } from "metabase/components/ToolbarButton";
 import type { Collection } from "metabase-types/api";
 
 import { CollectionInfoSidebar } from "../CollectionInfoSidebar";
-
-import { CollectionHeaderButton } from "./CollectionHeader.styled";
 
 export const CollectionInfoSidebarToggle = ({
   collection,
@@ -17,9 +16,12 @@ export const CollectionInfoSidebarToggle = ({
   const [showSidesheet, setShowSidesheet] = useState(false);
   return (
     <>
-      <CollectionHeaderButton onClick={() => setShowSidesheet((open) => !open)}>
-        <Icon name="info" />
-      </CollectionHeaderButton>
+      <ToolbarButton
+        icon="info"
+        aria-label={t`More info`}
+        tooltipLabel={t`More info`}
+        onClick={() => setShowSidesheet((open) => !open)}
+      />
       {showSidesheet && (
         <CollectionInfoSidebar
           onClose={() => setShowSidesheet(false)}

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionNewButton.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionNewButton.tsx
@@ -1,27 +1,23 @@
 import { t } from "ttag";
 
+import { ToolbarButton } from "metabase/components/ToolbarButton";
 import { useDispatch } from "metabase/lib/redux";
 import { setOpenModal } from "metabase/redux/ui";
-import { Tooltip } from "metabase/ui";
 
-import { CollectionHeaderButton } from "./CollectionHeader.styled";
 import { trackNewCollectionFromHeaderInitiated } from "./analytics";
 
 export const CollectionNewButton = () => {
   const dispatch = useDispatch();
 
   return (
-    <Tooltip label={t`Create a new collection`} position="bottom">
-      <div>
-        <CollectionHeaderButton
-          aria-label={t`Create a new collection`}
-          icon="add_folder"
-          onClick={() => {
-            trackNewCollectionFromHeaderInitiated();
-            dispatch(setOpenModal("collection"));
-          }}
-        />
-      </div>
-    </Tooltip>
+    <ToolbarButton
+      icon="add_folder"
+      aria-label={t`Create a new collection`}
+      tooltipLabel={t`Create a new collection`}
+      onClick={() => {
+        trackNewCollectionFromHeaderInitiated();
+        dispatch(setOpenModal("collection"));
+      }}
+    />
   );
 };

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionPermissions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionPermissions.tsx
@@ -1,11 +1,9 @@
 import { t } from "ttag";
 
+import { ToolbarButton } from "metabase/components/ToolbarButton";
 import Link from "metabase/core/components/Link/Link";
 import * as Urls from "metabase/lib/urls";
-import { Tooltip } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
-
-import { CollectionHeaderButton } from "./CollectionHeader.styled";
 
 interface CollectionPermissionsProps {
   collection: Collection;
@@ -17,10 +15,12 @@ export const CollectionPermissions = ({
   const url = `${Urls.collection(collection)}/permissions`;
 
   return (
-    <Tooltip label={t`Edit permissions`} position="bottom">
-      <div>
-        <CollectionHeaderButton as={Link} to={url} icon="lock" />
-      </div>
-    </Tooltip>
+    <Link to={url}>
+      <ToolbarButton
+        icon="lock"
+        aria-label={t`Edit permissions`}
+        tooltipLabel={t`Edit permissions`}
+      />
+    </Link>
   );
 };

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.tsx
@@ -40,13 +40,16 @@ const BookmarkToggle = forwardRef(function BookmarkToggle(
   }, []);
 
   const iconName = isBookmarked ? "bookmark_filled" : "bookmark";
+  const label = isBookmarked ? t`Remove from bookmarks` : t`Bookmark`;
 
   return (
-    <Tooltip
-      label={isBookmarked ? t`Remove from bookmarks` : t`Bookmark`}
-      position={tooltipPlacement}
-    >
-      <BookmarkButton {...props} ref={ref} onClick={handleClick}>
+    <Tooltip label={label} position={tooltipPlacement}>
+      <BookmarkButton
+        {...props}
+        aria-label={label}
+        ref={ref}
+        onClick={handleClick}
+      >
         <BookmarkIcon
           name={iconName}
           isBookmarked={isBookmarked}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -4,13 +4,13 @@ import type { WithRouterProps } from "react-router/lib/withRouter";
 import { push } from "react-router-redux";
 import { c, t } from "ttag";
 
-import Button from "metabase/core/components/Button";
+import { ToolbarButton } from "metabase/components/ToolbarButton";
 import { useRefreshDashboard } from "metabase/dashboard/hooks";
 import type { DashboardFullscreenControls } from "metabase/dashboard/types";
 import { useDispatch } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { Icon, Menu, Tooltip } from "metabase/ui";
+import { Icon, Menu } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
 
 type DashboardActionMenuProps = {
@@ -71,13 +71,11 @@ const DashboardActionMenuInner = ({
     <Menu position="bottom-end" opened={opened} onChange={setOpened}>
       <Menu.Target>
         <div>
-          <Tooltip label={t`Move, trash, and more…`} disabled={opened}>
-            <Button
-              onlyIcon
-              icon="ellipsis"
-              aria-label={t`Move, trash, and more…`}
-            />
-          </Tooltip>
+          <ToolbarButton
+            icon="ellipsis"
+            aria-label={t`Move, trash, and more…`}
+            tooltipLabel={t`Move, trash, and more…`}
+          />
         </div>
       </Menu.Target>
       <Menu.Dropdown>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -2,23 +2,21 @@ import type { ChangeEvent } from "react";
 import { useRef, useState } from "react";
 import { t } from "ttag";
 
+import { ToolbarButton } from "metabase/components/ToolbarButton";
 import { UploadInput } from "metabase/components/upload";
 import BookmarkToggle from "metabase/core/components/BookmarkToggle";
-import Button from "metabase/core/components/Button";
 import { color } from "metabase/lib/colors";
 import { useDispatch } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { QuestionMoreActionsMenu } from "metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { uploadFile } from "metabase/redux/uploads";
-import { Box, Divider, Icon, Menu, Tooltip } from "metabase/ui";
+import { Box, Divider, Icon, Menu } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase-types/store";
 import { UploadMode } from "metabase-types/store/upload";
 
 import ViewTitleHeaderS from "../../ViewTitleHeader.module.css";
-
-const HEADER_ICON_SIZE = 16;
 
 interface Props {
   isBookmarked: boolean;
@@ -114,19 +112,17 @@ export const QuestionActions = ({
           />
         </Box>
       )}
-      <Tooltip label={t`More info`}>
-        <Box className={ViewTitleHeaderS.ViewHeaderIconButtonContainer}>
-          <Button
-            className={ViewTitleHeaderS.ViewHeaderIconButton}
-            onlyIcon
-            icon="info"
-            iconSize={HEADER_ICON_SIZE}
-            onClick={onInfoClick}
-            color={infoButtonColor}
-            data-testid="qb-header-info-button"
-          />
-        </Box>
-      </Tooltip>
+      <Box className={ViewTitleHeaderS.ViewHeaderIconButtonContainer}>
+        <ToolbarButton
+          className={ViewTitleHeaderS.ViewHeaderIconButton}
+          icon="info"
+          onClick={onInfoClick}
+          color={infoButtonColor}
+          data-testid="qb-header-info-button"
+          tooltipLabel={t`More info`}
+          aria-label={t`More info`}
+        />
+      </Box>
       {canAppend && (
         <>
           <UploadInput
@@ -134,37 +130,35 @@ export const QuestionActions = ({
             ref={fileInputRef}
             onChange={handleFileUpload}
           />
-          <Tooltip label={t`Upload data to this model`}>
-            <Box className={ViewTitleHeaderS.ViewHeaderIconButtonContainer}>
-              <Menu position="bottom-end">
-                <Menu.Target>
-                  <Button
-                    className={ViewTitleHeaderS.ViewHeaderIconButton}
-                    onlyIcon
-                    icon="upload"
-                    iconSize={HEADER_ICON_SIZE}
-                    color={infoButtonColor}
-                    data-testid="qb-header-append-button"
-                  />
-                </Menu.Target>
-                <Menu.Dropdown>
-                  <Menu.Item
-                    leftSection={<Icon name="add" />}
-                    onClick={() => handleUploadClick(UploadMode.append)}
-                  >
-                    {t`Append data to this model`}
-                  </Menu.Item>
+          <Box className={ViewTitleHeaderS.ViewHeaderIconButtonContainer}>
+            <Menu position="bottom-end">
+              <Menu.Target>
+                <ToolbarButton
+                  className={ViewTitleHeaderS.ViewHeaderIconButton}
+                  icon="upload"
+                  color={infoButtonColor}
+                  data-testid="qb-header-append-button"
+                  tooltipLabel={t`Upload data to this model`}
+                  aria-label={t`Upload data to this model`}
+                />
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Item
+                  leftSection={<Icon name="add" />}
+                  onClick={() => handleUploadClick(UploadMode.append)}
+                >
+                  {t`Append data to this model`}
+                </Menu.Item>
 
-                  <Menu.Item
-                    leftSection={<Icon name="refresh" />}
-                    onClick={() => handleUploadClick(UploadMode.replace)}
-                  >
-                    {t`Replace all data in this model`}
-                  </Menu.Item>
-                </Menu.Dropdown>
-              </Menu>
-            </Box>
-          </Tooltip>
+                <Menu.Item
+                  leftSection={<Icon name="refresh" />}
+                  onClick={() => handleUploadClick(UploadMode.replace)}
+                >
+                  {t`Replace all data in this model`}
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
+          </Box>
         </>
       )}
       {!question.isArchived() && (

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
@@ -8,6 +8,7 @@ import {
   renderWithProviders,
   screen,
   waitFor,
+  within,
 } from "__support__/ui";
 import * as modelActions from "metabase/query_builder/actions/models";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
@@ -30,11 +31,17 @@ const ICON_CASES_CARDS = [
 ];
 
 const ICON_CASES_LABELS = [
-  { label: "bookmark icon", tooltipText: "Bookmark" },
-  { label: "info icon", tooltipText: "More info" },
   {
-    label: "Move, trash, and more…",
-    tooltipText: "Move, trash, and more…",
+    iconLabel: "bookmark icon",
+    buttonLabel: "Bookmark",
+  },
+  {
+    iconLabel: "info icon",
+    buttonLabel: "More info",
+  },
+  {
+    iconLabel: "ellipsis icon",
+    buttonLabel: "Move, trash, and more…",
   },
 ];
 
@@ -94,13 +101,15 @@ describe("QuestionActions", () => {
   });
 
   it.each(ICON_CASES)(
-    `should display the "$label" icon with the "$tooltipText" tooltip for $card.name questions`,
-    async ({ label, tooltipText, card }) => {
+    `should display the "$iconLabel" icon with the "$buttonLabel" tooltip for $card.name questions`,
+    async ({ iconLabel, buttonLabel, card }) => {
       setup({ card });
 
-      await userEvent.hover(screen.getByRole("button", { name: label }));
-      const tooltip = await screen.findByRole("tooltip", { name: tooltipText });
-      expect(tooltip).toHaveTextContent(tooltipText);
+      const button = await screen.findByRole("button", { name: buttonLabel });
+      expect(within(button).getByLabelText(iconLabel)).toBeInTheDocument();
+      await userEvent.hover(button);
+      const tooltip = await screen.findByRole("tooltip", { name: buttonLabel });
+      expect(tooltip).toHaveTextContent(buttonLabel);
     },
   );
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/QuestionMoreActionsMenu.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/QuestionMoreActionsMenu.tsx
@@ -2,7 +2,7 @@ import { Fragment, type JSX, useState } from "react";
 import { c, t } from "ttag";
 import _ from "underscore";
 
-import Button from "metabase/core/components/Button";
+import { ToolbarButton } from "metabase/components/ToolbarButton";
 import { useUserAcknowledgement } from "metabase/hooks/use-user-acknowledgement";
 import { useDispatch } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
@@ -20,7 +20,7 @@ import {
   MODAL_TYPES,
   type QueryModalType,
 } from "metabase/query_builder/constants";
-import { Icon, Menu, Tooltip } from "metabase/ui";
+import { Icon, Menu } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import { checkCanBeModel } from "metabase-lib/v1/metadata/utils/models";
@@ -225,9 +225,11 @@ export const QuestionMoreActionsMenu = ({
     <Menu position="bottom-end" opened={opened} onChange={setOpened}>
       <Menu.Target>
         <div>
-          <Tooltip label={label} disabled={opened}>
-            <Button onlyIcon icon="ellipsis" aria-label={label} />
-          </Tooltip>
+          <ToolbarButton
+            icon="ellipsis"
+            aria-label={label}
+            tooltipLabel={label}
+          />
         </div>
       </Menu.Target>
 


### PR DESCRIPTION
Standardizes on `ToolbarButton` for header actions so we get consistent hover states on our main headers, particularly our `...` menus.

Before
![Screenshot 2025-05-09 at 3 24 13 PM](https://github.com/user-attachments/assets/f61d30a5-ee54-438a-b005-e7d21205a865)

After - now matches other states
![Screenshot 2025-05-09 at 3 23 16 PM](https://github.com/user-attachments/assets/5f295981-5380-400c-911d-f668ff1a553e)
