### PR TITLE
Fix delete action response for H2

### DIFF
--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -628,7 +628,13 @@
                        :results     results})))
     {:context (record-mutations context results)
      :outputs (for [diff results]
-                (select-keys (:before diff) (table-id->pk-keys (:table-id diff))))}))
+                (select-keys
+                 (let [row (:before diff)]
+                   ;; Hideous workaround for QP and direct JDBC disagreeing on case
+                   (merge (update-keys row (comp keyword u/upper-case-en name))
+                          (u/lower-case-map-keys row)
+                          row))
+                 (table-id->pk-keys (:table-id diff))))}))
 
 ;;;; `bulk/update`
 

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -332,15 +332,16 @@
                (categories-row-count)))
         (is (= [{:id 75}
                 {:id 74}]
-               (:outputs
-                (actions/perform-action! :table.row/delete
-                                         test-scope
-                                         [{:database (mt/id)
-                                           :table-id (mt/id :categories)
-                                           :arg      {(format-field-name :id) 75}}
-                                          {:database (mt/id)
-                                           :table-id (mt/id :categories)
-                                           :arg      {(format-field-name :id) 74}}]))))
+               (map u/lower-case-map-keys
+                    (:outputs
+                     (actions/perform-action! :table.row/delete
+                                              test-scope
+                                              [{:database (mt/id)
+                                                :table-id (mt/id :categories)
+                                                :arg      {(format-field-name :id) 75}}
+                                               {:database (mt/id)
+                                                :table-id (mt/id :categories)
+                                                :arg      {(format-field-name :id) 74}}])))))
         (is (= 73
                (categories-row-count)))))))
 


### PR DESCRIPTION
Databases returning case inconsistently strikes again. This is a fairly innocuous bug since the application doesn't depend on the return type of these actions anywhere.