### PR TITLE
WRK-415, WRK-416: Minor fixes for custom templates

### DIFF
--- a/e2e/support/helpers/e2e-email-helpers.js
+++ b/e2e/support/helpers/e2e-email-helpers.js
@@ -58,7 +58,9 @@ export const viewEmailPage = (emailSubject) => {
   const webmailInterface = `http://localhost:${WEB_PORT}`;
 
   cy.window().then((win) => (win.location.href = webmailInterface));
-  cy.findByText(emailSubject).click();
+  if (emailSubject) {
+    cy.findByText(emailSubject).click();
+  }
 };
 
 export const openEmailPage = (emailSubject) => {
@@ -125,5 +127,23 @@ export function sendEmailAndVisitIt() {
   return cy.request("GET", emailUrl).then(({ body }) => {
     const latest = body.slice(-1)[0];
     cy.visit(`${emailUrl}/${latest.id}/html`);
+  });
+}
+
+export function checkEmailContent(subject, body) {
+  viewEmailPage(subject);
+
+  cy.get(".main-container").within(() => {
+    cy.get(".subject").should("contain", subject);
+    cy.get(".preview-iframe")
+      .its("0.contentDocument.body")
+      .should("not.be.empty")
+      .then(($body) => {
+        if (Array.isArray(body)) {
+          body.forEach((str) => expect($body).to.contain(str));
+        } else {
+          expect($body).to.contain(body);
+        }
+      });
   });
 }

--- a/e2e/test/scenarios/data-editing/data-editing-alerts.cy.spec.ts
+++ b/e2e/test/scenarios/data-editing/data-editing-alerts.cy.spec.ts
@@ -1,0 +1,378 @@
+import { USERS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
+
+import { setupAlert } from "./helpers/setup";
+
+const { H } = cy;
+
+const TABLE_NAME = "colors27745";
+const TABLE_ID = 22;
+const ADMIN_NAME = `${USERS.admin.first_name} ${USERS.admin.last_name}`;
+
+describe("scenarios > data editing > setting alerts", () => {
+  beforeEach(() => {
+    cy.log("Setting up writable PostgresDB");
+    H.restore("postgres-writable");
+    H.resetTestTable({
+      type: "postgres",
+      table: TABLE_NAME,
+    });
+    cy.signInAsAdmin();
+    H.resyncDatabase({
+      dbId: WRITABLE_DB_ID,
+      tableName: TABLE_NAME,
+    });
+
+    H.setTokenFeatures("all");
+    H.setupSMTP();
+
+    H.setTableEditingEnabledForDB(WRITABLE_DB_ID);
+
+    openDatabaseTable();
+  });
+
+  it("should have icon to set alerts", () => {
+    cy.findByTestId("table-notifications-trigger").should("be.visible");
+  });
+
+  describe("Show list of existing alerts", () => {
+    it("should show list of existing alerts", () => {
+      H.getTableId({
+        name: TABLE_NAME,
+      }).then((tableId) => {
+        setupAlert(tableId, "event/row.created");
+        setupAlert(tableId, "event/row.updated");
+        setupAlert(tableId, "event/row.deleted");
+        cy.findByTestId("table-notifications-trigger").click();
+        cy.findByTestId("alert-list-modal")
+          .should("be.visible")
+          .within(() => {
+            cy.findByText("Notify when new records are created").should(
+              "be.visible",
+            );
+            cy.findByText("Notify when records are updated").should(
+              "be.visible",
+            );
+            cy.findByText("Notify when records are deleted").should(
+              "be.visible",
+            );
+          });
+      });
+    });
+  });
+
+  describe("Create an alert for each event type", () => {
+    describe("create event", () => {
+      it("should create an alert for 'row created' events with default template", () => {
+        cy.findByTestId("table-notifications-trigger").click();
+
+        cy.findByTestId("table-notification-create").within(() => {
+          cy.findByTestId("notification-event-select").click();
+          cy.document()
+            .findByRole("option", {
+              name: /when new records are created/i,
+            })
+            .click();
+          cy.findByRole("button", { name: "Done" }).click();
+        });
+
+        cy.findByTestId("table-notification-create").should("not.exist");
+
+        cy.findByTestId("toast-undo").within(() => {
+          cy.findByText("Alert created.").should("be.visible");
+        });
+
+        H.getInbox().then(({ body }: { body: { subject: string }[] }) => {
+          expect(body[0].subject).to.include("You set up an alert");
+        });
+
+        cy.findByTestId("table-data-view-header").within(() => {
+          cy.findByText("New record").click();
+        });
+
+        H.modal().within(() => {
+          // Focus on 1st input, no other way to select it currently.
+          cy.findByPlaceholderText("Required").type("10003");
+
+          cy.findByRole("button", { name: "Create new record" }).click();
+        });
+
+        cy.wait(1000);
+
+        cy.log("Testing default email template");
+
+        H.checkEmailContent(
+          `A new record was added to "${TABLE_NAME}" by ${ADMIN_NAME}`,
+          `A new record was created in Table ${TABLE_NAME}`,
+        );
+      });
+
+      it("should create an alert for 'row created' events with custom template", () => {
+        cy.findByTestId("table-notifications-trigger").click();
+
+        cy.findByTestId("table-notification-create").within(() => {
+          cy.findByTestId("notification-event-select").click();
+          cy.document()
+            .findByRole("option", {
+              name: /when new records are created/i,
+            })
+            .click();
+
+          cy.findByTestId("email-template-subject")
+            .findByRole("textbox")
+            .click({ force: true })
+            .invoke("text", "My custom subject for {{table.name}}")
+            .blur();
+
+          cy.findByTestId("email-template-body")
+            .findByRole("textbox")
+            .click({ force: true })
+            .invoke("text", "{{#each record}} {{@key}}: {{@value}} {{/each}}")
+            .blur();
+
+          cy.findByRole("button", { name: "Done" }).click();
+        });
+
+        cy.findByTestId("table-notification-create").should("not.exist");
+
+        cy.findByTestId("toast-undo").within(() => {
+          cy.findByText("Alert created.").should("be.visible");
+        });
+
+        H.getInbox().then(({ body }: { body: { subject: string }[] }) => {
+          expect(body[0].subject).to.include("You set up an alert");
+        });
+
+        cy.findByTestId("table-data-view-header").within(() => {
+          cy.findByText("New record").click();
+        });
+
+        H.modal().within(() => {
+          // Focus on 1st input, no other way to select it currently.
+          cy.findByPlaceholderText("Required").type("10003");
+
+          cy.findByRole("button", { name: "Create new record" }).click();
+        });
+
+        cy.wait(1000);
+
+        cy.log("Testing default email template");
+
+        H.checkEmailContent(`My custom subject for ${TABLE_NAME}`, [
+          "id",
+          "10003",
+        ]);
+      });
+    });
+
+    describe("update event", () => {
+      it("should create an alert for 'row updated' events with default template", () => {
+        cy.findByTestId("table-notifications-trigger").click();
+
+        cy.findByTestId("table-notification-create").within(() => {
+          cy.findByTestId("notification-event-select").click();
+          cy.document()
+            .findByRole("option", {
+              name: /when any cell changes it's value/i,
+            })
+            .click();
+          cy.findByRole("button", { name: "Done" }).click();
+        });
+
+        cy.findByTestId("table-notification-create").should("not.exist");
+
+        cy.findByTestId("toast-undo").within(() => {
+          cy.findByText("Alert created.").should("be.visible");
+        });
+
+        H.getInbox().then(({ body }: { body: { subject: string }[] }) => {
+          expect(body[0].subject).to.include("You set up an alert");
+        });
+
+        cy.findByTestId("table-body").within(() => {
+          cy.findByText("red").click();
+          cy.focused().type("blue").blur();
+        });
+
+        cy.wait(1000);
+
+        cy.log("Testing default email template");
+
+        H.checkEmailContent(
+          `A record was updated in "${TABLE_NAME}" by ${ADMIN_NAME}`,
+          [`A record was updated in Table ${TABLE_NAME}`, "redblue"],
+        );
+      });
+
+      it("should create an alert for 'row updated' events with custom template", () => {
+        cy.findByTestId("table-notifications-trigger").click();
+
+        cy.findByTestId("table-notification-create").within(() => {
+          cy.findByTestId("notification-event-select").click();
+          cy.document()
+            .findByRole("option", {
+              name: /when any cell changes it's value/i,
+            })
+            .click();
+
+          cy.findByTestId("email-template-subject")
+            .findByRole("textbox")
+            .click({ force: true })
+            .invoke("text", "My custom subject for {{table.name}}")
+            .blur();
+
+          cy.findByTestId("email-template-body")
+            .findByRole("textbox")
+            .click({ force: true })
+            .invoke("text", "{{#each record}} {{@key}}: {{@value}} {{/each}}")
+            .blur();
+
+          cy.findByRole("button", { name: "Done" }).click();
+        });
+
+        cy.findByTestId("table-notification-create").should("not.exist");
+
+        cy.findByTestId("toast-undo").within(() => {
+          cy.findByText("Alert created.").should("be.visible");
+        });
+
+        H.getInbox().then(({ body }: { body: { subject: string }[] }) => {
+          expect(body[0].subject).to.include("You set up an alert");
+        });
+
+        cy.findByTestId("table-body").within(() => {
+          cy.findByText("red").click();
+          cy.focused().type("blue").blur();
+        });
+
+        cy.wait(1000);
+
+        cy.log("Testing custom email template");
+
+        H.checkEmailContent(`My custom subject for ${TABLE_NAME}`, [
+          "id",
+          "name",
+          "redblue",
+        ]);
+      });
+    });
+
+    describe("delete event", () => {
+      it("should create an alert for 'row deleted' events with default template", () => {
+        cy.findByTestId("table-notifications-trigger").click();
+
+        cy.findByTestId("table-notification-create").within(() => {
+          cy.findByTestId("notification-event-select").click();
+          cy.document()
+            .findByRole("option", {
+              name: /when records are deleted/i,
+            })
+            .click();
+          cy.findByRole("button", { name: "Done" }).click();
+        });
+
+        cy.findByTestId("table-notification-create").should("not.exist");
+
+        cy.findByTestId("toast-undo").within(() => {
+          cy.findByText("Alert created.").should("be.visible");
+        });
+
+        H.getInbox().then(({ body }: { body: { subject: string }[] }) => {
+          expect(body[0].subject).to.include("You set up an alert");
+        });
+
+        cy.findByTestId("table-body").within(() => {
+          cy.get("[data-index=0]").within(() => {
+            cy.findByRole("checkbox").click();
+          });
+        });
+
+        cy.findByTestId("table-data-view-header").within(() => {
+          // TODO: Uncomment when button is working and delete request & wait
+          // cy.findByText("Delete").click();
+          cy.request("POST", `/api/ee/data-editing/table/${TABLE_ID}/delete`, {
+            rows: [{ id: 1 }],
+            scope: { "table-id": TABLE_ID },
+          });
+        });
+
+        cy.wait(1000);
+
+        cy.log("Testing default email template");
+
+        H.checkEmailContent(
+          `A record was deleted from "${TABLE_NAME}" by ${ADMIN_NAME}`,
+          [`A record was deleted in Table ${TABLE_NAME}`],
+        );
+      });
+
+      it.only("should create an alert for 'row deleted' events with custom template", () => {
+        cy.findByTestId("table-notifications-trigger").click();
+
+        cy.findByTestId("table-notification-create").within(() => {
+          cy.findByTestId("notification-event-select").click();
+          cy.document()
+            .findByRole("option", {
+              name: /when records are deleted/i,
+            })
+            .click();
+
+          cy.findByTestId("email-template-subject")
+            .findByRole("textbox")
+            .click({ force: true })
+            .invoke("text", "My custom subject for {{table.name}}")
+            .blur();
+
+          cy.findByTestId("email-template-body")
+            .findByRole("textbox")
+            .click({ force: true })
+            .invoke("text", "{{#each record}} {{@key}}: {{@value}} {{/each}}")
+            .blur();
+
+          cy.findByRole("button", { name: "Done" }).click();
+        });
+
+        cy.findByTestId("table-notification-create").should("not.exist");
+
+        cy.findByTestId("toast-undo").within(() => {
+          cy.findByText("Alert created.").should("be.visible");
+        });
+
+        H.getInbox().then(({ body }: { body: { subject: string }[] }) => {
+          expect(body[0].subject).to.include("You set up an alert");
+        });
+
+        cy.findByTestId("table-body").within(() => {
+          cy.get("[data-index=0]").within(() => {
+            cy.findByRole("checkbox").click();
+          });
+        });
+
+        cy.findByTestId("table-data-view-header").within(() => {
+          // TODO: Uncomment when button is working and delete request & wait
+          // cy.findByText("Delete").click();
+          cy.request("POST", `/api/ee/data-editing/table/${TABLE_ID}/delete`, {
+            rows: [{ id: 1 }],
+            scope: { "table-id": TABLE_ID },
+          });
+        });
+
+        cy.wait(1000);
+
+        cy.log("Testing custom email template");
+
+        H.checkEmailContent(`My custom subject for ${TABLE_NAME}`, [
+          "id",
+          "name",
+        ]);
+      });
+    });
+  });
+});
+
+function openDatabaseTable() {
+  H.getTableId({
+    name: TABLE_NAME,
+  }).then((tableId) => {
+    cy.visit(`/browse/databases/${WRITABLE_DB_ID}/tables/${tableId}/edit`);
+  });
+}

--- a/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
+++ b/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
@@ -31,28 +31,27 @@ export const fillInCustomTemplate = (subject: string, body: string) => {
         });
         cm.contentDOM.blur();
       }
