### PR TITLE
slow down entity id backfill

### DIFF
--- a/src/metabase/lib_be/task/backfill_entity_ids.clj
+++ b/src/metabase/lib_be/task/backfill_entity_ids.clj
@@ -16,12 +16,12 @@
 
 (def ^:dynamic *drain-batch-size*
   "The number of records the drain entity ids job will process at once"
-  60)
+  10)
 (def ^:dynamic *backfill-batch-size*
   "The number of records the backfill entity ids job will process at once.  Defaults to slightly smaller than
   *drain-batch-size* so that if the user adds a few entities to the cache, the entire thing will still drain in one
   batch."
-  50)
+  6)
 (def ^:private min-repeat-ms
   "The minimum acceptable repeat rate for the backfill entity ids job"
   1000)


### PR DESCRIPTION
### Description

the old default is causing issues with our managed instances, so slow things down

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
