### PR TITLE
fix question analysis is triggered multiple times

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisSidebar/AIQuestionAnalysisSidebar.tsx
@@ -23,8 +23,8 @@ const RENDER_DELAY_MS = 100;
 
 export function AIQuestionAnalysisSidebar({
   question,
-  timelines = [],
-  visibleTimelineEvents = [],
+  timelines,
+  visibleTimelineEvents,
   className,
   onClose,
 }: AIQuestionAnalysisSidebarProps) {
@@ -54,8 +54,8 @@ export function AIQuestionAnalysisSidebar({
       questionCollectionId == null
         ? []
         : getTimelineEventsForAnalysis(
-            visibleTimelineEvents,
-            timelines,
+            visibleTimelineEvents ?? [],
+            timelines ?? [],
             questionCollectionId,
           );
 


### PR DESCRIPTION
[Slack report](https://metaboat.slack.com/archives/C07SJT1P0ET/p1747576687074699)

### Description

In `AIQuestionAnalysisSidebar` default array props for timeline events change on every rerender and trigger more rerenders. 

Preventable by using `react-x/no-unstable-default-props` eslint rule but it requires upgrading to ESLint 8 — will do as a follow-up.

### How to verify

- Run Metabase EE
- Open a question that do not have any timeline events
- Open the network tab in dev tools
- Click on the Metabot analysis button
- Ensure it sends only one request