### PR TITLE
[Backend modularization] Move `metabase.util.ssh` into `driver`

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -538,16 +538,17 @@
   metabase.driver.mongo.connection/with-mongo-database                                  clojure.core/let
   metabase.driver.mongo.query-processor/mongo-let                                       clojure.core/let
   metabase.driver.sql-jdbc.actions/with-jdbc-transaction                                clojure.core/let
+  metabase.driver.sql-jdbc.connection.ssh-tunnel/with-ssh-tunnel                        clojure.core/let
   metabase.driver.sql-jdbc.connection/with-connection-spec-for-testing-connection       clojure.core/let
   metabase.driver.sql-jdbc.execute.diagnostic/capturing-diagnostic-info                 clojure.core/fn
   metabase.models.json-migration/def-json-migration                                     clj-kondo.lint-as/def-catch-all
   metabase.models.util.spec-update/define-spec                                          clojure.core/def
-  metabase.notification.test-util/with-temp-notification                                clojure.core/let
   metabase.notification.test-util/with-card-notification                                clojure.core/let
   metabase.notification.test-util/with-system-event-notification!                       clojure.core/let
+  metabase.notification.test-util/with-temp-notification                                clojure.core/let
   metabase.premium-features.core/defenterprise-schema                                   clj-kondo.lint-as/def-catch-all
-  metabase.premium-features.settings/define-premium-feature                             clojure.core/def
   metabase.premium-features.defenterprise/defenterprise-schema                          clj-kondo.lint-as/def-catch-all
+  metabase.premium-features.settings/define-premium-feature                             clojure.core/def
   metabase.pulse.send-test/with-pulse-for-card                                          clojure.core/let
   metabase.query-processor-test.pipeline-queries-test/pmbql-query                       clojure.core/->
   metabase.query-processor-test.pipeline-queries-test/run-pmbql-query                   clojure.core/->
@@ -556,10 +557,10 @@
   metabase.query-processor.middleware.process-userland-query-test/with-query-execution! clojure.core/let
   metabase.query-processor.setup/with-qp-setup                                          clojure.core/let
   metabase.search.api-test/do-test-users                                                clojure.core/let
-  metabase.settings.core/defsetting                                                     clj-kondo.lint-as/def-catch-all
   metabase.settings.core/define-multi-setting                                           clojure.core/def
-  metabase.settings.models.setting/defsetting                                           clj-kondo.lint-as/def-catch-all
+  metabase.settings.core/defsetting                                                     clj-kondo.lint-as/def-catch-all
   metabase.settings.models.setting.multi-setting/define-multi-setting                   clojure.core/def
+  metabase.settings.models.setting/defsetting                                           clj-kondo.lint-as/def-catch-all
   metabase.sso.ldap/with-ldap-connection                                                clojure.core/fn
   metabase.sync.util/sum-for                                                            clojure.core/for
   metabase.sync.util/with-emoji-progress-bar                                            clojure.core/let
@@ -567,6 +568,7 @@
   metabase.task.impl/defjob                                                             clojure.core/defn
   metabase.test.data.interface/defdataset                                               clojure.core/def
   metabase.test.data.interface/defdataset-edn                                           clojure.core/def
+  metabase.test.gentest/defgentest                                                      clojure.test/deftest
   metabase.test/defdataset                                                              clojure.core/def
   metabase.test/let-url                                                                 clojure.core/let
   metabase.test/with-actions                                                            clojure.core/let
@@ -577,9 +579,7 @@
   metabase.test/with-temp-empty-app-db                                                  clojure.core/let
   metabase.test/with-temp-file                                                          clojure.core/let
   metabase.test/with-user-in-groups                                                     clojure.core/let
-  metabase.test.gentest/defgentest                                                      clojure.test/deftest
   metabase.upload.impl-test/with-upload-table!                                          clojure.core/let
-  metabase.util/with-timer-ms                                                           clojure.core/fn
   metabase.util.files/with-open-path-to-resource                                        clojure.core/let
   metabase.util.malli.defn/defn                                                         schema.core/defn
   metabase.util.malli.defn/defn-                                                        schema.core/defn
