### PR TITLE
sdk(docs): Remove remarks from SdkDashboardDisplayProps type annotations

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
@@ -28,9 +28,6 @@ export type SdkDashboardDisplayProps = {
   /**
    * Query parameters for the dashboard. For a single option, use a `string` value, and use a list of strings for multiple options.
    * <br/>
-   * <br/>
-   * @remarks
-   * <br/>
    * - Combining {@link SdkDashboardDisplayProps.initialParameters | initialParameters} and {@link SdkDashboardDisplayProps.hiddenParameters | hiddenParameters} to filter data on the frontend is a [security risk](https://www.metabase.com/docs/latest/embedding/sdk/authentication.html#security-warning-each-end-user-must-have-their-own-metabase-account).
    * <br/>
    * - Combining {@link SdkDashboardDisplayProps.initialParameters | initialParameters} and {@link SdkDashboardDisplayProps.hiddenParameters | hiddenParameters} to declutter the user interface is fine.
@@ -54,9 +51,6 @@ export type SdkDashboardDisplayProps = {
 
   /**
    * A list of [parameters to hide](https://www.metabase.com/docs/latest/embedding/public-links.html#appearance-parameters).
-   * <br/>
-   * <br/>
-   * @remarks
    * <br/>
    * - Combining {@link SdkDashboardDisplayProps.initialParameters | initialParameters} and {@link SdkDashboardDisplayProps.hiddenParameters | hiddenParameters} to filter data on the frontend is a [security risk](https://www.metabase.com/docs/latest/embedding/sdk/authentication.html#security-warning-each-end-user-must-have-their-own-metabase-account).
    * <br/>


### PR DESCRIPTION
Remove remarks from SdkDashboardDisplayProps type annotations

It fixes the [broken link](https://www.metabase.com/docs/v0.54/embedding/sdk/api/StaticDashboard)

It's difficult to make remarks look good in HTML and MD docs, so it's better just to remove this annotation.

![image](https://github.com/user-attachments/assets/faaf2ffc-1f23-4348-a1c8-7cf61dbccfe9)
