### PR TITLE
Introduce new data-grid actions to replace CRUD endpoints

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
@@ -1,0 +1,70 @@
+(ns metabase-enterprise.data-editing.actions
+  (:require
+   [clojure.spec.alpha :as s]
+   [metabase-enterprise.data-editing.data-editing :as data-editing]
+   [metabase.actions.actions :as actions]
+   [metabase.lib.schema.actions :as lib.schema.actions]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]))
+
+(derive :data-grid/create :data-grid/common)
+(derive :data-grid/update :data-grid/common)
+(derive :data-grid/delete :data-grid/common)
+
+(s/def :actions.args.data-grid/common
+  :actions.args.crud.table/row)
+
+(defmethod actions/action-arg-map-spec :data-grid/common
+  [_action]
+  :actions.args.data-grid/common)
+
+(defmethod actions/normalize-action-arg-map :data-grid/common
+  [_action input]
+  (update-keys input u/qualified-name))
+
+(defn- scope->table-id [context]
+  (u/prog1 (-> context :scope :table-id)
+    (when-not <>
+      (throw (ex-info "Cannot perform data-grid actions without a table in scope."
+                      {:error :data-grid/unknown-table})))))
+
+(defn- map-inputs [table-id inputs]
+  (for [row (data-editing/apply-coercions table-id inputs)]
+    {:table-id table-id :row row}))
+
+(defn- perform-table-row-action! [action-kw context inputs]
+  (->> (actions/perform-action!* action-kw context inputs)
+       :context :effects
+       (filter (comp #{:effect/row.modified} first))
+       (map second)
+       (map :after)))
+
+(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid/create]
+  [_action context inputs :- [:sequential ::lib.schema.actions/row]]
+  ;; We could enhance this in future to work more richly with multi-table editable models.
+  (let [table-id    (scope->table-id context)
+        next-inputs (map-inputs table-id inputs)
+        rows-after  (perform-table-row-action! :table.row/create context next-inputs)]
+    ;; todo add on effects
+    {:context context
+     :outputs (data-editing/invalidate-and-present! table-id rows-after)}))
+
+(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid/update]
+  [_action context inputs :- [:sequential ::lib.schema.actions/row]]
+  ;; We could enhance this in future to work more richly with multi-table editable models.
+  (let [table-id (scope->table-id context)
+        next-inputs (map-inputs table-id inputs)
+        rows-after  (perform-table-row-action! :table.row/update context next-inputs)]
+    ;; todo add on effects
+    {:context context
+     :outputs (data-editing/invalidate-and-present! table-id rows-after)}))
+
+(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid/delete]
+  [_action context inputs :- [:sequential ::lib.schema.actions/row]]
+  ;; We could enhance this in future to work more richly with multi-table editable models.
+  (let [table-id    (scope->table-id context)
+        next-inputs (map-inputs table-id inputs)
+        _           (perform-table-row-action! :table.row/delete context next-inputs)]
+    ;; todo add on effects
+    {:context context
+     :outputs [{:success true}]}))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.data-editing.api
   (:require
-   [clojure.set :as set]
    [metabase-enterprise.data-editing.data-editing :as data-editing]
    [metabase-enterprise.data-editing.undo :as undo]
    [metabase.actions.core :as actions]
@@ -11,7 +10,6 @@
    [metabase.driver :as driver]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [tru]]
-   [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
   (:import

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -39,7 +39,7 @@
   (let [;; This is a bit unfortunate... we ignore the table-id in the path when called with a custom scope...
         ;; The solution is to stop accepting custom scope once we migrate the data grid to action/execute
         scope (or scope {:table-id table-id})]
-    {:created-rows (:outputs (actions/perform-action! :data-grid/update scope rows))}))
+    {:created-rows (:outputs (actions/perform-action! :data-grid/create scope rows))}))
 
 (api.macros/defendpoint :put "/table/:table-id"
   "Update row(s) within the given table."

--- a/enterprise/backend/src/metabase_enterprise/data_editing/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/core.clj
@@ -3,6 +3,9 @@
    [metabase-enterprise.data-editing.data-editing :as data-editing]
    [potemkin :as p]))
 
