### PR TITLE
Improved search metrics

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -248,20 +248,31 @@
                        {:description "Number of queries with metrics processed by the metrics adjust middleware."})
    (prometheus/counter :metabase-query-processor/metrics-adjust-errors
                        {:description "Number of errors when processing metrics in the metrics adjust middleware."})
-   (prometheus/counter :metabase-search/index
-                       {:description "Number of entries indexed for search"
-                        :labels      [:model]})
    (prometheus/gauge :metabase-database/status
                      {:description "Does a given database using driver pass a health check."
                       :labels [:driver :healthy :reason]})
+   (prometheus/counter :metabase-search/index-reindexes
+                       {:description "Number of reindexed search entries"
+                        :labels      [:model]})
+   (prometheus/counter :metabase-search/index-updates
+                       {:description "Number of updated search entries"
+                        :labels      [:model]})
    (prometheus/counter :metabase-search/index-error
                        {:description "Number of errors encountered when indexing for search"})
-   (prometheus/counter :metabase-search/index-ms
-                       {:description "Total number of ms indexing took"})
-   (prometheus/histogram :metabase-search/index-duration-ms
-                         {:description "Duration in milliseconds that indexing jobs take."
+   (prometheus/counter :metabase-search/index-update-ms
+                       {:description "Total number of ms updating the index"})
+   (prometheus/histogram :metabase-search/index-update-duration-ms
+                         {:description "Duration in milliseconds that index update jobs took."
       ;; 1ms -> 10minutes
                           :buckets [1 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+   (prometheus/counter :metabase-search/index-reindex-ms
+                       {:description "Total number of ms reindexing the index"})
+   (prometheus/histogram :metabase-search/index-reindex-duration-ms
+                         {:description "Duration in milliseconds that index reindex jobs took."
+      ;; 1ms -> 10minutes
+                          :buckets [1 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+   (prometheus/gauge :metabase-search/appdb-index-size
+                     {:description "Number of rows in the active index table."})
    (prometheus/gauge :metabase-search/queue-size
                      {:description "Number of updates on the search indexing queue."})
    (prometheus/counter :metabase-search/response-ok
@@ -496,6 +507,9 @@
   ;; want to see what's in the registry?
   (require 'iapetos.export)
   (spit "metrics" (iapetos.export/text-format (:registry system)))
+
+  ;; See all metrics that match a given prefix:
+  ; (filter #(.startsWith % "metabase_search_") (clojure.string/split-lines (iapetos.export/text-format (:registry system))))
 
   ;; need to restart the server to see the metrics? use:
   (shutdown!)

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -66,7 +66,7 @@
     ;; The job appears to wait on the main thread when run from tests, so, unfortunately, testing this branch is hard.
     (if (and (task/job-exists? task.search-index/reindex-job-key) (or (not ingestion/*force-sync*) config/is-test?))
       (do (task/trigger-now! task.search-index/reindex-job-key) {:message "task triggered"})
-      (do (task.search-index/reindex!) {:message "done"}))
+      (do (search/reindex!) {:message "done"}))
 
     (throw (ex-info "Search index is not supported for this installation." {:status-code 501}))))
 

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -266,7 +266,7 @@
       (u/prog1 (->> entries (map :model) frequencies)
         (log/trace "indexed documents for " <>)
         (when active-updated?
-          (analytics/set! :metabase-search/appdb-index-size (t2/count #p (name #p active-table))))))))
+          (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-table))))))))
 
 (defn index-docs!
   "Indexes the documents. The context should be :search/updating or :search/reindexing.

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -264,10 +264,7 @@
     (when (or active-updated? pending-updated?)
       (u/prog1 (->> entries (map :model) frequencies)
         (log/trace "indexed documents for " <>)
-        (analytics/set! :metabase-search/appdb-index-size
-                        (:count (t2/query-one {:select [[:%count.* :count]]
-                                               :from   [(active-table)]
-                                               :limit  1})))))))
+        (analytics/set! :metabase-search/appdb-index-size (t2/count (active-table)))))))
 
 (defn index-docs!
   "Indexes the documents. The context should be :search/updating or :search/reindexing.

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -2,6 +2,7 @@
   "NOT the API namespace for the search module!! See [[metabase.search]] instead."
   (:require
    [metabase.analytics.core :as analytics]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.search.appdb.core :as search.engines.appdb]
    [metabase.search.config :as search.config]
    [metabase.search.engine :as search.engine]
@@ -10,6 +11,7 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.spec :as search.spec]
    [metabase.search.util :as search.util]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [potemkin :as p]))
 
@@ -43,7 +45,12 @@
  [search.spec
   define-spec])
 
-(defmethod analytics/known-labels :metabase-search/index
+(defmethod analytics/known-labels :metabase-search/index-updates
+  [_]
+  (for [model (keys (search.spec/specifications))]
+    {:model model}))
+
+(defmethod analytics/known-labels :metabase-search/index-reindexes
   [_]
   (for [model (keys (search.spec/specifications))]
     {:model model}))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -83,20 +83,48 @@
   (when (supports-index?)
     (log/info "Initializing search indexes")
     ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
-    (reduce (partial merge-with max)
-            nil
-            (for [e (search.engine/active-engines)]
-              (search.engine/init! e opts)))))
+    (try
+      (let [timer (u/start-timer)
+            report (reduce (partial merge-with max)
+                           nil
+                           (for [e (search.engine/active-engines)]
+                             (search.engine/init! e opts)))
+            duration (u/since-ms timer)]
+        (if (seq report)
+          (do
+            (analytics/inc! :metabase-search/index-reindex-ms duration)
+            (prometheus/observe! :metabase-search/index-reindex-duration-ms duration)
+            (doseq [[model cnt] report]
+              (analytics/inc! :metabase-search/index-reindexes {:model model} cnt))
+            (log/infof "Index initialized in %.0fms %s" duration (sort-by (comp - val) report))
+            report)
+          (log/info "Found existing search index, and using it.")))
+      (catch Exception e
+        (analytics/inc! :metabase-search/index-error)
+        (throw e)))))
 
 (defn reindex!
   "Populate a new index, and make it active. Simultaneously updates the current index."
   [& {:as opts}]
   ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
   (when (supports-index?)
-    (reduce (partial merge-with max)
-            nil
-            (for [e (search.engine/active-engines)]
-              (search.engine/reindex! e opts)))))
+    (try
+      (log/info "Reindexing searchable entities")
+      (let [timer (u/start-timer)
+            report (reduce (partial merge-with max)
+                           nil
+                           (for [e (search.engine/active-engines)]
+                             (search.engine/reindex! e opts)))
+            duration (u/since-ms timer)]
+        (analytics/inc! :metabase-search/index-reindex-ms duration)
+        (prometheus/observe! :metabase-search/index-reindex-duration-ms duration)
+        (doseq [[model cnt] report]
+          (analytics/inc! :metabase-search/index-reindexes {:model model} cnt))
+        (log/infof "Done reindexing in %.0fms %s" duration (sort-by (comp - val) report))
+        report)
+      (catch Exception e
+        (analytics/inc! :metabase-search/index-error)
+        (throw e)))))
 
 (defn reset-tracking!
   "Stop tracking the current indexes. Used when resetting the appdb."

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -30,13 +30,15 @@
    :score  (:score result)})
 
 (defmulti update!
-  "Updates the existing search index by consuming the documents from the given reducible."
+  "Updates the existing search index by consuming the documents from the given reducible.
+  Returns a map of the number of documents indexed in each model"
   {:arglists '([search-engine document-reducible])}
   (fn [search-engine _document-reducible]
     search-engine))
 
 (defmulti delete!
-  "Removes the documents from the search index."
+  "Removes the documents from the search index.
+  Returns a map of the number of documents deleted in each model"
   {:arglists '([search-engine model ids])}
   (fn [search-engine _model _ids]
     search-engine))

--- a/src/metabase/search/task/search_index.clj
+++ b/src/metabase/search/task/search_index.clj
@@ -9,6 +9,7 @@
    [metabase.search.ingestion :as ingestion]
    [metabase.startup.core :as startup]
    [metabase.task.core :as task]
+   [metabase.util.cluster-lock :as cluster-lock]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.queue :as queue]
@@ -38,39 +39,12 @@
   []
   (when (search/supports-index?)
     (cluster-lock/with-cluster-lock ::search-init-lock
-      (try
-        (let [timer (u/start-timer)
-              report (search/init-index! {:force-reset? false, :re-populate? false})
-              duration (u/since-ms timer)]
-          (if (seq report)
-            (do (ingestion/report->prometheus! duration report)
-                (log/infof "Done indexing in %.0fms %s" duration (sort-by (comp - val) report))
-                true)
-            (log/info "Found existing search index, and using it.")))
-        (catch Exception e
-          (analytics/inc! :metabase-search/index-error)
-          (throw e))))))
-
-(defn reindex!
-  "Reindex the whole AppDB"
-  []
-  (when (search/supports-index?)
-    (try
-      (log/info "Reindexing searchable entities")
-      (let [timer    (u/start-timer)
-            report   (search/reindex!)
-            duration (u/since-ms timer)]
-        (ingestion/report->prometheus! duration report)
-        (log/infof "Done reindexing in %.0fms %s" duration (sort-by (comp - val) report))
-        report)
-      (catch Exception e
-        (analytics/inc! :metabase-search/index-error)
-        (throw e)))))
+      (search/init-index! {:force-reset? false, :re-populate? false}))))
 
 (task/defjob ^{DisallowConcurrentExecution true
                :doc                        "Populate a new Search Index"}
   SearchIndexReindex [_ctx]
-  (reindex!))
+  (search/reindex!))
 
 (defmethod startup/def-startup-logic! ::SearchIndexInit [_]
   (quick-task/submit-task! (init!)))

--- a/src/metabase/search/task/search_index.clj
+++ b/src/metabase/search/task/search_index.clj
@@ -3,15 +3,11 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.simple :as simple]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.analytics.core :as analytics]
    [metabase.app-db.cluster-lock :as cluster-lock]
    [metabase.search.core :as search]
    [metabase.search.ingestion :as ingestion]
    [metabase.startup.core :as startup]
    [metabase.task.core :as task]
-   [metabase.util.cluster-lock :as cluster-lock]
-   [metabase.util :as u]
-   [metabase.util.log :as log]
    [metabase.util.queue :as queue]
    [metabase.util.quick-task :as quick-task])
   (:import

--- a/test/metabase/search/task/search_index_test.clj
+++ b/test/metabase/search/task/search_index_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [honey.sql.helpers :as sql.helpers]
    [metabase.search.appdb.index :as search.index]
+   [metabase.search.core :as search]
    [metabase.search.task.search-index :as task]
    [metabase.search.test-util :as search.tu]
    [toucan2.core :as t2]))
@@ -27,12 +28,12 @@
    ;; TODO this is coupled to appdb engines at the moment
     (t2/query (sql.helpers/drop-table (search.index/active-table)))
     (testing "It can recreate the index from scratch"
-      (is (task/reindex!))
+      (is (search/reindex!))
       (let [initial-size (index-size)
             table-name (search.index/active-table)]
         (is (pos? initial-size))
         (t2/delete! table-name (t2/select-one-pk table-name))
         (is (= (dec initial-size) (index-size)))
         (testing "It can cycle the index gracefully"
-          (is (task/reindex!))
+          (is (search/reindex!))
           (is (= initial-size (index-size))))))))

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -1333,8 +1333,8 @@
           (with-redefs [driver/create-table! (fn [& _args] (throw (Exception. "Boom")))
                         analytics/inc! (fn
                                          ([k] (swap! metrics update k (fnil inc 0)))
-                                         ([k v] (swap! metrics update k (fnil #(+ % v) 0)))
-                                         ([k v _opts] (swap! metrics update k (fnil #(+ % v) 0))))]
+                                         ([k v] (when (number? v) (swap! metrics update k (fnil #(+ % v) 0))))
+                                         ([k v _opts] (when (number? v) (swap! metrics update k (fnil #(+ % v) 0)))))]
             (is (thrown-with-msg?
                  Exception
                  #"Boom"

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -1331,7 +1331,10 @@
       (testing "Driver error"
         (let [metrics (atom {})]
           (with-redefs [driver/create-table! (fn [& _args] (throw (Exception. "Boom")))
-                        analytics/inc! #(swap! metrics update % (fnil inc 0))]
+                        analytics/inc! (fn
+                                         ([k] (swap! metrics update k (fnil inc 0)))
+                                         ([k v] (swap! metrics update k (fnil #(+ % v) 0)))
+                                         ([k v _opts] (swap! metrics update k (fnil #(+ % v) 0))))]
             (is (thrown-with-msg?
                  Exception
                  #"Boom"


### PR DESCRIPTION
### Description

Improves the metrics generated by the search indexing:
- Separates counts and times for index updates vs. reindexes and fixes them so they work again
- Tracks size of the appdb index

**Removed metric:**
```
# HELP metabase_search_index_total Number of entries indexed for search
# TYPE metabase_search_index_total counter
metabase_search_index_total{model="card",} 34.0
metabase_search_index_total{model="dataset",} 1.0
metabase_search_index_total{model="indexed-entity",} 0.0
metabase_search_index_total{model="database",} 3.0
metabase_search_index_total{model="segment",} 0.0
metabase_search_index_total{model="collection",} 5.0
metabase_search_index_total{model="dashboard",} 9.0
metabase_search_index_total{model="action",} 0.0
metabase_search_index_total{model="metric",} 2.0
metabase_search_index_total{model="table",} 15.0

# HELP metabase_search_index_created Number of entries indexed for search
# TYPE metabase_search_index_created gauge
metabase_search_index_created{model="card",} 1.747672315285E9
metabase_search_index_created{model="dataset",} 1.747672315285E9
metabase_search_index_created{model="indexed-entity",} 1.747672315285E9
metabase_search_index_created{model="database",} 1.747672315285E9
metabase_search_index_created{model="segment",} 1.747672315285E9
metabase_search_index_created{model="collection",} 1.747672315285E9
metabase_search_index_created{model="dashboard",} 1.747672315277E9
metabase_search_index_created{model="action",} 1.747672315285E9
metabase_search_index_created{model="metric",} 1.747672315285E9
metabase_search_index_created{model="table",} 1.747672315284E9
```

**New metrics:**
```
# HELP metabase_search_index_reindexes_total Number of reindexed search entries
# TYPE metabase_search_index_reindexes_total counter
metabase_search_index_reindexes_total{model="card",} 34.0
metabase_search_index_reindexes_total{model="dataset",} 1.0
metabase_search_index_reindexes_total{model="indexed-entity",} 0.0
metabase_search_index_reindexes_total{model="database",} 3.0
metabase_search_index_reindexes_total{model="segment",} 0.0
metabase_search_index_reindexes_total{model="collection",} 5.0
metabase_search_index_reindexes_total{model="dashboard",} 9.0
metabase_search_index_reindexes_total{model="action",} 0.0
metabase_search_index_reindexes_total{model="metric",} 2.0
metabase_search_index_reindexes_total{model="table",} 15.0

# HELP metabase_search_index_reindexes_created Number of reindexed search entries
# TYPE metabase_search_index_reindexes_created gauge
metabase_search_index_reindexes_created{model="card",} 1.747667404327E9
metabase_search_index_reindexes_created{model="dataset",} 1.747667404327E9
metabase_search_index_reindexes_created{model="indexed-entity",} 1.747667404327E9
metabase_search_index_reindexes_created{model="database",} 1.747667404327E9
metabase_search_index_reindexes_created{model="segment",} 1.747667404327E9
metabase_search_index_reindexes_created{model="collection",} 1.747667404327E9
metabase_search_index_reindexes_created{model="dashboard",} 1.74766740432E9
metabase_search_index_reindexes_created{model="action",} 1.747667404327E9
metabase_search_index_reindexes_created{model="metric",} 1.747667404327E9
metabase_search_index_reindexes_created{model="table",} 1.747667404327E9
```

```
# HELP metabase_search_index_updates_total Number of updated search entries
# TYPE metabase_search_index_updates_total counter
metabase_search_index_updates_total{model="card",} 0.0
metabase_search_index_updates_total{model="dataset",} 0.0
metabase_search_index_updates_total{model="indexed-entity",} 0.0
metabase_search_index_updates_total{model="database",} 0.0
metabase_search_index_updates_total{model="segment",} 0.0
metabase_search_index_updates_total{model="collection",} 0.0
metabase_search_index_updates_total{model="dashboard",} 0.0
metabase_search_index_updates_total{model="action",} 0.0
metabase_search_index_updates_total{model="metric",} 0.0
metabase_search_index_updates_total{model="table",} 0.0

# HELP metabase_search_index_updates_created Number of updated search entries
# TYPE metabase_search_index_updates_created gauge
metabase_search_index_updates_created{model="card",} 1.747667404328E9
metabase_search_index_updates_created{model="dataset",} 1.747667404328E9
metabase_search_index_updates_created{model="indexed-entity",} 1.747667404328E9
metabase_search_index_updates_created{model="database",} 1.747667404328E9
metabase_search_index_updates_created{model="segment",} 1.747667404328E9
metabase_search_index_updates_created{model="collection",} 1.747667404328E9
metabase_search_index_updates_created{model="dashboard",} 1.747667404328E9
metabase_search_index_updates_created{model="action",} 1.747667404328E9
metabase_search_index_updates_created{model="metric",} 1.747667404328E9
metabase_search_index_updates_created{model="table",} 1.747667404328E9
```

```
# HELP metabase_search_index_update_duration_ms_created Duration in milliseconds that index update jobs took.
# TYPE metabase_search_index_update_duration_ms_created gauge
metabase_search_index_update_duration_ms_created 1.747667404314E9

# HELP metabase_search_index_update_duration_ms Duration in milliseconds that index update jobs took.
# TYPE metabase_search_index_update_duration_ms histogram
metabase_search_index_update_duration_ms_bucket{le="1.0",} 0.0
metabase_search_index_update_duration_ms_bucket{le="500.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="1000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="5000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="10000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="30000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="60000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="120000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="300000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="600000.0",} 1.0
metabase_search_index_update_duration_ms_bucket{le="+Inf",} 1.0
metabase_search_index_update_duration_ms_count 1.0
metabase_search_index_update_duration_ms_sum 12.58625
```

```
# HELP metabase_search_index_update_ms_total Total number of ms updating the index
# TYPE metabase_search_index_update_ms_total counter
metabase_search_index_update_ms_total 12.58625

# HELP metabase_search_index_update_ms_created Total number of ms updating the index
# TYPE metabase_search_index_update_ms_created gauge
metabase_search_index_update_ms_created 1.747667404314E9
```

```
# HELP metabase_search_index_reindex_duration_ms Duration in milliseconds that index reindex jobs took.
# TYPE metabase_search_index_reindex_duration_ms histogram
metabase_search_index_reindex_duration_ms_bucket{le="1.0",} 0.0
metabase_search_index_reindex_duration_ms_bucket{le="500.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="1000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="5000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="10000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="30000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="60000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="120000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="300000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="600000.0",} 1.0
metabase_search_index_reindex_duration_ms_bucket{le="+Inf",} 1.0
metabase_search_index_reindex_duration_ms_count 1.0
metabase_search_index_reindex_duration_ms_sum 161.755458

# HELP metabase_search_index_reindex_duration_ms_created Duration in milliseconds that index reindex jobs took.
# TYPE metabase_search_index_reindex_duration_ms_created gauge
metabase_search_index_reindex_duration_ms_created 1.747667404314E9
```

```
# HELP metabase_search_index_reindex_ms_created Total number of ms reindexing the index
# TYPE metabase_search_index_reindex_ms_created gauge
metabase_search_index_reindex_ms_created 1.747667404314E9

# HELP metabase_search_index_reindex_ms_total Total number of ms reindexing the index
# TYPE metabase_search_index_reindex_ms_total counter
metabase_search_index_reindex_ms_total 161.755458
```

```
# HELP metabase_search_appdb_index_size Number of rows in the active index table.
# TYPE metabase_search_appdb_index_size gauge
metabase_search_appdb_index_size 69.0
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
