### PR TITLE
Log view count information

### DIFF
--- a/src/metabase/view_log/events/view_log.clj
+++ b/src/metabase/view_log/events/view_log.clj
@@ -40,6 +40,7 @@
                           cluster-lock/card-statistics-lock ;; need to use a shared lock for all updates to the card table
                           (keyword "metabase.events.view_log"
                                    (str (name (t2/table-name model)) "-view-count")))]
+          (log/debugf "Writing %d items to %s view counts with lock %s" (count ids) model lock-name)
           (cluster-lock/with-cluster-lock lock-name
             (t2/query {:update (t2/table-name model)
                        :set    {:view_count [:+ :view_count (into [:case]


### PR DESCRIPTION
BEFORE:
```
2025-05-20 22:24:17,586 DEBUG middleware.log :: POST /api/dashboard/pivot/1/dashcard/12/card/10/query 202 [ASYNC: completed] 634ms (81 DB calls) App DB connections: 1/15 Jetty threads: 4/50 (3 idle, 0 queued) (132 total active threads) Queries in flight: 1 (0 queued); h2 DB 1 connections: 0/7 (0 threads blocked) {:metabase-user-id 1}
2025-05-20 22:24:25,629 DEBUG events.view-log :: Increment view counts of 24 items
```

AFTER:

```
2025-05-20 22:24:17,586 DEBUG middleware.log :: POST /api/dashboard/pivot/1/dashcard/12/card/10/query 202 [ASYNC: completed] 634ms (81 DB calls) App DB connections: 1/15 Jetty threads: 4/50 (3 idle, 0 queued) (132 total active threads) Queries in flight: 1 (0 queued); h2 DB 1 connections: 0/7 (0 threads blocked) {:metabase-user-id 1}
2025-05-20 22:24:25,629 DEBUG events.view-log :: Increment view counts of 24 items
2025-05-20 22:24:25,638 DEBUG events.view-log :: Writing 3 items to :model/Dashboard with lock :metabase.events.view_log/report_dashboard-view-count
2025-05-20 22:24:25,654 DEBUG events.view-log :: Writing 21 items to :model/Card with lock :metabase.util.cluster-lock/statistics-lock
2025-05-20 22:24:27,649 WARN models.card :: Best-effort backfill of :entity_id failed for Card null
2025-05-20 22:24:27,656 WARN models.card :: Best-effort backfill of :entity_id failed for Card null
2025-05-20 22:24:27,660 WARN models.card :: Best-effort backfill of :entity_id failed for Card null
```

![image](https://github.com/user-attachments/assets/240c2990-86b4-4543-8939-b99b3f77974b)

highlighted lines are new