### PR TITLE
Render bucketing popover in portal

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -128,7 +128,7 @@ describe("issue 39487", () => {
       .findAllByTestId("notebook-cell-item")
       .first()
       .click();
-    H.popover().scrollTo("bottom");
+    H.popover().findByTestId("popover-content").scrollTo("bottom");
     H.popover().button("Update filter").should("be.visible").click();
   });
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -115,6 +115,7 @@ function _BaseBucketPickerPopover({
     <Popover
       opened={isOpened}
       position="right"
+      withinPortal={false}
       onClose={handlePopoverClose}
       onChange={(v) => !v && handlePopoverClose()}
       floatingStrategy="fixed"

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -116,7 +116,6 @@ function _BaseBucketPickerPopover({
       opened={isOpened}
       position="right"
       onClose={handlePopoverClose}
-      withinPortal={false}
       onChange={(v) => !v && handlePopoverClose()}
       floatingStrategy="fixed"
     >

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -115,8 +115,8 @@ function _BaseBucketPickerPopover({
     <Popover
       opened={isOpened}
       position="right"
-      withinPortal={false}
       onClose={handlePopoverClose}
+      withinPortal={false}
       onChange={(v) => !v && handlePopoverClose()}
       floatingStrategy="fixed"
     >

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.module.css
@@ -1,0 +1,21 @@
+.dropdown {
+  /** Safari has a bug where parent elements with overflow: auto
+   *  will clip elements that are positioned with fixed/absolute
+   *  whenever the parent element is overflowing (ie. has scrollbars).
+   *
+   *  See https://bugs.webkit.org/show_bug.cgi?id=160953
+   *
+   *  This causes popovers rendered by children of this popover to be
+   *  clipped.
+   *
+   *  This workaround solves the issue by moving the overflow
+   *  onto a child element instead.
+   */
+  overflow: visible;
+}
+
+.dropdownContent {
+  overflow: auto;
+  max-width: inherit;
+  max-height: inherit;
+}

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -36,6 +36,8 @@ export function ClausePopover({
     }
   }, [active]);
 
+  const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined);
+
   return (
     <PreventPopoverExitProvider>
       <Popover
@@ -45,6 +47,25 @@ export function ClausePopover({
         trapFocus
         onChange={handleChange}
         floatingStrategy="fixed"
+        middlewares={{
+          size: {
+            padding: 10,
+            apply(args) {
+              // HACK: Safari has a bug where parent elements with overflow: auto
+              // will clip elements that are positioned with fixed/absolute
+              // whenever the parent element is overflowing (ie. has scrollbars).
+              //
+              // See https://bugs.webkit.org/show_bug.cgi?id=160953
+              //
+              // This causes popovers rendered by children of this popover to be
+              // clipped.
+              //
+              // This workaround solves the issue by moving the overflow
+              // onto a child element instead.
+              setMaxHeight(args.availableHeight);
+            },
+          },
+        }}
         styles={{
           dropdown: {
             overflow: "visible",
@@ -53,7 +74,9 @@ export function ClausePopover({
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">
-          <Box style={{ overflow: "auto" }}>{renderPopover(handleClose)}</Box>
+          <Box style={{ overflow: "auto", maxHeight }}>
+            {renderPopover(handleClose)}
+          </Box>
         </Popover.Dropdown>
       </Popover>
     </PreventPopoverExitProvider>

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -4,6 +4,8 @@ import { useCallback, useLayoutEffect, useState } from "react";
 import { Box, Popover } from "metabase/ui";
 import { PreventPopoverExitProvider } from "metabase/ui/components/utils/PreventPopoverExit";
 
+import S from "./ClausePopover.module.css";
+
 interface ClausePopoverProps {
   isInitiallyOpen?: boolean;
   renderItem: (open: () => void) => JSX.Element | string;
@@ -36,8 +38,6 @@ export function ClausePopover({
     }
   }, [active]);
 
-  const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined);
-
   return (
     <PreventPopoverExitProvider>
       <Popover
@@ -47,36 +47,11 @@ export function ClausePopover({
         trapFocus
         onChange={handleChange}
         floatingStrategy="fixed"
-        middlewares={{
-          size: {
-            padding: 10,
-            apply(args) {
-              // HACK: Safari has a bug where parent elements with overflow: auto
-              // will clip elements that are positioned with fixed/absolute
-              // whenever the parent element is overflowing (ie. has scrollbars).
-              //
-              // See https://bugs.webkit.org/show_bug.cgi?id=160953
-              //
-              // This causes popovers rendered by children of this popover to be
-              // clipped.
-              //
-              // This workaround solves the issue by moving the overflow
-              // onto a child element instead.
-              setMaxHeight(args.availableHeight);
-            },
-          },
-        }}
-        styles={{
-          dropdown: {
-            overflow: "visible",
-          },
-        }}
+        classNames={{ dropdown: S.dropdown }}
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">
-          <Box style={{ overflow: "auto", maxHeight }}>
-            {renderPopover(handleClose)}
-          </Box>
+          <Box className={S.dropdownContent}>{renderPopover(handleClose)}</Box>
         </Popover.Dropdown>
       </Popover>
     </PreventPopoverExitProvider>

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -46,12 +46,13 @@ export function ClausePopover({
         offset={{ mainAxis: 4 }}
         trapFocus
         onChange={handleChange}
-        floatingStrategy="fixed"
         classNames={{ dropdown: S.dropdown }}
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">
-          <Box className={S.dropdownContent}>{renderPopover(handleClose)}</Box>
+          <Box className={S.dropdownContent} data-testid="popover-content">
+            {renderPopover(handleClose)}
+          </Box>
         </Popover.Dropdown>
       </Popover>
     </PreventPopoverExitProvider>

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -1,7 +1,7 @@
 import { useDndContext } from "@dnd-kit/core";
 import { useCallback, useLayoutEffect, useState } from "react";
 
-import { Popover } from "metabase/ui";
+import { Box, Popover } from "metabase/ui";
 import { PreventPopoverExitProvider } from "metabase/ui/components/utils/PreventPopoverExit";
 
 interface ClausePopoverProps {
@@ -44,10 +44,16 @@ export function ClausePopover({
         offset={{ mainAxis: 4 }}
         trapFocus
         onChange={handleChange}
+        floatingStrategy="fixed"
+        styles={{
+          dropdown: {
+            overflow: "visible",
+          },
+        }}
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">
-          {renderPopover(handleClose)}
+          <Box style={{ overflow: "auto" }}>{renderPopover(handleClose)}</Box>
         </Popover.Dropdown>
       </Popover>
     </PreventPopoverExitProvider>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58151

The issue only happens on Safari, so I've not added e2e tests. 

The problem is that the bucket picker popover is rendered as a child of the `AccordionList` which has `overflow: auto` and so doesn't render children outside of it's bounding box the way it should (which seems to be related to [this Safari bug](https://bugs.webkit.org/show_bug.cgi?id=160953)).

Moving it to it's own portal fixes the issue.