### PR TITLE
WRK-415, WRK-416: Minor fixes for custom templates

### DIFF
--- a/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
+++ b/e2e/test/scenarios/data-editing/e2e-helpers/notification-helpers.ts
@@ -10,11 +10,6 @@ type Interception = {
   };
 };
 
-/**
- * Fills in the custom template fields with the provided subject and body
- * @param subject The subject template to use
- * @param body The body template to use
- */
 export const fillInCustomTemplate = (subject: string, body: string) => {
   cy.findByTestId("email-template-subject")
     .find(".cm-content")
@@ -54,13 +49,7 @@ export const fillInCustomTemplate = (subject: string, body: string) => {
     });
 };
 
-/**
- * Verifies that the notification was created with the expected custom template
- * @param response The intercepted response from the notification creation request
- * @param expectedSubject The expected subject template
- * @param expectedBody The expected body template
- */
-export const verifyNotificationTemplate = (
+export const verifyNotificationTemplateResponse = (
   response: Interception,
   expectedSubject: string,
   expectedBody: string,
@@ -73,20 +62,12 @@ export const verifyNotificationTemplate = (
   expect(stringifiedTemplate).to.contain(expectedBody);
 };
 
-/**
- * Creates a notification with a custom template
- * @param eventName The name of the event to select (e.g., "when new records are created")
- * @param subject The subject template to use
- * @param body The body template to use
- */
 export const createNotificationWithCustomTemplate = (
   eventName: string | RegExp,
   subject: string,
   body: string,
 ) => {
-  // Open the notification creation modal
   cy.findByTestId("table-notification-create").within(() => {
-    // Select the event type
     cy.findByTestId("notification-event-select").click();
     cy.document()
       .findByRole("option", {
@@ -94,10 +75,8 @@ export const createNotificationWithCustomTemplate = (
       })
       .click();
 
-    // Fill in the custom templates
     fillInCustomTemplate(subject, body);
 
-    // Submit the form
     cy.findByRole("button", { name: "Done" }).click();
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewTemplatePanel/PreviewTemplatePanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/components/PreviewTemplatePanel/PreviewTemplatePanel.tsx
@@ -65,12 +65,7 @@ export const PreviewTemplatePanel = ({
           </Flex>
         )}
         {error && (
-          <Text c="error">
-            {t`Error during generation of template preview. Check your template.
-            We will provide better error messages soon 🙏.`}
-            {/* TODO: Un-comment this line when BE return human-readable error without stack trace */}
-            {/* {JSON.stringify(error)} */}
-          </Text>
+          <code style={{ color: "var(--mb-color-error)" }}>{error}</code>
         )}
         {previewContent && !error ? (
           <Stack className={S.previewStack}>

--- a/frontend/src/metabase/api/notification.ts
+++ b/frontend/src/metabase/api/notification.ts
@@ -151,6 +151,9 @@ export const notificationApi = Api.injectEndpoints({
         url: "/api/notification/preview_template",
         body,
       }),
+      transformErrorResponse: (response: { data: string }) => {
+        return response.data;
+      },
     }),
   }),
 });

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableFilters.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableFilters.tsx
@@ -61,7 +61,7 @@ export function ConfigureEditableTableFilters({
   };
 
   if (!query) {
-    return <div>ERROR: no query</div>;
+    return <div>{t`ERROR: no query`}</div>;
   }
 
   return (

--- a/frontend/src/metabase/notifications/modals/shared/components/HandlersInfo.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/HandlersInfo.tsx
@@ -101,7 +101,9 @@ const formatEmailHandlerInfo = (
 };
 
 const formatSlackHandlerInfo = (handler: NotificationHandlerSlack) => {
-  return handler.recipients[0]?.details.value;
+  return handler.recipients
+    .map((recipient) => recipient.details.value)
+    .join(", ");
 };
 
 const formatHttpHandlersInfo = (


### PR DESCRIPTION
Closes [WRK-415](https://linear.app/metabase/issue/WRK-415/fix-display-of-multiple-slack-channels-in-notification-list-items), [WRK-416](https://linear.app/metabase/issue/WRK-416/add-template-preview-error-message-output)

**Display all configured slack channels in alerts list**

<img width="569" alt="image" src="https://github.com/user-attachments/assets/cb8cacc0-22b5-4bb0-aa7a-28b8caba6839" />


**Display server error if template preview request fails**

<img width="465" alt="image" src="https://github.com/user-attachments/assets/5c9ff248-44e5-4dba-96f3-1c269bd54025" />

Also, minor lint fix, added e2e test for preview error display.