### PR TITLE
Prefix all of our log context with mb-

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -50,7 +50,8 @@
   format-milliseconds
   format-nanoseconds
   format-seconds
-  format-plural])
+  format-plural
+  qualified-name])
 
 #?(:clj (p/import-vars [u.jvm
                         all-ex-data
@@ -149,32 +150,6 @@
   [^String msg]
   #?(:clj  (Exception. msg)
      :cljs (js/Error. msg)))
-
-(defn qualified-name
-  "Return `k` as a string, qualified by its namespace, if any (unlike `name`). Handles `nil` values gracefully as well
-  (also unlike `name`).
-
-     (u/qualified-name :type/FK) -> \"type/FK\""
-  [k]
-  (cond
-    (nil? k)
-    nil
-
-    ;; optimization in Clojure: calling [[symbol]] on a keyword returns the underlying symbol, and [[str]] on a symbol
-    ;; is cached internally (see `clojure.lang.Symbol/toString()`). So we can avoid constructing a new string here.
-    ;; Not sure whether this is cached in ClojureScript as well.
-    (keyword? k)
-    (str (symbol k))
-
-    (symbol? k)
-    (str k)
-
-    :else
-    (if-let [namespac (when #?(:clj  (instance? clojure.lang.Named k)
-                               :cljs (satisfies? INamed k))
-                        (namespace k))]
-      (str namespac "/" (name k))
-      (name k))))
 
 (defn remove-nils
   "Given a map, returns a new map with all nil values removed."

--- a/src/metabase/util/format.cljc
+++ b/src/metabase/util/format.cljc
@@ -100,3 +100,29 @@
      (if plural
        plural
        (str singular \s)))))
+
+(defn qualified-name
+  "Return `k` as a string, qualified by its namespace, if any (unlike `name`). Handles `nil` values gracefully as well
+  (also unlike `name`).
+
+     (u/qualified-name :type/FK) -> \"type/FK\""
+  [k]
+  (cond
+    (nil? k)
+    nil
+
+    ;; optimization in Clojure: calling [[symbol]] on a keyword returns the underlying symbol, and [[str]] on a symbol
+    ;; is cached internally (see `clojure.lang.Symbol/toString()`). So we can avoid constructing a new string here.
+    ;; Not sure whether this is cached in ClojureScript as well.
+    (keyword? k)
+    (str (symbol k))
+
+    (symbol? k)
+    (str k)
+
+    :else
+    (if-let [namespac (when #?(:clj  (instance? clojure.lang.Named k)
+                               :cljs (satisfies? INamed k))
+                        (namespace k))]
+      (str namespac "/" (name k))
+      (name k))))

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -9,6 +9,7 @@
    [clojure.tools.logging]
    [clojure.tools.logging.impl]
    [metabase.config :as config]
+   [metabase.util.format :as u.format]
    [metabase.util.log.capture]
    [net.cgrand.macrovich :as macros])
   (:import
@@ -222,7 +223,7 @@
    ThreadContext will contain: {\"notification_id\" \"1\"} and stack \"Notification 1\""
   [context-map & body]
   (macros/case
-    :clj `(let [ctx-map# ~context-map
+    :clj `(let [ctx-map# ~(update-keys context-map #(str "mb-" (u.format/qualified-name %)))
                 ctx-keys# (keys ctx-map#)
                 ;; Store original values before modifying
                 original-values# (into {}

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -16,7 +16,7 @@
     (is (empty? (get-context)))  ; Initially context should be nil
 
     (log/with-context {:user-id 123 :action "test"}
-      (is (= {"user-id" "123" "action" "test"}
+      (is (= {"mb-user-id" "123" "mb-action" "test"}
              (get-context))
           "Context should be set inside macro"))
 
@@ -25,16 +25,16 @@
 
   (testing "with-context should handle nested contexts"
     (log/with-context {:outer "value" :empty "" :false false}
-      (is (= {"outer" "value" "empty" "" "false" "false"}
+      (is (= {"mb-outer" "value" "mb-empty" "" "mb-false" "false"}
              (get-context))
           "Outer context should be set")
 
       (log/with-context {:inner "nested"}
-        (is (= {"outer" "value" "inner" "nested" "empty" "" "false" "false"}
+        (is (= {"mb-outer" "value" "mb-inner" "nested" "mb-empty" "" "mb-false" "false"}
                (get-context))
             "Inner context should replace outer context"))
 
-      (is (= {"outer" "value" "empty" "" "false" "false"}
+      (is (= {"mb-outer" "value" "mb-empty" "" "mb-false" "false"}
              (get-context))
           "Outer context should be restored after nested macro")))
 


### PR DESCRIPTION
so we can filter it in the log layout like this

```
"thread_context": {
    "$resolver": "mdc",
     "pattern": "mb-.*"
}
```