### PR TITLE
Update colors in Card component

### DIFF
--- a/frontend/src/metabase/components/Card/Card.tsx
+++ b/frontend/src/metabase/components/Card/Card.tsx
@@ -21,7 +21,7 @@ const Card = styled.div<CardProps>`
   border: 1px solid
     ${(props) => (props.dark ? "transparent" : "var(--mb-color-border)")};
   ${(props) => props.dark && `color: white`};
-  border-radius: 8px;
+  border-radius: var(--mantine-radius-md);
   box-shadow: 0 7px 20px var(--mb-color-shadow);
   line-height: 24px;
   ${({ hoverable, theme }) =>

--- a/frontend/src/metabase/components/Card/Card.tsx
+++ b/frontend/src/metabase/components/Card/Card.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { alpha, color } from "metabase/lib/colors";
+import { alpha } from "metabase/lib/colors";
 
 type CardProps = {
   className?: string;
@@ -15,11 +15,13 @@ type CardProps = {
 
 const Card = styled.div<CardProps>`
   background-color: ${(props) =>
-    props.dark ? color("text-dark") : color("bg-white")};
+    props.dark
+      ? "var(--mb-color-background-inverse)"
+      : "var(--mb-color-background)"};
   border: 1px solid
-    ${(props) => (props.dark ? "transparent" : "var(--mb-color-bg-medium)")};
+    ${(props) => (props.dark ? "transparent" : "var(--mb-color-border)")};
   ${(props) => props.dark && `color: white`};
-  border-radius: 6px;
+  border-radius: 8px;
   box-shadow: 0 7px 20px var(--mb-color-shadow);
   line-height: 24px;
   ${({ hoverable, theme }) =>


### PR DESCRIPTION
### Description
- Updates Card to use semantic colors, including our new dark bg color, `background-inverse`. This mostly makes the toast and collectionbulkactions components use the new dark color, which will make sure they match when a different upgrade to the toast component @romeovs is making merges.
- Also makes cards use our standard 8px border-radius instead of non-standard 6px.

### How to verify

- Click on a checkbox in a collection to see the bulk actions thing.
- Try making a change to something in Table Metadata in Admin to see the toast component.

### Demo

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/08ef3488-6776-45d8-9a38-12119399f508" />

