### PR TITLE
Metadata table and detail preview

### DIFF
--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -16,6 +16,7 @@ import type {
   DashboardSubscription,
   Database,
   DatabaseXray,
+  Dataset,
   Field,
   FieldDimension,
   FieldId,
@@ -113,10 +114,10 @@ export function provideAdhocQueryTags(
     idTag("database", dataset.database_id),
     listTag("field"),
     ...(dataset.data?.results_metadata?.columns
-      .map((column) =>
+      ?.map((column) =>
         column.id !== undefined ? idTag("field", column.id) : null,
       )
-      .filter(isNotNull) ?? []),
+      .filter((tag): tag is TagType => tag !== null) ?? []),
   ];
 }
 

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -105,6 +105,21 @@ export function provideActivityItemTags(
   return [idTag(TAG_TYPE_MAPPING[item.model], item.id)];
 }
 
+export function provideAdhocQueryTags(
+  dataset: Dataset,
+): TagDescription<TagType>[] {
+  return [
+    listTag("database"),
+    idTag("database", dataset.database_id),
+    listTag("field"),
+    ...(dataset.data?.results_metadata?.columns
+      .map((column) =>
+        column.id !== undefined ? idTag("field", column.id) : null,
+      )
+      .filter(isNotNull) ?? []),
+  ];
+}
+
 export function provideAdhocQueryMetadataTags(
   metadata: CardQueryMetadata,
 ): TagDescription<TagType>[] {

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -120,13 +120,18 @@ export const DataModel = ({ params }: Props) => {
             </LoadingAndErrorWrapper>
           </Box>
 
-          <Box flex="1 1 200px" p="xl" pl={0} miw={0}>
-            <PreviewSection
-              fieldId={fieldId}
-              previewType={previewType}
-              onPreviewTypeChange={setPreviewType}
-            />
-          </Box>
+          {field && (
+            <Box flex="1 1 200px" p="xl" pl={0} miw={0}>
+              <PreviewSection
+                databaseId={databaseId}
+                tableId={tableId}
+                fieldId={fieldId}
+                field={field}
+                previewType={previewType}
+                onPreviewTypeChange={setPreviewType}
+              />
+            </Box>
+          )}
         </>
       )}
     </Flex>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/Error.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/Error.module.css
