### PR TITLE
Call AI service endpoints without trailing slashes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -84,10 +84,10 @@
   (str (ai-proxy-base-url) "/v1/sql/generate"))
 
 (defn- analyze-chart-endpoint []
-  (str (ai-proxy-base-url) "/v1/analyze/chart/"))
+  (str (ai-proxy-base-url) "/v1/analyze/chart"))
 
 (defn- analyze-dashboard-endpoint []
-  (str (ai-proxy-base-url) "/v1/analyze/dashboard/"))
+  (str (ai-proxy-base-url) "/v1/analyze/dashboard"))
 
 (mu/defn request :- ::metabot-v3.client.schema/ai-proxy.response
   "Make a V2 request to the AI Proxy."


### PR DESCRIPTION
### Description

This is just a cleanup to follow a convention.