### PR TITLE
Robust `InitSendPulseTriggers`

### DIFF
--- a/src/metabase/db/custom_migrations/pulse_to_notification.clj
+++ b/src/metabase/db/custom_migrations/pulse_to_notification.clj
@@ -1,6 +1,10 @@
 (ns metabase.db.custom-migrations.pulse-to-notification
   (:require
    [clojure.string :as str]
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.scheduler :as qs]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.db.custom-migrations.util :as custom-migrations.util]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
@@ -81,10 +85,17 @@
              (assoc pc :recipients (get pc-id->recipients (:id pc))))
            pcs))))
 
+(defn- send-pulse-trigger-key
+  [pulse-id schedule-map]
+  (triggers/key (format "metabase.task.send-pulse.trigger.%d.%s"
+                        pulse-id (-> schedule-map
+                                     schedule-map->cron-string
+                                     (str/replace " " "_")))))
+
 (defn- alert->notification!
   "Create a new notification with `subsciptions`.
   Return the created notifications."
-  [pulse]
+  [scheduler pulse]
   (let [pulse-id   (:id pulse)
         pcs        (hydrate-recipients (t2/select :pulse_channel :pulse_id pulse-id :enabled true))
         ;; alerts have one pulse-card, but to be safe we select the latest one by id
@@ -136,16 +147,18 @@
                                      {:channel_type "channel/http"
                                       :channel_id    (:channel_id pc)})))
                                 pcs)]
