### PR TITLE
fix flaky timelines spec

### DIFF
--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -423,7 +423,7 @@ describe("scenarios > organization > timelines > question", () => {
       H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
       H.echartsIcon("star").should("be.visible");
-      H.echartsIcon("star").realClick();
+      H.echartsIcon("star").click();
 
       // event should be selected in sidebar
       timelineEventCard("RC1").should("be.visible");


### PR DESCRIPTION
Fixes flaky question timelines spec from [this slack report](https://metaboat.slack.com/archives/C5XHN8GLW/p1747307066220459)

Stress test: https://github.com/metabase/metabase/actions/runs/15057623951