### PR TITLE
WRK-380, WRK-387: Custom templates improvements

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
@@ -567,7 +567,7 @@ export const CreateOrEditTableNotificationModal = ({
             }}
           >
             <NotificationChannelsPicker
-              enableTemplates
+              enableTemplates={{ email: true, slack: true }}
               notificationHandlers={requestBody.handlers}
               channels={channelSpec ? channelSpec.channels : undefined}
               onChange={handleChannelHandlersChange}

--- a/frontend/src/metabase/components/CodeEditor/types.ts
+++ b/frontend/src/metabase/components/CodeEditor/types.ts
@@ -7,4 +7,5 @@ export type CodeLanguage =
   | "pug"
   | "python"
   | "ruby"
-  | "typescript";
+  | "typescript"
+  | "text/plain";

--- a/frontend/src/metabase/components/CodeEditor/utils.ts
+++ b/frontend/src/metabase/components/CodeEditor/utils.ts
@@ -23,7 +23,9 @@ import { type RefObject, useEffect } from "react";
 import S from "./CodeEditor.module.css";
 import type { CodeLanguage } from "./types";
 
-export function getLanguageExtension(language: CodeLanguage): Extension {
+export function getLanguageExtension(
+  language: CodeLanguage,
+): Extension | undefined {
   switch (language) {
     case "clojure":
       return StreamLanguage.define(clojure);

--- a/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.tsx
@@ -1,17 +1,14 @@
-import { useState } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
-import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import { Autocomplete } from "metabase/ui";
+import { MultiSelect } from "metabase/ui";
 import type { ChannelSpec, NotificationHandlerSlack } from "metabase-types/api";
 
 const CHANNEL_FIELD_NAME = "channel";
 const CHANNEL_PREFIX = "#";
 const USER_PREFIX = "@";
-
-const ALLOWED_PREFIXES = [CHANNEL_PREFIX, USER_PREFIX];
 
 interface SlackChannelFieldProps {
   channel: NotificationHandlerSlack;
@@ -25,67 +22,68 @@ export const SlackChannelFieldNew = ({
   channelSpec,
   onChange,
 }: SlackChannelFieldProps) => {
-  const [hasPrivateChannelWarning, setHasPrivateChannelWarning] =
-    useState(false);
-
   const channelField = channelSpec.fields?.find(
     (field) => field.name === CHANNEL_FIELD_NAME,
   );
-  const value = channel.recipients[0]?.details.value ?? "";
 
-  const updateChannel = (value: string) => {
-    onChange({
-      ...channel,
-      recipients: [
-        {
+  const value = useMemo(
+    () => channel.recipients.map((r) => r.details.value),
+    [channel],
+  );
+
+  const updateChannel = useCallback(
+    (value: string[]) => {
+      onChange({
+        ...channel,
+        recipients: value.map((v) => ({
           type: "notification-recipient/raw-value",
           details: {
-            value,
+            value: v,
           },
-        },
-      ],
+        })),
+      });
+    },
+    [channel, onChange],
+  );
+
+  const handleBlur = useCallback(() => {
+    const formattedValues = value.map((v) => {
+      if (v.startsWith(USER_PREFIX)) {
+        return v;
+      }
+      if (v.startsWith(CHANNEL_PREFIX)) {
+        return v;
+      }
+      return `${CHANNEL_PREFIX}${v}`;
     });
-  };
 
-  const handleChange = (value: string) => {
-    updateChannel(value);
-    setHasPrivateChannelWarning(false);
-  };
-
-  const handleBlur = () => {
-    const shouldAddPrefix =
-      value.length > 0 && !ALLOWED_PREFIXES.includes(value[0]);
-    const fullChannelName = shouldAddPrefix
-      ? `${CHANNEL_PREFIX}${value}`
-      : value;
-
-    if (shouldAddPrefix) {
-      updateChannel(fullChannelName);
-    }
-
-    const isPrivate =
-      value.trim().length > 0 && !channelField?.options?.includes(value);
-
-    setHasPrivateChannelWarning(isPrivate);
-  };
+    updateChannel(formattedValues);
+  }, [updateChannel, value]);
 
   const applicationName = useSelector(getApplicationName);
 
   return (
     <div>
-      <Autocomplete
+      <MultiSelect
+        multiple
+        searchable
+        hidePickedOptions
         data={channelField?.options || []}
         value={value}
         placeholder={t`Pick a user or channel...`}
         limit={300}
+        styles={{
+          input: {
+            paddingRight: "0.25rem",
+          },
+          section: {
+            display: "none",
+          },
+        }}
         onBlur={handleBlur}
-        onChange={handleChange}
+        onChange={updateChannel}
+        nothingFoundMessage={t`In order to send subscriptions and alerts to private Slack channels, you must first add the ${applicationName} bot to them.`}
       />
-      {hasPrivateChannelWarning && (
-        <div
-          className={CS.mt1}
-        >{t`In order to send subscriptions and alerts to private Slack channels, you must first add the ${applicationName} bot to them.`}</div>
-      )}
     </div>
   );
 };

--- a/frontend/src/metabase/notifications/modals/AlertsModals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/AlertsModals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -405,7 +405,7 @@ export const CreateOrEditQuestionAlertModal = ({
                   ? t`You're only allowed to email alerts to addresses ending in ${domains}`
                   : t`You're only allowed to email alerts to allowed domains`
               }
-              enableTemplates
+              enableTemplates={{ slack: true }}
               defaultTemplates={defaultTemplates}
               templateContext={templateContext}
             />

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -171,43 +171,44 @@ interface AccordionButtonProps {
   size?: number;
 }
 
-const TemplateButton = React.forwardRef<HTMLDivElement, AccordionButtonProps>(
-  function TemplateButton({ icon, label, onClick, size = 32 }, ref) {
-    return (
-      <Tooltip label={label} ref={ref}>
-        <ActionIcon
-          size={size}
-          variant="viewHeader"
-          style={{
-            cursor: "pointer",
-            backgrond: "transparent",
-            border: "none",
-          }}
-          onClickCapture={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onClick();
-          }}
-        >
-          <Icon name={icon} size={size * 0.6} />
-        </ActionIcon>
-      </Tooltip>
-    );
-  },
-);
+const TemplateToolbarButton = React.forwardRef<
+  HTMLDivElement,
+  AccordionButtonProps
+>(function TemplateToolbarButton({ icon, label, onClick, size = 32 }, ref) {
+  return (
+    <Tooltip label={label} ref={ref}>
+      <ActionIcon
+        size={size}
+        variant="viewHeader"
+        style={{
+          cursor: "pointer",
+          backgrond: "transparent",
+          border: "none",
+        }}
+        onClickCapture={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onClick();
+        }}
+      >
+        <Icon name={icon} size={size * 0.6} />
+      </ActionIcon>
+    </Tooltip>
+  );
+});
 
-interface TemplateHelperTooltipProps {
-  payload?: any;
+interface TemplateInfoTooltipProps {
+  context?: Record<string, any>;
 }
 
-const TemplateHelperTooltip = ({ payload }: TemplateHelperTooltipProps) => {
+const TemplateInfoTooltip = ({ context }: TemplateInfoTooltipProps) => {
   const [open, setOpen] = useState(false);
-  const formattedPayload = useMemo(() => {
-    if (!payload) {
+  const formattedContext = useMemo(() => {
+    if (!context) {
       return "";
     }
-    return JSON.stringify(payload, null, 2);
-  }, [payload]);
+    return JSON.stringify(context, null, 2);
+  }, [context]);
 
   return (
     <Popover
@@ -220,7 +221,7 @@ const TemplateHelperTooltip = ({ payload }: TemplateHelperTooltipProps) => {
       onChange={setOpen}
     >
       <Popover.Target>
-        <TemplateButton
+        <TemplateToolbarButton
           icon="info"
           label={t`Template instructions`}
           onClick={() => setOpen(!open)}
@@ -265,7 +266,7 @@ const TemplateHelperTooltip = ({ payload }: TemplateHelperTooltipProps) => {
             overflowY: "auto",
           }}
         >
-          <CodeEditor language="json" value={formattedPayload} />
+          <CodeEditor language="json" value={formattedContext} />
         </div>
       </Popover.Dropdown>
     </Popover>
@@ -658,17 +659,17 @@ export const NotificationChannelsPicker = ({
                 >{t`Custom email template`}</Text>
                 <Flex gap="sm" align="center" mr="0.25rem">
                   {!!emailHandler.template && (
-                    <TemplateButton
+                    <TemplateToolbarButton
                       icon="history"
                       label={t`Reset to default`}
                       onClick={() => resetTemplateForChannel("email")}
                     />
                   )}
-                  <TemplateHelperTooltip
-                    payload={templateContext["channel/email"]}
+                  <TemplateInfoTooltip
+                    context={templateContext["channel/email"]}
                   />
                   {onPreviewClick && (
-                    <TemplateButton
+                    <TemplateToolbarButton
                       icon="eye"
                       label={isPreviewOpen ? t`Close preview` : t`Show preview`}
                       onClick={() =>
@@ -756,14 +757,14 @@ export const NotificationChannelsPicker = ({
                 >{t`Custom Slack message`}</Text>
                 <Flex gap="xs" align="center">
                   {!!slackHandler.template && (
-                    <TemplateButton
+                    <TemplateToolbarButton
                       icon="history"
                       label={t`Reset to default`}
                       onClick={() => resetTemplateForChannel("slack")}
                     />
                   )}
-                  <TemplateHelperTooltip
-                    payload={templateContext["channel/slack"]}
+                  <TemplateInfoTooltip
+                    context={templateContext["channel/slack"]}
                   />
                 </Flex>
               </Flex>

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -144,7 +144,10 @@ interface NotificationChannelsPickerProps {
   channels: ChannelApiResponse["channels"] | undefined;
   onChange: (newHandlers: NotificationHandler[]) => void;
   getInvalidRecipientText?: (domains: string) => string;
-  enableTemplates?: boolean;
+  enableTemplates?: {
+    email?: boolean;
+    slack?: boolean;
+  };
   templateContext?: Record<string, any>;
   onPreviewClick?: (channelType: NotificationChannelType) => void;
   isPreviewOpen?: boolean;
@@ -289,7 +292,7 @@ export const NotificationChannelsPicker = ({
   channels: nullableChannels,
   onChange,
   getInvalidRecipientText = defaultGetInvalidRecipientText,
-  enableTemplates = false,
+  enableTemplates,
   templateContext = {},
   onPreviewClick,
   isPreviewOpen,
@@ -640,7 +643,7 @@ export const NotificationChannelsPicker = ({
             invalidRecipientText={getInvalidRecipientText}
             onChange={(newConfig) => onChannelChange(emailHandler, newConfig)}
           />
-          {enableTemplates && (
+          {enableTemplates?.email && (
             <Stack
               mt="sm"
               className={cx({ [S.defaultTemplate]: !emailHandler.template })}
@@ -738,7 +741,7 @@ export const NotificationChannelsPicker = ({
             channelSpec={channels.slack as SlackChannelSpec}
             onChange={(newConfig) => onChannelChange(slackHandler, newConfig)}
           />
-          {enableTemplates && (
+          {enableTemplates?.slack && (
             <Stack
               mt="sm"
               className={cx({ [S.defaultTemplate]: !slackHandler.template })}
@@ -772,10 +775,12 @@ export const NotificationChannelsPicker = ({
                   placeholder={t`Your custom Markdown template`}
                   templateContext={templateContext["channel/slack"]}
                   defaultValue={getTemplateValue("slack", "body")}
+                  onChange={(value) => {
+                    handleTemplateBlur("slack", "body", value);
+                  }}
                   onBlur={(newValue) => {
                     handleTemplateBlur("slack", "body", newValue);
                   }}
-                  language="markdown"
                 />
               </Stack>
             </Stack>

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -539,10 +539,11 @@ export const NotificationChannelsPicker = ({
     }
   };
 
-  const handleTemplateBlur = (
+  const handleTemplateChange = (
     channel: "email" | "slack",
     field: "subject" | "body",
     value: string,
+    isFocused = false,
   ) => {
     const updateAction: TemplateAction = {
       type: "UPDATE_TEMPLATE",
@@ -573,7 +574,7 @@ export const NotificationChannelsPicker = ({
       }));
 
       if (bothEmpty) {
-        shouldRemove = !isCurrentTemplateNull;
+        shouldRemove = !isCurrentTemplateNull && !isFocused;
       } else if (bothFilled) {
         shouldUpdate = true;
       }
@@ -581,7 +582,7 @@ export const NotificationChannelsPicker = ({
       // Slack
       // No validation, since it's always valid (either empty of filled)
       if (!hasBody) {
-        shouldRemove = !isCurrentTemplateNull;
+        shouldRemove = !isCurrentTemplateNull && !isFocused;
       } else {
         shouldUpdate = true;
       }
@@ -688,10 +689,15 @@ export const NotificationChannelsPicker = ({
                     templateContext={templateContext["channel/email"]}
                     defaultValue={getTemplateValue("email", "subject")}
                     onChange={(value) => {
-                      handleTemplateBlur("email", "subject", value);
+                      handleTemplateChange("email", "subject", value, true);
                     }}
                     onFocus={(initialValue) => {
-                      handleTemplateBlur("email", "subject", initialValue);
+                      handleTemplateChange(
+                        "email",
+                        "subject",
+                        initialValue,
+                        true,
+                      );
                     }}
                     error={
                       validationErrors.email.subject
@@ -711,10 +717,13 @@ export const NotificationChannelsPicker = ({
                     height="10rem"
                     defaultValue={getTemplateValue("email", "body")}
                     onFocus={(initialValue) => {
-                      handleTemplateBlur("email", "body", initialValue);
+                      handleTemplateChange("email", "body", initialValue, true);
                     }}
                     onChange={(value) => {
-                      handleTemplateBlur("email", "body", value);
+                      handleTemplateChange("email", "body", value, true);
+                    }}
+                    onBlur={(value) => {
+                      handleTemplateChange("email", "body", value);
                     }}
                     error={
                       validationErrors.email.body
@@ -777,10 +786,10 @@ export const NotificationChannelsPicker = ({
                   templateContext={templateContext["channel/slack"]}
                   defaultValue={getTemplateValue("slack", "body")}
                   onChange={(value) => {
-                    handleTemplateBlur("slack", "body", value);
+                    handleTemplateChange("slack", "body", value, true);
                   }}
                   onBlur={(newValue) => {
-                    handleTemplateBlur("slack", "body", newValue);
+                    handleTemplateChange("slack", "body", newValue);
                   }}
                 />
               </Stack>

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.unit.spec.tsx
@@ -220,7 +220,10 @@ describe("NotificationChannelsPicker", () => {
           createMockNotificationHandlerSlack(),
         ],
         defaultTemplates,
-        enableTemplates: true,
+        enableTemplates: {
+          email: true,
+          slack: true,
+        },
       });
       // Email template editor should show default subject/body
       expect(
@@ -250,7 +253,10 @@ describe("NotificationChannelsPicker", () => {
             },
           },
         },
-        enableTemplates: true,
+        enableTemplates: {
+          email: true,
+          slack: true,
+        },
       });
       // Confirm initial value
       expect(
@@ -285,7 +291,7 @@ describe("NotificationChannelsPicker", () => {
               },
             },
           }}
-          enableTemplates={true}
+          enableTemplates={{ email: true, slack: true }}
         />,
       );
       // TemplateEditor should update
@@ -309,7 +315,10 @@ describe("NotificationChannelsPicker", () => {
             },
           },
         },
-        enableTemplates: true,
+        enableTemplates: {
+          email: true,
+          slack: true,
+        },
       });
       const subjectInput = await screen.findByDisplayValue("Default subject");
       await userEvent.clear(subjectInput);
@@ -324,7 +333,10 @@ describe("NotificationChannelsPicker", () => {
       setup({
         isEmailSetup: true,
         notificationHandlers: [createMockNotificationHandlerEmail()],
-        enableTemplates: true,
+        enableTemplates: {
+          email: true,
+          slack: true,
+        },
       });
       expect(
         await screen.findByPlaceholderText("Your custom email template"),

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/test-utils.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/test-utils.tsx
@@ -38,7 +38,10 @@ export interface SetupOpts {
       };
     }
   > | null;
-  enableTemplates?: boolean;
+  enableTemplates?: {
+    email?: boolean;
+    slack?: boolean;
+  };
 }
 
 export const setup = ({
@@ -51,7 +54,7 @@ export const setup = ({
   notificationHandlers = [],
   onChange = jest.fn(),
   defaultTemplates = null,
-  enableTemplates = false,
+  enableTemplates,
 }: SetupOpts = {}) => {
   const settings = mockSettings({
     "token-features": createMockTokenFeatures({

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -89,7 +89,7 @@ export const TemplateEditor = ({
   defaultValue = "",
   onChange,
   minHeight = "5rem",
-  language = "html",
+  language = "text/plain",
   placeholder,
   className,
   variant = "textarea",


### PR DESCRIPTION
Closes [WRK-380](https://linear.app/metabase/issue/WRK-380/until-you-blur-codemirror-instance-template-is-not-synced-to-the-text), [WRK-387](https://linear.app/metabase/issue/WRK-387/add-possibility-to-send-alerts-to-multiple-slack-channels)

- allow selecting multiple channels/users for Slack alerts
- disable markdown highlighting for Slack template editor
- fix onChange handling in Alerts templates