### PR TITLE
fix sdk-storybook: restore missing code after bad conflict resolution on metabot branch

### DIFF
--- a/.storybook-sdk/preview.tsx
+++ b/.storybook-sdk/preview.tsx
@@ -56,3 +56,15 @@ const globalTypes: GlobalTypes = {
   },
 };
 
+/*
+ * Initializes MSW
+ * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * to learn how to customize it
+ */
+
+initialize({
+  onUnhandledRequest: "bypass",
+});
+const preview = { parameters, decorators, globalTypes, loaders: [mswLoader] };
+
+export default preview;


### PR DESCRIPTION
[Metabot v3 PoC](https://github.com/metabase/metabase/pull/52436) contained this:
![image](https://github.com/user-attachments/assets/d115dfde-2eb4-4ff9-a796-ba4d34992f0e)
which broke some features on storybook like the user/theme/locale pickers.

I looked into how that pr happened to contain that change that didn't make any sense, here's what I understood:
- (a commit on) https://github.com/metabase/metabase/pull/52436 *moved* the exports, removing the `export const` and adding the default export of an object at the end of the file
- [what looks like a bad conflict resolution](https://github.com/metabase/metabase/commit/64e11becee9f8282d6e2209628d45aa2a3d38c53#diff-5b8ea0036d952624cc25d75075db714e9a1cdd744cca434e046e0ac547643edaL6-L59) removed the default export, making the file end up with no export at all