+(comment
+  data-editing/keep-me)
+
 (p/import-vars
  [data-editing
-  insert!])
+  perform-bulk-action!])

--- a/enterprise/backend/src/metabase_enterprise/data_editing/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/core.clj
@@ -1,5 +1,7 @@
 (ns metabase-enterprise.data-editing.core
   (:require
+   ;; Loaded for side effects (defmethod)
+   [metabase-enterprise.data-editing.actions]
    [metabase-enterprise.data-editing.data-editing :as data-editing]
    [potemkin :as p]))
 

--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -101,7 +101,7 @@
                                                  :field field-name
                                                  :coercion_strategy coercion_strategy})))])
                          (into {}))
-        coerce      (fn [k v] (some-> v ((coerce-fn k identity))))]
+        coerce      (fn [k v] (some-> v ((coerce-fn (keyword k) identity))))]
     (for [row input-rows]
       (m/map-kv-vals coerce row))))
 

--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.data-editing.data-editing
   (:require
+   [clojure.set :as set]
    [java-time.api :as t]
    [medley.core :as m]
    [metabase-enterprise.data-editing.coerce :as data-editing.coerce]
@@ -9,6 +10,7 @@
    [metabase.events.core :as events]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.models.field-values :as field-values]
    [metabase.query-processor :as qp]
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
@@ -128,15 +130,6 @@
            (filter (comp #{:effect/row.modified} first))
            (map second)))))
 
-(defn insert!
-  "Inserts rows into the table, recording their creation as an event. Returns the inserted records.
-  Expects rows that are acceptable directly by [[actions/perform-action!]]. If casts or reversing coercion strategy
-  are required, that work must be done before calling this function."
-  [user-id scope table-id rows]
-  (api/check-500 user-id)
-  (let [res (perform-bulk-action! :table.row/create user-id scope table-id rows)]
-    {:created-rows (map :after res)}))
-
 (defn- row-update-event
   "Given a :effect/row.modified diff, figure out what kind of mutation it was."
   [{:keys [before after]}]
@@ -192,3 +185,46 @@
                                         :args       {:table_id  table-id
                                                      :db_id     db-id
                                                      :timestamp (t/zoned-date-time (t/zone-id "UTC"))}}))))))
+
+(defn- invalidate-field-values! [table-id rows]
+  ;; Be conservative with respect to case sensitivity, invalidate every field when there is ambiguity.
+  (let [ln->values  (u/group-by first second (for [row rows [k v] row] [(u/lower-case-en (name k)) v]))
+        lower-names (keys ln->values)
+        ln->ids     (when (seq lower-names)
+                      (u/group-by
+                       :lower_name :id
+                       (t2/query {:select [:id [[:lower :name] :lower_name]]
+                                  :from   [(t2/table-name :model/Field)]
+                                  :where  [:and
+                                           [:= :table_id table-id]
+                                           [:in [:lower :name] lower-names]
+                                           [:in :has_field_values ["list" "auto-list"]]
+                                           [:= :semantic_type "type/Category"]]})))
+        stale-fields (->> (for [[lower-name field-ids] ln->ids
+                                :let [new-values (into #{} (filter some?) (ln->values lower-name))
+                                      old-values (into #{} cat (t2/select-fn-vec :values :model/FieldValues
+                                                                                 :field_id [:in field-ids]))]]
+                            (when (seq (set/difference new-values old-values))
+                              field-ids))
+                          (apply concat))]
+    ;; Note that for now we only rescan field values when values are *added* and not when they are *removed*.
+    (when (seq stale-fields)
+      ;; Using a future is not ideal, it would be better to use a queue and a single worker, to avoid tying up threads.
+      (future
+        (->> (t2/select :model/Field :id [:in stale-fields])
+             (run! field-values/create-or-update-full-field-values!))))))
+
+(defn invalidate-and-present!
+  "We invalidate the field-values, in case any new category values were added.
+  The FE also expects data to be formatted according to PQ logic, e.g. considering semantic types.
+  Actions, however, return raw values, since lossy coercions would limit composition.
+  So, we apply the coercions here."
+  [table-id rows]
+  ;; We could optimize this significantly:
+  ;; 1. Skip if no category fields were changes on update.
+  ;; 2. Check whether all corresponding categorical field values are already in the database.
+  (invalidate-field-values! table-id rows)
+  ;; right now the FE works off qp outputs, which coerce output row data
+  ;; still feels messy, revisit this
+  (let [pk-fields (select-table-pk-fields table-id)]
+    (query-db-rows table-id pk-fields rows)))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/scope.clj
@@ -18,7 +18,7 @@
     :model-id     :model
     :webhook-id   :webhook
     :table-id     :table
