### PR TITLE
Field description editor

### DIFF
--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/Input.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/Input.tsx
@@ -5,21 +5,22 @@ import {
   Icon,
   TextInputBlurChange,
   type TextInputBlurChangeProps,
+  TextareaBlurChange,
+  type TextareaBlurChangeProps,
 } from "metabase/ui";
 
 import S from "./NameDescriptionInput.module.css";
 
-interface Props
-  extends Omit<
-    TextInputBlurChangeProps,
-    "normalize" | "value" | "onBlurChange" | "onChange"
-  > {
+type Props<Base> = Omit<
+  Base,
+  "normalize" | "value" | "onBlurChange" | "onChange"
+> & {
   normalize?: (
     value: string | number | readonly string[] | undefined,
   ) => string;
   value: string;
   onChange: (value: string) => void;
-}
+};
 
 export const Input = ({
   normalize,
@@ -27,7 +28,7 @@ export const Input = ({
   value,
   onChange,
   ...props
-}: Props) => {
+}: Props<TextInputBlurChangeProps>) => {
   const [isFocused, setIsFocused] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
@@ -41,6 +42,46 @@ export const Input = ({
             <Icon name="pencil" size={12} />
           </Flex>
         ) : undefined
+      }
+      rightSectionPointerEvents="none"
+      value={value}
+      onBlur={() => setIsFocused(false)}
+      onBlurChange={(event) => {
+        const newValue = event.target.value;
+        const newNormalizedValue = normalize ? normalize(newValue) : newValue;
+
+        if (newNormalizedValue !== value) {
+          onChange(event.target.value);
+        }
+      }}
+      onFocus={() => setIsFocused(true)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      {...props}
+    />
+  );
+};
+
+export const Textarea = ({
+  normalize,
+  required,
+  value,
+  onChange,
+  ...props
+}: Props<TextareaBlurChangeProps>) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <TextareaBlurChange
+      normalize={normalize}
+      required={required}
+      rightSection={
+        <Flex className={S.rightSection}>
+          {isHovered && !isFocused ? (
+            <Icon name="pencil" size={12} />
+          ) : undefined}
+        </Flex>
       }
       rightSectionPointerEvents="none"
       value={value}

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -7,7 +7,7 @@
 
 .description {
   position: relative;
-  top: -1px; /* imitate collapsed borders */
+  top: -2px; /* imitate collapsed borders */
 }
 
 .nameInput {

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -1,6 +1,6 @@
 import { Box } from "metabase/ui";
 
-import { Input } from "./Input";
+import { Input, Textarea } from "./Input";
 import S from "./NameDescriptionInput.module.css";
 
 interface Props {
@@ -43,7 +43,7 @@ export const NameDescriptionInput = ({
         onChange={onNameChange}
       />
 
-      <Input
+      <Textarea
         classNames={{
           input: S.descriptionInput,
           root: S.description,
@@ -51,6 +51,9 @@ export const NameDescriptionInput = ({
         placeholder={descriptionPlaceholder}
         value={description}
         onChange={onDescriptionChange}
+        autosize
+        minRows={2}
+        maxRows={4}
       />
     </Box>
   );

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
@@ -1,12 +1,17 @@
+import { t } from "ttag";
+
+import { useUpdateFieldMutation } from "metabase/api";
+import { useToast } from "metabase/common/hooks";
 import {
   DiscardFieldValuesButton,
+  NameDescriptionInput,
   RescanFieldButton,
 } from "metabase/metadata/components";
 import {
   getFieldDisplayName,
   getRawTableFieldId,
 } from "metabase/metadata/utils/field";
-import { Stack, Title } from "metabase/ui";
+import { Stack } from "metabase/ui";
 import type { DatabaseId, Field } from "metabase-types/api";
 
 import { BehaviorSection } from "./BehaviorSection";
@@ -20,11 +25,29 @@ interface Props {
 }
 
 export const FieldSection = ({ databaseId, field }: Props) => {
+  const [updateField] = useUpdateFieldMutation();
+  const id = getRawTableFieldId(field);
+  const [sendToast] = useToast();
+  function confirm(message: string) {
+    sendToast({ message });
+  }
+
   return (
-    <Stack gap={0} h="100%">
-      <Title order={2} pb="md">
-        {getFieldDisplayName(field)}
-      </Title>
+    <Stack gap="lg" h="100%">
+      <NameDescriptionInput
+        name={field.display_name}
+        namePlaceholder={t`Give this field a name`}
+        onNameChange={async (display_name) => {
+          await updateField({ id, display_name });
+          confirm(t`Display name for ${display_name} updated`);
+        }}
+        description={field.description ?? ""}
+        descriptionPlaceholder={t`Give this field a description`}
+        onDescriptionChange={async (description) => {
+          await updateField({ id, description });
+          confirm(t`Description for ${getFieldDisplayName(field)} updated`);
+        }}
+      />
 
       <Stack gap="xl">
         <DataSection field={field} />

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/MetadataSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/MetadataSection.tsx
@@ -8,12 +8,7 @@ import { useToast } from "metabase/common/hooks";
 import { SemanticTypeAndTargetPicker } from "metabase/metadata/components";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import {
-  Box,
-  Stack,
-  TextInputBlurChange,
-  TextareaBlurChange,
-} from "metabase/ui";
+import { Box, Stack } from "metabase/ui";
 import type { DatabaseId, Field } from "metabase-types/api";
 
 import { SectionPill } from "../SectionPill";
@@ -29,7 +24,6 @@ export const MetadataSection = ({ databaseId, field }: Props) => {
     ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
   });
   const [updateField] = useUpdateFieldMutation();
-  const id = getRawTableFieldId(field);
   const [sendToast] = useToast();
   function confirm(message: string) {
     sendToast({ message, icon: "check" });
@@ -40,39 +34,6 @@ export const MetadataSection = ({ databaseId, field }: Props) => {
       <Box>
         <SectionPill icon="model" title={t`Metadata`} />
       </Box>
-
-      <TextInputBlurChange
-        label={t`Display name`}
-        normalize={(newValue) => {
-          if (typeof newValue !== "string") {
-            return field.display_name;
-          }
-
-          const isNewValueEmpty = newValue.trim().length === 0;
-          return isNewValueEmpty ? field.display_name : newValue.trim();
-        }}
-        value={field.display_name}
-        onBlurChange={async (event) => {
-          await updateField({ id, display_name: event.target.value });
-          confirm(t`Display name for ${event.target.value} updated`);
-        }}
-      />
-
-      <TextareaBlurChange
-        label={t`Description`}
-        minRows={3}
-        placeholder={t`What is this field about?`}
-        value={field.description ?? ""}
-        onBlurChange={async (event) => {
-          const newValue = event.target.value;
-
-          await updateField({
-            id,
-            description: newValue.trim().length > 0 ? newValue : null,
-          });
-          confirm(t`Description for ${field.display_name} updated`);
-        }}
-      />
 
       <SemanticTypeAndTargetPicker
         description={t`What this data represents`}


### PR DESCRIPTION
Closes [SEM-335](https://linear.app/metabase/issue/SEM-335/move-the-fields-description-back-up-next-to-its-display-name)
Closes [SEM-326](https://linear.app/metabase/issue/SEM-326/get-table-description-multiline)

Reuse the name and description editor that we use for tables in the field section as well.

<img width="1474" alt="Screenshot 2025-05-21 at 15 51 42" src="https://github.com/user-attachments/assets/86fb52d8-0afc-4b72-bb1b-38a08bc70e58" />

Tests will be added in a later PR.