### PR TITLE
Refactor `browse` navigation section

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -1,13 +1,13 @@
+import { useDisclosure } from "@mantine/hooks";
 import { c, t } from "ttag";
 
 import { useUserSetting } from "metabase/common/hooks";
-import CollapseSection from "metabase/components/CollapseSection";
-import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import {
   getEmbedOptions,
   getIsEmbeddingIframe,
 } from "metabase/selectors/embed";
+import { Collapse, Group, Icon } from "metabase/ui";
 
 import { PaddedSidebarLink, SidebarHeading } from "../MainNavbar.styled";
 import type { SelectedItem } from "../types";
@@ -29,59 +29,71 @@ export const BrowseNavSection = ({
     "expand-browse-in-nav",
   );
 
+  const [opened, { toggle }] = useDisclosure(expandBrowse);
+
   const entityTypes = useSelector(
     (state) => getEmbedOptions(state).entity_types,
   );
   const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
 
+  const handleToggle = () => {
+    toggle();
+    setExpandBrowse(!opened);
+  };
+
   return (
-    <CollapseSection
-      header={
+    <div aria-selected={opened} role="tab">
+      <Group
+        align="center"
+        gap="0.5rem"
+        onClick={handleToggle}
+        component="button"
+        c="var(--mb-color-text-medium)"
+        mb="sm"
+      >
         <SidebarHeading>{c("A verb, shown in the sidebar")
           .t`Browse`}</SidebarHeading>
-      }
-      initialState={expandBrowse ? "expanded" : "collapsed"}
-      iconPosition="right"
-      iconSize={8}
-      headerClass={CS.mb1}
-      onToggle={setExpandBrowse}
-    >
-      {(!isEmbeddingIframe || entityTypes.includes("model")) && (
-        <PaddedSidebarLink
-          icon="model"
-          url={BROWSE_MODELS_URL}
-          isSelected={nonEntityItem?.url?.startsWith(BROWSE_MODELS_URL)}
-          onClick={onItemSelect}
-          aria-label={t`Browse models`}
-        >
-          {t`Models`}
-        </PaddedSidebarLink>
-      )}
+        <Icon name={opened ? "chevrondown" : "chevronright"} size={8} />
+      </Group>
 
-      {hasDataAccess &&
-        (!isEmbeddingIframe || entityTypes.includes("table")) && (
+      <Collapse in={opened} transitionDuration={0} role="tabpanel">
+        {(!isEmbeddingIframe || entityTypes.includes("model")) && (
           <PaddedSidebarLink
-            icon="database"
-            url={BROWSE_DATA_URL}
-            isSelected={nonEntityItem?.url?.startsWith(BROWSE_DATA_URL)}
+            icon="model"
+            url={BROWSE_MODELS_URL}
+            isSelected={nonEntityItem?.url?.startsWith(BROWSE_MODELS_URL)}
             onClick={onItemSelect}
-            aria-label={t`Browse databases`}
+            aria-label={t`Browse models`}
           >
-            {t`Databases`}
+            {t`Models`}
           </PaddedSidebarLink>
         )}
 
-      {!isEmbeddingIframe && (
-        <PaddedSidebarLink
-          icon="metric"
-          url={BROWSE_METRICS_URL}
-          isSelected={nonEntityItem?.url?.startsWith(BROWSE_METRICS_URL)}
-          onClick={onItemSelect}
-          aria-label={t`Browse metrics`}
-        >
-          {t`Metrics`}
-        </PaddedSidebarLink>
-      )}
-    </CollapseSection>
+        {hasDataAccess &&
+          (!isEmbeddingIframe || entityTypes.includes("table")) && (
+            <PaddedSidebarLink
+              icon="database"
+              url={BROWSE_DATA_URL}
+              isSelected={nonEntityItem?.url?.startsWith(BROWSE_DATA_URL)}
+              onClick={onItemSelect}
+              aria-label={t`Browse databases`}
+            >
+              {t`Databases`}
+            </PaddedSidebarLink>
+          )}
+
+        {!isEmbeddingIframe && (
+          <PaddedSidebarLink
+            icon="metric"
+            url={BROWSE_METRICS_URL}
+            isSelected={nonEntityItem?.url?.startsWith(BROWSE_METRICS_URL)}
+            onClick={onItemSelect}
+            aria-label={t`Browse metrics`}
+          >
+            {t`Metrics`}
+          </PaddedSidebarLink>
+        )}
+      </Collapse>
+    </div>
   );
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -48,7 +48,7 @@ export const BrowseNavSection = ({
         gap="0.5rem"
         onClick={handleToggle}
         component="button"
-        c="var(--mb-color-text-medium)"
+        c="text-medium"
         mb="sm"
       >
         <SidebarHeading>{c("A verb, shown in the sidebar")

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -45,7 +45,7 @@ export const BrowseNavSection = ({
     <div aria-selected={opened} role="tab">
       <Group
         align="center"
-        gap="0.5rem"
+        gap="sm"
         onClick={handleToggle}
         component="button"
         c="text-medium"

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -8,7 +8,7 @@ import {
   getEmbedOptions,
   getIsEmbeddingIframe,
 } from "metabase/selectors/embed";
-import { Collapse, Group, Icon } from "metabase/ui";
+import { Collapse, Group, Icon, UnstyledButton } from "metabase/ui";
 
 import { PaddedSidebarLink, SidebarHeading } from "../MainNavbar.styled";
 import type { SelectedItem } from "../types";
@@ -48,7 +48,7 @@ export const BrowseNavSection = ({
         align="center"
         gap="sm"
         onClick={handleToggle}
-        component="button"
+        component={UnstyledButton}
         c="text-medium"
         mb="sm"
         className={CS.cursorPointer}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -2,6 +2,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { c, t } from "ttag";
 
 import { useUserSetting } from "metabase/common/hooks";
+import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import {
   getEmbedOptions,
@@ -50,6 +51,7 @@ export const BrowseNavSection = ({
         component="button"
         c="text-medium"
         mb="sm"
+        className={CS.cursorPointer}
       >
         <SidebarHeading>{c("A verb, shown in the sidebar")
           .t`Browse`}</SidebarHeading>


### PR DESCRIPTION
- Removes the dependency on the `CollapseSection` custom component
- Prepares the section for the "Add Data" project

> [!NOTE]
> The added bonus is that the browse section now reacts to the "Space" keypress on top of the "Enter" that was present in the previous implementation. The keyboard navigation comes "for free" with Mantine [Collapse](https://v7.mantine.dev/core/collapse/).

### Demo
![Kapture 2025-05-21 at 20 19 37](https://github.com/user-attachments/assets/5c829606-5133-4edf-b53a-827b1a48eef2)

