### PR TITLE
Join fields experiment

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
@@ -157,7 +157,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],
@@ -169,7 +169,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
@@ -157,7 +157,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],
@@ -169,7 +169,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage.cy.spec.ts
@@ -675,7 +675,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],
@@ -687,7 +687,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],
@@ -1070,7 +1070,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],
@@ -1082,7 +1082,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
                 null,
                 [
                   "Reviews - Created At: Month → Reviewer",
-                  "Products Via Product ID Category",
+                  "Product → Category",
                 ],
               ],
             ],

--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -673,12 +673,12 @@ export function setup2ndStageBreakoutFilter() {
 
   H.getDashboardCard(2).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverItem("Products Via Product ID Category").click();
+    getPopoverItem("Product → Category").click();
   });
 
   H.getDashboardCard(3).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverItem("Products Via Product ID Category").click();
+    getPopoverItem("Product → Category").click();
   });
 
   H.saveDashboard({ waitMs: 250 });

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -127,7 +127,7 @@
 ;;; --------------------------------------------------- Field Info ---------------------------------------------------
 
 (defn- name-for-joined-field
-  [name {:keys [fk-field-id], join-alias :alias}]
+  [name {join-alias :alias}]
   (str join-alias "__" name))
 
 (defn- display-name-for-joined-field

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -126,6 +126,10 @@
 
 ;;; --------------------------------------------------- Field Info ---------------------------------------------------
 
+(defn- name-for-joined-field
+  [name {:keys [fk-field-id], join-alias :alias}]
+  (str join-alias "__" name))
+
 (defn- display-name-for-joined-field
   "Return an appropriate display name for a joined field. For *explicitly* joined Fields, the qualifier is the join
   alias; for implicitly joined fields, it is the display name of the foreign key used to create the join."
@@ -311,6 +315,9 @@
 
       (or (:join-alias opts) (:alias join))
       (assoc :source_alias (or (:join-alias opts) (:alias join)))
+
+      join
+      (update :name name-for-joined-field join)
 
       join
       (update :display_name display-name-for-joined-field join)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/54920
Fixes https://github.com/metabase/metabase/issues/32499

The problem is that with joins (explicit or implicit) QP returns wrong column names in `result_metadata` that do not correspond to the top-level column names in the query:
<img width="962" alt="Screenshot 2025-05-22 at 15 20 36" src="https://github.com/user-attachments/assets/1849f29b-b7b0-49e9-981d-cf2502082762" />
<img width="975" alt="Screenshot 2025-05-22 at 15 20 48" src="https://github.com/user-attachments/assets/3e1153fe-e0c7-4bdb-82a9-2b6829835c19" />
<img width="788" alt="Screenshot 2025-05-22 at 15 21 07" src="https://github.com/user-attachments/assets/b72ff382-7087-4a03-b922-41a3e8f4a3c5" />

This leads to duplicated column names, which get de-duplicated, and it creates issues when the query changes -> columns get deduplicated differently. The expected behavior is that column names in `result_metadata` match column names in the top-level SELECT. So when this query as used as a source-query, it should match. It seems that practically it means that the join alias should be added to the column name.

After the fix:
<img width="777" alt="Screenshot 2025-05-22 at 15 26 35" src="https://github.com/user-attachments/assets/0f542d0c-7fcc-4051-a142-0c22b6c0b10b" />
