### PR TITLE
fix: do not display action cannot be undone message for row deletion

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/DeleteBulkRowConfirmationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/DeleteBulkRowConfirmationModal.tsx
@@ -1,6 +1,6 @@
 import { msgid, ngettext, t } from "ttag";
 
-import { Button, Group, Modal, Stack, Text } from "metabase/ui";
+import { Button, Group, Modal } from "metabase/ui";
 
 type DeleteBulkRowConfirmationModalProps = {
   opened: boolean;
@@ -27,26 +27,23 @@ export function DeleteBulkRowConfirmationModal({
       opened={opened}
       onClose={onClose}
     >
-      <Stack>
-        <Text>{t`This action can not be undone.`}</Text>
-        <Group justify="flex-end">
-          <Button variant="subtle" onClick={onClose}>
-            {t`Cancel`}
-          </Button>
-          <Button
-            variant="filled"
-            color="danger"
-            onClick={onConfirm}
-            loading={isLoading}
-          >
-            {ngettext(
-              msgid`Delete ${rowCount} record`,
-              `Delete ${rowCount} records`,
-              rowCount,
-            )}
-          </Button>
-        </Group>
-      </Stack>
+      <Group justify="flex-end" mt="xl">
+        <Button variant="subtle" onClick={onClose}>
+          {t`Cancel`}
+        </Button>
+        <Button
+          variant="filled"
+          color="danger"
+          onClick={onConfirm}
+          loading={isLoading}
+        >
+          {ngettext(
+            msgid`Delete ${rowCount} record`,
+            `Delete ${rowCount} records`,
+            rowCount,
+          )}
+        </Button>
+      </Group>
     </Modal>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/DeleteRowConfirmationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/DeleteRowConfirmationModal.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { Button, Group, Modal, Stack, Text } from "metabase/ui";
+import { Button, Group, Modal } from "metabase/ui";
 
 type DeleteRowConfirmationModalProps = {
   onConfirm: () => void;
@@ -12,19 +12,16 @@ export function DeleteRowConfirmationModal({
 }: DeleteRowConfirmationModalProps) {
   return (
     <Modal size="md" title={t`Delete this record?`} opened onClose={onCancel}>
-      <Stack>
-        <Text>{t`This action can not be undone.`}</Text>
-        <Group justify="flex-end">
-          <Button variant="subtle" onClick={onCancel}>
-            {t`Cancel`}
-          </Button>
-          <Button
-            variant="filled"
-            color="danger"
-            onClick={onConfirm}
-          >{t`Delete record`}</Button>
-        </Group>
-      </Stack>
+      <Group justify="flex-end" mt="xl">
+        <Button variant="subtle" onClick={onCancel}>
+          {t`Cancel`}
+        </Button>
+        <Button
+          variant="filled"
+          color="danger"
+          onClick={onConfirm}
+        >{t`Delete record`}</Button>
+      </Group>
     </Modal>
   );
 }


### PR DESCRIPTION
Resolves [WRK-393](https://linear.app/metabase/issue/WRK-393/delete-confirmation-should-not-display-this-action-cannot-be-undone)
