### PR TITLE
nest-query explicitly adds all fields to the query

### DIFF
--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -26,14 +26,21 @@
               [:field (u/the-id field) nil]))))
 
 (defn- add-all-fields
+  "This adds all non-sensitive/retired fields (including fields with parent ids) to the passed-in query.
+
+  The issue is that nest-query mostly relies on the preprocessor (specifically, the add-implicit-clauses middleware)
+  to add all possible fields to the newly created inner query. However, add-implicit-fields ignores fields with a
+  parent id. The main user of parent-id is mongo, and mongo doesn't use nest-query, so this usually isn't an
+  issue. However, bigquery also uses parent-id, and bigquery is a sql driver that uses nest-query. As a result,
+  without this function, nest-query wasn't adding bigquery struct member fields to the inner query, which caused sql
+  errors. This function adds in any missing fields and fixes those errors."
   [{{source-table-id :source-table, :keys [fields]} :query, :as outer-query}]
   (if source-table-id
     (let [all-fields (all-fields-for-table source-table-id)
           existing-fields (into #{} (map second) fields)]
       (assoc-in outer-query [:query :fields]
                 (into fields
-                      (filter (fn [[_ field-id]]
-                                (not (existing-fields field-id))))
+                      (remove (comp existing-fields second))
                       all-fields)))
     outer-query))
 

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -21,6 +21,9 @@
 
 (defn- all-fields-for-table [table-id]
   (->> (lib.metadata/fields (qp.store/metadata-provider) table-id)
+       ;; The remove line is taken from the add-implicit-clauses middleware. It shouldn't be necessary, because any
+       ;; unused fields should be dropped from the inner query. It also shouldn't hurt anything, because the outer
+       ;; query shouldn't use these fields in the first place.
        (remove #(#{:sensitive :retired} (:visibility-type %)))
        (map (fn [field]
               [:field (u/the-id field) nil]))))

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -173,3 +173,19 @@
                    :source-query {:aggregation [[:count]]
                                   :breakout    [$tips.source.service]
                                   :source-table $$tips}}))))))))
+
+(deftest ^:parallel nested-query-2-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
+    (testing "Nested fields in a nested query where the outer query needs the nested field"
+      (mt/dataset geographical-tips
+        (is (= [["FACEBOOK"   107]
+                ["FLARE"      0]
+                ["FOURSQUARE" 0]
+                ["TWITTER"    0]
+                ["YELP"       0]]
+               (mt/formatted-rows
+                [str int]
+                (mt/run-mbql-query tips
+                  {:expressions {:cap_service [:upper [:field $tips.source.service]]}
+                   :aggregation [[:count-where [:= $tips.source.service "facebook"]]]
+                   :breakout [:expression :cap_service]}))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57784
Closes https://linear.app/metabase/issue/QUE-1173

### Description

Before, nest-query relied on the preprocessor (specifically, the add-implicit-clauses middleware) to add all possible fields to the newly created inner query (and then removes unnecessary fields later).  However, add-implicit-fields ignores fields with a parent id.  The main user of parent-id is mongo, and mongo doesn't use nest-query, so this usually isn't an issue.  However, bigquery also uses parent-id, and bigquery is a sql driver that uses nest-query.  As a result, nest-query wasn't adding bigquery struct member fields to the inner query, which caused some queries to break.  Now, nest-query explicitly finds all non-sensitive/retired fields (including fields with parent ids) and ensures that they are in the inner query.

### How to verify

1. Set up a bigquery table with a struct field -- dev.struct-test in bigquery-driver-dev works
2. Create a query with a custom column and a summarize block that uses both the custom column and a column from the struct
3. Verify that the inner query in the resulting sql selects the struct column and that the query runs correctly

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
