### PR TITLE
Exclude parent from recents and search when moving items

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -387,6 +387,24 @@ describe("scenarios > collection defaults", () => {
     });
   });
 
+  it("should not show you the parent collection in recents or search results", () => {
+    H.visitCollection(THIRD_COLLECTION_ID);
+    H.openCollectionMenu();
+    H.popover().findByText("Move").click();
+    H.entityPickerModal().within(() => {
+      cy.findByRole("button", { name: /First collection / }).should("exist");
+      cy.findByRole("button", { name: /Second collection/ }).should(
+        "not.exist",
+      );
+
+      cy.findByPlaceholderText("Search…").type("coll");
+      cy.findByRole("button", { name: /Robert Tableton/ }).should("exist");
+      cy.findByRole("button", { name: /Second collection/ }).should(
+        "not.exist",
+      );
+    });
+  });
+
   describe("Collection related issues reproductions", () => {
     beforeEach(() => {
       H.restore();

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -260,6 +260,32 @@ describe("managing dashboard from the dashboard's edit menu", () => {
 
                 H.appBar().contains("Our analytics");
                 H.appBar().should("not.contain", "First collection");
+
+                // Assert that dashboard parent does not show up in recents
+                if (user === "admin") {
+                  H.openDashboardMenu();
+                  // Move the dashboard back to first collection
+                  H.popover().findByText("Move").click();
+
+                  H.entityPickerModal().within(() => {
+                    cy.findByText("First collection").click();
+                    cy.button("Move").click();
+                  });
+
+                  H.openDashboardMenu();
+                  H.popover().findByText("Move").click();
+                  H.entityPickerModal().within(() => {
+                    cy.findByRole("button", {
+                      name: /Third collection /,
+                    }).should("exist");
+                    // The space at the end of the regex is important since the "second collection"
+                    // recent item also contains the text "in First collection", but at the end of the
+                    // name
+                    cy.findByRole("button", {
+                      name: /First collection /,
+                    }).should("not.exist");
+                  });
+                }
               });
             });
 

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -653,11 +653,19 @@ describe("scenarios > organization > entity picker", () => {
     it("should search for collections when there is no access to the root collection", () => {
       cy.signInAsAdmin();
       createTestCollections();
-      cy.log("grant `nocollection` user access to `First collection`");
+      cy.log(
+        "grant `nocollection` user access to `First collection` and `Another collection",
+      );
       cy.log("personal collections are always available");
-      cy.updateCollectionGraph({
-        [ALL_USERS_GROUP]: { [FIRST_COLLECTION_ID]: "write" },
+      cy.get("@anotherCollection").then((anotherCollectionId) => {
+        cy.updateCollectionGraph({
+          [ALL_USERS_GROUP]: {
+            [FIRST_COLLECTION_ID]: "write",
+            [anotherCollectionId]: "write",
+          },
+        });
       });
+
       cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
         collection_id: FIRST_COLLECTION_ID,
       });
@@ -676,15 +684,19 @@ describe("scenarios > organization > entity picker", () => {
         });
         localSearchTab("Collections").should("be.checked");
         assertSearchResults({
-          foundItems: ["First collection"],
-          notFoundItems: ["No Collection Tableton's Personal Collection"],
+          foundItems: ["Another collection"],
+          notFoundItems: [
+            "No Collection Tableton's Personal Collection",
+            "First Collection",
+          ],
         });
         selectGlobalSearchTab();
         assertSearchResults({
           foundItems: [
-            "First collection",
+            "Another collection",
             "No Collection Tableton's Personal Collection",
           ],
+          notFoundItems: ["First Collection"],
         });
       });
 
@@ -1227,6 +1239,12 @@ function createTestCollections() {
         name: `${collection.name} ${suffix}`,
       }),
     );
+  });
+
+  H.createCollection({
+    name: "Another collection",
+    parent_id: null,
+    alias: "anotherCollection",
   });
 }
 

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -97,6 +97,19 @@ describe(
                       .parents("li")
                       .should("have.attr", "aria-selected", "true");
                   });
