### PR TITLE
Clean up table.row and grid-edit actions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -35,7 +35,8 @@
   [scope]
   (if (string? scope)
     scope
-    (or (some-> scope actions/normalize-scope nested-sort pr-str) "unknown")))
+    ;; For now :type is ignored for undo scope, but once the FE starts passing it in, we'll probably change that.
+    (or (some-> scope actions/normalize-scope (dissoc :type) nested-sort pr-str) "unknown")))
 
 (defn- next-batch [undo? user-id scope]
   ;; For now, we assume all the changes are to the same table.

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -92,6 +92,9 @@
 
           (testing "DELETE should remove the corresponding rows"
             (is (= {:success true}
+                   ;; TODO change what we return to be more useful, for example it can contain children in the same
+                   ;;      table.
+                   #_[{:id 1} {:id 2}]
                    (mt/user-http-request :crowberto :post 200 (str url "/delete")
                                          {:rows [{:id 1}
                                                  {:id 2}]})))

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -177,11 +177,12 @@
     (doseq [[event-type payloads] (u/group-by first second effects)]
       (handle-effects!* event-type sans-effects payloads))))
 
-(mu/defn- perform-action-internal! [action-kw :- qualified-keyword?
-                                    ctx       :- :map
+(mu/defn- perform-action-internal!
+  [action-kw :- qualified-keyword?
+   ctx       :- :map
    ;; Since the inner map shape will depend on action-kw, we will need to dynamically validate it.
-                                    inputs    :- [:sequential :map]
-                                    & {:as _opts}]
+   inputs    :- [:sequential :map]
+   & {:as _opts}]
   (let [invocation-id  (nano-id/nano-id)
         context-before (-> (assoc ctx :invocation-id invocation-id)
                            (update :invocation-stack u/conjv [action-kw invocation-id]))]

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -177,15 +177,11 @@
     (doseq [[event-type payloads] (u/group-by first second effects)]
       (handle-effects!* event-type sans-effects payloads))))
 
-(mu/defn perform-action-internal!
-  "A more modern version of [[perform-action!]] that takes an existing context, and multiple arg-maps.
-   Assumes (for now) that the schemas have been checked and args coerced, etc. Also doesn't do perms checks yet.
-   Use this if you want to explicitly call an action from within an action and have it traced in the audit log etc."
-  [action-kw :- qualified-keyword?
-   ctx       :- :map
+(mu/defn- perform-action-internal! [action-kw :- qualified-keyword?
+                                    ctx       :- :map
    ;; Since the inner map shape will depend on action-kw, we will need to dynamically validate it.
-   inputs    :- [:sequential :map]
-   & {:as _opts}]
+                                    inputs    :- [:sequential :map]
+                                    & {:as _opts}]
   (let [invocation-id  (nano-id/nano-id)
         context-before (-> (assoc ctx :invocation-id invocation-id)
                            (update :invocation-stack u/conjv [action-kw invocation-id]))]
@@ -208,6 +204,16 @@
           ;; Need to think about how we learn about already performed effects this way, since we don't get a context.
           (actions.events/publish-action-failure! action-kw context-before msg info)
           (throw e))))))
