### PR TITLE
Add embed options for templates to new iframe embedding

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -1,4 +1,3 @@
-const { H } = cy;
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -21,6 +20,8 @@ import {
 } from "e2e/support/helpers/component-testing-sdk";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { Flex } from "metabase/ui";
+
+const { H } = cy;
 
 describe("scenarios > embedding-sdk > interactive-question > creating a question", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -1,0 +1,156 @@
+import {
+  FIRST_COLLECTION_ID,
+  ORDERS_DASHBOARD_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
+
+const { H } = cy;
+
+describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
+  beforeEach(() => {
+    H.prepareSdkIframeEmbedTest();
+    cy.signOut();
+  });
+
+  it("shows a static question with drillThroughEnabled=false", () => {
+    const frame = H.loadSdkIframeEmbedTestPage({
+      questionId: ORDERS_QUESTION_ID,
+      drillThroughEnabled: false,
+    });
+
+    cy.wait("@getCardQuery");
+
+    frame.within(() => {
+      cy.log("1. static question must not contain title and toolbar");
+      cy.findByText("Orders").should("not.exist");
+      cy.findByTestId("interactive-question-result-toolbar").should(
+        "not.exist",
+      );
+
+      cy.log("2. clicking on the column value should not show the popover");
+      cy.findAllByText("37.65").first().should("be.visible").click();
+      cy.findByText(/Filter by this value/).should("not.exist");
+    });
+  });
+
+  it("shows a static dashboard using drillThroughEnabled=false, withTitle=false, withDownloads=true", () => {
+    const frame = H.loadSdkIframeEmbedTestPage({
+      dashboardId: ORDERS_DASHBOARD_ID,
+      drillThroughEnabled: false,
+      withTitle: false,
+      withDownloads: true,
+    });
+
+    cy.wait("@getDashCardQuery");
+
+    frame.within(() => {
+      cy.log("1. card title should be visible");
+      cy.findByText("Orders").should("be.visible");
+
+      cy.log("2. dashboard title should not exist -- withTitle=false");
+      cy.findByText("Orders in a dashboard").should("not.exist");
+
+      cy.log("3. download button should be visible -- withDownloads=true");
+      cy.get('[aria-label="Download as PDF"]').should("be.visible");
+
+      cy.log("4. clicking on the column value should not show the popover");
+      cy.findAllByText("37.65").first().should("be.visible").click();
+      cy.findByText(/Filter by this value/).should("not.exist");
+    });
+  });
+
+  it("renders an interactive question with drillThroughEnabled=true, withTitle=false, withDownloads=true", () => {
+    const frame = H.loadSdkIframeEmbedTestPage({
+      questionId: ORDERS_QUESTION_ID,
+      drillThroughEnabled: true,
+      withDownloads: true,
+      withTitle: false,
+    });
+
+    cy.wait("@getCardQuery");
+
+    frame.within(() => {
+      cy.log("1. card title should not exist");
+      cy.findByText("Orders").should("not.exist");
+
+      cy.log("2. download button on the toolbar should be visible");
+      cy.get("[aria-label='download icon']").should("be.visible");
+
+      cy.log("3. clicking on the column value should show the popover");
+      cy.findAllByText("37.65").first().should("be.visible").click();
+      cy.findByText(/Filter by this value/).should("be.visible");
+
+      cy.log("4. clicking on the filter should drill down");
+      cy.get('[type="filter"] button').first().click();
+      cy.findAllByText("29.8").first().should("be.visible");
+    });
+  });
+
+  it("renders an interactive dashboard with drillThroughEnabled=true, withDownloads=true, withTitle=false", () => {
+    const frame = H.loadSdkIframeEmbedTestPage({
+      dashboardId: ORDERS_DASHBOARD_ID,
+      drillThroughEnabled: true,
+      withDownloads: true,
+      withTitle: false,
+    });
+
+    cy.wait("@getDashCardQuery");
+
+    frame.within(() => {
+      cy.log("1. dashboard title should not exist -- withTitle=false");
+      cy.findByText("Orders in a dashboard").should("not.exist");
+
+      cy.log("2. card title should be visible");
+      cy.findByText("Orders").should("be.visible");
+
+      cy.log("3. download button should be visible -- withDownloads=true");
+      cy.get('[aria-label="Download as PDF"]').should("be.visible");
+
+      cy.log("4. clicking on the column value should show the popover");
+      cy.findAllByText("37.65").first().should("be.visible").click();
+      cy.findByText(/Filter by this value/).should("be.visible");
+
+      cy.log("5. clicking on the filter should drill down");
+      cy.get('[type="filter"] button').first().click();
+      cy.findAllByText("29.8").first().should("be.visible");
+      cy.findByText("New question").should("be.visible");
+
+      cy.log("6. saving should be disabled in drill-throughs");
+      cy.findByText("Save").should("not.exist");
+    });
+  });
+
+  it("renders the exploration template with isSaveEnabled=true, targetCollection, entityTypes", () => {
+    const frame = H.loadSdkIframeEmbedTestPage({
+      template: "exploration",
+      isSaveEnabled: true,
+      targetCollection: FIRST_COLLECTION_ID,
+      entityTypes: ["table"],
+    });
+
+    frame.within(() => {
+      cy.findByText("Pick your starting data").should("be.visible");
+
+      H.popover().within(() => {
+        cy.findByText("Orders").click();
+      });
+
+      cy.findByRole("button", { name: "Visualize" }).click();
+
+      cy.log("1. clicking on the filter should drill down");
+      cy.findAllByText("37.65").first().should("be.visible").click();
+      cy.findByText(/Filter by this value/).should("be.visible");
+      cy.get('[type="filter"] button').first().click();
+      cy.findAllByText("29.8").first().should("be.visible");
+      cy.findByText("New question").should("be.visible");
+
+      cy.log("2. saving should be enabled");
+      cy.findByText("Save").click();
+
+      cy.log(
+        "3. we should not see the collection picker as we have a target collection",
+      );
+      cy.findByText("Where do you want to save this?").should("not.exist");
+    });
+  });
+});

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -12,10 +12,10 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
     cy.signOut();
   });
 
