### PR TITLE
Make "still waiting" messages visible on static embedding

### DIFF
--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -68,7 +68,7 @@
     card
     (mi/instance
      :model/Card
-     (u/select-nested-keys card [:id :name :description :display :visualization_settings :parameters :entity_id
+     (u/select-nested-keys card [:id :name :description :display :visualization_settings :parameters :entity_id :query_average_duration
                                  [:dataset_query :type [:native :template-tags]]]))))
 
 (defn public-card

--- a/test/metabase/public_sharing/api_test.clj
+++ b/test/metabase/public_sharing/api_test.clj
@@ -140,7 +140,12 @@
         (testing "Check that we cannot fetch a public Card that has been archived"
           (mt/with-temp-vals-in-db :model/Card card-id {:archived true}
             (is (= "Not found."
-                   (client/client :get 404 (str "public/card/" uuid))))))))))
+                   (client/client :get 404 (str "public/card/" uuid))))))
+
+        (testing "Check that a public Card has the average query duration (metabase#57869)"
+          (let [card-response (client/client :get 200 (str "public/card/" uuid))]
+            (is (contains? card-response :query_average_duration)
+                "Card should include :query_average_duration")))))))
 
 (deftest public-queries-are-counted-test
   (testing "GET /api/public/card/:uuid/query counts as a public query"


### PR DESCRIPTION
Closes #57869
Closes EMB-384

### Description

We must've removed the `query_average_duration` from the card's API at some point, so the frontend weren't able to show the "Still waiting..." messages on questions that loaded slower than the average query duration.

I didn't add in an end-to-end test for slow queries yet though as it is a little tricky; the only way to show it afaik would be to create an actually slow query using sleep.

### How to verify

1. create a sql question with "select pg_sleep(30)" on a postgres db
2. it and run it (see that it returns the column name)
3. add it to a dashboard 4 times, save the dashboard
4. run the dashboard, see that it will eventually show the "still waiting" sign after 20 seconds
5. now embed it (or use the embedding preview)
6. the "still waiting" sign will show after 20-ish seconds, same as in main app.

### Demo

![CleanShot 2568-05-19 at 23 05 56@2x](https://github.com/user-attachments/assets/6d2a254d-fb9c-43ba-aa90-aa75b8575983)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - backend test
