### PR TITLE
Fix default for condense duplicate totals setting

### DIFF
--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -355,9 +355,11 @@
 (defn- subtotal-visible?
   "Determines whether a subtotal should be shown for a given row."
   [row-item settings]
-  (let [condense? (true? (:pivot.condense_duplicate_totals settings))
+  (let [condense? (true? (:pivot.condense_duplicate_totals settings true))
         child-count (count (:children row-item))]
-    (or (not condense?) (> child-count 1) (:isCollapsed row-item))))
+    (or (not condense?)
+        (> child-count 1)
+        (:isCollapsed row-item))))
 
 (declare add-subtotal)
 
@@ -373,7 +375,8 @@
                              acc
                              settings)
                (conj! acc child)))
-           (transient []) children)))
+           (transient [])
+           children)))
 
 (defn- add-subtotal
   "Adds subtotal nodes to a row item based on subtotal settings.
@@ -413,7 +416,8 @@
                                (subtotal-visible? row-item settings)
                                acc
                                settings))
-               (transient []) row-tree)))))
+               (transient [])
+               row-tree)))))
 
 (defn display-name-for-col
   "Translated from frontend/src/metabase/lib/formatting/column.ts"

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -357,8 +357,8 @@
   [row-item settings]
   (let [condense? (true? (:pivot.condense_duplicate_totals settings true))
         child-count (count (:children row-item))]
-    (or (not condense?)
-        (> child-count 1)
+    (or (> child-count 1)
+        (not condense?)
         (:isCollapsed row-item))))
 
 (declare add-subtotal)

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -1670,3 +1670,47 @@
               pivot        (read-xlsx result)
               subtotal-row (first (filter #(str/starts-with? (first %) "Totals for") pivot))]
           (is (= "Totals for 2016" (first subtotal-row))))))))
+
+(deftest ^:parallel pivot-condense-duplicate-totals-csv-test
+  (testing "`pivot.condense_duplicate_totals` affects CSV output as expected"
+    (let [viz-settings (fn [condense?]
+                         {:pivot_table.column_split {:rows ["CATEGORY"]
+                                                     :columns ["CREATED_AT"]
+                                                     :values ["count"]}
+                          :column_settings
+                          {"[\"name\",\"sum\"]" {:number_style "currency"}
+                           "[\"name\",\"avg\"]" {:number_style "decimal"}}
+                          ;; Optionally include the condense setting
+                          :pivot.condense_duplicate_totals condense?})
+          expected-condensed
+          [["Category" "2016" "2017" "2018" "2019" "Row totals"]
+           ["Doohickey" "13" "17" "8" "4" "42"]
+           ["Gadget"    "13" "19" "14" "7" "53"]
+           ["Gizmo"     "9"  "21" ""  ""  "51"]
+           ["Grand totals" "54" "75" "53" "18" "200"]]
+
+          expected-uncondensed
+          [["Category" "2016" "2017" "2018" "2019" "Row totals"]
+           ["Doohickey" "13" "17" "8" "4" "42"]
+           ["Totals for Doohickey" "13" "17" "8" "4" "42"]
+           ["Gadget" "13" "19" "14" "7" "53"]
+           ["Totals for Gadget" "13" "19" "14" "7" "53"]
+           ["Gizmo" "9" "21" "" "" "51"]
+           ["Totals for Gizmo" "9" "21" "" "" "51"]
+           ["Grand totals" "54" "75" "53" "18" "200"]]]
+      (mt/dataset test-data
+        (doseq [[condense? expected]
+                [[true expected-condensed]
+                 [false expected-uncondensed]
+                 [nil expected-condensed]]]
+          (mt/with-temp [:model/Card card
+                         {:display :pivot
+                          :visualization_settings (cond-> (viz-settings condense?)
+                                                    (nil? condense?) (dissoc :pivot.condense_duplicate_totals))
+                          :dataset_query (mt/mbql-query products
+                                           {:aggregation [[:count]]
+                                            :breakout [$category !year.created_at]
+                                            :limit 10})}]
+            (let [result (card-download card {:export-format :csv :format-rows true :pivot true})]
+              (is (= expected (take (count expected) result))
+                  (str "Failed for condense_duplicate_totals=" condense?)))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/58084

Ensures we use `true` as a default for the collapsed duplicate totals setting even when unset in viz settings, and adds a new test for all possible states of this setting in CSV exports.