### PR TITLE
fix(datagrid): improved row selection control

### DIFF
--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.stories.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.stories.tsx
@@ -286,6 +286,8 @@ export const CombinedFeatures: Story = () => {
 };
 
 export const SelectableRows: Story = () => {
+  const [rowSelection, setRowSelection] = useState<Record<number, boolean>>({});
+
   const columns: ColumnOptions<SampleDataType>[] = useMemo(
     () => [
       {
@@ -330,6 +332,8 @@ export const SelectableRows: Story = () => {
     columnsOptions: columns,
     columnPinning: { left: ["row_selection"] },
     enableRowSelection: true,
+    rowSelection,
+    onRowSelectionChange: setRowSelection,
     columnRowSelectOptions: {
       id: "row_selection",
       name: "Row Selection",

--- a/frontend/src/metabase/data-grid/hooks/use-data-grid-instance.tsx
+++ b/frontend/src/metabase/data-grid/hooks/use-data-grid-instance.tsx
@@ -1,7 +1,6 @@
 import {
   type ColumnSizingState,
   type PaginationState,
-  type RowSelectionState,
   getCoreRowModel,
   getPaginationRowModel,
   getSortedRowModel,
@@ -62,6 +61,8 @@ export const useDataGridInstance = <TData, TValue>({
   theme,
   pageSize,
   enableRowSelection,
+  rowSelection,
+  onRowSelectionChange,
   enableSelection,
   onColumnResize,
   onColumnReorder,
@@ -188,8 +189,6 @@ export const useDataGridInstance = <TData, TValue>({
   const enablePagination =
     pagination?.pageSize !== DISABLED_PAGINATION_STATE.pageSize;
 
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-
   const table = useReactTable({
     data,
     columns,
@@ -199,7 +198,7 @@ export const useDataGridInstance = <TData, TValue>({
       columnPinning: controlledColumnPinning ?? { left: [ROW_ID_COLUMN_ID] },
       sorting,
       pagination,
-      rowSelection,
+      rowSelection: rowSelection ?? {},
     },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -210,7 +209,7 @@ export const useDataGridInstance = <TData, TValue>({
     onColumnOrderChange: setColumnOrder,
     onColumnSizingChange: setColumnSizingMap,
     onPaginationChange: setPagination,
-    onRowSelectionChange: setRowSelection,
+    onRowSelectionChange,
     enableRowSelection,
   });
 

--- a/frontend/src/metabase/data-grid/types.ts
+++ b/frontend/src/metabase/data-grid/types.ts
@@ -5,9 +5,11 @@ import type {
   ColumnPinningState,
   ColumnSizingState,
   HeaderContext,
+  OnChangeFn,
   Row,
   RowData,
   RowSelectionOptions,
+  RowSelectionState,
   SortingState,
   Table,
 } from "@tanstack/react-table";
@@ -184,6 +186,12 @@ export interface DataGridOptions<TData = any, TValue = any> {
 
   /** Controlls whether row selection is enabled */
   enableRowSelection?: RowSelectionOptions<TData>["enableRowSelection"];
+
+  /** Row selection state */
+  rowSelection?: RowSelectionState;
+
+  /** Callback when row selection is changed */
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
 
   /** Items per page. Undefined disables pagination. */
   pageSize?: number;


### PR DESCRIPTION
The `rowSelection` state is moved outside of `useDataGridInstance` and passed as a prop. This allows better control over row selection state when UI components are placed outside of `DataGrid` (e.g. delete selected rows button which clears selection state after successful deletion)