### PR TITLE
Unlimit pivot exports

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -18,7 +18,6 @@
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
-   [metabase.query-processor.middleware.limit :as limit]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.schema :as qp.schema]

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -344,7 +344,7 @@
    column-mapping-fn                                :- ::column-mapping-fn]
   (let [{:keys [rff execute reduce]} (append-queries-rff-and-fns info rff more-queries column-mapping-fn)
         first-query                  (cond-> first-query
-                                       (seq info) qp/userland-query-with-default-constraints)]
+                                       (seq info) qp/userland-query-with-default-constrainty)]
     (binding [qp.pipeline/*execute* (or execute qp.pipeline/*execute*)
               qp.pipeline/*reduce*  (or reduce qp.pipeline/*reduce*)]
       (qp/process-query first-query rff))))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -344,7 +344,7 @@
    column-mapping-fn                                :- ::column-mapping-fn]
   (let [{:keys [rff execute reduce]} (append-queries-rff-and-fns info rff more-queries column-mapping-fn)
         first-query                  (cond-> first-query
-                                       (seq info) qp/userland-query-with-default-constrainty)]
+                                       (seq info) qp/userland-query)]
     (binding [qp.pipeline/*execute* (or execute qp.pipeline/*execute*)
               qp.pipeline/*reduce*  (or reduce qp.pipeline/*reduce*)]
       (qp/process-query first-query rff))))

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -773,6 +773,31 @@
                        {:query q, :format_rows apply-formatting?})
                       ((get output-helper export-format))))))))))
 
+(deftest pivot-exports-ignore-query-constraints
+  (testing "POST /api/dataset/:format with pivot-results=true"
+    (testing "Downloading pivot CSV/JSON/XLSX results shouldn't be subject to the default query constraints"
+      (with-redefs [qp.constraints/default-query-constraints (constantly {:max-results 10, :max-results-bare-rows 10})]
+        (doseq [:let     [query {:database (mt/id)
+                                 :type     :query
+                                 :query    {:source-table (mt/id :venues)
+                                            :breakout     [[:field (mt/id :venues :name) nil]
+                                                           [:field (mt/id :venues :category_id) nil]]
+                                            :aggregation  [[:count]]}
+                                 :middleware
+                                 {:add-default-userland-constraints? true
+                                  :userland-query?                   true
+                                  :pivot?                            true}}]
+                encoded? [true false]
+                :let     [query (cond-> query
+                                  encoded? json/encode)]]
+          (let [result (mt/user-http-request :crowberto :post 200 "dataset/csv"
+                                             {:query query})]
+            (def result result)
+            (is (some? result))
+            (when (some? result)
+              ;; The venues table has 100+ rows, so we should get more than default constraints (10)
+              (is (> (count (csv/read-csv result)) 10)))))))))
+
 (deftest ^:parallel query-metadata-test
   (testing "MBQL query"
     (is (=? {:databases [{:id (mt/id)}]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/58087

Removes default 10k row limits for pivot exports (but preserves them for normal API queries)

I'm not totally sure yet how & where to test the row limit stuff since it's spread across a number of files, and I want to avoid executing huge queries in tests if possible. It might be worth refactoring & consolidating this logic first and then adding focused tests