### PR TITLE
[Backend modularization] Move `util/password_check` into `session`

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -16,6 +16,8 @@ title: API changelog
 
 - `POST /api/util/entity_id` has been renamed to `POST /api/eid-translation/translate`.
 
+- `POST /api/util/password_check` has been renamed to `POST /api/session/password-check`.
+
 ## Metabase 0.54.0
 
 - The alert system has been migrated from the legacy pulse infrastructure to the new notification system. This migration includes the following changes:

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -318,7 +318,7 @@ export const UserApi = {
 };
 
 export const UtilApi = {
-  password_check: POST("/api/util/password_check"),
+  password_check: POST("/api/session/password-check"),
   random_token: GET("/api/util/random_token"),
   logs: GET("/api/util/logs"),
   bug_report_details: GET("/api/bug-reporting/details"),

--- a/frontend/src/metabase/setup/tests/setup.tsx
+++ b/frontend/src/metabase/setup/tests/setup.tsx
@@ -57,7 +57,7 @@ export async function setup({
     setupEnterprisePlugins();
   }
 
-  fetchMock.post("path:/api/util/password_check", { valid: true });
+  fetchMock.post("path:/api/session/password-check", { valid: true });
   fetchMock.post("path:/api/setup", {});
   fetchMock.put("path:/api/setting/anon-tracking-enabled", 200);
   setupPropertiesEndpoints(

--- a/frontend/test/__support__/server-mocks/util.ts
+++ b/frontend/test/__support__/server-mocks/util.ts
@@ -1,7 +1,7 @@
 import fetchMock from "fetch-mock";
 
 export function setupPasswordCheckEndpoint() {
-  fetchMock.post("path:/api/util/password_check", 204);
+  fetchMock.post("path:/api/session/password-check", 204);
 }
 
 type ResponseInfo = {

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -9,19 +9,9 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.open-api :as open-api]
    [metabase.logger :as logger]
-   [metabase.util.malli.schema :as ms]
    [ring.util.response :as response]))
 
 (set! *warn-on-reflection* true)
-
-(api.macros/defendpoint :post "/password_check"
-  "Endpoint that checks if the supplied password meets the currently configured password complexity rules."
-  [_route-params
-   _query-params
-   _body :- [:map
-             [:password ms/ValidPassword]]]
-  ;; if we pass the su/ValidPassword test we're g2g
-  {:valid true})
 
 (api.macros/defendpoint :get "/logs"
   "Logs."

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -305,6 +305,15 @@
         (throttle/with-throttling [(login-throttlers :ip-address) (request/ip-address request)]
           (do-login))))))
 
+(api.macros/defendpoint :post "/password_check"
+  "Endpoint that checks if the supplied password meets the currently configured password complexity rules."
+  [_route-params
+   _query-params
+   _body :- [:map
+             [:password ms/ValidPassword]]]
+  ;; if we pass the [[ms/ValidPassword]] test we're g2g
+  {:valid true})
+
 (defn- +log-all-request-failures [handler]
   (open-api/handler-with-open-api-spec
    (fn [request respond raise]

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -305,7 +305,7 @@
         (throttle/with-throttling [(login-throttlers :ip-address) (request/ip-address request)]
           (do-login))))))
 
-(api.macros/defendpoint :post "/password_check"
+(api.macros/defendpoint :post "/password-check"
   "Endpoint that checks if the supplied password meets the currently configured password complexity rules."
   [_route-params
    _query-params

--- a/test/metabase/api/util_test.clj
+++ b/test/metabase/api/util_test.clj
@@ -5,24 +5,6 @@
    [metabase.test :as mt]
    [metabase.util.log :as log]))
 
-(deftest ^:parallel password-check-test
-  (testing "POST /api/util/password_check"
-    (testing "Test for required params"
-      (is (=? {:errors {:password "password is too common."}}
-              (mt/client :post 400 "util/password_check" {}))))))
-
-(deftest ^:parallel password-check-test-2
-  (testing "POST /api/util/password_check"
-    (testing "Test complexity check"
-      (is (=? {:errors {:password "password is too common."}}
-              (mt/client :post 400 "util/password_check" {:password "blah"}))))))
-
-(deftest ^:parallel password-check-test-3
-  (testing "POST /api/util/password_check"
-    (testing "Should be a valid password"
-      (is (= {:valid true}
-             (mt/client :post 200 "util/password_check" {:password "something123"}))))))
-
 (deftest logs-test
   (testing "Call includes recent logs (#24616)"
     (mt/with-log-level :warn

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -652,3 +652,21 @@
              clojure.lang.ExceptionInfo
              #"Password did not match stored password"
              (#'api.session/login (:email user) "password" device-info)))))))
+
+(deftest ^:parallel password-check-test
+  (testing "POST /api/session/password-check"
+    (testing "Test for required params"
+      (is (=? {:errors {:password "password is too common."}}
+              (mt/client :post 400 "session/password-check" {}))))))
+
+(deftest ^:parallel password-check-test-2
+  (testing "POST /api/session/password-check"
+    (testing "Test complexity check"
+      (is (=? {:errors {:password "password is too common."}}
+              (mt/client :post 400 "session/password-check" {:password "blah"}))))))
+
+(deftest ^:parallel password-check-test-3
+  (testing "POST /api/session/password-check"
+    (testing "Should be a valid password"
+      (is (= {:valid true}
+             (mt/client :post 200 "session/password-check" {:password "something123"}))))))


### PR DESCRIPTION
Resolves DEV-528

We're trying to move the random grab bag of stuff out of `util/` into appropriate modules.