### PR TITLE
alerts template use slack syntax

### DIFF
--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -213,7 +213,11 @@
   (let [event-name (:event_name context)
         template   (or template
                        (channel.template/default-template :notification/system-event context channel-type))
-        sections    [(text->markdown-section (channel.template/render-template template notification-payload))]]
+        sections    [{:type "section"
+                      :text {:type "mrkdwn"
+                             :text (truncate
+                                    (channel.template/render-template template notification-payload)
+                                    block-text-length-limit)}}]]
     (assert template (str "No template found for event " event-name))
     (for [channel (map notification-recipient->channel recipients)]
       {:channel channel

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -137,7 +137,7 @@
     {:creator  (select-keys ?creator [:first_name :last_name :email :common_name])
      :card     {:id   ?card_id
                 :name ?card_name}
-     :rows     (let [col-names (map :display_name ?result_cols)]
+     :rows     (let [col-names (map :name ?result_cols)]
                  (vec (for [row ?result_rows]
                         (zipmap col-names row))))}))
 
@@ -149,8 +149,7 @@
         _             (assert link-template "No template found")
         card-url-text (some->> (update-in notification-payload [:payload :card_part] channel.shared/maybe-realize-data-rows)
                                (channel/template-context channel-type payload-type)
-                               (channel.template/render-template link-template)
-                               (#(markdown/process-markdown % :slack)))
+                               (channel.template/render-template link-template))
         blocks        (concat [{:type "header"
                                 :text {:type "plain_text"
                                        :text (truncate (str "🔔 " (-> payload :card :name)) header-text-limit)

--- a/src/metabase/channel/template/default.clj
+++ b/src/metabase/channel/template/default.clj
@@ -50,7 +50,7 @@
                                                                                               "{{/each}}\n")}}
                    [:notification/card nil] {:channel_type :channel/slack
                                              :details      {:type :slack/handlebars-text
-                                                            :body "[{{card.name}}]({{card-url card.id}})"}}}
+                                                            :body "<{{card-url card.id}}|{{card.name}}>"}}}
    :channel/http {[:notification/system-event :event/row.created] default-http-template
                   [:notification/system-event :event/row.updated] default-http-template
                   [:notification/system-event :event/row.deleted] default-http-template}})

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -1089,8 +1089,8 @@
                             :email       "crowberto@metabase.com"
                             :first_name  "Crowberto"
                             :last_name   "Corv"}
-                  :rows [{:ID 1 :Name "African"}
-                         {:ID 2 :Name "American"}]}
+                  :rows [{:ID 1 :NAME "African"}
+                         {:ID 2 :NAME "American"}]}
                  (:payload result))))))
 
     (testing "email"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/WRK-379/check-if-translation-layer-ruins-userids-for-slack

We need to use slack syntax directly because the markdown -> slack translation escape characters like ">, <", so you can't make mentioning work properly.