### PR TITLE
ci(sdk): fix flaky tests on interactive question theming

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -240,11 +240,11 @@ export function assertBackgroundColorEqual($element: JQuery, expected: string) {
   );
 
   // the dynamically lightened/darkened colors are off by one,
-  // so we must compare with 5% tolerance.
+  // so we must compare with 1% tolerance.
   expect(
     colorDifferencePercentage,
     "color difference percentage is higher than expected",
-  ).to.be.lte(5);
+  ).to.be.lte(1);
 }
 
 function getColorDifferencePercentage(color1: string, color2: string) {

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -240,8 +240,11 @@ export function assertBackgroundColorEqual($element: JQuery, expected: string) {
   );
 
   // the dynamically lightened/darkened colors are off by one,
-  // so we must compare with 1% tolerance.
-  expect(colorDifferencePercentage).to.be.lte(1);
+  // so we must compare with 5% tolerance.
+  expect(
+    colorDifferencePercentage,
+    "color difference percentage is higher than expected",
+  ).to.be.lte(5);
 }
 
 function getColorDifferencePercentage(color1: string, color2: string) {

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -85,14 +85,6 @@ describe(
           assertBackgroundColorEqual($el, buttonHoverBg),
         );
 
-        // Hover should be a less lightened version of the background color.
-        cy.get(customColumn)
-          .should("be.visible")
-          .realHover()
-          .should(($el) =>
-            assertBackgroundColorEqual($el, lighten(BACKGROUND_COLOR, 0.4)),
-          );
-
         cy.findByTestId("interactive-question-result-toolbar").should(($el) =>
           assertBackgroundColorEqual($el, lighten(BACKGROUND_COLOR, 0.5)),
         );
@@ -122,14 +114,6 @@ describe(
         cy.get(customColumn).should(($el) =>
           assertBackgroundColorEqual($el, darken(BACKGROUND_COLOR, 0.05)),
         );
-
-        // Hover should be an even darker version of the background color
-        cy.get(customColumn)
-          .should("be.visible")
-          .realHover()
-          .should(($el) =>
-            assertBackgroundColorEqual($el, darken(BACKGROUND_COLOR, 0.1)),
-          );
 
         cy.findByTestId("interactive-question-result-toolbar").should(($el) =>
           assertBackgroundColorEqual($el, darken(BACKGROUND_COLOR, 0.04)),


### PR DESCRIPTION
Fixes the flake by removing an assertion that relies on checking colors after realHover, which is a known cause of flake: https://github.com/dmtrKovalenko/cypress-real-events/issues/691. We actually do not need that as we have other assertions that already checks that dynamic CSS is working.

Flake report: https://metaboat.slack.com/archives/C5XHN8GLW/p1747261303870599

After removing those assertions, tests no longer flake as before:

![CleanShot 2568-05-15 at 15 13 10@2x](https://github.com/user-attachments/assets/30f1fcc9-7140-4fa8-ba28-94253ec451c1)