-    });
 
-  cy.wait(100);
+      cy.wait(200);
 
-  cy.findByTestId("email-template-body")
-    .find(".cm-content")
-    .then(([contentElement]) => {
-      const cm = contentElement.cmView?.view;
-      if (cm) {
-        cm.contentDOM.focus();
-        cm.dispatch({
-          changes: {
-            from: 0,
-            to: cm.state.doc.length,
-            insert: body,
-          },
+      cy.document()
+        .findByTestId("email-template-body")
+        .find(".cm-content")
+        .then(([contentElement]) => {
+          const cm = contentElement.cmView?.view;
+          if (cm) {
+            cm.contentDOM.focus();
+            cm.dispatch({
+              changes: {
+                from: 0,
+                to: cm.state.doc.length,
+                insert: body,
+              },
+            });
+            cm.contentDOM.blur();
+          }
         });
-        cm.contentDOM.blur();
-      }
     });
-
-  cy.wait(100);
 };
 
 /**

--- a/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
+++ b/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
@@ -1,0 +1,107 @@
+// Using type import to avoid runtime dependency on cypress types
+type Interception = {
+  response?: {
+    statusCode?: number;
+    body?: {
+      handlers?: Array<{
+        template?: Record<string, unknown>;
+      }>;
+    };
+  };
+};
+
+/**
+ * Fills in the custom template fields with the provided subject and body
+ * @param subject The subject template to use
+ * @param body The body template to use
+ */
+export const fillInCustomTemplate = (subject: string, body: string) => {
+  cy.findByTestId("email-template-subject")
+    .find(".cm-content")
+    .then(([contentElement]) => {
+      const cm = contentElement.cmView?.view;
+      if (cm) {
+        cm.contentDOM.focus();
+        cm.dispatch({
+          changes: {
+            from: 0,
+            to: cm.state.doc.length,
+            insert: subject,
+          },
+        });
+        cm.contentDOM.blur();
+      }
+    });
+
+  cy.wait(100);
+
+  cy.findByTestId("email-template-body")
+    .find(".cm-content")
+    .then(([contentElement]) => {
+      const cm = contentElement.cmView?.view;
+      if (cm) {
+        cm.contentDOM.focus();
+        cm.dispatch({
+          changes: {
+            from: 0,
+            to: cm.state.doc.length,
+            insert: body,
+          },
+        });
+        cm.contentDOM.blur();
+      }
+    });
+
+  cy.wait(100);
+};
+
+/**
+ * Verifies that the notification was created with the expected custom template
+ * @param response The intercepted response from the notification creation request
+ * @param expectedSubject The expected subject template
+ * @param expectedBody The expected body template
+ */
+export const verifyNotificationTemplate = (
+  response: Interception,
+  expectedSubject: string,
+  expectedBody: string,
+) => {
+  expect(response?.response?.statusCode).to.equal(200);
+  const stringifiedTemplate = JSON.stringify(
+    response?.response?.body?.handlers?.[0]?.template,
+  );
+  expect(stringifiedTemplate).to.contain(expectedSubject);
+  expect(stringifiedTemplate).to.contain(expectedBody);
+};
+
+/**
+ * Creates a notification with a custom template
+ * @param eventName The name of the event to select (e.g., "when new records are created")
+ * @param subject The subject template to use
+ * @param body The body template to use
+ */
+export const createNotificationWithCustomTemplate = (
+  eventName: string | RegExp,
+  subject: string,
+  body: string,
+) => {
+  // Open the notification creation modal
+  cy.findByTestId("table-notification-create").within(() => {
+    // Select the event type
+    cy.findByTestId("notification-event-select").click();
+    cy.document()
+      .findByRole("option", {
+        name: eventName,
+      })
+      .click();
+
+    // Fill in the custom templates
+    fillInCustomTemplate(subject, body);
+
+    // Submit the form
+    cy.findByRole("button", { name: "Done" }).click();
+  });
+
+  // Wait for the notification to be created and return the response
+  return cy.wait("@createNotification");
+};

--- a/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
+++ b/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
@@ -10,11 +10,6 @@ type Interception = {
   };
 };
 
