### PR TITLE
Fix past1hours and past1seconds filters

### DIFF
--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -398,7 +398,7 @@
 
 (mu/defn- adjust-inclusive-range-if-needed :- [:maybe TemporalRange]
   "Make an inclusive date range exclusive as needed."
-  [{:keys [inclusive-start? inclusive-end?]} temporal-range :- [:maybe TemporalRange]]
+  [temporal-range :- [:maybe TemporalRange] {:keys [inclusive-start? inclusive-end?]}]
   (-> temporal-range
       (m/update-existing :start #(if inclusive-start?
                                    %
@@ -434,6 +434,20 @@
       (m/update-existing :end u.date/format)
       (dissoc :unit)))
 
+(defn- date-string->raw-range
+  [date-string]
+  (let [now (t/local-date-time)]
+    ;; Relative dates respect the given time zone because a notion like "last 7 days" might mean a different range of
+    ;; days depending on the user timezone
+    (or (execute-decoders relative-date-string-decoders :range now date-string)
+        ;; Absolute date ranges don't need the time zone conversion because in SQL the date ranges are compared
+        ;; against the db field value that is casted granularity level of a day in the db time zone
+        (execute-decoders absolute-date-string-decoders :range nil date-string)
+        ;; if both of the decoders above fail, then the date string is invalid
+        (throw (ex-info (tru "Don''t know how to parse date param ''{0}'' — invalid format" date-string)
+                        {:param date-string
+                         :type  qp.error-type/invalid-parameter})))))
+
 (mu/defn date-string->range :- DateStringRange
   "Takes a string description of a date range such as `lastmonth` or `2016-07-15~2016-08-6` and returns a map with
   `:start` and/or `:end` keys, as ISO-8601 *date* strings. By default, `:start` and `:end` are inclusive,
@@ -456,22 +470,10 @@
   ([date-string  :- ::lib.schema.common/non-blank-string
     {:keys [inclusive-start? inclusive-end?]
      :or   {inclusive-start? true inclusive-end? true}}]
-   (let [options {:inclusive-start? inclusive-start?, :inclusive-end? inclusive-end?}
-         now (t/local-date-time)]
-     ;; Relative dates respect the given time zone because a notion like "last 7 days" might mean a different range of
-     ;; days depending on the user timezone
-     (or (->> (execute-decoders relative-date-string-decoders :range now date-string)
-              (adjust-inclusive-range-if-needed options)
-              format-date-range)
-         ;; Absolute date ranges don't need the time zone conversion because in SQL the date ranges are compared
-         ;; against the db field value that is casted granularity level of a day in the db time zone
-         (->> (execute-decoders absolute-date-string-decoders :range nil date-string)
-              (adjust-inclusive-range-if-needed options)
-              format-date-range)
-         ;; if both of the decoders above fail, then the date string is invalid
-         (throw (ex-info (tru "Don''t know how to parse date param ''{0}'' — invalid format" date-string)
-                         {:param date-string
-                          :type  qp.error-type/invalid-parameter}))))))
+   (let [options {:inclusive-start? inclusive-start?, :inclusive-end? inclusive-end?}]
+     (-> (date-string->raw-range date-string)
+         (adjust-inclusive-range-if-needed options)
+         format-date-range))))
 
 (defn- date-str->qp-aware-offset-dt
   "Generate offset datetime from `date-str` with respect to qp's `results-timezone`."
@@ -539,14 +541,16 @@
   [raw-date-str field-type]
   (let [;; `raw-date-str` is sanitized in case it contains millis and timezone which are incompatible
         ;; with [[date-string->range]]. `substitute-field-filter-test` expects that to happen.
-        range-raw (try (date-string->range raw-date-str)
-                       (catch Throwable _
-                         (fallback-raw-range raw-date-str)))
+        [range-raw unit] (try (let [r (date-string->raw-range raw-date-str)]
+                                [(format-date-range r) (:unit r)])
+                              (catch Throwable _
+                                [(fallback-raw-range raw-date-str) :day]))
         date-str-conversion (if (isa? field-type :type/DateTimeWithTZ)
                               date-str->qp-aware-offset-dt
                               date-str->local-dt)]
     (-> (update-vals range-raw date-str-conversion)
-        (m/update-existing :end exclusive-datetime-range-end (date-str->unit-fn (:end range-raw)))
+        (m/update-existing :end exclusive-datetime-range-end (or ({:second t/seconds, :hour t/hours} unit)
+                                                                 (date-str->unit-fn (:end range-raw))))
         (maybe-adjust-open-range (date-str->unit-fn ((some-fn :start :end) range-raw)))
         format-date-range)))
 


### PR DESCRIPTION
Fixes #57767 

### Description

This is a minimal change to make sure past1hours and past1seconds filters generate 1 hour and 1 second intervals respectively.

These filters are problematic, because they "bucket" to minute unit and complicated, because we >= for the "After" filters although we want them to mean strictly after. These problems will be solved as a properly planned feature, not as a bugfix (see the [slack conversation](https://metaboat.slack.com/archives/C0645JP1W81/p1747150935283919?thread_ts=1747146990.283349&cid=C0645JP1W81)).

### How to verify

Repeat the reproduction steps from #57767 and check that the generated query filters a one hour period, not a one minute one.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
