### PR TITLE
Correctly format string/contains parameter

### DIFF
--- a/src/metabase/models/params/shared.cljc
+++ b/src/metabase/models/params/shared.cljc
@@ -28,6 +28,13 @@
   {:arglists '([tyype value locale])}
   (fn [tyype _value _locale] (keyword tyype)))
 
+(declare formatted-list)
+
+(defmethod formatted-value :string/contains
+  [_ values _]
+  (let [values (u/one-or-many values)]
+    (trs "contains {0}" (formatted-list values :conjunction (trs "or")))))
+
 ;; TODO: Refactor to use time/parse-unit and time/format-unit
 (defmethod formatted-value :date/single
   [_ value locale]
@@ -131,14 +138,15 @@
 
 (defn formatted-list
   "Given a seq of parameter values, returns them as a single comma-separated string. Does not do additional formatting
-  on the values."
-  [values]
+  on the values. The conjunction parameter determines whether to use 'and' or 'or' to join the last two items."
+  [values & {:keys [conjunction] :or {conjunction (trs "and")}}]
   (condp = (count values)
     1 (str (first values))
-    2 (trs "{0} and {1}" (first values) (second values))
-    (trs "{0}, {1}, and {2}"
+    2 (trs "{0} {1} {2}" (first values) conjunction (second values))
+    (trs "{0}, {1}, {2} {3}"
          (str/join ", " (drop-last 2 values))
          (nth values (- (count values) 2))
+         conjunction
          (last values))))
 
 (defmethod formatted-value :default

--- a/test/metabase/models/params/shared_test.cljc
+++ b/test/metabase/models/params/shared_test.cljc
@@ -387,3 +387,19 @@
                (param-val-or-default {:default "my default value"}))))
     (t/testing "When the parameter’s :value is explicitly nil (i.e. for no-op filters), do not fallback to the :default key"
       (t/is (nil? (param-val-or-default {:value nil :default "my default value"}))))))
+
+(t/deftest ^:parallel value-string-contains-test
+  (t/testing "string/contains parameters are correctly formatted"
+    (let [format-param (fn [default] (params/value-string {:name "State",
+                                                           :slug "state",
+                                                           :id "63e719d0",
+                                                           :default default,
+                                                           :type "string/contains",
+                                                           :sectionId "location"}
+                                                          "en"))]
+      (t/is (= "contains CA"
+               (format-param ["CA"])))
+      (t/is (= "contains CA or NY"
+               (format-param ["CA" "NY"])))
+      (t/is (= "contains CA, NY, or NJ"
+               (format-param ["CA" "NY" "NJ"]))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #56633
Closes https://linear.app/metabase/issue/WRK-293/subscriptions-that-have-a-contains-filter-go-out-with-and-on-the


The param now will be formatted as "contains A or B"


![Screenshot 2025-05-13 at 14 40 58](https://github.com/user-attachments/assets/a87828d2-e993-4114-b507-3d7292d4cd6d)