### PR TITLE
Backfill metabase_database.entity_id in a migration

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11395,6 +11395,15 @@ databaseChangeLog:
             tableName: metabase_database
             constraintName: idx_unique_database
 
+  - changeSet:
+      id: v55.2025-05-16T05:00:00
+      validCheckSum: ANY
+      author: ranquild
+      comment: Backfill metabase_database.entity_id
+      changes:
+        - customChange:
+            class: "metabase.db.custom_migrations.BackfillDatabaseEntityIds"
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1782,7 +1782,7 @@
 
 (defn- generate-database-entity-id
   [database]
-  (-> database (select-keys [:name :engine]) raw-hash generate-nano-id))
+  (-> [(:name database) (:engine database)] raw-hash generate-nano-id))
 
 (defn- backfill-database-entity-ids!
   []

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1761,10 +1761,12 @@
 (define-migration MigrateAlertToNotification
   (pulse-to-notification/migrate-alerts!))
 
+;; copied from metabase.models.serialization
 (defn- raw-hash
   [target]
   (format "%08x" (hash target)))
 
+;; copied from metabase.models.serialization
 (defn- generate-nano-id
   [seed-str]
   (let [seed (Long/parseLong seed-str 16)


### PR DESCRIPTION
Since we generally have <1k databases, we can backfill them directly in a migration, at once. Together with https://github.com/metabase/metabase/pull/58116 it should make sure that `metabase_database.entity_id` is always set!

Tests TBD.