### PR TITLE
Add types, normalization, and hydration for action scopes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -318,19 +318,6 @@
         provided    (update-keys params #(api/check-400 (param-id (name %)) "Unexpected parameter provided"))]
     (actions/execute-action! action (merge row-params provided))))
 
-;; These don't belong under /data-editing, but for now we have them nested here to avoid adding a new premium feature.
-
-(api.macros/defendpoint :post "/actions/v2/:action-id/describe" :- [:map
-                                                                    ;;
-                                                                    ]
-  "Can optionally take arguments, in order to partially apply them."
-  [{:keys [action-id]} :- [:map [:action-id :string]]
-   {:keys []}
-   {:keys [scope input]} :- [:map
-                             [:scope ::types/scope.raw]
-                            ;; this spec is going to come from the action (and depend on mapping)
-                             [:input :map]]])
-
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."
   (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -190,4 +190,3 @@
                                         :args       {:table_id  table-id
                                                      :db_id     db-id
                                                      :timestamp (t/zoned-date-time (t/zone-id "UTC"))}}))))))
-

--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -190,3 +190,4 @@
                                         :args       {:table_id  table-id
                                                      :db_id     db-id
                                                      :timestamp (t/zoned-date-time (t/zone-id "UTC"))}}))))))
+

--- a/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
@@ -11,11 +11,11 @@
   "Classify the scope, useful for switching on in logic and templates."
   [scope :- ::types/scope.raw] :- :keyword
   (condp #(contains? %2 %1) scope
-    :dashcard-id :dashcard
+    :dashcard-id   :dashcard
     :dashboard-id :dashboard
-    :card-id :card
-    :webhook-id :webhook
-    :table-id :table))
+    :card-id      :card
+    :webhook-id   :webhook
+    :table-id     :table))
 
 (defn- hydrate-from-dashcard-id* [scope]
   (if (and (contains? scope :card-id) (contains? scope :dashboard-id))
@@ -38,13 +38,10 @@
     (:dashcard-id scope) hydrate-from-dashcard-id*
 
     (:dashboard-id scope)
-    (update :collection-id #(or % (t2/select-one-fn :collection_id
-                                                    [:model/Dashboard :collection_id]
-                                                    (:dashboard-id scope))))
+    (update :collection-id #(or % (t2/select-one-fn :collection_id [:model/Dashboard :collection_id] (:dashboard-id scope))))
 
-    (:webhook-id scope) (update :table-id #(or % (t2/select-one-fn :table_id
-                                                                   [:table_webhook_token :table_id]
-                                                                   (:webhook-id scope))))
+    (:webhook-id scope)
+    (update :table-id #(or % (t2/select-one-fn :table_id [:table_webhook_token :table_id] (:webhook-id scope))))
 
     (:card-id scope) hydrate-from-card-id*
 

--- a/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
@@ -59,11 +59,11 @@
   [scope :- ::types/scope.raw] :- ::types/scope.normalized
   (cond-> scope
     (:table-id scope)     (dissoc :database-id)
-    (:card-id scope)      (dissoc :table-id)
+    (:card-id scope)      (-> (dissoc :table-id)
+                              (dissoc :collection-id))
     (:dashcard-id scope)  (-> (dissoc :card-id)
                               (dissoc :dashboard-id))
-    (:dashboard_id scope) (dissoc :collection-id)
-    (:card-id scope)      (dissoc :collection-id)))
+    (:dashboard_id scope) (dissoc :collection-id)))
 
 (comment
   (hydrate-scope {:dashcard-id 1})

--- a/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
@@ -1,0 +1,77 @@
+(ns metabase-enterprise.data-editing.scope
+  (:require
+   [metabase-enterprise.data-editing.types :as types]
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2]))
+
+;; TODO Perhaps we will prefer the FE just sending this explicitly instead?
+;; For now, it is not doing this, so we infer it.
+(mu/defn scope-type
+  "Classify the scope, useful for switching on in logic and templates."
+  [scope :- ::types/scope.raw] :- :keyword
+  (condp contains? scope
+    :dashcard-id :dashcard
+    :dashboard-id :dashboard
+    :card-id :card
+    :table-id :table
+    :webhook-id :webhook))
+
+(defn- hydrate-from-card-id* [scope]
+  (if (and (contains? scope :collection-id) (contains? scope :table-id))
+    scope
+    (let [card         (t2/select-one [:model/Card :dataset_query :collection_id] (:card-id scope))
+          source-table (-> card :dataset_query :query :source-table)
+          table-id     (when (pos-int? source-table)
+                         source-table)]
+      (-> scope
+          (update :table-id #(or % table-id))
+          (update :collection-id #(or % (:collection_id card)))))))
+
+(defn hydrate-scope* [scope]
+  (cond-> scope
+    (:dashcard-id scope)
+    (update :dashboard-id #(or % (t2/select-one-fn :dashboard_id
+                                                   [:model/DashboardCard :dashboard_id]
+                                                   (:dashcard-id scope))))
+
+    (:dashboard-id scope)
+    (update :collection-id #(or % (t2/select-one-fn :collection_id
+                                                    [:model/Dashboard :collection_id]
+                                                    (:dashboard-id scope))))
+
+    (:webhook-id scope) (update :table-id #(or % (t2/select-one-fn :table_id
+                                                                   [:table_webhook_token :table_id]
+                                                                   (:webhook-id scope))))
+
+    (:card-id scope) hydrate-from-card-id*
+
+    (:table-id scope)
+    (update :database-id #(or % (t2/select-one-fn :db_id [:model/Table :db_id] (:table-id scope))))))
+
+(mu/defn hydrate-scope
+  "Add the implicit keys that can be derived from the existing ones in a scope. Idempotent."
+  [scope :- ::types/scope.raw] :- ::types/scope.hydrated
+  ;; Rerun until it converges.
+  (ffirst (filter (partial apply =) (partition 2 1 (iterate hydrate-scope* scope)))))
+
+(mu/defn normalize-scope
+  "Remove all the implicit keys that can be derived from others. Useful to form stable keys. Idempotent."
+  [scope :- ::types/scope.raw] :- ::types/scope.normalized
+  (cond-> scope
+    (:table-id scope)     (dissoc :database-id)
+    (:card-id scope)      (dissoc :table-id)
+    (:dashcard-id scope)  (-> (dissoc :card-id)
+                              (dissoc :dashboard-id))
+    (:dashboard_id scope) (dissoc :collection-id)
+    (:card-id scope)      (dissoc :collection-id)))
+
+(comment
+  (hydrate-scope {:dashcard-id 1})
+  (hydrate-scope {:card-id 1})
+
+  (normalize-scope (hydrate-scope {:dashcard-id 1}))
+
+  (normalize-scope {:dashboard-id 1})
+  (normalize-scope {:dashboard-id 1 :dashcard-id 2 :card-id 3 :table-id 4 :database-id 5})
+  (normalize-scope {:card-id 3 :table-id 4 :database-id 5})
+  (normalize-scope {:table-id 4 :database-id 5}))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
@@ -8,6 +8,8 @@
   [[:map [:dashboard-id pos-int?]]
    [:map [:dashcard-id pos-int?]]
    [:map [:card-id pos-int?]]
+   ;; We treat legacy-actions, which get called against a model, distinctly. Treated the same as card-id, mostly.
+   [:map [:model-id pos-int?]]
    [:map [:table-id pos-int?]]
    [:map [:webhook-id pos-int?]]])
 
@@ -39,9 +41,22 @@
     [:collection-id pos-int?]
     [:table-id pos-int?]
     [:database-id pos-int?]]
-   ;; card without table (e.g., native or join)
+   ;; card without table (e.g., native)
    [:map {:closed true}
-    [:card-id pos-int?]]
+    [:card-id pos-int?]
+    [:collection-id pos-int?]
+    [:database-id pos-int?]]
+   ;; model with a table (e.g., mbql) - if there are joins we take the initial source table.
+   [:map {:closed true}
+    [:model-id pos-int?]
+    [:collection-id pos-int?]
+    [:table-id pos-int?]
+    [:database-id pos-int?]]
+   ;; model without a table
+   [:map {:closed true}
+    [:model-id pos-int?]
+    [:collection-id pos-int?]
+    [:database-id pos-int?]]
    ;; dashcard with both card and table
    [:map {:closed true}
     [:dashcard-id pos-int?]
@@ -55,7 +70,8 @@
     [:dashcard-id pos-int?]
     [:dashboard-id pos-int?]
     [:collection-id pos-int?]
-    [:card-id pos-int?]]
+    [:card-id pos-int?]
+    [:database-id pos-int?]]
    ;; non-card dashcard
    [:map {:closed true}
     [:dashcard-id pos-int?]
@@ -69,4 +85,5 @@
    ;; for now, webhooks can only point at tables, not editables
    [:map {:closed false}
     [:webhook-id pos-int?]
-    [:table-id pos-int?]]])
+    [:table-id pos-int?]
+    [:database-id pos-int?]]])

