### PR TITLE
cljs: Fix obscenely large schema expansions

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -144,9 +144,9 @@
                "datetime" ::lib.schema.literal/datetime
                "unit"     ::DateTimeUnit)]])
 
-(def ^:internal ^{:clause-name :absolute-datetime} absolute-datetime
+(def ^:internal absolute-datetime
   "Schema for an `:absolute-datetime` clause."
-  [:ref ::absolute-datetime])
+  (with-meta [:ref ::absolute-datetime] {:clause-name :absolute-datetime}))
 
 ;; almost exactly the same as `absolute-datetime`, but generated in some sitations where the literal in question was
 ;; clearly a time (e.g. "08:00:00.000") and/or the Field derived from `:type/Time` and/or the unit was a
@@ -330,18 +330,20 @@
     {:description "Fields using names rather than integer IDs are required to specify `:base-type`."}
     ::require-base-type-for-field-name]])
 
-(def ^{:clause-name :field, :added "0.39.0"} field
+(def ^{:added "0.39.0"} field
   "Schema for a `:field` clause."
-  [:ref ::field])
+  (with-meta [:ref ::field] {:clause-name :field}))
 
-(def ^{:clause-name :field, :added "0.39.0"} field:id
+(def ^{:added "0.39.0"} field:id
   "Schema for a `:field` clause, with the added constraint that it must use an integer Field ID."
-  [:and
-   field
-   [:fn
-    {:error/message "Must be a :field with an integer Field ID."}
-    (fn [[_ id-or-name]]
-      (integer? id-or-name))]])
+  (with-meta
+   [:and
+    field
+    [:fn
+     {:error/message "Must be a :field with an integer Field ID."}
+     (fn [[_ id-or-name]]
+       (integer? id-or-name))]]
+   {:clause-name :field}))
 
 (mr/def ::Field
   [:schema
@@ -851,22 +853,20 @@
                      "second-string-or-field" StringExpressionArg
                      "more-strings-or-fields" [:rest StringExpressionArg])]))
 
-(def ^{:clause-name :starts-with} starts-with
+(def starts-with
   "Schema for a valid :starts-with clause."
-  [:ref ::starts-with])
-(def ^{:clause-name :ends-with} ends-with
+  (with-meta [:ref ::starts-with] {:clause-name :starts-with}))
+(def ends-with
   "Schema for a valid :ends-with clause."
-  [:ref ::ends-with])
-(def ^{:clause-name :contains} contains
+  (with-meta [:ref ::ends-with] {:clause-name :ends-with}))
+(def contains
   "Schema for a valid :contains clause."
-  [:ref ::contains])
+  (with-meta [:ref ::contains] {:clause-name :contains}))
 
 ;; SUGAR: this is rewritten as [:not [:contains ...]]
-(def ^{:sugar       true
-       :clause-name :does-not-contain}
-  does-not-contain
+(def ^:sugar does-not-contain
   "Schema for a valid :does-not-contain clause."
-  [:ref ::does-not-contain])
+  (with-meta [:ref ::does-not-contain] {:clause-name :does-not-contain}))
 
 (def ^:private TimeIntervalOptions
   ;; Should we include partial results for the current day/month/etc? Defaults to `false`; set this to `true` to
@@ -1583,9 +1583,9 @@
     [:target [:schema [:or [:ref ::Field] [:ref ::template-tag]]]]
     [:options [:? [:maybe [:map {:error/message "dimension options"} [:stage-number {:optional true} :int]]]]]]])
 
-(def ^{:clause-name :dimension} dimension
+(def dimension
   "Schema for a valid dimension clause."
-  [:ref ::dimension])
+  (with-meta [:ref ::dimension] {:clause-name :dimension}))
 
 (defclause variable
   target template-tag)

--- a/src/metabase/util/malli/registry.cljc
+++ b/src/metabase/util/malli/registry.cljc
@@ -1,7 +1,8 @@
 (ns metabase.util.malli.registry
   (:refer-clojure :exclude [declare def])
   (:require
-   #?@(:clj ([malli.experimental.time :as malli.time]))
+   #?@(:clj ([malli.experimental.time :as malli.time]
+             [net.cgrand.macrovich :as macros]))
    [malli.core :as mc]
    [malli.registry]
    [malli.util :as mut])
@@ -136,7 +137,10 @@
      ([type docstring schema]
       (assert (string? docstring))
       `(metabase.util.malli.registry/def ~type
-         (-with-doc ~schema ~docstring)))))
+         ~(macros/case
+           :clj `(-with-doc ~schema ~docstring)
+           ;; Ignore docstring for CLJS.
+           :cljs schema)))))
 
 (defn- deref-all-preserving-properties
   "Like [[mc/deref-all]] but preserves properties attached to a `:ref` by wrapping the result in `:schema`."


### PR DESCRIPTION
This has a big impact on `metabase.lib.metadata.calculation`: 411.67 KB -> 305.04 KB. I just hope nothing is depending on that metadata at runtime.