### PR TITLE
fix(sdk): fix tooltip crash by migrating away from renderToString

### DIFF
--- a/frontend/src/metabase/data-grid/hooks/use-body-cell-measure.tsx
+++ b/frontend/src/metabase/data-grid/hooks/use-body-cell-measure.tsx
@@ -1,8 +1,8 @@
 import type React from "react";
 import { useCallback, useMemo, useRef } from "react";
-import { renderToString } from "react-dom/server";
 
 import { BodyCell } from "metabase/data-grid/components/BodyCell/BodyCell";
+import { reactNodeToHtmlString } from "metabase/lib/react-to-html";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 import { ThemeProvider } from "metabase/ui";
 
@@ -61,7 +61,7 @@ export const useCellMeasure = (
       if (typeof content === "string") {
         contentCell.textContent = content;
       } else {
-        contentCell.innerHTML = renderToString(content);
+        contentCell.innerHTML = reactNodeToHtmlString(content);
       }
       const boundingRect = rootEl.getBoundingClientRect();
       return {

--- a/frontend/src/metabase/lib/react-to-html.tsx
+++ b/frontend/src/metabase/lib/react-to-html.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+/**
+ * Given a React node, it renders the node into a HTML string synchronously.
+ *
+ * https://18.react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code
+ */
+export function reactNodeToHtmlString(node: ReactNode) {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(node);
+  });
+
+  return container.innerHTML;
+}

--- a/frontend/src/metabase/lib/react-to-html.unit.spec.tsx
+++ b/frontend/src/metabase/lib/react-to-html.unit.spec.tsx
@@ -1,0 +1,10 @@
+import { reactNodeToHtmlString } from "./react-to-html";
+
+describe("reactNodeToHtmlString", () => {
+  it("should render a html string given a react node", () => {
+    const node = <div>Hello, world!</div>;
+    const html = reactNodeToHtmlString(node);
+
+    expect(html).toBe("<div>Hello, world!</div>");
+  });
+});

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/tooltip.tsx
@@ -1,6 +1,6 @@
 import type { TooltipOption } from "echarts/types/dist/shared";
-import { renderToString } from "react-dom/server";
 
+import { reactNodeToHtmlString } from "metabase/lib/react-to-html";
 import { EChartsTooltip } from "metabase/visualizations/components/ChartTooltip/EChartsTooltip";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import { getTooltipModel } from "metabase/visualizations/visualizations/CartesianChart/events";
@@ -70,7 +70,7 @@ export const getTooltipOption = (
         return "";
       }
 
-      return renderToString(
+      return reactNodeToHtmlString(
         <ChartItemTooltip
           settings={settings}
           chartModel={chartModel}

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
@@ -1,7 +1,7 @@
 import type { TooltipOption } from "echarts/types/dist/shared";
-import { renderToString } from "react-dom/server";
 import { t } from "ttag";
 
+import { reactNodeToHtmlString } from "metabase/lib/react-to-html";
 import { formatPercent } from "metabase/static-viz/lib/numbers";
 import {
   EChartsTooltip,
@@ -101,7 +101,7 @@ export const getTooltipOption = (
         return "";
       }
 
-      return renderToString(
+      return reactNodeToHtmlString(
         <ChartItemTooltip params={params} chartModel={chartModel} />,
       );
     },

--- a/frontend/src/metabase/visualizations/echarts/pie/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/pie/tooltip.tsx
@@ -1,6 +1,6 @@
 import type { TooltipOption } from "echarts/types/dist/shared";
-import { renderToString } from "react-dom/server";
 
+import { reactNodeToHtmlString } from "metabase/lib/react-to-html";
 import { EChartsTooltip } from "metabase/visualizations/components/ChartTooltip/EChartsTooltip";
 import { getTooltipModel } from "metabase/visualizations/visualizations/PieChart/use-chart-events";
 
@@ -41,7 +41,7 @@ export const getTooltipOption = (
       // the type provided by ECharts.
       const sliceKeyPath = getSliceKeyPath(params);
 
-      return renderToString(
+      return reactNodeToHtmlString(
         <ChartItemTooltip
           formatters={formatters}
           chartModel={chartModel}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58393

### Description

Rendering an `<InteractiveQuestion />` in the SDK can crash a very specific setup due to the use of `renderToString` from `react-dom/server`, which we used in several tooltip-related components to pass the HTML to echarts. The React documentation specifically tell us to migrate away from this API in React 18: https://18.react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code

### How to verify

- Render an `InteractiveQuestion`
- Hover on echarts visualizations (e.g. bar chart) to show the tooltip
- Echarts tooltip should show 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
