### PR TITLE
Add Text/Description back to public field-types docs

### DIFF
--- a/docs/data-modeling/field-types.md
+++ b/docs/data-modeling/field-types.md
@@ -77,6 +77,7 @@ You can think of semantic types as adding extra flavor to a field to communicate
 - Category
 - Name
 - Title
+- Description
 - Product
 - Source
 - Location


### PR DESCRIPTION
Didn't realize this was mastered in the repo, or I would have included it in #58235 