### PR TITLE
[DRAFT] feat: Add newline to text formatting options

### DIFF
--- a/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.module.css
+++ b/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.module.css
@@ -14,6 +14,10 @@
   overflow: visible;
 }
 
+.formatNewlines {
+  white-space: pre-wrap;
+}
+
 .noWrap {
   white-space: nowrap;
   overflow: hidden;

--- a/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.tsx
+++ b/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type React from "react";
+import React from "react";
 import { type MouseEventHandler, memo, useCallback, useMemo } from "react";
 
 import { BaseCell } from "metabase/data-grid/components/BaseCell/BaseCell";
@@ -23,6 +23,7 @@ export const BodyCell = memo(function BodyCell<TValue>({
   align = "left",
   variant = "text",
   wrap = false,
+  formatNewlines = false,
   canExpand = false,
   columnId,
   rowIndex,
@@ -78,10 +79,18 @@ export const BodyCell = memo(function BodyCell<TValue>({
           data-grid-cell-content
           className={cx(S.content, {
             [S.noWrap]: !wrap,
+            [S.formatNewlines]: formatNewlines,
           })}
           data-testid={contentTestId}
         >
-          {formattedValue}
+          {formatNewlines && typeof formattedValue === "string"
+            ? formattedValue.split("\n").map((line, i) => (
+                <React.Fragment key={i}>
+                  {i > 0 && <br />}
+                  {line}
+                </React.Fragment>
+              ))
+            : formattedValue}
         </div>
       ) : null}
 

--- a/frontend/src/metabase/data-grid/types.ts
+++ b/frontend/src/metabase/data-grid/types.ts
@@ -20,6 +20,7 @@ declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData, TValue> {
     wrap?: boolean;
+    formatNewlines?: boolean;
     enableReordering?: boolean;
     enableSelection?: boolean;
     headerClickTargetSelector?: string;
@@ -38,6 +39,7 @@ export type BodyCellBaseProps<TValue> = {
   backgroundColor?: string;
   align?: CellAlign;
   wrap?: boolean;
+  formatNewlines?: boolean;
   canExpand?: boolean;
   columnId: string;
   rowIndex: number;
@@ -88,6 +90,9 @@ export interface ColumnOptions<TRow extends RowData, TValue = unknown> {
 
   /** Whether text should wrap in this column */
   wrap?: boolean;
+
+  /** Whether to format newlines in text */
+  formatNewlines?: boolean;
 
   /** Initial sort direction for this column */
   sortDirection?: "asc" | "desc";

--- a/frontend/src/metabase/data-grid/utils/columns/data-column.tsx
+++ b/frontend/src/metabase/data-grid/utils/columns/data-column.tsx
@@ -22,6 +22,7 @@ const getDefaultCellTemplate = <TRow, TValue>(
     formatter,
     cellVariant,
     wrap,
+    formatNewlines,
     getCellClassName,
     getCellStyle,
   }: ColumnOptions<TRow, TValue>,
@@ -49,6 +50,7 @@ const getDefaultCellTemplate = <TRow, TValue>(
         onExpand={onExpand}
         variant={cellVariant}
         wrap={wrap}
+        formatNewlines={formatNewlines}
         className={getCellClassName?.(value, row.index)}
         style={getCellStyle?.(value, row.index)}
       />
@@ -82,8 +84,15 @@ export const getDataColumn = <TRow, TValue>(
   truncateWidth: number,
   onExpand: (columnName: string, content: React.ReactNode) => void,
 ): ColumnDef<TRow, TValue> => {
-  const { id, accessorFn, wrap, cell, header, headerClickTargetSelector } =
-    columnOptions;
+  const {
+    id,
+    accessorFn,
+    wrap,
+    formatNewlines,
+    cell,
+    header,
+    headerClickTargetSelector,
+  } = columnOptions;
   const columnWidth = columnSizing[id] ?? 0;
   const measuredColumnWidth = measuredColumnSizing[id] ?? 0;
 
@@ -110,6 +119,7 @@ export const getDataColumn = <TRow, TValue>(
     enableResizing: true,
     meta: {
       wrap,
+      formatNewlines,
       enableReordering: true,
       enableSelection: true,
       headerClickTargetSelector,

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -424,6 +424,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
       const wrap =
         !settings["table.pagination"] &&
         Boolean(columnSettings["text_wrapping"]);
+      const formatNewlines = Boolean(columnSettings["format_newlines"]);
       const isMinibar = columnSettings["show_mini_bar"];
       const cellVariant = getBodyCellVariant(col);
       const isImage = columnSettings["view_as"] === "image";
@@ -491,6 +492,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
         headerClickTargetSelector: "[data-header-click-target]",
         align,
         wrap,
+        formatNewlines,
         sortDirection,
         enableResizing: true,
         getBackgroundColor,

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -292,6 +292,19 @@ class Table extends Component<TableProps, TableState> {
           return !canWrapText(columnSettings);
         },
       };
+
+      settings["format_newlines"] = {
+        title: t`Format newlines`,
+        default: false,
+        widget: "toggle",
+        inline: true,
+        isValid: (_column, columnSettings) => {
+          return canWrapText(columnSettings);
+        },
+        getHidden: (_column, columnSettings) => {
+          return !canWrapText(columnSettings);
+        },
+      };
     }
 
     let defaultValue = !column.semantic_type || isURL(column) ? "link" : null;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56542 (Maybe?)

### Description

To be able to display LLM outputs in Metabase, i'd like to display newlines, wrapping text was a nice improvement, but it's still quite hard to read. With Snowflake allowing us to run LLM inside Metabase, it's such a waste we can't properly leverage this without building a separate App.

I open this PR as a draft/PoC to see if it's interesting enough, it doesn't have tests, and it doesn't yet force the users to pick wrap text when this is selected. Not sure if this should be the default behavior with Wrap text either; i'd like to propose this as an MVP of what we can do, if there's some minimal change we can do to make it work let me know, otherwise just close it and consider it an idea that someone considers useful; we'll use our own fork with this semi-working feature in the meantime.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New sql question -> write `select STRINGDECODE(listagg(body, '\n\n'))  as body from feedback`
2. Choose "Format newlines" from the column options

### Demo

![image](https://github.com/user-attachments/assets/c01894b8-eb41-431b-94ec-a22b0527ea12)
![image](https://github.com/user-attachments/assets/0a60d15a-60f3-4330-a6ec-a455e917409b)


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
