### PR TITLE
include visible timeline events from different collections in ai analysis

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 
 import { CopyButton } from "metabase/components/CopyButton";
 import { useSelector } from "metabase/lib/redux";
-import { isNotNull } from "metabase/lib/types";
 import type { AIQuestionAnalysisSidebarProps } from "metabase/plugins";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import { getIsLoadingComplete } from "metabase/query_builder/selectors";
@@ -17,12 +16,15 @@ import {
 import { useAnalyzeChartMutation } from "../../../api/ai-entity-analysis";
 import { AIAnalysisContent } from "../AIAnalysisContent/AIAnalysisContent";
 
+import { getTimelineEventsForAnalysis } from "./utils";
+
 // This is a hack to ensure visualizations have rendered after data loading, as they can render asynchronously.
 const RENDER_DELAY_MS = 100;
 
 export function AIQuestionAnalysisSidebar({
   question,
-  timelines,
+  timelines = [],
+  visibleTimelineEvents = [],
   className,
   onClose,
 }: AIQuestionAnalysisSidebarProps) {
@@ -47,20 +49,15 @@ export function AIQuestionAnalysisSidebar({
       return;
     }
 
+    const questionCollectionId = question.card().collection_id;
     const timelineEvents =
-      timelines
-        ?.filter(
-          (timeline) =>
-            timeline.collection_id === question.card().collection_id,
-        )
-        .flatMap((timeline) =>
-          timeline.events?.map((event) => ({
-            name: event.name,
-            description: event.description ?? undefined,
-            timestamp: event.timestamp,
-          })),
-        )
-        ?.filter(isNotNull) ?? [];
+      questionCollectionId == null
+        ? []
+        : getTimelineEventsForAnalysis(
+            visibleTimelineEvents,
+            timelines,
+            questionCollectionId,
+          );
 
     analysisTimeoutRef.current = setTimeout(async () => {
       const imageBase64 = await getBase64ChartImage(
@@ -86,7 +83,13 @@ export function AIQuestionAnalysisSidebar({
         analysisTimeoutRef.current = null;
       }
     };
-  }, [analyzeChart, isLoadingComplete, question, timelines]);
+  }, [
+    analyzeChart,
+    isLoadingComplete,
+    question,
+    timelines,
+    visibleTimelineEvents,
+  ]);
 
   const renderCopyButton = () => {
     if (!analysisData?.summary) {

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.unit.spec.tsx
@@ -1,11 +1,16 @@
 import { screen, waitFor } from "@testing-library/react";
 import fetchMock from "fetch-mock";
+import _ from "underscore";
 
 import { setupAnalyzeChartEndpoint } from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
 import Question from "metabase-lib/v1/Question";
 import type { AIEntityAnalysisResponse } from "metabase-types/api";
-import { createMockCard } from "metabase-types/api/mocks";
+import {
+  createMockCard,
+  createMockTimeline,
+  createMockTimelineEvent,
+} from "metabase-types/api/mocks";
 import { createMockQueryBuilderState } from "metabase-types/store/mocks";
 
 import { AIQuestionAnalysisSidebar } from "./AIQuestionAnalysisSidebar";
@@ -47,7 +52,7 @@ describe("AIQuestionAnalysisSidebar", () => {
     expect(copyButton).toBeInTheDocument();
   });
 
-  it("should send only timeline events from the question's collection", async () => {
+  it("should send only visible timeline events with ones from the same collection", async () => {
     const collectionId = 42;
 
     const question = new Question(
@@ -56,28 +61,51 @@ describe("AIQuestionAnalysisSidebar", () => {
       }),
     );
 
-    const timelineEventSameCollection = {
+    const timelineEventSameCollection = createMockTimelineEvent({
+      id: 1,
       name: "Release v1",
       description: "Released version 1",
       timestamp: "2024-05-12T00:00:00Z",
-    };
+    });
+    const invisibleTimelineEventSameCollection = createMockTimelineEvent({
+      id: 2,
+      name: "Beta Release v1",
+      description: "Beta release",
+      timestamp: "2024-04-12T00:00:00Z",
+    });
+    const visibleTimelineEventFromAnotherCollection = createMockTimelineEvent({
+      id: 3,
+      name: "Marketing Launch",
+      description: "Rolled out our new website",
+      timestamp: "2024-03-12T00:00:00Z",
+    });
 
     const timelines = [
-      {
+      createMockTimeline({
         collection_id: collectionId,
-        events: [timelineEventSameCollection],
-      },
-      {
+        events: [
+          timelineEventSameCollection,
+          invisibleTimelineEventSameCollection,
+        ],
+      }),
+      createMockTimeline({
         // Different collection – should be ignored
         collection_id: collectionId + 1,
         events: [
-          {
+          createMockTimelineEvent({
+            id: 4,
             name: "Irrelevant event",
             description: "Should be filtered out",
             timestamp: "2024-05-13T00:00:00Z",
-          },
+          }),
+          visibleTimelineEventFromAnotherCollection,
         ],
-      },
+      }),
+    ];
+
+    const visibleTimelineEvents = [
+      timelineEventSameCollection,
+      visibleTimelineEventFromAnotherCollection,
     ];
 
     const mockResponse: AIEntityAnalysisResponse = {
@@ -89,8 +117,9 @@ describe("AIQuestionAnalysisSidebar", () => {
     renderWithProviders(
       <AIQuestionAnalysisSidebar
         question={question}
+        visibleTimelineEvents={visibleTimelineEvents}
         onClose={jest.fn()}
-        timelines={timelines as any}
+        timelines={timelines}
       />,
       {
         storeInitialState: {
@@ -110,7 +139,16 @@ describe("AIQuestionAnalysisSidebar", () => {
     )?.request;
     const body = await lastCallRequest?.json();
 
-    expect(body.timeline_events).toHaveLength(1);
-    expect(body.timeline_events[0]).toMatchObject(timelineEventSameCollection);
+    const analysisEventsFields = ["name", "description", "timestamp"];
+    expect(body.timeline_events).toHaveLength(3);
+    expect(body.timeline_events[0]).toMatchObject(
+      _.pick(timelineEventSameCollection, analysisEventsFields),
+    );
+    expect(body.timeline_events[1]).toMatchObject(
+      _.pick(invisibleTimelineEventSameCollection, analysisEventsFields),
+    );
+    expect(body.timeline_events[2]).toMatchObject(
+      _.pick(visibleTimelineEventFromAnotherCollection, analysisEventsFields),
+    );
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/utils.ts
@@ -1,0 +1,30 @@
+import { isNotNull } from "metabase/lib/types";
+import type { CollectionId, Timeline, TimelineEvent } from "metabase-types/api";
+
+export const getTimelineEventsForAnalysis = (
+  visibleTimelineEvents: TimelineEvent[],
+  timelines: Timeline[],
+  questionCollectionId: CollectionId,
+) => {
+  const sameCollectionTimelineEvents = timelines
+    .filter((timeline) => timeline.collection_id === questionCollectionId)
+    .flatMap((timeline) => timeline.events ?? [])
+    .filter(isNotNull);
+
+  const sameCollectionTimelineEventIds = new Set(
+    sameCollectionTimelineEvents.map((e) => e.id),
+  );
+
+  const visibleEventsFromOtherCollections = visibleTimelineEvents.filter(
+    (event) => !sameCollectionTimelineEventIds.has(event.id),
+  );
+
+  return [
+    ...sameCollectionTimelineEvents,
+    ...visibleEventsFromOtherCollections,
+  ].map((event) => ({
+    name: event.name,
+    description: event.description ?? undefined,
+    timestamp: event.timestamp,
+  }));
+};

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -75,6 +75,7 @@ import type {
   Revision,
   TableId,
   Timeline,
+  TimelineEvent,
   User,
 } from "metabase-types/api";
 import type { AdminPathKey, Dispatch, State } from "metabase-types/store";
@@ -679,6 +680,7 @@ export interface AIQuestionAnalysisSidebarProps {
   className?: string;
   onClose?: () => void;
   timelines?: Timeline[];
+  visibleTimelineEvents?: TimelineEvent[];
 }
 
 export type PluginAIEntityAnalysis = {

--- a/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NativeQueryRightSidebar/NativeQueryRightSidebar.jsx
@@ -11,6 +11,7 @@ import TimelineSidebar from "metabase/query_builder/components/view/sidebars/Tim
 export const NativeQueryRightSidebar = (props) => {
   const {
     question,
+    timelineEvents,
     timelines,
     toggleTemplateTagsEditor,
     toggleDataReference,
@@ -79,6 +80,7 @@ export const NativeQueryRightSidebar = (props) => {
     .with({ isShowingAIQuestionAnalysisSidebar: true }, () => (
       <PLUGIN_AI_ENTITY_ANALYSIS.AIQuestionAnalysisSidebar
         question={question}
+        visibleTimelineEvents={timelineEvents}
         timelines={timelines}
         onClose={onCloseAIQuestionAnalysisSidebar}
       />

--- a/frontend/src/metabase/query_builder/components/view/View/StructuredQueryRightSidebar/StructuredQueryRightSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/StructuredQueryRightSidebar/StructuredQueryRightSidebar.jsx
@@ -25,6 +25,7 @@ export const StructuredQueryRightSidebar = ({
   selectTimelineEvents,
   selectedTimelineEventIds,
   showTimelineEvents,
+  timelineEvents,
   timelines,
   updateQuestion,
   visibleTimelineEventIds,
@@ -45,6 +46,7 @@ export const StructuredQueryRightSidebar = ({
       () => (
         <PLUGIN_AI_ENTITY_ANALYSIS.AIQuestionAnalysisSidebar
           question={question}
+          visibleTimelineEvents={timelineEvents}
           timelines={timelines}
           onClose={onCloseAIQuestionAnalysisSidebar}
         />


### PR DESCRIPTION
### Description

A follow-up adjustment to https://github.com/metabase/metabase/pull/57926 that ensures we send manually made visible timeline events even from different collections.

### How to verify

- Run Metabase EE
- Create E1 and E2 timeline events in the Our Analytics collection
- Create a nested Collection 1
- Create some timeline events in Collection 1
- Create [Orders Count by Created At] timeseries line chart in Collection 1
- Open the timeline events sidebar to enable event E2 from Our Analytics collection
- Open the network tab in dev tools
- Click on the Metabot analysis button
- Ensure it sends timeline events only from Collection 1 plus E2 from Our Analytics collection as it was explicitly enabled

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
