### PR TITLE
fix: Disable quartz metrics trigger listener

### DIFF
--- a/src/metabase/analytics/quartz.clj
+++ b/src/metabase/analytics/quartz.clj
@@ -90,6 +90,4 @@
 (defn add-listeners-to-scheduler!
   "Add triggers to the quartz scheduler, must be initialized before adding."
   []
-  (when-let [scheduler (task/scheduler)]
-    (task/add-trigger-listener! (create-trigger-listener scheduler))
-    (task/add-job-listener! (create-job-execution-listener))))
+  (task/add-job-listener! (create-job-execution-listener)))


### PR DESCRIPTION
### Description

The quartz trigger listener seems to be causing higher than expected db connection usage and memory pressure. This disables it for now. 
