### PR TITLE
Remove :expression_name from col-info-for-expression in annotate middleware

### DIFF
--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -60,6 +60,7 @@ export interface DatasetColumn {
   remapped_to_column?: DatasetColumn;
   unit?: DatetimeUnit;
   field_ref?: DimensionReference;
+  // Deprecated. Columns from old saved questions might have expression_name, but new columns do not.
   expression_name?: any;
   base_type?: string;
   semantic_type?: string | null;

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-data-labels-negatives.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-data-labels-negatives.json
@@ -318,7 +318,6 @@
           "base_type": "type/BigInteger",
           "name": "Count Inverted",
           "display_name": "Count Inverted",
-          "expression_name": "Count Inverted",
           "field_ref": ["expression", "Count Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-log-y-scale-stacked-negative.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-log-y-scale-stacked-negative.json
@@ -504,7 +504,6 @@
           "base_type": "type/Float",
           "name": "Average of Defense Inverted",
           "display_name": "Average of Defense Inverted",
-          "expression_name": "Average of Defense Inverted",
           "field_ref": ["expression", "Average of Defense Inverted"],
           "source": "fields",
           "effective_type": "type/Float"
@@ -513,7 +512,6 @@
           "base_type": "type/Float",
           "name": "Average of Sp Defense Inverted",
           "display_name": "Average of Sp Defense Inverted",
-          "expression_name": "Average of Sp Defense Inverted",
           "field_ref": ["expression", "Average of Sp Defense Inverted"],
           "source": "fields",
           "effective_type": "type/Float"

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-stacked-pow-y-axis-negatives.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-stacked-pow-y-axis-negatives.json
@@ -506,7 +506,6 @@
           "base_type": "type/Float",
           "name": "Average of Defense Inverted",
           "display_name": "Average of Defense Inverted",
-          "expression_name": "Average of Defense Inverted",
           "field_ref": ["expression", "Average of Defense Inverted"],
           "source": "fields",
           "effective_type": "type/Float"
@@ -515,7 +514,6 @@
           "base_type": "type/Float",
           "name": "Average of Sp Defense Inverted",
           "display_name": "Average of Sp Defense Inverted",
-          "expression_name": "Average of Sp Defense Inverted",
           "field_ref": ["expression", "Average of Sp Defense Inverted"],
           "source": "fields",
           "effective_type": "type/Float"

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/line-log-y-scale-negative.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/line-log-y-scale-negative.json
@@ -252,7 +252,6 @@
           "base_type": "type/BigInteger",
           "name": "Total Accident Inverted",
           "display_name": "Total Accident Inverted",
-          "expression_name": "Total Accident Inverted",
           "field_ref": ["expression", "Total Accident Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/data-labels-mixed.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/data-labels-mixed.json
@@ -197,7 +197,6 @@
           "base_type": "type/BigInteger",
           "name": "Change Inverted",
           "display_name": "Change Inverted",
-          "expression_name": "Change Inverted",
           "field_ref": ["expression", "Change Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/log-y-scale-negative.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/log-y-scale-negative.json
@@ -133,7 +133,6 @@
           "base_type": "type/BigInteger",
           "name": "Total Accident Inverted",
           "display_name": "Total Accident Inverted",
-          "expression_name": "Total Accident Inverted",
           "field_ref": ["expression", "Total Accident Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/mixed-below-zero.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/mixed-below-zero.json
@@ -199,7 +199,6 @@
           "base_type": "type/BigInteger",
           "name": "Change Inverted",
           "display_name": "Change Inverted",
-          "expression_name": "Change Inverted",
           "field_ref": ["expression", "Change Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/negative-only.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/negative-only.json
@@ -222,7 +222,6 @@
           "base_type": "type/BigInteger",
           "name": "Total Accident Inverted",
           "display_name": "Total Accident Inverted",
-          "expression_name": "Total Accident Inverted",
           "field_ref": ["expression", "Total Accident Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/pow-y-scale-negative-only.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/pow-y-scale-negative-only.json
@@ -224,7 +224,6 @@
           "base_type": "type/BigInteger",
           "name": "Total Accident Inverted",
           "display_name": "Total Accident Inverted",
-          "expression_name": "Total Accident Inverted",
           "field_ref": ["expression", "Total Accident Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/starts-below-zero-crosses-ends-below.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/starts-below-zero-crosses-ends-below.json
@@ -196,7 +196,6 @@
           "base_type": "type/BigInteger",
           "name": "Change Inverted",
           "display_name": "Change Inverted",
-          "expression_name": "Change Inverted",
           "field_ref": ["expression", "Change Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/starts-below-zero-ends-above.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/starts-below-zero-ends-above.json
@@ -196,7 +196,6 @@
           "base_type": "type/BigInteger",
           "name": "Change Inverted",
           "display_name": "Change Inverted",
-          "expression_name": "Change Inverted",
           "field_ref": ["expression", "Change Inverted"],
           "source": "fields",
           "effective_type": "type/BigInteger"

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -277,6 +277,6 @@ export const getOrderedSeries = (
 export const sanatizeResultData = (data: DatasetData) => {
   return {
     ...data,
-    cols: data.cols.filter((col) => col.expression_name !== "pivot-grouping"),
+    cols: data.cols.filter((col) => col.name !== "pivot-grouping"),
   };
 };

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
@@ -82,7 +82,6 @@ const setup = () => {
                 createMockColumn({
                   name: "pivot-grouping",
                   display_name: "pivot-grouping",
-                  expression_name: "pivot-grouping",
                   field_ref: ["expression", "pivot-grouping"],
                   source: "breakout",
                   base_type: "type/Integer",

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/-fFVxT-GLz6WO41bvw-Ar_dashboards_without_recent_views.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/-fFVxT-GLz6WO41bvw-Ar_dashboards_without_recent_views.yaml
@@ -205,7 +205,6 @@ result_metadata:
   visibility_type: normal
 - base_type: type/Float
   display_name: Days since last view
-  expression_name: Days since last view
   field_ref:
   - expression
   - Days since last view

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -500,7 +500,8 @@
     ;; reference. `:lib/expression-name` is only set for expression references, so if it's set, we have to generate an
     ;; expression ref, otherwise we generate a normal field ref.
     (:source/fields :source/breakouts)
-    (if (:lib/expression-name metadata)
+    (if (and (:lib/expression-name metadata)
+             (:fingerprint metadata))
       (lib.expression/column-metadata->expression-ref metadata)
       (column-metadata->field-ref metadata))
 

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -500,8 +500,7 @@
     ;; reference. `:lib/expression-name` is only set for expression references, so if it's set, we have to generate an
     ;; expression ref, otherwise we generate a normal field ref.
     (:source/fields :source/breakouts)
-    (if (and (:lib/expression-name metadata)
-             (:fingerprint metadata))
+    (if (:lib/expression-name metadata)
       (lib.expression/column-metadata->expression-ref metadata)
       (column-metadata->field-ref metadata))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -250,7 +250,6 @@
    (infer-expression-type (mbql.u/expression-with-name inner-query expression-name))
    {:name            expression-name
     :display_name    expression-name
-    ;; provided so the FE can add easily add sorts and the like when someone clicks a column header
     :ident           (get-in inner-query [:expression-idents expression-name])
     :field_ref       (fe-friendly-expression-ref clause)}
    (when temporal-unit

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -251,7 +251,6 @@
    {:name            expression-name
     :display_name    expression-name
     ;; provided so the FE can add easily add sorts and the like when someone clicks a column header
-    :expression_name expression-name
     :ident           (get-in inner-query [:expression-idents expression-name])
     :field_ref       (fe-friendly-expression-ref clause)}
    (when temporal-unit

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -530,7 +530,6 @@
                          :effective_type  "type/Integer"
                          :name            "pivot-grouping"
                          :display_name    "pivot-grouping"
-                         :expression_name "pivot-grouping"
                          :field_ref       ["expression" "pivot-grouping"]
                          :source          "breakout"}
                         (nth cols 3))))

--- a/test/metabase/pivot/core_test.cljc
+++ b/test/metabase/pivot/core_test.cljc
@@ -84,7 +84,6 @@
            :base_type "type/Text"}
           {:database_type "INTEGER",
            :name "pivot-grouping",
-           :expression_name "pivot-grouping",
            :source "breakout",
            :field_ref ["expression" "pivot-grouping"],
            :effective_type "type/Integer",

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -758,7 +758,7 @@
                        {:name "count_2", :display_name "count_2", :base_type :type/Number}]}))))))
 
 (deftest ^:parallel expressions-keys-test
-  (testing "make sure expressions come back with the right set of keys, including `:expression_name` (#8854)"
+  (testing "make sure expressions come back with the right set of keys (#8854)"
     (is (= {:name            "discount_price"
             :display_name    "discount_price"
             :base_type       :type/Float

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -350,7 +350,6 @@
       (is (= {:base_type       :type/Float
               :name            "double-price"
               :display_name    "double-price"
-              :expression_name "double-price"
               :ident           "eG2KisFcSyHRqACHSmmbN"
               :field_ref       [:expression "double-price"]}
              (lib.tu.macros/$ids venues
@@ -393,7 +392,6 @@
               :base_type          :type/DateTime,
               :name               "last-login-converted",
               :display_name       "last-login-converted",
-              :expression_name    "last-login-converted",
               :ident              "aP4kbV3PYLhLoK3o3F5xx"
               :field_ref          [:expression "last-login-converted"]}
              (lib.tu.macros/$ids users
@@ -405,7 +403,6 @@
               :base_type          :type/DateTime,
               :name               "last-login-converted",
               :display_name       "last-login-converted",
-              :expression_name    "last-login-converted",
               :ident              "aP4kbV3PYLhLoK3o3F5xx"
               :field_ref          [:expression "last-login-converted"]}
              (lib.tu.macros/$ids users
@@ -624,7 +621,6 @@
           (is (= {:semantic_type :type/Name,
                   :coercion_strategy nil,
                   :name "expr",
-                  :expression_name "expr",
                   :ident "LbroONhJ5OWyvFCQB4zp3"
                   :source :fields,
                   :field_ref [:expression "expr"],
@@ -639,7 +635,6 @@
           (is (= {:base_type :type/Text,
                   :name "expr",
                   :display_name "expr",
-                  :expression_name "expr",
                   :ident "LbroONhJ5OWyvFCQB4zp3"
                   :field_ref [:expression "expr"],
                   :source :fields}
@@ -650,7 +645,6 @@
           (is (= {:semantic_type :type/Name,
                   :coercion_strategy nil,
                   :name "expr",
-                  :expression_name "expr",
                   :ident "LbroONhJ5OWyvFCQB4zp3"
                   :source :fields,
                   :field_ref [:expression "expr"],
@@ -768,7 +762,6 @@
     (is (= {:name            "discount_price"
             :display_name    "discount_price"
             :base_type       :type/Float
-            :expression_name "discount_price"
             :ident           "bdW6mQ49dxdMbC1CheUpt"
             :source          :fields
             :field_ref       [:expression "discount_price"]}
@@ -808,7 +801,6 @@
         (is (=? [{:name            "prev_month"
                   :display_name    "prev_month"
                   :base_type       :type/DateTime
-                  :expression_name "prev_month"
                   :ident           (get-in query [:query :expression-idents "prev_month"])
                   :source          :fields
                   :field_ref       [:expression "prev_month"]}]


### PR DESCRIPTION
Running CI for external contribution #54548

Commits from the above external PR, plus

* merge in latest master and resolve conflicts
* [Use col.name instead of expression_name in sanatizeResultData](https://github.com/metabase/metabase/pull/57981/commits/bfe9315f3f8d2b4b99abe5b12ced54b01864d122) when filtering out pivot-grouping columns 
* [Remove additional :expression_name references in tests](https://github.com/metabase/metabase/pull/57981/commits/f8d4bc8277c917de2f78d6be2c475f7d7814b574)
* [Remove comment that was attached to now-removed :expression_name](https://github.com/metabase/metabase/pull/57981/commits/6f3036ab8645b9ec90daf8bb3104a39033bdae29)
* [Remove expression_name from static-viz components](https://github.com/metabase/metabase/pull/57981/commits/7c745061d86e3f4d4c8e8ee2272f55f6bd1f2782)
* [Remove expression_name from instance_analytics export](https://github.com/metabase/metabase/pull/57981/commits/bf659cebd94f6547231ed7fb812e31a1eac3eddc)

TODO

- [x] tests for sort fix