### PR TITLE
Fix visualizer cards do not work on public dashboards

### DIFF
--- a/e2e/support/test-visualizer-data.ts
+++ b/e2e/support/test-visualizer-data.ts
@@ -358,7 +358,11 @@ export const VIEWS_COLUMN_CARD: NativeQuestionDetailsWithName = {
   },
 };
 
-export function createDashboardWithVisualizerDashcards() {
+export function createDashboardWithVisualizerDashcards(
+  { enable_embedding }: { enable_embedding: boolean } = {
+    enable_embedding: false,
+  },
+) {
   cy.get("@ordersCountByCreatedAtQuestionId").then(function () {
     const {
       ordersCountByCreatedAtQuestionId,
@@ -381,93 +385,96 @@ export function createDashboardWithVisualizerDashcards() {
       viewsColumnQuestionEntityId,
     } = this;
 
-    H.createDashboard().then(({ body: { id: dashboardId } }) => {
-      const dc1 = createVisualizerDashcardWithTimeseriesBreakout(
-        ordersCountByCreatedAtQuestionId,
-        ordersCountByCreatedAtQuestionEntityId,
-        productsCountByCreatedAtQuestionId,
-        productsCountByCreatedAtQuestionEntityId,
-        {
-          id: -1,
-          col: 0,
-          row: 0,
-          size_x: 12,
-          size_y: 8,
-        },
-      );
+    H.createDashboard({ enable_embedding }).then(
+      ({ body: { id: dashboardId } }) => {
+        const dc1 = createVisualizerDashcardWithTimeseriesBreakout(
+          ordersCountByCreatedAtQuestionId,
+          ordersCountByCreatedAtQuestionEntityId,
+          productsCountByCreatedAtQuestionId,
+          productsCountByCreatedAtQuestionEntityId,
+          {
+            id: -1,
+            col: 0,
+            row: 0,
+            size_x: 12,
+            size_y: 8,
+          },
+        );
 
-      const dc2 = createVisualizerDashcardWithCategoryBreakout(
-        ordersCountByProductCategoryQuestionId,
-        ordersCountByProductCategoryQuestionEntityId,
-        productsCountByCategoryQuestionId,
-        productsCountByCategoryQuestionEntityId,
-        {
-          id: -2,
+        const dc2 = createVisualizerDashcardWithCategoryBreakout(
+          ordersCountByProductCategoryQuestionId,
+          ordersCountByProductCategoryQuestionEntityId,
+          productsCountByCategoryQuestionId,
+          productsCountByCategoryQuestionEntityId,
+          {
+            id: -2,
+            col: 12,
+            row: 0,
+            size_x: 12,
+            size_y: 8,
+          },
+        );
+
+        const dc3 = createVisualizerPieChartDashcard(
+          productsCountByCategoryQuestionId,
+          productsCountByCategoryQuestionEntityId,
+          {
+            id: -3,
+            col: 0,
+            row: 8,
+            size_x: 12,
+            size_y: 8,
+          },
+        );
+
+        const dc4 = {
+          id: -4,
+          card_id: productsCountByCreatedAtQuestionId,
+
           col: 12,
-          row: 0,
-          size_x: 12,
-          size_y: 8,
-        },
-      );
-
-      const dc3 = createVisualizerPieChartDashcard(
-        productsCountByCategoryQuestionId,
-        productsCountByCategoryQuestionEntityId,
-        {
-          id: -3,
-          col: 0,
           row: 8,
           size_x: 12,
           size_y: 8,
-        },
-      );
+        };
 
-      const dc4 = {
-        id: -4,
-        card_id: productsCountByCreatedAtQuestionId,
+        const dc5 = createVisualizerFunnel(
+          stepColumnQuestionId,
+          stepColumnQuestionEntityId,
+          viewsColumnQuestionId,
+          viewsColumnQuestionEntityId,
+          {
+            id: -5,
+            col: 0,
+            row: 16,
+            size_x: 12,
+            size_y: 8,
+          },
+        );
 
-        col: 12,
-        row: 8,
-        size_x: 12,
-        size_y: 8,
-      };
+        const dc6 = createVisualizerScalarFunnel(
+          landingPageViewsScalarQuestionId,
+          landingPageViewsScalarQuestionEntityId,
+          checkoutPageViewsScalarQuestionId,
+          checkoutPageViewsScalarQuestionEntityId,
+          paymentDonePageViewsScalarQuestionId,
+          paymentDonePageViewsScalarQuestionEntityId,
+          {
+            id: -6,
+            col: 12,
+            row: 16,
+            size_x: 12,
+            size_y: 8,
+          },
+        );
 
-      const dc5 = createVisualizerFunnel(
-        stepColumnQuestionId,
-        stepColumnQuestionEntityId,
-        viewsColumnQuestionId,
-        viewsColumnQuestionEntityId,
-        {
-          id: -5,
-          col: 0,
-          row: 16,
-          size_x: 12,
-          size_y: 8,
-        },
-      );
-
-      const dc6 = createVisualizerScalarFunnel(
-        landingPageViewsScalarQuestionId,
-        landingPageViewsScalarQuestionEntityId,
-        checkoutPageViewsScalarQuestionId,
-        checkoutPageViewsScalarQuestionEntityId,
-        paymentDonePageViewsScalarQuestionId,
-        paymentDonePageViewsScalarQuestionEntityId,
-        {
-          id: -6,
-          col: 12,
-          row: 16,
-          size_x: 12,
-          size_y: 8,
-        },
-      );
-
-      cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-        dashcards: [dc1, dc2, dc3, dc4, dc5, dc6],
-      }).then(() => {
-        H.visitDashboard(dashboardId);
-      });
-    });
+        cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+          dashcards: [dc1, dc2, dc3, dc4, dc5, dc6],
+        }).then(() => {
+          cy.wrap(dashboardId).as("dashboardId");
+          H.visitDashboard(dashboardId);
+        });
+      },
+    );
   });
 }
 

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -512,4 +512,49 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       });
     });
   });
