### PR TITLE
fix: appdb table permssions search slowdown

### DIFF
--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -81,7 +81,12 @@
                       [:!= :search_index.model [:inline "table"]]
                       [:and
                        [:= :search_index.model [:inline "table"]]
-                       (search.permissions/permitted-tables-clause search-ctx :search_index.model_id)]]))
+                       [:exists {:select [1]
+                                 :from   [[:metabase_table :mt_toplevel]]
+                                 :where  [:and [:= :mt_toplevel.id [:cast :search_index.model_id (case (mdb/db-type)
+                                                                                                   :mysql :signed
+                                                                                                   :integer)]]
+                                          (search.permissions/permitted-tables-clause search-ctx :mt_toplevel.id)]}]]]))
 
 (defn add-collection-join-and-where-clauses
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,

--- a/src/metabase/search/permissions.clj
+++ b/src/metabase/search/permissions.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.permissions
   (:require
-   [metabase.app-db.core :as mdb]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
@@ -48,9 +47,7 @@
   [{:keys [current-user-id is-superuser?]} :- SearchContext table-id-col :- :keyword]
   (mi/visible-filter-clause
    :model/Table
-   [:cast table-id-col (case (mdb/db-type)
-                         :mysql :signed
-                         :integer)]
+   table-id-col
    {:user-id current-user-id
     :is-superuser? is-superuser?}
    {:perms/view-data :unrestricted


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #58192
### Description

The appdb search table permissions were resulting a full table scan of tables. This use a correlated subquery to limit the search of table permissions to just candidates selected from the search engine and to make sure we compare the permission subquery against the pk index from the metabase_table table.

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
