### PR TITLE
Show "Use instance font" in default dropdown in static embed

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/config.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/config.ts
@@ -4,7 +4,7 @@ export function getDefaultDisplayOptions(
   shouldShownDownloadData: boolean,
 ): EmbeddingDisplayOptions {
   return {
-    font: null,
+    font: "",
     theme: "light",
     background: true,
     bordered: true,

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
@@ -51,6 +51,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
 
         const fontSelect = screen.getByLabelText("Font");
         expect(fontSelect).toBeVisible();
+        expect(fontSelect).toHaveValue("Use instance font");
 
         await userEvent.click(fontSelect);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54490

### Description

When embedding a question or a dashboard with static embed and going to the "Look and Feel" tab, the default font box was showing up as an empty box. Now it shows "Use instance font".

### How to verify

- Open a static embed modal
- Font shows "Use instance font" by default

### Demo

![CleanShot 2568-05-22 at 15 14 31@2x](https://github.com/user-attachments/assets/e155ca82-d01f-407d-acff-5dfa2d57579e)

## Checklist

- [x] Tests have been added/updated to cover changes in this PR
