### PR TITLE
make the uberjar artifact from the cross-version tests not collide with the one from component tests

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar-cross-version
 
   resolve-sdk-version:
     if: |


### PR DESCRIPTION
`.github/workflows/embedding-sdk.yml` currently starts two jobs that build the uberjar and try to store it as artifact with the same name:
- https://github.com/metabase/metabase/blob/f2004162a1e24df239177bd13a323519f04e8804/.github/workflows/e2e-component-tests-embedding-sdk.yml#L90-L93

- https://github.com/metabase/metabase/blob/f2004162a1e24df239177bd13a323519f04e8804/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml#L82-L85


This is causing this error: ([example](https://github.com/metabase/metabase/actions/runs/15025209379/job/42224705834?pr=57964#step:6:61))
<img width="1627" alt="image" src="https://github.com/user-attachments/assets/45b33f45-8cb2-4b21-800f-347048c11d64" />


This PR renames the cross-version one to avoid the error.
In the future we can optimize this and only build it once, for now I just want to make CI green.


How to verify: [make the uberjar artifact from the cross-version tests not collide with](https://github.com/metabase/metabase/pull/57972) (which cherry-picks this) should be green, hopefully.