--- a/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
@@ -2,13 +2,16 @@
   (:require
    [metabase.util.malli.registry :as mr]))
 
-;; Maybe we want to add an origin? e.g., CRUD API versus action execute API. YAGNI for now.
+;; Maybe we want to add an origin? e.g., CRUD API versus action execute API versus v2 API. YAGNI for now.
 
 (def ^:private raw-scope-types
   [[:map [:dashboard-id pos-int?]]
    [:map [:dashcard-id pos-int?]]
    [:map [:card-id pos-int?]]
-   ;; We treat legacy-actions, which get called against a model, distinctly. Treated the same as card-id, mostly.
+   ;; We represent legacy-actions, which get called against a model, distinctly.
+   ;; Treated the same as card-id, mostly.
+   ;; Might end up always assigning the key according to the card type, or always use card-id, but either way we would
+   ;; then need some way to tell legacy-action invocations apart.
    [:map [:model-id pos-int?]]
    [:map [:table-id pos-int?]]
    [:map [:webhook-id pos-int?]]])

--- a/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
@@ -2,15 +2,13 @@
   (:require
    [metabase.util.malli.registry :as mr]))
 
-;; Maybe we want to add an origin? e.g., CRUD API versus action execute API.
+;; Maybe we want to add an origin? e.g., CRUD API versus action execute API. YAGNI for now.
 
 (def ^:private raw-scope-types
   [[:map [:dashboard-id pos-int?]]
    [:map [:dashcard-id pos-int?]]
    [:map [:card-id pos-int?]]
    [:map [:table-id pos-int?]]
-   ;[:map [:rest-api [:enum :table]]]
-   ;[:map [:action-api [:execute]]]
    [:map [:webhook-id pos-int?]]])
 
 ;; Relaxed, as we support it being