+
+(defn perform-nested-action!
+  "Similar to [[perform-action!]] but taking an existing context.
+   Assumes (for now) that the schemas have been checked and args coerced, etc. Also doesn't do perms checks yet.
+   Use this if you want to explicitly call an action from within an action and have it traced in the audit log etc."
+  [action-kw context inputs]
+  ;; For now, we are handling effects whenever we "pop" an action, but in future we may want them to propagate.
+  ;; The rationale for this is that it would allow us batch things more atomically (e.g., for notifications)
+  {:context context #_(update context :effects into (:effects context-after))
+   :outputs (:outputs (perform-action-internal! action-kw context inputs))})
 
 (defn cached-database
   "Uses cache to prevent redundant look-ups with an action call chain."

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -27,7 +27,11 @@
   cached-database-via-table-id
   handle-effects!*
   perform-action!
-  perform-action!*]
+  ;; allow actions to be defined in the data-editing module
+  perform-action!*
+  perform-nested-action!
+  action-arg-map-spec
+  normalize-action-arg-map]
  [metabase.actions.error
   incorrect-value-type
   violate-foreign-key-constraint

--- a/src/metabase/actions/scope.clj
+++ b/src/metabase/actions/scope.clj
@@ -68,7 +68,7 @@
 (mu/defn normalize-scope :- ::types/scope.normalized
   "Remove all the implicit keys that can be derived from others. Useful to form stable keys. Idempotent."
   [scope :- ::types/scope.raw]
-  (cond-> scope
+  (cond-> (update scope :type #(or % (scope-type scope)))
     (:table-id scope)     (dissoc :database-id)
     (:card-id scope)      (-> (dissoc :table-id)
                               (dissoc :collection-id)

--- a/src/metabase/actions/types.clj
+++ b/src/metabase/actions/types.clj
@@ -23,11 +23,10 @@
 
 ;; All derivable or unknown data removed, so that this is safe to use as a key.
 (mr/def ::scope.normalized
-
   (into [:or] (for [s raw-scope-types]
                 (vec (concat (subvec s 0 1)
                              [{:closed true}
-                              [:type {:optional true} :keyword]]
+                              [:type :keyword]]
                              (subvec s 1))))))
 
 ;; All derivable data included.

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -601,7 +601,11 @@
 
 (mu/defmethod actions/perform-action!* [:sql-jdbc :table.row/delete]
   [_action context inputs :- [:sequential ::table-row-input]]
-  (let [[errors results]
+  (let [table-id->pk-keys (u/for-map [table-id (distinct (map :table-id inputs))]
+                            (let [database       (actions/cached-database-via-table-id table-id)
+                                  field-name->id (table-id->pk-field-name->id (:id database) table-id)]
+                              [table-id (map keyword (keys field-name->id))]))
+        [errors results]
         (batch-execution-by-table-id!
          {:inputs        inputs
           :row-action    :model.row/delete
@@ -623,7 +627,8 @@
                        :errors      errors
                        :results     results})))
     {:context (record-mutations context results)
-     :outputs [{:success true}]}))
+     :outputs (for [diff results]
+                (select-keys (:before diff) (table-id->pk-keys (:table-id diff))))}))
 
 ;;;; `bulk/update`
 
@@ -678,4 +683,4 @@
                        :errors      errors
                        :results     results})))
     {:context (record-mutations context results)
-     :outputs [{:rows-updated (count results)}]}))
+     :outputs (mapv :after results)}))

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -330,17 +330,17 @@
       (with-actions-test-data-and-actions-permissively-enabled!
         (is (= 75
                (categories-row-count)))
-        (is (= {:success true}
-               (first
-                (:outputs
-                 (actions/perform-action! :table.row/delete
-                                          test-scope
-                                          [{:database (mt/id)
-                                            :table-id (mt/id :categories)
-                                            :arg      {(format-field-name :id) 75}}
-                                           {:database (mt/id)
-                                            :table-id (mt/id :categories)
-                                            :arg      {(format-field-name :id) 74}}])))))
+        (is (= [{:id 75}
+                {:id 74}]
+               (:outputs
+                (actions/perform-action! :table.row/delete
+                                         test-scope
+                                         [{:database (mt/id)
+                                           :table-id (mt/id :categories)
+                                           :arg      {(format-field-name :id) 75}}
+                                          {:database (mt/id)
+                                           :table-id (mt/id :categories)
+                                           :arg      {(format-field-name :id) 74}}]))))
         (is (= 73
                (categories-row-count)))))))
 
@@ -418,18 +418,18 @@
                 [2 "American"]
                 [3 "Artisan"]]
                (first-three-categories)))
