### PR TITLE
Fix the escape char followed by a newline

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -75,12 +75,12 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.server.core :as server]
+   [metabase.server.test-handler :as server.test-handler]
    [metabase.settings.core :as setting]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test-runner]
    [metabase.test.data.impl :as data.impl]
-   [metabase.server.test-handler :as server.test-handler]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
@@ -405,9 +405,9 @@
 
   You can also run it with `clojure -X`:
 
-    clojure -X:dev dev/find-root-test-failure! \
-     :failing-test-var metabase.users.models.user-parameter-value-test/user-parameter-value-store-test \
-     :scope :full-suite \
+    clojure -X:dev dev/find-root-test-failure!
+     :failing-test-var metabase.users.models.user-parameter-value-test/user-parameter-value-store-test
+     :scope :full-suite
      :find-tests-options '{:exclude-tags [:mb/driver-tests] :only [\"test\"] :partition/total 2 :partition/index 1}'"
   ([opts]
    (find-root-test-failure! (requiring-resolve (:failing-test-var opts)) opts))


### PR DESCRIPTION
Running `yarn dev-ee` was broken on the latest master. (introduced in https://github.com/metabase/metabase/pull/58054)
The compiler was complaining about the `\` in the docstring because it was interpreting it as an escape character followed by a newline.
```
{:clojure.main/message "Syntax error reading source at (dev.clj:409:1).\nUnsupported escape character: \\\n\n",
 :clojure.main/triage
 {:clojure.error/phase :read-source,
  :clojure.error/line 409,
  :clojure.error/column 1,
  :clojure.error/source "dev.clj",
  :clojure.error/path "dev.clj",
  :clojure.error/cause "Unsupported escape character: \\\n"},
 :clojure.main/trace
 {:via
  [{:type clojure.lang.Compiler$CompilerException,
    :message "Syntax error reading source at (dev.clj:409:1).",
    :data
    {:clojure.error/phase :read-source,
     :clojure.error/line 409,
     :clojure.error/column 1,
     :clojure.error/source "dev.clj"},
    :at [clojure.lang.Compiler load "Compiler.java" 8172]}
   {:type java.lang.RuntimeException,
    :message "Unsupported escape character: \\\n",
    :at [clojure.lang.Util runtimeException "Util.java" 221]}],
  :trace
  [[clojure.lang.Util runtimeException "Util.java" 221]
   [clojure.lang.LispReader$StringReader invoke "LispReader.java" 615]
   [clojure.lang.LispReader read "LispReader.java" 287]
   [clojure.lang.LispReader readDelimitedList "LispReader.java" 1401]
   [clojure.lang.LispReader$ListReader invoke "LispReader.java" 1246]
   [clojure.lang.LispReader read "LispReader.java" 287]
   [clojure.lang.LispReader read "LispReader.java" 218]
   [clojure.lang.Compiler load "Compiler.java" 8160]
   [clojure.lang.RT loadResourceScript "RT.java" 401]
   [clojure.lang.RT loadResourceScript "RT.java" 392]
   [clojure.lang.RT load "RT.java" 479]
   [clojure.lang.RT load "RT.java" 444]
   [clojure.core$load$fn__6931 invoke "core.clj" 6189]
   [clojure.core$load invokeStatic "core.clj" 6188]
   [clojure.core$load doInvoke "core.clj" 6172]
   [clojure.lang.RestFn invoke "RestFn.java" 411]
   [clojure.core$load_one invokeStatic "core.clj" 5961]
   [clojure.core$load_one invoke "core.clj" 5956]
   [clojure.core$load_lib$fn__6873 invoke "core.clj" 6003]
   [clojure.core$load_lib invokeStatic "core.clj" 6002]
   [clojure.core$load_lib doInvoke "core.clj" 5981]
   [clojure.lang.RestFn applyTo "RestFn.java" 145]
   [clojure.core$apply invokeStatic "core.clj" 669]
   [clojure.core$load_libs invokeStatic "core.clj" 6044]
   [clojure.core$load_libs doInvoke "core.clj" 6028]
   [clojure.lang.RestFn applyTo "RestFn.java" 140]
   [clojure.core$apply invokeStatic "core.clj" 669]
   [clojure.core$require invokeStatic "core.clj" 6066]
   [clojure.core$require doInvoke "core.clj" 6066]
   [clojure.lang.RestFn applyTo "RestFn.java" 140]
   [clojure.core$apply invokeStatic "core.clj" 667]
   [clojure.core$serialized_require invokeStatic "core.clj" 6142]
   [clojure.core$requiring_resolve invokeStatic "core.clj" 6151]
   [clojure.core$requiring_resolve invoke "core.clj" 6145]
   [user$_main invokeStatic "user.clj" 68]
   [user$_main doInvoke "user.clj" 56]
   [clojure.lang.RestFn applyTo "RestFn.java" 140]
   [clojure.lang.Var applyTo "Var.java" 707]
   [clojure.core$apply invokeStatic "core.clj" 667]
   [clojure.main$main_opt invokeStatic "main.clj" 515]
   [clojure.main$main_opt invoke "main.clj" 511]
   [clojure.main$main invokeStatic "main.clj" 665]
   [clojure.main$main doInvoke "main.clj" 617]
   [clojure.lang.RestFn applyTo "RestFn.java" 140]
   [clojure.lang.Var applyTo "Var.java" 707]
   [clojure.main main "main.java" 40]],
  :cause "Unsupported escape character: \\\n",
  :phase :read-source}}

Syntax error reading source at (dev.clj:409:1).
Unsupported escape character: \
```

### How to test
1. checkout this branch
2. run `yarn dev-ee`