### PR TITLE
Fix menu text on sharing and subscription menu

### DIFF
--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
@@ -48,11 +48,9 @@ export function PublicLinkMenuItem({
       onClick={onClick}
       disabled={!hasPublicLink}
     >
-      <Title order={4} c="inherit">
-        {hasPublicLink
-          ? t`Public link`
-          : t`Ask your admin to create a public link`}
-      </Title>
+      {hasPublicLink
+        ? t`Public link`
+        : t`Ask your admin to create a public link`}
     </Menu.Item>
   );
 }

--- a/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
+++ b/frontend/src/metabase/notifications/NotificationsActionsMenu/DashboardSubscriptionMenuItem.tsx
@@ -6,7 +6,7 @@ import {
   canManageSubscriptions as canManageSubscriptionsSelector,
   getUserIsAdmin,
 } from "metabase/selectors/user";
-import { Icon, Menu, Stack, Text, Title } from "metabase/ui";
+import { Icon, Menu, Text } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
 
 export function DashboardSubscriptionMenuItem({
@@ -37,13 +37,8 @@ export function DashboardSubscriptionMenuItem({
         leftSection={<Icon name="subscription" />}
         disabled
       >
-        <Stack gap="xs">
-          <Title order={4} c="inherit">{t`Can't send subscriptions`}</Title>
-          <Text
-            size="sm"
-            color="inherit"
-          >{t`Ask your admin to set up email`}</Text>
-        </Stack>
+        <Text size="md" c="inherit">{t`Can't send subscriptions`}</Text>
+        <Text size="sm" c="inherit">{t`Ask your admin to set up email`}</Text>
       </Menu.Item>
     );
   }


### PR DESCRIPTION
We were using a `Title` element on the non-admin menu items but not the admin ones. This just makes it consistent bewteen the two modes  

Before:
![image](https://github.com/user-attachments/assets/6d7da45d-5b05-440e-a187-7707c28345a4)
 

After:

<img width="312" alt="image" src="https://github.com/user-attachments/assets/491fbde8-ca53-471a-8dab-24aa212aa830" />

---

Same thing on the subscription menu - we were using a `Title` element which made the header stick out like a sore thumb.

Before:
![image](https://github.com/user-attachments/assets/0323e3a4-cfb5-4303-b4f8-e3682e8dacc0)
 
After:
<img width="237" alt="image" src="https://github.com/user-attachments/assets/38eed607-f8cf-4de2-a544-5e328efdf341" />

---

I'm pretty sure this code has been here since I wrote the original menu but I guess the text in the other menu items changed but this one stayed stuck in 2023. We'll bring it to 2025 Metabase Design Standards® now