### PR TITLE
Fix FE permission checks for Edit query definition

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1477,6 +1477,39 @@ describe("issue 56698", () => {
   });
 });
 
+describe("issue 57557", () => {
+  beforeEach(() => {
+    H.restore();
+  });
+
+  it("should not allow to see the query definition for a user without data permissions (metabase#57557)", () => {
+    cy.log("create a native model");
+    cy.signInAsNormalUser();
+    H.createNativeQuestion(
+      {
+        name: "Native model",
+        native: { query: "select 1 union all select 2" },
+        type: "model",
+      },
+      { wrapId: true, idAlias: "modelId" },
+    );
+
+    cy.log("verify that query editing functionality is hidden");
+    cy.signIn("nodata");
+    cy.get("@modelId").then((modelId) =>
+      H.visitModel(Number(modelId), { hasDataAccess: false }),
+    );
+    H.openQuestionActions();
+    H.popover().within(() => {
+      cy.findByText("Edit metadata").should("be.visible");
+      cy.findByText("Edit query definition").should("not.exist");
+      cy.findByText("Edit metadata").click();
+    });
+    cy.findByTestId("editor-tabs-query").should("be.disabled");
+    cy.findByTestId("editor-tabs-metadata").should("be.checked");
+  });
+});
+
 describe("issue 56775", () => {
   const MODEL_NAME = "Model 56775";
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
@@ -207,7 +207,7 @@ const _DatasetEditorInner = (props) => {
     onOpenModal,
   } = props;
 
-  const { isNative } = Lib.queryDisplayInfo(question.query());
+  const { isNative, isEditable } = Lib.queryDisplayInfo(question.query());
   const isDirty = isModelQueryDirty || isMetadataDirty;
   const [showCancelEditWarning, setShowCancelEditWarning] = useState(false);
   const fields = useMemo(
@@ -490,6 +490,7 @@ const _DatasetEditorInner = (props) => {
         center={
           <EditorTabs
             currentTab={datasetEditorTab}
+            disabledQuery={!isEditable}
             disabledMetadata={!resultsMetadata}
             onChange={onChangeEditorTab}
           />

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -9,11 +9,17 @@ import EditorTabsS from "./EditorTabs.module.css";
 
 type Props = {
   currentTab: string;
+  disabledQuery: boolean;
   disabledMetadata: boolean;
   onChange: (optionId: string) => void;
 };
 
-export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
+export function EditorTabs({
+  currentTab,
+  disabledQuery,
+  disabledMetadata,
+  onChange,
+}: Props) {
   const theme = useMantineTheme();
 
   return (
@@ -34,6 +40,7 @@ export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
           className={cx(EditorTabsS.Tab, {
             [EditorTabsS.active]: currentTab === "query",
             [EditorTabsS.inactive]: currentTab !== "query",
+            [EditorTabsS.disabled]: disabledQuery,
           })}
           htmlFor="editor-tabs-query"
         >
@@ -45,9 +52,11 @@ export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
             name="editor-tabs"
             value="query"
             checked={currentTab === "query"}
+            disabled={disabledQuery}
             onChange={() => {
               onChange("query");
             }}
+            data-testid="editor-tabs-query"
           />
           <span data-testid="editor-tabs-query-name">{t`Query`}</span>
         </label>

--- a/frontend/src/metabase/query_builder/components/QueryModals/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals/QueryModals.tsx
@@ -19,7 +19,7 @@ import { QuestionEmbedWidget } from "metabase/query_builder/components/QuestionE
 import { PreviewQueryModal } from "metabase/query_builder/components/view/PreviewQueryModal";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
-import { getQuestionWithParameters } from "metabase/query_builder/selectors";
+import { getQuestionWithoutComposing } from "metabase/query_builder/selectors";
 import ArchiveQuestionModal from "metabase/questions/containers/ArchiveQuestionModal";
 import EditEventModal from "metabase/timelines/questions/containers/EditEventModal";
 import MoveEventModal from "metabase/timelines/questions/containers/MoveEventModal";
@@ -68,7 +68,7 @@ export function QueryModals({
   const dispatch = useDispatch();
 
   const initialCollectionId = useGetDefaultCollectionId();
-  const questionWithParameters = useSelector(getQuestionWithParameters);
+  const underlyingQuestion = useSelector(getQuestionWithoutComposing);
 
   const handleSaveAndClose = useCallback(
     async (question: Question) => {
@@ -259,11 +259,11 @@ export function QueryModals({
                 : initialCollectionId,
             }}
             copy={async (formValues) => {
-              if (!questionWithParameters) {
+              if (!underlyingQuestion) {
                 return;
               }
 
-              const question = questionWithParameters
+              const question = underlyingQuestion
                 .setDisplayName(formValues.name)
                 .setCollectionId(formValues.collection_id)
                 .setDashboardId(formValues.dashboard_id)

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
@@ -21,7 +21,10 @@ import {
   createMockTable,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import { createMockState } from "metabase-types/store/mocks";
+import {
+  createMockQueryBuilderState,
+  createMockState,
+} from "metabase-types/store/mocks";
 
 import { QuestionActions } from "./QuestionActions";
 
@@ -71,6 +74,9 @@ function setup({
       databases: hasDataPermissions ? [createSampleDatabase()] : [],
       tables: [createMockTable({ id: `card__${card.id}` })],
       questions: [card],
+    }),
+    qb: createMockQueryBuilderState({
+      card,
     }),
   });
 
@@ -214,10 +220,9 @@ describe("QuestionActions", () => {
     });
 
     it("should allow to turn into a question with write data & collection permissions", async () => {
-      const turnModelIntoQuestionSpy = jest.spyOn(
-        modelActions,
-        "turnModelIntoQuestion",
-      );
+      const turnModelIntoQuestionSpy = jest
+        .spyOn(modelActions, "turnModelIntoQuestion")
+        .mockImplementation(() => () => Promise.resolve());
       setup({
         card: createMockCard({
           type: "model",
@@ -275,10 +280,9 @@ describe("QuestionActions", () => {
     });
 
     it("should allow to turn into a question without data permissions", async () => {
-      const turnModelIntoQuestionSpy = jest.spyOn(
-        modelActions,
-        "turnModelIntoQuestion",
-      );
+      const turnModelIntoQuestionSpy = jest
+        .spyOn(modelActions, "turnModelIntoQuestion")
+        .mockImplementation(() => () => Promise.resolve());
       setup({
         card: createMockCard({
           type: "model",

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/QuestionMoreActionsMenu.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionMoreActionsMenu/QuestionMoreActionsMenu.tsx
@@ -4,7 +4,7 @@ import _ from "underscore";
 
 import { ToolbarButton } from "metabase/components/ToolbarButton";
 import { useUserAcknowledgement } from "metabase/hooks/use-user-acknowledgement";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import {
@@ -20,6 +20,7 @@ import {
   MODAL_TYPES,
   type QueryModalType,
 } from "metabase/query_builder/constants";
+import { getQuestionWithoutComposing } from "metabase/query_builder/selectors";
 import { Icon, Menu } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -52,6 +53,7 @@ export const QuestionMoreActionsMenu = ({
   onSetQueryBuilderMode,
 }: QuestionMoreActionsMenuProps): JSX.Element | null => {
   const [opened, setOpened] = useState(false);
+  const underlyingQuestion = useSelector(getQuestionWithoutComposing);
 
   const dispatch = useDispatch();
 
@@ -67,9 +69,9 @@ export const QuestionMoreActionsMenu = ({
   const hasCollectionPermissions = question.canWrite();
   const enableSettingsSidebar = shouldShowQuestionSettingsSidebar(question);
 
-  const { isEditable: hasDataPermissions } = Lib.queryDisplayInfo(
-    question.query(),
-  );
+  const hasDataPermissions =
+    underlyingQuestion != null &&
+    Lib.queryDisplayInfo(underlyingQuestion.query()).isEditable;
 
   const reload = () => dispatch(softReloadCard());
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
@@ -4,7 +4,7 @@ import { c } from "ttag";
 import { SidesheetCardSection } from "metabase/common/components/Sidesheet";
 import Link from "metabase/core/components/Link";
 import { useSelector } from "metabase/lib/redux";
-import { getQuestionWithParameters } from "metabase/query_builder/selectors";
+import { getQuestionWithoutComposing } from "metabase/query_builder/selectors";
 import { Flex, FixedSizeIcon as Icon } from "metabase/ui";
 
 import { getDataSourceParts } from "../../../ViewHeader/components/QuestionDataSource/utils";
@@ -14,12 +14,12 @@ import { getIconPropsForSource } from "./utils";
 
 export const QuestionSources = () => {
   /** Retrieve current question from the Redux store */
-  const questionWithParameters = useSelector(getQuestionWithParameters);
+  const underlyingQuestion = useSelector(getQuestionWithoutComposing);
 
   const sourcesWithIcons: QuestionSource[] = useMemo(() => {
-    const sources = questionWithParameters
+    const sources = underlyingQuestion
       ? (getDataSourceParts({
-          question: questionWithParameters,
+          question: underlyingQuestion,
           subHead: false,
           isObjectDetail: true,
           formatTableAsComponent: false,
@@ -29,9 +29,9 @@ export const QuestionSources = () => {
       ...source,
       iconProps: getIconPropsForSource(source),
     }));
-  }, [questionWithParameters]);
+  }, [underlyingQuestion]);
 
-  if (!questionWithParameters || !sourcesWithIcons.length) {
+  if (!underlyingQuestion || !sourcesWithIcons.length) {
     return null;
   }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -281,7 +281,7 @@ export const getLastRunQuestion = createSelector(
     card && metadata && new Question(card, metadata, parameterValues),
 );
 
-export const getQuestionWithParameters = createSelector(
+export const getQuestionWithoutComposing = createSelector(
   [getCard, getMetadata, getParameterValues],
   (card, metadata, parameterValues) => {
     if (!card || !metadata) {
@@ -292,7 +292,7 @@ export const getQuestionWithParameters = createSelector(
 );
 
 export const getQuestion = createSelector(
-  [getQuestionWithParameters, getQueryBuilderMode],
+  [getQuestionWithoutComposing, getQueryBuilderMode],
   (question, queryBuilderMode) => {
     if (!question) {
       return;


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/57557

We need to check permissions on the underlying model and not the ad-hoc question.

<img width="247" alt="Screenshot 2025-05-14 at 13 09 06" src="https://github.com/user-attachments/assets/d2e38e44-b237-45d6-959d-a02c39c06e3a" />
<img width="698" alt="Screenshot 2025-05-14 at 13 08 59" src="https://github.com/user-attachments/assets/7a07eb5e-4e19-4ecb-9583-c282d5e733f6" />