--- a/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/types.clj
@@ -1,0 +1,74 @@
+(ns metabase-enterprise.data-editing.types
+  (:require
+   [metabase.util.malli.registry :as mr]))
+
+;; Maybe we want to add an origin? e.g., CRUD API versus action execute API.
+
+(def ^:private raw-scope-types
+  [[:map [:dashboard-id pos-int?]]
+   [:map [:dashcard-id pos-int?]]
+   [:map [:card-id pos-int?]]
+   [:map [:table-id pos-int?]]
+   ;[:map [:rest-api [:enum :table]]]
+   ;[:map [:action-api [:execute]]]
+   [:map [:webhook-id pos-int?]]])
+
+;; Relaxed, as we support it being
+(mr/def ::scope.raw
+  (into [:or] raw-scope-types))
+
+;; All derivable or unknown data removed, so that this is safe to use as a key.
+(mr/def ::scope.normalized
+  (into [:or] (for [s raw-scope-types]
+                (vec (concat (subvec s 0 1)
+                             [{:closed true}]
+                             (subvec s 1))))))
+
+;; All derivable data included.
+(mr/def ::scope.hydrated
+  [:or
+   ;; dashboard
+   [:map {:closed true}
+    [:dashboard-id pos-int?]
+    [:collection-id pos-int?]]
+   ;; table
+   [:map {:closed true}
+    [:table-id pos-int?]
+    [:database-id pos-int?]]
+   ;; card with table (e.g., mbql with no join)
+   [:map {:closed true}
+    [:card-id pos-int?]
+    [:collection-id pos-int?]
+    [:table-id pos-int?]
+    [:database-id pos-int?]]
+   ;; card without table (e.g., native or join)
+   [:map {:closed true}
+    [:card-id pos-int?]]
+   ;; dashcard with both card and table
+   [:map {:closed true}
+    [:dashcard-id pos-int?]
+    [:dashboard-id pos-int?]
+    [:collection-id pos-int?]
+    [:card-id pos-int?]
+    [:table-id pos-int?]
+    [:database-id pos-int?]]
+   ;; dashcard with card but no table
+   [:map {:closed true}
+    [:dashcard-id pos-int?]
+    [:dashboard-id pos-int?]
+    [:collection-id pos-int?]
+    [:card-id pos-int?]]
+   ;; non-card dashcard
+   [:map {:closed true}
+    [:dashcard-id pos-int?]
+    [:dashboard-id pos-int?]
+    [:collection-id pos-int?]]
+   ;; table crud
+   [:map {:closed true}
+    [:rest-api [:enum :table]]
+    [:table-id pos-int?]
+    [:database-id pos-int?]]
+   ;; for now, webhooks can only point at tables, not editables
+   [:map {:closed false}
+    [:webhook-id pos-int?]
+    [:table-id pos-int?]]])

--- a/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
@@ -14,6 +14,7 @@
       {:dashcard-id 1, :dashboard-id 2, :collection-id 3, :card-id 4, :table-id 5, :database-id 6}  :dashcard
       {:dashboard-id 1, :collection-id 2}                                                           :dashboard
       {:card-id 1, :table-id 2, :database-id 3}                                                     :card
+      {:model-id 1, :table-id 2, :database-id 3}                                                    :model
       {:table-id 1, :database-id 4}                                                                 :table
       {:webhook-id 1, :table-id 2}                                                                  :webhook)))
 
@@ -32,13 +33,29 @@
                            :model/Card         {mbql-card-id :id}    {:dataset_query {:database db-id
                                                                                       :type     :query
                                                                                       :query    {:source-table table-id}}
+                                                                      :database_id   db-id
                                                                       :name          "Test MBQL Card"
                                                                       :collection_id collection-id}
+                           :model/Card         {mbql-model-id :id}   {:dataset_query {:database db-id
+                                                                                      :type     :query
+                                                                                      :query    {:source-table table-id}}
+                                                                      :database_id   db-id
+                                                                      :name          "Test MBQL Model"
+                                                                      :collection_id collection-id
+                                                                      :dataset       true}
+                           :model/Card          {native-model-id :id} {:dataset_query {:database db-id
+                                                                                       :type     :native
+                                                                                       :native   {:query "SELECT * FROM venues"}}
+                                                                       :database_id   db-id
+                                                                       :name          "Test Native Model"
+                                                                       :collection_id collection-id
+                                                                       :dataset       true}
                            :model/Dashboard     {dashboard-id :id}   {:name          "Test Dashboard"
                                                                       :collection_id collection-id}
                            :model/Card          {native-card-id :id} {:dataset_query {:database db-id
                                                                                       :type     :native
                                                                                       :native   {:query "SELECT * FROM venues"}}
+                                                                      :database_id   db-id
                                                                       :name          "Test Native Card"
                                                                       :dashboard_id  dashboard-id}
                            :model/DashboardCard {dashcard-id-1 :id}  {:dashboard_id dashboard-id
@@ -86,6 +103,18 @@
                         :collection-id collection-id}
                        (scope/hydrate {:card-id native-card-id}))))
 
