### PR TITLE
Bump HoneySQL

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -47,7 +47,7 @@
                                             {:mvn/version "4.3.1"}              ; templating engine
   com.github.pangloss/transducers           {:git/sha "c91d39046c8c64dc31b84ebb27154a8084fcda4c" ; like medley for transducers
                                              :git/url "https://github.com/pangloss/transducers"}
-  com.github.seancorfield/honeysql          {:mvn/version "2.7.1295"}           ; Honey SQL 2. SQL generation from Clojure data maps
+  com.github.seancorfield/honeysql          {:mvn/version "2.7.1310"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:mvn/version "1.3.1002"}            ; Talk to JDBC DBs
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.7"}              ; Telemetry library
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1816,19 +1816,12 @@
 (defn- format-honeysql-2 [driver dialect honeysql-form]
   ;; make sure [[driver/*driver*]] is bound, we need it for [[sqlize-value]]
   (binding [driver/*driver* driver]
-    (if (map? honeysql-form)
-      (sql/format honeysql-form {:dialect      dialect
-                                 :quoted       true
-                                 :quoted-snake false
-                                 :inline       driver/*compile-with-inline-parameters*})
-      ;; for weird cases when we want to compile just one particular snippet. Why are we doing this? Who knows. This seems
-      ;; to not really be supported by Honey SQL 2, so hack around it for now. See upstream issue
-      ;; https://github.com/seancorfield/honeysql/issues/456
-      (binding [sql/*dialect*      (sql/get-dialect dialect)
-                sql/*quoted*       true
-                sql/*quoted-snake* false
-                sql/*inline*       driver/*compile-with-inline-parameters*]
-        (sql/format-expr honeysql-form {:nested true})))))
+    (sql/format honeysql-form {:dialect      dialect
+                               :quoted       true
+                               :quoted-snake false
+                               :inline       driver/*compile-with-inline-parameters*
+                               ;; Enable :nested when we want to compile just one particular snippet.
+                               :nested (not (map? honeysql-form))})))
 
 (defmulti format-honeysql
   "Compile `honeysql-form` to a `[sql & args]` vector. Prior to 0.51.0, this was a plain function, but was made a

--- a/src/metabase/driver/sql_jdbc/quoting.clj
+++ b/src/metabase/driver/sql_jdbc/quoting.clj
@@ -7,7 +7,7 @@
   "Helper macro for quoting identifiers."
   [driver & body]
   `(binding [sql/*dialect* (sql/get-dialect (sql.qp/quote-style ~driver))
-             sql/*quoted*  true]
+             sql/*options* (assoc @#'sql/*options* :quoted true)]
      ~@body))
 
 (defn quote-table

--- a/src/metabase/util/honey_sql_2.clj
+++ b/src/metabase/util/honey_sql_2.clj
@@ -133,7 +133,7 @@
 (defn- format-identifier [_tag [_identifier-type components :as _args]]
   ;; don't error if the identifier has something 'suspicious' like a semicolon in it -- it's ok because we're quoting
   ;; everything
-  (binding [sql/*allow-suspicious-entities* true]
+  (binding [sql/*options* (assoc @#'sql/*options* :allow-suspicious-entities true)]
     [(str/join \. (map (fn [component]
                          ;; `:aliased` `true` => don't split dots in the middle of components
                          (sql/format-entity component {:aliased true}))


### PR DESCRIPTION
Not a simple bump this time. This version of HoneySQL changes its private dynamic variables, so this PR reflects that.

~I've also removed `with-quoting` in some places because the code wrapped by this macro also provides explicit `:dialect` and `:quoted` options, so it looks redundant.~ It looks redundant but tests fail when it is removed, I can't yet tell why.