+
+  describe("public sharing and embedding", () => {
+    function ensureVisualizerCardsAreRendered() {
+      // Checks a cartesian chart has an axis name
+      H.getDashboardCard(0).within(() => {
+        H.echartsContainer().findByText("Count").should("be.visible");
+      });
+
+      // Checks a funnel has a step name
+      H.getDashboardCard(5)
+        .findByText("Checkout Page")
+        .scrollIntoView()
+        .should("be.visible");
+    }
+
+    it("visualizer cards should work in public dashboards", () => {
+      cy.signInAsAdmin();
+      createDashboardWithVisualizerDashcards();
+      cy.log("Visit public dashboard");
+      cy.get("@dashboardId")
+        .then((dashboardId) => {
+          H.createPublicDashboardLink(dashboardId);
+        })
+        .then(({ body: { uuid } }: any) => {
+          cy.visit(`/public/dashboard/${uuid}`);
+        });
+
+      ensureVisualizerCardsAreRendered();
+    });
+
+    it("visualizer cards should work in embedded dashboards", () => {
+      cy.signInAsAdmin();
+      createDashboardWithVisualizerDashcards({ enable_embedding: true });
+      cy.log("Visit public dashboard");
+
+      cy.get("@dashboardId").then((dashboard: any) => {
+        H.visitEmbeddedPage({
+          resource: { dashboard: dashboard },
+          params: {},
+        });
+      });
+
+      ensureVisualizerCardsAreRendered();
+    });
+  });
 });

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -68,7 +68,7 @@
     card
     (mi/instance
      :model/Card
-     (u/select-nested-keys card [:id :name :description :display :visualization_settings :parameters
+     (u/select-nested-keys card [:id :name :description :display :visualization_settings :parameters :entity_id
                                  [:dataset_query :type [:native :template-tags]]]))))
 
 (defn public-card


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #58050

### Description

Visualizer cards were broken on public dashboards because the dashboard API endpoint did not return `entity_id` fields for cards. This PR fixes it and adds tests on both public and embedded dashboards.

### How to verify

- Create a dashboard with a visualizer card
- Enable public sharing
- Visit the public dashboard link
- Ensure the visualizer card is rendered 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
