### PR TITLE
Set entity_id in before-insert for databases, tables, fields

### DIFF
--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -117,10 +117,7 @@
 (doto :model/Field
   (derive :metabase/model)
   (derive :hook/timestamped?)
-  ;; Deliberately **not** deriving from `:hook/entity-id` because we should not be randomizing the `entity_id`s on
-  ;; databases, tables or fields. Since the sync process can create them in multiple instances, randomizing them would
-  ;; cause duplication rather than good matching if the two instances are later linked by serdes.
-  #_(derive :hook/entity-id))
+  (derive :hook/entity-id))
 
 (t2/define-after-select :model/Field
   [field]

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -40,10 +40,7 @@
   (derive ::mi/read-policy.full-perms-for-perms-set)
   (derive ::mi/write-policy.full-perms-for-perms-set)
   (derive :hook/timestamped?)
-  ;; Deliberately **not** deriving from `:hook/entity-id` because we should not be randomizing the `entity_id`s on
-  ;; databases, tables or fields. Since the sync process can create them in multiple instances, randomizing them would
-  ;; cause duplication rather than good matching if the two instances are later linked by serdes.
-  #_(derive :hook/entity-id))
+  (derive :hook/entity-id))
 
 (t2/deftransforms :model/Table
   {:entity_type     mi/transform-keyword

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -60,10 +60,7 @@
 (doto :model/Database
   (derive :metabase/model)
   (derive :hook/timestamped?)
-  ;; Deliberately **not** deriving from `:hook/entity-id` because we should not be randomizing the `entity_id`s on
-  ;; databases, tables or fields. Since the sync process can create them in multiple instances, randomizing them would
-  ;; cause duplication rather than good matching if the two instances are later linked by serdes.
-  #_(derive :hook/entity-id))
+  (derive :hook/entity-id))
 
 (methodical/defmethod t2.with-temp/do-with-temp* :before :model/Database
   [_model _explicit-attributes f]

--- a/test/metabase/sync/sync_test.clj
+++ b/test/metabase/sync/sync_test.clj
@@ -123,7 +123,7 @@
     :db_id       true
     :entity_type :entity/GenericTable
     :id          true
-    :entity_id   false
+    :entity_id   true
     :updated_at  true}))
 
 (defn- field-defaults []
@@ -135,7 +135,7 @@
     :fk_target_field_id  false
     :database_is_auto_increment false
     :id                  true
-    :entity_id           false
+    :entity_id           true
     :last_analyzed       false
     :parent_id           false
     :position            0

--- a/test/metabase/warehouse_schema/models/field_test.clj
+++ b/test/metabase/warehouse_schema/models/field_test.clj
@@ -95,3 +95,8 @@
       (is (= "913269d5"
              (serdes/raw-hash ["child" (serdes/identity-hash table) (serdes/identity-hash parent2)])
              (serdes/identity-hash child2))))))
+
+(deftest create-field-entity-id
+  (testing "Fields should get :entity_id on creation"
+    (mt/with-temp [:model/Field {entity-id :entity_id} {}]
+      (is (some? entity-id)))))

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -364,3 +364,8 @@
             (is (= #{table-id-1 table-id-2 table-id-3}
                    (fetch-visible-ids user-info permission-map :id))
                 "Clause should filter correctly when requiring :blocked level")))))))
+
+(deftest create-table-entity-id
+  (testing "Tables should get :entity_id on creation"
+    (mt/with-temp [:model/Table {entity-id :entity_id} {}]
+      (is (some? entity-id)))))

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -604,6 +604,17 @@
         (is (partial= {:details {}}
                       db))))))
 
+(deftest create-database-entity-id
+  (testing "Databases should get :entity_id on creation"
+    (mt/with-temp [:model/Database {entity-id :entity_id} {}]
+      (is (some? entity-id))))
+  (testing "Should handle name & engine collisions"
+    (mt/with-temp [:model/Database {entity-id-1 :entity_id} {}
+                   :model/Database {entity-id-2 :entity_id} {}]
+      (is (some? entity-id-1))
+      (is (some? entity-id-2))
+      (is (not= entity-id-1 entity-id-2)))))
+
 (deftest ^:parallel after-select-driver-features-realize-db-row-test
   ;; This test is necessary because driver multimethods should be able to assume that the db argument is a Database
   ;; instance, not a transient row. Otherwise a call like `(mi/instance-of :model/Database db)` will return false


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-323/set-entity-id-in-places-where-databases-tables-fields-are-created

Sets random `:entity_id` for `metabase_database`, `metabase_table`, and `metabase_field`.

Note that I had to remove the tests for the background job since they become all invalid now. The tests should be restored when the job gets fixed.