### PR TITLE
Metadata preview boilerplate

### DIFF
--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -39,8 +39,18 @@ export const DataModel = ({ params }: Props) => {
   const field = table?.fields?.find((field) => field.id === fieldId);
 
   return (
-    <Flex h={`calc(100% - ${DATA_MODEL_APP_NAV_BAR_HEIGHT}px)`}>
-      <Stack className={S.sidebar} flex="0 0 400px" gap={0} h="100%">
+    <Flex
+      h={`calc(100% - ${DATA_MODEL_APP_NAV_BAR_HEIGHT}px)`}
+      w="100%"
+      bg="accent-gray-light"
+    >
+      <Stack
+        className={S.sidebar}
+        flex="0 0 320px"
+        gap={0}
+        h="100%"
+        bg="bg-white"
+      >
         <Title order={2} px="xl" py="lg" pb="md">
           {t`Data model`}
         </Title>
@@ -83,7 +93,7 @@ export const DataModel = ({ params }: Props) => {
       )}
 
       {!isEmptyStateShown && (
-        <Flex bg="accent-gray-light" flex="1">
+        <>
           <Box flex="0 0 400px" h="100%">
             <LoadingAndErrorWrapper
               className={S.contentLoadingAndErrorWrapper}
@@ -104,10 +114,10 @@ export const DataModel = ({ params }: Props) => {
             </LoadingAndErrorWrapper>
           </Box>
 
-          <Box flex="1" p="xl" pl={0}>
+          <Box flex="1 1 200px" p="xl" pl={0} miw={0}>
             <PreviewSection fieldId={fieldId} />
           </Box>
-        </Flex>
+        </>
       )}
     </Flex>
   );

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -19,10 +19,6 @@ interface Props {
 
 const DATA_MODEL_APP_NAV_BAR_HEIGHT = 53;
 
-// TODO: remove this in Milestone 2
-// https://linear.app/metabase/project/up-level-admin-metadata-editing-0399213bee40
-const PREVIEW_NOT_IMPLEMENTED_YET = true;
-
 export const DataModel = ({ params }: Props) => {
   const { databaseId, tableId, fieldId } = parseRouteParams(params);
   const isEmptyStateShown =
@@ -108,11 +104,9 @@ export const DataModel = ({ params }: Props) => {
             </LoadingAndErrorWrapper>
           </Box>
 
-          {!PREVIEW_NOT_IMPLEMENTED_YET && (
-            <Box flex="1" p="xl" pl={0}>
-              <PreviewSection fieldId={fieldId} />
-            </Box>
-          )}
+          <Box flex="1" p="xl" pl={0}>
+            <PreviewSection fieldId={fieldId} />
+          </Box>
         </Flex>
       )}
     </Flex>

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -9,7 +9,12 @@ import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import { Box, Flex, Stack, Title } from "metabase/ui";
 
 import S from "./DataModel.module.css";
-import { FieldSection, PreviewSection, TableSection } from "./components";
+import {
+  FieldSection,
+  PreviewSection,
+  TableSection,
+  usePreviewType,
+} from "./components";
 import type { RouteParams } from "./types";
 import { parseRouteParams } from "./utils";
 
@@ -37,6 +42,7 @@ export const DataModel = ({ params }: Props) => {
         },
   );
   const field = table?.fields?.find((field) => field.id === fieldId);
+  const [previewType, setPreviewType] = usePreviewType();
 
   return (
     <Flex
@@ -115,7 +121,11 @@ export const DataModel = ({ params }: Props) => {
           </Box>
 
           <Box flex="1 1 200px" p="xl" pl={0} miw={0}>
-            <PreviewSection fieldId={fieldId} />
+            <PreviewSection
+              fieldId={fieldId}
+              previewType={previewType}
+              onPreviewTypeChange={setPreviewType}
+            />
           </Box>
         </>
       )}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
@@ -4,19 +4,21 @@ import { t } from "ttag";
 import { Box, Card, Flex, SegmentedControl, Text } from "metabase/ui";
 import type { FieldId } from "metabase-types/api";
 
+export type PreviewType = ReturnType<
+  typeof getTypeSelectorData
+>[number]["value"];
+
 interface Props {
   fieldId?: FieldId;
+  previewType: PreviewType;
+  onPreviewTypeChange: (value: PreviewType) => void;
 }
 
-type PreviewType = ReturnType<typeof getTypeSelectorData>[number]["value"];
-
-export const PreviewSection = (_props: Props) => {
-  const [previewType, setPreviewType] = useState<PreviewType>("table");
-
+export const PreviewSection = ({ previewType, onPreviewTypeChange }: Props) => {
   return (
     <Card bg="white" h="100%" px="lg" py="md" shadow="xs">
       <Text fw="bold">Field preview</Text>
-      <PreviewTypeSelector value={previewType} onChange={setPreviewType} />
+      <PreviewTypeSelector value={previewType} onChange={onPreviewTypeChange} />
 
       {previewType === "table" && <Box>TABLE</Box>}
       {previewType === "detail" && <Box>DETAIL</Box>}
@@ -31,6 +33,10 @@ function getTypeSelectorData() {
     { label: t`Detail`, value: "detail" as const },
     { label: t`Filtering`, value: "filtering" as const },
   ];
+}
+
+export function usePreviewType() {
+  return useState<PreviewType>("table");
 }
 
 function PreviewTypeSelector({

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
@@ -1,15 +1,55 @@
-import { Box, Card, Text } from "metabase/ui";
+import { useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { Box, Card, Flex, SegmentedControl, Text } from "metabase/ui";
 import type { FieldId } from "metabase-types/api";
 
 interface Props {
   fieldId?: FieldId;
 }
 
-export const PreviewSection = ({ fieldId }: Props) => {
+type PreviewType = ReturnType<typeof getTypeSelectorData>[number]["value"];
+
+export const PreviewSection = (_props: Props) => {
+  const [previewType, setPreviewType] = useState<PreviewType>("table");
+
   return (
     <Card bg="white" h="100%" px="lg" py="md" shadow="xs">
       <Text fw="bold">Field preview</Text>
-      <Box>Field: {fieldId}</Box>
+      <PreviewTypeSelector value={previewType} onChange={setPreviewType} />
+
+      {previewType === "table" && <Box>TABLE</Box>}
+      {previewType === "detail" && <Box>DETAIL</Box>}
+      {previewType === "filtering" && <Box>FILTERING</Box>}
     </Card>
   );
 };
+
+function getTypeSelectorData() {
+  return [
+    { label: t`Table`, value: "table" as const },
+    { label: t`Detail`, value: "detail" as const },
+    { label: t`Filtering`, value: "filtering" as const },
+  ];
+}
+
+function PreviewTypeSelector({
+  value,
+  onChange,
+}: {
+  value: PreviewType;
+  onChange: (value: PreviewType) => void;
+}) {
+  const data = useMemo(getTypeSelectorData, []);
+
+  return (
+    <Flex py="sm" w="100%">
+      <SegmentedControl
+        data={data}
+        value={value}
+        onChange={onChange}
+        w="100%"
+      />
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
@@ -1,12 +1,9 @@
-import { useMemo, useState } from "react";
-import { t } from "ttag";
+import { useMemo } from "react";
 
 import { Box, Card, Flex, SegmentedControl, Text } from "metabase/ui";
 import type { FieldId } from "metabase-types/api";
 
-export type PreviewType = ReturnType<
-  typeof getTypeSelectorData
->[number]["value"];
+import { type PreviewType, getTypeSelectorData } from "./utils";
 
 interface Props {
   fieldId?: FieldId;
@@ -26,18 +23,6 @@ export const PreviewSection = ({ previewType, onPreviewTypeChange }: Props) => {
     </Card>
   );
 };
-
-function getTypeSelectorData() {
-  return [
-    { label: t`Table`, value: "table" as const },
-    { label: t`Detail`, value: "detail" as const },
-    { label: t`Filtering`, value: "filtering" as const },
-  ];
-}
-
-export function usePreviewType() {
-  return useState<PreviewType>("table");
-}
 
 function PreviewTypeSelector({
   value,

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.unit.spec.tsx
@@ -1,0 +1,49 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { PreviewSection } from "./PreviewSection";
+import { type PreviewType, usePreviewType } from "./utils";
+
+function Wrapper({
+  onPreviewTypeChange,
+}: {
+  onPreviewTypeChange: (value: PreviewType) => void;
+}) {
+  const [previewType, setPreviewType] = usePreviewType();
+
+  function handlePreviewTypeChange(previewType: PreviewType) {
+    onPreviewTypeChange(previewType);
+    setPreviewType(previewType);
+  }
+
+  return (
+    <PreviewSection
+      previewType={previewType}
+      onPreviewTypeChange={handlePreviewTypeChange}
+    />
+  );
+}
+
+function setup() {
+  const onPreviewTypeChange = jest.fn();
+
+  renderWithProviders(<Wrapper onPreviewTypeChange={onPreviewTypeChange} />);
+
+  return { onPreviewTypeChange };
+}
+
+describe("PreviewSection", () => {
+  it("should be possible to change the preview type", async () => {
+    const { onPreviewTypeChange } = setup();
+
+    await userEvent.click(screen.getByText("Detail"));
+    expect(onPreviewTypeChange).toHaveBeenCalledWith("detail");
+
+    await userEvent.click(screen.getByText("Filtering"));
+    expect(onPreviewTypeChange).toHaveBeenCalledWith("filtering");
+
+    await userEvent.click(screen.getByText("Table"));
+    expect(onPreviewTypeChange).toHaveBeenCalledWith("table");
+  });
+});

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/index.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/index.ts
@@ -1,1 +1,2 @@
 export * from "./PreviewSection";
+export { usePreviewType } from "./utils";

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/utils.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/utils.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+export type PreviewType = ReturnType<
+  typeof getTypeSelectorData
+>[number]["value"];
+
+export function getTypeSelectorData() {
+  return [
+    { label: t`Table`, value: "table" as const },
+    { label: t`Detail`, value: "detail" as const },
+    { label: t`Filtering`, value: "filtering" as const },
+  ];
+}
+
+export function usePreviewType() {
+  return useState<PreviewType>("table");
+}


### PR DESCRIPTION
Closes [SEM-243](https://linear.app/metabase/issue/SEM-243/data-model-preview-boilerplate)

Adds more boilerplate for the preview section of the metadata editor and fixes the flex layout.

The state of which preview mode is being used is lifted to the top so users can switch between fields while keeping the same preview type open. 

Tests will be added in a later PR.

<img width="1474" alt="Screenshot 2025-05-15 at 10 24 37" src="https://github.com/user-attachments/assets/ce4252e1-57d1-4d46-baed-02ec91e37006" />
