### PR TITLE
mage jar-download improvments

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -108,7 +108,7 @@
   jar-download
   {:doc        "Given a version, downloads a metabase jar"
    :examples   [["./bin/mage jar-download 50" "Download the latest enterprise version of release 50 to ~/path/to/my/metabase/jars"]
-                ["./bin/mage jar-download 1.45.2 -r" "Download and run metabase_1.45.2.jar to ~/path/to/my/metabase/jars"]
+                ["./bin/mage jar-download 1.45.2 -r" "Download and run metabase_1.45.2.jar"]
                 ["./bin/mage jar-download 1.45.2 -d ~/path/to/my/jars" "Download metabase_1.45.2.jar to ~/path/to/my/jars, deleting if it exists"]
                 ["JARS=~/my-stuff ./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/my-stuff"]]
    :requires   [[mage.jar-download :as jar-download]]

--- a/bb.edn
+++ b/bb.edn
@@ -108,17 +108,17 @@
   jar-download
   {:doc        "Given a version, downloads a metabase jar"
    :examples   [["./bin/mage jar-download 50" "Download the latest enterprise version of release 50 to ~/path/to/my/metabase/jars"]
-                ["./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/path/to/my/metabase/jars"]
-                ["./bin/mage jar-download 1.45.2 ~/path/to/my/jars" "Download metabase_1.45.2.jar to ~/path/to/my/jars"]
+                ["./bin/mage jar-download 1.45.2 -r" "Download and run metabase_1.45.2.jar to ~/path/to/my/metabase/jars"]
+                ["./bin/mage jar-download 1.45.2 -d ~/path/to/my/jars" "Download metabase_1.45.2.jar to ~/path/to/my/jars, deleting if it exists"]
                 ["JARS=~/my-stuff ./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/my-stuff"]]
    :requires   [[mage.jar-download :as jar-download]]
+   :options    [["-r" "--run" "run the new jar after downloading it"]
+                ["-d" "--delete" "delete the old jar if found, by default does not re-download it"]]
+   :usage-fn  (fn [_] "note: If you get an error about 'Invalid or corrupt jarfile', run this command again with the -d option.")
    :arg-schema [:or
                 [:tuple [:string {:desc "version"}]]
-                [:tuple
-                 [:string {:desc "version"}]
-                 [:string {:desc "path"}]]]
-   :task       (task!
-                (jar-download/jar-download *command-line-args*))}
+                [:tuple [:string {:desc "version"}] [:string {:desc "path"}]]]
+   :task       (task! (jar-download/jar-download parsed))}
 
   setup-stats-repl
   {:doc "Connect to the stats repl"

--- a/mage/jar_download_config.yml
+++ b/mage/jar_download_config.yml
@@ -1,0 +1,22 @@
+version: 1
+config:
+  users:
+    - first_name: Crowberto
+      last_name: C
+      email: crowberto@metabase.com
+      password: blackjet
+      is_superuser: true
+    - first_name: Rasta
+      last_name: R
+      email: rasta@metabase.com
+      password: blueberries
+      is_superuser: false
+  api-keys:
+    - name: "Admin API key"
+      group: admin
+      creator: crowberto@metabase.com
+      key: mb_theadminapikey
+    - name: "All Users API key"
+      group: all-users
+      creator: crowberto@metabase.com
+      key: mb_theallusersapikey

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -109,8 +109,6 @@
                                    without-slash)
         {:keys [latest-version
                 jar-path]} (download-jar! version dir delete?)]
-    (prn {:latest-version latest-version
-          :version version})
     (when run?
       ;; Check that the embedding token is set:
       (u/env "MB_PREMIUM_EMBEDDING_TOKEN"
@@ -119,16 +117,17 @@
                               {:parsed-args    (dissoc parsed :summary)
                                :latest-version latest-version})))
       (let [port        (+ 3000 (major-version latest-version))
-            _ (prn "after")
+            socket-port (+ 3000 port)
             db-file     (str "metabase_" version ".db")
             extra-env   {"MB_DB_TYPE"          "h2"
                          "MB_DB_FILE"          db-file
                          "MB_JETTY_PORT"       port
                          "MB_CONFIG_FILE_PATH" (str u/project-root-directory "/mage/jar_download_config.yml")}
-            run-jar-cmd (str "java -jar " jar-path)]
+            run-jar-cmd (str "java -Dclojure.server.repl=\"{:port " socket-port " :accept clojure.core.server/repl}\" -jar " jar-path)]
         (println (c/magenta "Running: " run-jar-cmd))
         (println "env:")
         (doseq [[k v] extra-env]
           (println (str "  " (c/yellow k) "=" (c/green v))))
+        (println "Socket repl will open on " socket-port)
         (println (str "\n\n   Open in browser: http://localhost:" port "\n"))
         (p/shell {:dir dir :extra-env extra-env} run-jar-cmd)))))

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -2,6 +2,7 @@
   (:require
    [babashka.curl :as curl]
    [babashka.fs :as fs]
+   [babashka.process :as p]
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.repl :refer [pst]]
@@ -54,28 +55,80 @@
     :else (throw (ex-info (str "Invalid version format:" version)
                           {:version version}))))
 
-(defn- download-jar! [version dir]
+(defn- size-mb [bytes]
+  (let [size (/ bytes 1024.0 1024.0)]
+    (if (< size 1)
+      (str (int (* size 1000)) " KB")
+      (str (int size) " MB"))))
+
+(defn- download-jar! [version dir delete?]
   (let [latest-version (find-latest-version version)]
-    (when (fs/delete-if-exists (dir->file latest-version dir))
-      ;; TODO: keep it?
-      (println "Found and deleted old jar."))
-    (when-not (.exists (io/file dir))
-      (println (c/blue "Creating directory " dir " ..."))
-      (fs/create-dirs dir)
-      (println (c/green "Created.\n")))
-    (try
-      (println (str "Downloading from: " (url latest-version)
-                    "\n              to: " (dir->file latest-version dir) " ..."))
-      (download latest-version dir)
-      (println (str "Downloaded " latest-version ".jar to " dir))
-      (catch Exception e
-        (println (str "Error downloading version " latest-version ". Do both the directory and version exist?"))
-        (pst e)))))
+    (when (and delete? (fs/exists? (dir->file latest-version dir)))
+      (fs/delete (dir->file latest-version dir))
+      (println (c/red "Found and deleted old jar.")))
+    (when-not (fs/exists? (io/file dir))
+      (println (c/blue "Creating directory " dir))
+      (fs/create-dirs dir))
+    (if (fs/exists? (dir->file latest-version dir))
+      (println "Already downloaded" (c/green (url latest-version))
+               ".jar to" (c/green (dir->file latest-version dir))
+               ", size:" (c/red (size-mb (fs/size (dir->file latest-version dir)))))
+      (try
+        (println (str "Downloading from: " (url latest-version)
+                      "\n              to: " (dir->file latest-version dir) " ..."))
+        (u/with-throbber "Downloading... " (fn [] (download latest-version dir)))
+        (println (str "Downloaded."))
+        (catch Exception e
+          (throw (ex-info (str "Error downloading version " latest-version ". Do both the directory and version exist?")
+                          {:version version
+                           :dir     dir
+                           :url     (url latest-version)
+                           :jar-path (dir->file latest-version dir)})))))
+    {:latest-version latest-version
+     :jar-path (dir->file latest-version dir)}))
 
 (defn- without-slash [s] (str/replace s #"/$" ""))
 
+(defn- major-version [version]
+  (if (re-matches #"\d+\.\d+\.\d+" version)
+    (Integer/parseInt (second (str/split version #"\.")))
+    (Integer/parseInt version)))
+
 (defn jar-download
-  "Download a specific version of Metabase to a directory."
-  [[version dir]]
-  (let [dir (some-> (or dir (u/env "JARS") (str u/project-root-directory "/jars")) without-slash)]
-    (download-jar! version dir)))
+  "Download a specific version of Metabase to a directory.
+
+  Version can be a major version (like 50), or a full version (like 50.0.1). If only a major version is provided, the
+  latest minor version will be used."
+  [parsed]
+  (let [[version dir]      (:arguments parsed)
+        delete?            (:delete (:options parsed))
+        run?               (:run (:options parsed))
+        dir                (some-> (or dir (u/env "JARS" (fn [] (println "JARS not set in env, defaulting to"
+                                                                         (str u/project-root-directory "/jars"))))
+                                       (str u/project-root-directory "/jars"))
+                                   without-slash)
+        {:keys [latest-version
+                jar-path]} (download-jar! version dir delete?)]
+    (prn {:latest-version latest-version
+          :version version})
+    (when run?
+      ;; Check that the embedding token is set:
+      (u/env "MB_PREMIUM_EMBEDDING_TOKEN"
+             #(throw (ex-info (str "MB_PREMIUM_EMBEDDING_TOKEN is not set, please set it to run "
+                                   "your jar (it is in 1password. ask on slack if you need help).")
+                              {:parsed-args    (dissoc parsed :summary)
+                               :latest-version latest-version})))
+      (let [port        (+ 3000 (major-version latest-version))
+            _ (prn "after")
+            db-file     (str "metabase_" version ".db")
+            extra-env   {"MB_DB_TYPE"          "h2"
+                         "MB_DB_FILE"          db-file
+                         "MB_JETTY_PORT"       port
+                         "MB_CONFIG_FILE_PATH" (str u/project-root-directory "/mage/jar_download_config.yml")}
+            run-jar-cmd (str "java -jar " jar-path)]
+        (println (c/magenta "Running: " run-jar-cmd))
+        (println "env:")
+        (doseq [[k v] extra-env]
+          (println (str "  " (c/yellow k) "=" (c/green v))))
+        (println (str "\n\n   Open in browser: http://localhost:" port "\n"))
+        (p/shell {:dir dir :extra-env extra-env} run-jar-cmd)))))

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -128,6 +128,6 @@
         (println "env:")
         (doseq [[k v] extra-env]
           (println (str "  " (c/yellow k) "=" (c/green v))))
-        (println "Socket repl will open on " socket-port)
+        (println "Socket repl will open on " socket-port ". See: https://lambdaisland.com/guides/clojure-repls/clojure-repls#org259d775")
         (println (str "\n\n   Open in browser: http://localhost:" port "\n"))
         (p/shell {:dir dir :extra-env extra-env} run-jar-cmd)))))