-/**
- * Fills in the custom template fields with the provided subject and body
- * @param subject The subject template to use
- * @param body The body template to use
- */
 export const fillInCustomTemplate = (subject: string, body: string) => {
   cy.findByTestId("email-template-subject")
     .find(".cm-content")
@@ -54,13 +49,7 @@ export const fillInCustomTemplate = (subject: string, body: string) => {
     });
 };
 
-/**
- * Verifies that the notification was created with the expected custom template
- * @param response The intercepted response from the notification creation request
- * @param expectedSubject The expected subject template
- * @param expectedBody The expected body template
- */
-export const verifyNotificationTemplate = (
+export const verifyNotificationTemplateResponse = (
   response: Interception,
   expectedSubject: string,
   expectedBody: string,
@@ -73,20 +62,12 @@ export const verifyNotificationTemplate = (
   expect(stringifiedTemplate).to.contain(expectedBody);
 };
 
-/**
- * Creates a notification with a custom template
- * @param eventName The name of the event to select (e.g., "when new records are created")
- * @param subject The subject template to use
- * @param body The body template to use
- */
 export const createNotificationWithCustomTemplate = (
   eventName: string | RegExp,
   subject: string,
   body: string,
 ) => {
-  // Open the notification creation modal
   cy.findByTestId("table-notification-create").within(() => {
-    // Select the event type
     cy.findByTestId("notification-event-select").click();
     cy.document()
       .findByRole("option", {
@@ -94,10 +75,8 @@ export const createNotificationWithCustomTemplate = (
       })
       .click();
 
-    // Fill in the custom templates
     fillInCustomTemplate(subject, body);
 
-    // Submit the form
     cy.findByRole("button", { name: "Done" }).click();
   });
 

--- a/e2e/test/scenarios/data-editing/e2e-helpers/setup.ts
+++ b/e2e/test/scenarios/data-editing/e2e-helpers/setup.ts
@@ -1,7 +1,7 @@
 import { ADMIN_USER_ID } from "e2e/support/cypress_sample_instance_data";
 
 export const setupAlert = (tableId: number, eventName: string) => {
-  cy.request("POST", "/api/notification", {
+  return cy.request("POST", "/api/notification", {
     payload_type: "notification/system-event",
     payload: { event_name: eventName, table_id: tableId },
     payload_id: null,

--- a/e2e/test/scenarios/data-editing/helpers/setup.ts
+++ b/e2e/test/scenarios/data-editing/helpers/setup.ts
@@ -1,0 +1,26 @@
+import { ADMIN_USER_ID } from "e2e/support/cypress_sample_instance_data";
+
+export const setupAlert = (tableId: number, eventName: string) => {
+  cy.request("POST", "/api/notification", {
+    payload_type: "notification/system-event",
+    payload: { event_name: eventName, table_id: tableId },
+    payload_id: null,
+    handlers: [
+      {
+        channel_type: "channel/email",
+        recipients: [
+          {
+            type: "notification-recipient/user",
+            user_id: ADMIN_USER_ID,
+            details: null,
+          },
+        ],
+      },
+    ],
+    condition: [
+      "and",
+      ["=", ["context", "table_id"], tableId],
+      ["=", ["context", "event_name"], eventName],
+    ],
+  });
+};

--- a/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/notification_test.clj
@@ -160,7 +160,7 @@
                              message)))
     :channel/email (fn [[email :as emails]]
                      (is (= 1 (count emails)))
-                     (is (=? {:subject "A new record was deleted from \"CATEGORIES\" by Crowberto Corv"
+                     (is (=? {:subject "A record was deleted from \"CATEGORIES\" by Crowberto Corv"
                               :body    [{"<strong>A record was <i>deleted</i></strong> in <span[^>]*>Table CATEGORIES</span> by Crowberto Corv" true
                                          "Field" true
                                          "Value" true

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
@@ -611,9 +611,7 @@ export const CreateOrEditTableNotificationModal = ({
             (isEditMode && !hasChanges)
           }
           onClickOperation={onCreateOrEditAlert}
-        >
-          {isEditMode ? t`Update` : t`Create`}
-        </ButtonWithStatus>
+        />
       </Flex>
 
       {hasChanges && (

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/AlertConditionBuilder/AlertConditionBuilder.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/AlertConditionBuilder/AlertConditionBuilder.tsx
@@ -313,7 +313,7 @@ const ConditionRowComponent = ({
               initialValue={condition.value}
               onSubmit={(value) => handleValueChange(value as string)}
               onCancel={() => {}}
-              inputProps={{ disabled: false, placeholder: "" }}
+              inputProps={{ disabled: false, placeholder: t`Select value` }}
             />
           </>
         )}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewTemplatePanel/PreviewTemplatePanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewTemplatePanel/PreviewTemplatePanel.tsx
@@ -32,7 +32,13 @@ export const PreviewTemplatePanel = ({
   const htmlContent = previewContent?.body?.[0]?.content;
 
   return (
-    <Flex direction="column" mah="100%" gap="md" className={S.root}>
+    <Flex
+      direction="column"
+      mah="100%"
+      gap="md"
+      className={S.root}
+      data-testid="preview-template-panel"
+    >
       <Flex gap="sm" align="center" h="1.625rem" className={S.header}>
         <Icon name="eye" size={16} />
         <Title size="h4">{t`Email message preview`}</Title>

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewTemplatePanel/PreviewTemplatePanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewTemplatePanel/PreviewTemplatePanel.tsx
@@ -65,12 +65,7 @@ export const PreviewTemplatePanel = ({
           </Flex>
         )}
         {error && (
-          <Text c="error">
-            {t`Error during generation of template preview. Check your template.
-            We will provide better error messages soon 🙏.`}
-            {/* TODO: Un-comment this line when BE return human-readable error without stack trace */}
-            {/* {JSON.stringify(error)} */}
-          </Text>
+          <code style={{ color: "var(--mb-color-error)" }}>{error}</code>
         )}
         {previewContent && !error ? (
           <Stack className={S.previewStack}>

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/TableNotificationsTrigger/TableNotificationsTrigger.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/TableNotificationsTrigger/TableNotificationsTrigger.tsx
@@ -124,6 +124,7 @@ export const TableNotificationsTrigger = ({
     <>
       <Tooltip label={hasNotifications ? t`Edit alerts` : t`Create alert`}>
         <ActionIcon
+          data-testid="table-notifications-trigger"
           className={S.alertIcon}
           variant="subtle"
           size="lg"

--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -151,6 +151,9 @@ export const notificationApi = Api.injectEndpoints({
         url: "/api/notification/preview_template",
         body,
       }),
+      transformErrorResponse: (response: { data: string }) => {
+        return response.data;
+      },
     }),
   }),
 });

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableFilters.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableFilters.tsx
@@ -61,7 +61,7 @@ export function ConfigureEditableTableFilters({
   };
 
   if (!query) {
-    return <div>ERROR: no query</div>;
+    return <div>{t`ERROR: no query`}</div>;
   }
 
   return (

--- a/frontend/src/metabase/notifications/modals/shared/components/HandlersInfo.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/HandlersInfo.tsx
@@ -101,7 +101,9 @@ const formatEmailHandlerInfo = (
 };
 
 const formatSlackHandlerInfo = (handler: NotificationHandlerSlack) => {
-  return handler.recipients[0]?.details.value;
+  return handler.recipients
+    .map((recipient) => recipient.details.value)
+    .join(", ");
 };
 
 const formatHttpHandlersInfo = (

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -178,6 +178,7 @@ const TemplateToolbarButton = React.forwardRef<
   return (
     <Tooltip label={label} ref={ref}>
       <ActionIcon
+        aria-label={label}
         size={size}
         variant="viewHeader"
         style={{

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -240,7 +240,7 @@ const TemplateInfoTooltip = ({ context }: TemplateInfoTooltipProps) => {
               textDecoration: "underline",
             }}
           >
-            Handlebars
+            {t`Handlebars`}
           </a>
         )} syntax.`}</Text>
         <Text>{jt`Use ${(<code key="brackets">{"{{ }}"}</code>)} to reference fields, ${(<code key="key">{"@key"}</code>)} and ${(<code key="value">{"@value"}</code>)} when iterating over objects, or ${(<code key="index">{"@index"}</code>)} for arrays.`}</Text>
@@ -255,7 +255,7 @@ const TemplateInfoTooltip = ({ context }: TemplateInfoTooltipProps) => {
               textDecoration: "underline",
             }}
           >
-            this formatting reference
+            {t`this formatting reference`}
           </a>
         )}.`}</Text>
         <Text>{t`Example payload for selected alert:`}</Text>
@@ -694,7 +694,7 @@ export const NotificationChannelsPicker = ({
                       handleTemplateChange("email", "subject", value, true);
                     }}
                     onBlur={(value) => {
-                      handleTemplateChange("email", "subject", value, true);
+                      handleTemplateChange("email", "subject", value);
                     }}
                     onFocus={(initialValue) => {
                       handleTemplateChange(
@@ -792,6 +792,9 @@ export const NotificationChannelsPicker = ({
                   placeholder={t`Your custom Slack template`}
                   templateContext={templateContext["channel/slack"]}
                   defaultValue={getTemplateValue("slack", "body")}
+                  onFocus={(value) => {
+                    handleTemplateChange("slack", "body", value, true);
+                  }}
                   onChange={(value) => {
                     handleTemplateChange("slack", "body", value, true);
                   }}

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -299,6 +299,7 @@ export const NotificationChannelsPicker = ({
   isPreviewOpen,
   defaultTemplates,
 }: NotificationChannelsPickerProps) => {
+  console.log(JSON.stringify(templateContext));
   const { data: httpChannelsConfig = [] } = useListChannelsQuery();
   const { data: users } = useListUserRecipientsQuery();
   const user = useSelector(getUser);
@@ -555,6 +556,7 @@ export const NotificationChannelsPicker = ({
     const template = stateAfterUpdateAction.templates[channel];
     const subjectValue = template?.subject || "";
     const bodyValue = template?.body || "";
+    console.log({ subjectValue, bodyValue });
 
     const hasSubject = !!subjectValue.trim();
     const hasBody = !!bodyValue.trim();
@@ -684,11 +686,16 @@ export const NotificationChannelsPicker = ({
                 <Stack gap="xs">
                   <Text size="sm" fw={700}>{t`Subject`}</Text>
                   <TemplateEditor
+                    data-testid="email-template-subject"
                     variant="textinput"
                     placeholder={t`Alert from {{payload.result.table.name}} table`}
                     templateContext={templateContext["channel/email"]}
                     defaultValue={getTemplateValue("email", "subject")}
                     onChange={(value) => {
+                      handleTemplateChange("email", "subject", value, true);
+                    }}
+                    onBlur={(value) => {
+                      console.log("blur", value);
                       handleTemplateChange("email", "subject", value, true);
                     }}
                     onFocus={(initialValue) => {
@@ -711,6 +718,7 @@ export const NotificationChannelsPicker = ({
                   <Text size="sm" fw={700}>{t`Message`}</Text>
                   <TemplateEditor
                     variant="textarea"
+                    data-testid="email-template-body"
                     placeholder={t`Your custom email template`}
                     templateContext={templateContext["channel/email"]}
                     minHeight="10rem"
@@ -780,9 +788,10 @@ export const NotificationChannelsPicker = ({
               <Stack gap="xs">
                 <Text size="sm" fw={700}>{t`Message`}</Text>
                 <TemplateEditor
+                  data-testid="slack-template-body"
                   minHeight="10rem"
                   height="10rem"
-                  placeholder={t`Your custom Markdown template`}
+                  placeholder={t`Your custom Slack template`}
                   templateContext={templateContext["channel/slack"]}
                   defaultValue={getTemplateValue("slack", "body")}
                   onChange={(value) => {

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -299,7 +299,6 @@ export const NotificationChannelsPicker = ({
   isPreviewOpen,
   defaultTemplates,
 }: NotificationChannelsPickerProps) => {
-  console.log(JSON.stringify(templateContext));
   const { data: httpChannelsConfig = [] } = useListChannelsQuery();
   const { data: users } = useListUserRecipientsQuery();
   const user = useSelector(getUser);
@@ -556,7 +555,6 @@ export const NotificationChannelsPicker = ({
     const template = stateAfterUpdateAction.templates[channel];
     const subjectValue = template?.subject || "";
     const bodyValue = template?.body || "";
-    console.log({ subjectValue, bodyValue });
 
     const hasSubject = !!subjectValue.trim();
     const hasBody = !!bodyValue.trim();
@@ -695,7 +693,6 @@ export const NotificationChannelsPicker = ({
                       handleTemplateChange("email", "subject", value, true);
                     }}
                     onBlur={(value) => {
-                      console.log("blur", value);
                       handleTemplateChange("email", "subject", value, true);
                     }}
                     onFocus={(initialValue) => {

--- a/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/TemplateEditor/TemplateEditor.tsx
@@ -120,9 +120,10 @@ export const TemplateEditor = ({
       if (update.focusChanged && !update.view.hasFocus && onBlur) {
         const currentValue = update.state.doc.toString();
         onBlur(currentValue);
+        onChangeDebounced.cancel();
       }
     });
-  }, [onBlur]);
+  }, [onBlur, onChangeDebounced]);
 
   const templateAutocompleteExtension = useMemo(() => {
     if (!templateContext) {

--- a/src/metabase/channel/template/default.clj
+++ b/src/metabase/channel/template/default.clj
@@ -19,7 +19,7 @@
                                                                                    :path    "metabase/channel/email/data_editing_row_update.hbs"}}
                    [:notification/system-event :event/row.deleted] {:channel_type :channel/email
                                                                     :details      {:type    :email/handlebars-resource
-                                                                                   :subject "A new record was deleted from \"{{table.name}}\" by {{editor.common_name}}"
+                                                                                   :subject "A record was deleted from \"{{table.name}}\" by {{editor.common_name}}"
                                                                                    :path    "metabase/channel/email/data_editing_row_delete.hbs"}}}
    :channel/slack {[:notification/system-event :event/row.created] {:channel_type :channel/slack
                                                                     :details      {:type :slack/handlebars-text


### PR DESCRIPTION
Closes [WRK-415](https://linear.app/metabase/issue/WRK-415/fix-display-of-multiple-slack-channels-in-notification-list-items), [WRK-416](https://linear.app/metabase/issue/WRK-416/add-template-preview-error-message-output)

**Display all configured slack channels in alerts list**

<img width="569" alt="image" src="https://github.com/user-attachments/assets/cb8cacc0-22b5-4bb0-aa7a-28b8caba6839" />


**Display server error if template preview request fails**

<img width="465" alt="image" src="https://github.com/user-attachments/assets/5c9ff248-44e5-4dba-96f3-1c269bd54025" />

Also, minor lint fix, added e2e test for preview error display.