+         (qs/delete-trigger scheduler (send-pulse-trigger-key pulse-id pc))
          (create-notification! notification subscriptions handlers))))))
 
 (defn migrate-alerts!
   "Migrate alerts from `pulse` to `notification`."
   []
   #_{:clj-kondo/ignore [:unresolved-symbol]}
-  (run! alert->notification!
-        (t2/reducible-query {:select [:*]
-                             :from   [:pulse]
-                             :where  [:and [:in :alert_condition ["rows" "goal"]] [:not :archived]]})))
+  (custom-migrations.util/with-temp-schedule! [scheduler]
+    (run! #(alert->notification! scheduler %)
+          (t2/reducible-query {:select [:*]
+                               :from   [:pulse]
+                               :where  [:and [:in :alert_condition ["rows" "goal"]] [:not :archived]]}))))
 
 (comment
   (t2/delete! :model/Notification)

--- a/src/metabase/db/custom_migrations/pulse_to_notification.clj
+++ b/src/metabase/db/custom_migrations/pulse_to_notification.clj
@@ -1,7 +1,6 @@
 (ns metabase.db.custom-migrations.pulse-to-notification
   (:require
    [clojure.string :as str]
-   [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.scheduler :as qs]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.db.custom-migrations.util :as custom-migrations.util]

--- a/src/metabase/db/custom_migrations/util.clj
+++ b/src/metabase/db/custom_migrations/util.clj
@@ -24,7 +24,7 @@
   Since we don't really need to run migrations against the scheduler in tests, this function will throw an exception if it sees an already-running scheduler.
   The various 'run this test with a temp database' functions should set `*allow-temp-scheduling*` to false so this call does nothing, so you should still never see the exception."
   [f]
-  (when  *allow-temp-scheduling*
+  (when *allow-temp-scheduling*
     (classloader/the-classloader)
     (set-jdbc-backend-properties!)
     (let [scheduler (qs/initialize)]

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -182,7 +182,12 @@
 (task/defjob
   ^{:doc
     "Find all notification subscriptions with cron schedules and create a trigger for each.
-    Run once on startup."
+    Run once on startup.
+
+    Context: We've migrated alerts from pulse to notifications, see the `v53.2024-12-12T08:05:00` migration.
+    This job is needed to create triggers for all existing notification subscriptions after the migration.
+    The fact that it runs on every startup is because we have no way to have it run only once.
+    Ideally this should be a migration."
     DisallowConcurrentExecution true}
   InitNotificationTriggers
   [_context]

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -172,8 +172,7 @@
   Called once when Metabase starts up to create triggers for all existing PulseChannels"
   []
   (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
-  (let [trigger-slot->pc-ids (as-> (active-dashsub-pcs)
-                                   results
+  (let [trigger-slot->pc-ids (as-> (active-dashsub-pcs) results
                                (group-by #(select-keys % [:pulse_id :schedule_type :schedule_day :schedule_hour :schedule_frame]) results)
                                (update-vals results #(map :id %)))]
     (doseq [[{:keys [pulse_id] :as schedule-map} pc-ids] trigger-slot->pc-ids]

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -230,8 +230,14 @@
 
 (task/defjob
   ^{:doc
-    "Find all active Dashboard Subscriptino channels, group them by pulse-id and schedule time and create a trigger for each.
-    Do this every startup to make sure all active pulse channels are triggered correctly."
+    "Find all notification subscriptions with cron schedules and create a trigger for each.
+    Run once on startup.
+
+    Context: Prior to 50, the SendPulse job has a single trigger that sends all pulses, but in #42316
+    We've changed it to one trigger per PulseChannel. We need this job so that users migrate from < 50
+    have all the triggers initiated properly.
+    The fact that it runs on every startup is because we have no way to have it run only once.
+    Ideally this should be a migration."
     DisallowConcurrentExecution true}
   InitSendPulseTriggers
   [_context]

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -158,7 +158,6 @@
   Called once when Metabase starts up to create triggers for all existing PulseChannels"
   []
   (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
-  (task/delete-all-triggers-of-job! send-pulse-job-key)
   (let [trigger-slot->pc-ids (as-> (t2/select :model/PulseChannel
                                               {:select    [:pc.*]
                                                :from      [[:pulse_channel :pc]]

--- a/test/metabase/db/custom_migrations/pulse_to_notification_test.clj
+++ b/test/metabase/db/custom_migrations/pulse_to_notification_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.db.custom-migrations.pulse-to-notification-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.db.custom-migrations.pulse-to-notification :as pulse-to-notification]
    [metabase.notification.models :as models.notification]
@@ -15,7 +14,7 @@
   [notiification]
   (update notiification :handler #(sort-by :channel_type %)))
 
-(defmacro with-test-setup
+(defmacro with-test-setup!
   [& body]
   `(mt/with-model-cleanup [:model/Pulse :model/Notification]
      (mt/with-temp-scheduler!
@@ -71,7 +70,7 @@
 
 (deftest migrate-alert-test
   (testing "basic alert migration"
-    (with-test-setup
+    (with-test-setup!
       (mt/with-temp [:model/Card {card-id :id} {}]
         (testing "has one subscription, one email handler with one recipient"
           (let [alert-id (create-alert! {} card-id [{:channel_type "email"
@@ -97,7 +96,7 @@
 
 (deftest migrate-alert-http-test
   (testing "migrate alert with http channel"
-    (with-test-setup
+    (with-test-setup!
       (mt/with-temp [:model/Card {card-id :id} {}
                      :model/Channel {channel-id :id} {}]
         (let [alert-id (create-alert! {} card-id [{:channel_type "http"
@@ -117,7 +116,7 @@
 
 (deftest migrate-alert-multiple-channels-test
   (testing "migrate alert with multiple channels 1 slack, 1 email with 1 external recipient and one user, 1 disabled email, one http"
-    (with-test-setup
+    (with-test-setup!
       (mt/with-temp [:model/Card {card-id :id} {}
                      :model/Channel {channel-id :id} {:type "channel/http"}]
         (let [alert-id (create-alert! {} card-id [{:channel_type "email"
@@ -154,7 +153,7 @@
 
 (deftest migrate-alert-send-condition-test
   (testing "migrate alert with different send conditions"
-    (with-test-setup
+    (with-test-setup!
       (mt/with-temp [:model/Card {card-id :id} {}]
         (doseq [{:keys [expected alert-props]} [{:expected    {:send_condition :has_result
                                                                :send_once      false}

--- a/test/metabase/db/custom_migrations/pulse_to_notification_test.clj
+++ b/test/metabase/db/custom_migrations/pulse_to_notification_test.clj
@@ -4,6 +4,9 @@
    [clojure.test :refer :all]
    [metabase.db.custom-migrations.pulse-to-notification :as pulse-to-notification]
    [metabase.notification.models :as models.notification]
+   [metabase.pulse.models.pulse-channel-test :as pulse-channel-test]
+   [metabase.pulse.task.send-pulses :as task.send-pulses]
+   [metabase.task.core :as task]
    [metabase.test :as mt]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
@@ -12,9 +15,16 @@
   [notiification]
   (update notiification :handler #(sort-by :channel_type %)))
 
+(defmacro with-test-setup
+  [& body]
+  `(mt/with-model-cleanup [:model/Pulse :model/Notification]
+     (mt/with-temp-scheduler!
+       (task/init! ::task.send-pulses/SendPulses)
+       ~@body)))
+
 (defn migrate-alert!
-  [pulse-id]
-  (->> (#'pulse-to-notification/alert->notification! (t2/select-one :pulse pulse-id))
+  [scheduler pulse-id]
+  (->> (#'pulse-to-notification/alert->notification! scheduler (t2/select-one :pulse pulse-id))
        (map :id)
        (map (partial t2/select-one :model/Notification))
        (map models.notification/hydrate-notification)
@@ -42,7 +52,7 @@
   (let [pulse-id (t2/insert-returning-pk! :pulse (add-timestamp pulse))]
     (t2/insert! :pulse_card (map #(assoc % :pulse_id pulse-id) pulse-cards))
     (doseq [pcr pcs+recipients]
-      (let [pc-id (t2/insert-returning-pk! :pulse_channel (-> pcr (assoc :pulse_id pulse-id) (dissoc :recipients) add-timestamp))]
+      (let [pc-id (t2/insert-returning-pk! :model/PulseChannel (-> pcr (assoc :pulse_id pulse-id) (dissoc :recipients) add-timestamp))]
         (when (seq (:recipients pcr))
           (t2/insert! :pulse_channel_recipient (map #(assoc % :pulse_channel_id pc-id) (:recipients pcr))))))
     pulse-id))
@@ -61,13 +71,18 @@
 
 (deftest migrate-alert-test
   (testing "basic alert migration"
-    (mt/with-model-cleanup [:model/Pulse :model/Notification]
+    (with-test-setup
       (mt/with-temp [:model/Card {card-id :id} {}]
         (testing "has one subscription, one email handler with one recipient"
           (let [alert-id (create-alert! {} card-id [{:channel_type "email"
                                                      :recipients  [{:user_id (mt/user->id :rasta)}]}])
                 alert    (t2/select-one :model/Pulse alert-id)
-                notification (first (migrate-alert! alert-id))]
+                alert-triggers (pulse-channel-test/send-pulse-triggers alert-id)
+                notification (first (migrate-alert! (task/scheduler) alert-id))]
+            (testing "sanity check that there is a trigger for the alert to begin with"
+              (is (= 1 (count alert-triggers)))
+              (testing "after the migration it got deleted"
+                (is (zero? (count (pulse-channel-test/send-pulse-triggers alert-id))))))
             (is (=? {:payload_type :notification/card
                      :active       true
                      :creator_id   (mt/user->id :crowberto)
@@ -82,12 +97,12 @@
 
 (deftest migrate-alert-http-test
   (testing "migrate alert with http channel"
-    (mt/with-model-cleanup [:model/Pulse :model/Notification]
+    (with-test-setup
       (mt/with-temp [:model/Card {card-id :id} {}
                      :model/Channel {channel-id :id} {}]
         (let [alert-id (create-alert! {} card-id [{:channel_type "http"
                                                    :channel_id   channel-id}])
-              notification (first (migrate-alert! alert-id))]
+              notification (first (migrate-alert! (task/scheduler) alert-id))]
           (is (=? {:payload_type :notification/card
                    :payload      {:card_id        card-id
                                   :send_once      false
@@ -102,7 +117,7 @@
 
 (deftest migrate-alert-multiple-channels-test
   (testing "migrate alert with multiple channels 1 slack, 1 email with 1 external recipient and one user, 1 disabled email, one http"
-    (mt/with-model-cleanup [:model/Pulse :model/Notification]
+    (with-test-setup
       (mt/with-temp [:model/Card {card-id :id} {}
                      :model/Channel {channel-id :id} {:type "channel/http"}]
         (let [alert-id (create-alert! {} card-id [{:channel_type "email"
@@ -118,7 +133,7 @@
                                                   {:channel_type "email"
                                                    :enabled      false
                                                    :recipients   [{:user_id (mt/user->id :crowberto)}]}])
-              notification (first (migrate-alert! alert-id))]
+              notification (first (migrate-alert! (task/scheduler) alert-id))]
           (testing "are correctly migrated, the disabled channel is not migrated"
             (is (=? {:payload_type :notification/card
                      :active       true
@@ -139,7 +154,7 @@
 
 (deftest migrate-alert-send-condition-test
   (testing "migrate alert with different send conditions"
-    (mt/with-model-cleanup [:model/Pulse :model/Notification]
+    (with-test-setup
       (mt/with-temp [:model/Card {card-id :id} {}]
         (doseq [{:keys [expected alert-props]} [{:expected    {:send_condition :has_result
                                                                :send_once      false}
@@ -159,40 +174,9 @@
           (testing (format "testing %s condition" alert-props)
             (let [alert-id (create-alert! alert-props card-id [{:channel_type "email"
                                                                 :recipients  [{:user_id (mt/user->id :rasta)}]}])
-                  notification (first (migrate-alert! alert-id))]
+                  notification (first (migrate-alert! (task/scheduler) alert-id))]
               (is (=? {:payload_type :notification/card
                        :payload      (merge {:card_id card-id} expected)
                        :active       true
                        :creator_id   (mt/user->id :crowberto)}
                       notification)))))))))
-
-(defn- bit->boolean
-  "Coerce a bit returned by some MySQL/MariaDB versions in some situations to Boolean."
-  [v]
-  (if (number? v)
-    (not (zero? v))
-    v))
-
-(defn test-alert-view!
-  [{:keys [alert pcs expected-views]}]
-  (mt/with-model-cleanup [:model/Pulse :model/Notification]
-    (mt/with-temp [:model/Card {card-id :id} {}]
-      (let [alert-id (create-alert! alert card-id pcs)
-            notification-id (:id (first (migrate-alert! alert-id)))
-            entity-id       (format "notification_%s" notification-id)
-            card-entity-id  (format "card_%s" card-id)]
-        (is (=? (map #(assoc %
-                             :card_qualified_id card-entity-id
-                             :card_id card-id
-                             :entity_id notification-id)
-                     expected-views)
-                (map #(-> %
-                          (update :archived bit->boolean)
-                          (update :recipients (fn [recipients]
-                                                (some-> recipients
-                                                        (str/split #",")
-                                                        set))))
-                     (t2/query {:select [:*]
-                                :from [:v_alerts]
-                                :where [:= :entity_qualified_id entity-id]
-                                :order-by [:recipient_type]}))))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -2585,11 +2585,11 @@
           (testing "after migration"
             (migrate!)
             (testing "pulse is migrated to notification"
-              (let [notification (t2/select-one :notification)
+              (let [notification      (t2/select-one :notification)
                     notification-card (t2/select-one :notification_card :id (:payload_id notification))
-                    subscription (t2/select-one :notification_subscription :notification_id (:id notification))
-                    handler      (t2/select-one :notification_handler :notification_id (:id notification))
-                    recipient    (t2/select-one :notification_recipient :notification_handler_id (:id handler))]
+                    subscription      (t2/select-one :notification_subscription :notification_id (:id notification))
+                    handler           (t2/select-one :notification_handler :notification_id (:id notification))
+                    recipient         (t2/select-one :notification_recipient :notification_handler_id (:id handler))]
                 (is (= {:payload_type "notification/card"
                         :active       true
                         :creator_id   user-id}

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -24,6 +24,7 @@
    [metabase.db :as mdb]
    [metabase.db.connection :as mdb.connection]
    [metabase.db.custom-migrations :as custom-migrations]
+   [metabase.db.custom-migrations.util :as custom-migrations.util]
    [metabase.db.schema-migrations-test.impl :as impl]
    [metabase.driver :as driver]
    [metabase.models.database :as database]
@@ -2554,8 +2555,8 @@
 ;; see [[custom-migrations/MigrateAlertToNotification]] for info about how this migration works
 (deftest migrate-alert-to-notification-test
   (testing "v53.2024-12-12T08:06:00: migrate alerts from pulse to notification"
-    (mt/with-temp-scheduler!
-      (impl/test-migrations ["v53.2024-12-12T08:05:00"] [migrate!]
+    (impl/test-migrations ["v53.2024-12-12T08:05:00"] [migrate!]
+      (binding [custom-migrations.util/*allow-temp-scheduling* true]
         (let [user-id     (:id (new-instance-with-default :core_user))
               database-id (:id (new-instance-with-default :metabase_database))
               card-id     (:id (new-instance-with-default :report_card

--- a/test/metabase/pulse/task/send_pulses_test.clj
+++ b/test/metabase/pulse/task/send_pulses_test.clj
@@ -329,14 +329,9 @@
       (task/init! ::task.send-pulses/SendPulses)
       (mt/with-temp
         [:model/Pulse        {pulse-id :id} {:alert_condition "goal"}
-         :model/PulseChannel {_pc-id :id}   (merge
+         :model/PulseChannel {pc-id :id}    (merge
                                              {:pulse_id     pulse-id
                                               :channel_type :slack
                                               :details      {:channel "#random"}}
                                              daily-at-1am)]
-        (let [pulse-triggers (pulse-channel-test/send-pulse-triggers pulse-id)]
-          (testing "sanity check that it has triggers to begin with"
-            (is (not-empty pulse-triggers)))
-          (testing "init send pulse triggers skip alerts"
-            (#'task.send-pulses/init-dashboard-subscription-triggers!)
-            (is (empty? (pulse-channel-test/send-pulse-triggers pulse-id)))))))))
+        (is (not (contains? (set (map :id (#'task.send-pulses/active-dashsub-pcs))) pc-id)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58004

The `InitSendPulseTriggers` background job was running on every startup were deleting all dashboard subscriptions triggers then recreate each of them.

This makes it so that we'll only update the triggers only if it changes.

But why did we have the deletion step in the first place? because when we migrated alerts to notification, we need a way to delete the existing quartz triggers of the old alerts, so we used that.

In this PR, we've changed the deletion process to the AlertToNotification migration itself.

How safe is that?:
- for instances that are on 54 already, it's totally fine because those triggers were already deleted
- for instances that upgrade to 54, the migration will take care of those triggers