### PR TITLE
Restore embed signal fallback when in embedding

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
@@ -17,17 +17,15 @@ interface LoadingViewProps {
 }
 
 function SlowQueryView({ expectedDuration, isSlow }: LoadingViewProps) {
-  if (!expectedDuration) {
-    return null;
-  }
-
   return (
     <SlowQueryMessageContainer>
       <ShortMessage>{t`Still Waiting…`}</ShortMessage>
       {isSlow === "usually-slow" ? (
         <div>
           {jt`This usually takes an average of ${(
-            <Duration key="duration">{duration(expectedDuration)}</Duration>
+            <Duration key="duration">
+              {duration(expectedDuration ?? 0)}
+            </Duration>
           )}, but is currently taking longer.`}
         </div>
       ) : (

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.unit.spec.tsx
@@ -36,4 +36,15 @@ describe("LoadingView", () => {
       screen.getByText(/but is currently taking longer./),
     ).toBeInTheDocument();
   });
+
+  it("should show the usually slow message even when the expected duration is 0 (metabase#57869)", () => {
+    setup({
+      expectedDuration: 0,
+      isSlow: "usually-slow",
+    });
+
+    expect(
+      screen.queryByText(/This usually takes an average of 0 seconds/),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.unit.spec.tsx
@@ -44,7 +44,7 @@ describe("LoadingView", () => {
     });
 
     expect(
-      screen.queryByText(/This usually takes an average of 0 seconds/),
-    ).not.toBeInTheDocument();
+      screen.getByText(/This usually takes an average of/),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes EMB-384
Closes #57869

### Description

We used to show "Still waiting..." when encountering slow cards in embedding, but it no longer shows up.

Bisect shows that it was [this change](https://github.com/metabase/metabase/pull/54303/files#diff-078a4088d6847984d85695aa8a2aa62149e48693548d283fbf8f09dda91bead0R20-R22) which removes the fallback message for when the query duration is missing. It turns out we have never sent the proper `query_average_duration` to the embed's endpoint, and we've thus always relied on the fallback that shows the query duration as 0.

We agreed to [restore the original behavior](https://metaboat.slack.com/archives/C063Q3F1HPF/p1747760679579239?thread_ts=1747684325.104879&cid=C063Q3F1HPF) instead.

### How to verify

1. create a SQL question with "select pg_sleep(30)" on a postgres db
2. save it and run it (see that it returns the column name)
3. add it to a dashboard 4 times, save the dashboard
4. open the dashboard in the main app, see that it will eventually show the "still waiting" sign after 20 seconds
5. now embed it (you can use the embedding preview)
6. the "still waiting" sign will show after 20-ish seconds, same as in main app.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit
