### PR TITLE
Fix ModalHeader back button position

### DIFF
--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -21,8 +21,6 @@ export const ModalContentActionIcon = styled(Icon)`
 export const ModalHeaderBackIcon = styled(ModalContentActionIcon)`
   flex-shrink: 0;
 
-  margin: -0.5rem 0 -0.5rem -0.5rem;
-
   :hover {
     color: var(--mb-color-brand);
   }

--- a/frontend/src/metabase/components/ModalContent/ModalHeader.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalHeader.tsx
@@ -39,6 +39,7 @@ export const ModalHeader = ({
     >
       <Flex
         align="center"
+        gap="sm"
         className={cx(S.HeaderTextContainer, {
           [S.clickable]: !!onBack,
         })}


### PR DESCRIPTION
Fix ModalHeader back button position.
Looks like it is Mantine 7 regression, it looks ok in v53

Before:
![image](https://github.com/user-attachments/assets/a9fdb5d1-6431-4a58-a9d0-99c2ee987d6e)


After:
![image](https://github.com/user-attachments/assets/0788a7de-e6ef-4d02-b921-33d344c2be56)
