### PR TITLE
add pivot xlsx export hint

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -106,11 +106,14 @@ export function downloadAndAssert(
   popover().within(() => {
     cy.findByText(`.${fileType}`).click();
 
-    const formattingButtonLabel = enableFormatting
-      ? "Formatted"
-      : "Unformatted";
-
-    cy.findByText(formattingButtonLabel).click();
+    cy.findByTestId("keep-data-formatted")
+      .as("keep-data-formatted")
+      .then(($checkbox) => {
+        const isChecked = $checkbox.prop("checked");
+        if (enableFormatting !== isChecked) {
+          cy.get("@keep-data-formatted").click();
+        }
+      });
 
     if (pivoting != null) {
       cy.findByTestId("keep-data-pivoted")

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -348,7 +348,7 @@ describe("scenarios > embedding > questions > downloads", () => {
         cy.findByRole("button", { name: "Download results" }).click();
 
         H.popover().within(() => {
-          cy.findAllByText("Download").should("have.length", 2);
+          cy.findByText("Download");
           cy.findByText(".csv");
           cy.findByText(".xlsx");
           cy.findByText(".json");

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -1004,7 +1004,7 @@ describe("issue 49525", { tags: "@external" }, () => {
     });
   });
 
-  it("Subscriptions with 'Keep data pivoted' checked should work (metabase#49525)", () => {
+  it("Subscriptions with 'Keep the data pivoted' checked should work (metabase#49525)", () => {
     // Send a test email subscription
     H.openSharingMenu("Subscriptions");
     H.sidebar().within(() => {
@@ -1018,7 +1018,7 @@ describe("issue 49525", { tags: "@external" }, () => {
       // Click this just to close the popover that is blocking the "Send email now" button
       cy.findByText("To:").click();
       cy.findByLabelText("Attach results").click();
-      cy.findByText("Keep data pivoted").click();
+      cy.findByText("Keep the data pivoted").click();
       cy.findByText("Questions to attach").click();
     });
 

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -711,12 +711,32 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     });
   });
 
-  it("should open the download popover (metabase#14750)", () => {
+  it("should show a download widget with a hint about pivoted xlsx exports (metabase#14750)", () => {
+    const HINT_TEXT =
+      "Trying to pivot this data in Excel? You should download the raw data instead.";
     createTestQuestion();
     cy.icon("download").click();
-    H.popover().within(() =>
-      cy.findAllByText("Download").should("have.length", 2),
-    );
+
+    H.popover().within(() => {
+      cy.findByText(".xlsx").click();
+      cy.findByText(HINT_TEXT);
+      cy.findByText("Read the docs").should(
+        "have.attr",
+        "href",
+        "https://www.metabase.com/docs/latest/questions/exporting-results.html#exporting-pivot-tables",
+      );
+
+      cy.findByLabelText("Close hint").click();
+      cy.findByText(HINT_TEXT).should("not.exist");
+
+      cy.findByText("Download");
+    });
+
+    // Ensure the hint is not visible after a page reload
+    cy.reload();
+
+    cy.icon("download").click();
+    H.popover().findByText(HINT_TEXT).should("not.exist");
   });
 
   it.skip("should work for user without data permissions (metabase#14989)", () => {

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -445,6 +445,7 @@ interface PublicSettings {
 }
 
 export type UserSettings = {
+  "dismissed-excel-pivot-exports-banner"?: boolean;
   "dismissed-collection-cleanup-banner"?: boolean;
   "dismissed-browse-models-banner"?: boolean;
   "dismissed-custom-dashboard-toast"?: boolean;

--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -6,7 +6,7 @@ import type { ExportFormat } from "metabase/common/types/export";
 import { useSelector } from "metabase/lib/redux";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import { Checkbox, Chip, Group, Radio, Stack, Text } from "metabase/ui";
+import { Checkbox, SegmentedControl, Stack } from "metabase/ui";
 
 interface ExportSettingsWidgetProps {
   formats: ExportFormat[];
@@ -75,52 +75,33 @@ export const ExportSettingsWidget = ({
   const arePivotedExportsEnabled = useSetting("enable-pivoted-exports") ?? true;
 
   const formattingLabel = useFormattingLabel({ isFormattingEnabled });
+  const formatOptions = formats.map((format) => ({
+    label: `.${format}`,
+    value: format,
+  }));
 
   return (
-    <Stack>
-      <Chip.Group
+    <Stack gap="lg">
+      <SegmentedControl
+        w="100%"
+        data={formatOptions}
         value={selectedFormat}
-        onChange={(newValue: string | string[]) => {
-          Array.isArray(newValue)
-            ? onChangeFormat(newValue[0] as ExportFormat)
-            : onChangeFormat(newValue as ExportFormat);
-        }}
-      >
-        <Group gap="xs" wrap="nowrap">
-          {formats.map((format) => (
-            <Chip
-              key={format}
-              value={format}
-              variant="brand"
-            >{`.${format}`}</Chip>
-          ))}
-        </Group>
-      </Chip.Group>
-      {canConfigureFormatting ? (
-        <Stack gap="xs">
-          <Radio.Group
-            value={isFormattingEnabled ? "true" : "false"}
-            onChange={() => onToggleFormatting()}
-          >
-            <Group>
-              <Radio value="true" label={t`Formatted`} />
-              <Radio value="false" label={t`Unformatted`} />
-            </Group>
-          </Radio.Group>
+        onChange={onChangeFormat}
+      />
 
-          <Text
-            data-testid="formatting-description"
-            size="sm"
-            color="text-medium"
-          >
-            {formattingLabel}
-          </Text>
-        </Stack>
+      {canConfigureFormatting ? (
+        <Checkbox
+          data-testid="keep-data-formatted"
+          label={t`Keep the data formatted`}
+          checked={isFormattingEnabled}
+          onChange={() => onToggleFormatting()}
+          description={formattingLabel}
+        />
       ) : null}
       {arePivotedExportsEnabled && canConfigurePivoting ? (
         <Checkbox
           data-testid="keep-data-pivoted"
-          label={t`Keep data pivoted`}
+          label={t`Keep the data pivoted`}
           checked={isPivotingEnabled}
           onChange={() => onTogglePivoting()}
         />

--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -96,6 +96,7 @@ export const ExportSettingsWidget = ({
           checked={isFormattingEnabled}
           onChange={() => onToggleFormatting()}
           description={formattingLabel}
+          styles={{ inner: { alignSelf: "flex-start" } }}
         />
       ) : null}
       {arePivotedExportsEnabled && canConfigurePivoting ? (

--- a/frontend/src/metabase/css/core/colors.module.css
+++ b/frontend/src/metabase/css/core/colors.module.css
@@ -89,6 +89,7 @@
   --mb-color-background-disabled: var(--mb-base-color-gray-10);
   --mb-color-background-inverse: var(--mb-color-bg-black);
   --mb-color-background-brand: var(--mb-base-color-brand-40);
+  --mb-color-background-light: var(--mb-base-color-orion-5);
   /* The primary color is still `bg-error` not `background-error` */
   --mb-color-background-error-secondary: var(--mb-base-color-lobster-5);
   --mb-color-icon-primary: var(--mb-base-color-brand-40);

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
@@ -106,12 +106,12 @@ describe("QuestionDownloadWidget", () => {
       const { onDownload } = setup();
 
       await userEvent.click(screen.getByLabelText(`.${format}`));
-      await userEvent.click(screen.getByLabelText("Unformatted"));
-      expect(screen.queryByTestId("formatting-description")).toHaveTextContent(
-        `E.g. 2024-09-06 or 187.50, like in the database`,
-      );
+      await userEvent.click(screen.getByLabelText("Keep the data formatted"));
       expect(
-        screen.queryByLabelText("Keep data pivoted"),
+        screen.getByText("E.g. 2024-09-06 or 187.50, like in the database"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Keep the data pivoted"),
       ).not.toBeInTheDocument();
       await userEvent.click(
         await screen.findByTestId("download-results-button"),
@@ -131,12 +131,11 @@ describe("QuestionDownloadWidget", () => {
       const { onDownload } = setup();
 
       await userEvent.click(screen.getByLabelText(`.${format}`));
-      await userEvent.click(screen.getByLabelText("Formatted"));
-      expect(screen.queryByTestId("formatting-description")).toHaveTextContent(
-        `E.g. September 6, 2024 or $187.50, like in Metabase`,
-      );
       expect(
-        screen.queryByLabelText("Keep data pivoted"),
+        screen.getByText("E.g. September 6, 2024 or $187.50, like in Metabase"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Keep the data pivoted"),
       ).not.toBeInTheDocument();
       await userEvent.click(
         await screen.findByTestId("download-results-button"),
@@ -155,9 +154,11 @@ describe("QuestionDownloadWidget", () => {
     const { onDownload } = setup({ card: { ...TEST_CARD, display: "line" } });
 
     await userEvent.click(screen.getByLabelText(`.${format}`));
-    expect(screen.queryByLabelText(`Formatted`)).not.toBeInTheDocument();
     expect(
-      screen.queryByLabelText("Keep data pivoted"),
+      screen.queryByLabelText(`Keep the data formatted`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Keep the data pivoted"),
     ).not.toBeInTheDocument();
     await userEvent.click(await screen.findByTestId("download-results-button"));
 
@@ -179,7 +180,7 @@ describe("QuestionDownloadWidget", () => {
       });
 
       await userEvent.click(screen.getByLabelText(`.${format}`));
-      await userEvent.click(screen.getByLabelText(`Unformatted`));
+      await userEvent.click(screen.getByLabelText(`Keep the data formatted`));
       await userEvent.click(
         await screen.findByTestId("download-results-button"),
       );
@@ -192,7 +193,7 @@ describe("QuestionDownloadWidget", () => {
     },
   );
 
-  it("should hide 'Keep data pivoted' option when enable-pivoted-exports setting is false", async () => {
+  it("should hide 'Keep the data pivoted' option when enable-pivoted-exports setting is false", async () => {
     setup({
       card: { ...TEST_CARD, display: "pivot" },
       settings: { "enable-pivoted-exports": false },
@@ -200,7 +201,7 @@ describe("QuestionDownloadWidget", () => {
 
     await userEvent.click(screen.getByLabelText(".csv"));
     expect(
-      screen.queryByLabelText("Keep data pivoted"),
+      screen.queryByLabelText("Keep the data pivoted"),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.module.css
@@ -55,6 +55,10 @@
   align-items: center;
 }
 
+.inner {
+  align-self: flex-start;
+}
+
 .input {
   cursor: pointer;
   border: 1px solid var(--mb-color-bg-dark);

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.module.css
@@ -55,10 +55,6 @@
   align-items: center;
 }
 
-.inner {
-  align-self: flex-start;
-}
-
 .input {
   cursor: pointer;
   border: 1px solid var(--mb-color-bg-dark);

--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -24,6 +24,7 @@
 (defsetting dismissed-excel-pivot-exports-banner
   (deferred-tru "Toggle which is true after a user has dismissed the excel pivot exports banner.")
   :user-local :only
+  :export?    false
   :visibility :authenticated
   :type       :boolean
   :default    false

--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -21,6 +21,14 @@
             (when-let [id (setting/get-value-of-type :integer :last-used-native-database-id)]
               (when (t2/exists? :model/Database :id id) id))))
 
+(defsetting dismissed-excel-pivot-exports-banner
+  (deferred-tru "Toggle which is true after a user has dismissed the excel pivot exports banner.")
+  :user-local :only
+  :visibility :authenticated
+  :type       :boolean
+  :default    false
+  :audit      :never)
+
 (defsetting dismissed-custom-dashboard-toast
   (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")
   :user-local :only


### PR DESCRIPTION
Closes https://www.notion.so/metabase/Resolve-correctness-and-formatting-issues-with-XLSX-pivot-downloads-1a169354c90180bebfafeab5bc40178d#1f569354c90180d99745ce40c8fbb516

### Description

Tweaks the download results widget UI and adds a hint to guide users how to get natively pivoted xlsx files by pointing out to docs.

### How to verify

- Create a pivot table question
- Click on the "Download results" button in the bottom-right corner
- Ensure it shows the updated widget UI
- Ensure it shows the hint
- Click on the hint's "Close" button
- Reload the page
- Ensure there is no hint in this widget anymore

### Demo

<img width="997" alt="Screenshot 2025-05-22 at 2 25 04 AM" src="https://github.com/user-attachments/assets/87e7f2a0-05f1-475c-93ac-bef1ba43ff44" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
