### PR TITLE
Handle decoding of nil (unknown) field type

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -259,7 +259,7 @@
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (mr/def ::field-type
-  [:enum {:decode/tool-api-response (comp u/->snake_case_en name)}
+  [:enum {:decode/tool-api-response #(when % (-> % name u/->snake_case_en))}
    "boolean" "date" "datetime" "time" "number" "string"])
 
 (mr/def ::column

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -1,6 +1,8 @@
 (ns metabase-enterprise.metabot-v3.tools.api-test
   (:require
    [clojure.test :refer :all]
+   [malli.core :as mc]
+   [malli.transform :as mtx]
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.tools.api :as metabot-v3.tools.api]
@@ -16,8 +18,18 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.malli.registry :as mr]
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2]))
+
+(deftest column-decode-test
+  (let [base-col {:field_id "fid", :name "fname"}]
+    (doseq [{:keys [test-case type-value]} [{:test-case "known type",   :type-value :boolean}
+                                            {:test-case "unknown type", :type-value nil}]]
+      (testing test-case
+        (let [col (assoc base-col :type type-value)
+              decoded (mc/decode ::metabot-v3.tools.api/column col (mtx/transformer {:name :tool-api-response}))]
+          (is (mr/validate ::metabot-v3.tools.api/column decoded)))))))
 
 (defn- ai-session-token
   ([] (ai-session-token :rasta (str (random-uuid))))


### PR DESCRIPTION
Fixes BOT-162

### Description

Hopefully this fixes the issue we are experiencing on stats related to the answer-sources endpoint. All it does is fixing the conversion of unknown (`nil`) field types, which means this fix might uncover other issues related to unknown types.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
