### PR TITLE
Fix timeline event tooltip date text color for SDK

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TimelineEventTooltip.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TimelineEventTooltip.styled.tsx
@@ -34,7 +34,6 @@ export const TimelineEventName = styled.span`
 `;
 
 export const TimelineEventDate = styled(DateTime)`
-  color: var(--mb-color-text-white);
   font-size: 0.75rem;
   margin-top: 0.0625rem;
 `;


### PR DESCRIPTION
Fix timeline event tooltip date text color for SDK

It should not affect main app color.

Technically we can't display timeline events for SDK yet. But if we do (the image below contains a hardcoded event) - the date text color is white, though it should be black, as the event name.

Fixed color:
![image](https://github.com/user-attachments/assets/2921e67f-3ed2-4299-93cd-1d703be20cba)
