### PR TITLE
Use more informative icons in Filter popover

### DIFF
--- a/frontend/src/metabase/common/utils/column-groups.ts
+++ b/frontend/src/metabase/common/utils/column-groups.ts
@@ -13,6 +13,15 @@ export function getColumnGroupIcon(
   if (groupInfo.isImplicitlyJoinable) {
     return "connections";
   }
+  if (groupInfo.isQuestion) {
+    return "question";
+  }
+  if (groupInfo.isModel) {
+    return "model";
+  }
+  if (groupInfo.isMetric) {
+    return "metric";
+  }
   if (groupInfo.isMainGroup) {
     return "sum";
   }


### PR DESCRIPTION
https://linear.app/metabase/issue/DSN-17/in-the-filter-popover-in-chill-mode-there-shouldnt-be-a-sigma-icon

In the filter popover, models, questions, and metrics should have appropriate icons rather than a sigma

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/b02599a3-d0db-4653-acae-f9eca544aa27.png)