-        (is (= {:rows-updated 2}
+        (is (= [{:id 1 :name "Seed Bowl"}
+                {:id 2 :name "Millet Treat"}]
                (let [id   (format-field-name :id)
                      name (format-field-name :name)]
-                 (first
-                  (:outputs
-                   (actions/perform-action! :table.row/update
-                                            test-scope
-                                            (for [row [{id 1, name "Seed Bowl"}
-                                                       {id 2, name "Millet Treat"}]]
-                                              {:database (mt/id)
-                                               :table-id (mt/id :categories)
-                                               :row      row})))))))
+                 (:outputs
+                  (actions/perform-action! :table.row/update
+                                           test-scope
+                                           (for [row [{id 1, name "Seed Bowl"}
+                                                      {id 2, name "Millet Treat"}]]
+                                             {:database (mt/id)
+                                              :table-id (mt/id :categories)
+                                              :row      row}))))))
 
         (testing "rows should be updated in the DB"
           (is (= [[1 "Seed Bowl"]
@@ -539,21 +539,22 @@
                                              :tunnel-user username
                                              :tunnel-pass ssh-password)}))
               (testing "Can perform implicit actions on ssh-enabled database"
-                (let [response (try (first
-                                     (:outputs
-                                      (actions/perform-action!
-                                       :table.row/update
-                                       test-scope
-                                       (let [id   (format-field-name :id)
-                                             name (format-field-name :name)]
-                                         (for [row [{id 1, name "Seed Bowl"}
-                                                    {id 2, name "Millet Treat"}]]
-                                           {:database (mt/id)
-                                            :table-id (mt/id :categories)
-                                            :row      row})))))
+                (let [response (try (:outputs
+                                     (actions/perform-action!
+                                      :table.row/update
+                                      test-scope
+                                      (let [id   (format-field-name :id)
+                                            name (format-field-name :name)]
+                                        (for [row [{id 1, name "Seed Bowl"}
+                                                   {id 2, name "Millet Treat"}]]
+                                          {:database (mt/id)
+                                           :table-id (mt/id :categories)
+                                           :row      row}))))
                                     (catch Exception e e))]
                   (if correct-password?
-                    (is (= {:rows-updated 2} response))
+                    (is (= [{:id 1, :name "Seed Bowl"}
+                            {:id 2, :name "Millet Treat"}]
+                           response))
                     (do
                       (is (instance? Exception response) "Did not get an error with wrong password")
                       (is (some (partial instance? org.apache.sshd.common.SshException)

--- a/test/metabase/actions/scope_test.clj
+++ b/test/metabase/actions/scope_test.clj
@@ -128,30 +128,35 @@
 (deftest normalize-test
   (mt/with-premium-features #{:table-data-editing}
     (testing "normalize with various scopes"
-      (is (= {:dashcard-id 2}
-             (actions.scope/normalize-scope {:dashboard-id 1
-                                             :dashcard-id        2
-                                             :card-id            3
-                                             :table-id           4
-                                             :collection-id      5
-                                             :database-id        6})))
-
-      (is (= {:dashboard-id 1}
-             (actions.scope/normalize-scope {:dashboard-id 1
-                                             :collection-id      5})))
-
-      (is (= {:card-id 3}
-             (actions.scope/normalize-scope {:card-id 3
+      (is (= {:type        :dashcard
+              :dashcard-id 2}
+             (actions.scope/normalize-scope {:dashboard-id  1
+                                             :dashcard-id   2
+                                             :card-id       3
                                              :table-id      4
                                              :collection-id 5
                                              :database-id   6})))
 
-      (is (= {:model-id 7}
-             (actions.scope/normalize-scope {:model-id 7
-                                             :table-id       4
-                                             :collection-id  5
-                                             :database-id    6})))
+      (is (= {:type         :dashboard
+              :dashboard-id 1}
+             (actions.scope/normalize-scope {:dashboard-id  1
+                                             :collection-id 5})))
 
-      (is (= {:table-id 4}
-             (actions.scope/normalize-scope {:table-id 4
-                                             :database-id    6}))))))
+      (is (= {:type    :card
+              :card-id 3}
+             (actions.scope/normalize-scope {:card-id       3
+                                             :table-id      4
+                                             :collection-id 5
+                                             :database-id   6})))
+
+      (is (= {:type     :model
+              :model-id 7}
+             (actions.scope/normalize-scope {:model-id      7
+                                             :table-id      4
+                                             :collection-id 5
+                                             :database-id   6})))
+
+      (is (= {:type     :table
+              :table-id 4}
+             (actions.scope/normalize-scope {:table-id    4
+                                             :database-id 6}))))))


### PR DESCRIPTION
This improves a few things:

1. Sates the kondo gods.
2. Adds a less error prone way to make nested action calls.
3. Makes a breaking change to the return values of the `table.row` actions, so they're more useful.

A notable thing about changing `table.row/delete` to return the pks of deleted rows is this will be improve the fast-reload and chained-action experience when we delete child rows.