### PR TITLE
Closes VIZ-656 better mapping when switching to/from non-cartesians

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -78,7 +78,7 @@ export function assertCurrentVisualization(name: VisualizationDisplay) {
 
 export function selectVisualization(visualization: VisualizationDisplay) {
   cy.findByTestId("viz-picker-main").within(() => {
-    cy.icon(visualization as any).click();
+    cy.findByTestId(visualization).click();
   });
 }
 
@@ -110,6 +110,47 @@ export function deselectColumnFromColumnsList(
 
 export function verticalWell() {
   return cy.findByTestId("vertical-well");
+}
+
+export function assertWellItems(items: {
+  horizontal?: string[];
+  vertical?: string[];
+  pieMetric?: string[];
+  pieDimensions?: string[];
+}) {
+  const { horizontal, vertical, pieMetric, pieDimensions } = items;
+
+  if (horizontal) {
+    horizontalWell().within(() => {
+      horizontal.forEach((item) => {
+        cy.findByText(item).should("exist");
+      });
+    });
+  }
+
+  if (vertical) {
+    verticalWell().within(() => {
+      vertical.forEach((item) => {
+        cy.findByText(item).should("exist");
+      });
+    });
+  }
+
+  if (pieMetric) {
+    pieMetricWell().within(() => {
+      pieMetric.forEach((item) => {
+        cy.findByText(item).should("exist");
+      });
+    });
+  }
+
+  if (pieDimensions) {
+    pieDimensionWell().within(() => {
+      pieDimensions.forEach((item) => {
+        cy.findByText(item).should("exist");
+      });
+    });
+  }
 }
 
 export function horizontalWell() {

--- a/e2e/support/test-visualizer-data.ts
+++ b/e2e/support/test-visualizer-data.ts
@@ -18,7 +18,8 @@ type NativeQuestionDetailsWithName = NativeQuestionDetails & {
   name: string;
 };
 
-const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID, ACCOUNTS, ACCOUNTS_ID } =
+  SAMPLE_DATABASE;
 
 // Not using the one from "metabase/visualizer/utils"
 // because it creates a circular dependency
@@ -58,6 +59,20 @@ export const ORDERS_COUNT_BY_PRODUCT_CATEGORY: StructuredQuestionDetailsWithName
       "graph.metrics": ["count"],
     },
   };
+
+export const ACCOUNTS_COUNT_BY_COUNTRY: StructuredQuestionDetailsWithName = {
+  display: "bar",
+  name: "Accounts by Country",
+  query: {
+    "source-table": ACCOUNTS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", ACCOUNTS.COUNTRY, null]],
+  },
+  visualization_settings: {
+    "graph.dimensions": ["COUNTRY"],
+    "graph.metrics": ["count"],
+  },
+};
 
 export const ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY: StructuredQuestionDetailsWithName =
   {

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -265,50 +265,6 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     });
   });
 
