### PR TITLE
remove support for the already deprecated `hide_download_button` hash parameter

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -22,7 +22,6 @@ import { openSharingMenu } from "./e2e-sharing-helpers";
  * @typedef {object} PageStyle
  * @property {boolean} [bordered]
  * @property {boolean} [titled]
- * @property {boolean} [hide_download_button] - EE/PRO only feature to disable downloads
  * @property {boolean} [downloads] - EE/PRO only feature to disable downloads
  */
 

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
@@ -11,12 +11,10 @@ if (hasPremiumFeature("whitelabel")) {
   PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
     downloads,
   }: {
-    hide_download_button?: boolean | null;
     downloads?: string | boolean | null;
   }): EmbedResourceDownloadOptions => {
     return (
       match({ downloads })
-        // `downloads` has priority over `hide_download_button`
         .with({ downloads: true }, () => ({ pdf: true, results: true }))
         .with({ downloads: false }, () => ({ pdf: false, results: false }))
         // supports `downloads=pdf`, `downloads=results` and `downloads=pdf,results`

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
@@ -9,14 +9,13 @@ if (hasPremiumFeature("whitelabel")) {
    * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
    */
   PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
-    hide_download_button,
     downloads,
   }: {
     hide_download_button?: boolean | null;
     downloads?: string | boolean | null;
   }): EmbedResourceDownloadOptions => {
     return (
-      match({ hide_download_button, downloads })
+      match({ downloads })
         // `downloads` has priority over `hide_download_button`
         .with({ downloads: true }, () => ({ pdf: true, results: true }))
         .with({ downloads: false }, () => ({ pdf: false, results: false }))
@@ -34,11 +33,6 @@ if (hasPremiumFeature("whitelabel")) {
             };
           },
         )
-        // but we still support the old `hide_download_button` option
-        .with({ hide_download_button: true }, () => ({
-          pdf: false,
-          results: false,
-        }))
         // by default downloads are enabled
         .otherwise(() => ({ pdf: true, results: true }))
     );

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/common.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/common.unit.spec.ts
@@ -9,11 +9,10 @@ describe("[OSS] resource downloads plugin", () => {
 
   describe("areDownloadsEnabled - should always return true on OSS", () => {
     it.each(downloadsEnabledTestData)(
-      `with { downloads:$downloads, hide_download_button:$hide_download_button } it should return true`,
-      ({ hide_download_button, downloads }) => {
+      `with { downloads:$downloads } it should return true`,
+      ({ downloads }) => {
         expect(
           PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
-            hide_download_button,
             downloads,
           }),
         ).toStrictEqual({ pdf: true, results: true });

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/enterprise.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/enterprise.unit.spec.ts
@@ -9,11 +9,10 @@ describe("[EE - no features] resource downloads plugin", () => {
 
   describe("areDownloadsEnabled - should always return true if we don't have the whitelabel feature", () => {
     it.each(downloadsEnabledTestData)(
-      `with { downloads:$downloads, hide_download_button:$hide_download_button } it should return true`,
-      ({ hide_download_button, downloads }) => {
+      `with { downloads:$downloads } it should return true`,
+      ({ downloads }) => {
         expect(
           PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
-            hide_download_button,
             downloads,
           }),
         ).toStrictEqual({ pdf: true, results: true });

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/premium.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/premium.unit.spec.ts
@@ -13,11 +13,10 @@ describe("[EE - with token features] resource downloads plugin", () => {
     });
 
     it.each(downloadsEnabledTestData)(
-      `with { downloads:$downloads, hide_download_button:$hide_download_button } it should return $downloadsEnabled`,
-      ({ hide_download_button, downloads, downloadsEnabled }) => {
+      `with { downloads:$downloads } it should return $downloadsEnabled`,
+      ({ downloads, downloadsEnabled }) => {
         expect(
           PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
-            hide_download_button,
             downloads,
           }),
         ).toStrictEqual(downloadsEnabled);

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
@@ -31,73 +31,34 @@ const ALL_DOWNLOADS_DISABLED: EmbedResourceDownloadOptions = {
 };
 
 export const downloadsEnabledTestData: {
-  hide_download_button?: boolean;
   downloads?: string | boolean;
   downloadsEnabled: EmbedResourceDownloadOptions;
 }[] = [
   {
-    hide_download_button: true,
     downloads: true,
     downloadsEnabled: ALL_DOWNLOADS_ENABLED,
   },
   {
-    hide_download_button: true,
     downloads: false,
     downloadsEnabled: ALL_DOWNLOADS_DISABLED,
   },
   {
-    hide_download_button: true,
-    downloads: undefined,
-    // `hide_download_button` is not supported anymore
-    downloadsEnabled: ALL_DOWNLOADS_ENABLED,
-  },
-  {
-    hide_download_button: false,
-    downloads: true,
-    downloadsEnabled: ALL_DOWNLOADS_ENABLED,
-  },
-  {
-    hide_download_button: false,
-    downloads: false,
-    downloadsEnabled: ALL_DOWNLOADS_DISABLED,
-  },
-  {
-    hide_download_button: false,
     downloads: undefined,
     downloadsEnabled: ALL_DOWNLOADS_ENABLED,
   },
   {
-    hide_download_button: undefined,
-    downloads: true,
-    downloadsEnabled: ALL_DOWNLOADS_ENABLED,
-  },
-  {
-    hide_download_button: undefined,
-    downloads: false,
-    downloadsEnabled: ALL_DOWNLOADS_DISABLED,
-  },
-  {
-    hide_download_button: undefined,
-    downloads: undefined,
-    downloadsEnabled: ALL_DOWNLOADS_ENABLED,
-  },
-  {
-    hide_download_button: undefined,
     downloads: "pdf",
     downloadsEnabled: { pdf: true, results: false },
   },
   {
-    hide_download_button: undefined,
     downloads: "results",
     downloadsEnabled: { pdf: false, results: true },
   },
   {
-    hide_download_button: undefined,
     downloads: "pdf,results",
     downloadsEnabled: ALL_DOWNLOADS_ENABLED,
   },
   {
-    hide_download_button: undefined,
     downloads: "results,pdf",
     downloadsEnabled: ALL_DOWNLOADS_ENABLED,
   },

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
@@ -48,7 +48,8 @@ export const downloadsEnabledTestData: {
   {
     hide_download_button: true,
     downloads: undefined,
-    downloadsEnabled: ALL_DOWNLOADS_DISABLED,
+    // `hide_download_button` is not supported anymore
+    downloadsEnabled: ALL_DOWNLOADS_ENABLED,
   },
   {
     hide_download_button: false,

--- a/frontend/src/metabase-types/analytics/embed-flow.ts
+++ b/frontend/src/metabase-types/analytics/embed-flow.ts
@@ -14,7 +14,6 @@ type EmbedFlowAppearance = {
   font?: string;
   downloads?: boolean | null;
   enabled_download_types?: EmbedResourceDownloadOptions | null;
-  hide_download_button?: boolean | null;
 };
 
 type EmbedFlowEventSchema = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -628,10 +628,10 @@ export const PLUGIN_RESOURCE_DOWNLOADS = {
   /**
    * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
    */
-  areDownloadsEnabled: (_args: {
-    hide_download_button?: boolean | null;
-    downloads?: string | boolean | null;
-  }) => ({ pdf: true, results: true }),
+  areDownloadsEnabled: (_args: { downloads?: string | boolean | null }) => ({
+    pdf: true,
+    results: true,
+  }),
 };
 
 const defaultMetabotContextValue: MetabotContext = {

--- a/frontend/src/metabase/public/components/EmbedFrame/SyncedEmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/SyncedEmbedFrame.tsx
@@ -11,14 +11,8 @@ const SyncedEmbedFrameInner = ({
   children,
   ...embedFrameProps
 }: Partial<EmbedFrameProps> & WithRouterProps) => {
-  const {
-    background,
-    bordered,
-    hide_download_button,
-    hide_parameters,
-    theme,
-    titled,
-  } = useEmbedFrameOptions({ location });
+  const { background, bordered, hide_parameters, theme, titled } =
+    useEmbedFrameOptions({ location });
 
   return (
     <EmbedFrame
@@ -28,7 +22,6 @@ const SyncedEmbedFrameInner = ({
       titled={titled}
       theme={theme}
       hide_parameters={hide_parameters}
-      hide_download_button={hide_download_button}
     >
       {children}
     </EmbedFrame>

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -1,4 +1,5 @@
 import type { Location } from "history";
+import { useEffect } from "react";
 
 import { parseHashOptions } from "metabase/lib/browser";
 import { isWithinIframe } from "metabase/lib/dom";
@@ -18,6 +19,15 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     downloads = DEFAULT_EMBED_DISPLAY_PARAMS.downloadsEnabled,
     locale,
   } = parseHashOptions(location.hash) as EmbeddingHashOptions;
+
+  useEffect(() => {
+    if (hide_download_button !== null) {
+      console.error(
+        "%c⚠️ The `hide_download_button` option has been removed. Please use the `downloads` option instead.",
+        "font-size: 14px; font-weight: bold; color: red",
+      );
+    }
+  }, [hide_download_button]);
 
   const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
     hide_download_button,

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -18,7 +18,10 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     hide_download_button = null,
     downloads = DEFAULT_EMBED_DISPLAY_PARAMS.downloadsEnabled,
     locale,
-  } = parseHashOptions(location.hash) as EmbeddingHashOptions;
+  } = parseHashOptions(location.hash) as EmbeddingHashOptions & {
+    // this parameter is not supported anymore, but we access it in this hook to log an error
+    hide_download_button?: boolean | null;
+  };
 
   useEffect(() => {
     if (hide_download_button !== null) {
@@ -30,7 +33,6 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
   }, [hide_download_button]);
 
   const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
-    hide_download_button,
     downloads,
   });
 
@@ -40,7 +42,6 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     titled,
     theme,
     hide_parameters,
-    hide_download_button,
     downloadsEnabled,
     locale,
   };

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -36,7 +36,8 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     if (hide_download_button !== null) {
       console.error(
         `%c⚠️ The \`hide_download_button\` option has been removed. Please use the \`downloads\` option instead: ${staticEmbedParametersDocsUrl}`,
-        "font-size: 14px; font-weight: bold; color: red",
+        // eslint-disable-next-line no-color-literals
+        "color: #FF2222; font-size: 16px; font-weight: bold;",
       );
     }
   }, [hide_download_button, staticEmbedParametersDocsUrl]);

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -1,6 +1,7 @@
 import type { Location } from "history";
 import { useEffect } from "react";
 
+import { useDocsUrl } from "metabase/common/hooks";
 import { parseHashOptions } from "metabase/lib/browser";
 import { isWithinIframe } from "metabase/lib/dom";
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
@@ -23,14 +24,22 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     hide_download_button?: boolean | null;
   };
 
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- this is a console.error for a deprecated parameter
+  const { url: staticEmbedParametersDocsUrl } = useDocsUrl(
+    "embedding/static-embedding-parameters",
+    {
+      anchor: "customizing-the-appearance-of-a-static-embed",
+    },
+  );
+
   useEffect(() => {
     if (hide_download_button !== null) {
       console.error(
-        "%c⚠️ The `hide_download_button` option has been removed. Please use the `downloads` option instead.",
+        `%c⚠️ The \`hide_download_button\` option has been removed. Please use the \`downloads\` option instead: ${staticEmbedParametersDocsUrl}`,
         "font-size: 14px; font-weight: bold; color: red",
       );
     }
-  }, [hide_download_button]);
+  }, [hide_download_button, staticEmbedParametersDocsUrl]);
 
   const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
     downloads,

--- a/frontend/src/metabase/public/lib/code-templates.ts
+++ b/frontend/src/metabase/public/lib/code-templates.ts
@@ -16,7 +16,6 @@ export function getIframeQueryWithoutDefaults(
   return optionsToHashParams(
     removeDefaultValueParameters(hashOptions, {
       theme: "light",
-      hide_download_button: false,
       background: true,
     }),
   );

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -40,8 +40,6 @@ export type EmbeddingDisplayOptions = {
   background: boolean;
   bordered: boolean;
   titled: boolean;
-  /** this is deprecated in favor of `downloads`, but it's still supported */
-  hide_download_button?: boolean | null;
   downloads: EmbedResourceDownloadOptions | null;
 };
 


### PR DESCRIPTION
This was already "deprecated" a few versions ago, in favor of `#downloads`, see https://www.metabase.com/docs/latest/embedding/static-embedding-parameters

Closes [EMB-419: remove `hide_download_button` from the code](https://linear.app/metabase/issue/EMB-419/remove-hide-download-button-from-the-code)