### PR TITLE
fix: editable settings without column order settings

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
@@ -72,7 +72,7 @@ export const EditTableDataGrid = ({
 
   const columnOrder = useMemo(
     () =>
-      columnsConfig
+      columnsConfig?.columnOrder.length
         ? [ROW_SELECT_COLUMN_ID, ...columnsConfig.columnOrder]
         : [ROW_SELECT_COLUMN_ID, ...cols.map(({ name }) => name)],
     [cols, columnsConfig],

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
@@ -144,7 +144,7 @@ export function EditingBaseRowModal({
 
   // Columns might be reordered to match the order in `columnsConfig`
   const orderedDatasetColumns = useMemo(() => {
-    if (!columnsConfig) {
+    if (!columnsConfig?.columnOrder.length) {
       return datasetColumns;
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
@@ -24,16 +24,10 @@ export function useEditableTableColumnConfigFromVisualizationSettings(
     const editableColumns =
       visualizationSettings["table.editableColumns"] ?? [];
 
-    if (columnSettings.length === 0) {
-      return undefined;
-    }
-
-    const isAllColumnsEditable = editableColumns.length === 0;
     const editableColumnSet = new Set(editableColumns);
 
     const columnOrder: string[] = [];
     const columnVisibilityMap: Record<string, boolean> = {};
-    const readonlyColumnSet = new Set<string>();
     const hiddenColumnSet = new Set<string>();
 
     for (const column of columnSettings) {
@@ -43,10 +37,6 @@ export function useEditableTableColumnConfigFromVisualizationSettings(
       if (!column.enabled) {
         hiddenColumnSet.add(column.name);
       }
-
-      if (!isAllColumnsEditable && !editableColumnSet.has(column.name)) {
-        readonlyColumnSet.add(column.name);
-      }
     }
 
     return {
@@ -54,7 +44,8 @@ export function useEditableTableColumnConfigFromVisualizationSettings(
       columnVisibilityMap,
       isColumnHidden: (columnName: string) => hiddenColumnSet.has(columnName),
       isColumnReadonly: (columnName: string) =>
-        readonlyColumnSet.has(columnName),
+        // If there are no editable columns settings, all columns are editable
+        editableColumnSet.size > 0 && !editableColumnSet.has(columnName),
     };
   }, [visualizationSettings]);
 }


### PR DESCRIPTION
Resolves [WRK-391](https://linear.app/metabase/issue/WRK-391/non-editable-settings-doesnt-work-for-editables-as-expected)
