### PR TITLE
Support markdown messages from Metabot

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
@@ -165,6 +165,7 @@
 .responseMessage code {
   background-color: rgba(255, 255, 255, 0.2);
   padding: 0.1rem 0.3rem;
+  margin-right: 0.25rem;
   border-radius: 3px;
   font-family: monospace;
   font-size: 0.8rem;
@@ -178,6 +179,8 @@
   overflow-x: auto;
   margin: 0.5rem 0;
   width: 100%;
+  white-space: pre-wrap; /* CSS3 */
+  word-wrap: break-word; /* Modern browsers */
 }
 
 .responseMessage pre code {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
@@ -135,10 +135,106 @@
   pointer-events: auto;
   margin-bottom: 0.25rem;
   position: relative;
+  max-width: 90%;
+  align-items: flex-start;
 }
 
 .responseMessage {
   flex-grow: 1;
+  line-height: 1.5;
+}
+
+/* Markdown specific styles */
+.responseMessage p {
+  margin: 0.5rem 0;
+}
+
+.responseMessage p:first-of-type {
+  margin-top: 0;
+}
+
+.responseMessage p:last-of-type {
+  margin-bottom: 0;
+}
+
+.responseMessage a {
+  color: white;
+  text-decoration: underline;
+}
+
+.responseMessage code {
+  background-color: rgba(255, 255, 255, 0.2);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 0.8rem;
+  font-weight: normal;
+}
+
+.responseMessage pre {
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 0.5rem;
+  border-radius: 5px;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+  width: 100%;
+}
+
+.responseMessage pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+.responseMessage ul,
+.responseMessage ol {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+
+.responseMessage ul {
+  list-style-type: disc;
+}
+
+.responseMessage ol {
+  list-style-type: decimal;
+}
+
+.responseMessage li {
+  margin-bottom: 0.25rem;
+}
+
+.responseMessage table {
+  border-collapse: collapse;
+  margin: 0.5rem 0;
+  width: 100%;
+}
+
+.responseMessage th,
+.responseMessage td {
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}
+
+.responseMessage th {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.responseMessage h1,
+.responseMessage h2,
+.responseMessage h3,
+.responseMessage h4,
+.responseMessage h5,
+.responseMessage h6 {
+  margin: 0.5rem 0;
+  font-weight: bold;
+}
+
+.responseMessage blockquote {
+  border-left: 3px solid rgba(255, 255, 255, 0.5);
+  margin: 0.5rem 0;
+  padding-left: 0.75rem;
+  font-style: italic;
 }
 
 button.responseDismissBtn {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import { useCallback, useRef, useState } from "react";
 import { t } from "ttag";
 
+import Markdown from "metabase/core/components/Markdown";
 import { Box, Flex, Icon, Textarea, UnstyledButton } from "metabase/ui";
 
 import { useMetabotAgent } from "../../hooks";
@@ -84,7 +85,9 @@ export const MetabotChat = ({ onClose }: { onClose: () => void }) => {
               key={msg}
               data-testid="metabot-chat-message"
             >
-              <Box>{msg}</Box>
+              <Markdown unstyleLinks className={Styles.responseMessage}>
+                {msg}
+              </Markdown>
               <UnstyledButton
                 className={Styles.responseDismissBtn}
                 onClick={() => metabot.dismissUserMessage(index)}


### PR DESCRIPTION
## Context

Metabot currently cannot render markdown responses. I quickly gave it a try to add it locally.
<img width="518" alt="image" src="https://github.com/user-attachments/assets/53cf50c4-62c4-428f-bab7-4628110ce00b" />


## What to look for

Please deeply check the CSS. I just vibe coded that part. I am also not sure whether we have some global Markdown CSS to use by default.