### PR TITLE
perf: Small optimizations for metabase.search.spec

### DIFF
--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -153,9 +153,10 @@
          (not (str/includes? (name kw) ".")))))
 
 (defn- get-table [kw]
-  (let [parts (str/split (name kw) #"\.")]
-    (when (> (count parts) 1)
-      (keyword (first parts)))))
+  (let [kws (name kw)
+        dot (str/index-of kws ".")]
+    (when (and dot (< dot (count kws)))
+      (keyword (subs kws 0 dot)))))
 
 (defn- remove-table [table kw]
   (if (and table (not (namespace kw)))
@@ -169,18 +170,18 @@
 
 (defn- find-fields-kw [kw]
   ;; Filter out SQL functions
-  (when-not (str/starts-with? (name kw) "%")
-    (when-not (#{:else :integer :float} kw)
-      (let [table (get-table kw)]
-        (list [(or table :this) (remove-table table kw)])))))
+  (when-not (or (str/starts-with? (name kw) "%")
+                (#{:else :integer :float} kw))
+    (let [table (get-table kw)]
+      [[(or table :this) (remove-table table kw)]])))
 
 (defn- find-fields-expr [expr]
   (cond
     (keyword? expr)
     (find-fields-kw expr)
 
-    (vector? expr)
-    (mapcat find-fields-expr (rest expr))))
+    (and (vector? expr) (> (count expr) 1))
+    (into [] (mapcat find-fields-expr) (subvec expr 1))))
 
 (defn- find-fields-attr [[k v]]
   (when v
@@ -199,10 +200,10 @@
 (defn- find-fields-top [x]
   (cond
     (map? x)
-    (mapcat find-fields-attr x)
+    (into [] (mapcat find-fields-attr) x)
 
     (sequential? x)
-    (mapcat find-fields-select-item x)
+    (into [] (mapcat find-fields-select-item) x)
 
     :else
     (throw (ex-info "Unexpected format for fields" {:x x}))))
@@ -210,13 +211,12 @@
 (defn- find-fields
   "Search within a definition for all the fields referenced on the given table alias."
   [spec]
-  (u/group-by first second conj #{}
-              (concat
-               (mapcat
-                find-fields-top
-                ;; Remove the keys with special meanings (should probably switch this to an allowlist rather)
-                (vals (dissoc spec :name :visibility :native-query :where :joins :bookmark :model)))
-               (find-fields-expr (:where spec)))))
+  (u/group-by #(nth % 0) #(nth % 1) conj #{}
+              (-> []
+                  (into (mapcat find-fields-top)
+                        ;; Remove the keys with special meanings (should probably switch this to an allowlist rather)
+                        (vals (dissoc spec :name :visibility :native-query :where :joins :bookmark :model)))
+                  (into (find-fields-expr (:where spec))))))
 
 (defn- replace-qualification [expr from to]
   (cond
@@ -254,16 +254,16 @@
   [spec]
   (let [s      (:name spec)
         fields (find-fields spec)]
-    (into {}
-          (cons
-           [(:model spec) #{{:search-model s
-                             :fields       (:this (find-fields spec))
-                             :where        (construct-source-where (-> spec :attrs :id))}}]
-           (for [[table-alias [model join-condition]] (:joins spec)]
-             (let [table-fields (fields table-alias)]
-               [model #{{:search-model s
-                         :fields       table-fields
-                         :where        (replace-qualification join-condition table-alias :updated)}}]))))))
+    (reduce (fn [res [table-alias [model join-condition]]]
+              (let [table-fields (fields table-alias)]
+                (assoc res model #{{:search-model s
+                                    :fields       table-fields
+                                    :where        (replace-qualification join-condition table-alias :updated)}})))
+
+            {(:model spec) #{{:search-model s
+                              :fields       (:this (find-fields spec))
+                              :where        (construct-source-where (-> spec :attrs :id))}}}
+            (:joins spec))))
 
 (defn- merge-hooks
   "Combine the search index hooks corresponding to different search models."


### PR DESCRIPTION
`metabase.search.spec/search-model-hooks` often comes up in a profiler when running tests. The presented changes cut the allocation and running time of these functions by half.