### PR TITLE
Remove edit permissions from other users personal collections

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -20,7 +20,6 @@ import type {
   UploadFile,
 } from "metabase/collections/types";
 import {
-  isPersonalCollectionChild,
   isRootTrashCollection,
   isTrashedCollection,
 } from "metabase/collections/utils";
@@ -57,7 +56,6 @@ const CollectionContentViewInner = ({
   databases,
   bookmarks,
   collection,
-  collections: collectionList = [],
   collectionId,
   createBookmark,
   deleteBookmark,
@@ -72,7 +70,6 @@ const CollectionContentViewInner = ({
   databases?: Database[];
   bookmarks?: Bookmark[];
   collection: Collection;
-  collections: Collection[];
   collectionId: CollectionId;
   createBookmark: CreateBookmark;
   deleteBookmark: DeleteBookmark;
@@ -234,10 +231,6 @@ const CollectionContentViewInner = ({
             collection={collection}
             isAdmin={isAdmin}
             isBookmarked={isBookmarked}
-            isPersonalCollectionChild={isPersonalCollectionChild(
-              collection,
-              collectionList,
-            )}
             onCreateBookmark={handleCreateBookmark}
             onDeleteBookmark={handleDeleteBookmark}
             canUpload={canCreateUpload}

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -21,7 +21,6 @@ export interface CollectionHeaderProps {
   collection: Collection;
   isAdmin: boolean;
   isBookmarked: boolean;
-  isPersonalCollectionChild: boolean;
   onUpdateCollection: (entity: Collection, values: Partial<Collection>) => void;
   onCreateBookmark: (collection: Collection) => void;
   onDeleteBookmark: (collection: Collection) => void;
@@ -34,7 +33,6 @@ const CollectionHeader = ({
   collection,
   isAdmin,
   isBookmarked,
-  isPersonalCollectionChild,
   onUpdateCollection,
   onCreateBookmark,
   onDeleteBookmark,
@@ -87,7 +85,6 @@ const CollectionHeader = ({
             <CollectionMenu
               collection={collection}
               isAdmin={isAdmin}
-              isPersonalCollectionChild={isPersonalCollectionChild}
               onUpdateCollection={onUpdateCollection}
             />
           )}

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
@@ -23,7 +23,6 @@ const getProps = (
   isBookmarked: false,
   canUpload: false,
   uploadsEnabled: true,
-  isPersonalCollectionChild: false,
   onUpdateCollection: jest.fn(),
   onCreateBookmark: jest.fn(),
   saveFile: jest.fn(),

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import {
   isInstanceAnalyticsCustomCollection,
+  isPersonalCollection,
   isRootCollection,
   isRootPersonalCollection,
 } from "metabase/collections/utils";
@@ -18,7 +19,6 @@ import type { Collection } from "metabase-types/api";
 export interface CollectionMenuProps {
   collection: Collection;
   isAdmin: boolean;
-  isPersonalCollectionChild: boolean;
   onUpdateCollection: (entity: Collection, values: Partial<Collection>) => void;
 }
 
@@ -34,7 +34,6 @@ const mergeArrays = (arr: ReactNode[][]): ReactNode[] => {
 export const CollectionMenu = ({
   collection,
   isAdmin,
-  isPersonalCollectionChild,
   onUpdateCollection,
 }: CollectionMenuProps): JSX.Element | null => {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -43,13 +42,16 @@ export const CollectionMenu = ({
 
   const url = Urls.collection(collection);
   const isRoot = isRootCollection(collection);
-  const isPersonal = isRootPersonalCollection(collection);
+  const isPersonal = isPersonalCollection(collection);
   const isInstanceAnalyticsCustom =
     isInstanceAnalyticsCustomCollection(collection);
 
   const canWrite = collection.can_write;
   const canMove =
-    !isRoot && !isPersonal && canWrite && !isInstanceAnalyticsCustom;
+    !isRoot &&
+    !isRootPersonalCollection(collection) &&
+    canWrite &&
+    !isInstanceAnalyticsCustom;
 
   const moveItems = [];
   const cleanupItems = [];
@@ -76,7 +78,7 @@ export const CollectionMenu = ({
     );
   }
 
-  if (isAdmin && !isPersonal && !isPersonalCollectionChild) {
+  if (isAdmin && !isPersonal) {
     editItems.push(
       <Menu.Item
         key="collection-edit"

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
@@ -36,6 +36,7 @@ describe("CollectionMenu", () => {
       collection: createMockCollection({
         personal_owner_id: 1,
         can_write: true,
+        is_personal: true,
       }),
       isAdmin: true,
     });
@@ -47,9 +48,9 @@ describe("CollectionMenu", () => {
     setup({
       collection: createMockCollection({
         can_write: true,
+        is_personal: true,
       }),
       isAdmin: true,
-      isPersonalCollectionChild: true,
     });
 
     await userEvent.click(getIcon("ellipsis"));

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -105,11 +105,11 @@ describe("CollectionMenu", () => {
   it("should be able to make the collection official if even it's a personal collection child", async () => {
     const collection = createMockCollection({
       can_write: true,
+      is_personal: true,
     });
     setupPremium({
       collection,
       isAdmin: true,
-      isPersonalCollectionChild: true,
     });
 
     await userEvent.click(getIcon("ellipsis"));

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/setup.tsx
@@ -40,7 +40,6 @@ export const setup = ({
   collection = createMockCollection(),
   tokenFeatures = createMockTokenFeatures(),
   isAdmin = false,
-  isPersonalCollectionChild = false,
   hasEnterprisePlugins = false,
   dashboardQuestionCandidates = [],
   moveToDashboard = false,
@@ -91,7 +90,6 @@ export const setup = ({
           <CollectionMenu
             collection={collection}
             isAdmin={isAdmin}
-            isPersonalCollectionChild={isPersonalCollectionChild}
             onUpdateCollection={onUpdateCollection}
           />
         )}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57906

### Description
This PR changes how we decide if a collection is a personal collection in the collection header. We currently have a bug where if an admin navigates to the sub collection of a personal collection of another user, we show "edit permissions" in the collection menu but clicking that leads to an error. However, we don't show this menu option for a users own personal sub collections.

This PR updates how we determine if a collection is a personal sub collection to use the `is_personal` prop on the collection object, which is properly set by the BE, rather than the `isPersonalCollectionChild`, which leveraged the `personal_owner_id` prop (this doesn't appear to be set on personal sub collections).

This PR also removes "Make Collection Official" from root personal collections, since that is not a valid action.

### How to verify
1. Log in as an admin
2. navigate to another users personal collections, and then to a sub collection from there
3. Open the collection Menu
4. There should be no option for `Edit Collection Permissions`

### Demo
[Loom](https://www.loom.com/share/e57962376fb24d028bdae4ea8e87b7cd)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
