### PR TITLE
fix: refetch table on filter change

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
@@ -60,7 +60,10 @@ export const EditTableDataContainer = ({
     isFetching,
     isLoading,
     refetch,
-  } = useGetAdhocQueryQuery(fakeTableQuery || skipToken);
+  } = useGetAdhocQueryQuery(fakeTableQuery || skipToken, {
+    // Invalidates cache when filter changes (some records might be updated)
+    refetchOnMountOrArgChange: true,
+  });
 
   const datasetData = useMemo(() => {
     return rawDatasetResult


### PR DESCRIPTION
Currently adhoc query cache is stored separately for each applied filter. This results in data inconsistencies after editing, for example:
1. User opens a table editing view and adhoc query cache is populated.
2. User applies a filter and new adhoc query cache entry is created and populated.
3. User edits the data (either create, update or delete), and state update strategy updates current adhoc query cache. The initial adhoc query cache is not updated.
4. After removing the filter user can see non-updated entries from the old cache, if there's any row intersection between two queries.  

Resolves [WRK-394](https://linear.app/metabase/issue/WRK-394/records-still-display-in-a-filtered-table-after-bulk-delete) and similar use cases.
