### PR TITLE
Replace Mongo 4.4/5.0 with 6.0

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -428,12 +428,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - name: MongoDB 4.4
-            junit-name: be-tests-mongo-4-4-ee
-            image: metabase/qa-databases:mongo-sample-4.4
-          - name: MongoDB 5.0
-            junit-name: be-tests-mongo-5-0-ee
-            image: metabase/qa-databases:mongo-sample-5.0
+          - name: MongoDB 6.0
+            junit-name: be-tests-mongo-6-0-ee
+            image: metabase/qa-databases:mongo-sample-6.0
           - name: MongoDB Latest
             junit-name: be-tests-mongo-latest-ee
             image: mongo:latest
@@ -480,12 +477,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - name: MongoDB 4.4
-            junit-name: be-tests-mongo-4-4-ee
-            image: metabase/qa-databases:mongo-sample-4.4
-          - name: MongoDB 5.0
-            junit-name: be-tests-mongo-5-0-ssl-ee
-            image: metabase/qa-databases:mongo-sample-5.0
+          - name: MongoDB 6.0
+            junit-name: be-tests-mongo-6-0-ssl-ee
+            image: metabase/qa-databases:mongo-sample-6.0
     env:
       CI: 'true'
       DRIVERS: mongo

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -430,7 +430,7 @@ jobs:
         version:
           - name: MongoDB 6.0
             junit-name: be-tests-mongo-6-0-ee
-            image: metabase/qa-databases:mongo-sample-6.0
+            image: metabase/qa-databases:mongo-sample-6
           - name: MongoDB Latest
             junit-name: be-tests-mongo-latest-ee
             image: mongo:latest
@@ -479,7 +479,7 @@ jobs:
         version:
           - name: MongoDB 6.0
             junit-name: be-tests-mongo-6-0-ssl-ee
-            image: metabase/qa-databases:mongo-sample-6.0
+            image: metabase/qa-databases:mongo-sample-6
     env:
       CI: 'true'
       DRIVERS: mongo


### PR DESCRIPTION
### Description

Upgrade Mongo images to 6.0 since that is oldest version with EOL support. 
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
