### PR TITLE
Fix 401 versus 403 for dataset routes

### DIFF
--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -148,7 +148,7 @@
    "/collection"           (+auth 'metabase.api.collection)
    "/dashboard"            (+auth 'metabase.api.dashboard)
    "/database"             (+auth 'metabase.api.database)
-   "/dataset"              'metabase.api.dataset
+   "/dataset"              (+auth 'metabase.api.dataset)
    "/docs"                 (metabase.api.docs/make-routes #'routes)
    "/eid-translation"      'metabase.eid-translation.api
    "/email"                metabase.channel.api/email-routes


### PR DESCRIPTION
I realized I accidentally messed this up when refactoring things and these endpoints aren't short-circuiting right away if you're not logged in which can mess up the test code since it doesn't get the 401 response code and doesn't log back in and retrry. The endpoints still have separate permissions checks around them but they fail with 403s "you aren't allowed to do that"  instead of 401 "unauthenticated" responses.