### PR TITLE
use original series settings visibility in visualizer

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -455,5 +455,62 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
         H.chartLegend().should("not.exist");
       });
     });
+
+    it("should show only enabled series in the visualizer based on the card's viz settings", () => {
+      const visualization_settings = {
+        ...ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY.visualization_settings,
+        "graph.series_order": [
+          {
+            name: "Gadget",
+            enabled: false,
+            color: "#F9D45C",
+            key: "Gadget",
+          },
+          {
+            key: "Doohickey",
+            color: "#88BF4D",
+            enabled: true,
+            name: "Doohickey",
+          },
+          {
+            key: "Gizmo",
+            color: "#A989C5",
+            enabled: true,
+            name: "Gizmo",
+          },
+          {
+            name: "Widget",
+            enabled: false,
+            color: "#F2A86F",
+            key: "Widget",
+          },
+        ],
+        "graph.series_order_dimension": "CATEGORY",
+      };
+
+      H.createDashboardWithQuestions({
+        questions: [
+          {
+            ...ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY,
+            visualization_settings,
+          },
+        ],
+      }).then(({ dashboard }) => {
+        H.visitDashboard(dashboard.id);
+      });
+
+      H.getDashboardCard(0)
+        .findAllByTestId("legend-item")
+        .should("have.length", 2);
+
+      H.editDashboard();
+      H.showDashcardVisualizerModal(0);
+
+      H.modal().within(() => {
+        cy.findAllByTestId("legend-item").should("have.length", 2);
+        cy.button("Settings").click();
+        cy.findAllByTestId("series-name-input").should("have.length", 2);
+      });
+    });
   });
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import { Component } from "react";
+import { t } from "ttag";
 
 import IconWrapper from "metabase/components/IconWrapper";
 import { ColorSelector } from "metabase/core/components/ColorSelector";
@@ -24,6 +25,7 @@ export default class ChartNestedSettingSeriesMultiple extends Component {
       object,
       allComputedSettings,
       seriesCardNames,
+      settings: visualizationSettings,
     } = this.props;
     const objectKey = object && getObjectKey(object);
     const isSelected = (single) => objectKey === getObjectKey(single);
