### PR TITLE
add remember me to google sign in

### DIFF
--- a/e2e/test/scenarios/admin-2/sso/google.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/google.cy.spec.js
@@ -73,6 +73,7 @@ describe("scenarios > admin > settings > SSO > Google", () => {
       .findByText("Sign in with email")
       .should("be.visible");
     cy.findByRole("button", { name: /Google/ }).should("be.visible");
+    cy.findByRole("checkbox", { name: /remember me/i }).should("be.visible");
 
     cy.signInAsAdmin();
     setupGoogleAuth({ enabled: false });

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -72,14 +72,21 @@ export const login = createAsyncThunk(
 interface LoginGooglePayload {
   credential: string;
   redirectUrl?: string;
+  remember?: boolean;
 }
 
 export const LOGIN_GOOGLE = "metabase/auth/LOGIN_GOOGLE";
 export const loginGoogle = createAsyncThunk(
   LOGIN_GOOGLE,
-  async ({ credential }: LoginGooglePayload, { dispatch, rejectWithValue }) => {
+  async (
+    { credential, remember }: LoginGooglePayload,
+    { dispatch, rejectWithValue },
+  ) => {
     try {
-      await SessionApi.createWithGoogleAuth({ token: credential });
+      await SessionApi.createWithGoogleAuth({
+        token: credential,
+        remember,
+      });
       await dispatch(refreshSession()).unwrap();
       if (!isSmallScreen()) {
         dispatch(openNavbar());

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -6,6 +6,7 @@ import { t } from "ttag";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { Checkbox } from "metabase/ui";
 
 import { loginGoogle } from "../../actions";
 import { getGoogleClientId, getSiteLocale } from "../../selectors";
@@ -27,6 +28,7 @@ interface CredentialResponse {
 }
 
 export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
+  const [remember, setRemember] = useState(false);
   const clientId = useSelector(getGoogleClientId);
   const locale = useSelector(getSiteLocale);
   const [errors, setErrors] = useState<string[]>([]);
@@ -36,12 +38,14 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
     async ({ credential = "" }: CredentialResponse) => {
       try {
         setErrors([]);
-        await dispatch(loginGoogle({ credential, redirectUrl })).unwrap();
+        await dispatch(
+          loginGoogle({ credential, redirectUrl, remember }),
+        ).unwrap();
       } catch (error) {
         setErrors(getErrors(error));
       }
     },
-    [dispatch, redirectUrl],
+    [dispatch, redirectUrl, remember],
   );
 
   const handleError = useCallback(() => {
@@ -62,6 +66,12 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
               locale={locale}
             />
           </GoogleOAuthProvider>
+          <Checkbox
+            mt="0.5rem"
+            checked={remember}
+            onChange={(e) => setRemember(e.target.checked)}
+            label="Remember me"
+          />
         </ErrorBoundary>
       ) : (
         <TextLink to={Urls.login(redirectUrl)}>

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -6,17 +6,12 @@ import { t } from "ttag";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { Checkbox } from "metabase/ui";
+import { Box, Checkbox } from "metabase/ui";
 
 import { loginGoogle } from "../../actions";
 import { getGoogleClientId, getSiteLocale } from "../../selectors";
 
-import {
-  AuthError,
-  AuthErrorRoot,
-  GoogleButtonRoot,
-  TextLink,
-} from "./GoogleButton.styled";
+import { AuthError, AuthErrorRoot, TextLink } from "./GoogleButton.styled";
 
 interface GoogleButtonProps {
   redirectUrl?: string;
@@ -55,7 +50,7 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
   }, []);
 
   return (
-    <GoogleButtonRoot>
+    <Box>
       {isCard && clientId ? (
         <ErrorBoundary>
           <GoogleOAuthProvider clientId={clientId} nonce={window.MetabaseNonce}>
@@ -67,10 +62,10 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
             />
           </GoogleOAuthProvider>
           <Checkbox
-            mt="0.5rem"
+            mt="1rem"
             checked={remember}
             onChange={(e) => setRemember(e.target.checked)}
-            label="Remember me"
+            label={t`Remember me`}
           />
         </ErrorBoundary>
       ) : (
@@ -86,7 +81,7 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
           ))}
         </AuthErrorRoot>
       )}
-    </GoogleButtonRoot>
+    </Box>
   );
 };
 

--- a/frontend/src/metabase/auth/components/Login/Login.tsx
+++ b/frontend/src/metabase/auth/components/Login/Login.tsx
@@ -1,10 +1,11 @@
 import type { Location } from "history";
 import { t } from "ttag";
+import _ from "underscore";
 
 import { useSelector } from "metabase/lib/redux";
 import type { AuthProvider } from "metabase/plugins/types";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import { Box } from "metabase/ui";
+import { Box, Divider } from "metabase/ui";
 
 import { getAuthProviders } from "../../selectors";
 import { AuthLayout } from "../AuthLayout";
@@ -27,6 +28,11 @@ export const Login = ({ params, location }: LoginProps): JSX.Element => {
   const selection = getSelectedProvider(providers, params?.provider);
   const redirectUrl = location?.query?.redirect;
   const applicationName = useSelector(getApplicationName);
+
+  const [passwordProvider, otherProviders] = _.partition(
+    providers,
+    (provider) => provider.name === "password",
+  );
   return (
     <AuthLayout>
       <Box
@@ -46,10 +52,18 @@ export const Login = ({ params, location }: LoginProps): JSX.Element => {
       )}
       {!selection && (
         <Box mt="3.5rem">
-          {providers.map((provider) => (
+          {otherProviders.map((provider) => (
             <Box key={provider.name} mt="2rem" ta="center">
               <provider.Button isCard={true} redirectUrl={redirectUrl} />
             </Box>
+          ))}
+          {passwordProvider.map((provider) => (
+            <>
+              <Divider mt="2rem" />
+              <Box key={provider.name} mt="1rem" ta="center">
+                <provider.Button isCard={true} redirectUrl={redirectUrl} />
+              </Box>
+            </>
           ))}
         </Box>
       )}

--- a/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
@@ -2,11 +2,10 @@ import { useMemo } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 
-import FormCheckBox from "metabase/core/components/FormCheckBox";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
-import { Form, FormProvider } from "metabase/forms";
+import { Form, FormCheckbox, FormProvider } from "metabase/forms";
 import * as Errors from "metabase/lib/errors";
 
 import type { LoginData } from "../../types";
@@ -73,7 +72,7 @@ export const LoginForm = ({
           placeholder={t`Shhh...`}
         />
         {!hasSessionCookies && (
-          <FormCheckBox name="remember" title={t`Remember me`} />
+          <FormCheckbox name="remember" label={t`Remember me`} mb="1.25rem" />
         )}
         <FormSubmitButton title={t`Sign in`} primary fullWidth />
         <FormErrorMessage />

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -533,11 +533,12 @@
 
 ;;; ------------------------------------------- TESTS FOR GOOGLE SIGN-IN ---------------------------------------------
 
-(deftest google-auth-test
+(deftest google-auth-remember-test
   (reset-throttlers!)
   (testing "POST /google_auth"
     (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
-      (mt/with-discard-model-updates! [:model/User]
+      (mt/with-model-cleanup [:model/User]
+        (t2/insert! :model/User (merge  (mt/with-temp-defaults :model/User) {:email "test@metabase.com" :is_active true}))
         (testing "Google auth works with remember me and rasta"
           (with-redefs [http/post (constantly
                                    {:status 200
@@ -545,12 +546,17 @@
                                                  "\"email_verified\":\"true\","
                                                  "\"first_name\":\"test\","
                                                  "\"last_name\":\"user\","
-                                                 "\"email\":\"rasta@metabase.com\"}")})]
+                                                 "\"email\":\"test@metabase.com\"}")})]
             (testing "Test that 'remember me' checkbox sets expiration on session"
               (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember true})]
                 (is (some? (get-in response [:cookies session-cookie :expires])) "Session should have expiration set when remember=true"))
               (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember false})]
-                (is (nil? (get-in response [:cookies session-cookie :expires])) "Session should not have expiration set when remember=false"))))))
+                (is (nil? (get-in response [:cookies session-cookie :expires])) "Session should not have expiration set when remember=false")))))))))
+
+(deftest google-auth-test
+  (reset-throttlers!)
+  (testing "POST /google_auth"
+    (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
       (testing "Google auth works with an active account"
         (mt/with-temp [:model/User _ {:email "test@metabase.com" :is_active true}]
           (with-redefs [http/post (constantly

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -537,19 +537,20 @@
   (reset-throttlers!)
   (testing "POST /google_auth"
     (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
-      (testing "Google auth works with remember me and rasta"
-        (with-redefs [http/post (constantly
-                                 {:status 200
-                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                               "\"email_verified\":\"true\","
-                                               "\"first_name\":\"test\","
-                                               "\"last_name\":\"user\","
-                                               "\"email\":\"rasta@metabase.com\"}")})]
-          (testing "Test that 'remember me' checkbox sets expiration on session"
-            (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember true})]
-              (is (some? (get-in response [:cookies session-cookie :expires])) "Session should have expiration set when remember=true"))
-            (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember false})]
-              (is (nil? (get-in response [:cookies session-cookie :expires])) "Session should not have expiration set when remember=false")))))
+      (mt/with-discard-model-updates! [:model/User]
+        (testing "Google auth works with remember me and rasta"
+          (with-redefs [http/post (constantly
+                                   {:status 200
+                                    :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                 "\"email_verified\":\"true\","
+                                                 "\"first_name\":\"test\","
+                                                 "\"last_name\":\"user\","
+                                                 "\"email\":\"rasta@metabase.com\"}")})]
+            (testing "Test that 'remember me' checkbox sets expiration on session"
+              (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember true})]
+                (is (some? (get-in response [:cookies session-cookie :expires])) "Session should have expiration set when remember=true"))
+              (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember false})]
+                (is (nil? (get-in response [:cookies session-cookie :expires])) "Session should not have expiration set when remember=false"))))))
       (testing "Google auth works with an active account"
         (mt/with-temp [:model/User _ {:email "test@metabase.com" :is_active true}]
           (with-redefs [http/post (constantly


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51889

### Description
Adds a remember me button to the login screen under the `Sign in with Google` button. This value is passed to the BE and reflected in the stored cookie for `metabase.SESSION`

### How to verify
1. Set up google sso locally
2. log out, then on the login screen, check remember me under `Sign in with Google`
3. click `Sign in with Google` and go through the OAuth flow
4. Once you're logged in, close the browser
5. Re-open the browser and navigate back to metabase. You should still be logged in.

### Demo
![image](https://github.com/user-attachments/assets/5797d869-97a2-4017-8df9-b5f54d054028)

### Checklist
_No tests have been added here as I'm not really sure what they would look like. Open to suggestions!_
- [ ] Tests have been added/updated to cover changes in this PR
