### PR TITLE
Questions in usage analytics should never show native preview panel

### DIFF
--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -22,6 +22,23 @@ describe("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
       H.setTokenFeatures("all");
     });
 
+    it("should not show the sidebar preview when working with instance analyics (metabase#49904)", () => {
+      cy.signInAsAdmin();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      cy.findByRole("button", { name: /Editor/ }).click();
+      cy.findByRole("button", { name: /View SQL/ }).click();
+      cy.findByTestId("native-query-preview-sidebar").should("be.visible");
+
+      H.openNavigationSidebar();
+      cy.findByRole("link", { name: /Usage analytics/i }).click();
+      cy.findByRole("link", { name: /Metabase metrics/i }).click();
+      cy.findByRole("link", { name: /Question views last week/i }).click();
+
+      cy.findByRole("button", { name: /Editor/ }).click();
+      cy.findByRole("button", { name: /View SQL/ }).should("not.exist");
+      cy.findByTestId("native-query-preview-sidebar").should("not.exist");
+    });
+
     it("allows admins to see the instance analytics collection content", () => {
       visitCollection(ANALYTICS_COLLECTION_NAME);
       cy.findByTestId("pinned-items")

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -96,6 +96,23 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.get("code").should("not.exist");
   });
 
+  it("should conditiaonlly show the sidebar preview when navigating between questions (metabase#49904)", () => {
+    cy.signInAsAdmin();
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    cy.findByRole("button", { name: /Editor/ }).click();
+    cy.findByRole("button", { name: /View SQL/ }).click();
+    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
+
+    H.openNavigationSidebar();
+    cy.findByRole("link", { name: /Usage analytics/i }).click();
+    cy.findByRole("link", { name: /Metabase metrics/i }).click();
+    cy.findByRole("link", { name: /Question views last week/i }).click();
+
+    cy.findByRole("button", { name: /Editor/ }).click();
+    cy.findByRole("button", { name: /View SQL/ }).should("not.exist");
+    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
+  });
+
   it(
     "should work on small screens",
     { viewportWidth: 480, viewportHeight: 800 },

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -20,6 +20,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
   });
 
   it("should not an show empty sidebar when no data source is selected", () => {
+    H.setTokenFeatures("all");
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
     H.openReviewsTable({ mode: "notebook", limit: 1 });
     cy.findByLabelText("View SQL").click();
@@ -89,23 +90,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.findByLabelText("View SQL").should("not.exist");
     cy.findByTestId("native-query-preview-sidebar").should("not.exist");
     cy.get("code").should("not.exist");
-  });
-
-  it("should conditiaonlly show the sidebar preview when navigating between questions (metabase#49904)", () => {
-    cy.signInAsAdmin();
-    H.visitQuestion(ORDERS_QUESTION_ID);
-    cy.findByRole("button", { name: /Editor/ }).click();
-    cy.findByRole("button", { name: /View SQL/ }).click();
-    cy.findByTestId("native-query-preview-sidebar").should("be.visible");
-
-    H.openNavigationSidebar();
-    cy.findByRole("link", { name: /Usage analytics/i }).click();
-    cy.findByRole("link", { name: /Metabase metrics/i }).click();
-    cy.findByRole("link", { name: /Question views last week/i }).click();
-
-    cy.findByRole("button", { name: /Editor/ }).click();
-    cy.findByRole("button", { name: /View SQL/ }).should("not.exist");
-    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
   });
 
   it(

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -19,7 +19,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     );
   });
 
