### PR TITLE
Stop returning field values in the answer-sources response

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -380,7 +380,7 @@
                                    :type :metric}]
             (mt/with-temp [:model/Card {model-metric-id :id} (assoc model-metric-data :collection_id collection-id)]
               (ensure-field-values! :products)
-              (testing "Calling with Wrong metabot-id"
+              (testing "Calling with wrong metabot-id"
                 (let [conversation-id (str (random-uuid))
                       ai-token (ai-session-token (str metabot-id "-"))]
                   (mt/user-http-request :rasta :post 400 "ee/metabot-tools/answer-sources"
@@ -395,10 +395,10 @@
                                                       :conversation_id conversation-id})
                       expected-fields
                       [{:name "ID", :type "number", :semantic_type "pk"}
-                       {:name "Ean", :type "string", :field_values string-sequence?}
-                       {:name "Title", :type "string", :semantic_type "title", :field_values string-sequence?}
-                       {:name "Category", :type "string", :semantic_type "category", :field_values string-sequence?}
-                       {:name "Vendor", :type "string", :semantic_type "company", :field_values string-sequence?}
+                       {:name "Ean", :type "string"}
+                       {:name "Title", :type "string", :semantic_type "title"}
+                       {:name "Category", :type "string", :semantic_type "category"}
+                       {:name "Vendor", :type "string", :semantic_type "company"}
                        {:name "Price", :type "number"}
                        {:name "Rating", :type "number", :semantic_type "score"}
                        {:name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]]


### PR DESCRIPTION
Fixes BOT-137

Describe the overall approach and the problem being solved.

### How to verify

The answer-sources endpoint makes lots of DB requests and is very slow. A big part of the slowness is caused by reading the field values. These values are not always necessary, so this is the first step in reducing unnecessary work.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
