### PR TITLE
[Backend modularization] Eliminate `util` dep on `channel` and `parameters`

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -379,7 +379,6 @@
     metabase.util.markdown                    markdown
     metabase.util.password                    u.password
     metabase.util.ui-logic                    ui-logic
-    metabase.util.urls                        urls
     metabase.xrays.core                       xrays
     monger.collection                         mcoll
     ring.mock.request                         ring.mock

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -213,7 +213,8 @@
            metabase.channel.render.core
            metabase.channel.settings
            metabase.channel.slack
-           metabase.channel.template.core}
+           metabase.channel.template.core
+           metabase.channel.urls}
    :uses #{analytics
            api
            app-db
@@ -540,7 +541,6 @@
    :uses #{lib
            models
            settings
-           task
            util}}
 
   logger
@@ -1191,13 +1191,11 @@
   util
   {:api :any
    :uses #{app-db
-           channel
            classloader
            config
            driver
            legacy-mbql
            lib
-           parameters
            settings
            system}}
 

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -204,7 +204,7 @@
   "Technically `config` 'uses' `enterprise/core` and `test` since it tries to load them to see if they exist so we know
   if EE/test code is available; however we can ignore them since they're not 'real' usages. So add them here so we
   don't include them in our deps tree."
-  '{metabase.config #{metabase-enterprise.core.dummy-namespace metabase.test.dummy-namespace}})
+  '{metabase.config.core #{metabase-enterprise.core.dummy-namespace metabase.test.dummy-namespace}})
 
 (mu/defn- file-dependencies :- [:map
                                 [:namespace simple-symbol?]

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -9,12 +9,12 @@
    [metabase-enterprise.sso.integrations.saml]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.api.macros :as api.macros]
+   [metabase.channel.urls :as urls]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.urls :as urls]
    [saml20-clj.core :as saml]
    [stencil.core :as stencil]
    [toucan2.core :as t2]))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -36,6 +36,7 @@
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
    [metabase.api.common :as api]
+   [metabase.channel.urls :as urls]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
@@ -46,7 +47,6 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.urls :as urls]
    [ring.util.response :as response]
    [saml20-clj.core :as saml]
    [toucan2.core :as t2]))

--- a/src/metabase/app_db/query_cancelation.clj
+++ b/src/metabase/app_db/query_cancelation.clj
@@ -1,0 +1,53 @@
+(ns metabase.app-db.query-cancelation)
+
+(set! *warn-on-reflection* true)
+
+(defmulti ^:private query-canceled-exception?*
+  {:arglists '([db-type ^java.sql.SQLException e])}
+  (fn [db-type _e]
+    (keyword db-type)))
+
+(defmethod query-canceled-exception?* :h2
+  [_db-type ^java.sql.SQLException e]
+  (= (.getErrorCode e) org.h2.api.ErrorCode/STATEMENT_WAS_CANCELED))
+
+(defn- sql-state
+  [^java.sql.SQLException e]
+  (loop [exception e]
+    (if-let [sql-state (.getSQLState exception)]
+      sql-state
+      (when-let [next-ex (.getNextException exception)]
+        (recur next-ex)))))
+
+(defmethod query-canceled-exception?* :postgres
+  [_db-type e]
+  (= (sql-state e)
+     (.getState org.postgresql.util.PSQLState/QUERY_CANCELED)))
+
+;;; MariaDB and MySQL report different error codes for the timeout caused by using .setQueryTimeout. This happens
+;;; because they use different mechanisms for causing this timeout. MySQL timesout and terminates the connection
+;;; externally. MariaDB uses the max_statement_time configuration that can be passed to a SQL statement to set its.
+;;;
+;;; Docs for MariaDB:
+;;; https://mariadb.com/kb/en/e1317/
+;;; https://mariadb.com/kb/en/e1969/
+;;; https://mariadb.com/kb/en/e3024/
+;;;
+;;; Docs for MySQL:
+;;; https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+;;;
+;;; MySQL can return 1317 and 3024, but 1969 is not an error code in the mysql reference. All of these codes make sense
+;;; for MariaDB to return. Hibernate expects 3024, but in testing 1969 was observered.
+(defmethod query-canceled-exception?* :mysql
+  [_db-type ^java.sql.SQLException e]
+  ;; apparently there is no enum in the MariaDB JDBC driver for different error codes >:(
+  (contains? #{1317 1969 3024} (.getErrorCode e)))
+
+(defn query-canceled-exception?
+  "Whether exception `e` represents a query cancelation."
+  [db-type ^Throwable e]
+  (boolean
+   (or (when (instance? java.sql.SQLException e)
+         (query-canceled-exception?* db-type e))
+       (when-let [cause (ex-cause e)]
+         (query-canceled-exception? db-type cause)))))

--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -14,6 +14,7 @@
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.template.core :as channel.template]
+   [metabase.channel.urls :as urls]
    [metabase.collections.models.collection :as collection]
    [metabase.lib.util :as lib.util]
    [metabase.permissions.core :as perms]
@@ -27,7 +28,6 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.urls :as urls]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -13,6 +13,7 @@
    [metabase.channel.render.util :as render.util]
    [metabase.channel.shared :as channel.shared]
    [metabase.channel.template.handlebars :as handlebars]
+   [metabase.channel.urls :as urls]
    [metabase.notification.models :as models.notification]
    [metabase.parameters.shared :as shared.params]
    [metabase.system.core :as system]
@@ -23,7 +24,6 @@
    [metabase.util.malli.schema :as ms]
    [metabase.util.markdown :as markdown]
    [metabase.util.ui-logic :as ui-logic]
-   [metabase.util.urls :as urls]
    [ring.util.codec :as codec]))
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -5,11 +5,11 @@
    [metabase.channel.core :as channel]
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.shared :as channel.shared]
+   [metabase.channel.urls :as urls]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms]
-   [metabase.util.urls :as urls]))
+   [metabase.util.malli.schema :as ms]))
 
 (def ^:private image-width
   "Maximum width of the rendered PNG of HTML to be sent to HTTP Content that exceeds this width (e.g. a table with

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -6,12 +6,12 @@
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.shared :as channel.shared]
    [metabase.channel.slack :as slack]
