### PR TITLE
do not show visualize another way on text cards

### DIFF
--- a/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
@@ -85,6 +85,13 @@ describe("scenarios > dashboard > text and headings", () => {
           cy.findByLabelText("Show visualization options").click();
         });
 
+      // should not render visualizer option
+      H.getDashboardCard(1)
+        .realHover()
+        .within(() => {
+          cy.findByLabelText("Visualize another way").should("not.exist");
+        });
+
       cy.findByRole("dialog").within(() => {
         cy.findByTestId("chartsettings-sidebar").within(() => {
           cy.findByText("Vertical Alignment").should("be.visible");

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -177,8 +177,10 @@ function DashCardActionsPanelInner({
     }
 
     if (
+      dashcard &&
       !isVisualizerDashboardCard(dashcard) &&
-      !isVisualizerSupportedVisualization(dashcard?.card.display)
+      !isVisualizerSupportedVisualization(dashcard?.card.display) &&
+      !isVirtualDashCard(dashcard)
     ) {
       buttons.push(
         <DashCardActionButton


### PR DESCRIPTION
### Description

Hides "Visualize another way" dashcard action button on text cards.

### Demo

Before

<img width="572" alt="Screenshot 2025-05-09 at 10 00 32 PM" src="https://github.com/user-attachments/assets/98bf29d5-5f12-443e-b063-7909bbba2278" />

After

<img width="545" alt="Screenshot 2025-05-09 at 10 00 17 PM" src="https://github.com/user-attachments/assets/df3948b4-0257-4704-b559-12ee6f96c92e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
