### PR TITLE
fix(ci-sdk): make cross versions tests run again

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -133,13 +133,24 @@ jobs:
     with:
       cached-embedding-sdk-dist-artifact-name: embedding-sdk-${{ github.event.pull_request.head.sha || github.sha }}
 
+  debug-variables:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug Variables
+        run: |
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.base_ref: ${{ github.base_ref }}"
+          echo "github.head_ref: ${{ github.head_ref }}"
+          echo "Condition result: ${{ startsWith(github.ref, 'refs/heads/release-x.') || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.')) }}"
+
   e2e-component-tests-embedding-sdk-cross-version:
-    if: ${{ startsWith(inputs.branch, 'release-x.') }}
+    if: ${{ startsWith(github.ref, 'refs/heads/release-x.') || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.')) }}
     uses: ./.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
     secrets: inherit
 
   cross-version-for-breaking-changes:
-    if: github.event_name == 'pull_request' && startsWith(inputs.branch, 'release-x.')
+    if: ${{ github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.') }}
     uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
     secrets: inherit
     with:

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -131,23 +131,14 @@ jobs:
     with:
       cached-embedding-sdk-dist-artifact-name: embedding-sdk-${{ github.event.pull_request.head.sha || github.sha }}
 
-  debug-variables:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug Variables
-        run: |
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.base_ref: ${{ github.base_ref }}"
-          echo "github.head_ref: ${{ github.head_ref }}"
-          echo "Condition result: ${{ startsWith(github.ref, 'refs/heads/release-x.') || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.')) }}"
-
   e2e-component-tests-embedding-sdk-cross-version:
+    # run on: every push on release branches, and every pr that targets a release branch
     if: ${{ startsWith(github.ref, 'refs/heads/release-x.') || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.')) }}
     uses: ./.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
     secrets: inherit
 
   cross-version-for-breaking-changes:
+    # run on: every pr that targets a release branch
     if: ${{ github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.') }}
     uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
     secrets: inherit

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -2,9 +2,7 @@ name: Embedding SDK
 
 on:
   push:
-    branches:
-      - "master"
-      - "release-**"
+
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
I apparently broke the conditions for both cross versions tests, see for example: https://github.com/metabase/metabase/actions/runs/14978031028?pr=57854
the cross versions tests should have run but didn't

Here's some debug logs I put in ci so that we can verify the variables:

push on branch "fix-sdk-ci-conditions" https://github.com/metabase/metabase/actions/runs/14978277749/job/42076010821
```
github.ref: refs/heads/fix-sdk-ci-conditions
github.event_name: push
github.base_ref:
github.head_ref:
```
pr from 'fix-sdk-ci-conditions' to 'master' https://github.com/metabase/metabase/actions/runs/14978278314/job/42076016699?pr=57856
```
github.ref: refs/pull/57856/merge
github.event_name: pull_request
github.base_ref: master
github.head_ref: fix-sdk-ci-conditions
```