### PR TITLE
Fix Undo / Redo

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -187,7 +187,8 @@
             :let [rows (batch->rows undo? sub-batch)
                   iid  (nano-id/nano-id)
                   opts {:existing-context {:invocation_id    iid
-                                           :invocation-stack [[action-kw iid]]}}]]
+                                           :invocation-stack [[action-kw iid]]
+                                           :scope            scope}}]]
       (case (if undo? (invert category) category)
         :create (try (data-editing/perform-bulk-action! :table.row/create user-id scope table-id rows opts)
                      (catch Exception e


### PR DESCRIPTION
These broke because there was a bug in how we passed the `:scope` from undo 

Two things:

1. Sprinkling some new malli type checks in a few more places would have found this bug. Let's do that.
2. The work cleaning things up to make `undo` and `redo` into first class actions will delete a lot of this machinery, making it perfectly tested code by definition.