### PR TITLE
Return `nil` when there are no params in a subscription

### DIFF
--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -305,7 +305,7 @@
                                                     :management_url     (if (nil? non-user-email)
                                                                           (urls/notification-management-url)
                                                                           (pulse-unsubscribe-url-for-non-user (:id dashboard_subscription) non-user-email))
-                                                    :filters           (when parameters
+                                                    :filters           (when (seq parameters)
                                                                          (render-filters parameters))})
                                   (m/update-existing-in [:payload :dashboard :description] #(markdown/process-markdown % :html))))]
     (construct-emails template message-context-fn attachments recipients)))


### PR DESCRIPTION
This PR resolves #58074 

We're using the `computed.filters` value in the handlebars email template. Previously, if `parameters` were an empty list `[]` we were returning a truthy value, and handlebars was rendering an empty row in an email.

@ngoc figured out that we need to wrap parameters with `seq` in order to have a a proper `nil` assigned to `:parameters`.


### Before and after
![Kapture 2025-05-16 at 12 29 44](https://github.com/user-attachments/assets/b06f1b67-9809-4631-8e5d-04b7fcd021ee)

### Tests
I didn't find related tests for this.