-    :unknown      :unknown))
+    :unknown))
 
 (defn- hydrate-from-dashcard [scope]
   (if (and (contains? scope :card-id) (contains? scope :dashboard-id))

--- a/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing_public/api.clj
@@ -22,11 +22,10 @@
         rows (if (map? row-or-rows) [row-or-rows] row-or-rows)]
     (api/check-400 (seq rows) "Please supply at least one row.")
     (api/check-400 (every? seq rows) "Every row should not be empty.")
-    ;; TODO just call the action directly once we have it, get rid of this `insert!` method.
-    {:created (count (:created-rows (data-editing/insert! (:creator_id hook)
-                                                          {:webhook-id (:id hook)}
-                                                          (:table_id hook)
-                                                          rows)))}))
+    (let [user-id  (:creator_id hook)
+          scope    {:webhook-id (:id hook)}
+          table-id (:table_id hook)]
+      {:created (count (data-editing/perform-bulk-action! :table.row/create user-id scope table-id rows))})))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -250,9 +250,7 @@
           (data-editing.tu/table-url (mt/id :categories))
           {:rows [{:ID 1 :NAME "2025-03-25T00:00:00Z"}]})))
      {:channel/email (fn [[email :as _emails]]
-                       ;; Note sure why it changed, perhaps due to changes in master?
-                       ;; "Name: 2025-03-25T00:00Z[UTC]\nName: African\nName: 2025-03-25T00:00Z[UTC]"
-                       (is (=? {:body    [{:content "Name: 2025-03-25T00:00:00Z\nName: African\nName: 2025-03-25T00:00:00Z"
+                       (is (=? {:body    [{:content "Name: 2025-03-25T00:00Z[UTC]\nName: African\nName: 2025-03-25T00:00Z[UTC]"
                                            :type "text/html; charset=utf-8"}]}
                                email)))})))
 

--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -250,7 +250,9 @@
           (data-editing.tu/table-url (mt/id :categories))
           {:rows [{:ID 1 :NAME "2025-03-25T00:00:00Z"}]})))
      {:channel/email (fn [[email :as _emails]]
-                       (is (=? {:body    [{:content "Name: 2025-03-25T00:00Z[UTC]\nName: African\nName: 2025-03-25T00:00Z[UTC]"
+                       ;; Note sure why it changed, perhaps due to changes in master?
+                       ;; "Name: 2025-03-25T00:00Z[UTC]\nName: African\nName: 2025-03-25T00:00Z[UTC]"
+                       (is (=? {:body    [{:content "Name: 2025-03-25T00:00:00Z\nName: African\nName: 2025-03-25T00:00:00Z"
                                            :type "text/html; charset=utf-8"}]}
                                email)))})))
 

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -19,6 +19,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :each (fn [thunk] (mt/with-test-user :rasta (thunk))))
+
 (def ^:private test-scope {:unknown :legacy-action})
 
 (defmacro with-actions-test-data-and-actions-permissively-enabled!


### PR DESCRIPTION
We're wanting to introduce a new API for action execution which can subsume the existing action API (which are filling with hacks) and the CRUD endpoints.

Why replace the CRUD endpoints?

1. To have more use cases driving the new endpoint.
2. For consistency - every button you click is an action.
3. To remove cruft from the CRUD endpoints - why do they take `:scope`? That's an action concept.
4. It looks cool if we have more actions.
5. It'll allow us to shortly remove some really weird hacks, when we make Undo and Redo into actions as well.