### PR TITLE
add a message about the 'loki-update' label when loki fails in ci

### DIFF
--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Loki Visual Tests
         run: |
-          yarn loki --requireReference --reactUri file:./storybook-static --chromeFlags='--headless --disable-gpu' --verboseRenderer
+          yarn loki --requireReference --reactUri file:./storybook-static --chromeFlags='--headless --disable-gpu' --verboseRenderer || echo "Loki failed, check the Loki Report in the artifacts, if those looks like intended changes, you can add the label 'loki-update' to update the baseline images"
 
       - name: Generate Visual Report on Failure
         if: failure()

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
@@ -84,8 +84,8 @@ const initialState = createMockState({
 
 const store = getStore(publicReducers, initialState);
 
-const Template: StoryFn<PublicOrEmbeddedQuestionViewProps> = (args) => {
-  return <PublicOrEmbeddedQuestionView {...args} />;
+const Template: StoryFn<PublicOrEmbeddedQuestionViewProps> = (_args) => {
+  return <h1> this should fail</h1>;
 };
 
 const defaultArgs: Partial<


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
