### PR TITLE
Metadata editing UI tweaks

### DIFF
--- a/frontend/src/metabase/metadata/components/SortableField/SortableField.tsx
+++ b/frontend/src/metabase/metadata/components/SortableField/SortableField.tsx
@@ -49,6 +49,7 @@ export const SortableField = ({
         px="sm"
         py="xs"
         role="listitem"
+        bg="bg-white"
         // "to" prop should be undefined when Link component is not used.
         // Types do not account for conditional Link usage, hence cast.
         to={href ? href : (undefined as unknown as string)}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection.tsx
@@ -39,7 +39,7 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
   return (
     <Stack gap="md">
       <Box>
-        <SectionPill icon="filter" title={t`Behavior`} />
+        <SectionPill title={t`Behavior`} />
       </Box>
 
       <FieldVisibilityPicker

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.module.css
@@ -1,0 +1,9 @@
+.disabledInput:disabled {
+  background: var(--mb-color-bg-white);
+  color: var(--mb-color-text-primary);
+  opacity: 1;
+}
+
+.disabledInputIcon {
+  color: var(--mb-color-text-light);
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
@@ -39,7 +39,7 @@ export const DataSection = ({ field }: Props) => {
   return (
     <Stack gap="md">
       <Box>
-        <SectionPill icon="database" title={t`Data`} />
+        <SectionPill title={t`Data`} />
       </Box>
 
       <TextInput

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
@@ -13,6 +13,7 @@ import type { Field } from "metabase-types/api";
 
 import { SectionPill } from "../SectionPill";
 
+import S from "./DataSection.module.css";
 import SubInputFollowIllustration from "./illustrations/sub-input-follow.svg?component";
 import SubInputIllustration from "./illustrations/sub-input.svg?component";
 
@@ -44,18 +45,20 @@ export const DataSection = ({ field }: Props) => {
       <TextInput
         disabled
         label={t`Field name`}
-        rightSection={<Icon name="lock" />}
+        rightSection={<Icon name="lock" className={S.disabledInputIcon} />}
         rightSectionPointerEvents="none"
         value={field.name}
+        classNames={{ input: S.disabledInput }}
       />
 
       <Stack gap={0}>
         <TextInput
           disabled
           label={t`Data type`}
-          rightSection={<Icon name="lock" />}
+          rightSection={<Icon name="lock" className={S.disabledInputIcon} />}
           rightSectionPointerEvents="none"
           value={field.database_type}
+          classNames={{ input: S.disabledInput }}
         />
 
         {canCoerceFieldType(field) && (

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FormattingSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FormattingSection.tsx
@@ -36,7 +36,7 @@ export const FormattingSection = ({ field }: Props) => {
   return (
     <Stack gap="md">
       <Box>
-        <SectionPill icon="variable" title={t`Formatting`} />
+        <SectionPill title={t`Formatting`} />
       </Box>
 
       <ColumnSettings

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/MetadataSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/MetadataSection.tsx
@@ -38,7 +38,7 @@ export const MetadataSection = ({ databaseId, field }: Props) => {
   return (
     <Stack gap="md">
       <Box>
-        <SectionPill icon="model" title={t`Metadata`} />
+        <SectionPill title={t`Metadata`} />
       </Box>
 
       <TextInputBlurChange

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/PreviewSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { t } from "ttag";
 
 import { Box, Card, Flex, SegmentedControl, Text } from "metabase/ui";
 import type { DatabaseId, Field, FieldId, TableId } from "metabase-types/api";
@@ -26,7 +27,7 @@ export const PreviewSection = ({
 }: Props) => {
   return (
     <Card bg="white" h="100%" px="lg" py="md" shadow="xs">
-      <Text fw="bold">Field preview</Text>
+      <Text fw="bold">{t`Field preview`}</Text>
       <PreviewTypeSelector value={previewType} onChange={onPreviewTypeChange} />
 
       {previewType === "table" && (

--- a/frontend/src/metabase/metadata/pages/DataModel/components/SectionPill/SectionPill.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/SectionPill/SectionPill.tsx
@@ -1,13 +1,12 @@
-import { Box, Flex, Icon, type IconName, Text } from "metabase/ui";
+import { Flex, Text } from "metabase/ui";
 
 import S from "./SectionPill.module.css";
 
 interface Props {
-  icon: IconName;
   title: string;
 }
 
-export const SectionPill = ({ icon, title }: Props) => {
+export const SectionPill = ({ title }: Props) => {
   return (
     <Flex
       align="center"
@@ -18,10 +17,6 @@ export const SectionPill = ({ icon, title }: Props) => {
       px="sm"
       py={6}
     >
-      <Box c="text-dark" flex="0 0 auto">
-        <Icon name={icon} size={12} />
-      </Box>
-
       <Text c="text-primary" size="sm">
         {title}
       </Text>


### PR DESCRIPTION
Closes [SEM-337](https://linear.app/metabase/issue/SEM-337/adjust-readonly-look-and-feel-of-field-settings-data-section)
Closes [SEM-336](https://linear.app/metabase/issue/SEM-336/remove-icons-from-field-settings-section-header-pills)


Also fixes the background color of the fields in the table section.

<img width="1474" alt="Screenshot 2025-05-21 at 18 42 21" src="https://github.com/user-attachments/assets/7ac57888-a7cf-4ce9-8c2f-890eb35bf928" />
