### PR TITLE
Cleanup deprecation notice code

### DIFF
--- a/frontend/src/metabase/admin/app/containers/DeprecationNotice/DeprecationNotice.tsx
+++ b/frontend/src/metabase/admin/app/containers/DeprecationNotice/DeprecationNotice.tsx
@@ -10,7 +10,7 @@ import DeprecationNotice from "../../components/DeprecationNotice";
 import {
   hasDeprecatedDatabase,
   hasSlackBot,
-  isNoticeEnabled,
+  isDeprecationNoticeEnabled,
 } from "../../selectors";
 
 interface Props {
@@ -20,7 +20,7 @@ interface Props {
 const mapStateToProps = (state: State, props: Props) => ({
   hasSlackBot: hasSlackBot(state),
   hasDeprecatedDatabase: hasDeprecatedDatabase(state, props),
-  isEnabled: isNoticeEnabled(state),
+  isEnabled: isDeprecationNoticeEnabled(state),
 });
 
 const mapDispatchToProps = {

--- a/frontend/src/metabase/admin/app/reducers.ts
+++ b/frontend/src/metabase/admin/app/reducers.ts
@@ -2,7 +2,6 @@ import { createReducer } from "@reduxjs/toolkit";
 import { t } from "ttag";
 
 import { combineReducers } from "metabase/lib/redux";
-import Settings from "metabase/lib/settings";
 import { isNotNull } from "metabase/lib/types";
 import {
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS,
@@ -10,8 +9,6 @@ import {
 } from "metabase/plugins";
 import { refreshCurrentUser } from "metabase/redux/user";
 import type { AdminPath, AdminPathKey } from "metabase-types/store";
-
-import { disableNotice } from "./actions";
 
 export const getAdminPaths: () => AdminPath[] = () => {
   const items: AdminPath[] = [
@@ -82,14 +79,6 @@ const paths = createReducer(getAdminPaths(), (builder) => {
   });
 });
 
-const isNoticeEnabled = createReducer(
-  Settings.deprecationNoticeEnabled(),
-  (builder) => {
-    builder.addCase(disableNotice.fulfilled, () => false);
-  },
-);
-
 export const appReducer = combineReducers({
-  isNoticeEnabled,
   paths,
 });

--- a/frontend/src/metabase/admin/app/selectors.ts
+++ b/frontend/src/metabase/admin/app/selectors.ts
@@ -12,10 +12,6 @@ export const hasSlackBot = (state: State): boolean => {
   return getSetting(state, "slack-token") != null;
 };
 
-export const isNoticeEnabled = (state: State): boolean => {
-  return state.admin.app.isNoticeEnabled;
-};
-
 export const hasDeprecatedDatabase = (state: State, props: Props): boolean => {
   const engines = getEngines(state);
   return (
@@ -31,4 +27,12 @@ export const getAdminPaths = (state: State) => {
 
 export const getIsOnboardingSidebarLinkDismissed = (state: State) => {
   return getSetting(state, "dismissed-onboarding-sidebar-link");
+};
+
+export const isDeprecationNoticeEnabled = (state: State): boolean => {
+  // check if the deprecation notice has been dismissed on this version
+  return (
+    state.settings?.values?.version?.tag !==
+    state.settings?.values?.["deprecation-notice-version"]
+  );
 };

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -1,8 +1,6 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
-import { parseTimestamp } from "metabase/lib/time";
 import { numberToWord } from "metabase/lib/utils";
 import type {
   PasswordComplexity,
@@ -216,17 +214,6 @@ class MetabaseSettings {
   }
 
   /**
-   * @deprecated use getSetting(state, "deprecation-notice-version")
-   */
-  deprecationNoticeVersion() {
-    return this.get("deprecation-notice-version");
-  }
-
-  deprecationNoticeEnabled() {
-    return this.currentVersion() !== this.deprecationNoticeVersion();
-  }
-
-  /**
    * @deprecated use getSetting(state, "premium-embedding-token")
    */
   token() {
@@ -239,35 +226,6 @@ class MetabaseSettings {
   formattingOptions() {
     const opts = this.get("custom-formatting");
     return opts && opts["type/Temporal"] ? opts["type/Temporal"] : {};
-  }
-
-  versionInfoLastChecked() {
-    const ts = this.get("version-info-last-checked");
-
-    if (ts) {
-      // app DB stores this timestamp in UTC, so convert it to the local zone to render
-      return moment
-        .utc(parseTimestamp(ts))
-        .local()
-        .format("MMMM Do YYYY, h:mm:ss a");
-    } else {
-      return t`never`;
-    }
-  }
-
-  /**
-   * @deprecated use getSetting(state, "version-info")
-   */
-  versionInfo() {
-    return this.get("version-info") || {};
-  }
-
-  /**
-   * @deprecated use getSetting(state, "version")
-   */
-  currentVersion() {
-    const version = this.get("version") || {};
-    return version.tag;
   }
 
   /**


### PR DESCRIPTION

### Description

See [mad ravings](https://metaboat.slack.com/archives/C064EB1UE5P/p1747257437459359)

If you have a deprecated slack integration or database, we show a banner in admin settings. This banner used a silly chain of redux mess and some deprecated settings code to do something very simple: check if the banner has been dismissed on this version. This just deletes a bunch of code and still does the exact same thing. Much of the code it used was deprecated

![Screenshot 2025-05-14 at 4 46 09 PM](https://github.com/user-attachments/assets/77b1b187-e6c9-4206-9991-a7fdbe469a2a)
