### PR TITLE
Set sensible default data picker step when joining

### DIFF
--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -909,10 +909,13 @@ describe("scenarios > embedding > full app", () => {
      * This step only shows when there are more than 1 option in the bucket step, the only time this happens
      * is when there are both selectable models and tables for the current user.
      */
-    function goBackToBucketStep() {
+    /** @param {'from-table' | 'from-model'} fromStep */
+    function goBackToBucketStep(fromStep = "from-table") {
       H.popover().within(() => {
         cy.icon("chevronleft").click();
-        cy.icon("chevronleft").click();
+        if (fromStep === "from-table") {
+          cy.icon("chevronleft").click();
+        }
       });
     }
 
@@ -1299,7 +1302,7 @@ describe("scenarios > embedding > full app", () => {
         });
 
         H.getNotebookStep("data").button("Join data").click();
-        goBackToBucketStep();
+        goBackToBucketStep("from-model");
         selectCard({
           cardName: ordersCountModelDetails.name,
           cardType: "model",
@@ -1329,7 +1332,7 @@ describe("scenarios > embedding > full app", () => {
         });
 
         H.getNotebookStep("data").button("Join data").click();
-        goBackToBucketStep();
+        goBackToBucketStep("from-model");
 
         selectTable({
           tableName: "Products",

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
@@ -372,10 +372,10 @@ export class UnconnectedDataSelector extends Component {
       await this.switchToStep(TABLE_STEP);
     } else if (this.state.selectedDatabaseId && steps.includes(SCHEMA_STEP)) {
       await this.switchToStep(SCHEMA_STEP);
-    } else if (steps[0] === DATA_BUCKET_STEP && !this.hasUsableModels()) {
-      await this.switchToStep(steps[1]);
+    } else if (!this.hasUsableModels()) {
+      await this.switchToStep(DATABASE_STEP);
     } else {
-      await this.switchToStep(steps[0]);
+      await this.switchToStep(DATA_BUCKET_STEP);
     }
   }
 

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
@@ -361,7 +361,6 @@ export class UnconnectedDataSelector extends Component {
   };
 
   async hydrateActiveStep() {
-    const { steps } = this.props;
     if (
       this.isSavedEntitySelected() ||
       this.state.selectedDataBucketId === DATA_BUCKET.MODELS

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.jsx
@@ -36,7 +36,7 @@ import { getDataTypes } from "../utils";
 
 // chooses a data source bucket (datasets / raw data (tables) / saved questions)
 const DATA_BUCKET_STEP = "BUCKET";
-// chooses a database
+// chooses a database or a model
 const DATABASE_STEP = "DATABASE";
 // chooses a schema (given that a database has already been selected)
 const SCHEMA_STEP = "SCHEMA";

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSelector.unit.spec.js
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSelector.unit.spec.js
@@ -163,7 +163,6 @@ describe("DataSelector", () => {
     let nextMetadata = createMockMetadata({ databases });
     nextMetadata.schemas = {};
     nextMetadata.tables = {};
-    nextMetadata.fields = {};
     rerenderWith(nextMetadata);
 
     expect(screen.getByText("Sample Database")).toBeInTheDocument();
@@ -177,7 +176,6 @@ describe("DataSelector", () => {
     // select a schema
     nextMetadata = createMockMetadata({ databases });
     nextMetadata.tables = {};
-    nextMetadata.fields = {};
     rerenderWith(nextMetadata);
     expect(screen.getByText("First Schema")).toBeInTheDocument();
     expect(screen.getByText("Second Schema")).toBeInTheDocument();
@@ -332,38 +330,6 @@ describe("DataSelector", () => {
     expect(screen.getByText("Multi-schema Database")).toBeInTheDocument();
     // check for chevron icon
     expect(getIcon("chevrondown")).toBeInTheDocument();
-  });
-
-  it("should auto-advance past db and schema in field picker", async () => {
-    render(
-      <DataSelector
-        steps={["SCHEMA", "TABLE", "FIELD"]}
-        selectedDatabaseId={SAMPLE_DATABASE.id}
-        databases={[SAMPLE_DATABASE]}
-        triggerElement={<div />}
-        metadata={metadata}
-        isOpen={true}
-      />,
-    );
-    await delay(1);
-
-    expect(await screen.findByText("Orders")).toBeInTheDocument();
-  });
-
-  it("should select schema in field picker", async () => {
-    render(
-      <DataSelector
-        steps={["SCHEMA", "TABLE", "FIELD"]}
-        selectedDatabaseId={MULTI_SCHEMA_DATABASE.id}
-        databases={[MULTI_SCHEMA_DATABASE]}
-        triggerElement={<div />}
-        metadata={metadata}
-        isOpen={true}
-      />,
-    );
-
-    await userEvent.click(screen.getByText("First Schema"));
-    expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
   });
 
   it("should open database picker with correct database selected", () => {

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
@@ -71,6 +71,7 @@ function setup({
   return renderWithProviders(
     <DataSourceSelector
       isInitiallyOpen
+      isQuerySourceModel={false}
       canChangeDatabase={!isJoinStep}
       selectedDatabaseId={selectedTable ? selectedTable.databaseId : null}
       selectedTableId={selectedTable ? selectedTable.id : undefined}

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -2,6 +2,7 @@ import type { TableId } from "metabase-types/api";
 
 export interface DataSourceSelectorProps {
   isInitiallyOpen: boolean;
+  isQuerySourceModel: boolean;
   /** false when joining data, true otherwise */
   canChangeDatabase: boolean;
   selectedDatabaseId: number | null;

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -2,6 +2,7 @@ import type { TableId } from "metabase-types/api";
 
 export interface DataSourceSelectorProps {
   isInitiallyOpen: boolean;
+  /** Whether the first stage of the query uses a model */
   isQuerySourceModel: boolean;
   /** false when joining data, true otherwise */
   canChangeDatabase: boolean;

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -52,7 +52,7 @@ export function EmbeddingDataPicker({
     isFetching: isSourceModelFetching,
   } = useSourceModelCollectionId(query);
 
-  if (isDataSourceCountLoading || isSourceModelFetching) {
+  if (isDataSourceCountLoading) {
     return null;
   }
 
@@ -83,10 +83,15 @@ export function EmbeddingDataPicker({
     );
   }
 
+  const isSourceSelected = Boolean(pickerInfo?.tableId);
   return (
     <PLUGIN_EMBEDDING.DataSourceSelector
-      key={pickerInfo?.tableId ?? sourceTable?.id}
-      isInitiallyOpen={!table}
+      key={
+        isSourceSelected
+          ? pickerInfo?.tableId
+          : `${sourceTable?.id}:${isSourceModelFetching}`
+      }
+      isInitiallyOpen={isSourceModelFetching ? false : !table}
       isQuerySourceModel={isSourceModel}
       canChangeDatabase={canChangeDatabase}
       selectedDatabaseId={databaseId}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -51,6 +51,7 @@ export function EmbeddingDataPicker({
     (state) => getEmbedOptions(state).entity_types,
   );
 
+  // a table or a virtual table (card)
   const sourceTable = useSourceTable(query);
   const isSourceModel = sourceTable?.type === "model";
   const {

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -2,6 +2,7 @@ import { skipToken, useGetCardQuery, useSearchQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING } from "metabase/plugins";
 import { getEmbedOptions } from "metabase/selectors/embed";
+import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import type { TableId } from "metabase-types/api";
 
@@ -43,6 +44,8 @@ export function EmbeddingDataPicker({
     (state) => getEmbedOptions(state).entity_types,
   );
 
+  const metadata = useSelector(getMetadata);
+
   if (isDataSourceCountLoading) {
     return null;
   }
@@ -73,11 +76,14 @@ export function EmbeddingDataPicker({
       />
     );
   }
+  const sourceTable = metadata.table(Lib.sourceTableOrCardId(query));
+  const isSourceModel = sourceTable?.type === "model";
 
   return (
     <PLUGIN_EMBEDDING.DataSourceSelector
-      key={pickerInfo?.tableId}
+      key={pickerInfo?.tableId ?? sourceTable?.id}
       isInitiallyOpen={!table}
+      isQuerySourceModel={isSourceModel}
       canChangeDatabase={canChangeDatabase}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -40,6 +40,12 @@ export function EmbeddingDataPicker({
   const { data: card } = useGetCardQuery(
     pickerInfo?.cardId != null ? { id: pickerInfo.cardId } : skipToken,
   );
+  /**
+   * This is when we change the starting query source, and `card` is already cached.
+   * If we use `card` as is, it will use the cached data from a different query source
+   * which is incorrect.
+   */
+  const normalizedCard = pickerInfo?.cardId ? card : undefined;
 
   const entityTypes = useSelector(
     (state) => getEmbedOptions(state).entity_types,
@@ -96,7 +102,9 @@ export function EmbeddingDataPicker({
       canChangeDatabase={canChangeDatabase}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}
-      selectedCollectionId={card?.collection_id ?? sourceModelCollectionId}
+      selectedCollectionId={
+        normalizedCard?.collection_id ?? sourceModelCollectionId
+      }
       canSelectModel={entityTypes.includes("model")}
       canSelectTable={entityTypes.includes("table")}
       triggerElement={


### PR DESCRIPTION
Closes EMB-189, closes #51934

### Backport reason
Can't be double backported because the [Refactor multi-stage data picker](https://linear.app/metabase/project/refactor-multi-stage-data-picker-5bb9b4155c81) prs are only backported once

### Description
Based on the [solution here](https://metaboat.slack.com/archives/C063Q3F1HPF/p1739808652233439?thread_ts=1739800920.795329&cid=C063Q3F1HPF)

>Intuitively I would say:
> - start from whatever was picked first, if a model, model in same collection, if table, table in same DB
> - if there is nothing else to choose, go back to the top category or up one level instead of showing an empty list


### How to verify
Embed interactive embedding, and try to join data with different scenarios.
- starting data source: model/table
- when joining data it should show the starting step according to the selecting data source type
- try to change the query data source when the join hasn't been selected vs when the join has been selected
- test query model data source in different collection.
- The starting model step should auto select the model source collection.

### Demo

When joining from a table
![image](https://github.com/user-attachments/assets/b841847b-0cde-4d04-92a9-8b3548dbfed9)

When joining from a model
![image](https://github.com/user-attachments/assets/4b343787-599a-4264-b2a3-eede39152994)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
