### PR TITLE
Tenants and Tenant Users

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1475,6 +1475,10 @@
            settings
            util}}
 
+  enterprise/tenants
+  {:api #{}
+   :uses #{api util}}
+
   enterprise/upload-management
   {:api  #{metabase-enterprise.upload-management.api}
    :uses #{api

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -25,6 +25,7 @@
    [metabase-enterprise.scim.routes]
    [metabase-enterprise.serialization.api]
    [metabase-enterprise.stale.api]
+   [metabase-enterprise.tenants.api]
    [metabase-enterprise.upload-management.api]
    [metabase.api.macros :as api.macros]
    [metabase.api.util.handlers :as handlers]
@@ -35,12 +36,13 @@
 
 (def ^:private required-feature->message
   {:advanced-permissions       (deferred-tru "Advanced Permissions")
-   :attached-dwh               (deferred-tru "Attached DWH")
-   :audit-app                  (deferred-tru "Audit app")
-   :collection-cleanup         (deferred-tru "Collection Cleanup")
    :ai-sql-fixer               (deferred-tru "AI SQL Fixer")
    :ai-sql-generation          (deferred-tru "AI SQL Generation")
    :ai-entity-analysis         (deferred-tru "AI Entity Analysis")
+   :attached-dwh               (deferred-tru "Attached DWH")
+   :audit-app                  (deferred-tru "Audit app")
+   :collection-cleanup         (deferred-tru "Collection Cleanup")
+   :database-routing           (deferred-tru "Database Routing")
    :etl-connections            (deferred-tru "ETL Connections")
    :table-data-editing         (deferred-tru "Editing Table Data")
    :llm-autodescription        (deferred-tru "LLM Auto-description")
@@ -48,8 +50,8 @@
    :query-reference-validation (deferred-tru "Query Reference Validation")
    :scim                       (deferred-tru "SCIM configuration")
    :serialization              (deferred-tru "Serialization")
-   :upload-management          (deferred-tru "Upload Management")
-   :database-routing           (deferred-tru "Database Routing")})
+   :tenants                    (deferred-tru "Tenants")
+   :upload-management          (deferred-tru "Upload Management")})
 
 (defn- premium-handler [handler required-feature]
   (let [handler (cond-> handler
@@ -89,6 +91,7 @@
    "/scim"                       (premium-handler metabase-enterprise.scim.routes/routes :scim)
    "/serialization"              (premium-handler metabase-enterprise.serialization.api/routes :serialization)
    "/stale"                      (premium-handler metabase-enterprise.stale.api/routes :collection-cleanup)
+   "/tenants"                    (premium-handler metabase-enterprise.tenants.api/routes :tenants)
    "/upload-management"          (premium-handler metabase-enterprise.upload-management.api/routes :upload-management)})
 ;;; ↑↑↑ KEEP THIS SORTED OR ELSE ↑↑↑
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -86,6 +86,7 @@
    "Secret"
    "Session"
    "TaskHistory"
+   "Tenant"
    "User"
    "UserKeyValue"
    "UserParameterValue"

--- a/enterprise/backend/src/metabase_enterprise/tenants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/api.clj
@@ -1,0 +1,22 @@
+(ns metabase-enterprise.tenants.api
+  (:require
+   [metabase-enterprise.tenants.model :as tenant]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
+
+(api.macros/defendpoint :post "/"
+  "Create a new Tenant"
+  [_route-params
+   _query-params
+   tenant :- [:map {:closed true}
+              [:name ms/NonBlankString]]]
+  (api/check-400 (not (tenant/name-exists? (:name tenant)))
+                 "This tenant name is already taken.")
+  (t2/insert! :model/Tenant tenant))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/ee/tenants` routes"
+  (api.macros/ns-handler *ns* api/+check-superuser +auth))

--- a/enterprise/backend/src/metabase_enterprise/tenants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/api.clj
@@ -12,9 +12,10 @@
   [_route-params
    _query-params
    tenant :- [:map {:closed true}
-              [:name ms/NonBlankString]]]
-  (api/check-400 (not (tenant/name-exists? (:name tenant)))
-                 "This tenant name is already taken.")
+              [:name ms/NonBlankString]
+              [:slug ms/NonBlankString]]]
+  (api/check-400 (not (tenant/tenant-exists? tenant))
+                 "This tenant name or slug is already taken.")
   (t2/insert! :model/Tenant tenant))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/enterprise/backend/src/metabase_enterprise/tenants/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/core.clj
@@ -1,0 +1,1 @@
+(ns metabase-enterprise.tenants.core)

--- a/enterprise/backend/src/metabase_enterprise/tenants/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/model.clj
@@ -6,10 +6,9 @@
 
 (methodical/defmethod t2/table-name :model/Tenant [_model] :tenant)
 
-(defn name->slug [n]
-  (u/slugify n))
-
-(defn name-exists? [n]
+(defn name-exists?
+  "Given a tenant name, returns truthy if the name (or its slugified version) is already reserved."
+  [n]
   (t2/exists? :model/Tenant {:where [:or
                                      [:= :slug (u/slugify n)]
                                      [:= :name n]]}))

--- a/enterprise/backend/src/metabase_enterprise/tenants/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/model.clj
@@ -1,0 +1,21 @@
+(ns metabase-enterprise.tenants.model
+  (:require
+   [metabase.util :as u]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/Tenant [_model] :tenant)
+
+(defn name->slug [n]
+  (u/slugify n))
+
+(defn name-exists? [n]
+  (t2/exists? :model/Tenant {:where [:or
+                                     [:= :slug (u/slugify n)]
+                                     [:= :name n]]}))
+
+(t2/define-before-insert :model/Tenant [tenant]
+  (assoc tenant :slug (u/slugify (:name tenant))))
+
+(doto :model/Tenant
+  (derive :metabase/model))

--- a/enterprise/backend/src/metabase_enterprise/tenants/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/model.clj
@@ -1,20 +1,16 @@
 (ns metabase-enterprise.tenants.model
   (:require
-   [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
 (methodical/defmethod t2/table-name :model/Tenant [_model] :tenant)
 
-(defn name-exists?
+(defn tenant-exists?
   "Given a tenant name, returns truthy if the name (or its slugified version) is already reserved."
-  [n]
+  [{n :name slug :slug}]
   (t2/exists? :model/Tenant {:where [:or
-                                     [:= :slug (u/slugify n)]
+                                     [:= :slug slug]
                                      [:= :name n]]}))
-
-(t2/define-before-insert :model/Tenant [tenant]
-  (assoc tenant :slug (u/slugify (:name tenant))))
 
 (doto :model/Tenant
   (derive :metabase/model))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -79,7 +79,7 @@
               (delete-group user 204 true)
 
               (testing "admins could view all groups"
-                (is (= (t2/select-fn-set :name :model/PermissionsGroup)
+                (is (= (t2/select-fn-set :name :model/PermissionsGroup :is_tenant_group false)
                        (set (map :name (get-groups :crowberto 200)))))))))))))
 
 (defn- get-membership [user status]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -126,8 +126,8 @@
        (map :group_id)
        set))
 
-(deftest memebership-apis-permissions-test
-  (testing "/api/permissions/memebership"
+(deftest membership-apis-permissions-test
+  (testing "/api/permissions/membership"
     (mt/with-user-in-groups
       [group  {:name "New Group"}
        user   [group]]
@@ -175,8 +175,8 @@
               (delete-membership! user-2 204 group-2)
               (clear-memberships! user-2 204 group-2))))))))
 
-(deftest memebership-apis-edge-cases-test
-  (testing "/api/permissions/memebership"
+(deftest membership-apis-edge-cases-test
+  (testing "/api/permissions/membership"
     (mt/with-user-in-groups
       [group {:name "New Group"}
        user  [group]]
@@ -211,7 +211,7 @@
                                             :is_group_manager true})))))
 
           (testing "Admin can could view all groups"
-            (is (= (t2/select-fn-set :id :model/PermissionsGroup)
+            (is (= (t2/select-fn-set :id :model/PermissionsGroup :is_tenant_group false)
                    (membership->groups-ids (get-membership :crowberto 200))))))))))
 
 (deftest get-users-api-test

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -77,6 +77,7 @@
     :model/Secret
     :model/Session
     :model/TaskHistory
+    :model/Tenant
     :model/TimelineEvent
     :model/User
     :model/UserParameterValue

--- a/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
@@ -14,16 +14,17 @@
   (testing "I can create a tenant with a unique name"
     (mt/with-model-cleanup [:model/Tenant]
       (mt/user-http-request :crowberto :post 200 "ee/tenants/"
-                            {:name "My Tenant"})
+                            {:name "My Tenant"
+                             :slug "my-tenant"})
       (is (t2/exists? :model/Tenant :name "My Tenant"))))
   (testing "Duplicate names results in an error"
     (mt/with-model-cleanup [:model/Tenant]
       (mt/user-http-request :crowberto :post 200 "ee/tenants/"
-                            {:name "My Tenant"})
+                            {:name "My Tenant" :slug "my-tenant"})
       (is (t2/exists? :model/Tenant :name "My Tenant"))
-      (is (= "This tenant name is already taken."
+      (is (= "This tenant name or slug is already taken."
              (mt/user-http-request :crowberto :post 400 "ee/tenants/"
-                                   {:name "My Tenant"})))
-      (is (= "This tenant name is already taken."
+                                   {:name "My Tenant" :slug "foo"})))
+      (is (= "This tenant name or slug is already taken."
              (mt/user-http-request :crowberto :post 400 "ee/tenants/"
-                                   {:name "my tenant"}))))))
+                                   {:name "Foo" :slug "my-tenant"}))))))

--- a/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
@@ -1,7 +1,8 @@
 (ns metabase-enterprise.tenants.api-test
-  (:require [clojure.test :refer [deftest testing is]]
-            [metabase.test :as mt]
-            [toucan2.core :as t2]))
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (defn with-premium-feature-fixture [f]
   (mt/with-premium-features #{:tenants}

--- a/enterprise/backend/test/metabase_enterprise/tenants/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/permissions_test.clj
@@ -1,0 +1,37 @@
+(ns metabase-enterprise.tenants.permissions-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(deftest tenant-users-are-added-to-correct-groups
+  (mt/with-temp [:model/Tenant {tenant-id :id} {:name "name" :slug "name"}
+                 :model/User {user-id :id} {:tenant_id tenant-id}]
+    (testing "Should NOT be added to the 'All Users' group"
+      (is (not (t2/exists? :model/PermissionsGroupMembership
+                           :user_id user-id
+                           :group_id (u/the-id (perms-group/all-users))))))
+    (testing "Should be added to the 'All External Users' group"
+      (is (t2/exists? :model/PermissionsGroupMembership
+                      :user_id user-id
+                      :group_id (u/the-id (perms-group/all-external-users)))))))
+
+(deftest tenant-groups-get-no-perms-on-new-dbs
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {:is_tenant_group true}
+                 :model/Database {db-id :id} {}]
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/view-data :perm_value :blocked))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/create-queries :perm_value :no))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/download-results :perm_value :no))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/manage-table-metadata :perm_value :no))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/manage-database :perm_value :no))))
+
+(deftest new-tenant-groups-get-no-perms-on-existing-dbs
+  (mt/with-temp [:model/Database {db-id :id} {}
+                 :model/PermissionsGroup {group-id :id} {:is_tenant_group true}]
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/view-data :perm_value :blocked))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/create-queries :perm_value :no))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/download-results :perm_value :no))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/manage-table-metadata :perm_value :no))
+    (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/manage-database :perm_value :no))))

--- a/enterprise/backend/test/metabase_enterprise/tenants/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/permissions_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.tenants.permissions-test
   (:require
    [clojure.test :refer [deftest testing is]]
-   [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -12,11 +12,11 @@
     (testing "Should NOT be added to the 'All Users' group"
       (is (not (t2/exists? :model/PermissionsGroupMembership
                            :user_id user-id
-                           :group_id (u/the-id (perms-group/all-users))))))
+                           :group_id (u/the-id (perms/all-users-group))))))
     (testing "Should be added to the 'All External Users' group"
       (is (t2/exists? :model/PermissionsGroupMembership
                       :user_id user-id
-                      :group_id (u/the-id (perms-group/all-external-users)))))))
+                      :group_id (u/the-id (perms/all-external-users-group)))))))
 
 (deftest tenant-groups-get-no-perms-on-new-dbs
   (mt/with-temp [:model/PermissionsGroup {group-id :id} {:is_tenant_group true}
@@ -35,3 +35,24 @@
     (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/download-results :perm_value :no))
     (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/manage-table-metadata :perm_value :no))
     (is (t2/exists? :model/DataPermissions :db_id db-id :group_id group-id :perm_type :perms/manage-database :perm_value :no))))
+
+(deftest tenant-users-and-groups
+  (mt/with-temp [:model/Tenant {tenant-id :id} {:name "name" :slug "slug"}
+                 :model/User {tenant-user :id} {:tenant_id tenant-id}
+                 :model/User {normal-user :id} {}
+                 :model/PermissionsGroup {tenant-group :id} {:is_tenant_group true}
+                 :model/PermissionsGroup {normal-group :id} {:is_tenant_group false}]
+    (testing "A tenant user"
+      (testing "cannot be added to a normal group"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Cannot add non-tenant user to tenant-group or vice versa"
+                              (perms/add-user-to-group! tenant-user normal-group))))
+      (testing "can be added to tenant groups"
+        (perms/add-user-to-group! tenant-user tenant-group)))
+    (testing "A normal user"
+      (testing "cannot be added to a tenant group"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Cannot add non-tenant user to tenant-group or vice versa"
+                              (perms/add-user-to-group! normal-user tenant-group))))
+      (testing "can be added to a normal group"
+        (perms/add-user-to-group! normal-user normal-group)))))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11255,6 +11255,17 @@ databaseChangeLog:
               )
 
 
+  - changeSet:
+      id: v55.2025-05-07T11:43:54
+      author: johnswanson
+      comment: Add All External Users group
+      changes:
+        - sql:
+            sql: >-
+              INSERT INTO permissions_group (name, magic_group_type, is_tenant_group)
+              VALUES
+              ('All External Users', 'all-external-users', true);
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11305,7 +11305,17 @@ databaseChangeLog:
                     unique: true
 
   - changeSet:
-      id: v55.2025-05-12T09:43:32
+      id: v55.2025-05-16T06:21:36
+      author: johnswanson
+      comment: add an index for `core_user.tenant_id`
+      changes:
+        - addUniqueConstraint:
+            tableName: core_user
+            constraintName: idx_unique_core_user_tenant_id
+            columnNames: tenant_id
+
+  - changeSet:
+      id: v55.2025-05-16T07:15:37
       author: johnswanson
       comment: Add foreign key for `core_user.tenant_id`
       preConditions: # not needed
@@ -11317,6 +11327,7 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_core_user_tenant_id
             onDelete: RESTRICT
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11260,7 +11260,7 @@ databaseChangeLog:
       rollback:
         - sql:
             sql: >-
-              DELETE FROM permissions_group WHERE type = 'all-external-users';
+              DELETE FROM permissions_group WHERE magic_group_type = 'all-external-users';
       comment: Add All External Users group
       changes:
         - sql:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11254,10 +11254,13 @@ databaseChangeLog:
                 'type/Number'
               )
 
-
   - changeSet:
       id: v55.2025-05-07T11:43:54
       author: johnswanson
+      rollback:
+        - sql:
+            sql: >-
+              DELETE FROM permissions_group WHERE type = 'all-external-users';
       comment: Add All External Users group
       changes:
         - sql:
@@ -11282,18 +11285,21 @@ databaseChangeLog:
                   name: id
                   type: int
                   autoIncrement: true
+                  remarks: the ID of the tenant
                   constraints:
                     primaryKey: true
                     nullable: false
               - column:
                   name: "name"
                   type: varchar(254)
+                  remarks: the unique name of the tenant
                   constraints:
                     nullable: false
                     unique: true
               - column:
                   name: "slug"
                   type: varchar(254)
+                  remarks: "the slugified version of this tenant's name"
                   constraints:
                     nullable: false
                     unique: true

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11266,6 +11266,52 @@ databaseChangeLog:
               VALUES
               ('All External Users', 'all-external-users', true);
 
+
+  - changeSet:
+      id: v55.2025-05-12T09:39:20
+      author: johnswanson
+      comment: Create `tenant` table
+      preConditions: # not needed
+      changes:
+        - createTable:
+            tableName: tenant
+            remarks: |
+              Tenants (collections of external users). A user can be in exactly zero or one tenants.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: "name"
+                  type: varchar(254)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: "slug"
+                  type: varchar(254)
+                  constraints:
+                    nullable: false
+                    unique: true
+
+  - changeSet:
+      id: v55.2025-05-12T09:43:32
+      author: johnswanson
+      comment: Add foreign key for `core_user.tenant_id`
+      preConditions: # not needed
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: core_user
+            baseColumnNames: tenant_id
+            referencedTableName: tenant
+            referencedColumnNames: id
+            constraintName: fk_core_user_tenant_id
+            onDelete: RESTRICT
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -17,7 +17,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.session.models.session :as session]
-   [metabase.settings.core :refer [defsetting]]
+   [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.sso.core :as sso]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -367,10 +367,14 @@
   (api/check-superuser)
   (api/checkp (not (t2/exists? :model/User :%lower.email (u/lower-case-en email)))
               "email" (tru "Email address already in use."))
+  (api/checkp (not (and (:tenant_id body)
+                        (not (setting/get :use-tenants))))
+              "tenant_id"
+              (tru "Cannot create a Tenant User as Tenants are not enabled for this instance."))
   (t2/with-transaction [_conn]
     (let [new-user-id (u/the-id (user/create-and-invite-user!
                                  (u/select-keys-when body
-                                                     :non-nil [:first_name :last_name :email :password :login_attributes])
+                                                     :non-nil [:first_name :last_name :email :password :login_attributes :tenant_id])
                                  @api/*current-user*
                                  false))]
       (maybe-set-user-group-memberships! new-user-id user_group_memberships)
@@ -390,7 +394,8 @@
             [:last_name              {:optional true} [:maybe ms/NonBlankString]]
             [:email                  ms/Email]
             [:user_group_memberships {:optional true} [:maybe [:sequential ::user-group-membership]]]
-            [:login_attributes       {:optional true} [:maybe user/LoginAttributes]]]]
+            [:login_attributes       {:optional true} [:maybe user/LoginAttributes]]
+            [:tenant_id              {:optional true} [:maybe ms/PositiveInt]]]]
   (invite-user body))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -51,68 +51,68 @@
 (def entities
   "Entities in the order they should be serialized/deserialized. This is done so we make sure that we load
   instances of entities before others that might depend on them, e.g. `Databases` before `Tables` before `Fields`."
-  (concat
-   [:model/Channel
-    :model/ChannelTemplate
-    :model/Database
-    :model/User
-    :model/Setting
-    :model/Table
-    :model/Field
-    :model/FieldValues
-    :model/Segment
-    :model/ModerationReview
-    :model/Revision
-    :model/ViewLog
-    :model/Session
-    :model/Collection
-    :model/CollectionPermissionGraphRevision
-    :model/Dashboard
-    :model/Card
-    :model/CardBookmark
-    :model/DashboardBookmark
-    :model/DataPermissions
-    :model/CollectionBookmark
-    :model/BookmarkOrdering
-    :model/DashboardCard
-    :model/DashboardCardSeries
-    :model/Pulse
-    :model/PulseCard
-    :model/PulseChannel
-    :model/PulseChannelRecipient
-    :model/PermissionsGroup
-    :model/PermissionsGroupMembership
-    :model/Permissions
-    :model/PermissionsRevision
-    :model/PersistedInfo
-    :model/ApplicationPermissionsRevision
-    :model/Dimension
-    :model/NativeQuerySnippet
-    :model/LoginHistory
-    :model/Timeline
-    :model/TimelineEvent
-    :model/Secret
-    :model/ParameterCard
-    :model/Action
-    :model/ImplicitAction
-    :model/HTTPAction
-    :model/QueryAction
-    :model/DashboardTab
-    :model/ModelIndex
-    :model/ModelIndexValue
-    ;; 48+
-    :model/AuditLog
-    :model/RecentViews
-    :model/UserParameterValue
-    ;; 51+
-    :model/Notification
-    :model/NotificationSubscription
-    :model/NotificationHandler
-    :model/NotificationRecipient
-    :model/NotificationCard]
-   (when config/ee-available?
-     [:model/GroupTableAccessPolicy
-      :model/ConnectionImpersonation])))
+  (keep identity
+        [:model/Channel
+         :model/ChannelTemplate
+         :model/Database
+         (when config/ee-available? :model/Tenant)
+         :model/User
+         :model/Setting
+         :model/Table
+         :model/Field
+         :model/FieldValues
+         :model/Segment
+         :model/ModerationReview
+         :model/Revision
+         :model/ViewLog
+         :model/Session
+         :model/Collection
+         :model/CollectionPermissionGraphRevision
+         :model/Dashboard
+         :model/Card
+         :model/CardBookmark
+         :model/DashboardBookmark
+         :model/DataPermissions
+         :model/CollectionBookmark
+         :model/BookmarkOrdering
+         :model/DashboardCard
+         :model/DashboardCardSeries
+         :model/Pulse
+         :model/PulseCard
+         :model/PulseChannel
+         :model/PulseChannelRecipient
+         :model/PermissionsGroup
+         :model/PermissionsGroupMembership
+         :model/Permissions
+         :model/PermissionsRevision
+         :model/PersistedInfo
+         :model/ApplicationPermissionsRevision
+         :model/Dimension
+         :model/NativeQuerySnippet
+         :model/LoginHistory
+         :model/Timeline
+         :model/TimelineEvent
+         :model/Secret
+         :model/ParameterCard
+         :model/Action
+         :model/ImplicitAction
+         :model/HTTPAction
+         :model/QueryAction
+         :model/DashboardTab
+         :model/ModelIndex
+         :model/ModelIndexValue
+         ;; 48+
+         :model/AuditLog
+         :model/RecentViews
+         :model/UserParameterValue
+         ;; 51+
+         :model/Notification
+         :model/NotificationSubscription
+         :model/NotificationHandler
+         :model/NotificationRecipient
+         :model/NotificationCard
+         (when config/ee-available? :model/GroupTableAccessPolicy)
+         (when config/ee-available? :model/ConnectionImpersonation)]))
 
 (defn- objects->colums+values
   "Given a sequence of objects/rows fetched from the H2 DB, return a the `columns` that should be used in the `INSERT`

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -77,6 +77,7 @@
     :model/Setting                           metabase.settings.models.setting
     :model/Table                             metabase.models.table
     :model/TaskHistory                       metabase.task-history.models.task-history
+    :model/Tenant                            metabase-enterprise.tenant.model
     :model/Timeline                          metabase.timeline.models.timeline
     :model/TimelineEvent                     metabase.timeline.models.timeline-event
     :model/User                              metabase.models.user

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -77,7 +77,7 @@
     :model/Setting                           metabase.settings.models.setting
     :model/Table                             metabase.models.table
     :model/TaskHistory                       metabase.task-history.models.task-history
-    :model/Tenant                            metabase-enterprise.tenant.model
+    :model/Tenant                            metabase-enterprise.tenants.model
     :model/Timeline                          metabase.timeline.models.timeline
     :model/TimelineEvent                     metabase.timeline.models.timeline-event
     :model/User                              metabase.models.user

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -117,6 +117,7 @@
     (when superuser?
       (log/infof "Adding User %s to All Users permissions group..." user-id))
     (let [groups (filter some? [(when-not (:tenant_id user) (perms/all-users-group))
+                                (when (:tenant_id user) (perms/all-external-users-group))
                                 (when superuser? (perms/admin-group))])]
       (perms/allow-changing-all-users-group-members
         (perms/without-is-superuser-sync-on-add-to-admin-group
@@ -313,7 +314,8 @@
    [:login_attributes {:optional true} [:maybe LoginAttributes]]
    [:sso_source       {:optional true} [:maybe ms/NonBlankString]]
    [:locale           {:optional true} [:maybe ms/KeywordOrString]]
-   [:type             {:optional true} [:maybe ms/KeywordOrString]]])
+   [:type             {:optional true} [:maybe ms/KeywordOrString]]
+   [:tenant_id        {:optional true} [:maybe ms/PositiveInt]]])
 
 (def ^:private Invitor
   "Map with info about the admin creating the user, used in the new user notification code"

--- a/src/metabase/permissions/api.clj
+++ b/src/metabase/permissions/api.clj
@@ -259,7 +259,7 @@
   (api/check-404
    (-> (t2/select-one :model/PermissionsGroup :id id)
        (t2/hydrate :members)
-       maybe-fix-name)))
+       (maybe-fix-name (setting/get :use-tenants)))))
 
 (api.macros/defendpoint :post "/group"
   "Create a new `PermissionsGroup`."

--- a/src/metabase/permissions/api.clj
+++ b/src/metabase/permissions/api.clj
@@ -257,9 +257,9 @@
                     [:id ms/PositiveInt]]]
   (validation/check-group-manager id)
   (api/check-404
-   (-> (t2/select-one :model/PermissionsGroup :id id)
-       (t2/hydrate :members)
-       (maybe-fix-name (setting/get :use-tenants)))))
+   (some-> (t2/select-one :model/PermissionsGroup :id id)
+           (t2/hydrate :members)
+           (maybe-fix-name (setting/get :use-tenants)))))
 
 (api.macros/defendpoint :post "/group"
   "Create a new `PermissionsGroup`."

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -26,6 +26,7 @@
   prime-db-cache
   schema-permission-for-user
   set-database-permission!
+  set-external-group-permissions!
   set-new-database-permissions!
   set-new-table-permissions!
   user-has-any-perms-of-type?

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -76,3 +76,6 @@
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.permissions.models.permissions-group/admin admin-group)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(p/import-def metabase.permissions.models.permissions-group/all-external-users all-external-users-group)

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -687,6 +687,12 @@
      :perms/manage-table-metadata :no
      :perms/manage-database :no}))
 
+(defn set-external-group-permissions!
+  "Sets the appropriate data permissions for a new external group or database - always the minimum possible data permissions."
+  [group-or-id db-id]
+  (doseq [[perm-type perm-value] (m/map-vals (fn [{:keys [values]}] (last values)) Permissions)]
+    (set-database-permission! group-or-id db-id perm-type perm-value)))
+
 (defn set-new-group-permissions!
   "Sets permissions for a newly-added group to their appropriate values for a single database. This is generally based
   on the permissions of the All Users group."

--- a/src/metabase/permissions/models/data_permissions/graph.clj
+++ b/src/metabase/permissions/models/data_permissions/graph.clj
@@ -54,8 +54,7 @@
   graph)
 
 (mu/defn ellide? :- :boolean
-  "If a table has the least permissive value for a perm type, leave it out,
-   Unless it's :data perms, in which case, leave it out only if it's no-self-service"
+  "If a table has the least permissive value for a perm type, leave it out."
   [type :- data-perms/PermissionType
    value :- data-perms/PermissionValue]
   (= (data-perms/least-permissive-value type) value))

--- a/src/metabase/permissions/models/permissions_group.clj
+++ b/src/metabase/permissions/models/permissions_group.clj
@@ -59,24 +59,9 @@
   "The magic group type of the \"All External Users\" magic group."
   "all-external-users")
 
-#_(def ^{:arglists '([])} all-external-users
-    "Fetch the `all-external-users` magic group"
-    (mdb/memoize-for-application-db
-     (fn []
-     ;; Don't use `magic-group` here, because this one might not exist and that's ok.
-       (t2/select-one [:model/PermissionsGroup :id :name :magic_group_type] :magic_group_type all-external-users-magic-group-type))))
-
-(defn create-all-external-users!
-  "Creates the \"All External Users\" magic group."
-  []
-  (t2/insert! :model/PermissionsGroup {:magic_group_type all-external-users-magic-group-type
-                                       :name "All External Users"
-                                       :is_tenant_group true}))
-
-(defn delete-all-external-users!
-  "Deletes the \"All External Users\" magic group."
-  []
-  (t2/delete! :model/PermissionsGroup {:magic_group_type all-external-users-magic-group-type}))
+(def ^{:arglists '([])} all-external-users
+  "Fetch the `All External Users` permissions group"
+  (magic-group all-external-users-magic-group-type))
 
 (def admin-magic-group-type
   "The magic-group type of the \"Administrators\" magic group."

--- a/src/metabase/permissions/models/permissions_group.clj
+++ b/src/metabase/permissions/models/permissions_group.clj
@@ -106,7 +106,9 @@
   [group]
   (t2/with-transaction [_conn]
     (doseq [db-id (t2/select-pks-vec :model/Database)]
-      (data-perms/set-new-group-permissions! group db-id (u/the-id (all-users))))))
+      (if (:is_tenant_group group)
+        (data-perms/set-external-group-permissions! group db-id)
+        (data-perms/set-new-group-permissions! group db-id (u/the-id (all-users)))))))
 
 (t2/define-after-insert :model/PermissionsGroup
   [group]

--- a/test/metabase/db/setup_test.clj
+++ b/test/metabase/db/setup_test.clj
@@ -32,7 +32,7 @@
     (letfn [(test* [data-source]
               (is (= :done
                      (mdb.setup/setup-db! :h2 data-source true true)))
-              (is (= ["Administrators" "All Users"]
+              (is (= ["Administrators" "All External Users" "All Users"]
                      (mapv :name (jdbc/query {:datasource data-source}
                                              "SELECT name FROM permissions_group ORDER BY name ASC;")))))]
       (let [subname (fn [] (format "mem:%s;DB_CLOSE_DELAY=10" (mt/random-name)))]

--- a/test/metabase/permissions/models/permissions_group_membership_test.clj
+++ b/test/metabase/permissions/models/permissions_group_membership_test.clj
@@ -34,25 +34,3 @@
                                     :is_superuser true}]
         (is (thrown? Exception
                      (t2/delete! :model/PermissionsGroupMembership :user_id id, :group_id (u/the-id (perms-group/admin)))))))))
-
-(deftest tenant-users-and-groups
-  ;; This will need to get fixed once we have actual tenants - right now the `tenant_id` doesn't actually connect to
-  ;; anything.
-  (mt/with-temp [:model/User {tenant-user :id} {:tenant_id 1}
-                 :model/User {normal-user :id} {}
-                 :model/PermissionsGroup {tenant-group :id} {:is_tenant_group true}
-                 :model/PermissionsGroup {normal-group :id} {:is_tenant_group false}]
-    (testing "A tenant user"
-      (testing "cannot be added to a normal group"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"Cannot add non-tenant user to tenant-group or vice versa"
-                              (perms/add-user-to-group! tenant-user normal-group))))
-      (testing "can be added to tenant groups"
-        (perms/add-user-to-group! tenant-user tenant-group)))
-    (testing "A normal user"
-      (testing "cannot be added to a tenant group"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"Cannot add non-tenant user to tenant-group or vice versa"
-                              (perms/add-user-to-group! normal-user tenant-group))))
-      (testing "can be added to a normal group"
-        (perms/add-user-to-group! normal-user normal-group)))))

--- a/test/metabase/permissions/models/permissions_group_test.clj
+++ b/test/metabase/permissions/models/permissions_group_test.clj
@@ -54,17 +54,7 @@
         (testing "Should not be added to Admin group"
           (is (not (t2/exists? :model/PermissionsGroupMembership
                                :user_id  user-id
-                               :group_id (u/the-id (perms-group/admin))))))))
-    (testing "tenant user"
-      (mt/with-temp [:model/User {user-id :id} {:tenant_id 123}]
-        (testing "Should NOT be added to the 'All Users' group"
-          (is (not (t2/exists? :model/PermissionsGroupMembership
-                               :user_id user-id
-                               :group_id (u/the-id (perms-group/all-users))))))
-        (testing "Should be added to the 'All External Users' group"
-          (is (t2/exists? :model/PermissionsGroupMembership
-                          :user_id user-id
-                          :group_id (u/the-id (perms-group/all-external-users)))))))))
+                               :group_id (u/the-id (perms-group/admin))))))))))
 
 (deftest ^:parallel new-users-test-2
   (testing "newly created users should get added to the appropriate magic groups"
@@ -131,7 +121,7 @@
 (deftest data-graph-for-group-check-all-groups-test
   (mt/with-temp [:model/PermissionsGroup {} {}
                  :model/Database         {} {}]
-    (doseq [group-id (t2/select-fn-set :id :model/PermissionsGroup)]
+    (doseq [group-id (t2/select-fn-set :id :model/PermissionsGroup :is_tenant_group false)]
       (testing (str "testing data-graph-for-group with group-id: [" group-id "].")
         (let [graph (data-perms.graph/api-graph {:group-id group-id})]
           (is (malli= [:map [:revision :int] [:groups :map]] graph))

--- a/test/metabase/permissions/models/permissions_group_test.clj
+++ b/test/metabase/permissions/models/permissions_group_test.clj
@@ -54,7 +54,17 @@
         (testing "Should not be added to Admin group"
           (is (not (t2/exists? :model/PermissionsGroupMembership
                                :user_id  user-id
-                               :group_id (u/the-id (perms-group/admin))))))))))
+                               :group_id (u/the-id (perms-group/admin))))))))
+    (testing "tenant user"
+      (mt/with-temp [:model/User {user-id :id} {:tenant_id 123}]
+        (testing "Should NOT be added to the 'All Users' group"
+          (is (not (t2/exists? :model/PermissionsGroupMembership
+                               :user_id user-id
+                               :group_id (u/the-id (perms-group/all-users))))))
+        (testing "Should be added to the 'All External Users' group"
+          (is (t2/exists? :model/PermissionsGroupMembership
+                          :user_id user-id
+                          :group_id (u/the-id (perms-group/all-external-users)))))))))
 
 (deftest ^:parallel new-users-test-2
   (testing "newly created users should get added to the appropriate magic groups"

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1038,7 +1038,9 @@
     (finally
       (when (and (:metabase.collections.models.collection.root/is-root? collection)
                  (not (:namespace collection)))
-        (doseq [group-id (t2/select-pks-set :model/PermissionsGroup :id [:not= (u/the-id (perms-group/admin))])]
+        (doseq [group-id (t2/select-pks-set :model/PermissionsGroup
+                                            :id [:not= (u/the-id (perms-group/admin))]
+                                            :is_tenant_group false)]
           (when-not (t2/exists? :model/Permissions :group_id group-id, :object "/collection/root/")
             (perms/grant-collection-readwrite-permissions! group-id collection/root-collection)))))))
 


### PR DESCRIPTION
Two commits here with two main new changes:

1. allow the creation of Tenants. Enterprise-only and gated behind the `tenants` feature flag.
1. allow the creation of Tenant Users by passing a `tenant_id` when creating a user. `tenant_id` is a foreign key so for now (since the `tenants` feature flag doesn't exist yet) there should be no user-visible changes here.

While working on this, I realized that my approach to the "All External
Users" group and renaming the "All Users" group was untenable.

I had been planning to just update these things in the database (create
AEU, rename AU to AIU) in the setter function for the `:use-tenants`
setting. The issue here is caching: we don't want to need to actually
reach out to the database every time we need to fetch the All Users or
All External Users, but it would also be quite unfortunate if one
Metabase instance in a cluster had an outdated view of, e.g. the ID of
"All External Users".

(Although - I'm not really sure how much we use the *name* of "All
Users" when we fetch `(all-users)`, so that might be worth a look.)

For now, I've modified things to just update things dynamically in the
`GET /api/permissions/group` and `GET /api/permissions/group/:id`
endpoints: we show/hide the "All External Users" group, and rename the
"All Users" group, based on whether Tenants are enabled.

Fixes [ADM-652: API to create a new Tenant User](https://linear.app/metabase/issue/ADM-652/api-to-create-a-new-tenant-user)

Fixes [ADM-651: API to create a new Tenant](https://linear.app/metabase/issue/ADM-651/api-to-create-a-new-tenant)
