### PR TITLE
Use user locale setting if available for lang prop in <html>

### DIFF
--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -88,7 +88,7 @@
       :userLocalizationJSON (escape-script (load-localization (when should-load-locale-params? (:locale params))))
       :siteLocalizationJSON (escape-script (load-localization (system/site-locale)))
       :nonceJSON            (escape-script (json/encode nonce))
-      :language             (hiccup.util/escape-html (system/site-locale))
+      :language             (hiccup.util/escape-html (or (i18n/user-locale-string) (system/site-locale)))
       :favicon              (hiccup.util/escape-html (appearance/application-favicon-url))
       :applicationName      (hiccup.util/escape-html (appearance/application-name))
       :uri                  (hiccup.util/escape-html uri)

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -76,26 +76,30 @@
         (log/error e message)
         (throw (Exception. message e))))))
 
-(defn- load-entrypoint-template [entrypoint-name embeddable? {:keys [uri params nonce]}]
+(defn- template-parameters
+  [embeddable? {:keys [uri params nonce]}]
+  (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})
+        ;; We disable `locale` parameter on static embeds/public links (metabase#50313)
+        should-load-locale-params? (not embeddable?)]
+    {:bootstrapJS          (load-inline-js "index_bootstrap")
+     :bootstrapJSON        (escape-script (json/encode public-settings))
+     :assetOnErrorJS       (load-inline-js "asset_loading_error")
+     :userLocalizationJSON (escape-script (load-localization (when should-load-locale-params? (:locale params))))
+     :siteLocalizationJSON (escape-script (load-localization (system/site-locale)))
+     :nonceJSON            (escape-script (json/encode nonce))
+     :language             (hiccup.util/escape-html (or (i18n/user-locale-string) (system/site-locale)))
+     :favicon              (hiccup.util/escape-html (appearance/application-favicon-url))
+     :applicationName      (hiccup.util/escape-html (appearance/application-name))
+     :uri                  (hiccup.util/escape-html uri)
+     :baseHref             (hiccup.util/escape-html (base-href))
+     :embedCode            (when embeddable? (embed/head uri))
+     :enableGoogleAuth     (boolean google-auth-client-id)
+     :enableAnonTracking   (boolean anon-tracking-enabled)}))
+
+(defn- load-entrypoint-template [entrypoint-name embeddable? opts]
   (load-template
    (str "frontend_client/" entrypoint-name ".html")
-   (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})
-         ;; We disable `locale` parameter on static embeds/public links (metabase#50313)
-         should-load-locale-params? (not embeddable?)]
-     {:bootstrapJS          (load-inline-js "index_bootstrap")
-      :bootstrapJSON        (escape-script (json/encode public-settings))
-      :assetOnErrorJS       (load-inline-js "asset_loading_error")
-      :userLocalizationJSON (escape-script (load-localization (when should-load-locale-params? (:locale params))))
-      :siteLocalizationJSON (escape-script (load-localization (system/site-locale)))
-      :nonceJSON            (escape-script (json/encode nonce))
-      :language             (hiccup.util/escape-html (or (i18n/user-locale-string) (system/site-locale)))
-      :favicon              (hiccup.util/escape-html (appearance/application-favicon-url))
-      :applicationName      (hiccup.util/escape-html (appearance/application-name))
-      :uri                  (hiccup.util/escape-html uri)
-      :baseHref             (hiccup.util/escape-html (base-href))
-      :embedCode            (when embeddable? (embed/head uri))
-      :enableGoogleAuth     (boolean google-auth-client-id)
-      :enableAnonTracking   (boolean anon-tracking-enabled)})))
+   (template-parameters embeddable? opts)))
 
 (defn- load-init-template []
   (load-template

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.server.routes.index :as index]
+   [metabase.test :as mt]
    [metabase.util.i18n :as i18n]
    [metabase.util.json :as json]))
 
@@ -72,3 +73,19 @@
             (binding [i18n/*user-locale* "xx"]
               (#'index/load-localization "yy"))
             json/decode)))))
+
+(deftest load-entrypoint-template-contains-user-locale
+  (let [get-lang (fn [html]
+                   (let [[_ lang :as matched?] (re-find #"lang=\"(\w+)\"" html)]
+                     (is matched? "did not find `lang` in HTML")
+                     lang))]
+    (binding [i18n/*user-locale* "es"]
+      (is (= "es" (get-lang (#'index/load-entrypoint-template "index" false {})))))
+    (binding [i18n/*user-locale* "en"]
+      (is (= "en" (get-lang (#'index/load-entrypoint-template "index" false {})))))
+    (mt/with-temporary-setting-values [site-locale "es"]
+      ;; site locale is used as the default
+      (is (= "es" (get-lang (#'index/load-entrypoint-template "index" false {}))))
+      ;; but we can override with the user locale
+      (binding [i18n/*user-locale* "fr"]
+        (is (= "fr" (get-lang (#'index/load-entrypoint-template "index" false {}))))))))

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -75,17 +75,13 @@
             json/decode)))))
 
 (deftest load-entrypoint-template-contains-user-locale
-  (let [get-lang (fn [html]
-                   (let [[_ lang :as matched?] (re-find #"lang=\"(\w+)\"" html)]
-                     (is matched? "did not find `lang` in HTML")
-                     lang))]
-    (binding [i18n/*user-locale* "es"]
-      (is (= "es" (get-lang (#'index/load-entrypoint-template "index" false {})))))
-    (binding [i18n/*user-locale* "en"]
-      (is (= "en" (get-lang (#'index/load-entrypoint-template "index" false {})))))
-    (mt/with-temporary-setting-values [site-locale "es"]
-      ;; site locale is used as the default
-      (is (= "es" (get-lang (#'index/load-entrypoint-template "index" false {}))))
-      ;; but we can override with the user locale
-      (binding [i18n/*user-locale* "fr"]
-        (is (= "fr" (get-lang (#'index/load-entrypoint-template "index" false {}))))))))
+  (binding [i18n/*user-locale* "es"]
+    (is (= "es" (:language (#'index/template-parameters false {})))))
+  (binding [i18n/*user-locale* "en"]
+    (is (= "en" (:language (#'index/template-parameters false {})))))
+  (mt/with-temporary-setting-values [site-locale "es"]
+    ;; site locale is used as the default
+    (is (= "es" (:language (#'index/template-parameters false {}))))
+    ;; but we can override with the user locale
+    (binding [i18n/*user-locale* "fr"]
+      (is (= "fr" (:language (#'index/template-parameters false {})))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49538

### Description
Prioritizes the user locale in the index template when it's available.

### How to verify

1. Set your site local french, and your user locale to spanish
2. open the DOM inspector and you should notice that the `<html>` tag has `lang="es"`. Previously, this would have said `fr`.
3. As a result, chrome should offer to translate the appropriate language

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
