### PR TITLE
Manual backport of #57871

### DIFF
--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -142,7 +142,7 @@
    "/collection"           (+auth 'metabase.api.collection)
    "/dashboard"            (+auth 'metabase.api.dashboard)
    "/database"             (+auth 'metabase.api.database)
-   "/dataset"              'metabase.api.dataset
+   "/dataset"              (+auth 'metabase.api.dataset)
    "/docs"                 (metabase.api.docs/make-routes #'routes)
    "/email"                metabase.channel.api/email-routes
    "/embed"                (+message-only-exceptions 'metabase.api.embed)


### PR DESCRIPTION
description to appease brittle .js code in release milestone checks