### PR TITLE
feat(sdk): remove question and metric from entity type filters in the sdk's data picker

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -35,9 +35,7 @@ const DEFAULT_OPTIONS = {};
 const FILTER_MODEL_MAP: Record<EntityTypeFilterKeys, DataPickerValue["model"]> =
   {
     table: "table",
-    question: "card",
     model: "dataset",
-    metric: "metric",
   };
 const mapEntityTypeFilterToDataPickerModels = (
   entityTypeFilter: InteractiveQuestionProviderProps["entityTypeFilter"],

--- a/enterprise/frontend/src/embedding-sdk/types/question.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/question.ts
@@ -59,6 +59,6 @@ export type SdkQuestionTitleProps =
   // TODO: turn this into (question: Question) => ReactNode once we have the public-facing question type (metabase#50487)
   | (() => ReactNode);
 
-export type EntityTypeFilterKeys = "table" | "question" | "model" | "metric";
+export type EntityTypeFilterKeys = "table" | "model";
 
 export type SqlParameterValues = Record<string, string | number>;


### PR DESCRIPTION
Yeets the `question` and `metric` fields from the entityTypeFilter we used in InteractiveQuestion from the SDK's data picker. I believe we've already removed this already from the data picker, but we just haven't cleaned up the SDK type.