### PR TITLE
Make /api/content-translation/dictionary a public route

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
@@ -29,7 +29,7 @@ export const assertOnlyTheseTranslationsAreStored = (rows: DictionaryArray) => {
   cy.signInAsNormalUser();
   cy.request<DictionaryResponse>(
     "GET",
-    "/api/ee/content-translation/dictionary",
+    "/api/content-translation/dictionary",
   ).then((interception) => {
     const { data } = interception.body;
     const msgstrs = data.map((row) => row.msgstr);

--- a/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/api/routes.clj
@@ -31,14 +31,6 @@
    :headers {"Content-Type" "application/json"}
    :body (json/encode {:success true})})
 
-(api.macros/defendpoint :get "/dictionary"
-  "Provides content translations stored in the content_translations table"
-  [_route-params query-params _body]
-  (let [locale (:locale query-params)]
-    (if locale
-      {:data (ct/get-translations locale)}
-      {:data (ct/get-translations)})))
-
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/content-translation` routes."
   (api.macros/ns-handler *ns* +auth))

--- a/enterprise/frontend/src/metabase-enterprise/api/content-translation.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/content-translation.ts
@@ -20,7 +20,9 @@ export const contentTranslationApi = EnterpriseApi.injectEndpoints({
       >({
         query: (params) => ({
           method: "GET",
-          url: "/api/ee/content-translation/dictionary",
+          // This route is not prefixed with /api/ee/, because it is
+          // not authenticated
+          url: "/api/content-translation/dictionary",
           params,
         }),
         providesTags: () => [listTag("content-translation")],

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -18,6 +18,7 @@
    [metabase.cloud-migration.api]
    [metabase.collections.api]
    [metabase.config.core :as config]
+   [metabase.content-translation.api]
    [metabase.dashboards.api]
    [metabase.eid-translation.api]
    [metabase.embedding.api]
@@ -140,6 +141,7 @@
    "/channel"              (+auth metabase.channel.api/channel-routes)
    "/cloud-migration"      (+auth 'metabase.cloud-migration.api)
    "/collection"           (+auth 'metabase.collections.api)
+   "/content-translation"  metabase.content-translation.api/routes
    "/dashboard"            (+auth 'metabase.dashboards.api)
    "/database"             (+auth 'metabase.warehouses.api)
    "/dataset"              (+auth 'metabase.query-processor.api)

--- a/src/metabase/content_translation/api.clj
+++ b/src/metabase/content_translation/api.clj
@@ -5,7 +5,6 @@
 
 (api.macros/defendpoint :get "/dictionary"
   "Provides translations of user-generated content. This is a public route so that logged-out viewers of static-embedded questions and dashboards can retrieve translations"
-  ;; TODO: Secure this route against shenanigans
   [_route-params query-params _body]
   (let [locale (:locale query-params)]
     (if locale

--- a/src/metabase/content_translation/api.clj
+++ b/src/metabase/content_translation/api.clj
@@ -1,0 +1,17 @@
+(ns metabase.content-translation.api
+  (:require
+   [metabase-enterprise.content-translation.models :as ct]
+   [metabase.api.macros :as api.macros]))
+
+(api.macros/defendpoint :get "/dictionary"
+  "Provides translations of user-generated content. This is a public route so that logged-out viewers of static-embedded questions and dashboards can retrieve translations"
+  ;; TODO: Secure this route against shenanigans
+  [_route-params query-params _body]
+  (let [locale (:locale query-params)]
+    (if locale
+      {:data (ct/get-translations locale)}
+      {:data (ct/get-translations)})))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/content-translation-dictionary` routes"
+  (api.macros/ns-handler *ns*))


### PR DESCRIPTION
So that the content translation dictionary can be accessed in static embedding, this PR makes the dictionary endpoint a public route.

This is a provisional solution. In the long term, we will either secure the endpoint with JWT or, probably better, inject translations in the HTML at page load rather than load them asynchronously, which will remove the need for a separate, JWT-secured endpoint.