### PR TITLE
Overload PUT table rows to support efficient bulk updates

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -75,6 +75,21 @@
                      [3 "Farfetch'd" "The land of lisp"]}
                    (set (table-rows table-id)))))
 
+          (testing "PUT can also do bulk updates"
+            (is (= #{{:id 1, :name "Pidgey",     :song "The Star-Spangled Banner"}
+                     {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}
+                   (set
+                    (:updated
+                     (mt/user-http-request :crowberto :put 200 url
+                                           {:pks     [{:id 1}
+                                                      {:id 2}]
+                                            :updates {:song "The Star-Spangled Banner"}}))))
+
+                (is (= #{[1 "Pidgey" "The Star-Spangled Banner"]
+                         [2 "Speacolumn" "The Star-Spangled Banner"]
+                         [3 "Farfetch'd" "The land of lisp"]}
+                       (set (table-rows table-id))))))
+
           (testing "DELETE should remove the corresponding rows"
             (is (= {:success true}
                    (mt/user-http-request :crowberto :post 200 (str url "/delete")


### PR DESCRIPTION
This API overload the API used to update table rows to support either heterogeneous updates (`table.row/update`) or uniform ones (new action name to be determined, maybe `table.row/bulk-update`). 

While the existing API can already express the latter semantics, we can implement it more efficiently to use a single SQL statement.

Our plan is to move from the REST API to executing the corresponding action explicitly, so we're making this change now so the FE doesn't need to change the shape of what it sends in the future.