+   [metabase.channel.urls :as urls]
    [metabase.parameters.shared :as shared.params]
    [metabase.premium-features.core :as premium-features]
    [metabase.system.core :as system]
    [metabase.util.malli :as mu]
-   [metabase.util.markdown :as markdown]
-   [metabase.util.urls :as urls]))
+   [metabase.util.markdown :as markdown]))
 
 (defn- notification-recipient->channel-id
   [notification-recipient]

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -6,6 +6,7 @@
    [metabase.channel.render.png :as png]
    [metabase.channel.render.style :as style]
    [metabase.channel.render.util :as render.util]
+   [metabase.channel.urls :as urls]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util :as u]
@@ -14,7 +15,6 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.markdown :as markdown]
-   [metabase.util.urls :as urls]
    [toucan2.core :as t2]))
 
 ;;; I gave these keys below namespaces to make them easier to find usages for but didn't use `metabase.channel.render` so

--- a/src/metabase/channel/template/handlebars_helper.clj
+++ b/src/metabase/channel/template/handlebars_helper.clj
@@ -2,8 +2,8 @@
   (:refer-clojure :exclude [hash])
   (:require
    [java-time.api :as t]
-   [metabase.util.date-2 :as u.date]
-   [metabase.util.urls :as urls])
+   [metabase.channel.urls :as urls]
+   [metabase.util.date-2 :as u.date])
   (:import
    (com.github.jknack.handlebars
     Options Handlebars Helper Handlebars$SafeString)))

--- a/src/metabase/channel/urls.clj
+++ b/src/metabase/channel/urls.clj
@@ -1,10 +1,11 @@
-(ns metabase.util.urls
-  "Utility functions for generating the frontend URLs that correspond various user-facing Metabase *objects*, like Cards or Dashboards.
-   This is intended as the central place for all such URL-generation activity, so if frontend routes change, only this file need be changed
-   on the backend.
+(ns metabase.channel.urls
+  "Utility functions for generating the frontend URLs that correspond various user-facing Metabase *objects*, like Cards
+  or Dashboards. This is intended as the central place for all such URL-generation activity, so if frontend routes
+  change, only this file need be changed on the backend.
 
-   Functions for generating URLs not related to Metabase *objects* generally do not belong here, unless they are used in many places in the
-   codebase; one-off URL-generation functions should go in the same namespaces or modules where they are used."
+  Functions for generating URLs not related to Metabase *objects* generally do not belong here, unless they are used
+  in many places in the codebase; one-off URL-generation functions should go in the same namespaces or modules where
+  they are used."
   (:require
    [clojure.string :as str]
    [metabase.channel.settings :as channel.settings]

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -3,6 +3,7 @@
    [malli.core :as mc]
    [medley.core :as m]
    [metabase.api.common :as api]
+   [metabase.channel.urls :as urls]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
@@ -17,7 +18,6 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.urls :as urls]
    [toucan2.core :as t2]))
 
 (defn is-card-empty?

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -16,6 +16,7 @@
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.slack :as channel.slack]
+   [metabase.channel.urls :as urls]
    [metabase.classloader.core :as classloader]
    [metabase.collections.models.collection :as collection]
    [metabase.config.core :as config]
@@ -32,7 +33,6 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.urls :as urls]
    [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)))

--- a/src/metabase/pulse/task/email_remove_legacy_pulse.clj
+++ b/src/metabase/pulse/task/email_remove_legacy_pulse.clj
@@ -4,9 +4,9 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.channel.email :as email]
    [metabase.channel.template.core :as channel.template]
+   [metabase.channel.urls :as urls]
    [metabase.task.core :as task]
    [metabase.util.log :as log]
-   [metabase.util.urls :as urls]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)

--- a/test/metabase/channel/urls_test.clj
+++ b/test/metabase/channel/urls_test.clj
@@ -1,8 +1,8 @@
-(ns metabase.util.urls-test
+(ns metabase.channel.urls-test
   (:require
    [clojure.test :refer :all]
-   [metabase.test :as mt]
-   [metabase.util.urls :as urls]))
+   [metabase.channel.urls :as urls]
+   [metabase.test :as mt]))
 
 (deftest dashboard-url-test
   (mt/with-temporary-setting-values [site-url "https://metabase.com"]

--- a/test/metabase/notification/payload/impl/system_event_test.clj
+++ b/test/metabase/notification/payload/impl/system_event_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.notification.payload.impl.system-event-test
   (:require
    [clojure.test :refer :all]
+   [metabase.channel.urls :as urls]
    [metabase.events.core :as events]
    [metabase.notification.models :as models.notification]
    [metabase.notification.test-util :as notification.tu]
@@ -8,7 +9,6 @@
    [metabase.sso.settings :as sso.settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [metabase.util.urls :as urls]
    [toucan2.core :as t2]))
 
 (use-fixtures


### PR DESCRIPTION
Move `metabase.util.urls` to `metabase.channel.urls` (not 100% sure this is the best place for it, but it's definitely better than `util`)

Resolves DEV-532