@@ -35,6 +37,15 @@ export default class ChartNestedSettingSeriesMultiple extends Component {
             const key = getObjectKey(single);
             const settings = allComputedSettings[key] || {};
             const seriesCardName = seriesCardNames?.[key];
+            const seriesOrderSetting = visualizationSettings[
+              "graph.series_order"
+            ]?.find((seriesOrder) => seriesOrder.key === key);
+            const isHidden =
+              seriesOrderSetting != null && !seriesOrderSetting.enabled;
+
+            if (isHidden) {
+              return null;
+            }
             return (
               <div
                 key={key}
@@ -63,7 +74,9 @@ export default class ChartNestedSettingSeriesMultiple extends Component {
                       seriesCardName === settings.title ? "" : seriesCardName
                     }
                     onBlurChange={(e) =>
-                      onChangeObjectSettings(single, { title: e.target.value })
+                      onChangeObjectSettings(single, {
+                        title: e.target.value,
+                      })
                     }
                     data-testid="series-name-input"
                   />
@@ -72,7 +85,7 @@ export default class ChartNestedSettingSeriesMultiple extends Component {
                       <OptionsIcon
                         name={isSelected(single) ? "chevronup" : "chevrondown"}
                         tooltip={
-                          isSelected(single) ? "Hide options" : "More options"
+                          isSelected(single) ? t`Hide options` : t`More options`
                         }
                         onClick={() =>
                           onChangeEditingObject(

--- a/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.ts
+++ b/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.ts
@@ -12,7 +12,7 @@ import type { VisualizationSettings } from "metabase-types/api";
  * @param columnsToRefs the mapping of column names to their references
  * @returns the converted settings
  */
-export function updateVizSettingsWithRefs(
+export function updateVizSettingsKeysWithRefs(
   settings: VisualizationSettings,
   columnsToRefs: Record<string, string>,
 ): VisualizationSettings {
@@ -22,7 +22,7 @@ export function updateVizSettingsWithRefs(
 
   if (Array.isArray(settings)) {
     return settings.map((item) =>
-      updateVizSettingsWithRefs(item, columnsToRefs),
+      updateVizSettingsKeysWithRefs(item, columnsToRefs),
     );
   }
 
@@ -37,7 +37,7 @@ export function updateVizSettingsWithRefs(
       const value = settings[key];
       const newValue =
         typeof value === "object" && value !== null
-          ? updateVizSettingsWithRefs(value, columnsToRefs)
+          ? updateVizSettingsKeysWithRefs(value, columnsToRefs)
           : value;
 
       // Add the entry with the new key and processed value
@@ -48,4 +48,52 @@ export function updateVizSettingsWithRefs(
   }
 
   return settings;
+}
+
+/**
+ * Updates settings by replacing specified keys with their corresponding references
+ * @param {Object} settings - The original settings object
+ * @param {Object} columnsToRefs - Mapping of column names to their reference values
+ * @param {Array<string>} [keysToUpdate] - Optional list of specific settings keys to update
+ * @return {Object} - New settings object with updated references
+ */
+function updateSettingsValuesWithRefs(
+  settings: VisualizationSettings,
+  columnsToRefs: Record<string, string>,
+  keysToUpdate: [keyof VisualizationSettings],
+): VisualizationSettings {
+  const newSettings = structuredClone(settings);
+
+  keysToUpdate.forEach((key) => {
+    if (key in newSettings && newSettings[key] in columnsToRefs) {
+      newSettings[key] = columnsToRefs[newSettings[key]];
+    }
+  });
+
+  return newSettings;
+}
+
+/**
+ * Recursively converts visualization settings to use the new column references.
+ *
+ * If the settings contain the color for a series called, say, `avg` (`{colors: {avg: "#000"}}`),
+ * and the column reference for `avg` is `COLUMN_1`, this function will convert it
+ * to `{colors: {COLUMN_1: "#000"}}`.
+ *
+ *
+ * @param settings the settings to convert
+ * @param columnsToRefs the mapping of column names to their references
+ * @returns the converted settings
+ */
+export function updateVizSettingsWithRefs(
+  settings: VisualizationSettings,
+  columnsToRefs: Record<string, string>,
+): VisualizationSettings {
+  const settingsWithUpdatedKeys = updateVizSettingsKeysWithRefs(
+    settings,
+    columnsToRefs,
+  );
+  return updateSettingsValuesWithRefs(settingsWithUpdatedKeys, columnsToRefs, [
+    "graph.series_order_dimension",
+  ]);
 }

--- a/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.ts
+++ b/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.ts
@@ -62,7 +62,7 @@ function updateSettingsValuesWithRefs(
   columnsToRefs: Record<string, string>,
   keysToUpdate: [keyof VisualizationSettings],
 ): VisualizationSettings {
-  const newSettings = structuredClone(settings);
+  const newSettings = { ...settings };
 
   keysToUpdate.forEach((key) => {
     if (key in newSettings && newSettings[key] in columnsToRefs) {

--- a/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.unit.spec.ts
@@ -1,11 +1,14 @@
 import type { VisualizationSettings } from "metabase-types/api";
 
-import { updateVizSettingsWithRefs } from "./update-viz-settings-with-refs";
+import {
+  updateVizSettingsKeysWithRefs,
+  updateVizSettingsWithRefs,
+} from "./update-viz-settings-with-refs";
 
-describe("updateVizSettingsWithRefs", () => {
+describe("updateVizSettingsKeysWithRefs", () => {
   it("should handle empty objects", () => {
-    expect(updateVizSettingsWithRefs({}, {})).toEqual({});
-    expect(updateVizSettingsWithRefs({}, { avg: "COLUMN_1" })).toEqual({});
+    expect(updateVizSettingsKeysWithRefs({}, {})).toEqual({});
+    expect(updateVizSettingsKeysWithRefs({}, { avg: "COLUMN_1" })).toEqual({});
   });
 
   it("should convert column names to references in keys", () => {
@@ -17,7 +20,7 @@ describe("updateVizSettingsWithRefs", () => {
     };
     const columnsToRefs = { avg: "COLUMN_1", sum: "COLUMN_2" };
 
-    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+    const result = updateVizSettingsKeysWithRefs(settings, columnsToRefs);
 
     expect(result).toEqual({
       colors: {
@@ -40,7 +43,7 @@ describe("updateVizSettingsWithRefs", () => {
     };
     const columnsToRefs = { avg: "COLUMN_1", sum: "COLUMN_2" };
 
-    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+    const result = updateVizSettingsKeysWithRefs(settings, columnsToRefs);
 
     expect(result).toEqual({
       series: {
@@ -63,7 +66,7 @@ describe("updateVizSettingsWithRefs", () => {
     };
     const columnsToRefs = { avg: "COLUMN_1", sum: "COLUMN_2" };
 
-    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+    const result = updateVizSettingsKeysWithRefs(settings, columnsToRefs);
 
     expect(result).toEqual({
       dimensions: [
@@ -95,7 +98,7 @@ describe("updateVizSettingsWithRefs", () => {
       ['["name","avg"]']: "COLUMN_3",
     };
 
-    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+    const result = updateVizSettingsKeysWithRefs(settings, columnsToRefs);
 
     expect(result).toEqual({
       series_settings: {
@@ -125,7 +128,7 @@ describe("updateVizSettingsWithRefs", () => {
     };
     const columnsToRefs = { avg: "COLUMN_1", sum: "COLUMN_2" };
 
-    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+    const result = updateVizSettingsKeysWithRefs(settings, columnsToRefs);
 
     expect(result).toEqual({
       deep: {
@@ -143,7 +146,7 @@ describe("updateVizSettingsWithRefs", () => {
     };
     const columnsToRefs = { avg: "COLUMN_1" };
 
-    updateVizSettingsWithRefs(settings, columnsToRefs);
+    updateVizSettingsKeysWithRefs(settings, columnsToRefs);
 
     expect(settings).toEqual({
       colors: { avg: "#000" },
@@ -155,10 +158,42 @@ describe("updateVizSettingsWithRefs", () => {
       colors: { avg: "#000", sum: "#fff" },
     };
 
-    const result = updateVizSettingsWithRefs(settings, {});
+    const result = updateVizSettingsKeysWithRefs(settings, {});
 
     expect(result).toEqual({
       colors: { avg: "#000", sum: "#fff" },
+    });
+  });
+});
+
+describe("updateVizSettingsWithRefs", () => {
+  it("should not modify graph.series_order_dimension when value is not in columnsToRefs", () => {
+    const settings: VisualizationSettings = {
+      "graph.series_order_dimension": "other_field",
+      colors: { avg: "#000" },
+    };
+    const columnsToRefs = { avg: "COLUMN_1", sum: "COLUMN_2" };
+
+    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+
+    expect(result).toEqual({
+      "graph.series_order_dimension": "other_field",
+      colors: { COLUMN_1: "#000" },
+    });
+  });
+
+  it("should update graph.series_order_dimension with column reference", () => {
+    const settings: VisualizationSettings = {
+      "graph.series_order_dimension": "avg",
+      colors: { avg: "#000" },
+    };
+    const columnsToRefs = { avg: "COLUMN_1", sum: "COLUMN_2" };
+
+    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+
+    expect(result).toEqual({
+      "graph.series_order_dimension": "COLUMN_1",
+      colors: { COLUMN_1: "#000" },
     });
   });
 });


### PR DESCRIPTION
### Description

[Slack thread](https://metaboat.slack.com/archives/C072Q9XNQJW/p1747682195274859)
When a cartesian chart with a breakout is opened in visualizer we did not apply saved series order and visibility settings due to visualizer column remappings, this PR fixes it.

### How to verify

- Orders -> Count by Created At and Product -> Category
- Hide two series in viz settings and save
- Add the card on a dashboard
- Open it in the visualizer and ensure the two series are still hidden

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
