### PR TITLE
AI Question Analysis: sent timeline events only from the same collection as the chart

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
@@ -49,7 +49,11 @@ export function AIQuestionAnalysisSidebar({
 
     const timelineEvents =
       timelines
-        ?.flatMap((timeline) =>
+        ?.filter(
+          (timeline) =>
+            timeline.collection_id === question.card().collection_id,
+        )
+        .flatMap((timeline) =>
           timeline.events?.map((event) => ({
             name: event.name,
             description: event.description ?? undefined,

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
+import fetchMock from "fetch-mock";
 
 import { setupAnalyzeChartEndpoint } from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
@@ -44,5 +45,72 @@ describe("AIQuestionAnalysisSidebar", () => {
 
     const copyButton = await screen.findByLabelText("copy icon");
     expect(copyButton).toBeInTheDocument();
+  });
+
+  it("should send only timeline events from the question's collection", async () => {
+    const collectionId = 42;
+
+    const question = new Question(
+      createMockCard({
+        collection_id: collectionId,
+      }),
+    );
+
+    const timelineEventSameCollection = {
+      name: "Release v1",
+      description: "Released version 1",
+      timestamp: "2024-05-12T00:00:00Z",
+    };
+
+    const timelines = [
+      {
+        collection_id: collectionId,
+        events: [timelineEventSameCollection],
+      },
+      {
+        // Different collection – should be ignored
+        collection_id: collectionId + 1,
+        events: [
+          {
+            name: "Irrelevant event",
+            description: "Should be filtered out",
+            timestamp: "2024-05-13T00:00:00Z",
+          },
+        ],
+      },
+    ];
+
+    const mockResponse: AIEntityAnalysisResponse = {
+      summary: "Filtered analysis",
+    };
+
+    setupAnalyzeChartEndpoint(mockResponse);
+
+    renderWithProviders(
+      <AIQuestionAnalysisSidebar
+        question={question}
+        onClose={jest.fn()}
+        timelines={timelines as any}
+      />,
+      {
+        storeInitialState: {
+          qb: createMockQueryBuilderState({
+            queryStatus: "complete",
+          }),
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Filtered analysis")).toBeInTheDocument();
+    });
+
+    const lastCallRequest = fetchMock.lastCall(
+      "path:/api/ee/ai-entity-analysis/analyze-chart",
+    )?.request;
+    const body = await lastCallRequest?.json();
+
+    expect(body.timeline_events).toHaveLength(1);
+    expect(body.timeline_events[0]).toMatchObject(timelineEventSameCollection);
   });
 });


### PR DESCRIPTION
Closes [BOT-126](https://linear.app/metabase/issue/BOT-126/chart-summary-only-sent-events-in-collection)

### Description

This PR ensures only timeline events from the same collection as the question are sent to the AI Entity Analysis.

### How to verify

- Run Metabase EE
- Create some timeline events in the Our Analytics collection
- Create a nested Collection 1
- Create another timeline events in Collection 1
- Create [Orders Count by Created At] timeseries line chart in Collection 1
- Open the network tab in dev tools
- Click on the Metabot analysis button
- Ensure it sends timeline events only from Collection 1

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
