### PR TITLE
WRK-425 Hide table dashcard actions when editing dashboard

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
@@ -56,6 +56,7 @@ type EditTableDashcardVisualizationProps = {
   visualizationSettings?: VisualizationSettings;
   question: Question;
   withLeaveUnsavedConfirmation?: boolean;
+  isEditing?: boolean;
 };
 
 export const EditTableDashcardVisualization = ({
@@ -68,6 +69,7 @@ export const EditTableDashcardVisualization = ({
   visualizationSettings,
   question,
   withLeaveUnsavedConfirmation = true,
+  isEditing,
 }: EditTableDashcardVisualizationProps) => {
   const dispatch = useDispatch();
 
@@ -202,59 +204,61 @@ export const EditTableDashcardVisualization = ({
       >
         <Text fw="bold">{title}</Text>
 
-        <Group gap="sm" align="center">
-          {hasDeleteAction && (
-            <>
-              <ActionIcon
-                size="md"
-                onClick={requestDeleteBulk}
-                disabled={shouldDisableActions || !selectedRowIndices.length}
-              >
-                <Icon
-                  name="trash"
-                  tooltip={
-                    selectedRowIndices.length
-                      ? t`Delete`
-                      : t`Select rows for deletion`
-                  }
-                />
-              </ActionIcon>
-              <Box h={rem(16)}>
-                <Divider orientation="vertical" h="100%" />
-              </Box>
-            </>
-          )}
-          <ActionIcon
-            size="md"
-            onClick={undo}
-            disabled={shouldDisableActions}
-            loading={isUndoLoading}
-          >
-            <Icon name="undo" tooltip={t`Undo changes`} />
-          </ActionIcon>
-          <ActionIcon
-            size="md"
-            onClick={redo}
-            disabled={shouldDisableActions}
-            loading={isRedoLoading}
-          >
-            <Icon name="redo" tooltip={t`Redo changes`} />
-          </ActionIcon>
-          {hasCreateAction && (
-            <Box h={rem(16)}>
-              <Divider orientation="vertical" h="100%" />
-            </Box>
-          )}
-          {hasCreateAction && (
+        {!isEditing && (
+          <Group gap="sm" align="center">
+            {hasDeleteAction && (
+              <>
+                <ActionIcon
+                  size="md"
+                  onClick={requestDeleteBulk}
+                  disabled={shouldDisableActions || !selectedRowIndices.length}
+                >
+                  <Icon
+                    name="trash"
+                    tooltip={
+                      selectedRowIndices.length
+                        ? t`Delete`
+                        : t`Select rows for deletion`
+                    }
+                  />
+                </ActionIcon>
+                <Box h={rem(16)}>
+                  <Divider orientation="vertical" h="100%" />
+                </Box>
+              </>
+            )}
             <ActionIcon
               size="md"
-              onClick={openCreateRowModal}
+              onClick={undo}
               disabled={shouldDisableActions}
+              loading={isUndoLoading}
             >
-              <Icon name="add" tooltip={t`New record`} />
+              <Icon name="undo" tooltip={t`Undo changes`} />
             </ActionIcon>
-          )}
-        </Group>
+            <ActionIcon
+              size="md"
+              onClick={redo}
+              disabled={shouldDisableActions}
+              loading={isRedoLoading}
+            >
+              <Icon name="redo" tooltip={t`Redo changes`} />
+            </ActionIcon>
+            {hasCreateAction && (
+              <>
+                <Box h={rem(16)}>
+                  <Divider orientation="vertical" h="100%" />
+                </Box>
+                <ActionIcon
+                  size="md"
+                  onClick={openCreateRowModal}
+                  disabled={shouldDisableActions}
+                >
+                  <Icon name="add" tooltip={t`New record`} />
+                </ActionIcon>
+              </>
+            )}
+          </Group>
+        )}
       </Flex>
       {data.rows.length === 0 ? (
         <Stack

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -777,6 +777,7 @@ export const PLUGIN_DATA_EDITING = {
     className?: string;
     visualizationSettings?: VisualizationSettings;
     question: Question;
+    isEditing?: boolean;
   }>,
 };
 

--- a/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
@@ -83,7 +83,7 @@ export class TableEditable extends Component<
   }
 
   render() {
-    const { dashcard, className, metadata } = this.props;
+    const { dashcard, className, metadata, isEditing } = this.props;
     const { data, card, question } = this.state;
 
     if (card?.visualization_settings?.table_id && !data && dashcard?.isAdded) {
@@ -144,6 +144,7 @@ export class TableEditable extends Component<
         tableId={card.table_id}
         visualizationSettings={visualizationSettings}
         question={question}
+        isEditing={isEditing}
       />
     );
   }


### PR DESCRIPTION
Closes [WRK-425](https://linear.app/metabase/issue/WRK-425/hide-table-dashcard-actions-when-editing-a-question)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/aaaa63b4-f6bb-4425-badf-e02766bdd40b" />
