### PR TITLE
feat(sdk): Do not add unused Empty state SVG images to the SDK bundle

### DIFF
--- a/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.tsx
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.tsx
@@ -61,6 +61,7 @@ export const EmptyVizState = ({
     >
       <Box maw="20rem" mb="3rem">
         <img
+          className={CS.pointerEventsNone}
           src={imgSrc}
           alt={c("{0} refers to the chart type")
             .t`${emptyVizChart} chart example illustration`}

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.tsx
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.tsx
@@ -59,16 +59,13 @@ export const EmptyVizState = ({
       justify="center"
       data-testid="visualization-placeholder"
     >
-      {imgSrc && (
-        <Box maw="20rem" mb="3rem">
-          <img
-            src={imgSrc}
-            alt={c("{0} refers to the chart type")
-              .t`${emptyVizChart} chart example illustration`}
-            data-testid="visualization-placeholder-image"
-          />
-        </Box>
-      )}
+      <Box maw="20rem" mb="3rem">
+        <img
+          src={imgSrc}
+          alt={c("{0} refers to the chart type")
+            .t`${emptyVizChart} chart example illustration`}
+        />
+      </Box>
       <Stack gap="0.75rem" maw="25rem" ta="center" align="center">
         {isDocsCTA && (
           <>

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.tsx
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.tsx
@@ -59,13 +59,16 @@ export const EmptyVizState = ({
       justify="center"
       data-testid="visualization-placeholder"
     >
-      <Box maw="20rem" mb="3rem">
-        <img
-          src={imgSrc}
-          alt={c("{0} refers to the chart type")
-            .t`${emptyVizChart} chart example illustration`}
-        />
-      </Box>
+      {imgSrc && (
+        <Box maw="20rem" mb="3rem">
+          <img
+            src={imgSrc}
+            alt={c("{0} refers to the chart type")
+              .t`${emptyVizChart} chart example illustration`}
+            data-testid="visualization-placeholder-image"
+          />
+        </Box>
+      )}
       <Stack gap="0.75rem" maw="25rem" ta="center" align="center">
         {isDocsCTA && (
           <>

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.unit.spec.tsx
@@ -125,6 +125,26 @@ describe("EmptyVizState", () => {
       screen.queryByLabelText("Open summarize sidebar"),
     ).not.toBeInTheDocument();
   });
+
+  it("should render an empty-state svg image when is the Main App", async () => {
+    setup({ chartType: "line", onEditSummary: undefined });
+
+    expect(
+      screen.getByTestId("visualization-placeholder-image"),
+    ).toBeInTheDocument();
+  });
+
+  it("should not render an empty-state svg image when is the Embedding SDK", async () => {
+    process.env.IS_EMBEDDING_SDK = "true";
+
+    setup({ chartType: "line", onEditSummary: undefined });
+
+    expect(
+      screen.queryByTestId("visualization-placeholder-image"),
+    ).not.toBeInTheDocument();
+
+    delete process.env.IS_EMBEDDING_SDK;
+  });
 });
 
 const assertEmptyStateDidNotRender = () => {

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/EmptyVizState.unit.spec.tsx
@@ -125,26 +125,6 @@ describe("EmptyVizState", () => {
       screen.queryByLabelText("Open summarize sidebar"),
     ).not.toBeInTheDocument();
   });
-
-  it("should render an empty-state svg image when is the Main App", async () => {
-    setup({ chartType: "line", onEditSummary: undefined });
-
-    expect(
-      screen.getByTestId("visualization-placeholder-image"),
-    ).toBeInTheDocument();
-  });
-
-  it("should not render an empty-state svg image when is the Embedding SDK", async () => {
-    process.env.IS_EMBEDDING_SDK = "true";
-
-    setup({ chartType: "line", onEditSummary: undefined });
-
-    expect(
-      screen.queryByTestId("visualization-placeholder-image"),
-    ).not.toBeInTheDocument();
-
-    delete process.env.IS_EMBEDDING_SDK;
-  });
 });
 
 const assertEmptyStateDidNotRender = () => {

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
@@ -1,21 +1,6 @@
 import { t } from "ttag";
 
-import areaEmptyState from "assets/img/empty-states/visualizations/area.svg";
-import barEmptyState from "assets/img/empty-states/visualizations/bar.svg";
-import comboEmptyState from "assets/img/empty-states/visualizations/combo.svg";
-import funnelEmptyState from "assets/img/empty-states/visualizations/funnel.svg";
-import gaugeEmptyState from "assets/img/empty-states/visualizations/gauge.svg";
-import lineEmptyState from "assets/img/empty-states/visualizations/line.svg";
-import mapEmptyState from "assets/img/empty-states/visualizations/map-region.svg";
-import pieEmptyState from "assets/img/empty-states/visualizations/pie.svg";
-import pivotEmptyState from "assets/img/empty-states/visualizations/pivot.svg";
-import progressEmptyState from "assets/img/empty-states/visualizations/progress.svg";
-import rowEmptyState from "assets/img/empty-states/visualizations/row.svg";
-import sankeyEmptyState from "assets/img/empty-states/visualizations/sankey.svg";
-import scalarEmptyState from "assets/img/empty-states/visualizations/scalar.svg";
-import scatterEmptyState from "assets/img/empty-states/visualizations/scatter.svg";
-import smartscalarEmptyState from "assets/img/empty-states/visualizations/smartscalar.svg";
-import waterfallEmptyState from "assets/img/empty-states/visualizations/waterfall.svg";
+import { getSubpathSafeUrl } from "metabase/lib/urls";
 import type { CardDisplayType } from "metabase-types/api";
 
 /**
@@ -35,9 +20,16 @@ type EmptyVizConfig = {
   docsLink?: string;
 };
 
+// We should not import these large empty-state images directly,
+// because we don't need to inline them as base64 to the SDK bundle.
+// Insead we just define paths to them that is passed to the <img> tag directly.
 const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
   area: {
-    imgSrc: areaEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/area.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick a metric and multiple columns to group by.`;
     },
@@ -46,7 +38,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   bar: {
-    imgSrc: barEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/bar.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -55,7 +51,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   combo: {
-    imgSrc: comboEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/combo.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick two or more metrics and one or two columns to group by.`;
     },
@@ -64,17 +64,25 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   funnel: {
-    imgSrc: funnelEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/funnel.svg",
+      );
+    },
     get primaryText() {
       return t`Funnel charts visualize how a value is broken out by a series of steps, and the percent change between steps.`;
     },
     get secondaryText() {
       return t`Read the docs`;
     },
-    docsLink: "questions/visualizations/funnel",
+    docsLink: getSubpathSafeUrl("questions/visualizations/funnel"),
   },
   gauge: {
-    imgSrc: gaugeEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/gauge.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum) and customize the gauge in the visualization settings.`;
     },
@@ -83,7 +91,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   line: {
-    imgSrc: lineEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/line.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick one or more metrics and a time column to group by.`;
     },
@@ -92,7 +104,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   map: {
-    imgSrc: mapEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/map-region.svg",
+      );
+    },
     get primaryText() {
       return t`Build map visualizations with geospatial data: Pin and Grid maps require longitude and latitude columns, Region maps require a column with region names.`;
     },
@@ -102,7 +118,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/map",
   },
   pie: {
-    imgSrc: pieEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/pie.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -111,7 +131,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   pivot: {
-    imgSrc: pivotEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/pivot.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum) and multiple columns to group by.`;
     },
@@ -120,7 +144,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   progress: {
-    imgSrc: progressEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/progress.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Count or Sum) and customize the progress bar in the visualization settings.`;
     },
@@ -129,7 +157,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   row: {
-    imgSrc: rowEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/row.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -138,7 +170,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   sankey: {
-    imgSrc: sankeyEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/sankey.svg",
+      );
+    },
     get primaryText() {
       return t`Sankey charts show how data flows through multi-dimensional steps. They're useful for showing which elements, called nodes, contribute to the overall flow.`;
     },
@@ -148,14 +184,22 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/sankey",
   },
   scalar: {
-    imgSrc: scalarEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/scalar.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum).`;
     },
     secondaryText: `E.g. Average star rating`,
   },
   scatter: {
-    imgSrc: scatterEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/scatter.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick a metric and a number columns to group by.`;
     },
@@ -164,7 +208,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   smartscalar: {
-    imgSrc: smartscalarEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/smartscalar.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as the Average or Sum) and a time column to group by.`;
     },
@@ -173,7 +221,11 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   waterfall: {
-    imgSrc: waterfallEmptyState,
+    get imgSrc() {
+      return getSubpathSafeUrl(
+        "app/assets/img/empty-states/visualizations/waterfall.svg",
+      );
+    },
     get primaryText() {
       return t`Then pick a metric and a single column to group by: either time or category.`;
     },

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
@@ -29,18 +29,15 @@ type SupportedDisplayType = Exclude<
 >;
 
 type EmptyVizConfig = {
-  imgSrc: string | null;
+  imgSrc: string;
   primaryText: string;
   secondaryText: string;
   docsLink?: string;
 };
 
-// We have to use the `env` variable to tree-shake out svg images for SDK bundle
 const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
   area: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? areaEmptyState : null;
-    },
+    imgSrc: areaEmptyState,
     get primaryText() {
       return t`Then pick a metric and multiple columns to group by.`;
     },
@@ -49,9 +46,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   bar: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? barEmptyState : null;
-    },
+    imgSrc: barEmptyState,
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -60,9 +55,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   combo: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? comboEmptyState : null;
-    },
+    imgSrc: comboEmptyState,
     get primaryText() {
       return t`Then pick two or more metrics and one or two columns to group by.`;
     },
@@ -71,9 +64,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   funnel: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? funnelEmptyState : null;
-    },
+    imgSrc: funnelEmptyState,
     get primaryText() {
       return t`Funnel charts visualize how a value is broken out by a series of steps, and the percent change between steps.`;
     },
@@ -83,9 +74,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/funnel",
   },
   gauge: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? gaugeEmptyState : null;
-    },
+    imgSrc: gaugeEmptyState,
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum) and customize the gauge in the visualization settings.`;
     },
@@ -94,9 +83,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   line: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? lineEmptyState : null;
-    },
+    imgSrc: lineEmptyState,
     get primaryText() {
       return t`Then pick one or more metrics and a time column to group by.`;
     },
@@ -105,9 +92,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   map: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? mapEmptyState : null;
-    },
+    imgSrc: mapEmptyState,
     get primaryText() {
       return t`Build map visualizations with geospatial data: Pin and Grid maps require longitude and latitude columns, Region maps require a column with region names.`;
     },
@@ -117,9 +102,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/map",
   },
   pie: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? pieEmptyState : null;
-    },
+    imgSrc: pieEmptyState,
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -128,9 +111,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   pivot: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? pivotEmptyState : null;
-    },
+    imgSrc: pivotEmptyState,
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum) and multiple columns to group by.`;
     },
@@ -139,9 +120,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   progress: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? progressEmptyState : null;
-    },
+    imgSrc: progressEmptyState,
     get primaryText() {
       return t`Then pick an aggregate metric (such as Count or Sum) and customize the progress bar in the visualization settings.`;
     },
@@ -150,9 +129,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   row: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? rowEmptyState : null;
-    },
+    imgSrc: rowEmptyState,
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -161,9 +138,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   sankey: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? sankeyEmptyState : null;
-    },
+    imgSrc: sankeyEmptyState,
     get primaryText() {
       return t`Sankey charts show how data flows through multi-dimensional steps. They're useful for showing which elements, called nodes, contribute to the overall flow.`;
     },
@@ -173,18 +148,14 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/sankey",
   },
   scalar: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? scalarEmptyState : null;
-    },
+    imgSrc: scalarEmptyState,
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum).`;
     },
     secondaryText: `E.g. Average star rating`,
   },
   scatter: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? scatterEmptyState : null;
-    },
+    imgSrc: scatterEmptyState,
     get primaryText() {
       return t`Then pick a metric and a number columns to group by.`;
     },
@@ -193,9 +164,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   smartscalar: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? smartscalarEmptyState : null;
-    },
+    imgSrc: smartscalarEmptyState,
     get primaryText() {
       return t`Then pick an aggregate metric (such as the Average or Sum) and a time column to group by.`;
     },
@@ -204,9 +173,7 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   waterfall: {
-    get imgSrc() {
-      return !process.env.IS_EMBEDDING_SDK ? waterfallEmptyState : null;
-    },
+    imgSrc: waterfallEmptyState,
     get primaryText() {
       return t`Then pick a metric and a single column to group by: either time or category.`;
     },

--- a/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
+++ b/frontend/src/metabase/visualizations/components/EmptyVizState/utils.ts
@@ -29,15 +29,18 @@ type SupportedDisplayType = Exclude<
 >;
 
 type EmptyVizConfig = {
-  imgSrc: string;
+  imgSrc: string | null;
   primaryText: string;
   secondaryText: string;
   docsLink?: string;
 };
 
+// We have to use the `env` variable to tree-shake out svg images for SDK bundle
 const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
   area: {
-    imgSrc: areaEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? areaEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick a metric and multiple columns to group by.`;
     },
@@ -46,7 +49,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   bar: {
-    imgSrc: barEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? barEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -55,7 +60,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   combo: {
-    imgSrc: comboEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? comboEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick two or more metrics and one or two columns to group by.`;
     },
@@ -64,7 +71,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   funnel: {
-    imgSrc: funnelEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? funnelEmptyState : null;
+    },
     get primaryText() {
       return t`Funnel charts visualize how a value is broken out by a series of steps, and the percent change between steps.`;
     },
@@ -74,7 +83,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/funnel",
   },
   gauge: {
-    imgSrc: gaugeEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? gaugeEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum) and customize the gauge in the visualization settings.`;
     },
@@ -83,7 +94,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   line: {
-    imgSrc: lineEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? lineEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick one or more metrics and a time column to group by.`;
     },
@@ -92,7 +105,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   map: {
-    imgSrc: mapEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? mapEmptyState : null;
+    },
     get primaryText() {
       return t`Build map visualizations with geospatial data: Pin and Grid maps require longitude and latitude columns, Region maps require a column with region names.`;
     },
@@ -102,7 +117,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/map",
   },
   pie: {
-    imgSrc: pieEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? pieEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -111,7 +128,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   pivot: {
-    imgSrc: pivotEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? pivotEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum) and multiple columns to group by.`;
     },
@@ -120,7 +139,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   progress: {
-    imgSrc: progressEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? progressEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Count or Sum) and customize the progress bar in the visualization settings.`;
     },
@@ -129,7 +150,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   row: {
-    imgSrc: rowEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? rowEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick a metric and a column to group by.`;
     },
@@ -138,7 +161,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   sankey: {
-    imgSrc: sankeyEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? sankeyEmptyState : null;
+    },
     get primaryText() {
       return t`Sankey charts show how data flows through multi-dimensional steps. They're useful for showing which elements, called nodes, contribute to the overall flow.`;
     },
@@ -148,14 +173,18 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     docsLink: "questions/visualizations/sankey",
   },
   scalar: {
-    imgSrc: scalarEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? scalarEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as Average or Sum).`;
     },
     secondaryText: `E.g. Average star rating`,
   },
   scatter: {
-    imgSrc: scatterEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? scatterEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick a metric and a number columns to group by.`;
     },
@@ -164,7 +193,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   smartscalar: {
-    imgSrc: smartscalarEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? smartscalarEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick an aggregate metric (such as the Average or Sum) and a time column to group by.`;
     },
@@ -173,7 +204,9 @@ const emptyVizConfig: Record<SupportedDisplayType, EmptyVizConfig> = {
     },
   },
   waterfall: {
-    imgSrc: waterfallEmptyState,
+    get imgSrc() {
+      return !process.env.IS_EMBEDDING_SDK ? waterfallEmptyState : null;
+    },
     get primaryText() {
       return t`Then pick a metric and a single column to group by: either time or category.`;
     },

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -658,6 +658,8 @@ class Visualization extends PureComponent<
             e instanceof ChartSettingsError &&
             visualization?.hasEmptyState &&
             !isDashboard &&
+            // For the SDK the EmptyVizState component in some cases (a small container) looks really weird,
+            // so at least temporarily we don't display it when rendered in the SDK.
             !isEmbeddingSdk
           ) {
             // hide the error and display the empty state instead


### PR DESCRIPTION
Do not add unused Empty state SVG images to the bundle.

Closes https://linear.app/metabase/issue/EMB-394/do-not-add-unused-empty-state-svgs-to-the-sdk-bundle

These SVG's are not used in the SDK but we still inline them as base64:
- SVGs are rendered by the `EmptyVizState` component
- the `EmptyVizState` component is rendered conditionally in the `frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx`:
```
isPlaceholder ? (
  <EmptyVizState
    chartType={visualization?.identifier}
    isSummarizeSidebarOpen={isShowingSummarySidebar}
    onEditSummary={isDashboard ? undefined : onEditSummary}
  />
)
```
- the `isPlaceholder` value is initially `false` and is set to `true` via the following condition:
```    
let isPlaceholder = false;

if (
  e instanceof ChartSettingsError &&
  visualization?.hasEmptyState &&
  !isDashboard &&
  !isEmbeddingSdk
) {
  // hide the error and display the empty state instead
  error = null;
  isPlaceholder = true;
}
```
- so you can see, that it is never set the `isPlaceholder` value when the `isEmbeddingSdk === true` 


The approach is to load these SVGs directly both for Main App and SDK to avoid their inlining for SDK as base64.
This approach generates non-hashed URL's so these images WILL be cached by browsers, but I assume it's not a big issue, at least for this case.

How to verify:
- the CI is green