-  it("should show empty sidebar when no data source is selected", () => {
+  it("should not an show empty sidebar when no data source is selected", () => {
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
     H.openReviewsTable({ mode: "notebook", limit: 1 });
     cy.findByLabelText("View SQL").click();
@@ -27,18 +27,13 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
 
     cy.findByTestId("app-bar").findByLabelText("New").click();
     H.popover().findByTextEnsureVisible("Question").click();
-    cy.wait("@nativeDataset");
     cy.findByTestId("data-step-cell").should(
       "have.text",
       "Pick your starting data",
     );
     H.entityPickerModal().button("Close").click();
 
-    cy.findByTestId("native-query-preview-sidebar").within(() => {
-      cy.findByText("SQL for this question").should("exist");
-      H.NativeEditor.get().should("not.exist");
-      cy.button("Convert this question to SQL").should("be.disabled");
-    });
+    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
   });
 
   it("smoke test: should show the preview sidebar, update it, persist it and close it", () => {

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -21,6 +21,8 @@ import {
 import { NotebookNativePreview } from "metabase/querying/notebook/components/NotebookNativePreview";
 import { Box, Flex, rem } from "metabase/ui";
 
+import { canShowNativePreview } from "../../ViewHeader/utils";
+
 // There must exist some transition time, no matter how short,
 // because we need to trigger the 'onTransitionEnd' in the component
 const delayBeforeNotRenderingNotebook = 10;
@@ -51,6 +53,10 @@ export const NotebookContainer = ({
 
   const { isShowingNotebookNativePreview, notebookNativePreviewSidebarWidth } =
     useSelector(getUiControls);
+
+  const renderNativePreview =
+    isShowingNotebookNativePreview &&
+    canShowNativePreview({ question, queryBuilderMode: "notebook" });
 
   const minNotebookWidth = 640;
   const minSidebarWidth = 428;
@@ -163,7 +169,7 @@ export const NotebookContainer = ({
         </Box>
       )}
 
-      {isShowingNotebookNativePreview && screenSize && (
+      {renderNativePreview && screenSize && (
         <>
           {screenSize === "small" && (
             <Box pos="absolute" inset={0}>

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -56,7 +56,8 @@ export const NotebookContainer = ({
 
   const renderNativePreview =
     isShowingNotebookNativePreview &&
-    canShowNativePreview({ question, queryBuilderMode: "notebook" });
+    (question.database() === null ||
+      canShowNativePreview({ question, queryBuilderMode: "notebook" }));
 
   const minNotebookWidth = 640;
   const minSidebarWidth = 428;

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -56,8 +56,7 @@ export const NotebookContainer = ({
 
   const renderNativePreview =
     isShowingNotebookNativePreview &&
-    (question.database() === null ||
-      canShowNativePreview({ question, queryBuilderMode: "notebook" }));
+    canShowNativePreview({ question, queryBuilderMode: "notebook" });
 
   const minNotebookWidth = 640;
   const minSidebarWidth = 428;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
@@ -10,8 +10,9 @@ import { trackNotebookNativePreviewShown } from "metabase/query_builder/analytic
 import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
 import { getUiControls } from "metabase/query_builder/selectors";
 import { Button, Icon } from "metabase/ui";
-import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
+
+import { canShowNativePreview } from "../../utils";
 
 const BUTTON_TEXT = {
   get sql() {
@@ -76,23 +77,4 @@ export const ToggleNativeQueryPreview = ({
   );
 };
 
-interface ToggleNativeQueryPreviewOpts {
-  question: Question;
-  queryBuilderMode: string;
-}
-
-ToggleNativeQueryPreview.shouldRender = ({
-  question,
-  queryBuilderMode,
-}: ToggleNativeQueryPreviewOpts) => {
-  const { isNative } = Lib.queryDisplayInfo(question.query());
-  const isMetric = question.type() === "metric";
-
-  return (
-    !isNative &&
-    !isMetric &&
-    question.database()?.native_permissions === "write" &&
-    queryBuilderMode === "notebook" &&
-    !question.isArchived()
-  );
-};
+ToggleNativeQueryPreview.shouldRender = canShowNativePreview;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/utils.ts
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/utils.ts
@@ -19,3 +19,24 @@ export const canExploreResults = (question: Question): boolean => {
     !question.isArchived()
   );
 };
+
+interface CanShowNativePreviewOpts {
+  question: Question;
+  queryBuilderMode: string;
+}
+
+export const canShowNativePreview = ({
+  question,
+  queryBuilderMode,
+}: CanShowNativePreviewOpts) => {
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+  const isMetric = question.type() === "metric";
+
+  return (
+    !isNative &&
+    !isMetric &&
+    question.database()?.native_permissions === "write" &&
+    queryBuilderMode === "notebook" &&
+    !question.isArchived()
+  );
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49904

### Description
Updates the `<NotebookContainer>` to apply the same logic that we use for rendering the `<ToggleNativeQueryPreview>` button to the preview panel. Because this piece of QB UI state persists while navigating, it was possible to see the preview panel by opening it in one question, then navigating to another. Now, if we will not show you the toggle button, we will also never show you the panel

### How to verify
1. Go to any question and go to notebook mode, and turn on the native preview panel
2. Navigate to useage analytics
3. Inside an analytics dashboard, navigate to a question
4. Go to notebook mode, and you should see that the native preview panel is not shown
5. Navigate back to a regular question, and it should be visible again

### Demo

https://github.com/user-attachments/assets/8716f5ad-44bf-4728-a010-eecbe47b5771


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
