### PR TITLE
Fix race condition in sync, causing failure if a table gets deleted inbetween steps

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -52,6 +52,12 @@ title: Driver interface changelog
 
 - `metabase.util.ssh` has been moved to `metabase.driver.sql-jdbc.connection.ssh-tunnel`.
 
+## Metabase 0.54.10
+
+- Add `metabase.driver/table-known-to-not-exist?` for drivers to test if an exception is due to a query on a table that no longer exists
+- Add `metabase.driver.sql-jdbc/impl-table-known-to-not-exist?` for JDBC drivers. This is the implemenation of table-known-to-not-exist for jdbc and allows testing directly against `java.sql.SQLException` throwables without worrying about the exception cause chain.
+
+
 ## Metabase 0.54.0
 
 - Added the multi-method `allowed-promotions` that allows driver control over which column type promotions are supported for uploads.

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -20,7 +20,8 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.log :as log])
-  (:import  [com.clickhouse.client.api.query QuerySettings]))
+  (:import  [com.clickhouse.client.api.query QuerySettings]
+            [java.sql SQLException]))
 
 (set! *warn-on-reflection* true)
 
@@ -290,3 +291,8 @@
 (defmethod driver.sql/default-database-role :clickhouse
   [_ _]
   "NONE")
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :clickhouse
+  [_ ^SQLException e]
+  ;; the clickhouse driver doesn't set ErrorCode, we must parse it from the message
+  (str/starts-with? (.getMessage e) "Code: 60."))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -11,11 +11,9 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
-   [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.test :as mt]
    [metabase.test.data.clickhouse :as ctd]
    [taoensso.nippy :as nippy]
-   [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
@@ -229,12 +227,3 @@
                 ["2016-05-01T00:00:00Z" 81.892]
                 ["2016-06-01T00:00:00Z" 71.954]]
                (mt/rows (qp/process-query q))))))))
-
-(deftest clickhouse-sync-fields-resilient-to-non-existence-test
-  (testing "[[sync-fields/sync-fields-for-table!]] doesn't crash on a non-existent table"
-    (mt/test-driver
-      :clickhouse
-      (let [table (t2/instance :model/Table {:id 321 :name "tbl"})]
-        (is (not= ::thrown
-                  (try (sync-fields/sync-fields-for-table! (mt/db) table)
-                       (catch Throwable _ ::thrown))))))))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -11,9 +11,11 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
+   [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.test :as mt]
    [metabase.test.data.clickhouse :as ctd]
    [taoensso.nippy :as nippy]
+   [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
@@ -227,3 +229,12 @@
                 ["2016-05-01T00:00:00Z" 81.892]
                 ["2016-06-01T00:00:00Z" 71.954]]
                (mt/rows (qp/process-query q))))))))
+
+(deftest clickhouse-sync-fields-resilient-to-non-existence-test
+  (testing "[[sync-fields/sync-fields-for-table!]] doesn't crash on a non-existent table"
+    (mt/test-driver
+      :clickhouse
+      (let [table (t2/instance :model/Table {:id 321 :name "tbl"})]
+        (is (not= ::thrown
+                  (try (sync-fields/sync-fields-for-table! (mt/db) table)
+                       (catch Throwable _ ::thrown))))))))

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -7,6 +7,7 @@
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.hive-like :as driver.hive-like]
+   [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.execute.legacy-impl :as sql-jdbc.legacy]
@@ -395,3 +396,7 @@
 (defmethod sql.qp/->honeysql [:databricks ::sql.qp/cast-to-text]
   [driver [_ expr]]
   (sql.qp/->honeysql driver [::sql.qp/cast expr "string"]))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :databricks
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "42P01"))

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -725,3 +725,7 @@
 
 (defmethod sql-jdbc/impl-query-canceled? :oracle [_ ^SQLException e]
   (= (.getErrorCode e) 1013))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :oracle
+  [_ ^SQLException e]
+  (= (.getErrorCode e) 942))

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -7,6 +7,7 @@
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
+   [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -567,3 +568,7 @@
   [driver _coercion-strategy expr]
   (sql.qp/cast-temporal-string driver :Coercion/YYYYMMDDHHMMSSString->Temporal
                                [:from_varbyte expr (h2x/literal "UTF8")]))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :redshift
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "42P01"))

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -9,6 +9,7 @@
    [metabase.driver :as driver]
    [metabase.driver.hive-like :as hive-like]
    [metabase.driver.hive-like.fixed-hive-connection :as fixed-hive-connection]
+   [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
@@ -258,3 +259,7 @@
 (defmethod sql.qp/->honeysql [:sparksql ::sql.qp/cast-to-text]
   [driver [_ expr]]
   (sql.qp/->honeysql driver [::sql.qp/cast expr "string"]))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :sparksql
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "42P01"))

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -5,6 +5,7 @@
    [honey.sql :as sql]
    [java-time.api :as t]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -331,3 +332,7 @@
 (defmethod sql.qp/->honeysql [:vertica ::sql.qp/cast-to-text]
   [driver [_ expr]]
   (sql.qp/->honeysql driver [::sql.qp/cast expr "varchar"]))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :vertica
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "42V01"))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1379,3 +1379,11 @@
   :hierarchy #'hierarchy)
 
 (defmethod query-canceled? ::driver [_ _] false)
