### PR TITLE
Make sure dashcard parameter mappings have valid targets

### DIFF
--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -53,7 +53,7 @@
       (select-keys final-col [:id :ident :description :display_name :semantic_type :fk_target_field_id
                               :settings :field_ref :base_type :effective_type :database_type
                               :remapped_from :remapped_to :coercion_strategy :visibility_type
-                              :was_binned])
+                              :was_binned :table_id])
       insights-col
       {:name (:name final-col)} ; The final cols have correctly disambiguated ID_2 names, but the insights cols don't.
       (when (= our-base-type :type/*)


### PR DESCRIPTION
Fixes #58214

### Description

Preserve `table_id` in `results_metadata` when running cards.

### How to verify

The repro steps from #58214 should not lead to an error.

### Demo

After the fix the X-ray dashboard should look like this:
<img width="985" alt="image" src="https://github.com/user-attachments/assets/993bdc84-756f-45a4-93f6-0e0d5ad8e5d3" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
