### PR TITLE
fix: drop execution time quartz job metric

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -325,9 +325,6 @@
   [(prometheus/counter :metabase-tasks/quartz-tasks-executed
                        {:description "How many tasks this metabase instance has executed by job-name and status"
                         :labels [:status :job-name]})
-   (prometheus/histogram :metabase-tasks/quartz-tasks-execution-time-ms
-                         {:description "How long a task took to execute in ms by job-name and status"
-                          :labels [:status :job-name]})
    (prometheus/gauge :metabase-tasks/quartz-tasks-states
                      {:description "How many tasks are in a given state in the entire quartz cluster"
                       :labels [:state]})])

--- a/src/metabase/analytics/quartz.clj
+++ b/src/metabase/analytics/quartz.clj
@@ -31,8 +31,7 @@
       (try
         (let [tags {:status (if job-exception "failed" "succeeded")
                     :job-name (.. ctx getJobDetail getKey toString)}]
-          (prometheus/inc! :metabase-tasks/quartz-tasks-executed tags)
-          (prometheus/observe! :metabase-tasks/quartz-tasks-execution-time-ms tags (.getJobRunTime ctx)))
+          (prometheus/inc! :metabase-tasks/quartz-tasks-executed tags))
         (catch Throwable e
           (log/error e "Failed to record Prometheus metric for Quartz job completion"))))))
 

--- a/test/metabase/analytics/quartz_test.clj
+++ b/test/metabase/analytics/quartz_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.analytics.quartz-test
   (:require
    [clojure.test :refer :all]
-   [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.analytics.quartz :as analytics.quartz]
    [metabase.test :as mt])
   (:import
@@ -104,11 +103,7 @@
             (is (= 1.0 (mt/metric-value system :metabase-tasks/quartz-tasks-executed tags))
                 "Counter should increment for successful job with correct tags")
             (is (= 0.0 (mt/metric-value system :metabase-tasks/quartz-tasks-executed {:status "failed" :job-name job-name}))
-                "Failed counter should remain 0 for the specific job")
-            (is (prometheus-test/approx= run-time (:sum (mt/metric-value system :metabase-tasks/quartz-tasks-execution-time-ms tags)))
-                "Histogram sum should record the job run time for successful job")
-            (is (= 1.0 (:count (mt/metric-value system :metabase-tasks/quartz-tasks-execution-time-ms tags)))
-                "Histogram count should increment for successful job")))
+                "Failed counter should remain 0 for the specific job")))
 
         (testing "Failed execution"
           (let [ctx (mock-job-execution-context job-name run-time)
@@ -118,15 +113,7 @@
             (is (= 1.0 (mt/metric-value system :metabase-tasks/quartz-tasks-executed success-tags))
                 "Successful counter should remain unchanged")
             (is (= 1.0 (mt/metric-value system :metabase-tasks/quartz-tasks-executed fail-tags))
-                "Counter should increment for failed job with correct tags")
-            (is (prometheus-test/approx= run-time (:sum (mt/metric-value system :metabase-tasks/quartz-tasks-execution-time-ms fail-tags)))
-                "Histogram sum should record the job run time even for failed job")
-            (is (= 1.0 (:count (mt/metric-value system :metabase-tasks/quartz-tasks-execution-time-ms fail-tags)))
-                "Histogram count should increment for failed job")
-            (is (prometheus-test/approx= run-time (:sum (mt/metric-value system :metabase-tasks/quartz-tasks-execution-time-ms success-tags)))
-                "Successful histogram sum should remain unchanged")
-            (is (= 1.0 (:count (mt/metric-value system :metabase-tasks/quartz-tasks-execution-time-ms success-tags)))
-                "Successful histogram count should remain unchanged")))))))
+                "Counter should increment for failed job with correct tags")))))))
 
 (deftest trigger-listener-test
   (testing "Trigger listener should set the correct gauge values for task states"


### PR DESCRIPTION
### Description

Drops the execution time quartz job metric since we are having issues with the cardinality for now. 
