### PR TITLE
DANGEROUSLY allow patches on red commits

### DIFF
--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -8,6 +8,10 @@ on:
         description: 'Major Metabase version (e.g. 45, 52, 68)'
         type: number
         required: true
+      allow_red_patch:
+        description: DANGEROUSLY allow releasing from the last commit, regardless of the state of CI
+        type: boolean
+        default: false
   schedule:
     - cron: '0 21 * * 1-5' # every weekday at 4 pm EST/5 pm EDT
 
@@ -52,29 +56,39 @@ jobs:
                 branch: `release-x.${majorVersion}.x`,
               });
 
+              const latestCommit = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/release-x.${majorVersion}.x`,
+              });
+
+              const releaseCommit = String(context.payload.inputs.allow_red_patch) === "true"
+                ? latestCommit.data.object.sha
+                : goodCommit;
+
               const hasBeenReleased = await hasCommitBeenReleased({
                 github,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: goodCommit,
+                ref: releaseCommit,
                 majorVersion: Number(majorVersion),
               });
 
-              if (nextPatch && goodCommit && !hasBeenReleased) {
+              if (nextPatch && releaseCommit && !hasBeenReleased) {
                 await github.rest.actions.createWorkflowDispatch({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   workflow_id: 'tag-for-release.yml',
                   ref: 'refs/heads/master',
                   inputs: {
-                    commit: goodCommit,
+                    commit: releaseCommit,
                     version: nextPatch,
                     auto: true,
                   }
                 });
               } else {
                 console.log(
-                  { nextPatch, goodCommit, hasBeenReleased }
+                  { nextPatch, goodCommit, releaseCommit, hasBeenReleased }
                 );
                 console.error(`No new patch version or no green commit found for v${majorVersion}`);
               }

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -8,10 +8,11 @@ on:
         description: 'Major Metabase version (e.g. 45, 52, 68)'
         type: number
         required: true
-      allow_red_patch:
-        description: DANGEROUSLY allow releasing from the last commit, regardless of the state of CI
-        type: boolean
-        default: false
+      override_sha:
+        description: DANGEROUSLY allow releasing from this commit sha, regardless of the state of CI (can be empty)
+        type: string
+        required: false
+        default: ''
   schedule:
     - cron: '0 21 * * 1-5' # every weekday at 4 pm EST/5 pm EDT
 
@@ -49,22 +50,18 @@ jobs:
                 majorVersion,
               });
 
-              const goodCommit = await getLatestGreenCommit({
-                github,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: `release-x.${majorVersion}.x`,
-              });
+              // only allow overriding the commit SHA for workflow_dispatch events with a provided sha
+              const overrideSha = String(context.payload.inputs.override_sha).trim();
+              const isValidOverride = context.eventName === 'workflow_dispatch' && overrideSha.length === 40;
 
-              const latestCommit = await github.rest.git.getRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `heads/release-x.${majorVersion}.x`,
-              });
-
-              const releaseCommit = String(context.payload.inputs.allow_red_patch) === "true"
-                ? latestCommit.data.object.sha
-                : goodCommit;
+              const releaseCommit = isValidOverride
+                ? overrideSha
+                : await getLatestGreenCommit({
+                    github,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    branch: `release-x.${majorVersion}.x`,
+                  });
 
               const hasBeenReleased = await hasCommitBeenReleased({
                 github,
@@ -88,7 +85,7 @@ jobs:
                 });
               } else {
                 console.log(
-                  { nextPatch, goodCommit, releaseCommit, hasBeenReleased }
+                  { nextPatch, releaseCommit, hasBeenReleased }
                 );
                 console.error(`No new patch version or no green commit found for v${majorVersion}`);
               }

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -54,6 +54,10 @@ jobs:
               const overrideSha = String(context.payload.inputs.override_sha).trim();
               const isValidOverride = context.eventName === 'workflow_dispatch' && overrideSha.length === 40;
 
+              if (!isValidOverride && overrideSha.length > 0) {
+                throw new Error(`Invalid override SHA provided: ${overrideSha}`);
+              }
+
               const releaseCommit = isValidOverride
                 ? overrideSha
                 : await getLatestGreenCommit({

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -51,7 +51,7 @@ jobs:
               });
 
               // only allow overriding the commit SHA for workflow_dispatch events with a provided sha
-              const overrideSha = String(context.payload.inputs.override_sha).trim();
+              const overrideSha = String(context.payload.inputs.override_sha ?? '').trim();
               const isValidOverride = context.eventName === 'workflow_dispatch' && overrideSha.length === 40;
 
               if (!isValidOverride && overrideSha.length > 0) {


### PR DESCRIPTION
### Description

In some cases we have failing CI checks that are immaterial and want to release a patch off those commits without going through the whole minor release process. This allows the patch release workflow to accept a commit sha as an input that ignores CI checks, and just release that commit.

