### PR TITLE
Fix FE navigation when the query is running

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -386,3 +386,41 @@ describe("issue 54817", () => {
     H.popover().findByPlaceholderText(placeholder).should("be.focused");
   });
 });
+
+describe("issue 57398", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should show the query running state when navigating back (metabase#57398)", () => {
+    H.openProductsTable();
+    H.filter();
+    H.popover().within(() => {
+      cy.log("1st filter");
+      cy.findByText("Category").click();
+      cy.findByText("Widget").click();
+      cy.findByLabelText("Add another filter").click();
+
+      cy.log("2st filter");
+      cy.findByText("Vendor").click();
+      cy.findByText("Alfreda Konopelski II Group").click();
+      cy.findByLabelText("Add another filter").click();
+    });
+
+    cy.log("assert we show the running state when navigating back");
+    cy.intercept("POST", "/api/dataset", (req) => {
+      req.on("response", (res) => {
+        res.setDelay(5000);
+      });
+    });
+    cy.go("back");
+    H.queryBuilderMain().findByTestId("loading-indicator").should("be.visible");
+    H.queryBuilderFiltersPanel().within(() => {
+      cy.findByText("Category is Widget").should("be.visible");
+      cy.findByText("Vendor is Alfreda Konopelski II Group").should(
+        "not.exist",
+      );
+    });
+  });
+});

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -408,12 +408,13 @@ describe("issue 57398", () => {
       cy.findByLabelText("Add another filter").click();
     });
 
-    cy.log("assert we show the running state when navigating back");
+    cy.log("delay the response to be able to verify the running state");
     cy.intercept("POST", "/api/dataset", (req) => {
       req.on("response", (res) => {
         res.setDelay(5000);
       });
     });
+
     cy.go("back");
     H.queryBuilderMain().findByTestId("loading-indicator").should("be.visible");
     H.queryBuilderFiltersPanel().within(() => {

--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -12,7 +12,6 @@ export const createMockQueryBuilderUIControlsState = (
   isShowingTemplateTagsEditor: false,
   isShowingNewbModal: false,
   isRunning: false,
-  isQueryComplete: false,
   isShowingSummarySidebar: false,
   isShowingChartTypeSidebar: false,
   isShowingChartSettingsSidebar: false,

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -29,7 +29,6 @@ export interface QueryBuilderUIControls {
   isShowingTemplateTagsEditor: boolean;
   isShowingNewbModal: boolean;
   isRunning: boolean;
-  isQueryComplete: boolean;
   isShowingSummarySidebar: boolean;
   isShowingChartTypeSidebar: boolean;
   isShowingChartSettingsSidebar: boolean;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -40,7 +40,9 @@ export function FilterHeaderButton({
 
   const handleQueryChange = (newQuery: Lib.Query, opts: FilterChangeOpts) => {
     const newQuestion = question.setQuery(newQuery);
-    dispatch(updateQuestion(newQuestion, { run: opts.run }));
+    dispatch(
+      updateQuestion(newQuestion, { run: opts.run, shouldUpdateUrl: true }),
+    );
   };
 
   useRegisterShortcut([

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -40,9 +40,7 @@ export function FilterHeaderButton({
 
   const handleQueryChange = (newQuery: Lib.Query, opts: FilterChangeOpts) => {
     const newQuestion = question.setQuery(newQuery);
-    dispatch(
-      updateQuestion(newQuestion, { run: opts.run, shouldUpdateUrl: true }),
-    );
+    dispatch(updateQuestion(newQuestion, { run: opts.run }));
   };
 
   useRegisterShortcut([

--- a/frontend/src/metabase/query_builder/defaults.ts
+++ b/frontend/src/metabase/query_builder/defaults.ts
@@ -11,7 +11,6 @@ export const DEFAULT_UI_CONTROLS: QueryBuilderUIControls = {
   isShowingTemplateTagsEditor: false,
   isShowingNewbModal: false,
   isRunning: false,
-  isQueryComplete: false,
   isShowingSummarySidebar: false,
   isShowingChartTypeSidebar: false,
   isShowingChartSettingsSidebar: false,

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -107,7 +107,10 @@ export const uiControls = handleActions(
     },
 
     [RESET_UI_CONTROLS]: {
-      next: (state, { payload }) => DEFAULT_UI_CONTROLS,
+      next: (state) => ({
+        ...DEFAULT_UI_CONTROLS,
+        isRunning: state.isRunning,
+      }),
     },
 
     [INITIALIZE_QB]: {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/57398

When navigating back, we re-run the query from the previous location state _and_ reset UI controls. The problem is that it also clears the `isRunning` flag, and the UI shows an invalid UI because of that. This PR fixes this issue - we'll preserve the `isRunning` flag during navigation changes.

https://github.com/metabase/metabase/blob/c4cb9263f6478e82d0efae63ca80bb67b4b2e478/frontend/src/metabase/query_builder/actions/navigation.ts#L76