### PR TITLE
Branding email subscriptions

### DIFF
--- a/e2e/support/helpers/e2e-email-helpers.js
+++ b/e2e/support/helpers/e2e-email-helpers.js
@@ -127,3 +127,18 @@ export function sendEmailAndVisitIt() {
     cy.visit(`${emailUrl}/${latest.id}/html`);
   });
 }
+
+export function sendAlertAndVisitIt() {
+  cy.intercept("POST", "/api/notification/send").as("testAlert");
+  cy.findByLabelText("New alert")
+    .should("be.visible")
+    .findByText("Send now")
+    .click();
+  cy.wait("@testAlert");
+
+  const emailUrl = `http://localhost:${WEB_PORT}/email`;
+  return cy.request("GET", emailUrl).then(({ body }) => {
+    const latest = body.slice(-1)[0];
+    cy.visit(`${emailUrl}/${latest.id}/html`);
+  });
+}

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -501,8 +501,24 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("OSS email subscriptions", { tags: ["@OSS", "external"] }, () => {
     beforeEach(() => {
-      cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
       H.setupSMTP();
+      cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
+    });
+
+    it("should include branding", () => {
+      assignRecipient();
+      H.sendEmailAndVisitIt();
+      cy.findAllByRole("link")
+        .filter(":contains(Orders in a dashboard)")
+        .should("be.visible");
+      cy.findAllByRole("link")
+        .filter(":contains(Made with)")
+        .should("contain", "Metabase")
+        .and(
+          "have.attr",
+          "href",
+          "https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription",
+        );
     });
 
     describe("with parameters", () => {
@@ -569,6 +585,17 @@ describe("scenarios > dashboard > subscriptions", () => {
       H.setTokenFeatures("all");
       H.setupSMTP();
       cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
+    });
+
+    it("should not include branding", () => {
+      assignRecipient();
+      H.sendEmailAndVisitIt();
+      cy.findAllByRole("link")
+        .filter(":contains(Orders in a dashboard)")
+        .should("be.visible");
+      cy.findAllByRole("link")
+        .filter(":contains(Made with)")
+        .should("not.exist");
     });
 
     it("should only show current user in recipients dropdown if `user-visiblity` setting is `none`", () => {

--- a/enterprise/backend/test/metabase_enterprise/notification/payload/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/notification/payload/core_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.notification.payload.core-test
+(ns metabase-enterprise.notification.payload.core-test
   (:require
    [clojure.test :refer :all]
    [metabase.notification.payload.core :as notification.payload]

--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -5,9 +5,13 @@
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             {{#if context.include_branding}}
-              <div style="text-align: right; font-size: 12px;">
-                Made with <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=email">Metabase &#x1F499;</a>
-              </div>
+              <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=dashboard_subscription">
+                <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">
+                  <span style="font-size: 12px; vertical-align: middle;">Made with</span>
+                  <img width="22.4" height="28" src="{{context.application_logo_url}}" style="vertical-align: middle; margin-inline: 4px;"/>
+                  <span style='font-size: 16px; font-weight: 700; vertical-align: middle;'>Metabase</span>
+                </div>
+              </a>
             {{/if}}
             <table class="header">
               <tr>

--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -4,6 +4,11 @@
       <tr>
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
+            {{#if context.include_branding}}
+              <div style="text-align: right; font-size: 12px;">
+                Made with <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=email">Metabase &#x1F499;</a>
+              </div>
+            {{/if}}
             <table class="header">
               <tr>
                 <td width="28px" style="vertical-align: top;">

--- a/src/metabase/channel/email/notification_card.hbs
+++ b/src/metabase/channel/email/notification_card.hbs
@@ -5,9 +5,13 @@
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             {{#if context.include_branding}}
-              <div style="text-align: right; font-size: 12px;">
-                Made with <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=email">Metabase &#x1F499;</a>
-              </div>
+              <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=alert">
+                <div style="text-align: right; height: 28px; margin-bottom: 16px; color: {{payload.style.color_text_dark}};">
+                  <span style="font-size: 12px; vertical-align: middle;">Made with</span>
+                  <img width="22.4" height="28" src="{{context.application_logo_url}}" style="vertical-align: middle; margin-inline: 4px;"/>
+                  <span style='font-size: 16px; font-weight: 700; vertical-align: middle;'>Metabase</span>
+                </div>
+              </a>
             {{/if}}
             <table class="header">
               <tr>

--- a/src/metabase/channel/email/notification_card.hbs
+++ b/src/metabase/channel/email/notification_card.hbs
@@ -4,6 +4,11 @@
       <tr>
         <td>
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
+            {{#if context.include_branding}}
+              <div style="text-align: right; font-size: 12px;">
+                Made with <a href="https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=email">Metabase &#x1F499;</a>
+              </div>
+            {{/if}}
             <table class="header">
               <tr>
                 <td width="28px" style="vertical-align: top;">

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -4,6 +4,7 @@
    [metabase.notification.models :as models.notification]
    [metabase.notification.payload.execute :as notification.payload.execute]
    [metabase.notification.payload.temp-storage :as notification.payload.temp-storage]
+   [metabase.premium-features.core :as premium-features]
    [metabase.system.core :as system]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -131,6 +132,7 @@
   {:application_name     (appearance/application-name)
    :application_color    (appearance/application-color)
    :application_logo_url (logo-url)
+   :include_branding     (not (premium-features/enable-whitelabeling?))
    :site_name            (appearance/site-name)
    :site_url             (system/site-url)
    :admin_email          (system/admin-email)

--- a/test/metabase/notification/payload/core_test.clj
+++ b/test/metabase/notification/payload/core_test.clj
@@ -21,6 +21,7 @@
                 :context     {:application_name     "Metabase Test"
                               :application_color    "#509EE3"
                               :application_logo_url "http://static.metabase.com/email_logo.png"
+                              :include_branding     false
                               :site_name            "Metabase Test"
                               :site_url             "https://metabase.com"
                               :admin_email          "ngoc@metabase.com"


### PR DESCRIPTION
Resolves PRG-5
Resolves PRG-39
Resolves PRG-40

This PR adds the conditional branding to dashboard email subscriptions and to question alerts. It does so by altering the handlebars templates we use for each, respectively. It follows the same logic as the rest of the PRs from [this project](https://linear.app/metabase/project/exports-branding-dd12b390992f/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false). If a token has a `whitelabel` feature flag (Pro/Enterprise), the branding is not shown. It should be shown for OSS and for Starter plans.

### Demo

<img width="643" alt="image" src="https://github.com/user-attachments/assets/43df44d4-0953-4f9a-960d-9d5d5660c40f" />

### Testing
- [x] One existing backend test updated and moved to the enterprise directory
- [x] Cypress E2E tests added for both dashboard subscriptions and for alerts

> [!IWARNING]
> We don't have an automated way to test emails against the real email clients! The real-life testing will have to be done after we merge.