### PR TITLE
Simplify models/metrics filter

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -389,9 +389,7 @@ describe("scenarios > browse > metrics", () => {
 
       cy.findByLabelText("Table of metrics").should("be.visible");
 
-      cy.findByLabelText(
-        /Only show verified metrics|Show verified metrics, too/,
-      ).should("not.exist");
+      cy.findByLabelText(/show.*verified.*metrics/i).should("not.exist");
     });
 
     it("should show the verified metrics filter when there are verified metrics", () => {
@@ -446,10 +444,11 @@ describe("scenarios > browse > metrics", () => {
       cy.visit("/browse/metrics");
       verifyMetric(ORDERS_SCALAR_METRIC);
 
-      cy.findByLabelText("Filters").should("be.visible").click();
-      H.popover()
-        .findByLabelText("Show verified metrics only")
-        .should("be.checked");
+      cy.findByRole("switch", { name: /show.*verified.*metrics/i }).should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
 
       cy.intercept("GET", "/api/session/properties", (req) => {
         req.continue((res) => {
@@ -459,10 +458,11 @@ describe("scenarios > browse > metrics", () => {
       });
 
       cy.visit("/browse/metrics");
-      cy.findByLabelText("Filters").should("be.visible").click();
-      H.popover()
-        .findByLabelText("Show verified metrics only")
-        .should("not.be.checked");
+      cy.findByRole("switch", { name: /show.*verified.*metrics/i }).should(
+        "have.attr",
+        "aria-selected",
+        "false",
+      );
     });
   });
 });
@@ -523,7 +523,5 @@ function unverifyMetric(metric: StructuredQuestionDetailsWithName) {
 }
 
 function toggleVerifiedMetricsFilter() {
-  cy.findByLabelText(
-    /Only show verified metrics|Show verified metrics, too/,
-  ).click();
+  cy.findByLabelText(/show.*verified.*metrics/i).click();
 }

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -383,13 +383,15 @@ describe("scenarios > browse > metrics", () => {
       H.setTokenFeatures("all");
     });
 
-    it("should not the verified metrics filter when there are no verified metrics", () => {
+    it("should not show the verified metrics filter when there are no verified metrics", () => {
       createMetrics();
       cy.visit("/browse/metrics");
 
       cy.findByLabelText("Table of metrics").should("be.visible");
 
-      cy.findByLabelText("Filters").should("not.exist");
+      cy.findByLabelText(
+        /Only show verified metrics|Show verified metrics, too/,
+      ).should("not.exist");
     });
 
     it("should show the verified metrics filter when there are verified metrics", () => {
@@ -521,7 +523,7 @@ function unverifyMetric(metric: StructuredQuestionDetailsWithName) {
 }
 
 function toggleVerifiedMetricsFilter() {
-  cy.findByLabelText("Filters").should("be.visible").click();
-  H.popover().findByText("Show verified metrics only").click();
-  cy.findByLabelText("Filters").should("be.visible").click();
+  cy.findByLabelText(
+    /Only show verified metrics|Show verified metrics, too/,
+  ).click();
 }

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -8,10 +8,10 @@ import {
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
-const filterButton = () =>
+const verifiedFilterToggleButton = () =>
   cy
     .findByTestId("browse-models-header")
-    .findByRole("button", { name: /Filters/i });
+    .findByRole("switch", { name: /show.*verified.*models/i });
 
 describe("browse > models", () => {
   beforeEach(() => {
@@ -161,10 +161,7 @@ H.describeWithSnowplow("scenarios > browse", () => {
   it("on an open-source instance, the Browse models page has no controls for setting filters", () => {
     cy.visit("/");
     H.navigationSidebar().findByLabelText("Browse models").click();
-    filterButton().should("not.exist");
-    cy.findByRole("switch", { name: /Show verified models only/ }).should(
-      "not.exist",
-    );
+    verifiedFilterToggleButton().should("not.exist");
   });
 
   it("The Browse models page shows an error message if the search endpoint throws an error", () => {
@@ -203,10 +200,6 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
     cy.intercept("POST", "/api/moderation-review").as("updateVerification");
   });
 
-  const openFilterPopover = () => filterButton().click();
-  const toggle = () =>
-    cy.findByRole("switch", { name: /Show verified models only/ });
-
   const recentsGrid = () => cy.findByRole("grid", { name: "Recents" });
   const modelsTable = () => cy.findByRole("table", { name: "Table of models" });
   const model1 = () => modelsTable().findByRole("heading", { name: "Model 1" });
@@ -230,8 +223,7 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
   };
 
   const toggleVerificationFilter = () => {
-    openFilterPopover();
-    toggle().parent("label").click();
+    verifiedFilterToggleButton().click();
     cy.wait("@updateFilter");
   };
 
@@ -276,7 +268,7 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
     });
 
     cy.log("There are no verified models, so the filter toggle is not visible");
-    filterButton().should("not.exist");
+    verifiedFilterToggleButton().should("not.exist");
 
     cy.log("Verify Model 2");
     cy.findByRole("heading", { name: "Model 2" }).click();
@@ -300,7 +292,7 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
     });
 
     cy.log("The filter toggle is now visible");
-    filterButton().should("be.visible");
+    verifiedFilterToggleButton().should("be.visible");
 
     cy.log("Unverify Model 2");
     cy.findByRole("heading", { name: "Model 2" }).click();
@@ -314,7 +306,7 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
     browseModels();
 
     cy.log("The filter toggle is not visible");
-    filterButton().should("not.exist");
+    verifiedFilterToggleButton().should("not.exist");
 
     cy.log(
       "The verified filter, though still active, is not applied if there are no verified models",

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -277,9 +277,9 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
     browseModels();
 
     cy.log("Filter on verified models is enabled by default");
-    cy.findByTestId("browse-models-header")
-      .findByTestId("filter-dot")
-      .should("be.visible");
+    cy.findByTestId("browse-models-header").findByRole("switch", {
+      name: /Show unverified models, too/i,
+    });
 
     cy.log("Model 1 does not appear in the table, since it's not verified");
     model1().should("not.exist");

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/VerifiedFilter/VerifiedToggle.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/VerifiedFilter/VerifiedToggle.tsx
@@ -16,6 +16,7 @@ export const VerifiedToggle = ({
     <Tooltip label={buttonLabel} position="bottom">
       <ActionIcon
         aria-label={buttonLabel}
+        aria-selected={verified}
         size={32}
         role="switch"
         variant="viewHeader"

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/VerifiedFilter/VerifiedToggle.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/VerifiedFilter/VerifiedToggle.tsx
@@ -1,22 +1,23 @@
-import { t } from "ttag";
-
 import { ActionIcon, Icon, Tooltip } from "metabase/ui";
 
 export const VerifiedToggle = ({
   verified,
   handleVerifiedFilterChange,
+  labelWhenOn,
+  labelWhenOff,
 }: {
   verified?: boolean;
   handleVerifiedFilterChange: (val: boolean) => void;
+  labelWhenOn: string;
+  labelWhenOff: string;
 }) => {
-  const buttonLabel = verified
-    ? t`Show unverified models, too`
-    : t`Only show verified models`;
+  const buttonLabel = verified ? labelWhenOn : labelWhenOff;
   return (
     <Tooltip label={buttonLabel} position="bottom">
       <ActionIcon
         aria-label={buttonLabel}
         size={32}
+        role="switch"
         variant="viewHeader"
         onClick={() => handleVerifiedFilterChange(!verified)}
         c={verified ? "brand" : "text-dark"}

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/VerifiedFilter/VerifiedToggle.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/VerifiedFilter/VerifiedToggle.tsx
@@ -1,0 +1,28 @@
+import { t } from "ttag";
+
+import { ActionIcon, Icon, Tooltip } from "metabase/ui";
+
+export const VerifiedToggle = ({
+  verified,
+  handleVerifiedFilterChange,
+}: {
+  verified?: boolean;
+  handleVerifiedFilterChange: (val: boolean) => void;
+}) => {
+  const buttonLabel = verified
+    ? t`Show unverified models, too`
+    : t`Only show verified models`;
+  return (
+    <Tooltip label={buttonLabel} position="bottom">
+      <ActionIcon
+        aria-label={buttonLabel}
+        size={32}
+        variant="viewHeader"
+        onClick={() => handleVerifiedFilterChange(!verified)}
+        c={verified ? "brand" : "text-dark"}
+      >
+        <Icon name="verified" />
+      </ActionIcon>
+    </Tooltip>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useCallback } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 
 import type {
@@ -7,8 +7,9 @@ import type {
 } from "metabase/browse/metrics";
 import { useUserSetting } from "metabase/common/hooks";
 import { getSetting } from "metabase/selectors/settings";
-import { Button, Icon, Paper, Popover, Switch, Text } from "metabase/ui";
 import type { State } from "metabase-types/store";
+
+import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-metrics";
 
@@ -18,65 +19,34 @@ export function getDefaultMetricFilters(state: State): MetricFilterSettings {
   };
 }
 
-// This component is similar to the ModelFilterControls component from ./ModelFilterControls.tsx
-// merging them might be a good idea in the future.
+/**
+ * This was originally designed to support multiple filters but it currently
+ * just supports one.
+ *
+ * The "Browse models" page has a similar component
+ */
 export const MetricFilterControls = ({
   metricFilters,
   setMetricFilters,
 }: MetricFilterControlsProps) => {
-  const areAnyFiltersActive = Object.values(metricFilters).some(Boolean);
-
   const [_userSetting, setUserSetting] = useUserSetting(USER_SETTING_KEY);
 
   const handleVerifiedFilterChange = useCallback(
-    function (evt: ChangeEvent<HTMLInputElement>) {
-      setMetricFilters({ ...metricFilters, verified: evt.target.checked });
-      setUserSetting(evt.target.checked);
+    function (verified: boolean) {
+      setMetricFilters({ ...metricFilters, verified });
+      setUserSetting(verified);
     },
     [metricFilters, setMetricFilters, setUserSetting],
   );
 
-  return (
-    <Popover position="bottom-end">
-      <Popover.Target>
-        <Button
-          p="sm"
-          lh={0}
-          variant="subtle"
-          color="text-dark"
-          pos="relative"
-          aria-label={t`Filters`}
-        >
-          {areAnyFiltersActive && <Dot />}
-          <Icon name="filter" />
-        </Button>
-      </Popover.Target>
-      <Popover.Dropdown p="lg">
-        <Switch
-          label={
-            <Text ta="end" fw="bold">{t`Show verified metrics only`}</Text>
-          }
-          role="switch"
-          checked={Boolean(metricFilters.verified)}
-          onChange={handleVerifiedFilterChange}
-          labelPosition="left"
-        />
-      </Popover.Dropdown>
-    </Popover>
-  );
-};
+  const { verified } = metricFilters;
 
-const Dot = () => {
   return (
-    <Paper
-      pos="absolute"
-      right="0px"
-      top="7px"
-      radius="50%"
-      bg={"var(--mb-color-brand)"}
-      w="sm"
-      h="sm"
-      data-testid="filter-dot"
+    <VerifiedToggle
+      verified={verified}
+      handleVerifiedFilterChange={handleVerifiedFilterChange}
+      labelWhenOn={t`Show unverified metrics, too`}
+      labelWhenOff={t`Only show verified metrics`}
     />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { t } from "ttag";
 
 import type {
   ModelFilterControlsProps,
@@ -18,8 +19,12 @@ export function getDefaultModelFilters(state: State): ModelFilterSettings {
   };
 }
 
-// This component is similar to the MetricFilterControls component from ./MetricFilterControls.tsx
-// merging them might be a good idea in the future.
+/**
+ * This was originally designed to support multiple filters but it currently
+ * just supports one.
+ *
+ * The Browse metrics page has a similar component
+ */
 export const ModelFilterControls = ({
   modelFilters,
   setModelFilters,
@@ -39,6 +44,8 @@ export const ModelFilterControls = ({
     <VerifiedToggle
       verified={verified}
       handleVerifiedFilterChange={handleVerifiedFilterChange}
+      labelWhenOn={t`Show unverified models, too`}
+      labelWhenOff={t`Only show verified models`}
     />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
@@ -1,5 +1,4 @@
-import { type ChangeEvent, useCallback } from "react";
-import { t } from "ttag";
+import { useCallback } from "react";
 
 import type {
   ModelFilterControlsProps,
@@ -7,8 +6,9 @@ import type {
 } from "metabase/browse/models";
 import { useUserSetting } from "metabase/common/hooks";
 import { getSetting } from "metabase/selectors/settings";
-import { Button, Icon, Paper, Popover, Switch, Text } from "metabase/ui";
 import type { State } from "metabase-types/store";
+
+import { VerifiedToggle } from "./VerifiedFilter/VerifiedToggle";
 
 const USER_SETTING_KEY = "browse-filter-only-verified-models";
 
@@ -24,57 +24,21 @@ export const ModelFilterControls = ({
   modelFilters,
   setModelFilters,
 }: ModelFilterControlsProps) => {
-  const areAnyFiltersActive = Object.values(modelFilters).some(Boolean);
-
   const [_userSetting, setUserSetting] = useUserSetting(USER_SETTING_KEY);
 
   const handleVerifiedFilterChange = useCallback(
-    function (evt: ChangeEvent<HTMLInputElement>) {
-      setModelFilters({ ...modelFilters, verified: evt.target.checked });
-      setUserSetting(evt.target.checked);
+    function (verified: boolean) {
+      setModelFilters({ ...modelFilters, verified });
+      setUserSetting(verified);
     },
     [modelFilters, setModelFilters, setUserSetting],
   );
 
+  const { verified } = modelFilters;
   return (
-    <Popover position="bottom-end">
-      <Popover.Target>
-        <Button
-          p="sm"
-          lh={0}
-          variant="subtle"
-          color="var(--mb-color-text-dark)"
-          pos="relative"
-          aria-label={t`Filters`}
-        >
-          {areAnyFiltersActive && <Dot />}
-          <Icon name="filter" />
-        </Button>
-      </Popover.Target>
-      <Popover.Dropdown p="lg">
-        <Switch
-          label={<Text ta="end" fw="bold">{t`Show verified models only`}</Text>}
-          role="switch"
-          checked={Boolean(modelFilters.verified)}
-          onChange={handleVerifiedFilterChange}
-          labelPosition="left"
-        />
-      </Popover.Dropdown>
-    </Popover>
-  );
-};
-
-const Dot = () => {
-  return (
-    <Paper
-      pos="absolute"
-      right="0px"
-      top="7px"
-      radius="50%"
-      bg={"var(--mb-color-brand)"}
-      w="sm"
-      h="sm"
-      data-testid="filter-dot"
+    <VerifiedToggle
+      verified={verified}
+      handleVerifiedFilterChange={handleVerifiedFilterChange}
     />
   );
 };


### PR DESCRIPTION
This PR fixes https://linear.app/metabase/issue/DSN-16/show-verified-x-only-action-in-browse-models-and-browse-metrics

It moves the "Show verified models only" toggle into a simple button rather than hiding it in a one-item menu. It does the same with the equivalent toggle for metrics.

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/2dae1432-a987-4690-a842-b9710a6ee7b0.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/4918d91a-25c9-40e8-876b-26a71ef99726.png)

The tooltip position is on the bottom to match the tooltip of the "+" button to the left.