### PR TITLE
Refresh temporary tokens

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -179,6 +179,7 @@ const tokenStatusFeatures = [
   "official-collections",
   "query-reference-validation",
   "question-error-logs",
+  "refresh-token-features",
   "sandboxes",
   "scim",
   "serialization",

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -32,6 +32,7 @@ import type { AppErrorDescriptor, State } from "metabase-types/store";
 
 import { AppContainer, AppContent, AppContentContainer } from "./App.styled";
 import ErrorBoundary from "./ErrorBoundary";
+import { useTokenRefresh } from "./api/utils/use-token-refresh";
 import { NewModals } from "./new/components/NewModals/NewModals";
 import { Palette } from "./palette/components/Palette";
 
@@ -93,6 +94,7 @@ function App({
   onError,
 }: AppProps) {
   const [viewportElement, setViewportElement] = useState<HTMLElement | null>();
+  useTokenRefresh();
 
   useEffect(() => {
     initializeIframeResizer();

--- a/frontend/src/metabase/api/utils/index.ts
+++ b/frontend/src/metabase/api/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./settings";
+export * from "./use-token-refresh";

--- a/frontend/src/metabase/api/utils/use-token-refresh.ts
+++ b/frontend/src/metabase/api/utils/use-token-refresh.ts
@@ -7,10 +7,12 @@ const REFRESH_INTERVAL = 10 * 1000; // 10 seconds
 
 /**
  * In some circumstances, a metabase instance may have a temporary token signalling that we
- * should refresh session properties
+ * should refresh session properties. This hook will keep refreshing the session properties
+ * every 10 seconds until it gets a payload that doesn't have the refresh token feature.
  */
 export function useTokenRefresh() {
-  const res = useGetSettingsQuery(); // can't destructure so it will re-run after every refetch
+  /* in order to force this hook to re-run on every request, even if the response data is the same, we can't destructure only the data prop from this hook, as is the patten in many components */
+  const res = useGetSettingsQuery();
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/frontend/src/metabase/api/utils/use-token-refresh.ts
+++ b/frontend/src/metabase/api/utils/use-token-refresh.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+
+import { Api, useGetSettingsQuery } from "metabase/api";
+import { useDispatch } from "metabase/lib/redux";
+
+const REFRESH_INTERVAL = 10 * 1000; // 10 seconds
+
+/**
+ * In some circumstances, a metabase instance may have a temporary token signalling that we
+ * should refresh session properties
+ */
+export function useTokenRefresh() {
+  const res = useGetSettingsQuery(); // can't destructure so it will re-run after every refetch
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const tokenStatusFeatures = res?.data?.["token-status"]?.features;
+    const hasRefreshToken = tokenStatusFeatures?.includes(
+      "refresh-token-features",
+    );
+
+    if (hasRefreshToken) {
+      const timeout = setTimeout(() => {
+        dispatch(Api.util.invalidateTags(["session-properties"]));
+      }, REFRESH_INTERVAL);
+      return () => clearTimeout(timeout);
+    }
+  }, [res, dispatch]);
+}

--- a/frontend/src/metabase/api/utils/use-token-refresh.unit.spec.tsx
+++ b/frontend/src/metabase/api/utils/use-token-refresh.unit.spec.tsx
@@ -18,7 +18,7 @@ const TestComponent = () => {
   return <div>Test</div>;
 };
 
-const waitTime = async () => {
+const waitForElevenSeconds = async () => {
   act(() => {
     jest.advanceTimersByTime(11 * 1000);
   });
@@ -59,19 +59,19 @@ describe("useTokenRefresh", () => {
 
   it("should refetch every 10 seconds", async () => {
     await setup(true); // always start with 1 request
-    await waitTime(); // 2
+    await waitForElevenSeconds(); // 2
     expect((await findRequests("GET")).length).toBe(2);
-    await waitTime(); // 3
-    await waitTime(); // 4
+    await waitForElevenSeconds(); // 3
+    await waitForElevenSeconds(); // 4
     await waitForGets(4);
     expect((await findRequests("GET")).length).toBe(4);
   });
 
   it("should not refetch if the token lacks a refresh flag", async () => {
     await setup(false);
-    await waitTime();
-    await waitTime();
-    await waitTime();
+    await waitForElevenSeconds();
+    await waitForElevenSeconds();
+    await waitForElevenSeconds();
     const gets = await findRequests("GET");
     expect(gets.length).toBe(1);
   });
@@ -79,15 +79,15 @@ describe("useTokenRefresh", () => {
   it("should stop refetching once the token gets a refresh flag", async () => {
     await setup(true); // always start with 1 request
 
-    await waitTime();
+    await waitForElevenSeconds();
     await waitForGets(2);
 
     setupRefreshableProperties(false); // remove the refresh flag
-    await waitTime();
+    await waitForElevenSeconds();
     await waitForGets(3); // should get one more
 
-    await waitTime();
-    await waitTime();
+    await waitForElevenSeconds();
+    await waitForElevenSeconds();
 
     const gets = await findRequests("GET"); // should still be 3
     expect(gets.length).toBe(3);

--- a/frontend/src/metabase/api/utils/use-token-refresh.unit.spec.tsx
+++ b/frontend/src/metabase/api/utils/use-token-refresh.unit.spec.tsx
@@ -1,0 +1,79 @@
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import { act, renderWithProviders, waitFor } from "__support__/ui";
+import { findRequests } from "__support__/utils";
+import { createMockSettings } from "metabase-types/api/mocks";
+
+import { useTokenRefresh } from "./use-token-refresh";
+
+const TestComponent = () => {
+  useTokenRefresh();
+
+  return <div>Test</div>;
+};
+
+const waitTime = async () => act(() => jest.advanceTimersByTime(11 * 1000));
+
+const setupRefreshableProperties = (hasRefresh = true) => {
+  const settings = createMockSettings({
+    "site-name": "Test",
+    "token-status": {
+      valid: true,
+      status: "Token is Valid.",
+      features: hasRefresh ? ["refresh-token-features"] : [],
+    },
+  });
+  setupPropertiesEndpoints(settings);
+};
+
+const setup = async (hasRefresh = true) => {
+  setupRefreshableProperties(hasRefresh);
+  renderWithProviders(<TestComponent />);
+  return waitForGets(1);
+};
+
+const waitForGets = async (count: number) => {
+  return waitFor(async () => {
+    const gets = await findRequests("GET");
+    expect(gets.length).toBe(count);
+  });
+};
+
+describe("useTokenRefresh", () => {
+  beforeAll(() => {
+    jest.useFakeTimers({ advanceTimers: true });
+  });
+
+  it("should refetch every 10 seconds", async () => {
+    await setup(true); // always start with 1 request
+    await waitTime();
+    expect((await findRequests("GET")).length).toBe(2);
+
+    await waitTime();
+    await waitTime();
+    expect((await findRequests("GET")).length).toBe(4);
+  });
+
+  it("should not refetch if the token lacks a refresh flag", async () => {
+    await setup(false);
+    await waitTime();
+    await waitTime();
+    await waitTime();
+    const gets = await findRequests("GET");
+    expect(gets.length).toBe(1);
+  });
+
+  it("should stop refetching once the token gets a refresh flag", async () => {
+    await setup(true); // always start with 1 request
+
+    await waitTime();
+    await waitForGets(2);
+
+    setupRefreshableProperties(false); // remove the refresh flag
+    await waitTime();
+    await waitForGets(3); // should get one more
+
+    await waitTime();
+    const gets = await findRequests("GET"); // should still be 3
+    expect(gets.length).toBe(3);
+  });
+});


### PR DESCRIPTION

Closes adm-810

### Description

Sometimes, when setting up a new metabase instance, the instance will have a temporary token, which we want to refresh until we get a "real" token. This has to happen on the frontend, because sometimes we're actually swapping out backend instances, which we want to be seamless to the web client.

This adds a `useRefreshToken` hook which, if it finds a `refresh-token-features` value in the settings payload, will refresh the instance's settings every 10 seconds until it is found.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Use the chrome network inspector to spoof `/api/session/properties` to return a `refresh-token-features` element in the `token-status.features` array.
2. see that we keep re-fetching `/api/session/properties` every 10 seconds
3. remove the browser spoof
4. see that after a request that lacks `refresh-token-features` no more requests occur.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
