### PR TITLE
clean up settings menu

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -784,9 +784,10 @@ function setApplicationFontTo(font) {
   H.updateSetting("application-font", font);
 }
 
-const openSettingsMenu = () => H.appBar().icon("gear").click();
+const openSettingsMenu = () =>
+  H.appBar().findByRole("button", { name: "Settings" }).click();
 
-const helpLink = () => H.popover().findByRole("link", { name: "Help" });
+const helpLink = () => H.popover().findByRole("menuitem", { name: "Help" });
 
 const getHelpLinkCustomDestinationInput = () =>
   cy.findByPlaceholderText("Enter a URL it should go to");

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -77,7 +77,9 @@ H.describeWithSnowplow(
         "Ensure that table is visible in admin without refreshing (metabase#38041)",
       );
 
-      cy.findByTestId("app-bar").button(/gear/).click();
+      cy.findByTestId("app-bar")
+        .findByRole("button", { name: "Settings" })
+        .click();
       H.popover().findByText("Admin settings").click();
 
       cy.findByRole("link", { name: "Table Metadata" }).click();

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1150,7 +1150,7 @@ describe("issue 21528", () => {
 
     cy.log("The following scenario breaks on 46");
     // Navigating to another page via JavaScript is faster than using `cy.visit("/admin/datamodel")` to load the whole page again.
-    H.appBar().icon("gear").click();
+    H.appBar().findByRole("button", { name: "Settings" }).click();
     H.popover().findByText("Admin settings").click();
     H.appBar().findByText("Table Metadata").click();
     cy.findByRole("main")

--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -64,9 +64,8 @@ describe("Onboarding checklist page", () => {
 
     cy.log("The link should now live in the main settings menu");
     cy.findByLabelText("Settings menu").click();
-    cy.findAllByTestId("entity-menu-link")
-      .contains("How to use Metabase")
-      .click();
+
+    H.popover().should("contain", "How to use Metabase").click();
     cy.location("pathname").should("eq", "/getting-started");
   });
 });

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
@@ -167,6 +167,12 @@ function ProfileLink({
               return <Menu.Divider key={index} />;
             }
 
+            const component = item.externalLink
+              ? "a"
+              : item.link
+                ? ForwardRefLink
+                : "button";
+
             return (
               <Menu.Item
                 key={item.title}
@@ -176,7 +182,8 @@ function ProfileLink({
                     item.action();
                   }
                 }}
-                component={item.link ? ForwardRefLink : "button"}
+                component={component}
+                href={item.link}
                 to={item.link}
                 target={item.externalLink ? "_blank" : undefined}
                 rel={item.externalLink ? "noopener noreferrer" : undefined}

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
@@ -13,6 +13,7 @@ import { ErrorDiagnosticModalWrapper } from "metabase/components/ErrorPages/Erro
 import { trackErrorDiagnosticModalOpened } from "metabase/components/ErrorPages/analytics";
 import LogoIcon from "metabase/components/LogoIcon";
 import Modal from "metabase/components/Modal";
+import { ForwardRefLink } from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import {
   getCanAccessOnboardingPage,
@@ -175,8 +176,8 @@ function ProfileLink({
                     item.action();
                   }
                 }}
-                component={item.link ? "a" : "button"}
-                href={item.link}
+                component={item.link ? ForwardRefLink : "button"}
+                to={item.link}
                 target={item.externalLink ? "_blank" : undefined}
                 rel={item.externalLink ? "noopener noreferrer" : undefined}
               >

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
@@ -73,7 +73,6 @@ function ProfileLink({
     const showAdminSettingsItem = adminItems?.length > 0;
 
     return [
-      // Account/User settings
       {
         title: t`Account settings`,
         icon: null,
@@ -91,11 +90,9 @@ function ProfileLink({
         icon: null,
         action: () => dispatch(setOpenModal("help")),
       },
-      // Separator between Account and Help sections
       {
         separator: true,
       },
-      // Help/Support section
       helpLink.visible && {
         title: t`Help`,
         icon: null,
@@ -126,11 +123,9 @@ function ProfileLink({
         action: () => openModal("about"),
         event: `Navbar;Profile Dropdown;About ${tag}`,
       },
-      // Separator before Sign out
       {
         separator: true,
       },
-      // Sign out section
       {
         title: t`Sign out`,
         icon: null,

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
@@ -164,7 +164,7 @@ describe("ProfileLink", () => {
         });
         await openMenu();
 
-        const link = screen.queryByRole("link", { name: /help/i });
+        const link = screen.queryByRole("menuitem", { name: /help/i });
 
         expect(link).not.toBeInTheDocument();
       });
@@ -178,7 +178,7 @@ describe("ProfileLink", () => {
         });
         await openMenu();
 
-        const link = screen.getByRole("link", { name: /help/i });
+        const link = screen.getByRole("menuitem", { name: /help/i });
 
         expect(link).toBeInTheDocument();
         expect(link).toHaveProperty("href", "https://custom.example.org/help");
@@ -194,7 +194,7 @@ describe("ProfileLink", () => {
             helpLinkSetting: "metabase",
           });
           await openMenu();
-          const link = screen.getByRole("link", { name: /help/i });
+          const link = screen.getByRole("menuitem", { name: /help/i });
 
           expect(link).toBeInTheDocument();
           const mockBugReportDetails = encodeURIComponent(
@@ -215,7 +215,7 @@ describe("ProfileLink", () => {
             helpLinkSetting: "metabase",
           });
           await openMenu();
-          const link = screen.getByRole("link", { name: /help/i });
+          const link = screen.getByRole("menuitem", { name: /help/i });
 
           expect(link).toBeInTheDocument();
           expect(link).toHaveProperty(
@@ -230,5 +230,5 @@ describe("ProfileLink", () => {
 
 const openMenu = async () => {
   await userEvent.click(screen.getByRole("img", { name: /gear/i }));
-  await screen.findByRole("dialog");
+  await screen.findByRole("menu");
 };


### PR DESCRIPTION
Updates the settings menu to use our metabase/ui Menu and adds some dividers to help with content organization.

Before
![Screenshot 2025-05-22 at 11 35 36 AM](https://github.com/user-attachments/assets/fea80a3b-a05e-47ac-a704-0761cbec5286)

After
![Screenshot 2025-05-22 at 11 35 18 AM](https://github.com/user-attachments/assets/6f7cfac0-0c8d-4c9c-8b7d-70ad929e54ba)
