### PR TITLE
build colspan into table component empty state

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
@@ -1,15 +1,12 @@
-.NoResultsTableRow,
-.SkeletonTableRow {
-  &:hover {
-    background-color: transparent !important;
-  }
-}
-
 .SkeletonTableRow {
   height: 3rem;
 
   td {
     width: 20rem;
+  }
+
+  &:hover {
+    background-color: transparent !important;
   }
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -359,11 +359,7 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
 );
 
 const NoResultsTableRow = () => (
-  <tr className={Styles.NoResultsTableRow}>
-    <td colSpan={3}>
-      <Center fw="bold" c="text-light">
-        {t`No dashboards or questions have their own caching policies yet.`}
-      </Center>
-    </td>
-  </tr>
+  <Center fw="bold" c="text-light">
+    {t`No dashboards or questions have their own caching policies yet.`}
+  </Center>
 );

--- a/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
@@ -205,15 +205,11 @@ export const QueryValidator = () => {
 };
 
 const QueryValidatorEmpty = () => (
-  <tr>
-    <td colSpan={5}>
-      <Flex justify="center" p="1rem">
-        <Text fz="1rem" color="var(--mb-color-text-light)">
-          {t`No questions, models, or metrics with invalid references`}
-        </Text>
-      </Flex>
-    </td>
-  </tr>
+  <Flex justify="center" p="1rem">
+    <Text fz="1rem" color="var(--mb-color-text-light)">
+      {t`No questions, models, or metrics with invalid references`}
+    </Text>
+  </Flex>
 );
 
 const QueryValidatorRow = ({ row }: { row: TableRow }) => {

--- a/frontend/src/metabase/common/components/Table/Table.module.css
+++ b/frontend/src/metabase/common/components/Table/Table.module.css
@@ -29,3 +29,9 @@
     padding-inline: 0.75rem;
   }
 }
+
+.EmptyTableRow {
+  &:hover {
+    background-color: transparent !important;
+  }
+}

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -84,13 +84,17 @@ export function Table<Row extends BaseRow>({
           </tr>
         </thead>
         <tbody>
-          {rows.length > 0
-            ? rows.map((row, index) => (
-                <React.Fragment key={String(row.id) || index}>
-                  {rowRenderer(row)}
-                </React.Fragment>
-              ))
-            : emptyBody}
+          {rows.length > 0 ? (
+            rows.map((row, index) => (
+              <React.Fragment key={String(row.id) || index}>
+                {rowRenderer(row)}
+              </React.Fragment>
+            ))
+          ) : (
+            <tr className={CS.EmptyTableRow}>
+              <td colSpan={columns.length}>{emptyBody}</td>
+            </tr>
+          )}
         </tbody>
       </table>
 


### PR DESCRIPTION

### Description

Little bit of hygiene. The table component has a nice empty state prop, but for it to work properly, it always has to be embedded in a column-spanning table cell. This embeds that table cell in the table component itself and removes it from the few places it was implemented manually.

example: admin/performance questions tab

![Screenshot 2025-05-21 at 3 50 56 PM](https://github.com/user-attachments/assets/3ed39aff-ac08-43dd-905a-b81403e2d890)