-  it("should remap columns when changing a viz type", () => {
-    H.visitDashboard(ORDERS_DASHBOARD_ID);
-    H.editDashboard();
-
-    H.openQuestionsSidebar();
-    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_PRODUCT_CATEGORY.name);
-
-    H.modal().within(() => {
-      // Turn into a pie chart
-      cy.findByTestId("viz-picker-main").icon("pie").click();
-      H.assertDataSourceColumnSelected(
-        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
-        "Count",
-      );
-      H.assertDataSourceColumnSelected(
-        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
-        "Product → Category",
-      );
-      H.pieMetricWell().findByText("Count").should("exist");
-      H.pieDimensionWell().findByText("Product → Category").should("exist");
-      H.echartsContainer().findByText("18,760").should("exist"); // total value
-
-      // Turn into a funnel
-      cy.findByTestId("viz-picker-main").icon("funnel").click();
-      H.assertDataSourceColumnSelected(
-        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
-        "Count",
-      );
-      H.assertDataSourceColumnSelected(
-        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
-        "Product → Category",
-      );
-      H.verticalWell().findByText("Count").should("exist");
-      H.horizontalWell().within(() => {
-        cy.findByText("Product → Category").should("exist");
-        cy.findByText("Doohickey").should("exist");
-        cy.findByText("Gadget").should("exist");
-        cy.findByText("Gizmo").should("exist");
-        cy.findByText("Widget").should("exist");
-        cy.findAllByTestId("well-item").should("have.length", 5);
-      });
-    });
-  });
-
   it("should start in a pristine state and update dirtyness accordingly", () => {
     createDashboardWithVisualizerDashcards();
     H.editDashboard();

--- a/e2e/test/scenarios/dashboard/visualizer/columns-mapping.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/columns-mapping.cy.spec.ts
@@ -1,0 +1,110 @@
+const { H } = cy;
+
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ACCOUNTS_COUNT_BY_COUNTRY,
+  ORDERS_COUNT_BY_PRODUCT_CATEGORY,
+} from "e2e/support/test-visualizer-data";
+
+describe("scenarios > dashboard > visualizer > basics", () => {
+  beforeEach(() => {
+    H.restore();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+
+    cy.signInAsNormalUser();
+
+    H.createQuestion(ACCOUNTS_COUNT_BY_COUNTRY, {
+      idAlias: "accountsCountByCountryQuestionId",
+      entityIdAlias: "accountsCountByCountryQuestionEntityId",
+      wrapId: true,
+    });
+
+    H.createQuestion(ORDERS_COUNT_BY_PRODUCT_CATEGORY, {
+      idAlias: "ordersCountByProductCategoryQuestionId",
+      entityIdAlias: "ordersCountByProductCategoryQuestionEntityId",
+      wrapId: true,
+    });
+  });
+
+  it("should remap columns when changing a viz type", () => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_PRODUCT_CATEGORY.name);
+
+    H.modal().within(() => {
+      // Turn into a pie chart
+      cy.findByTestId("viz-picker-main").icon("pie").click();
+      H.assertDataSourceColumnSelected(
+        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
+        "Count",
+      );
+      H.assertDataSourceColumnSelected(
+        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
+        "Product → Category",
+      );
+      H.pieMetricWell().findByText("Count").should("exist");
+      H.pieDimensionWell().findByText("Product → Category").should("exist");
+      H.echartsContainer().findByText("18,760").should("exist"); // total value
+
+      // Turn into a funnel
+      cy.findByTestId("viz-picker-main").icon("funnel").click();
+      H.assertDataSourceColumnSelected(
+        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
+        "Count",
+      );
+      H.assertDataSourceColumnSelected(
+        ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
+        "Product → Category",
+      );
+      H.verticalWell().findByText("Count").should("exist");
+      H.horizontalWell().within(() => {
+        cy.findByText("Product → Category").should("exist");
+        cy.findByText("Doohickey").should("exist");
+        cy.findByText("Gadget").should("exist");
+        cy.findByText("Gizmo").should("exist");
+        cy.findByText("Widget").should("exist");
+        cy.findAllByTestId("well-item").should("have.length", 5);
+      });
+    });
+  });
+
+  it("should preserve column mapping when switching between cartesian and pie", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+    });
+
+    H.editDashboard();
+
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(ACCOUNTS_COUNT_BY_COUNTRY.name);
+
+    H.modal().within(() => {
+      H.assertWellItems({ horizontal: ["Country"], vertical: ["Count"] });
+
+      // cartesian (starting point) -> funnel -> scatter
+      H.selectVisualization("funnel");
+      H.assertWellItems({ horizontal: ["Country"], vertical: ["Count"] });
+      H.selectVisualization("scatter");
+      H.assertWellItems({ horizontal: ["Country"], vertical: ["Count"] });
+
+      // Resetting the visualization to cartesian
+      H.switchToAddMoreData();
+      H.selectDataset(ACCOUNTS_COUNT_BY_COUNTRY.name);
+
+      // cartesian (starting point) -> pie -> funnel -> scatter
+      H.selectVisualization("pie");
+      H.assertWellItems({ pieDimensions: ["Country"], pieMetric: ["Count"] });
+      H.selectVisualization("funnel");
+      H.assertWellItems({ horizontal: ["Country"], vertical: ["Count"] });
+      H.selectVisualization("scatter");
+      H.assertWellItems({ horizontal: ["Country"], vertical: ["Count"] });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizer/components/VisualizationPicker/VisualizationPicker.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationPicker/VisualizationPicker.tsx
@@ -56,7 +56,7 @@ export function VisualizationPicker({
           value: o.value,
           label: (
             <Center key={i} onClick={() => onChange(o.value)} p="sm">
-              <Icon name={o.icon} />
+              <Icon data-testid={o.value} name={o.icon} />
             </Center>
           ),
         }))}


### PR DESCRIPTION
Closes [VIZ-656: Switching viz type to pie with a new source removes mapping](https://linear.app/metabase/issue/VIZ-656/switching-viz-type-to-pie-with-a-new-source-removes-mapping)

### Description

Keeps `graph.metrics` and `graph.dimensions` whenever possible to maintain consistency when switching to and from cartesians/non-cartesians.
Also did a bit of reorg in the test files

`master` version of #57775 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