@@ -589,7 +589,7 @@
   metabase.util.malli/defn-                                                             schema.core/defn
   metabase.util.malli/fn                                                                schema.core/fn
   metabase.util.namespaces/import-fns                                                   potemkin/import-vars
-  metabase.util.ssh/with-ssh-tunnel                                                     clojure.core/let
+  metabase.util/with-timer-ms                                                           clojure.core/fn
   metabase.xrays.domain-entities.malli/defn                                             schema.core/defn
   metabuild-common.core/with-open-jar-file-system                                       clojure.core/let
   metabuild-common.files/with-open-jar-file-system                                      clojure.core/let

--- a/.clj-kondo/config/test-helpers/config.edn
+++ b/.clj-kondo/config/test-helpers/config.edn
@@ -65,6 +65,8 @@
      metabase.driver.postgres-test/drop-if-exists-and-create-db!
      metabase.driver.sql-jdbc.execute/execute-statement!
      metabase.indexed-entities.models.model-index/add-values!
+     metabase.driver.sql-jdbc.connection.ssh-tunnel-test/start-mock-servers!
+     metabase.driver.sql-jdbc.connection.ssh-tunnel-test/stop-mock-servers!
      metabase.indexed-entities.task.index-values/job-init!
      metabase.model-persistence.models.persisted-info/ready-database!
      metabase.model-persistence.task.persist-refresh/job-init!
@@ -101,7 +103,6 @@
      metabase.sync.core/sync-database!
      metabase.sync.sync-metadata.fields.sync-metadata/update-field-metadata-if-needed!
      metabase.sync.sync-metadata/sync-db-metadata!
-     metabase.warehouse-schema.models.field-values/create-or-update-full-field-values!
      metabase.sync.util-test/sync-database!
      metabase.sync.util/store-sync-summary!
      metabase.task.core/delete-task!
@@ -129,5 +130,4 @@
      metabase.test/with-temp-env-var-value!
      metabase.upload.impl-test/set-local-infile!
      metabase.util.files/create-dir-if-not-exists!
-     metabase.util.ssh-test/start-mock-servers!
-     metabase.util.ssh-test/stop-mock-servers!}}}}
+     metabase.warehouse-schema.models.field-values/create-or-update-full-field-values!}}}}

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -50,6 +50,8 @@ title: Driver interface changelog
 - `metabase.db.metadata-queries` has been removed; the parts meant for usage by drivers have been moved to
   `metabase.driver.common.table-rows-sample`.
 
+- `metabase.util.ssh` has been moved to `metabase.driver.sql-jdbc.connection.ssh-tunnel`.
+
 ## Metabase 0.54.0
 
 - Added the multi-method `allowed-promotions` that allows driver control over which column type promotions are supported for uploads.

--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -7,9 +7,9 @@
    [metabase.driver.druid.execute :as druid.execute]
    [metabase.driver.druid.query-processor :as druid.qp]
    [metabase.driver.druid.sync :as druid.sync]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.query-processor.pipeline :as qp.pipeline]
-   [metabase.util.json :as json]
-   [metabase.util.ssh :as ssh]))
+   [metabase.util.json :as json]))
 
 (driver/register! :druid)
 

--- a/modules/drivers/druid/src/metabase/driver/druid/client.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/client.clj
@@ -2,13 +2,13 @@
   (:require
    [clj-http.client :as http]
    [clojure.core.async :as a]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.secrets.core :as secret]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
-   [metabase.util.log :as log]
-   [metabase.util.ssh :as ssh]))
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 

--- a/modules/drivers/druid/src/metabase/driver/druid/sync.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/sync.clj
@@ -2,8 +2,8 @@
   (:require
    [medley.core :as m]
    [metabase.driver.druid.client :as druid.client]
-   [metabase.secrets.core :as secret]
-   [metabase.util.ssh :as ssh]))
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
+   [metabase.secrets.core :as secret]))
 
 (defn- do-segment-metadata-query [details datasource]
   {:pre [(map? details) (string? datasource)]}

--- a/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
@@ -5,10 +5,10 @@
    [metabase.config :as config]
    [metabase.driver.mongo.database :as mongo.db]
    [metabase.driver.mongo.util :as mongo.util]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
-   [metabase.util.log :as log]
-   [metabase.util.ssh :as ssh])
+   [metabase.util.log :as log])
   (:import
    (com.mongodb ConnectionString MongoClientSettings MongoClientSettings$Builder MongoCredential)
    (com.mongodb.connection SslSettings$Builder)))

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -12,6 +12,7 @@
    [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.common :as sql-jdbc.sync.common]
