### PR TITLE
fix(sdk): table cell background should not be transparent

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -164,8 +164,8 @@ describe(
           .findAllByRole("gridcell")
           .first()
           .should(($el) => {
-            // cell color should be transparent
-            assertBackgroundColorEqual($el, "rgba(0, 0, 0, 0)");
+            // cell color should also be solid
+            assertBackgroundColorEqual($el, BACKGROUND_COLOR);
           });
       });
     });

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion-themed.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion-themed.stories.tsx
@@ -74,3 +74,15 @@ export const WithWhiteTooltip = {
     },
   }),
 };
+
+export const UnthemedOnBlackBackground = {
+  render() {
+    return (
+      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+        <Box p="xl" bg="#000">
+          <InteractiveQuestion questionId={QUESTION_ID} isSaveEnabled />
+        </Box>
+      </MetabaseProvider>
+    );
+  },
+};

--- a/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
@@ -106,6 +106,10 @@ export const DEFAULT_EMBEDDED_COMPONENT_THEME: MetabaseComponentTheme = merge<
   table: {
     cell: {
       fontSize: FONT_SIZES.tableCell.em,
+
+      // Defaults to `theme.fn.themeColor("background")`
+      // We cannot use CSS variables like `var(--mb-color-background)` as the cell color must be a hex value.
+      backgroundColor: "background",
     },
   },
   pivotTable: {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -445,7 +445,9 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
             value,
             rowIndex,
             col.name,
-          ) ?? tableTheme?.cell?.backgroundColor,
+          ) ??
+          (tableTheme?.cell?.backgroundColor &&
+            theme.fn.themeColor(tableTheme?.cell?.backgroundColor)),
       );
 
       const formatter = columnFormatters[columnIndex];

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -446,6 +446,8 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
             rowIndex,
             col.name,
           ) ??
+          // we can't use CSS variables here.
+          // fn.themeColor allows us to default to "background" when on the SDK and still accept hex/rgb values.
           (tableTheme?.cell?.backgroundColor &&
             theme.fn.themeColor(tableTheme?.cell?.backgroundColor)),
       );


### PR DESCRIPTION
Closes EMB-411

### Description

When a dark-themed user did not configure any theming, the defaults is a bit wonky right now because the cell color is transparent:

![image](https://github.com/user-attachments/assets/64c7ee18-e4e1-49ae-9e2b-e4b5a244b3eb)

We can default the table cell background color to be solid, same as the table header. This makes it at least always legible by default. This matches the behavior of 53.

![image](https://github.com/user-attachments/assets/4a11a143-8402-4826-a688-bd6110edc730)

Should only be single-backported because the data table change is introduced in 54.

### How to verify

- Set the background of the page to be black (via CSS)
- Do not set any sdk theme
- Render a question with a table (you can try on Storybook)
- Cell should not be transparent

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
