### PR TITLE
fix: orphaned tables break migration (#58288)

### DIFF
--- a/resources/migrations/permissions/mysql_data_access.sql
+++ b/resources/migrations/permissions/mysql_data_access.sql
@@ -103,6 +103,7 @@ SELECT
     'no-self-service' AS perm_value
 FROM permissions_group pg
 CROSS JOIN metabase_table mt
+JOIN metabase_database db ON mt.db_id = db.id
 WHERE NOT EXISTS (
     SELECT 1
     FROM data_permissions dp


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

Closes https://github.com/metabase/metabase/issues/58288

### Description

In rare occasions, orphaned table nodes prevent the mysql migration v50.2024-01-10T03:27:30 due to a FK constraint.
This fix only applies changes to tables that have an db_id associated to it.

### How to verify
Read the code.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR