### PR TITLE
remove double concurrency group causing deadlock

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -3,10 +3,6 @@ name: E2E Cross-version Component Tests for Embedding SDK
 on:
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   files-changed:
     name: Check which files changed


### PR DESCRIPTION
On both backports of :merged: [fix(ci-sdk): make cross versions tests run again](https://github.com/metabase/metabase/pull/57856) I was runningo into cancelled tasks beacuse `Canceling since a deadlock for concurrency group 'Embedding SDK-refs/pull/57953/merge' was detected between 'top level workflow' and 'e2e-component-tests-embedding-sdk-cross-version'`
![image](https://github.com/user-attachments/assets/118be9ea-20aa-472a-a935-230c23dbffb9)

This removes the duplicated concurrency group (one is already there on `.github/workflows/embedding-sdk.yml`) so that the jobs actually start 🙃 

The commit from this PR is already on both PRs(https://github.com/metabase/metabase/pull/57953 and https://github.com/metabase/metabase/pull/57954), as I wanted to make sure it actually worked this time 🙃 🙃 🙃 