### PR TITLE
fix(sdk): questions shows an error while loading on strict mode

### DIFF
--- a/e2e/support/helpers/e2e-element-visibility-helpers.ts
+++ b/e2e/support/helpers/e2e-element-visibility-helpers.ts
@@ -54,3 +54,47 @@ export function isFixedPositionElementVisible(element: HTMLElement): boolean {
 
   return true;
 }
+
+/**
+ * Asserts that an element never exists from when this assertion was called
+ * up until the timeout expires, checked at every polling interval.
+ *
+ * @param selector - selector of the element to check for
+ * @param rejectionMessage - message to reject with if the element exists
+ * @param pollInterval - how often to check for the element
+ * @param timeout - how long to wait for the element to not exist
+ */
+export function assertElementNeverExists({
+  selector,
+  rejectionMessage,
+  pollInterval,
+  timeout,
+}: {
+  selector: string;
+  rejectionMessage: string;
+  pollInterval: number;
+  timeout: number;
+}) {
+  cy.window().then((win) => {
+    return new Cypress.Promise((resolve, reject) => {
+      let foundError = false;
+
+      const checkInterval = setInterval(() => {
+        const errorMessage = win.document.querySelector(selector);
+
+        if (errorMessage) {
+          foundError = true;
+          clearInterval(checkInterval);
+          reject(new Error(rejectionMessage));
+        }
+      }, pollInterval);
+
+      setTimeout(() => {
+        clearInterval(checkInterval);
+        if (!foundError) {
+          resolve();
+        }
+      }, timeout);
+    });
+  });
+}

--- a/e2e/support/helpers/index.ts
+++ b/e2e/support/helpers/index.ts
@@ -17,6 +17,7 @@ export * from "./e2e-downloads-helpers";
 export * from "./e2e-dragndrop-helpers";
 export * from "./e2e-email-helpers";
 export * from "./e2e-embedding-helpers";
+export * from "./e2e-element-visibility-helpers";
 export * from "./e2e-enterprise-helpers";
 export * from "./e2e-filter-helpers";
 export * from "./e2e-ldap-helpers";

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -475,4 +475,23 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       cy.findByRole("button", { name: "Visualize" }).should("be.visible");
     });
   });
+
+  it("should not show 'Question not found' error when rendered in StrictMode", () => {
+    cy.get<string>("@questionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />, {
+        strictMode: true,
+      });
+
+      getSdkRoot().within(() => {
+        cy.log("should not show the error message");
+        cy.findByText(
+          `Question ${questionId} not found. Make sure you pass the correct ID.`,
+        ).should("not.exist");
+
+        cy.log("should show the question's visualization");
+        cy.findByText("Product ID").should("be.visible");
+        cy.findByText("Max of Quantity").should("be.visible");
+      });
+    });
+  });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -476,7 +476,7 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     });
   });
 
-  it("should not show any sdk errors a question is rendered in strict mode", () => {
+  it("should not show any sdk error when showing a question in strict mode", () => {
     cy.get<string>("@questionId").then((questionId) => {
       mountSdkContent(<InteractiveQuestion questionId={questionId} />, {
         strictMode: true,

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -484,11 +484,12 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
 
       getSdkRoot().within(() => {
         H.assertElementNeverExists({
-          selector: "[data-testid='sdk-error-container']",
+          shouldNotExistSelector: "[data-testid='sdk-error-container']",
+          successSelector: "[data-testid='table-header']",
           rejectionMessage:
             "sdk errors should not show up when rendering an interactive question in strict mode",
           pollInterval: 20,
-          timeout: 500,
+          timeout: 15000,
         });
 
         cy.log("should show the question's visualization");

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -476,17 +476,20 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     });
   });
 
-  it("should not show 'Question not found' error when rendered in StrictMode", () => {
+  it("should not show any sdk errors a question is rendered in strict mode", () => {
     cy.get<string>("@questionId").then((questionId) => {
       mountSdkContent(<InteractiveQuestion questionId={questionId} />, {
         strictMode: true,
       });
 
       getSdkRoot().within(() => {
-        cy.log("should not show the error message");
-        cy.findByText(
-          `Question ${questionId} not found. Make sure you pass the correct ID.`,
-        ).should("not.exist");
+        H.assertElementNeverExists({
+          selector: "[data-testid='sdk-error-container']",
+          rejectionMessage:
+            "sdk errors should not show up when rendering an interactive question in strict mode",
+          pollInterval: 20,
+          timeout: 500,
+        });
 
         cy.log("should show the question's visualization");
         cy.findByText("Product ID").should("be.visible");

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
@@ -13,7 +13,7 @@ export const SdkError = ({ message }: SdkErrorComponentProps) => {
   const ErrorMessageComponent = CustomError || DefaultErrorMessage;
 
   return (
-    <Center h="100%" w="100%" mx="auto">
+    <Center h="100%" w="100%" mx="auto" data-testid="sdk-error-container">
       <ErrorMessageComponent message={message} />
     </Center>
   );

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-question.ts
@@ -16,6 +16,7 @@ import type {
 } from "embedding-sdk/types/question";
 import { type Deferred, defer } from "metabase/lib/promise";
 import type Question from "metabase-lib/v1/Question";
+import { isObject } from "metabase-types/guards";
 
 type LoadQuestionResult = Promise<
   SdkQuestionState & { originalQuestion?: Question }
@@ -111,6 +112,12 @@ export function useLoadQuestion({
       setIsQuestionLoading(false);
       return { ...results, originalQuestion };
     } catch (err) {
+      // Ignore cancelled requests (e.g. when the component unmounts).
+      // React simulates unmounting on strict mode, therefore "Question not found" will be shown without this.
+      if (isCancelledRequestError(err)) {
+        return {};
+      }
+
       mergeQuestionState({
         question: undefined,
         originalQuestion: undefined,
@@ -219,3 +226,6 @@ export const getParameterDependencyKey = (
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
     .map(([key, value]) => `${key}=${value}`)
     .join(":");
+
+const isCancelledRequestError = (error: unknown) =>
+  isObject(error) && "isCancelled" in error;

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-question.ts
@@ -228,4 +228,4 @@ export const getParameterDependencyKey = (
     .join(":");
 
 const isCancelledRequestError = (error: unknown) =>
-  isObject(error) && "isCancelled" in error;
+  isObject(error) && "isCancelled" in error && error.isCancelled === true;


### PR DESCRIPTION
Closes #57706
Closes EMB-379

### Description

When rendering an InteractiveQuestion on a strict mode tree, an error message "Question X is not found" is shown for a frame before disappearing. This is is caused by the request cancellation upon unmount in the `loadQuestionSdk/runQuestionQuerySdk` method, which is used in the `useLoadQuestion` sdk hook. When we are in a StrictMode tree, this gets triggered by React simulating [an extra cycle of mounting an unmounting](https://react.dev/reference/react/useEffect#caveats):

> When Strict Mode is on, React will run one extra development-only setup+cleanup cycle before the first real setup. This is a stress-test that ensures that your cleanup logic “mirrors” your setup logic and that it stops or undoes whatever the setup is doing. If this causes a problem, [implement the cleanup function.](https://react.dev/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development)

The fix is to not treat request cancellation as errors, so we only `setQuestionLoading(false)` in the case of legit errors.

### How to verify

- Render an `InteractiveQuestion` in a tree wrapped by `React.StrictMode`
- The "Question X is not found" should not flash.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