-  it("shows a static question with drillThroughEnabled=false", () => {
+  it("shows a static question with isDrillThroughEnabled=false", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
       questionId: ORDERS_QUESTION_ID,
-      drillThroughEnabled: false,
+      isDrillThroughEnabled: false,
     });
 
     cy.wait("@getCardQuery");
@@ -33,10 +33,10 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
     });
   });
 
-  it("shows a static dashboard using drillThroughEnabled=false, withTitle=false, withDownloads=true", () => {
+  it("shows a static dashboard using isDrillThroughEnabled=false, withTitle=false, withDownloads=true", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
       dashboardId: ORDERS_DASHBOARD_ID,
-      drillThroughEnabled: false,
+      isDrillThroughEnabled: false,
       withTitle: false,
       withDownloads: true,
     });
@@ -59,10 +59,10 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
     });
   });
 
-  it("renders an interactive question with drillThroughEnabled=true, withTitle=false, withDownloads=true", () => {
+  it("renders an interactive question with isDrillThroughEnabled=true, withTitle=false, withDownloads=true", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
       questionId: ORDERS_QUESTION_ID,
-      drillThroughEnabled: true,
+      isDrillThroughEnabled: true,
       withDownloads: true,
       withTitle: false,
     });
@@ -86,10 +86,10 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
     });
   });
 
