### PR TITLE
fix: editable table should not display visualize another way option

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -9,6 +9,7 @@ import { Box, Icon } from "metabase/ui";
 import { getVisualizationRaw } from "metabase/visualizations";
 import {
   isVisualizerDashboardCard,
+  isVisualizerDisabledVisualizeAnotherWay,
   isVisualizerSupportedVisualization,
 } from "metabase/visualizer/utils";
 import type {
@@ -196,7 +197,8 @@ function DashCardActionsPanelInner({
       dashcard &&
       !isVisualizerDashboardCard(dashcard) &&
       !isVisualizerSupportedVisualization(dashcard?.card.display) &&
-      !isVirtualDashCard(dashcard)
+      !isVirtualDashCard(dashcard) &&
+      !isVisualizerDisabledVisualizeAnotherWay(dashcard?.card.display)
     ) {
       buttons.push(
         <DashCardActionButton

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -314,6 +314,7 @@ export type VisualizationDefinition = {
   supportPreviewing?: boolean;
   supportsSeries?: boolean;
   supportsVisualizer?: boolean;
+  disableVisualizeAnotherWay?: boolean;
   disableReplaceCard?: boolean;
   disableNavigateToNewCardFromDashboard?: boolean;
 

--- a/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
@@ -33,6 +33,7 @@ export class TableEditable extends Component<
   static supportsSeries = false;
   static disableReplaceCard = true;
   static disableSettingsConfig = true;
+  static disableVisualizeAnotherWay = true;
   static disableNavigateToNewCardFromDashboard = true;
   static noHeader = true;
   static noResults = true;

--- a/frontend/src/metabase/visualizer/utils/dashboard-card-supports-visualizer.ts
+++ b/frontend/src/metabase/visualizer/utils/dashboard-card-supports-visualizer.ts
@@ -24,3 +24,13 @@ export function isVisualizerSupportedVisualization(
 
   return visualizations.get(display)?.supportsVisualizer;
 }
+
+export function isVisualizerDisabledVisualizeAnotherWay(
+  display: VisualizationDisplay | null | undefined,
+) {
+  if (!display) {
+    return false;
+  }
+
+  return visualizations.get(display)?.disableVisualizeAnotherWay;
+}


### PR DESCRIPTION
Resolves [WRK-389](https://linear.app/metabase/issue/WRK-389/editable-menu-should-not-display-visualize-another-way-option)

![image](https://github.com/user-attachments/assets/3b3445a0-cc2f-44ad-8e7f-1a400eb73d0c)