+
+(defmulti table-known-to-not-exist?
+  "Test if an exception is due to a table not existing."
+  {:added "0.53.17" :arglists '([driver ^Throwable e])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod table-known-to-not-exist? ::driver [_ _] false)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1382,7 +1382,7 @@
 
 (defmulti table-known-to-not-exist?
   "Test if an exception is due to a table not existing."
-  {:added "0.53.17" :arglists '([driver ^Throwable e])}
+  {:added "0.54.10" :arglists '([driver ^Throwable e])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -626,3 +626,7 @@
 
 (defmethod sql-jdbc/impl-query-canceled? :h2 [_ ^SQLException e]
   (= (.getErrorCode e) 57014))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :h2
+  [_ e]
+  (#{"42S02" "42S03" "42S04"} (sql-jdbc/get-sql-state e)))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1039,3 +1039,7 @@
   ;; MySQL can return 1317 and 3024, but 1969 is not an error code in the mysql reference. All of these codes make sense for MariaDB
   ;; to return. Hibernate expects 3024, but in testing 1969 was observered.
   (contains? #{1317 1969 3024} (.getErrorCode e)))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :mysql
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "42S02"))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1188,3 +1188,7 @@
 
 (defmethod sql-jdbc/impl-query-canceled? :postgres [_ e]
   (= (sql-jdbc/get-sql-state e) "57014"))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :postgres
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "42P01"))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -287,3 +287,18 @@
   (if-let [sql-exception (extract-sql-exception e)]
     (impl-query-canceled? driver sql-exception)
     false))
+
+(defmulti impl-table-known-to-not-exist?
+  "Implementing multimethod for is table known to not exist. Use this instead of implementing
+  driver/query-canceled so extracting the SQLException from an exception chain can happen once for jdbc-
+  based drivers."
+  {:added "0.53.17" :arglists '([driver ^SQLException e])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod impl-table-known-to-not-exist? ::driver/driver [_ _] false)
+
+(defmethod driver/table-known-to-not-exist? :sql-jdbc [driver e]
+  (if-let [sql-exception (extract-sql-exception e)]
+    (impl-table-known-to-not-exist? driver sql-exception)
+    false))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -292,7 +292,7 @@
   "Implementing multimethod for is table known to not exist. Use this instead of implementing
   driver/query-canceled so extracting the SQLException from an exception chain can happen once for jdbc-
   based drivers."
-  {:added "0.53.17" :arglists '([driver ^SQLException e])}
+  {:added "0.54.10" :arglists '([driver ^SQLException e])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -271,7 +271,7 @@
         (recur cause)))))
 
 (defmulti impl-query-canceled?
-  "Implmenting multimethod for is query canceled. Notes when a query is canceled due to user action,
+  "Implementing multimethod for is query canceled. Notes when a query is canceled due to user action,
   which can include using the `.setQueryTimeout` on a `PreparedStatement.` Use this instead of implementing
   driver/query-canceled so extracting the SQLException from an exception chain can happen once for jdbc-
   based drivers."

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -107,7 +107,8 @@
                (range 1 (inc (.getColumnCount metadata))))))
           (catch Exception e
             ;; if the table does not exist, we do nothing rather than failing with an exception
-            (when-not (driver/table-known-to-not-exist? driver e)
+            (if (driver/table-known-to-not-exist? driver e)
+              init
               (throw e))))))))
 
 (defn- jdbc-fields-metadata

--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -56,7 +56,7 @@
    (sync-util/create-sync-step "sync-fks" sync-fks/sync-fks! sync-fks-summary)
    ;; Sync index info if the database supports it
    (sync-util/create-sync-step "sync-indexes" sync-indexes/maybe-sync-indexes! sync-indexes-summary)
-   ;; Sync the metadata metadata table if it exists.
+   ;; Sync the metabase metadata table if it exists.
    (sync-util/create-sync-step "sync-metabase-metadata" #(metabase-metadata/sync-metabase-metadata! % db-metadata))])
 
 (mu/defn sync-db-metadata!

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -387,7 +387,7 @@
                   frequencies))))))
 
 (deftest sync-fields-resilient-to-non-existence-test
-  (testing "[[sync-fields/sync-fields-for-table!]] doesn't crash on a non-existent table"
+  (testing "[[sync-fields/sync-fields-for-table!]] doesn't crash on a non-existent table (SEM-39)"
     (mt/test-drivers (mt/normal-drivers)
       (let [table (t2/instance :model/Table {:id 321 :name "tbl"})]
         (is (not= ::thrown

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -385,3 +385,11 @@
              (->> (db->fields db)
                   (mapv :visibility_type)
                   frequencies))))))
+
+(deftest sync-fields-resilient-to-non-existence-test
+  (testing "[[sync-fields/sync-fields-for-table!]] doesn't crash on a non-existent table"
+    (mt/test-drivers (mt/normal-drivers)
+      (let [table (t2/instance :model/Table {:id 321 :name "tbl"})]
+        (is (not= ::thrown
+                  (try (sync-fields/sync-fields-for-table! (mt/db) table)
+                       (catch Throwable _ ::thrown))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #52496
Closes https://linear.app/metabase/issue/SEM-39/the-task-sync-fields-fail-if-table-doesnt-exist

### Description

If the DB has a lot of tables, and they get created/deleted often, we may be attempting to sync tables that no longer exist due to timing issues. 
In some cases, that currently crashes. This PR makes syncing a non-existent table a no-op. 

### How to verify

See steps in the ticket

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
