### PR TITLE
Add feedback to metadata editor when saving config

### DIFF
--- a/frontend/src/metabase/admin/datamodel/metadata/components/FieldFormattingSettings/FieldFormattingSettings.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/FieldFormattingSettings/FieldFormattingSettings.tsx
@@ -51,6 +51,7 @@ const FieldFormattingSettings = ({
         inheritedSettings={inheritedSettings}
         onChange={handleChangeSettings}
         extraData={{ forAdminSettings: true }}
+        style={{}}
       />
     </MetadataSection>
   );

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { useGetDatabaseQuery, useUpdateFieldMutation } from "metabase/api";
+import { useToast } from "metabase/common/hooks";
 import {
   FieldValuesTypePicker,
   FieldVisibilityPicker,
@@ -30,6 +31,11 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
   const [updateField] = useUpdateFieldMutation();
   const id = getRawTableFieldId(field);
 
+  const [sendToast] = useToast();
+  function confirm(message: string) {
+    sendToast({ message, icon: "check" });
+  }
+
   return (
     <Stack gap="md">
       <Box>
@@ -40,11 +46,12 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
         description={t`Where this field should be displayed`}
         label={t`Visibility`}
         value={field.visibility_type}
-        onChange={(visibilityType) => {
-          updateField({
+        onChange={async (visibilityType) => {
+          await updateField({
             id,
             visibility_type: visibilityType,
           });
+          confirm(t`Visibility for ${field.display_name} updated`);
         }}
       />
 
@@ -52,11 +59,12 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
         description={t`How this field should be filtered`}
         label={t`Filtering`}
         value={field.has_field_values}
-        onChange={(hasFieldValues) => {
-          updateField({
+        onChange={async (hasFieldValues) => {
+          await updateField({
             id,
             has_field_values: hasFieldValues,
           });
+          confirm(t`Filtering for ${field.display_name} updated`);
         }}
       />
 
@@ -65,11 +73,16 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
           description={t`Unfold JSON into component fields, where each JSON key becomes a column. You can turn this off if performance is slow.`}
           label={t`Unfold JSON`}
           value={isFieldJsonUnfolded(field, database)}
-          onChange={(jsonUnfolding) => {
-            updateField({
+          onChange={async (jsonUnfolding) => {
+            await updateField({
               id,
               json_unfolding: jsonUnfolding,
             });
+            if (jsonUnfolding) {
+              confirm(t`JSON unfloding for ${field.display_name} enabled`);
+            } else {
+              confirm(t`JSON unfloding for ${field.display_name} disabled`);
+            }
           }}
         />
       )}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { useUpdateFieldMutation } from "metabase/api";
+import { useToast } from "metabase/common/hooks";
 import { CoercionStrategyPicker } from "metabase/metadata/components";
 import {
   canCoerceFieldType,
@@ -25,6 +26,10 @@ export const DataSection = ({ field }: Props) => {
     field ? field.coercion_strategy != null : false,
   );
   const id = getRawTableFieldId(field);
+  const [sendToast] = useToast();
+  function confirm(message: string) {
+    sendToast({ message, icon: "check" });
+  }
 
   useEffect(() => {
     setIsCasting(field.coercion_strategy != null);
@@ -68,11 +73,12 @@ export const DataSection = ({ field }: Props) => {
                 label={t`Cast to a specific data type`}
                 mt="md"
                 size="xs"
-                onChange={(event) => {
+                onChange={async (event) => {
                   setIsCasting(event.target.checked);
 
                   if (!event.target.checked) {
-                    updateField({ id, coercion_strategy: null });
+                    await updateField({ id, coercion_strategy: null });
+                    confirm(t`Casting disabled for ${field.display_name}`);
                   }
                 }}
               />
@@ -82,8 +88,12 @@ export const DataSection = ({ field }: Props) => {
               <CoercionStrategyPicker
                 baseType={field.base_type}
                 value={field.coercion_strategy ?? undefined}
-                onChange={(coercionStrategy) => {
-                  updateField({ id, coercion_strategy: coercionStrategy });
+                onChange={async (coercionStrategy) => {
+                  await updateField({
+                    id,
+                    coercion_strategy: coercionStrategy,
+                  });
+                  confirm(t`Casting enabled for ${field.display_name}`);
                 }}
               />
             )}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FormattingSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FormattingSection.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useUpdateFieldMutation } from "metabase/api";
+import { useToast } from "metabase/common/hooks";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
 import { Box, Stack } from "metabase/ui";
 import ColumnSettings from "metabase/visualizations/components/ColumnSettings";
@@ -27,6 +28,10 @@ export const FormattingSection = ({ field }: Props) => {
       : new Set(["column_title"]);
   }, [field]);
   const inheritedSettings = useMemo(() => getGlobalSettingsForColumn(), []);
+  const [sendToast] = useToast();
+  function confirm(message: string) {
+    sendToast({ message, icon: "check" });
+  }
 
   return (
     <Stack gap="md">
@@ -41,8 +46,9 @@ export const FormattingSection = ({ field }: Props) => {
         inheritedSettings={inheritedSettings}
         style={{ maxWidth: undefined }}
         value={field.settings ?? {}}
-        onChange={(settings: FieldSettings) => {
-          updateField({ id, settings });
+        onChange={async (settings: FieldSettings) => {
+          await updateField({ id, settings });
+          confirm(t`Field formatting for ${field.display_name} updated`);
         }}
       />
     </Stack>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -4,6 +4,7 @@ import {
   useUpdateTableFieldsOrderMutation,
   useUpdateTableMutation,
 } from "metabase/api";
+import { useToast } from "metabase/common/hooks";
 import {
   DiscardTableFieldValuesButton,
   FieldOrderPicker,
@@ -26,6 +27,10 @@ export const TableSection = ({ params, table }: Props) => {
   const { fieldId, ...parsedParams } = parseRouteParams(params);
   const [updateTable] = useUpdateTableMutation();
   const [updateTableFieldsOrder] = useUpdateTableFieldsOrderMutation();
+  const [sendToast] = useToast();
+  function confirm(message: string) {
+    sendToast({ message, icon: "check" });
+  }
 
   return (
     <Stack gap="lg">
@@ -34,11 +39,13 @@ export const TableSection = ({ params, table }: Props) => {
         descriptionPlaceholder={t`Give this table a description`}
         name={table.display_name}
         namePlaceholder={t`Give this table a name`}
-        onDescriptionChange={(description) => {
-          updateTable({ id: table.id, description });
+        onDescriptionChange={async (description) => {
+          await updateTable({ id: table.id, description });
+          confirm(t`Table description updated`);
         }}
-        onNameChange={(name) => {
-          updateTable({ id: table.id, display_name: name });
+        onNameChange={async (name) => {
+          await updateTable({ id: table.id, display_name: name });
+          confirm(t`Table name updated`);
         }}
       />
 
@@ -50,9 +57,13 @@ export const TableSection = ({ params, table }: Props) => {
             checked={table.visibility_type === "hidden"}
             label={t`Hide this table`}
             size="sm"
-            onChange={(event) => {
+            onChange={async (event) => {
               const visibilityType = event.target.checked ? "hidden" : null;
-              updateTable({ id: table.id, visibility_type: visibilityType });
+              await updateTable({
+                id: table.id,
+                visibility_type: visibilityType,
+              });
+              confirm(t`Table visibility updated`);
             }}
           />
         </Card>
@@ -66,6 +77,7 @@ export const TableSection = ({ params, table }: Props) => {
             value={table.field_order}
             onChange={(fieldOrder) => {
               updateTable({ id: table.id, field_order: fieldOrder });
+              confirm(t`Field order updated`);
             }}
           />
         </Flex>
@@ -74,12 +86,13 @@ export const TableSection = ({ params, table }: Props) => {
           activeFieldId={fieldId}
           getFieldHref={(fieldId) => getUrl({ ...parsedParams, fieldId })}
           table={table}
-          onChange={(fieldOrder) => {
-            updateTableFieldsOrder({
+          onChange={async (fieldOrder) => {
+            await updateTableFieldsOrder({
               id: table.id,
               // in this context field id will never be a string because it's a raw table field, so it's ok to cast
               field_order: fieldOrder as FieldId[],
             });
+            confirm(t`Field order updated`);
           }}
         />
       </Stack>


### PR DESCRIPTION
Closes [SEM-303](https://linear.app/metabase/issue/SEM-303/data-model-saving-feedback)

Adds toast notifications to the metadata editor when a setting is changed.

e2e tests will be added in a later PR.