+              (testing "hydrate for MBQL model"
+                (is (= {:model-id      mbql-model-id
+                        :collection-id collection-id
+                        :table-id      table-id
+                        :database-id   db-id}
+                       (scope/hydrate {:model-id mbql-model-id}))))
+
+              (testing "hydrate for native model"
+                (is (= {:model-id      native-model-id
+                        :collection-id collection-id}
+                       (scope/hydrate {:model-id native-model-id}))))
+
               (testing "hydrate for table"
                 (is (= {:table-id    table-id
                         :database-id db-id}
@@ -117,6 +146,12 @@
 
       (is (= {:card-id 3}
              (scope/normalize {:card-id 3
+                               :table-id 4
+                               :collection-id 5
+                               :database-id 6})))
+
+      (is (= {:model-id 7}
+             (scope/normalize {:model-id 7
                                :table-id 4
                                :collection-id 5
                                :database-id 6})))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
@@ -30,33 +30,33 @@
                                                                         :creator_id (mt/user->id :rasta)})]
           (try
             (mt/with-temp [:model/Collection   {collection-id :id}   {:name "Test Collection"}
-                           :model/Card         {mbql-card-id :id}    {:dataset_query {:database db-id
+                           :model/Card         {mbql-card-id :id}    {:name          "Test MBQL Card"
+                                                                      :database_id   db-id
+                                                                      :dataset_query {:database db-id
                                                                                       :type     :query
                                                                                       :query    {:source-table table-id}}
-                                                                      :database_id   db-id
-                                                                      :name          "Test MBQL Card"
                                                                       :collection_id collection-id}
-                           :model/Card         {mbql-model-id :id}   {:dataset_query {:database db-id
+                           :model/Card         {mbql-model-id :id}   {:name          "Test MBQL Model"
+                                                                      :database_id   db-id
+                                                                      :dataset_query {:database db-id
                                                                                       :type     :query
                                                                                       :query    {:source-table table-id}}
-                                                                      :database_id   db-id
-                                                                      :name          "Test MBQL Model"
                                                                       :collection_id collection-id
                                                                       :dataset       true}
-                           :model/Card          {native-model-id :id} {:dataset_query {:database db-id
+                           :model/Card          {native-model-id :id} {:name          "Test Native Model"
+                                                                       :database_id   db-id
+                                                                       :dataset_query {:database db-id
                                                                                        :type     :native
                                                                                        :native   {:query "SELECT * FROM venues"}}
-                                                                       :database_id   db-id
-                                                                       :name          "Test Native Model"
                                                                        :collection_id collection-id
                                                                        :dataset       true}
                            :model/Dashboard     {dashboard-id :id}   {:name          "Test Dashboard"
                                                                       :collection_id collection-id}
-                           :model/Card          {native-card-id :id} {:dataset_query {:database db-id
+                           :model/Card          {native-card-id :id} {:name          "Test Native Card"
+                                                                      :database_id   db-id
+                                                                      :dataset_query {:database db-id
                                                                                       :type     :native
                                                                                       :native   {:query "SELECT * FROM venues"}}
-                                                                      :database_id   db-id
-                                                                      :name          "Test Native Card"
                                                                       :dashboard_id  dashboard-id}
                            :model/DashboardCard {dashcard-id-1 :id}  {:dashboard_id dashboard-id
                                                                       :card_id      mbql-card-id

--- a/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
@@ -30,34 +30,22 @@
                                                                         :creator_id (mt/user->id :rasta)})]
           (try
             (mt/with-temp [:model/Collection   {collection-id :id}   {:name "Test Collection"}
-                           :model/Card         {mbql-card-id :id}    {:name          "Test MBQL Card"
-                                                                      :database_id   db-id
-                                                                      :dataset_query {:database db-id
-                                                                                      :type     :query
-                                                                                      :query    {:source-table table-id}}
-                                                                      :collection_id collection-id}
-                           :model/Card         {mbql-model-id :id}   {:name          "Test MBQL Model"
+                           :model/Card         {mbql-card-id :id}    {:name          "Test MBQL Card/Model"
                                                                       :database_id   db-id
                                                                       :dataset_query {:database db-id
                                                                                       :type     :query
                                                                                       :query    {:source-table table-id}}
                                                                       :collection_id collection-id
-                                                                      :dataset       true}
-                           :model/Card          {native-model-id :id} {:name          "Test Native Model"
-                                                                       :database_id   db-id
-                                                                       :dataset_query {:database db-id
-                                                                                       :type     :native
-                                                                                       :native   {:query "SELECT * FROM venues"}}
-                                                                       :collection_id collection-id
-                                                                       :dataset       true}
+                                                                      :type          :model}
                            :model/Dashboard     {dashboard-id :id}   {:name          "Test Dashboard"
                                                                       :collection_id collection-id}
-                           :model/Card          {native-card-id :id} {:name          "Test Native Card"
+                           :model/Card          {native-card-id :id} {:name          "Test Native Card/Model"
                                                                       :database_id   db-id
                                                                       :dataset_query {:database db-id
                                                                                       :type     :native
                                                                                       :native   {:query "SELECT * FROM venues"}}
-                                                                      :dashboard_id  dashboard-id}
+                                                                      :collection_id collection-id
+                                                                      :type          :model}
                            :model/DashboardCard {dashcard-id-1 :id}  {:dashboard_id dashboard-id
                                                                       :card_id      mbql-card-id
                                                                       :row          0
@@ -83,7 +71,8 @@
                 (is (= {:dashcard-id   dashcard-id-2
                         :dashboard-id  dashboard-id
                         :collection-id collection-id
-                        :card-id       native-card-id}
+                        :card-id       native-card-id
+                        :database-id   db-id}
                        (scope/hydrate {:dashcard-id dashcard-id-2}))))
 
               (testing "hydrate for dashboard"
@@ -100,20 +89,22 @@
 
               (testing "hydrate for native card"
                 (is (= {:card-id       native-card-id
-                        :collection-id collection-id}
+                        :collection-id collection-id
+                        :database-id   db-id}
                        (scope/hydrate {:card-id native-card-id}))))
 
               (testing "hydrate for MBQL model"
-                (is (= {:model-id      mbql-model-id
+                (is (= {:model-id      mbql-card-id
                         :collection-id collection-id
                         :table-id      table-id
                         :database-id   db-id}
-                       (scope/hydrate {:model-id mbql-model-id}))))
+                       (scope/hydrate {:model-id mbql-card-id}))))
 
               (testing "hydrate for native model"
-                (is (= {:model-id      native-model-id
-                        :collection-id collection-id}
-                       (scope/hydrate {:model-id native-model-id}))))
+                (is (= {:model-id      native-card-id
+                        :collection-id collection-id
+                        :database-id   db-id}
+                       (scope/hydrate {:model-id native-card-id}))))
 
               (testing "hydrate for table"
                 (is (= {:table-id    table-id

--- a/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
@@ -54,16 +54,13 @@
                                                                       :size_x       4
                                                                       :size_y       4}]
               (testing "hydrate-scope for dashcard with MBQL card"
-                (let [scope    {:dashcard-id dashcard-id-1}
-                      hydrated (scope/hydrate scope)]
-                  (is (= #{:dashcard-id :dashboard-id :collection-id :card-id :table-id :database-id}
-                         (set (keys hydrated))))
-                  (is (= dashcard-id-1 (:dashcard-id hydrated)))
-                  (is (= dashboard-id (:dashboard-id hydrated)))
-                  (is (= collection-id (:collection-id hydrated)))
-                  (is (= mbql-card-id (:card-id hydrated)))
-                  (is (= table-id (:table-id hydrated)))
-                  (is (= db-id (:database-id hydrated)))))
+                (is (= {:dashcard-id   dashcard-id-1
+                        :dashboard-id  dashboard-id
+                        :collection-id collection-id
+                        :card-id       mbql-card-id
+                        :table-id      table-id
+                        :database-id   db-id}
+                       (scope/hydrate {:dashcard-id dashcard-id-1}))))
 
               (testing "hydrate-scope for dashcard with native card"
                 (let [scope    {:dashcard-id dashcard-id-2}

--- a/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/scope_test.clj
@@ -1,0 +1,145 @@
+(ns metabase-enterprise.data-editing.scope-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.data-editing.scope :as scope]
+   [metabase-enterprise.data-editing.test-util :as data-editing.tu]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(deftest scope-type-test
+  (testing "scope-type correctly classifies scope based on available keys"
+    (are [scope expected] (= expected (scope/scope-type scope))
+      {:dashcard-id 1, :dashboard-id 2, :collection-id 3, :card-id 4, :table-id 5, :database-id 6}  :dashcard
+      {:dashboard-id 1, :collection-id 2}                                                           :dashboard
+      {:card-id 1, :table-id 2, :database-id 3}                                                     :card
+      {:table-id 1, :database-id 4}                                                                 :table
+      {:webhook-id 1, :table-id 2}                                                                  :webhook)))
+
+(deftest hydrate-scope-test
+  (mt/with-premium-features #{:table-data-editing}
+    (data-editing.tu/with-temp-test-db!
+      (with-open [table-ref (data-editing.tu/open-test-table!)]
+        (let [db-id      (mt/id)
+              table-id   @table-ref
+             ;; It's not a model, so we need to manually insert (and delete) the webhook.
+              webhook-id (t2/insert-returning-pk! :table_webhook_token {:token      "test-token"
+                                                                        :table_id   table-id,
+                                                                        :creator_id (mt/user->id :rasta)})]
+          (try
+            (mt/with-temp [:model/Collection   {collection-id :id}   {:name "Test Collection"}
+                           :model/Card         {mbql-card-id :id}    {:dataset_query {:database db-id
+                                                                                      :type     :query
+                                                                                      :query    {:source-table table-id}}
+                                                                      :name          "Test MBQL Card"
+                                                                      :collection_id collection-id}
+                           :model/Dashboard     {dashboard-id :id}   {:name          "Test Dashboard"
+                                                                      :collection_id collection-id}
+                           :model/Card          {native-card-id :id} {:dataset_query {:database db-id
+                                                                                      :type     :native
+                                                                                      :native   {:query "SELECT * FROM venues"}}
+                                                                      :name          "Test Native Card"
+                                                                      :dashboard_id  dashboard-id}
+                           :model/DashboardCard {dashcard-id-1 :id}  {:dashboard_id dashboard-id
+                                                                      :card_id      mbql-card-id
+                                                                      :row          0
+                                                                      :col          0
+                                                                      :size_x       4
+                                                                      :size_y       4}
+                           :model/DashboardCard {dashcard-id-2 :id}  {:dashboard_id dashboard-id
+                                                                      :card_id      native-card-id
+                                                                      :row          0
+                                                                      :col          4
+                                                                      :size_x       4
+                                                                      :size_y       4}]
+              (testing "hydrate-scope for dashcard with MBQL card"
+                (let [scope    {:dashcard-id dashcard-id-1}
+                      hydrated (scope/hydrate scope)]
+                  (is (= #{:dashcard-id :dashboard-id :collection-id :card-id :table-id :database-id}
+                         (set (keys hydrated))))
+                  (is (= dashcard-id-1 (:dashcard-id hydrated)))
+                  (is (= dashboard-id (:dashboard-id hydrated)))
+                  (is (= collection-id (:collection-id hydrated)))
+                  (is (= mbql-card-id (:card-id hydrated)))
+                  (is (= table-id (:table-id hydrated)))
+                  (is (= db-id (:database-id hydrated)))))
+
+              (testing "hydrate-scope for dashcard with native card"
+                (let [scope    {:dashcard-id dashcard-id-2}
+                      hydrated (scope/hydrate scope)]
+                  (is (= #{:dashcard-id :dashboard-id :collection-id :card-id}
+                         (set (keys hydrated))))
+                  (is (= dashcard-id-2 (:dashcard-id hydrated)))
+                  (is (= dashboard-id (:dashboard-id hydrated)))
+                  (is (= collection-id (:collection-id hydrated)))
+                  (is (= native-card-id (:card-id hydrated)))
+                  (is (nil? (:table-id hydrated)))))
+
+              (testing "hydrate-scope for dashboard"
+                (let [scope    {:dashboard-id dashboard-id}
+                      hydrated (scope/hydrate scope)]
+                  (is (= #{:dashboard-id :collection-id}
+                         (set (keys hydrated))))
+                  (is (= dashboard-id (:dashboard-id hydrated)))
+                  (is (= collection-id (:collection-id hydrated)))))
+
+              (testing "hydrate-scope for MBQL card"
+                (let [scope    {:card-id mbql-card-id}
+                      hydrated (scope/hydrate scope)]
+                  (is (= #{:card-id :collection-id :table-id :database-id}
+                         (set (keys hydrated))))
+                  (is (= mbql-card-id (:card-id hydrated)))
+                  (is (= collection-id (:collection-id hydrated)))
+                  (is (= table-id (:table-id hydrated)))
+                  (is (= db-id (:database-id hydrated)))))
+
+              (testing "hydrate-scope for native card"
+                (let [scope    {:card-id native-card-id}
+                      hydrated (scope/hydrate scope)]
+                  (is (= #{:card-id :collection-id}
+                         (set (keys hydrated))))
+                  (is (= native-card-id (:card-id hydrated)))
+                  (is (= collection-id (:collection-id hydrated)))
+                  (is (nil? (:table-id hydrated)))))
+
+              (testing "hydrate-scope for table"
+                (let [scope    {:table-id table-id}
+                      hydrated (scope/hydrate scope)]
+                  (is (= #{:table-id :database-id}
+                         (set (keys hydrated))))
+                  (is (= table-id (:table-id hydrated)))
+                  (is (= db-id (:database-id hydrated)))))
+
+              (testing "hydrate-scope for webhook"
+                (let [scope    {:webhook-id webhook-id}
+                      hydrated (scope/hydrate scope)]
+                  (is (= #{:webhook-id :table-id :database-id}
+                         (set (keys hydrated))))
+                  (is (= webhook-id (:webhook-id hydrated)))
+                  (is (= table-id (:table-id hydrated)))
+                  (is (= db-id (:database-id hydrated))))))
+
+            (finally
+              (t2/delete! :table_webhook_token webhook-id))))))))
+
+(deftest normalize-scope-test
+  (mt/with-premium-features #{:table-data-editing}
+    (let [dashcard-scope {:dashboard-id  1
+                          :dashcard-id   2
+                          :card-id       3
+                          :table-id      4
+                          :collection-id 5
+                          :database-id   6}]
+
+      (testing "normalize-scope with dashcard scope"
+        (is (= {:dashcard-id 2} (scope/normalize dashcard-scope))))
+
+      (testing "normalize-scope with dashboard scope"
+        (is (= {:dashboard-id 1} (scope/normalize {:dashboard-id 1 :collection-id 5}))))
+
+      (testing "normalize-scope with card scope"
+        (is (= {:card-id 3} (scope/normalize {:card-id 3 :table-id 4 :collection-id 5 :database-id 6}))))
+
+      (testing "normalize-scope with table scope"
+        (is (= {:table-id 4} (scope/normalize {:table-id 4 :database-id 6})))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -293,15 +293,14 @@
           (let [table-1    @table-ref-1
                 table-2    @table-ref-2
                 user-1     (mt/user->id :crowberto)
-                user-2     (mt/user->id :rasta)
-                test-scope {:shared true}]
+                user-2     (mt/user->id :rasta)]
             (data-editing.tu/toggle-data-editing-enabled! true)
 
             (testing "Total rows"
               (with-redefs [undo/retention-total-rows 17]
                 (dotimes [i 25]
                   (undo/track-change! user-1
-                                      test-scope
+                                      {:table-id table-1}
                                       {table-1
                                        {{:id 1} [(if (even? i) {} nil)
                                                  (if (even? i) nil {})]
@@ -315,7 +314,7 @@
               (with-redefs [undo/retention-total-batches 15]
                 (dotimes [i 25]
                   (undo/track-change! user-1
-                                      test-scope
+                                      {:table-id table-1}
                                       {table-1
                                        {{:id 1} [(if (even? i) {} nil)
                                                  (if (even? i) nil {})]
@@ -330,7 +329,7 @@
                 (dotimes [i 25]
                   ;; just toggle existence
                   (undo/track-change! (if (zero? (mod i 3)) user-1 user-2)
-                                      test-scope
+                                      {:table-id table-1}
                                       {table-1
                                        {{:id 1} [(if (even? i) {} nil)
                                                  (if (even? i) nil {})]
@@ -370,7 +369,7 @@
                 (dotimes [i 25]
                   ;; just toggle existence
                   (undo/track-change! (if (zero? (mod i 3)) user-1 user-2)
-                                      test-scope
+                                      {:dashboard-id 1}
                                       {(if (zero? (mod i 5)) table-1 table-2)
                                        {{:id 1} [(if (even? i) {} nil)
                                                  (if (even? i) nil {})]

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -253,7 +253,7 @@
     ;; The action might not be database-centric (e.g., call a webhook)
     (when db
       (case policy
-        :ad-hoc-action-invocation
+        :ad-hoc-invocation
         (check-actions-enabled-for-database! db)
         :model-action
         (check-actions-enabled-for-database! db)
@@ -264,7 +264,7 @@
       (when (= :model-action policy)
         (doseq [arg-map arg-maps]
           (qp.perms/check-query-action-permissions* arg-map)))
-      (when (= :ad-hoc-action-invocation policy)
+      (when (= :ad-hoc-invocation policy)
         (doseq [arg-map arg-maps]
           (cond
             (:query arg-map) (qp.perms/check-query-action-permissions* arg-map)


### PR DESCRIPTION
Scopes indicate where an Action will be or is being called from.

Some examples of how scope will be used:

1. To discover actions that make sense somewhere, e.g. table CRUD.
2. To determine the undo scope for changes being made.
3. To power a link back to the same spot in the app, from a notification.
