### PR TITLE
Fix X-Ray URLs generated for models

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
@@ -2,6 +2,7 @@
   (:require
    [buddy.core.codecs :as codecs]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   [metabase.lib.util :as lib.util]
    [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
@@ -11,14 +12,17 @@
   [{what-for :for}]
   (try
     (let [[k id] (some #(find what-for %) [:metric_id :table_id :report_id :query])
+          model-id (when (= k :table_id)
+                     (lib.util/legacy-string-table-id->card-id id))
           entity-type (case k
                         (:metric_id :report_id) "question"
-                        :table_id "table"
+                        :table_id (if model-id "model" "table")
                         (:query :query_id) "adhoc"
                         (throw (ex-info (str "Cannot generate insights for " what-for) {:agent-error? true})))
-          entity-id (case k
-                      :query (-> id json/encode .getBytes codecs/bytes->b64-str)
-                      id)
+          entity-id (cond
+                      model-id     model-id
+                      (= k :query) (-> id json/encode .getBytes codecs/bytes->b64-str)
+                      :else        id)
           results-url (str "/auto/dashboard/" entity-type "/" entity-id)]
       (when (and (= k :table_id)
                  (not (int? id))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/generate_insights_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/generate_insights_test.clj
@@ -25,7 +25,7 @@
                    (metabot-v3.tools.generate-insights/generate-insights {:for {:table_id id}}))
         42
         "42"))
-    (let [results-url "/auto/dashboard/table/card__42"]
+    (let [results-url "/auto/dashboard/model/42"]
       (is (= {:output results-url
               :reactions [{:type :metabot.reaction/redirect :url results-url}]}
              (metabot-v3.tools.generate-insights/generate-insights {:for {:table_id "card__42"}}))))


### PR DESCRIPTION
Fixes BOT-125

### Description

This PR only fixes the URL generated for models. That means, it generates the same URL the FE would generate to X-Ray a model. It does _not_ fix the problem with the queries failing. In fact, it will keep producing the same page as before. The only thing that changes is that metabot will generate the exact same URL as the FE.

### How to verify

Go to a model in the `__METABOT__` collection, and ask metabot to "analyze this table". It should generate a URL like this:
`/auto/dashboard/model/6736`, where `6736` is the ID of the selected model.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
