### PR TITLE
Sync single table via UI

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1265,6 +1265,7 @@
            api
            app-db
            audit-app
+           database-routing
            driver
            events
            lib

--- a/frontend/src/metabase/api/table.ts
+++ b/frontend/src/metabase/api/table.ts
@@ -108,6 +108,8 @@ export const tableApi = Api.injectEndpoints({
         invalidateTags(error, [
           idTag("table", id),
           listTag("field"),
+          listTag("field-values"),
+          listTag("parameter-values"),
           tag("card"),
         ]),
     }),

--- a/frontend/src/metabase/api/table.ts
+++ b/frontend/src/metabase/api/table.ts
@@ -99,6 +99,18 @@ export const tableApi = Api.injectEndpoints({
       invalidatesTags: (_, error) =>
         invalidateTags(error, [tag("field-values"), tag("parameter-values")]),
     }),
+    syncTableSchema: builder.mutation<void, TableId>({
+      query: (id) => ({
+        method: "POST",
+        url: `/api/table/${id}/sync_schema`,
+      }),
+      invalidatesTags: (_, error, id) =>
+        invalidateTags(error, [
+          idTag("table", id),
+          listTag("field"),
+          tag("card"),
+        ]),
+    }),
     discardTableFieldValues: builder.mutation<void, TableId>({
       query: (id) => ({
         method: "POST",
@@ -119,5 +131,6 @@ export const {
   useUpdateTableListMutation,
   useUpdateTableFieldsOrderMutation,
   useRescanTableFieldValuesMutation,
+  useSyncTableSchemaMutation,
   useDiscardTableFieldValuesMutation,
 } = tableApi;

--- a/frontend/src/metabase/hooks/use-temporary-state.ts
+++ b/frontend/src/metabase/hooks/use-temporary-state.ts
@@ -1,0 +1,32 @@
+import { useCallback, useRef, useState } from "react";
+import { useUnmount } from "react-use";
+
+/**
+ * A hook that temporarily changes the value of a stateful value
+ * and automatically resets it to the baseValue after the specified
+ * amount of time.
+ *
+ * Ideal for feedback message on buttons that are clicked.
+ */
+export function useTemporaryState<T>(
+  baseValue: T,
+  ms: number,
+): [T, (newValue: T) => void] {
+  const [value, setValue] = useState(baseValue);
+  const timeoutIdRef = useRef<number>();
+
+  const changeValue = useCallback(
+    (newValue: T) => {
+      setValue(newValue);
+      window.clearTimeout(timeoutIdRef.current);
+      timeoutIdRef.current = window.setTimeout(() => setValue(baseValue), ms);
+    },
+    [baseValue, ms],
+  );
+
+  useUnmount(() => {
+    window.clearTimeout(timeoutIdRef.current);
+  });
+
+  return [value, changeValue];
+}

--- a/frontend/src/metabase/metadata/components/DiscardFieldValuesButton/DiscardFieldValuesButton.tsx
+++ b/frontend/src/metabase/metadata/components/DiscardFieldValuesButton/DiscardFieldValuesButton.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useRef, useState } from "react";
-import { useUnmount } from "react-use";
 import { t } from "ttag";
 
 import { useDiscardFieldValuesMutation } from "metabase/api";
-import { useDispatch } from "metabase/lib/redux";
-import { addUndo } from "metabase/redux/undo";
+import { useToast } from "metabase/common/hooks";
+import { useTemporaryState } from "metabase/hooks/use-temporary-state";
 import { Button } from "metabase/ui";
 import type { FieldId } from "metabase-types/api";
 
@@ -13,38 +11,23 @@ interface Props {
 }
 
 export const DiscardFieldValuesButton = ({ fieldId }: Props) => {
-  const dispatch = useDispatch();
-
-  const [started, setStarted] = useState(false);
-  const timeoutIdRef = useRef<number>();
-  const [discardFieldValues, { error }] = useDiscardFieldValuesMutation();
+  const [discardFieldValues] = useDiscardFieldValuesMutation();
+  const [sendToast] = useToast();
+  const [started, setStarted] = useTemporaryState(false, 2000);
 
   const handleClick = async () => {
-    const response = await discardFieldValues(fieldId);
+    const { error } = await discardFieldValues(fieldId);
 
-    if (!response.error) {
+    if (error) {
+      sendToast({
+        icon: "warning",
+        message: t`Failed to discard values`,
+        toastColor: "error",
+      });
+    } else {
       setStarted(true);
-
-      window.clearTimeout(timeoutIdRef.current);
-      timeoutIdRef.current = window.setTimeout(() => setStarted(false), 2000);
     }
   };
-
-  useUnmount(() => {
-    window.clearTimeout(timeoutIdRef.current);
-  });
-
-  useEffect(() => {
-    if (error) {
-      dispatch(
-        addUndo({
-          icon: "warning",
-          message: t`Failed to discard values`,
-          toastColor: "error",
-        }),
-      );
-    }
-  }, [dispatch, error]);
 
   return (
     <Button c="error" variant="subtle" onClick={handleClick}>

--- a/frontend/src/metabase/metadata/components/DiscardTableFieldValuesButton/DiscardTableFieldValuesButton.tsx
+++ b/frontend/src/metabase/metadata/components/DiscardTableFieldValuesButton/DiscardTableFieldValuesButton.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useRef, useState } from "react";
-import { useUnmount } from "react-use";
 import { t } from "ttag";
 
 import { useDiscardTableFieldValuesMutation } from "metabase/api";
-import { useDispatch } from "metabase/lib/redux";
-import { addUndo } from "metabase/redux/undo";
+import { useToast } from "metabase/common/hooks";
+import { useTemporaryState } from "metabase/hooks/use-temporary-state";
 import { Button } from "metabase/ui";
 import type { TableId } from "metabase-types/api";
 
@@ -13,39 +11,23 @@ interface Props {
 }
 
 export const DiscardTableFieldValuesButton = ({ tableId }: Props) => {
-  const dispatch = useDispatch();
-
-  const [started, setStarted] = useState(false);
-  const timeoutIdRef = useRef<number>();
-  const [discardTableFieldValues, { error }] =
-    useDiscardTableFieldValuesMutation();
+  const [discardTableFieldValues] = useDiscardTableFieldValuesMutation();
+  const [sendToast] = useToast();
+  const [started, setStarted] = useTemporaryState(false, 2000);
 
   const handleClick = async () => {
-    const response = await discardTableFieldValues(tableId);
+    const { error } = await discardTableFieldValues(tableId);
 
-    if (!response.error) {
+    if (error) {
+      sendToast({
+        icon: "warning",
+        message: t`Failed to discard values`,
+        toastColor: "error",
+      });
+    } else {
       setStarted(true);
-
-      window.clearTimeout(timeoutIdRef.current);
-      timeoutIdRef.current = window.setTimeout(() => setStarted(false), 2000);
     }
   };
-
-  useUnmount(() => {
-    window.clearTimeout(timeoutIdRef.current);
-  });
-
-  useEffect(() => {
-    if (error) {
-      dispatch(
-        addUndo({
-          icon: "warning",
-          message: t`Failed to discard values`,
-          toastColor: "error",
-        }),
-      );
-    }
-  }, [dispatch, error]);
 
   return (
     <Button c="error" variant="subtle" onClick={handleClick}>

--- a/frontend/src/metabase/metadata/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
+++ b/frontend/src/metabase/metadata/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const RescanTableFieldsButton = ({ tableId }: Props) => {
   const [rescanTableFieldValues] = useRescanTableFieldValuesMutation();
-  const [started, setStarted] = useTemporaryState(false);
+  const [started, setStarted] = useTemporaryState(false, 2000);
   const [sendToast] = useToast();
 
   const handleClick = async () => {

--- a/frontend/src/metabase/metadata/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
+++ b/frontend/src/metabase/metadata/components/RescanTableFieldsButton/RescanTableFieldsButton.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useRef, useState } from "react";
-import { useUnmount } from "react-use";
 import { t } from "ttag";
 
 import { useRescanTableFieldValuesMutation } from "metabase/api";
-import { useDispatch } from "metabase/lib/redux";
-import { addUndo } from "metabase/redux/undo";
+import { useToast } from "metabase/common/hooks";
+import { useTemporaryState } from "metabase/hooks/use-temporary-state";
 import { Button } from "metabase/ui";
 import type { TableId } from "metabase-types/api";
 
@@ -13,39 +11,23 @@ interface Props {
 }
 
 export const RescanTableFieldsButton = ({ tableId }: Props) => {
-  const dispatch = useDispatch();
-
-  const [started, setStarted] = useState(false);
-  const timeoutIdRef = useRef<number>();
-  const [rescanTableFieldValues, { error }] =
-    useRescanTableFieldValuesMutation();
+  const [rescanTableFieldValues] = useRescanTableFieldValuesMutation();
+  const [started, setStarted] = useTemporaryState(false);
+  const [sendToast] = useToast();
 
   const handleClick = async () => {
-    const response = await rescanTableFieldValues(tableId);
+    const { error } = await rescanTableFieldValues(tableId);
 
-    if (!response.error) {
+    if (error) {
+      sendToast({
+        icon: "warning",
+        message: t`Failed to start scan`,
+        toastColor: "error",
+      });
+    } else {
       setStarted(true);
-
-      window.clearTimeout(timeoutIdRef.current);
-      timeoutIdRef.current = window.setTimeout(() => setStarted(false), 2000);
     }
   };
-
-  useUnmount(() => {
-    window.clearTimeout(timeoutIdRef.current);
-  });
-
-  useEffect(() => {
-    if (error) {
-      dispatch(
-        addUndo({
-          icon: "warning",
-          message: t`Failed to start scan`,
-          toastColor: "error",
-        }),
-      );
-    }
-  }, [dispatch, error]);
 
   return (
     <Button variant="default" onClick={handleClick}>

--- a/frontend/src/metabase/metadata/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
+++ b/frontend/src/metabase/metadata/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { t } from "ttag";
+
+import { useSyncTableSchemaMutation } from "metabase/api";
+import { useToast } from "metabase/common/hooks";
+import { Button } from "metabase/ui";
+import type { TableId } from "metabase-types/api";
+
+export function SyncTableSchemaButton({ tableId }: { tableId: TableId }) {
+  const [started, setStarted] = useState(0);
+  const [syncTableSchema] = useSyncTableSchemaMutation();
+  const [sendToast] = useToast();
+
+  const handleClick = async () => {
+    const { error } = await syncTableSchema(tableId);
+
+    if (error) {
+      sendToast({
+        icon: "warning",
+        message: t`Failed to start sync`,
+        toastColor: "error",
+      });
+    } else {
+      setStarted((started) => started + 1);
+    }
+  };
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setStarted(0), 2000);
+    return () => window.clearTimeout(timeoutId);
+  }, [started]);
+
+  return (
+    <Button variant="default" onClick={handleClick}>
+      {started ? t`Sync triggered!` : t`Sync table schema`}
+    </Button>
+  );
+}

--- a/frontend/src/metabase/metadata/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
+++ b/frontend/src/metabase/metadata/components/SyncTableSchemaButton/SyncTableSchemaButton.tsx
@@ -1,17 +1,15 @@
-import { useRef, useState } from "react";
-import { useUnmount } from "react-use";
 import { t } from "ttag";
 
 import { useSyncTableSchemaMutation } from "metabase/api";
 import { useToast } from "metabase/common/hooks";
+import { useTemporaryState } from "metabase/hooks/use-temporary-state";
 import { Button } from "metabase/ui";
 import type { TableId } from "metabase-types/api";
 
 export function SyncTableSchemaButton({ tableId }: { tableId: TableId }) {
   const [syncTableSchema] = useSyncTableSchemaMutation();
+  const [started, setStarted] = useTemporaryState(false, 2000);
   const [sendToast] = useToast();
-  const [started, setStarted] = useState(false);
-  const timeoutIdRef = useRef<number>();
 
   const handleClick = async () => {
     const { error } = await syncTableSchema(tableId);
@@ -24,14 +22,8 @@ export function SyncTableSchemaButton({ tableId }: { tableId: TableId }) {
       });
     } else {
       setStarted(true);
-      window.clearTimeout(timeoutIdRef.current);
-      timeoutIdRef.current = window.setTimeout(() => setStarted(false), 2000);
     }
   };
-
-  useUnmount(() => {
-    window.clearTimeout(timeoutIdRef.current);
-  });
 
   return (
     <Button variant="default" onClick={handleClick}>

--- a/frontend/src/metabase/metadata/components/SyncTableSchemaButton/SyncTableSchemaButton.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/SyncTableSchemaButton/SyncTableSchemaButton.unit.spec.tsx
@@ -1,0 +1,129 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupTableEndpoints } from "__support__/server-mocks";
+import {
+  act,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from "__support__/ui";
+import { UndoListing } from "metabase/containers/UndoListing";
+import { createMockTable } from "metabase-types/api/mocks";
+
+import { SyncTableSchemaButton } from "./SyncTableSchemaButton";
+
+function setup() {
+  const table = createMockTable();
+
+  setupTableEndpoints(table);
+
+  renderWithProviders(
+    <>
+      <SyncTableSchemaButton tableId={table.id} />
+      <UndoListing />
+    </>,
+  );
+
+  return { table };
+}
+
+describe("SyncTableSchemaButton", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ advanceTimers: true });
+  });
+
+  it("should show success message for 2 seconds", async () => {
+    const { table } = setup();
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("Sync table schema");
+
+    await userEvent.click(button);
+    expect(
+      fetchMock.calls(`path:/api/table/${table.id}/sync_schema`, {
+        method: "POST",
+      }),
+    ).toHaveLength(1);
+    await waitFor(() => {
+      expect(button).toHaveTextContent("Sync triggered!");
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(button).toHaveTextContent("Sync table schema");
+  });
+
+  it("resets success message timer after next click", async () => {
+    const { table } = setup();
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("Sync table schema");
+
+    await userEvent.click(button);
+    expect(
+      fetchMock.calls(`path:/api/table/${table.id}/sync_schema`, {
+        method: "POST",
+      }),
+    ).toHaveLength(1);
+    await waitFor(() => {
+      expect(button).toHaveTextContent("Sync triggered!");
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(button).toHaveTextContent("Sync triggered!");
+    await userEvent.click(button);
+    expect(
+      fetchMock.calls(`path:/api/table/${table.id}/sync_schema`, {
+        method: "POST",
+      }),
+    ).toHaveLength(2);
+
+    await act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(button).toHaveTextContent("Sync triggered!");
+
+    await act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(button).toHaveTextContent("Sync table schema");
+  });
+
+  it("should show error message toast", async () => {
+    const { table } = setup();
+
+    fetchMock.post(
+      `path:/api/table/${table.id}/sync_schema`,
+      { status: 500 },
+      { overwriteRoutes: true },
+    );
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("Sync table schema");
+
+    await userEvent.click(button);
+    expect(
+      fetchMock.calls(`path:/api/table/${table.id}/sync_schema`, {
+        method: "POST",
+      }),
+    ).toHaveLength(1);
+    await waitFor(() => {
+      expect(button).toHaveTextContent("Sync table schema");
+    });
+
+    await waitFor(() => {
+      const undo = screen.getByTestId("undo-list");
+      expect(
+        within(undo).getByText("Failed to start sync"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/metadata/components/SyncTableSchemaButton/index.ts
+++ b/frontend/src/metabase/metadata/components/SyncTableSchemaButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./SyncTableSchemaButton";

--- a/frontend/src/metabase/metadata/components/index.ts
+++ b/frontend/src/metabase/metadata/components/index.ts
@@ -13,5 +13,6 @@ export * from "./SemanticTypeAndTargetPicker";
 export * from "./SemanticTypePicker";
 export * from "./SortableField";
 export * from "./SortableFieldList";
+export * from "./SyncTableSchemaButton";
 export * from "./TableBreadcrumbs";
 export * from "./UnfoldJsonPicker";

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -11,6 +11,7 @@ import {
   NameDescriptionInput,
   RescanTableFieldsButton,
   SortableFieldList,
+  SyncTableSchemaButton,
 } from "metabase/metadata/components";
 import { Box, Flex, Stack, Text } from "metabase/ui";
 import type { FieldId, Table } from "metabase-types/api";
@@ -113,6 +114,7 @@ export const TableSection = ({ params, table }: Props) => {
           </Text>
 
           <RescanTableFieldsButton tableId={table.id} />
+          <SyncTableSchemaButton tableId={table.id} />
 
           <DiscardTableFieldValuesButton tableId={table.id} />
         </Stack>

--- a/frontend/test/__support__/server-mocks/table.ts
+++ b/frontend/test/__support__/server-mocks/table.ts
@@ -12,6 +12,7 @@ export function setupTableEndpoints(
   fetchMock.get(`path:/api/table/${table.id}/fks`, foreignKeys);
   fetchMock.put(`path:/api/table/${table.id}`, {});
   fetchMock.post(`path:/api/table/${table.id}/rescan_values`, {});
+  fetchMock.post(`path:/api/table/${table.id}/sync_schema`, {});
   fetchMock.post(`path:/api/table/${table.id}/discard_values`, {});
   setupTableQueryMetadataEndpoint(table);
   table.fields?.forEach((field) => setupFieldEndpoints({ ...field, table }));

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -51,6 +51,7 @@
 
 (derive ::table-event ::event)
 (derive :event/table-manual-scan ::table-event)
+(derive :event/table-manual-sync ::table-event)
 
 (methodical/defmethod events/publish-event! ::table-event
   [topic event]

--- a/src/metabase/warehouse_schema/api/table.clj
+++ b/src/metabase/warehouse_schema/api/table.clj
@@ -318,3 +318,25 @@
                 :filename (get-in multipart-params ["file" :filename])
                 :file     (get-in multipart-params ["file" :tempfile])
                 :action   :metabase.upload/replace}))
+
+(api.macros/defendpoint :post "/:id/sync_schema"
+  "Trigger a manual update of the schema metadata for this `Table`."
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
+  (let [table (api/write-check (t2/select-one :model/Table :id id))]
+    (events/publish-event! :event/table-manual-sync {:object table :user-id api/*current-user-id*})
+    (let [database (table/database table)]
+      ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
+      ;; purposes of creating a new H2 database.
+      (if-let [ex (try
+                    (binding [h2/*allow-testing-h2-connections* true]
+                      (driver.u/can-connect-with-details? (:engine database) (:details database) :throw-exceptions))
+                    nil
+                    (catch Throwable e
+                      (log/warn (u/format-color :red "Cannot connect to database '%s' in order to sync table '%s'"
+                                                (:name database) (:name table)))
+                      e))]
+        (throw (ex-info (ex-message ex) {:status-code 422}))
+        (do
+          (quick-task/submit-task! #(sync/sync-table! table))
+          {:status :ok})))))

--- a/src/metabase/warehouse_schema/api/table.clj
+++ b/src/metabase/warehouse_schema/api/table.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]
@@ -25,6 +26,7 @@
    [metabase.util.quick-task :as quick-task]
    [metabase.warehouse-schema.models.table :as table]
    [metabase.warehouse-schema.table :as schema.table]
+   [metabase.warehouses.api :as warehouses]
    [metabase.xrays.core :as xrays]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
@@ -323,20 +325,20 @@
   "Trigger a manual update of the schema metadata for this `Table`."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (let [table (api/write-check (t2/select-one :model/Table :id id))]
+  (let [table (api/write-check (t2/select-one :model/Table :id id))
+        database (api/write-check (warehouses/get-database (table/database table) {:exclude-uneditable-details? true}))]
     (events/publish-event! :event/table-manual-sync {:object table :user-id api/*current-user-id*})
-    (let [database (table/database table)]
-      ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
-      ;; purposes of creating a new H2 database.
-      (if-let [ex (try
-                    (binding [h2/*allow-testing-h2-connections* true]
-                      (driver.u/can-connect-with-details? (:engine database) (:details database) :throw-exceptions))
-                    nil
-                    (catch Throwable e
-                      (log/warn (u/format-color :red "Cannot connect to database '%s' in order to sync table '%s'"
-                                                (:name database) (:name table)))
-                      e))]
-        (throw (ex-info (ex-message ex) {:status-code 422}))
-        (do
-          (quick-task/submit-task! #(sync/sync-table! table))
-          {:status :ok})))))
+    ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
+    ;; purposes of creating a new H2 database.
+    (if-let [ex (try
+                  (binding [h2/*allow-testing-h2-connections* true]
+                    (driver.u/can-connect-with-details? (:engine database) (:details database) :throw-exceptions))
+                  nil
+                  (catch Throwable e
+                    (log/warn (u/format-color :red "Cannot connect to database '%s' in order to sync table '%s'"
+                                              (:name database) (:name table)))
+                    e))]
+      (throw (ex-info (ex-message ex) {:status-code 422}))
+      (do
+        (quick-task/submit-task! #(database-routing/with-database-routing-off (sync/sync-table! table)))
+        {:status :ok}))))

--- a/src/metabase/warehouse_schema/api/table.clj
+++ b/src/metabase/warehouse_schema/api/table.clj
@@ -326,7 +326,7 @@
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (let [table (api/write-check (t2/select-one :model/Table :id id))
-        database (api/write-check (warehouses/get-database (table/database table) {:exclude-uneditable-details? true}))]
+        database (api/write-check (warehouses/get-database (:db_id table) {:exclude-uneditable-details? true}))]
     (events/publish-event! :event/table-manual-sync {:object table :user-id api/*current-user-id*})
     ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
     ;; purposes of creating a new H2 database.

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -358,7 +358,8 @@
                             ; filter hidden fields
                             (= include "tables.fields") (map #(update % :fields filter-sensitive-fields))))))))
 
-(mu/defn- get-database
+(mu/defn get-database
+  "Retrieve database respecting `include-editable-data-model?`, `exclude-uneditable-details?` and `include-mirror-databases?`"
   ([id] (get-database id {}))
   ([id :- ms/PositiveInt
     {:keys [include-editable-data-model?

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -14,6 +14,7 @@
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
    [metabase.timeseries-query-processor-test.util :as tqpt]
@@ -1248,3 +1249,29 @@
                             :table-id (:id table)
                             :file     file}))
             (is (not (.exists file)) "File should be deleted after replace-csv!")))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          POST /api/table/:id/sync_schema                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest ^:parallel non-admins-cant-trigger-sync-test
+  (testing "Non-admins should not be allowed to trigger sync"
+    (mt/with-temp [:model/Table table {}]
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 (format "table/%d/sync_schema" (u/the-id table))))))))
+
+(defn- deliver-when-tbl [promise-to-deliver expected-tbl]
+  (fn [tbl]
+    (when (= (u/the-id tbl) (u/the-id expected-tbl))
+      (deliver promise-to-deliver true))))
+
+(deftest trigger-metadata-sync-for-table-test
+  (testing "Can we trigger a metadata sync for a table?"
+    (let [sync-called? (promise)
+          timeout (* 10 60)]
+      (mt/with-temp [:model/Table table]
+        (with-redefs [sync/sync-table! (deliver-when-tbl sync-called? table)]
+          (mt/user-http-request :crowberto :post 200 (format "table/%d/sync_schema" (u/the-id table)))))
+      (testing "sync called?"
+        (is (true?
+             (deref sync-called? timeout :sync-never-called)))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> Closes #56252
Closes [SEM-221](https://linear.app/metabase/issue/SEM-221/sync-table-via-the-ui)

Adds a button to the table section to sync that table's schema.



<img width="381" alt="Screenshot 2025-05-22 at 13 11 37" src="https://github.com/user-attachments/assets/7492704f-2c34-40c2-8f47-4185607ce7e9" />

Unit tests have been added, e2e test will follow in a later PR.