@@ -26,8 +27,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]
-   [metabase.util.ssh :as ssh])
+   [metabase.util.malli.registry :as mr])
   (:import
    (com.mchange.v2.c3p0 C3P0ProxyConnection)
    (java.security KeyStore)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1034,7 +1034,7 @@
 
   WARNING! Implementations of this method may create new SSH tunnels, which need to be cleaned up. DO NOT USE THIS
   METHOD DIRECTLY UNLESS YOU ARE GOING TO BE CLEANING UP ANY CREATED TUNNELS! Instead, you probably want to
-  use [[metabase.util.ssh/with-ssh-tunnel]]. See #24445 for more information."
+  use [[metabase.driver.sql-jdbc.connection.ssh-tunnel/with-ssh-tunnel]]. See #24445 for more information."
   {:added "0.39.0" :arglists '([driver db-details])}
   dispatch-on-uninitialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -11,6 +11,7 @@
    [metabase.driver.h2.actions :as h2.actions]
    [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
@@ -21,8 +22,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]
-   [metabase.util.ssh :as ssh])
+   [metabase.util.malli :as mu])
   (:import
    (java.sql Clob ResultSet ResultSetMetaData SQLException)
    (java.time OffsetTime)

--- a/src/metabase/driver/init.clj
+++ b/src/metabase/driver/init.clj
@@ -8,4 +8,7 @@
    ;; Load up the drivers shipped as part of the main codebase, so they will show up in the list of available DB types
    [metabase.driver.h2]
    [metabase.driver.mysql]
-   [metabase.driver.postgres]))
+   [metabase.driver.postgres]
+   [metabase.driver.settings]
+   ;; for the `:sql-jdbc` implementation of [[metabase.driver/incorporate-ssh-tunnel-details]]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel]))

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -1,0 +1,11 @@
+(ns metabase.driver.settings
+  (:require
+   [metabase.settings.core :refer [defsetting]]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(defsetting ssh-heartbeat-interval-sec
+  (deferred-tru "Controls how often the heartbeats are sent when an SSH tunnel is established (in seconds).")
+  :visibility :public
+  :type       :integer
+  :default    180
+  :audit      :getter)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -8,6 +8,7 @@
    [metabase.database-routing.core :as database-routing]
    [metabase.db :as mdb]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
@@ -20,7 +21,6 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.ssh :as ssh]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/test/metabase/driver/sql_jdbc/connection/ssh_tunnel_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection/ssh_tunnel_test.clj
@@ -1,10 +1,10 @@
-(ns metabase.util.ssh-test
+(ns metabase.driver.sql-jdbc.connection.ssh-tunnel-test
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
    [metabase.util :as u]
-   [metabase.util.log :as log]
-   [metabase.util.ssh :as ssh])
+   [metabase.util.log :as log])
   (:import
    (java.io BufferedReader InputStreamReader PrintWriter)
    (java.net InetSocketAddress ServerSocket Socket)

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -10,6 +10,8 @@
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel-test :as ssh-test]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]
    [metabase.driver.util :as driver.u]
@@ -23,8 +25,6 @@
    [metabase.test.util :as tu]
    [metabase.util :as u]
    [metabase.util.http :as u.http]
-   [metabase.util.ssh :as ssh]
-   [metabase.util.ssh-test :as ssh-test]
    [next.jdbc :as next.jdbc]
    [toucan2.core :as t2])
   (:import


### PR DESCRIPTION
Resolves DEV-535

This "util" namespace was only used by the `:sql-jdbc` driver so it's appropriate to move it there. This removes part of the  dependency of `util` (and thus everything else) on `driver`