### PR TITLE
Fix column alignment for fully-collapsed pivot exports

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/task/refresh_cache_configs_test.clj
@@ -95,7 +95,7 @@
                                           :card_id      card-id-2}
                  :model/DashboardCard {} {:dashboard_id dashboard-id
                                           :card_id      card-id-2}]
-    (testing "Returns the card ID directly for a question cahce config"
+    (testing "Returns the card ID directly for a question cache config"
       (is (= [card-id-1] (@#'task.cache/schedule-cache-config->card-ids {:model_id card-id-1 :model "question"}))))
 
     (testing "Fetches card IDs associated with a dashboard cache config"

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -95,7 +95,7 @@
   [top-header-items left-header-items row-indexes display-name-for-col]
   (let [left-header-depth (->> left-header-items
                                (map :maxDepthBelow)
-                               (apply max)
+                               (reduce max 0)
                                inc)
         top-left-header   (sequence (comp (map display-name-for-col)
                                           (take left-header-depth))

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -92,25 +92,32 @@
      cols)))
 
 (defn- build-top-headers
-  [top-left-header top-header-items]
-  (if (empty? top-header-items)
-    [(vec top-left-header)]  ;; Return just the top-left header for empty input
-    (let [max-depth   (apply max (map :depth top-header-items))
-          left-width  (count top-left-header)
-          ;; Initialize rows - all rows except the last one are filled with nil
-          header-rows (-> (vec (repeat max-depth (vec (repeat left-width nil))))
-                          (conj (vec top-left-header)))]
-      ;; Fill in the header values for each item
-      (reduce
-       (fn [rows {:keys [depth value span]}]
-         (let [current-row (get rows depth)
-               ;; Add the value and repeat it for the span
-               new-row     (-> current-row
-                               (conj value)
-                               (into (repeat (dec span) value)))]
-           (assoc rows depth new-row)))
-       header-rows
-       top-header-items))))
+  [top-header-items left-header-items row-indexes display-name-for-col]
+  (let [left-header-depth (->> left-header-items
+                               (map :maxDepthBelow)
+                               (apply max)
+                               inc)
+        top-left-header   (sequence (comp (map display-name-for-col)
+                                          (take left-header-depth))
+                                    row-indexes)]
+    (if (empty? top-header-items)
+      [(vec top-left-header)]  ;; Return just the top-left header for empty input
+      (let [max-depth   (apply max (map :depth top-header-items))
+            left-width  (count top-left-header)
+            ;; Initialize rows - all rows except the last one are filled with nil
+            header-rows (-> (vec (repeat max-depth (vec (repeat left-width nil))))
+                            (conj (vec top-left-header)))]
+        ;; Fill in the header values for each item
+        (reduce
+         (fn [rows {:keys [depth value span]}]
+           (let [current-row (get rows depth)
+                 ;; Add the value and repeat it for the span
+                 new-row     (-> current-row
+                                 (conj value)
+                                 (into (repeat (dec span) value)))]
+             (assoc rows depth new-row)))
+         header-rows
+         top-header-items)))))
 
 (defn- build-left-headers
   [left-header-items]
@@ -181,10 +188,7 @@
                                                             format-rows?
                                                             settings
                                                             col-settings)
-        top-left-header          (map (fn [i] (pivot/display-name-for-col (nth columns i)
-                                                                          (nth col-settings i)
-                                                                          format-rows?))
-                                      row-indexes)
-        top-headers              (build-top-headers top-left-header topHeaderItems)
+        display-name-for-col-idx #(pivot/display-name-for-col (nth columns %) (nth col-settings %) format-rows?)
+        top-headers              (build-top-headers topHeaderItems leftHeaderItems row-indexes display-name-for-col-idx)
         left-headers             (build-left-headers leftHeaderItems)]
     (build-full-pivot getRowSection left-headers top-headers (count (:values column-split)))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/58340

We just need to make sure we're limiting the number of top-left column headers to the actual depth of the left column tree. 

This means that a column header that is fully collapsed is omitted from the export. I think this is reasonable behavior — on the FE it's useful to see the header to know that you _can_ un-collapse it, but in an export it contributes no data and no utility. And you can always un-collapse it prior to exporting if you need that column.

<img width="791" alt="image" src="https://github.com/user-attachments/assets/949cd71c-fc88-486e-9349-6a8aeb8aebce" />

<img width="445" alt="image" src="https://github.com/user-attachments/assets/8f902f0c-0907-4861-8eb9-a6912c84f5ea" />

