### PR TITLE
key prefixes must be unique, but they weren't

### DIFF
--- a/mage/jar_download_config.yml
+++ b/mage/jar_download_config.yml
@@ -15,8 +15,8 @@ config:
     - name: "Admin API key"
       group: admin
       creator: crowberto@metabase.com
-      key: mb_theadminapikey
+      key: mb_adminapikey
     - name: "All Users API key"
       group: all-users
       creator: crowberto@metabase.com
-      key: mb_theallusersapikey
+      key: mb_userapikey

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -118,7 +118,7 @@
                                :latest-version latest-version})))
       (let [port        (+ 3000 (major-version latest-version))
             socket-port (+ 3000 port)
-            db-file     (str "metabase_" version ".db")
+            db-file     (str u/project-root-directory "/metabase_" version ".db")
             extra-env   {"MB_DB_TYPE"          "h2"
                          "MB_DB_FILE"          db-file
                          "MB_JETTY_PORT"       port


### PR DESCRIPTION
- change the api keys that get auto-injected from config.yml when running jars via e.g. `./bin/mage jar-download 52 -r` to have unique prefixes
