### PR TITLE
Ensure we buffer the output stream for CSV downloads

### DIFF
--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -133,14 +133,12 @@
                                                       (formatter (streaming.common/format-value r)))
                                                     @ordered-formatters ordered-row)
                                          (m/remove-nth pivot-grouping-index))]
-                  (write-csv writer [formatted-row])
-                  (.flush writer)))
+                  (write-csv writer [formatted-row])))
               ;; All other results: write directly to the CSV
               (let [formatted-row (perf/mapv (fn [formatter r]
                                                (formatter (streaming.common/format-value r)))
                                              @ordered-formatters ordered-row)]
-                (write-csv writer [formatted-row])
-                (.flush writer))))))
+                (write-csv writer [formatted-row]))))))
 
       (finish! [_ _]
         (when (and (contains? @pivot-data :data) enable-pivoted-exports?)


### PR DESCRIPTION
We're currently flushing the `BufferedWriter` after writing every row, which seems to remove the utility of using a `BufferedWriter` in the first place, and make downloads take a lot longer than they need to. Let's try removing these and see what happens.