+
+                  if (user === "admin") {
+                    H.openQuestionActions();
+                    cy.findByTestId("move-button").click();
+                    H.entityPickerModal().within(() => {
+                      cy.findByRole("button", {
+                        name: /Orders in a dashboard/,
+                      }).should("exist");
+                      cy.findByRole("button", { name: /Bobby Table/ }).should(
+                        "not.exist",
+                      );
+                    });
+                  }
                 });
 
                 it("should be able to move the question to a collection created on the go", () => {

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 
 import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
 import { isTrashedCollection } from "metabase/collections/utils";
+import type { CollectionPickerItem } from "metabase/common/components/CollectionPicker";
 import { BulkActionBar } from "metabase/components/BulkActionBar";
 import Modal from "metabase/components/Modal";
 import { BulkMoveModal } from "metabase/containers/MoveModal";
@@ -114,6 +115,11 @@ export const CollectionBulkActions = memo(
       selected.length,
     );
 
+    // This is a little cheeky, but by virtue of the screens we show the BulkMoveModal, all
+    // selected items should have the same collection id. yatta!
+    const recentAndSearchFilter = (item: CollectionPickerItem) =>
+      item.model === "collection" && item.id === collection.id;
+
     return (
       <>
         <BulkActionBar message={actionMessage} opened={isVisible}>
@@ -156,6 +162,7 @@ export const CollectionBulkActions = memo(
             initialCollectionId={
               isTrashedCollection(collection) ? "root" : collection.id
             }
+            recentAndSearchFilter={recentAndSearchFilter}
           />
         )}
 

--- a/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
@@ -5,6 +5,7 @@ import type {
   MoveDestination,
   OnMoveWithSourceAndDestination,
 } from "metabase/collections/types";
+import type { CollectionPickerItem } from "metabase/common/components/CollectionPicker";
 import { useCollectionQuery } from "metabase/common/hooks";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import { MoveModal } from "metabase/containers/MoveModal";
@@ -32,6 +33,9 @@ const MoveCollectionModalView = ({
     [collection, onMove, onClose],
   );
 
+  const recentsAndSearchFilter = (item: CollectionPickerItem) =>
+    item.model === "collection" && item.id === collection.parent_id;
+
   return (
     <MoveModal
       title={t`Move "${collection.name}"?`}
@@ -39,6 +43,7 @@ const MoveCollectionModalView = ({
       movingCollectionId={collection.id}
       onMove={handleMove}
       onClose={onClose}
+      recentAndSearchFilter={recentsAndSearchFilter}
     />
   );
 };

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
@@ -2,6 +2,7 @@ import { c, t } from "ttag";
 import _ from "underscore";
 
 import { useGetCollectionQuery } from "metabase/api";
+import type { CollectionPickerItem } from "metabase/common/components/CollectionPicker";
 import { MoveModal } from "metabase/containers/MoveModal";
 import Link from "metabase/core/components/Link";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
@@ -32,6 +33,9 @@ function DashboardMoveModal({
     options: any,
   ) => void;
 }) {
+  const recentsAndSearchFilter = (item: CollectionPickerItem) =>
+    item.model === "collection" && item.id === dashboard.collection_id;
+
   return (
     <MoveModal
       title={t`Move dashboard to…`}
@@ -50,6 +54,7 @@ function DashboardMoveModal({
         });
         onClose();
       }}
+      recentAndSearchFilter={recentsAndSearchFilter}
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
+++ b/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
@@ -7,6 +7,7 @@ import { getDashboard, useUpdateCardMutation } from "metabase/api";
 import { QuestionMoveConfirmModal } from "metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal";
 import type { MoveDestination } from "metabase/collections/types";
 import { canonicalCollectionId } from "metabase/collections/utils";
+import type { CollectionPickerItem } from "metabase/common/components/CollectionPicker";
 import { ConfirmModal } from "metabase/components/ConfirmModal";
 import { MoveModal } from "metabase/containers/MoveModal";
 import Dashboards from "metabase/entities/dashboards";
@@ -238,6 +239,16 @@ export const MoveQuestionModal = ({
     );
   }
 
+  const recentAndSearchFilter = (item: CollectionPickerItem) => {
+    const dashboardId = question.dashboardId();
+
+    if (dashboardId) {
+      return item.model === "dashboard" && item.id === dashboardId;
+    } else {
+      return item.model === "collection" && item.id === question.collectionId();
+    }
+  };
+
   return (
     <MoveModal
       title={t`Where do you want to save this?`}
@@ -245,6 +256,7 @@ export const MoveQuestionModal = ({
       onClose={onClose}
       onMove={handleChooseMoveLocation}
       canMoveToDashboard={question.type() === "question"}
+      recentAndSearchFilter={recentAndSearchFilter}
     />
   );
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57057

### Description
Updates the move modal to accept custom recents and search filters, and adds a filter to bulk, collection, question and dashboard move modals to exclude the parent collection / dashboard from the recents and search tabs.

### How to verify

1. Go to a collection (to have it appear in recents), then try to move an entity in that collection
2. You should not see the parent collection in the recents tab
3. try searching for it, it should not appear there either

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
