### PR TITLE
Un-deprecate Text/Description semantic type

### DIFF
--- a/frontend/src/metabase/lib/core.ts
+++ b/frontend/src/metabase/lib/core.ts
@@ -86,7 +86,6 @@ export const FIELD_SEMANTIC_TYPES: FieldSemanticType[] = [
       return t`Common`;
     },
     icon: "string",
-    deprecated: true,
   },
   {
     id: TYPE.Title,


### PR DESCRIPTION
Expected some tests to break, but I guess was untested.

Certainly don't see any other code edited in #55343