### PR TITLE
API key creation modal alawys shows error after selecting group

### DIFF
--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
@@ -104,6 +104,12 @@ describe("ManageApiKeys", () => {
     await userEvent.click(await screen.findByLabelText(/which group/i));
     await userEvent.click(await screen.findByText("flamingos"));
 
+    // Blur the select
+    await userEvent.click(await screen.findByText(/We don't version/));
+    expect(
+      await screen.findByRole("textbox", { name: /which group/i }),
+    ).not.toHaveAttribute("data-error");
+
     const createButton = screen.getByRole("button", { name: "Create" });
     await waitFor(() => expect(createButton).toBeEnabled());
     await userEvent.click(createButton);

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/utils.ts
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/utils.ts
@@ -11,7 +11,7 @@ export const API_KEY_VALIDATION_SCHEMA = Yup.object({
   name: Yup.string().required(),
   group_id: Yup.number()
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    .typeError(t`Select a group`)
+    .typeError(t`Group is a required field`)
     .required(),
 });
 

--- a/frontend/src/metabase/forms/components/FormGroupWidget/FormGroupWidget.tsx
+++ b/frontend/src/metabase/forms/components/FormGroupWidget/FormGroupWidget.tsx
@@ -56,7 +56,7 @@ export const FormGroupWidget = forwardRef(function FormGroupWidget(
       ref={ref}
       name={name}
       value={value == null ? undefined : String(value)}
-      error={touched ? <div role="alert">{error}</div> : null}
+      error={touched && error ? <div role="alert">{error}</div> : null}
       data={groupOptions}
       onChange={handleChange}
       onBlur={handleBlur}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52520

### Description
<FormGroupWidget> would always pass a truthy value after `touched` was true. This updates it to be truthy when `touched && error`. This change also changes the error text

### How to verify
1. Admin -> authentication -> api keys
2. Select a group
3. The select should not be red after blurring the inpuy

### Demo
<img width="506" alt="image" src="https://github.com/user-attachments/assets/af639eab-7d20-4d19-959c-fde41ae1af2a" />
<img width="560" alt="image" src="https://github.com/user-attachments/assets/dc42f3af-0fa1-428d-947f-7f37196517e7" />

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
