### PR TITLE
default slack template should escape vals

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10634,6 +10634,7 @@ databaseChangeLog:
                     nullable: true
                     unique: true
 
+  # TODO this might make downgrade failed for the seeded notifications. Check before merging to master
   - changeSet:
       id: v54.2025-02-14T08:00:00
       author: qnkhuat

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -327,6 +327,8 @@
         template    (or template
                         ;; TODO: the context here does not nescessarily have the same shape as payload, needs to rethink this
                         (channel.template/default-template :notification/system-event (:context notification-payload) :channel/email))]
+    (def template template)
+    (def notification-payload notification-payload)
     (assert template (str "No template found for event " event-name))
     (if-not template
       []

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -211,9 +211,11 @@
 
 (mu/defmethod channel/render-notification [:channel/slack :notification/system-event] :- [:sequential SlackMessage]
   [channel-type _payload-type {:keys [context] :as notification-payload} template recipients]
+  (def notification-payload notification-payload)
   (let [event-name (:event_name context)
         template   (or template
                        (channel.template/default-template :notification/system-event context channel-type))
+        _ (def template template)
         sections    [{:type "section"
                       :text {:type "mrkdwn"
                              :text (truncate

--- a/src/metabase/channel/template/default.clj
+++ b/src/metabase/channel/template/default.clj
@@ -25,24 +25,24 @@
                                                                     :details      {:type :slack/handlebars-text
                                                                                    :body (str "*A new record was _created_* in <{{table.url}}|Table {{table.name}}>{{#if editor.common_name }} by {{editor.common_name}}{{/if}}.\n"
                                                                                               "{{#each record}}"
-                                                                                              "• *{{@key}}*: {{@value}}\n"
+                                                                                              "• *{{{@key}}}*: {{{@value}}}\n"
                                                                                               "{{/each}}")}}
                    [:notification/system-event :event/row.updated] {:channel_type :channel/slack
                                                                     :details      {:type :slack/handlebars-text
                                                                                    :body (str "*A record was _updated_* in <{{table.url}}|Table {{table.name}}>{{#if editor.common_name }} by {{editor.common_name}}{{/if}}\n"
                                                                                               "*Changed Fields*\n"
                                                                                               "{{#each changes}}"
-                                                                                              "• *{{@key}}*: ~{{@value.before}}~ → {{@value.after}}\n"
+                                                                                              "• *{{{@key}}}*: ~{{{@value.before}}}~ → {{{@value.after}}}\n"
                                                                                               "{{/each}}\n"
                                                                                               "*Current Record Details*\n"
                                                                                               "{{#each record}}"
-                                                                                              "• *{{@key}}*: {{@value}}\n"
+                                                                                              "• *{{{@key}}}*: {{{@value}}}\n"
                                                                                               "{{/each}}")}}
                    [:notification/system-event :event/row.deleted] {:channel_type :channel/slack
                                                                     :details      {:type :slack/handlebars-text
                                                                                    :body (str "*A record was _deleted_* in <{{table.url}}|Table {{table.name}}>{{#if editor.common_name }} by {{editor.common_name}}{{/if}}.\n"
                                                                                               "{{#each record}}"
-                                                                                              "• ~*{{@key}}*~: {{@value}}\n"
+                                                                                              "• ~*{{{@key}}}*~: {{{@value}}}\n"
                                                                                               "{{/each}}\n"
                                                                                               "This record is no longer available")}}
                    [:notification/card nil] {:channel_type :channel/slack


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C04R9F5A29F/p1747318729682429

By default the  `{{ }}` escape the value, to avoid escaping we need to use `{{{ }}}` for the values