-  it("renders an interactive dashboard with drillThroughEnabled=true, withDownloads=true, withTitle=false", () => {
+  it("renders an interactive dashboard with isDrillThroughEnabled=true, withDownloads=true, withTitle=false", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
       dashboardId: ORDERS_DASHBOARD_ID,
-      drillThroughEnabled: true,
+      isDrillThroughEnabled: true,
       withDownloads: true,
       withTitle: false,
     });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -73,7 +73,8 @@ const SdkIframeEmbedView = ({
         entityTypes={settings.entityTypes}
       />
     ))
-    .with({ template: "curation" }, (_settings) => null)
+    .with({ template: "curate-content" }, (_settings) => null)
+    .with({ template: "view-content" }, (_settings) => null)
     .with(
       {
         dashboardId: P.nonNullable,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -77,7 +77,7 @@ const SdkIframeEmbedView = ({
     .with(
       {
         dashboardId: P.nonNullable,
-        drillThroughEnabled: false,
+        isDrillThroughEnabled: false,
       },
       (settings) => (
         <StaticDashboard
@@ -92,7 +92,7 @@ const SdkIframeEmbedView = ({
     .with(
       {
         questionId: P.nonNullable,
-        drillThroughEnabled: false,
+        isDrillThroughEnabled: false,
       },
       (settings) => (
         <StaticQuestion
@@ -105,7 +105,7 @@ const SdkIframeEmbedView = ({
     .with(
       {
         dashboardId: P.nonNullable,
-        drillThroughEnabled: P.optional(true),
+        isDrillThroughEnabled: P.optional(true),
       },
       (settings) => (
         <InteractiveDashboard
@@ -122,7 +122,7 @@ const SdkIframeEmbedView = ({
     .with(
       {
         questionId: P.nonNullable,
-        drillThroughEnabled: P.optional(true),
+        isDrillThroughEnabled: P.optional(true),
       },
       (settings) => (
         <InteractiveQuestion

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -1,8 +1,11 @@
+import type { ReactNode } from "react";
 import { P, match } from "ts-pattern";
 
 import {
   InteractiveDashboard,
   InteractiveQuestion,
+  StaticDashboard,
+  StaticQuestion,
   defineMetabaseAuthConfig,
 } from "embedding-sdk";
 import { MetabaseProvider } from "embedding-sdk/components/public/MetabaseProvider";
@@ -59,25 +62,78 @@ const SdkIframeEmbedView = ({
   settings,
 }: {
   settings: SdkIframeEmbedSettings;
-}) => {
-  const { dashboardId, questionId, template } = settings;
-
-  return match({ dashboardId, questionId, template })
-    .with({ template: "exploration" }, () => (
+}): ReactNode => {
+  return match(settings)
+    .with({ template: "exploration" }, (settings) => (
       <InteractiveQuestion
         questionId="new"
         height="100%"
-        isSaveEnabled={false}
+        isSaveEnabled={settings.isSaveEnabled ?? false}
+        targetCollection={settings.targetCollection}
+        entityTypes={settings.entityTypes}
       />
     ))
-    .with({ dashboardId: P.nonNullable }, ({ dashboardId }) => (
-      <InteractiveDashboard
-        dashboardId={dashboardId}
-        drillThroughQuestionHeight="100%"
-      />
-    ))
-    .with({ questionId: P.nonNullable }, ({ questionId }) => (
-      <InteractiveQuestion questionId={questionId} height="100%" />
-    ))
+    .with({ template: "curation" }, (_settings) => null)
+    .with(
+      {
+        dashboardId: P.nonNullable,
+        drillThroughEnabled: false,
+      },
+      (settings) => (
+        <StaticDashboard
+          dashboardId={settings.dashboardId}
+          withTitle={settings.withTitle}
+          withDownloads={settings.withDownloads}
+          initialParameters={settings.initialParameters}
+          hiddenParameters={settings.hiddenParameters}
+        />
+      ),
+    )
+    .with(
+      {
+        questionId: P.nonNullable,
+        drillThroughEnabled: false,
+      },
+      (settings) => (
+        <StaticQuestion
+          questionId={settings.questionId}
+          height="100%"
+          initialSqlParameters={settings.initialSqlParameters}
+        />
+      ),
+    )
+    .with(
+      {
+        dashboardId: P.nonNullable,
+        drillThroughEnabled: P.optional(true),
+      },
+      (settings) => (
+        <InteractiveDashboard
+          dashboardId={settings.dashboardId}
+          withTitle={settings.withTitle}
+          withDownloads={settings.withDownloads}
+          initialParameters={settings.initialParameters}
+          hiddenParameters={settings.hiddenParameters}
+          drillThroughQuestionHeight="100%"
+          drillThroughQuestionProps={{ isSaveEnabled: false }}
+        />
+      ),
+    )
+    .with(
+      {
+        questionId: P.nonNullable,
+        drillThroughEnabled: P.optional(true),
+      },
+      (settings) => (
+        <InteractiveQuestion
+          questionId={settings.questionId}
+          withDownloads={settings.withDownloads}
+          height="100%"
+          initialSqlParameters={settings.initialSqlParameters}
+          title={settings.withTitle}
+          isSaveEnabled={false}
+        />
+      ),
+    )
     .otherwise(() => null);
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -136,6 +136,16 @@ class MetabaseEmbed {
       );
     }
 
+    if (
+      (settings.template === "view-content" ||
+        settings.template === "curate-content") &&
+      !settings.initialCollection
+    ) {
+      raiseError(
+        `initialCollection must be provided for the ${settings.template} template`,
+      );
+    }
+
     if (settings.dashboardId && settings.questionId) {
       raiseError(
         "can't use both dashboardId and questionId at the same time. to change the question to a dashboard, set the questionId to null (and vice-versa)",

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -127,8 +127,6 @@ class MetabaseEmbed {
       );
     }
 
-    settings.template;
-
     if (
       settings.template === "exploration" &&
       (settings.dashboardId || settings.questionId)

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -127,6 +127,8 @@ class MetabaseEmbed {
       );
     }
 
+    settings.template;
+
     if (
       settings.template === "exploration" &&
       (settings.dashboardId || settings.questionId)

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -12,11 +12,8 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   it("throws when target element is not found", () => {
     expect(() => {
-      new MetabaseEmbed({
-        ...defaultSettings,
-        questionId: 1,
-        target: "#not-existent-target",
-      });
+      // @ts-expect-error -- we are testing for incorrect configuration
+      new MetabaseEmbed({ ...defaultSettings, target: "#not-existent-target" });
     }).toThrow('cannot find embed container "#not-existent-target"');
   });
 
@@ -47,6 +44,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   it("throws when both question id and dashboard id are provided", () => {
     expect(() => {
+      // @ts-expect-error -- we are testing for incorrect configuration
       new MetabaseEmbed({
         ...defaultSettings,
         questionId: 10,
@@ -70,6 +68,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   it("throws when question id is provided in the exploration template", () => {
     expect(() => {
+      // @ts-expect-error -- we are testing for incorrect configuration
       new MetabaseEmbed({
         ...defaultSettings,
         template: "exploration",
@@ -82,6 +81,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   it("throws when dashboard id is provided in the exploration template", () => {
     expect(() => {
+      // @ts-expect-error -- we are testing for incorrect configuration
       new MetabaseEmbed({
         ...defaultSettings,
         template: "exploration",
@@ -94,6 +94,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   it("throws when neither question id, dashboard id, or template are provided", () => {
     expect(() => {
+      // @ts-expect-error -- we are testing for incorrect configuration
       new MetabaseEmbed({ ...defaultSettings });
     }).toThrow("either dashboardId, questionId, or template must be provided");
   });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -102,7 +102,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     }).toThrow("either dashboardId, questionId, or template must be provided");
   });
 
-  it.each([["view-content" as const], ["curate-content" as const]])(
+  it.each([["view-content"], ["curate-content"]] as const)(
     "throws when initialCollection is not provided for the %s template",
     (template: "view-content" | "curate-content") => {
       expect(() => {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -12,8 +12,11 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   it("throws when target element is not found", () => {
     expect(() => {
-      // @ts-expect-error -- we are testing for incorrect configuration
-      new MetabaseEmbed({ ...defaultSettings, target: "#not-existent-target" });
+      new MetabaseEmbed({
+        ...defaultSettings,
+        dashboardId: 1,
+        target: "#not-existent-target",
+      });
     }).toThrow('cannot find embed container "#not-existent-target"');
   });
 
@@ -98,4 +101,19 @@ describe("embed.js script tag for sdk iframe embedding", () => {
       new MetabaseEmbed({ ...defaultSettings });
     }).toThrow("either dashboardId, questionId, or template must be provided");
   });
+
+  it.each([["view-content" as const], ["curate-content" as const]])(
+    "throws when initialCollection is not provided for the %s template",
+    (template: "view-content" | "curate-content") => {
+      expect(() => {
+        // @ts-expect-error -- we are testing for incorrect configuration
+        new MetabaseEmbed({
+          ...defaultSettings,
+          template,
+        });
+      }).toThrow(
+        `initialCollection must be provided for the ${template} template`,
+      );
+    },
+  );
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -23,7 +23,7 @@ export type SdkIframeEmbedMessage = {
 export interface DashboardEmbedOptions {
   dashboardId: number | string;
 
-  drillThroughEnabled?: boolean;
+  isDrillThroughEnabled?: boolean;
   withTitle?: boolean;
   withDownloads?: boolean;
 
@@ -39,7 +39,7 @@ export interface DashboardEmbedOptions {
 export interface QuestionEmbedOptions {
   questionId: number | string;
 
-  drillThroughEnabled?: boolean;
+  isDrillThroughEnabled?: boolean;
   withTitle?: boolean;
   withDownloads?: boolean;
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -1,4 +1,11 @@
-import type { MetabaseTheme } from "embedding-sdk";
+import type { Query } from "history";
+
+import type {
+  EntityTypeFilterKeys,
+  MetabaseTheme,
+  SqlParameterValues,
+} from "embedding-sdk";
+import type { CollectionId } from "metabase-types/api";
 
 /** Events that the embed.js script listens for */
 export type SdkIframeEmbedTagMessage = {
@@ -11,24 +18,87 @@ export type SdkIframeEmbedMessage = {
   data: SdkIframeEmbedSettings;
 };
 
-/** Template to use for the embedded question or dashboard. Will be expanded in the future. */
-export type SdkIframeEmbedTemplate = "exploration";
+// --- Embed Option Interfaces ---
 
-/** Settings used by the sdk embed route */
-export interface SdkIframeEmbedSettings {
+export interface DashboardEmbedOptions {
+  dashboardId: number | string;
+
+  drillThroughEnabled?: boolean;
+  withTitle?: boolean;
+  withDownloads?: boolean;
+
+  // parameters
+  initialParameters?: Query;
+  hiddenParameters?: string[];
+
+  // incompatible options
+  template?: never;
+  questionId?: never;
+}
+
+export interface QuestionEmbedOptions {
+  questionId: number | string;
+
+  drillThroughEnabled?: boolean;
+  withTitle?: boolean;
+  withDownloads?: boolean;
+
+  // parameters
+  initialSqlParameters?: SqlParameterValues;
+
+  // incompatible options
+  template?: never;
+  dashboardId?: never;
+}
+
+export interface ExplorationEmbedOptions {
+  template: "exploration";
+
+  isSaveEnabled?: boolean;
+  targetCollection?: CollectionId;
+  entityTypes?: EntityTypeFilterKeys[];
+
+  // incompatible options
+  questionId?: never;
+  dashboardId?: never;
+}
+
+export interface CurationEmbedOptions {
+  template: "curation";
+  collectionId: CollectionId;
+
+  isReadOnly?: boolean;
+  entityTypes?: CollectionBrowserEntityTypes[];
+
+  questionId?: never;
+  dashboardId?: never;
+}
+
+type CollectionBrowserEntityTypes =
+  | "collection"
+  | "dashboard"
+  | "question"
+  | "model";
+
+type SdkIframeEmbedBaseSettings = {
   apiKey: string;
   instanceUrl: string;
-
-  dashboardId?: number | string;
-  questionId?: number | string;
-  template?: SdkIframeEmbedTemplate;
-
   theme?: MetabaseTheme;
   locale?: string;
 
   // Whether the embed is running on localhost. Cannot be set by the user.
   _isLocalhost?: boolean;
-}
+};
+
+type SdkIframeEmbedTemplateSettings =
+  | DashboardEmbedOptions
+  | QuestionEmbedOptions
+  | ExplorationEmbedOptions
+  | CurationEmbedOptions;
+
+/** Settings used by the sdk embed route */
+export type SdkIframeEmbedSettings = SdkIframeEmbedBaseSettings &
+  SdkIframeEmbedTemplateSettings;
 
 /** Settings used by the embed.js constructor */
 export type SdkIframeEmbedTagSettings = SdkIframeEmbedSettings & {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -63,11 +63,20 @@ export interface ExplorationEmbedOptions {
   dashboardId?: never;
 }
 
-export interface CurationEmbedOptions {
-  template: "curation";
-  collectionId: CollectionId;
+export interface CurateContentEmbedOptions {
+  template: "curate-content";
+  initialCollection: CollectionId;
 
-  isReadOnly?: boolean;
+  entityTypes?: CollectionBrowserEntityTypes[];
+
+  questionId?: never;
+  dashboardId?: never;
+}
+
+export interface ViewContentEmbedOptions {
+  template: "view-content";
+  initialCollection: CollectionId;
+
   entityTypes?: CollectionBrowserEntityTypes[];
 
   questionId?: never;
@@ -94,7 +103,8 @@ type SdkIframeEmbedTemplateSettings =
   | DashboardEmbedOptions
   | QuestionEmbedOptions
   | ExplorationEmbedOptions
-  | CurationEmbedOptions;
+  | CurateContentEmbedOptions
+  | ViewContentEmbedOptions;
 
 /** Settings used by the sdk embed route */
 export type SdkIframeEmbedSettings = SdkIframeEmbedBaseSettings &


### PR DESCRIPTION
Closes EMB-408

### Description

This adds a series of basic embed options for embedders to be able to customize their question, dashboard and exploration embeds.

- See this [tech doc section](https://www.notion.so/metabase/Tech-New-iframe-embedding-using-SDK-components-for-iframe-script-tag-1d969354c901805b9300d5f77064f265?pvs=4#1eb69354c90180289c4ddaf0997814fe) for the full list of embed options in TypeScript format + usage examples
- See this [product doc section](https://www.notion.so/metabase/New-iframe-embedding-using-SDK-components-9b484d5786c148e2b1389dd0e8614747?pvs=4#1f169354c901803aa936cba0a4ec517b) for the options proposed by Alberto initially
- See this [testing plan](https://www.notion.so/metabase/Testing-Plan-New-iframe-embedding-using-SDK-components-for-iframe-script-tag-1e469354c9018081b08be44571b82453?pvs=4#1fb69354c901803da73efe495f0776a9) for more information on the test cases.

This intentionally **excludes** the curation template for now as that is a lot more involved to implement.

### How to verify

See the [tech doc section](https://www.notion.so/metabase/Tech-New-iframe-embedding-using-SDK-components-for-iframe-script-tag-1d969354c901805b9300d5f77064f265?pvs=4#1eb69354c90180289c4ddaf0997814fe) as well as the [testing plan](https://www.notion.so/metabase/Testing-Plan-New-iframe-embedding-using-SDK-components-for-iframe-script-tag-1e469354c9018081b08be44571b82453?pvs=4#1fb69354c901803da73efe495f0776a9)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - e2e
