### PR TITLE
change retrieve key too for the uberjar artifact in the sdk workflow

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4
         with:
-          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar-cross-version
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend


### PR DESCRIPTION
Follow up to  [make the uberjar artifact from the cross-version tests not collide with the one from component tests](https://github.com/metabase/metabase/pull/57971).
In that PR I only changed the key when we were saving the artifact, which made it pass that step, but it failed when we tried to retrieve them.
Sorry about this mess, already cherry-picked on 
 [🤖 backported "make the uberjar artifact from the cross-version tests not collide with the one from component tests"](https://github.com/metabase/metabase/pull/57975)
 [🤖 backported "make the uberjar artifact from the cross-version tests not collide with the one from component tests"](https://github.com/metabase/metabase/pull/57976)