@@ -1,0 +1,4 @@
+.error {
+  border-radius: 200px;
+  background-color: var(--mb-color-bg-light);
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/Error.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/Error.tsx
@@ -1,0 +1,15 @@
+import { Box, Icon, Stack } from "metabase/ui";
+
+import S from "./Error.module.css";
+
+export function Error({ message }: { message: string }) {
+  return (
+    <Stack h="100%" p="xl" justify="center" align="center" color="text-light">
+      <Box p="md" mt="lg" className={S.error} bg="bg-medium">
+        <Icon name="warning" size={16} />
+      </Box>
+
+      <Box maw="500px">{message}</Box>
+    </Stack>
+  );
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/ObjectDetail.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/ObjectDetail.tsx
@@ -1,0 +1,109 @@
+import { t } from "ttag";
+
+import { useGetAdhocQueryQuery } from "metabase/api";
+import EmptyState from "metabase/components/EmptyState";
+import { Stack } from "metabase/ui";
+import Visualization from "metabase/visualizations/components/Visualization";
+import type {
+  Card,
+  DatabaseId,
+  DatasetQuery,
+  FieldFilter,
+  FieldId,
+  FieldReference,
+  RawSeries,
+  TableId,
+} from "metabase-types/api";
+
+import { Error } from "./Error";
+import { getErrorMessage } from "./utils";
+
+export function ObjectDetailPreview({
+  databaseId,
+  tableId,
+  fieldId,
+}: {
+  tableId: TableId;
+  databaseId: DatabaseId;
+  fieldId: FieldId;
+}) {
+  const { rawSeries, error } = useDataSample({
+    databaseId,
+    tableId,
+    fieldId,
+  });
+
+  if (error) {
+    return <Error message={error} />;
+  }
+
+  const data = rawSeries?.[0]?.data;
+  const zoomedRow = data?.rows[0];
+
+  if (!data || !zoomedRow) {
+    return (
+      <Stack h="100%" justify="center" p="md">
+        <EmptyState title={t`No data to show.`} />
+      </Stack>
+    );
+  }
+
+  return <Visualization rawSeries={rawSeries} />;
+}
+
+function useDataSample({
+  databaseId,
+  tableId,
+  fieldId,
+}: {
+  databaseId: DatabaseId;
+  tableId: TableId;
+  fieldId: FieldId;
+}) {
+  const reference: FieldReference = ["field", fieldId, null];
+  const filter: FieldFilter = ["not-null", reference];
+
+  const datasetQuery: DatasetQuery = {
+    type: "query" as const,
+    database: databaseId,
+    query: {
+      "source-table": tableId,
+      filter,
+      limit: 1,
+    },
+  };
+
+  const { data, ...rest } = useGetAdhocQueryQuery(datasetQuery);
+
+  const base = { ...rest, error: undefined, rawSeries: undefined };
+
+  if (data?.status === "failed") {
+    return {
+      ...rest,
+      rawSeries: undefined,
+      isError: true,
+      error: getErrorMessage(data),
+    };
+  }
+
+  if (!data?.data) {
+    return base;
+  }
+
+  const rawSeries: RawSeries = [
+    {
+      card: {
+        dataset_query: datasetQuery,
+        display: "object",
+        visualization_settings: {},
+      } as Card,
+      data: data.data,
+    },
+  ];
+
+  return {
+    ...rest,
+    error: undefined,
+    rawSeries,
+  };
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { Box, Card, Flex, SegmentedControl, Text } from "metabase/ui";
 import type { DatabaseId, Field, FieldId, TableId } from "metabase-types/api";
 
+import { ObjectDetailPreview } from "./ObjectDetail";
 import { TablePreview } from "./TablePreview";
 import { type PreviewType, getTypeSelectorData } from "./utils";
 
@@ -36,7 +37,13 @@ export const PreviewSection = ({
           field={field}
         />
       )}
-      {previewType === "detail" && <Box>DETAIL</Box>}
+      {previewType === "detail" && (
+        <ObjectDetailPreview
+          databaseId={databaseId}
+          tableId={tableId}
+          fieldId={fieldId}
+        />
+      )}
       {previewType === "filtering" && <Box>FILTERING</Box>}
     </Card>
   );

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
@@ -1,23 +1,41 @@
 import { useMemo } from "react";
 
 import { Box, Card, Flex, SegmentedControl, Text } from "metabase/ui";
-import type { FieldId } from "metabase-types/api";
+import type { DatabaseId, Field, FieldId, TableId } from "metabase-types/api";
 
+import { TablePreview } from "./TablePreview";
 import { type PreviewType, getTypeSelectorData } from "./utils";
 
 interface Props {
-  fieldId?: FieldId;
+  databaseId: DatabaseId;
+  tableId: TableId;
+  fieldId: FieldId;
+  field: Field;
   previewType: PreviewType;
   onPreviewTypeChange: (value: PreviewType) => void;
 }
 
-export const PreviewSection = ({ previewType, onPreviewTypeChange }: Props) => {
+export const PreviewSection = ({
+  databaseId,
+  tableId,
+  fieldId,
+  field,
+  previewType,
+  onPreviewTypeChange,
+}: Props) => {
   return (
     <Card bg="white" h="100%" px="lg" py="md" shadow="xs">
       <Text fw="bold">Field preview</Text>
       <PreviewTypeSelector value={previewType} onChange={onPreviewTypeChange} />
 
-      {previewType === "table" && <Box>TABLE</Box>}
+      {previewType === "table" && (
+        <TablePreview
+          databaseId={databaseId}
+          tableId={tableId}
+          fieldId={fieldId}
+          field={field}
+        />
+      )}
       {previewType === "detail" && <Box>DETAIL</Box>}
       {previewType === "filtering" && <Box>FILTERING</Box>}
     </Card>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.unit.spec.tsx
@@ -1,9 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
+import { createMockField } from "metabase-types/api/mocks";
 
 import { PreviewSection } from "./PreviewSection";
 import { type PreviewType, usePreviewType } from "./utils";
+
+const field = createMockField();
 
 function Wrapper({
   onPreviewTypeChange,
@@ -19,6 +22,10 @@ function Wrapper({
 
   return (
     <PreviewSection
+      databaseId={1}
+      tableId={field.table_id}
+      fieldId={16}
+      field={field}
       previewType={previewType}
       onPreviewTypeChange={handlePreviewTypeChange}
     />

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.module.css
@@ -1,7 +1,0 @@
-.error {
-  background-color: var(--mb-color-bg-light);
-  border: 1px solid var(--mb-color-border);
-  border-radius: 6px;
-  font-family: var(--mb-default-monospace-font-family);
-  font-size: 0.75rem;
-}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.module.css
@@ -1,0 +1,7 @@
+.error {
+  background-color: var(--mb-color-bg-light);
+  border: 1px solid var(--mb-color-border);
+  border-radius: 6px;
+  font-family: var(--mb-default-monospace-font-family);
+  font-size: 0.75rem;
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
@@ -36,9 +36,9 @@ export function TablePreview(props: TablePreviewProps) {
 
   return (
     <Visualization
-      // To hide the details column
+      // Setting queryBuilderMode to dataset will hide the object detail
+      // expaner column, which we don't want in this case
       queryBuilderMode="dataset"
-      // To hide the column headers
       rawSeries={rawSeries}
     />
   );

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
@@ -1,5 +1,3 @@
-import { t } from "ttag";
-
 import { useGetAdhocQueryQuery } from "metabase/api";
 import Visualization from "metabase/visualizations/components/Visualization";
 import { TYPE } from "metabase-lib/v1/types/constants";
@@ -18,6 +16,7 @@ import type {
 } from "metabase-types/api";
 
 import { Error } from "./Error";
+import { getErrorMessage } from "./utils";
 
 const PREVIEW_ROW_COUNT = 5;
 
@@ -79,21 +78,7 @@ function useDataSample({
   const base = { ...rest, error: undefined, rawSeries: undefined };
 
   if (data?.status === "failed") {
-    let error = typeof data.error === "string" ? data.error : data.error?.data;
-
-    if (data.error_type === "invalid-query") {
-      error = t`Something went wrong fetching the data for this field. This could mean something is wrong with the field settings, like a cast that is not supported for the underlying data type. Please check your settings and try again.`;
-    }
-
-    if (data.error_type === "missing-required-permissions") {
-      error = t`You do not have permission to preview this field's data.`;
-    }
-
-    return {
-      ...base,
-      isError: true,
-      error: error ?? t`Something went wrong`,
-    };
+    return { ...base, isError: true, error: getErrorMessage(data) };
   }
 
   if (!data?.data || data.data.cols.length === 0) {

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
@@ -1,0 +1,133 @@
+import { t } from "ttag";
+
+import { useGetAdhocQueryQuery } from "metabase/api";
+import { Box } from "metabase/ui";
+import Visualization from "metabase/visualizations/components/Visualization";
+import { TYPE } from "metabase-lib/v1/types/constants";
+import { isa } from "metabase-lib/v1/types/utils/isa";
+import type {
+  Card,
+  DatabaseId,
+  DatasetColumn,
+  DatasetQuery,
+  Field,
+  FieldFilter,
+  FieldId,
+  FieldReference,
+  RawSeries,
+  TableId,
+} from "metabase-types/api";
+
+import S from "./TablePreview.module.css";
+
+const PREVIEW_ROW_COUNT = 5;
+
+type TablePreviewProps = {
+  fieldId: FieldId;
+  databaseId: DatabaseId;
+  tableId: TableId;
+  field: Field;
+};
+
+export function TablePreview(props: TablePreviewProps) {
+  const { rawSeries, error } = useDataSample(props);
+
+  if (error) {
+    return (
+      <Box p="md" mt="lg" className={S.error}>
+        {error}
+      </Box>
+    );
+  }
+
+  return (
+    <Visualization
+      // To hide the details column
+      queryBuilderMode="dataset"
+      // To hide the column headers
+      rawSeries={rawSeries}
+    />
+  );
+}
+
+function useDataSample({
+  fieldId,
+  tableId,
+  databaseId,
+  field,
+}: TablePreviewProps) {
+  let options = null;
+  if (isa(field.base_type, TYPE.DateTime)) {
+    options = {
+      "base-type": "type/DateTime",
+      "temporal-unit": "minute" as const,
+    };
+  }
+
+  const fieldRef: FieldReference = ["field", fieldId, options];
+  const filter: FieldFilter = ["not-null", fieldRef];
+  const breakout = [fieldRef];
+
+  const datasetQuery: DatasetQuery = {
+    type: "query",
+    database: databaseId,
+    query: {
+      "source-table": tableId,
+      filter,
+      breakout,
+      limit: PREVIEW_ROW_COUNT,
+    },
+  };
+
+  const { data, ...rest } = useGetAdhocQueryQuery(datasetQuery);
+
+  const base = { ...rest, error: undefined, rawSeries: undefined };
+
+  if (data?.status === "failed") {
+    let error = typeof data.error === "string" ? data.error : data.error?.data;
+
+    if (data.error_type === "invalid-query") {
+      error = t`Something went wrong fetching the data for this field. This could mean something is wrong with the field settings, like a cast that is not supported for the underlying data type. Please check your settings and try again.`;
+    }
+
+    if (data.error_type === "missing-required-permissions") {
+      error = t`You do not have permission to preview this field's data.`;
+    }
+
+    return {
+      ...base,
+      isError: true,
+      error: error ?? t`Something went wrong`,
+    };
+  }
+
+  if (!data?.data || data.data.cols.length === 0) {
+    return base;
+  }
+
+  const stubColumn: DatasetColumn = {
+    name: "__metabase_generated",
+    display_name: "—",
+    source: "generated",
+    semantic_type: "type/PK",
+  };
+  const stubValue = "—";
+
+  const rawSeries: RawSeries = [
+    {
+      card: {
+        dataset_query: datasetQuery,
+        display: "table",
+        visualization_settings: {},
+      } as Card,
+      data: {
+        // create a stub column in the data
+        ...data.data,
+        cols: [stubColumn, ...data.data.cols],
+        rows: data.data.rows.map((row) => [stubValue, ...row]),
+      },
+    },
+  ];
+
+  return { ...base, rawSeries };
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import { useGetAdhocQueryQuery } from "metabase/api";
-import { Box } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import { TYPE } from "metabase-lib/v1/types/constants";
 import { isa } from "metabase-lib/v1/types/utils/isa";
@@ -18,7 +17,7 @@ import type {
   TableId,
 } from "metabase-types/api";
 
-import S from "./TablePreview.module.css";
+import { Error } from "./Error";
 
 const PREVIEW_ROW_COUNT = 5;
 
@@ -33,11 +32,7 @@ export function TablePreview(props: TablePreviewProps) {
   const { rawSeries, error } = useDataSample(props);
 
   if (error) {
-    return (
-      <Box p="md" mt="lg" className={S.error}>
-        {error}
-      </Box>
-    );
+    return <Error message={error} />;
   }
 
   return (

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/utils.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/utils.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { t } from "ttag";
 
+import type { Dataset } from "metabase-types/api";
+
 export type PreviewType = ReturnType<
   typeof getTypeSelectorData
 >[number]["value"];
@@ -15,4 +17,18 @@ export function getTypeSelectorData() {
 
 export function usePreviewType() {
   return useState<PreviewType>("table");
+}
+
+export function getErrorMessage(data: Dataset): string {
+  const error = typeof data.error === "string" ? data.error : data.error?.data;
+
+  if (data.error_type === "invalid-query") {
+    return t`Something went wrong fetching the data for this field. This could mean something is wrong with the field settings, like a cast that is not supported for the underlying data type. Please check your settings and try again.`;
+  }
+
+  if (data.error_type === "missing-required-permissions") {
+    return t`You do not have permission to preview this field's data.`;
+  }
+
+  return error ?? t`Something went wrong`;
 }


### PR DESCRIPTION
Closes [SEM-244](https://linear.app/metabase/issue/SEM-244/data-model-table-preview)
Closes [SEM-245](https://linear.app/metabase/issue/SEM-245/data-model-detail-preview)

Adds the table and detail preview to the metadata editor.

### To verify
- Navigate to a table field in the metadata editor, ie. [admin/datamodel/database/1/schema/1%3APUBLIC/table/1/field/7](http://localhost:3000/admin/datamodel/database/1/schema/1%3APUBLIC/table/1/field/7)
- Play around with the settings and swithc between table and detail preview.


<img width="1474" alt="Screenshot 2025-05-19 at 12 08 22" src="https://github.com/user-attachments/assets/798ef854-ac0d-4c13-8683-9fce3aa87cb1" />

<img width="1474" alt="Screenshot 2025-05-19 at 12 08 25" src="https://github.com/user-attachments/assets/6836a6cc-70b0-473e-862b-082e469e4947" />

