### PR TITLE
Do not transform :has css selectors by Post CSS

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -17,6 +17,7 @@ module.exports = {
         "custom-media-queries": true,
         "custom-properties": true,
         "focus-visible-pseudo-class": false,
+        "has-pseudo-class": false,
       },
     },
     "postcss-discard-comments": {},


### PR DESCRIPTION
Do not transform :has css selectors by Post CSS

Closes https://linear.app/metabase/issue/EMB-393/do-not-transform-has-css-selectors-by-post-css
Context https://metaboat.slack.com/archives/C505ZNNH4/p1746808284886489

Right now PostCSS tries to transform them because :has selectors are not the part of the `stage 2`.
It causes the following CSS both for the Main App and for the Embedding SDK:
```
 .vXegc[\:has\(.radio\:disabled\)] .fnJ5q{
      color:#949aab;
      color:var(--mb-color-text-light);
    }
    .vXegc[\:has\(.radio\:disabled\)] .Ysrub{
      color:#949aab;
      color:var(--mb-color-text-light);
    }
    .vXegc[\:has\(.radio\:disabled\)] .KRNGg{
      color:#fff;
      color:var(--mb-color-text-white);
    }

.vXegc:has(.XTmFw:disabled) .fnJ5q{
      color:#949aab;
      color:var(--mb-color-text-light);
    }

.vXegc:has(.XTmFw:disabled) .Ysrub{
      color:#949aab;
      color:var(--mb-color-text-light);
    }

.vXegc:has(.XTmFw:disabled) .KRNGg{
      color:#fff;
      color:var(--mb-color-text-white);
    }
```

So as we can see, initially the wrong CSS is added, then the proper CSS is added.
We can safely prevent this behavior by setting `"has-pseudo-class": false`.

This change IS required for the SDK transition from `webpack` to `esbuild`, because `esbuild` throws errors for wrong `[\:has\(.radio\:disabled\)]`-like selectors

Before:
![image](https://github.com/user-attachments/assets/ebec1837-875d-44e2-8d00-8e9cdf03e7ad)

After :
![image](https://github.com/user-attachments/assets/0ce17702-67fb-4e54-9fe8-a7da08fe1144)




How to verify:
- Open any page of the Metabase App
- Open network => find the main `app-main.css` file and inspect its content
- You should not find the occurrence of `[\:has\(.radio\:disabled\)]`-like broken CSS selectors