### PR TITLE
Handle emptyable expressions in desugar-is-empty-and-not-empty

### DIFF
--- a/src/metabase/legacy_mbql/predicates.cljc
+++ b/src/metabase/legacy_mbql/predicates.cljc
@@ -17,6 +17,10 @@
   "Is this a valid `:filter` clause?"
   (mr/validator mbql.s/Filter))
 
+(def ^{:arglists '([emptyable-clause])} Emptyable?
+  "Is this a valid Emptyable clause?"
+  (mr/validator mbql.s/Emptyable))
+
 (def ^{:arglists '([filter-clause])} DatetimeExpression?
   "Is this a valid DatetimeExpression clause?"
   (mr/validator mbql.s/DatetimeExpression))

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -821,7 +821,8 @@
 (defclause ^:sugar is-null,  field Field)
 (defclause ^:sugar not-null, field Field)
 
-(def ^:private Emptyable
+(def Emptyable
+  "Schema for a valid is-empty or not-empty argument."
   [:or StringExpressionArg Field])
 
 ;; These are rewritten as `[:or [:= <field> nil] [:= <field> ""]]` and

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -522,6 +522,11 @@
               [:= [:field 1 {:base-type :type/Text}] nil]
               [:= [:field 1 {:base-type :type/Text}] ""]]
              (mbql.u/desugar-filter-clause [:is-empty [:field 1 {:base-type :type/Text}]]))))
+  (t/testing "desugaring :is-empty of string expression #41265"
+    (t/is (= [:or
+              [:= [:regex-match-first "foo" "bar"] nil]
+              [:= [:regex-match-first "foo" "bar"] ""]]
+             (mbql.u/desugar-filter-clause [:is-empty [:regex-match-first "foo" "bar"]]))))
   (t/testing "desugaring :is-empty of not emptyable base-type :type/DateTime"
     (t/is (= [:= [:field 1 {:base-type :type/DateTime}] nil]
              (mbql.u/desugar-filter-clause [:is-empty [:field 1 {:base-type :type/DateTime}]]))))
@@ -536,6 +541,11 @@
               [:!= [:field 1 {:base-type :type/Text}] nil]
               [:!= [:field 1 {:base-type :type/Text}] ""]]
              (mbql.u/desugar-filter-clause [:not-empty [:field 1 {:base-type :type/Text}]]))))
+  (t/testing "desugaring :not-empty of string expression #41265"
+    (t/is (= [:and
+              [:!= [:regex-match-first "foo" "bar"] nil]
+              [:!= [:regex-match-first "foo" "bar"] ""]]
+             (mbql.u/desugar-filter-clause [:not-empty [:regex-match-first "foo" "bar"]]))))
   (t/testing "desugaring :not-empty of not emptyable base-type"
     (t/is (= [:!= [:field 1 {:base-type :type/DateTime}] nil]
              (mbql.u/desugar-filter-clause [:not-empty [:field 1 {:base-type :type/DateTime}]]))))


### PR DESCRIPTION
Closes #41265.

### Description

The schema for `:is-empty` and `:not-empty` was updated in #56855 to allow `StringExpressionArg` as well as `Field`. This PR updates `desugar-is-empty-and-not-empty` to also understand non-field args.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Analytic Events
2. Filter > Custom Expression > `isEmpty(substring([Page URL], 1, 0))`

You can also try the expression from the bug report: `notEmpty(regexExtract([Page URL], "piespace"))`

### Demo

![Screenshot 2025-05-12 at 4 33 58 PM](https://github.com/user-attachments/assets/3889b4a5-703d-4f52-98bc-d799ba5df6b6)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
