### PR TITLE
[Backend modularization] add tests to make sure we have requires

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1445,7 +1445,8 @@
            enterprise/sso}}
 
   enterprise/gsheets
-  {:api  #{metabase-enterprise.gsheets.api}
+  {:api  #{metabase-enterprise.gsheets.api
+           metabase-enterprise.gsheets.init}
    :uses #{api
            analytics
            premium-features
@@ -1478,7 +1479,8 @@
            settings}}
 
   enterprise/llm
-  {:api  #{metabase-enterprise.llm.api}
+  {:api  #{metabase-enterprise.llm.api
+           metabase-enterprise.llm.init}
    :uses #{analytics
            analyze
            api

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -9,5 +9,7 @@
    [metabase-enterprise.advanced-config.init]
    [metabase-enterprise.cache.init]
    [metabase-enterprise.enhancements.init]
+   [metabase-enterprise.gsheets.init]
+   [metabase-enterprise.llm.init]
    [metabase-enterprise.scim.init]
    [metabase-enterprise.stale.init]))

--- a/enterprise/backend/src/metabase_enterprise/gsheets/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets/init.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.gsheets.init
+  (:require
+   [metabase-enterprise.gsheets.settings]))

--- a/enterprise/backend/src/metabase_enterprise/llm/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/init.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.llm.init
+  (:require
+   [metabase-enterprise.llm.settings]))

--- a/test/metabase/core/init_test.clj
+++ b/test/metabase/core/init_test.clj
@@ -19,7 +19,7 @@
         (ns.find/find-namespaces (classpath/system-classpath))))
 
 (mu/defn- ns->file :- [:maybe (ms/InstanceOfClass java.net.URL)]
- ^java.net.URL [ns-symb :- simple-symbol?]
+  ^java.net.URL [ns-symb :- simple-symbol?]
   (let [filename (-> ns-symb
                      (str/replace #"\." "/")
                      (str/replace #"-" "_"))]

--- a/test/metabase/core/init_test.clj
+++ b/test/metabase/core/init_test.clj
@@ -1,0 +1,74 @@
+(ns metabase.core.init-test
+  (:require
+   [clojure.java.classpath :as classpath]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [clojure.tools.namespace.file :as ns.file]
+   [clojure.tools.namespace.find :as ns.find]
+   [clojure.tools.namespace.parse :as ns.parse]
+   [metabase.config :as config]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]))
+
+(mu/defn- init-namespaces :- [:set simple-symbol?]
+  []
+  (into (sorted-set)
+        (filter (fn [ns-symb]
+                  (re-matches #"^metabase(?:-enterprise)?\.(?!core)[^.]+\.init$" (str ns-symb))))
+        (ns.find/find-namespaces (classpath/system-classpath))))
+
+(mu/defn- ns->file :- [:maybe (ms/InstanceOfClass java.net.URL)]
+ ^java.net.URL [ns-symb :- simple-symbol?]
+  (let [filename (-> ns-symb
+                     (str/replace #"\." "/")
+                     (str/replace #"-" "_"))]
+    (some (fn [extension]
+            (io/resource (str filename extension)))
+          [".clj" ".cljc" ".cljs"])))
+
+(mu/defn ns-requires :- [:maybe [:set simple-symbol?]]
+  "Get the set of namespace symbols required by a namespace in its `ns` form."
+  [ns-symb :- simple-symbol?]
+  (when-let [file (ns->file ns-symb)]
+    (let [decl        (ns.file/read-file-ns-decl file)
+          static-deps (ns.parse/deps-from-ns-decl decl)]
+      (into (sorted-set) static-deps))))
+
+(deftest ^:parallel core-init-should-require-all-init-namespaces-test
+  (let [init-namespaces        (init-namespaces)
+        oss-core-init-requires (ns-requires 'metabase.core.init)
+        ee-core-init-requires  (when config/ee-available?
+                                 (ns-requires 'metabase-enterprise.core.init))]
+    (doseq [init-namespace init-namespaces
+            :let           [core-init-namespace (if (str/starts-with? init-namespace "metabase.")
+                                                  'metabase.core.init
+                                                  'metabase-enterprise.core.init)
+                            core-init-requires  (if (str/starts-with? init-namespace "metabase.")
+                                                  oss-core-init-requires
+                                                  ee-core-init-requires)]]
+      (testing (format "%s should require %s" core-init-namespace init-namespace)
+        (is (contains? core-init-requires init-namespace))))))
+
+(mu/defn settings-namespaces :- [:set simple-symbol?]
+  "Get the set of module settings namespaces starting with `ns-prefix` e.g. `\"metabase.\"`."
+  []
+  (into (sorted-set)
+        (filter (fn [ns-symb]
+                  (re-matches #"^metabase(?:-enterprise)?\.(?!core)[^.]+\.settings$" (str ns-symb))))
+        (ns.find/find-namespaces (classpath/system-classpath))))
+
+(mu/defn settings-namespace->init-namespace :- simple-symbol?
+  "Get the `.init` namespace that should require a `.settings` namespace
+
+    (settings-namespace->init-namespace 'metabase.query-processor.settings) => 'metabase.query-processor.init"
+  [ns-symb :- simple-symbol?]
+  (symbol (str/replace ns-symb #"\.settings$" ".init")))
+
+(deftest ^:parallel settings-namespaces-should-be-required-by-init-namespaces-test
+  (let [settings-namespaces (settings-namespaces)]
+    (doseq [settings-namespace settings-namespaces
+            :let               [init-namespace (settings-namespace->init-namespace settings-namespace)
+                                init-requires  (ns-requires init-namespace)]]
+      (testing (format "%s should require %s" init-namespace settings-namespace)
+        (is (contains? init-requires settings-namespace))))))


### PR DESCRIPTION
Add tests to make sure all module `.settings` namespaces are required by `.init` and all `.init` namespaces are required by the correct `core.init` namespaces

Resolves DEV-491
Resolves DEV-492