--- a/mage/mage/util.clj
+++ b/mage/mage/util.clj
@@ -108,3 +108,36 @@
 (comment
   (count (updated-files "master"))
   (count (updated-files "master...")))
+
+(defn with-throbber
+  "Calls a function f and displays a throbber animation while waiting
+   for it to complete. Returns the result of calling f."
+  [message f]
+  (let [frames ["⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"]
+        delay  100
+        done?  (atom false)
+        result (atom nil)
+        err    (atom nil)]
+    (future (try
+              (loop [i 0]
+                (when (not @done?)
+                  (print (str "\r" (nth frames (mod i (count frames))) " " message))
+                  (flush)
+                  (Thread/sleep delay)
+                  (recur (inc i))))
+              (catch Exception e
+                (reset! err e)))
+            ;; Clear the throbber when done
+            (print "\r")
+            (flush))
+
+    ;; Execute the function
+    (try
+      (let [res (f)]
+        (reset! result res)
+        res)
+      (catch Exception e
+        (reset! err e)
+        (throw e))
+      (finally
+        (reset! done? true)))))


### PR DESCRIPTION
- Use a default config.yml with `crowberto` (admin), and `rasta` (regular user)
- `-r` : run the jar, using a per-version port and h2 db
- `-d` : no longer delete the jar every run, if it is found, and -d is NOT passed, will skip download step
- show throbber during download



### Help:
```
$ ./bin/mage jar-download 45 -h
Task Name: jar-download
 Given a version, downloads a metabase jar
Usages:
  -r, --run     run the new jar after downloading it
  -d, --delete  delete the old jar if found, by default does not re-download it

Examples:

 ./bin/mage jar-download 50
 - Download the latest enterprise version of release 50 to ~/path/to/my/metabase/jars

 ./bin/mage jar-download 1.45.2 -r
 - Download and run metabase_1.45.2.jar to ~/path/to/my/metabase/jars

 ./bin/mage jar-download 1.45.2 -d ~/path/to/my/jars
 - Download metabase_1.45.2.jar to ~/path/to/my/jars, deleting if it exists

 JARS=~/my-stuff ./bin/mage jar-download 1.45.2
 - Download metabase_1.45.2.jar to ~/my-stuff

 note: If you get an error about 'Invalid or corrupt jarfile', run this command again with the -d option.
 ```