### PR TITLE
Closes VIZ-400 fix stickiness for initial rendering as well

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
@@ -49,6 +49,7 @@ export function DashboardParameterPanel({
   );
   const { isSticky, isStickyStateChanging } = useIsParameterPanelSticky({
     parameterPanelRef,
+    disabled: !allowSticky || !hasVisibleParameters,
   });
 
   const shouldApplyThemeChangeTransition = !isStickyStateChanging && isSticky;

--- a/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.ts
@@ -2,8 +2,10 @@ import { type RefObject, useEffect, useState } from "react";
 
 export function useIsParameterPanelSticky({
   parameterPanelRef,
+  disabled = false,
 }: {
   parameterPanelRef: RefObject<HTMLElement>;
+  disabled?: boolean;
 }) {
   const [isSticky, setIsSticky] = useState(false);
   const [isStickyStateChanging, setIsStickyStateChanging] = useState(false);
@@ -51,7 +53,7 @@ export function useIsParameterPanelSticky({
       observer.disconnect();
       sentinel.remove();
     };
-  }, [parameterPanelRef]);
+  }, [parameterPanelRef, disabled]);
 
   return {
     isSticky,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #53504
Followup on [VIZ-400: Dashboard filter sticky panel sometimes missing background color when scrolled](https://linear.app/metabase/issue/VIZ-400/dashboard-filter-sticky-panel-sometimes-missing-background-color-when) for initial rendering, the `useEffect` somehow would not kick in when needed, hence the addition of a dependency. Not sure why this works fine on Chrome though.