### PR TITLE
make the uberjar artifact from the cross-version tests not collide with

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar-cross-version
 
   resolve-sdk-version:
     if: |


### PR DESCRIPTION
to check if :draft-pull-request: [make the uberjar artifact from the cross-version tests not collide with the one from component tests](https://github.com/metabase/metabase/pull/57971) works