### PR TITLE
Optimize version info fetching

### DIFF
--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx
@@ -10,7 +10,7 @@ import _ from "underscore";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { SwagButton } from "metabase/admin/settings/components/Swag/SwagButton";
 import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
-import { useGetSettingQuery } from "metabase/api";
+import { useGetVersionInfoQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { AdminLayout } from "metabase/components/AdminLayout";
 import { NotFound } from "metabase/components/ErrorPages";
@@ -65,7 +65,7 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const NewVersionIndicatorWrapper = () => {
-  const { data: versionInfo } = useGetSettingQuery("version-info");
+  const { data: versionInfo } = useGetVersionInfoQuery();
   const currentVersion = useSelector(getCurrentVersion);
   const updateChannel = useSetting("update-channel") ?? "latest";
   const latestVersion = versionInfo?.[updateChannel]?.version;

--- a/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { c, t } from "ttag";
 
 import { getCurrentVersion } from "metabase/admin/settings/selectors";
-import { useGetSettingQuery } from "metabase/api";
+import { useGetVersionInfoQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import ButtonsS from "metabase/css/components/buttons.module.css";
@@ -18,9 +18,7 @@ import type {
 import S from "./VersionUpdateNotice.module.css";
 
 export function VersionUpdateNotice() {
-  const { data: versionInfo } = useGetSettingQuery("version-info") as {
-    data: VersionInfo;
-  };
+  const { data: versionInfo } = useGetVersionInfoQuery();
   const currentVersion = useSelector(getCurrentVersion);
   const updateChannel = useSetting("update-channel") ?? "latest";
   const latestVersion = versionInfo?.[updateChannel]?.version;

--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -22,12 +22,22 @@ export const settingsApi = Api.injectEndpoints({
       transformResponse: (response: SettingDefinition[]) =>
         _.indexBy(response, "key") as SettingDefinitionMap,
     }),
-    getSetting: builder.query<EnterpriseSettingValue, EnterpriseSettingKey>({
+    getSetting: builder.query<
+      EnterpriseSettingValue,
+      Exclude<EnterpriseSettingKey, "version-info">
+    >({
       query: (name) => ({
         method: "GET",
         url: `/api/setting/${encodeURIComponent(name)}`,
       }),
       providesTags: ["session-properties"],
+    }),
+    getVersionInfo: builder.query<EnterpriseSettings["version-info"], void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/setting/version-info",
+      }),
+      // don't provide a tag, this should never be refetched
     }),
     updateSetting: builder.mutation<
       void,
@@ -58,6 +68,7 @@ export const settingsApi = Api.injectEndpoints({
 
 export const {
   useGetSettingQuery,
+  useGetVersionInfoQuery,
   useGetAdminSettingsDetailsQuery,
   useUpdateSettingMutation,
   useUpdateSettingsMutation,

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
@@ -2,14 +2,13 @@ import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
 import { updateSetting } from "metabase/admin/settings/settings";
-import { useGetSettingQuery } from "metabase/api";
+import { useGetVersionInfoQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { color } from "metabase/lib/colors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import { Anchor, Flex, Icon, Paper, Stack, Text } from "metabase/ui";
-import type { VersionInfo } from "metabase-types/api";
 
 import { DismissIconButtonWrapper } from "./WhatsNewNotification.styled";
 import Sparkles from "./sparkles.svg?component";
@@ -18,9 +17,7 @@ import { getLatestEligibleReleaseNotes } from "./utils";
 export function WhatsNewNotification() {
   const dispatch = useDispatch();
   const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
-  const { data: versionInfo } = useGetSettingQuery("version-info") as {
-    data: VersionInfo;
-  };
+  const { data: versionInfo } = useGetVersionInfoQuery();
   const currentVersion = useSetting("version");
   const lastAcknowledgedVersion = useSetting("last-acknowledged-version");
   const isWhiteLabeling = useSelector(getIsWhiteLabeling);

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
@@ -14,7 +14,7 @@ export const getLatestEligibleReleaseNotes = ({
   isEmbeddingIframe = false,
   isWhiteLabeling = false,
 }: {
-  versionInfo: VersionInfo | null;
+  versionInfo: VersionInfo | null | undefined;
   currentVersion: string | undefined;
   lastAcknowledgedVersion: string | null;
   isEmbeddingIframe: boolean;


### PR DESCRIPTION

Closes adm-811

### Description

As a result of https://github.com/metabase/metabase/pull/57505, on every settings update we were re-fetching all version-info. 🤦 That defeats the whole purpose of that PR, which is to only fetch version info when we need it.

This sets up a different API hook for this setting with no invalidation tag so that it will never re-fetch (because this data should change, at most, weekly). As a nice side effect, this allows us to type this setting properly and avoid the type cast.

### How to verify

1. Open the network inspector
2. Open Admin Settings
3. Change Any setting
4. see that `/api/setting/version-info` doesn't get called again

