### PR TITLE
humanized erorr message for preview

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -392,6 +392,26 @@
                                  :notification {:payload_type :notification/system-event
                                                 :payload      {:event_name :event/row.created}}}))))
 
+(deftest preview-notification-nice-error-message-test
+  (testing "invalide handlebars template"
+    (is (=? "Failed to render template: found: '}'\n{{}\n  ^"
+            (mt/user-http-request :crowberto :post 400 "notification/preview_template"
+                                  {:template     {:channel_type :channel/email
+                                                  :details {:type    :email/handlebars-text
+                                                            :subject "subject"
+                                                            :body    "{{}"}}
+                                   :notification {:payload_type :notification/system-event
+                                                  :payload      {:event_name :event/row.created}}}))))
+  (testing "invalid subject template"
+    (is (=? "Failed to render template: Invalid query: found '[[' or '{{' with no matching ']]' or '}}'"
+            (mt/user-http-request :crowberto :post 400 "notification/preview_template"
+                                  {:template     {:channel_type :channel/email
+                                                  :details {:type    :email/handlebars-text
+                                                            :subject "{{"
+                                                            :body    "{{}"}}
+                                   :notification {:payload_type :notification/system-event
+                                                  :payload      {:event_name :event/row.created}}})))))
+
 (deftest preview-notification-custom-payload-test
   (testing "use the custom context if it's valid"
     (is (=? {:context  (mt/malli=? :map)

--- a/src/metabase/channel/template/core.clj
+++ b/src/metabase/channel/template/core.clj
@@ -8,7 +8,8 @@
 (p/import-vars
  [channel.handlebars
   render-string
-  render]
+  render
+  humanize-error-message]
  [channel.default
   default-template])
 

--- a/test/metabase/channel/template/handlebars_test.clj
+++ b/test/metabase/channel/template/handlebars_test.clj
@@ -57,3 +57,10 @@
   (testing "with custom req"
     (with-temp-template! [tmpl-name "tmpl.hbs" "Hello {{uppercase name}}"]
       (is (= "Hello NGOC" (handlebars/render custom-hbs tmpl-name {:name "Ngoc"}))))))
+
+(deftest humanize-renderring-error
+  (try
+    (handlebars/render-string "{{template}" {})
+    (catch Exception e
+      (is (= "found: '}'\n{{template}\n          ^"
+             (handlebars/humanize-error-message e))))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/WRK-398/improve-error-messaging-for-failed-template-preview

New error message looks like this: `Failed to render template: found: '}'\n{{}\n ^`