### PR TITLE
Closes VIZ-329 -> Applying formatting updates is unintuitive happens on scroll

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInput.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInput.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+import debounce from "lodash.debounce";
+import { useEffect, useMemo, useState } from "react";
+import { useLatest } from "react-use";
 
 import { TextInput } from "metabase/ui";
 
@@ -21,16 +23,26 @@ export const ChartSettingInput = ({
     setInputValue(value);
   }, [value]);
 
+  const onChangeRef = useLatest(onChange);
+  const onChangeDebounced = useMemo(
+    () => debounce((value: string) => onChangeRef.current(value), 400),
+    [onChangeRef],
+  );
+
   return (
     <TextInput
       id={id}
       data-testid={id}
       placeholder={placeholder}
       value={inputValue}
-      onChange={(e) => setInputValue(e.target.value)}
+      onChange={(e) => {
+        setInputValue(e.target.value);
+        onChangeDebounced(e.target.value);
+      }}
       onBlur={() => {
         if (inputValue !== (value || "")) {
-          onChange(inputValue);
+          onChangeDebounced.cancel();
+          onChangeRef.current(inputValue);
         }
       }}
     />

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -1,4 +1,6 @@
-import { type ChangeEvent, useState } from "react";
+import debounce from "lodash.debounce";
+import { type ChangeEvent, useMemo, useState } from "react";
+import { useLatest } from "react-use";
 
 import { TextInput } from "metabase/ui";
 
@@ -46,6 +48,28 @@ export const ChartSettingInputNumeric = ({
   const [inputValue, setInputValue] = useState<string>(value?.toString() ?? "");
   const defaultValueProps = getDefault ? { defaultValue: getDefault() } : {};
 
+  const handleChangeRef = useLatest((e: ChangeEvent<HTMLInputElement>) => {
+    let num = e.target.value !== "" ? Number(e.target.value) : Number.NaN;
+    if (options?.isInteger) {
+      num = Math.round(num);
+    }
+    if (options?.isNonNegative && num < 0) {
+      num *= -1;
+    }
+
+    if (isNaN(num)) {
+      onChange(undefined);
+    } else {
+      onChange(num);
+      setInputValue(String(num));
+    }
+  });
+  const handleChangeDebounced = useMemo(() => {
+    return debounce((e: ChangeEvent<HTMLInputElement>) => {
+      handleChangeRef.current(e);
+    }, 400);
+  }, [handleChangeRef]);
+
   return (
     <TextInput
       id={id}
@@ -57,23 +81,12 @@ export const ChartSettingInputNumeric = ({
       onChange={(e: ChangeEvent<HTMLInputElement>) => {
         if (e.target.value.split("").every((ch) => ALLOWED_CHARS.has(ch))) {
           setInputValue(e.target.value);
+          handleChangeDebounced(e);
         }
       }}
       onBlur={(e) => {
-        let num = e.target.value !== "" ? Number(e.target.value) : Number.NaN;
-        if (options?.isInteger) {
-          num = Math.round(num);
-        }
-        if (options?.isNonNegative && num < 0) {
-          num *= -1;
-        }
-
-        if (isNaN(num)) {
-          onChange(undefined);
-        } else {
-          onChange(num);
-          setInputValue(String(num));
-        }
+        handleChangeDebounced.cancel();
+        handleChangeRef.current(e);
       }}
       className={className}
     />

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -84,10 +84,6 @@ export const ChartSettingInputNumeric = ({
           handleChangeDebounced(e);
         }
       }}
-      onBlur={(e) => {
-        handleChangeDebounced.cancel();
-        handleChangeRef.current(e);
-      }}
       className={className}
     />
   );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
@@ -1,8 +1,16 @@
 import userEvent from "@testing-library/user-event";
 
-import { fireEvent, renderWithProviders, screen } from "__support__/ui";
+import { act, renderWithProviders, screen } from "__support__/ui";
 
 import { ChartSettingInputNumeric } from "./ChartSettingInputNumeric";
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 function setup({
   value,
@@ -30,9 +38,10 @@ function setup({
 }
 
 async function type({ input, value }: { input: HTMLElement; value: string }) {
-  await userEvent.clear(input);
-  await userEvent.type(input, value);
-  fireEvent.blur(input);
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  await user.clear(input);
+  await user.type(input, value);
+  act(() => jest.runAllTimers());
 }
 
 describe("ChartSettingInputNumber", () => {
@@ -117,24 +126,24 @@ describe("ChartSettingInputNumber", () => {
 
     await type({ input, value: "asdf" });
     expect(input).toHaveDisplayValue("");
-    expect(onChange).toHaveBeenCalledWith(undefined);
+    expect(onChange).not.toHaveBeenCalled();
 
     // Inputs with `e` that are not valid scientific notation
     type({ input, value: "e123" });
     expect(input).toHaveDisplayValue("");
-    expect(onChange).toHaveBeenCalledWith(undefined);
+    expect(onChange).not.toHaveBeenCalled();
 
     type({ input, value: "e123e" });
     expect(input).toHaveDisplayValue("");
-    expect(onChange).toHaveBeenCalledWith(undefined);
+    expect(onChange).not.toHaveBeenCalled();
 
     type({ input, value: "1e23e" });
     expect(input).toHaveDisplayValue("");
-    expect(onChange).toHaveBeenCalledWith(undefined);
+    expect(onChange).not.toHaveBeenCalled();
 
     type({ input, value: "e1e23e" });
     expect(input).toHaveDisplayValue("");
-    expect(onChange).toHaveBeenCalledWith(undefined);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("renders the `value` prop on load", () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #36557
Closes [VIZ-329: Applying formatting updates is unintuitive: Happens on scroll, but not on return or click out of popover](https://linear.app/metabase/issue/VIZ-329/applying-formatting-updates-is-unintuitive-happens-on-scroll-but-not)

### Description

This PR makes column formatting updates more intuitive for text and numeric inputs by applying the changes when the user pauses typing rather than when the input is blurred. This makes text and numeric column formatting work similarly to other formatting options (e.g. changing the alignment takes effect immediately).

### How to verify

1. Navigate to a table of results for a Question.
2. Click a column header for a numeric column then the gear icon to edit the column's formatting.
3. Edit the column's name and number of decimal places.
4. Verify the changes are applied when you pause typing, persist, and allow you to continue making changes.

### Demo

https://www.loom.com/share/bdc1250c88854a82ba7f213e8005e42f

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
