### PR TITLE
Disable distribution drill if binning is not available

### DIFF
--- a/src/metabase/lib/drill_thru/distribution.cljc
+++ b/src/metabase/lib/drill_thru/distribution.cljc
@@ -30,6 +30,7 @@
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
@@ -51,6 +52,7 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              column
              (nil? value)
+             (lib.metadata/database-supports? query :binning)
              (not (lib.underlying/aggregation-sourced? query column))
              (not (lib.types.isa/primary-key? column))
              (not (lib.types.isa/structured?  column))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-331/disable-distribution-drill-option-for-mongo-and-alike

### Description
Disable distribution drill if binning is not available on the current driver
