### PR TITLE
Closes VIZ-989 double scrollbars on tabular view

### DIFF
--- a/frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx
+++ b/frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx
@@ -22,7 +22,7 @@ export function TabularPreviewModal({
 
   return (
     <Modal opened={opened} title={t`Preview`} size="xl" onClose={onClose}>
-      <Box h="80vh">
+      <Box h="60vh">
         <Visualization
           rawSeries={series}
           // TableInteractive crashes when trying to use metabase-lib

--- a/frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx
+++ b/frontend/src/metabase/visualizer/components/TabularPreviewModal/TabularPreviewModal.tsx
@@ -22,7 +22,7 @@ export function TabularPreviewModal({
 
   return (
     <Modal opened={opened} title={t`Preview`} size="xl" onClose={onClose}>
-      <Box h="800px">
+      <Box h="80vh">
         <Visualization
           rawSeries={series}
           // TableInteractive crashes when trying to use metabase-lib


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57921
Closes [VIZ-989: "View as table" in visualizer can end up broken with double scrollbar madness](https://linear.app/metabase/issue/VIZ-989/view-as-table-in-visualizer-can-end-up-broken-with-double-scrollbar)