### PR TITLE
[Backend modularization] Remove `server`'s dependency on `api-routes`

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -971,7 +971,6 @@
    :uses #{analytics
            api
            api-keys
-           api-routes
            appearance
            config
            core

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -80,7 +80,7 @@
    [metabase.test :as mt]
    [metabase.test-runner]
    [metabase.test.data.impl :as data.impl]
-   [metabase.test.initialize.web-server :as initialize.web-server]
+   [metabase.server.test-handler :as server.test-handler]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
@@ -170,7 +170,7 @@
 (defn start!
   "Start Metabase"
   []
-  (server/start-web-server! (initialize.web-server/test-handler))
+  (server/start-web-server! (server.test-handler/test-handler))
   (init!)
   (when config/is-dev?
     (prune-deleted-inmem-databases!)

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -74,13 +74,13 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.timezone :as qp.timezone]
-   [metabase.server.handler :as handler]
-   [metabase.server.instance :as server]
+   [metabase.server.core :as server]
    [metabase.settings.core :as setting]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test-runner]
    [metabase.test.data.impl :as data.impl]
+   [metabase.test.initialize.web-server :as initialize.web-server]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
@@ -170,7 +170,7 @@
 (defn start!
   "Start Metabase"
   []
-  (server/start-web-server! #'handler/app)
+  (server/start-web-server! (initialize.web-server/test-handler))
   (init!)
   (when config/is-dev?
     (prune-deleted-inmem-databases!)

--- a/src/metabase/server/core.clj
+++ b/src/metabase/server/core.clj
@@ -3,19 +3,25 @@
   `metabase.api` module -- some middleware binds stuff like the current user or
   limit/offset (see [[metabase.request.current]]) that is then consumed by the `metabase.api` module."
   (:require
+   [metabase.server.handler]
    [metabase.server.instance]
    [metabase.server.middleware.auth]
    [metabase.server.middleware.exceptions]
    [metabase.server.protocols]
+   [metabase.server.routes]
    [potemkin :as p]))
 
 (comment
+  metabase.server.handler/keep-me
   metabase.server.instance/keep-me
   metabase.server.middleware.auth/keep-me
   metabase.server.middleware.exceptions/keep-me
-  metabase.server.protocols/keep-me)
+  metabase.server.protocols/keep-me
+  metabase.server.routes/keep-me)
 
 (p/import-vars
+ [metabase.server.handler
+  make-handler]
  [metabase.server.instance
   instance
   start-web-server!
@@ -28,14 +34,6 @@
   public-exceptions]
   ;; TODO -- I think all of this stuff probably belongs in [[metabase.request.*]]
  [metabase.server.protocols
-  Respond])
-
-(defn handler
-  "Get the top-level Ring handler."
-  []
-  ;; dynamically resolved for now because [[metabase.server.handler]] depends on [[metabase.server.routes]] which
-  ;; depends on [[metabase.api-routes.routes]] and thus would make a big old circular deps MESS...
-  ;;
-  ;; TODO -- we should clean this up somehow. Need to think about how. This is only used in one
-  ;; place, [[metabase.core.core/start-normally]].
-  (requiring-resolve 'metabase.server.handler/app))
+  Respond]
+ [metabase.server.routes
+  make-routes])

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -2,6 +2,7 @@
   "Top-level Metabase Ring handler."
   (:require
    [metabase.analytics.core :as analytics]
+   [metabase.api.macros :as api.macros]
    [metabase.config :as config]
    [metabase.server.middleware.auth :as mw.auth]
    [metabase.server.middleware.browser-cookie :as mw.browser-cookie]
@@ -14,8 +15,8 @@
    [metabase.server.middleware.security :as mw.security]
    [metabase.server.middleware.session :as mw.session]
    [metabase.server.middleware.ssl :as mw.ssl]
-   [metabase.server.routes :as routes]
    [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
    [ring.core.protocols :as ring.protocols]
    [ring.middleware.cookies :refer [wrap-cookies]]
    [ring.middleware.gzip :refer [wrap-gzip]]
@@ -82,22 +83,30 @@
        (remove nil?)))
 ;; ▲▲▲ PRE-PROCESSING ▲▲▲ happens from BOTTOM-TO-TOP
 
-(defn- apply-middleware
-  [handler]
+(mu/defn- apply-middleware :- ::api.macros/handler
+  [handler :- ::api.macros/handler]
   (reduce
    (fn [handler middleware-fn]
      (middleware-fn handler))
    handler
    middleware))
 
-(def ^{:arglists '([request respond raise])} app
-  "The primary entry point to the Ring HTTP server."
-  (apply-middleware #'routes/routes))
+;;; for interactive dev we'll create a handler that rebuilds itself (reapplies the middleware) whenever any of it
+;;; changes.
+(mu/defn- dev-handler :- ::api.macros/handler
+  [server-routes :- ::api.macros/handler]
+  (let [handler (atom (apply-middleware server-routes))]
+    (doseq [varr  middleware
+            :when (instance? clojure.lang.IRef varr)]
+      (add-watch varr ::reload (fn [_key _ref _old-state _new-state]
+                                 (log/infof "%s changed, rebuilding handler" varr)
+                                 (reset! handler (apply-middleware server-routes)))))
+    (fn dev-handler* [request respond raise]
+      (@handler request respond raise))))
 
-;; during interactive dev, recreate `app` whenever a middleware var or `routes/routes` changes.
-(when config/is-dev?
-  (doseq [varr  (cons #'routes/routes middleware)
-          :when (instance? clojure.lang.IRef varr)]
-    (add-watch varr ::reload (fn [_key _ref _old-state _new-state]
-                               (log/infof "%s changed, rebuilding %s" varr #'app)
-                               (alter-var-root #'app (constantly (apply-middleware routes/routes)))))))
+(mu/defn make-handler :- ::api.macros/handler
+  "Create the primary entry point to the Ring HTTP server."
+  [server-routes :- ::api.macros/handler]
+  (if config/is-dev?
+    (dev-handler server-routes)
+    (apply-middleware server-routes)))

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -11,10 +11,10 @@
    [malli.core :as mc]
    [medley.core :as m]
    [metabase.config :as config]
-   [metabase.server.handler :as handler]
    [metabase.server.middleware.session :as mw.session]
    [metabase.test-runner.assert-exprs :as test-runner.assert-exprs]
    [metabase.test.initialize :as initialize]
+   [metabase.test.initialize.web-server :as initialize.web-server]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.json :as json]
@@ -334,7 +334,7 @@
         _           (log/debug method-name (pr-str url) (pr-str request))
         thunk       (fn []
                       (try
-                        (handler/app request coerce-mock-response-body (fn raise [e] (throw e)))
+                        ((initialize.web-server/test-handler) request coerce-mock-response-body (fn raise [e] (throw e)))
                         (catch clojure.lang.ExceptionInfo e
                           (log/debug e method-name url)
                           (ex-data e))

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -12,9 +12,9 @@
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.server.test-handler :as server.test-handler]
    [metabase.test-runner.assert-exprs :as test-runner.assert-exprs]
    [metabase.test.initialize :as initialize]
-   [metabase.test.initialize.web-server :as initialize.web-server]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.json :as json]
@@ -334,7 +334,7 @@
         _           (log/debug method-name (pr-str url) (pr-str request))
         thunk       (fn []
                       (try
-                        ((initialize.web-server/test-handler) request coerce-mock-response-body (fn raise [e] (throw e)))
+                        ((server.test-handler/test-handler) request coerce-mock-response-body (fn raise [e] (throw e)))
                         (catch clojure.lang.ExceptionInfo e
                           (log/debug e method-name url)
                           (ex-data e))

--- a/test/metabase/server/test_handler.clj
+++ b/test/metabase/server/test_handler.clj
@@ -1,0 +1,31 @@
+(ns metabase.server.test-handler
+  (:require
+   [metabase.api.macros :as api.macros]
+   [metabase.server.core :as server]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]))
+
+(mu/defn- make-test-handler :- ::api.macros/handler
+  []
+  (let [api-routes    #_{:clj-kondo/ignore [:metabase/modules]} (requiring-resolve 'metabase.api-routes.core/routes)
+        server-routes (server/make-routes api-routes)
+        handler       (server/make-handler server-routes)]
+    (fn [request respond raise]
+      (letfn [(raise' [e]
+                (log/errorf "ERROR HANDLING REQUEST! <async raise> %s" request)
+                (log/error e)
+                (raise e))]
+        (try
+          (handler request respond raise')
+          (catch Throwable e
+            (log/errorf "ERROR HANDLING REQUEST! <async thrown> %s" request)
+            (log/error e)
+            (throw e)))))))
+
+(def ^:private -test-handler
+  (delay (make-test-handler)))
+
+(defn test-handler
+  "Build the Ring handler used in tests and by `dev`."
+  []
+  @-test-handler)

--- a/test/metabase/test/initialize/web_server.clj
+++ b/test/metabase/test/initialize/web_server.clj
@@ -1,43 +1,17 @@
 (ns metabase.test.initialize.web-server
   (:require
-   [metabase.api.macros :as api.macros]
    [metabase.config :as config]
    [metabase.core.initialization-status :as init-status]
    [metabase.server.core :as server]
+   [metabase.server.test-handler :as server.test-handler]
    [metabase.settings.core :as setting]
-   [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
-(mu/defn- make-test-handler :- ::api.macros/handler
-  []
-  (let [api-routes    (requiring-resolve 'metabase.api-routes.core/routes)
-        server-routes (server/make-routes api-routes)
-        handler       (server/make-handler server-routes)]
-    (fn [request respond raise]
-      (letfn [(raise' [e]
-                (log/errorf "ERROR HANDLING REQUEST! <async raise> %s" request)
-                (log/error e)
-                (raise e))]
-        (try
-          (handler request respond raise')
-          (catch Throwable e
-            (log/errorf "ERROR HANDLING REQUEST! <async thrown> %s" request)
-            (log/error e)
-            (throw e)))))))
-
-(def ^:private -test-handler
-  (delay (make-test-handler)))
-
-(defn test-handler
-  "Build the Ring handler used in tests and by `dev`."
-  []
-  @-test-handler)
-
 (defn init! []
   (try
-    (server/start-web-server! (test-handler))
+    (server/start-web-server! (server.test-handler/test-handler))
     (log/infof "Started test server on port %d" (config/config-int :mb-jetty-port))
     (catch Throwable e
       (log/fatal e "Web server failed to start")

--- a/test/metabase/test/initialize/web_server.clj
+++ b/test/metabase/test/initialize/web_server.clj
@@ -1,38 +1,43 @@
 (ns metabase.test.initialize.web-server
   (:require
+   [metabase.api.macros :as api.macros]
    [metabase.config :as config]
    [metabase.core.initialization-status :as init-status]
-   [metabase.server.handler :as handler]
-   [metabase.server.instance :as server]
+   [metabase.server.core :as server]
    [metabase.settings.core :as setting]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
 
-(defn- test-handler
-  ([request]
-   (try
-     (#'handler/app request)
-     (catch Throwable e
-       (log/errorf "ERROR HANDLING REQUEST! <sync> %s" request)
-       (log/error e)
-       (throw e))))
+(mu/defn- make-test-handler :- ::api.macros/handler
+  []
+  (let [api-routes    (requiring-resolve 'metabase.api-routes.core/routes)
+        server-routes (server/make-routes api-routes)
+        handler       (server/make-handler server-routes)]
+    (fn [request respond raise]
+      (letfn [(raise' [e]
+                (log/errorf "ERROR HANDLING REQUEST! <async raise> %s" request)
+                (log/error e)
+                (raise e))]
+        (try
+          (handler request respond raise')
+          (catch Throwable e
+            (log/errorf "ERROR HANDLING REQUEST! <async thrown> %s" request)
+            (log/error e)
+            (throw e)))))))
 
-  ([request respond raise]
-   (letfn [(raise' [e]
-             (log/errorf "ERROR HANDLING REQUEST! <async raise> %s" request)
-             (log/error e)
-             (raise e))]
-     (try
-       (#'handler/app request respond raise')
-       (catch Throwable e
-         (log/errorf "ERROR HANDLING REQUEST! <async thrown> %s" request)
-         (log/error e)
-         (throw e))))))
+(def ^:private -test-handler
+  (delay (make-test-handler)))
+
+(defn test-handler
+  "Build the Ring handler used in tests and by `dev`."
+  []
+  @-test-handler)
 
 (defn init! []
   (try
-    (server/start-web-server! test-handler)
+    (server/start-web-server! (test-handler))
     (log/infof "Started test server on port %d" (config/config-int :mb-jetty-port))
     (catch Throwable e
       (log/fatal e "Web server failed to start")


### PR DESCRIPTION
Resolves DEV-489

Dependency-inject `metabase.api-routes.core/routes` into the routes/handler created in `metabase.server.*` to remove the dependency of `server` on `api-routes`. Since `server` is used by a few other things and `api-routes` accumulates almost everything this removes a huge source of "everything depending on everything else" 