### PR TITLE
Add field-values endpoint

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
     :as metabot-v3.tools.create-dashboard-subscription]
+   [metabase-enterprise.metabot-v3.tools.field-stats :as metabot-v3.tools.field-stats]
    [metabase-enterprise.metabot-v3.tools.filters :as metabot-v3.tools.filters]
    [metabase-enterprise.metabot-v3.tools.find-metric :as metabot-v3.tools.find-metric]
    [metabase-enterprise.metabot-v3.tools.find-outliers :as metabot-v3.tools.find-outliers]
@@ -238,6 +239,56 @@
     [:limit {:optional true} [:maybe :int]]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
+(mr/def ::count
+  [:and
+   :int
+   [:fn
+    {:error/message "Valid count, a natural number"}
+    #(<= 0 %)]])
+
+(mr/def ::proportion
+  [:and
+   number?
+   [:fn
+    {:error/message "Valid proportion between (inclusive) 0 and 1."}
+    #(<= 0 % 1)]])
+
+(mr/def ::field-values
+  [:or
+   [:sequential :boolean]
+   [:sequential number?]
+   [:sequential :string]])
+
+(mr/def ::statistics
+  [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
+   [:distinct_count {:optional true} [:maybe ::count]]
+   [:percent_null   {:optional true} [:maybe ::proportion]]
+   [:min            {:optional true} [:maybe number?]]
+   [:max            {:optional true} [:maybe number?]]
+   [:avg            {:optional true} [:maybe number?]]
+   [:q1             {:optional true} [:maybe number?]]
+   [:q3             {:optional true} [:maybe number?]]
+   [:sd             {:optional true} [:maybe number?]]
+   [:percent_json   {:optional true} [:maybe ::proportion]]
+   [:percent_url    {:optional true} [:maybe ::proportion]]
+   [:percent_email  {:optional true} [:maybe ::proportion]]
+   [:percent_state  {:optional true} [:maybe ::proportion]]
+   [:average_length {:optional true} [:maybe number?]]
+   [:earliest       {:optional true} [:maybe :string]]
+   [:latest         {:optional true} [:maybe :string]]
+   [:values         {:optional true} [:maybe ::field-values]]])
+
+(mr/def ::field-values-result
+  [:or
+   [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
+    [:structured_output
+     [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
+      [:field_id :string]
+      [:statistics {:optional true} [:maybe ::statistics]]
+      [:values {:optional true} [:maybe [:sequential :any]]]]]]
+   [:map
+    [:output :string]]])
+
 (mr/def ::field-type
   [:enum {:decode/tool-api-response #(when % (-> % name u/->snake_case_en))}
    "boolean" "date" "datetime" "time" "number" "string"])
@@ -251,11 +302,7 @@
    [:semantic_type {:optional true
                     :decode/tool-api-response #(some-> % name u/->snake_case_en)}
     [:maybe :string]]
-   [:field_values {:optional true} [:or
-                                    [:sequential :boolean]
-                                    [:sequential :double]
-                                    [:sequential :int]
-                                    [:sequential :string]]]])
+   [:field_values {:optional true} ::field-values]])
 
 (mr/def ::columns
   [:sequential ::column])
@@ -303,6 +350,15 @@
     [:dashboard_id :int]
     [:email :string]
     [:schedule ::subscription-schedule]]
+   [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
+
+(mr/def ::field-values-arguments
+  [:and
+   [:map
+    [:entity_type [:enum "table" "model" "metric"]]
+    [:entity_id :int]
+    [:field_id :string]
+    [:limit {:optional true} [:maybe :int]]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (mr/def ::filter-records-arguments
@@ -506,6 +562,22 @@
   (let [arguments (mc/encode ::create-dashboard-subscription-arguments
                              arguments (mtx/transformer {:name :tool-api-request}))]
     (doto (-> (metabot-v3.tools.create-dashboard-subscription/create-dashboard-subscription arguments)
+              (assoc :conversation_id conversation_id))
+      (metabot-v3.context/log :llm.log/be->llm))))
+
+(api.macros/defendpoint :post "/field-values" :- [:merge ::field-values-result ::tool-request]
+  "Return statistics and/or values for a given field of a given entity."
+  [_route-params
+   _query-params
+   {:keys [arguments conversation_id] :as body} :- [:merge
+                                                    [:map [:arguments ::field-values-arguments]]
+                                                    ::tool-request]]
+  (metabot-v3.context/log (assoc body :api :field-values) :llm.log/llm->be)
+  (let [arguments (mc/encode ::field-values-arguments
+                             arguments (mtx/transformer {:name :tool-api-request}))]
+    (doto (-> (mc/decode ::field-values-result
+                         (metabot-v3.tools.field-stats/field-values arguments)
+                         (mtx/transformer {:name :tool-api-response}))
               (assoc :conversation_id conversation_id))
       (metabot-v3.context/log :llm.log/be->llm))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
@@ -1,0 +1,81 @@
+(ns metabase-enterprise.metabot-v3.tools.field-stats
+  (:require
+   [clojure.set :as set]
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   [metabase.api.common :as api]
+   [metabase.lib.core :as lib]
+   [metabase.warehouse-schema.models.field-values :as field-values]
+   [toucan2.core :as t2]))
+
+(defn- field-statistics
+  [column limit]
+  (merge (when-let [fp (:fingerprint column)]
+           {:statistics (-> (or (:global fp) {})
+                            (set/rename-keys {:nil% :percent-null})
+                            (into (vals (:type fp))))})
+         (when-let [id (:id column)]
+           (when-let [fvs (-> (field-values/get-latest-full-field-values id) :values not-empty)]
+             {:values (into [] (if limit (take limit) identity) fvs)}))))
+
+(defn- table-field-stats
+  [table-id agent-field-id limit]
+  (try
+    (let [field-id-prefix (metabot-v3.tools.u/table-field-id-prefix table-id)
+          index (metabot-v3.tools.u/resolve-column-index agent-field-id field-id-prefix)
+          query (metabot-v3.tools.u/table-query table-id)]
+      (if query
+        (if-let [col (nth (lib/visible-columns query) index nil)]
+          {:structured-output (field-statistics col limit)}
+          {:output (str "No field found with ID " agent-field-id)})
+        {:output (str "No table found with ID " table-id)}))
+    (catch Exception ex
+      (metabot-v3.tools.u/handle-agent-error ex))))
+
+(defn- card-field-stats
+  [card-id agent-field-id limit card-type]
+  (try
+    (let [field-id-prefix (metabot-v3.tools.u/card-field-id-prefix card-id)
+          index (metabot-v3.tools.u/resolve-column-index agent-field-id field-id-prefix)
+          query (metabot-v3.tools.u/card-query card-id)]
+      (if query
+        (if-let [col (nth (lib/visible-columns query) index nil)]
+          {:structured-output (field-statistics col limit)}
+          {:output (str "No field found with ID " agent-field-id)})
+        {:output (str "No " card-type " found with ID " card-id)}))
+    (catch Exception ex
+      (metabot-v3.tools.u/handle-agent-error ex))))
+
+(defn- metric-field-stats
+  [metric-id agent-field-id limit]
+  (try
+    (let [field-id-prefix (metabot-v3.tools.u/card-field-id-prefix metric-id)
+          index (metabot-v3.tools.u/resolve-column-index agent-field-id field-id-prefix)
+          query (metabot-v3.tools.u/metric-query metric-id)]
+      (if query
+        (if-let [col (nth (lib/filterable-columns query) index nil)]
+          {:structured-output (field-statistics col limit)}
+          {:output (str "No field found with ID " agent-field-id)})
+        {:output (str "No metric found with ID " metric-id)}))
+    (catch Exception ex
+      (metabot-v3.tools.u/handle-agent-error ex))))
+
+(comment
+  (t2/select-pk->fn :field_id :model/FieldValues)
+  (sort-by key (t2/select-pk->fn :name :model/Table))
+  (sort-by first (t2/select-fn-vec (juxt :position :name) :model/Field :table_id 8))
+  (binding [api/*current-user-permissions-set* (delay #{"/"})
+            api/*current-user-id* 2
+            api/*is-superuser?* true]
+    (let [table-id 25]
+      (-> (for [col-pos (range 15)]
+            [col-pos (table-field-stats table-id (str (metabot-v3.tools.u/table-field-id-prefix table-id) col-pos) 15)])
+          vec)))
+  -)
+
+(defn field-values
+  "Return statistics and/or values for a given field of a given entity."
+  [{:keys [entity-type entity-id field-id limit]}]
+  (case entity-type
+    "metric"           (metric-field-stats entity-id field-id limit)
+    ("model" "report") (card-field-stats entity-id field-id limit entity-type)
+    "table"            (table-field-stats entity-id field-id limit)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -331,30 +331,22 @@
                           (-> (lib/query mp query) lib/append-stage)]))]
     (cond
       model-id
-      (if-let [model (metabot-v3.tools.u/get-card model-id)]
-        (let [mp (lib.metadata.jvm/application-database-metadata-provider (:database_id model))]
-          [(metabot-v3.tools.u/card-field-id-prefix model-id)
-           (lib/query mp (lib.metadata/card mp model-id))])
+      (if-let [model-query (metabot-v3.tools.u/card-query model-id)]
+        [(metabot-v3.tools.u/card-field-id-prefix model-id) model-query]
         (throw (ex-info (str "No table found with table_id " table-id) {:agent-error? true
                                                                         :data-source data-source})))
 
       table-id
       (let [table-id (cond-> table-id
                        (string? table-id) parse-long)]
-        (if-let [table (metabot-v3.tools.u/get-table table-id :db_id)]
-          (let [mp (lib.metadata.jvm/application-database-metadata-provider (:db_id table))]
-            [(metabot-v3.tools.u/table-field-id-prefix table-id)
-             (lib/query mp (lib.metadata/table mp table-id))])
+        (if-let [table-query (metabot-v3.tools.u/table-query table-id)]
+          [(metabot-v3.tools.u/table-field-id-prefix table-id) table-query]
           (throw (ex-info (str "No table found with table_id " table-id) {:agent-error? true
                                                                           :data-source data-source}))))
 
       report-id
-      (if-let [card (metabot-v3.tools.u/get-card report-id)]
-        (let [mp (lib.metadata.jvm/application-database-metadata-provider (:database_id card))]
-          [(metabot-v3.tools.u/card-field-id-prefix report-id)
-           (lib/query mp (cond-> (lib.metadata/card mp report-id)
-                           ;; pivot questions have strange result-columns so we work with the dataset-query
-                           (#{:question} (:type card)) (get :dataset-query)))])
+      (if-let [query (metabot-v3.tools.u/card-query report-id)]
+        [(metabot-v3.tools.u/card-field-id-prefix report-id) query]
         (throw (ex-info (str "No report found with report_id " report-id) {:agent-error? true
                                                                            :data-source data-source})))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
@@ -1,0 +1,148 @@
+(ns metabase-enterprise.metabot-v3.tools.field-stats-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.tools.field-stats :as metabot-v3.tools.field-stats]
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.test :as mt]
+   [metabase.warehouse-schema.models.field-values :as field-values]
+   [toucan2.core :as t2]))
+
+(defn- ensure-fresh-field-values!
+  [field-id]
+  (t2/delete! :model/FieldValues :field_id field-id :type :full)
+  (is (= :full (-> (t2/select-one :model/Field :id field-id)
+                   field-values/get-or-create-full-field-values!
+                   :type)))
+  (is (= 1 (t2/count :model/FieldValues :field_id field-id :type :full))))
+
+(defn- table-query
+  [metadata-provider table-id]
+  (lib/query metadata-provider (lib.metadata/table metadata-provider table-id)))
+
+(defn- query-field-id [query field-id-prefix field-display-name columns-fn]
+  (->> (keep-indexed (fn [i col]
+                       (when (= (lib/display-name query col) field-display-name)
+                         i))
+                     (columns-fn query))
+       first
+       (str field-id-prefix)))
+
+(defn- visible-field-id [query field-id-prefix field-display-name]
+  (query-field-id query field-id-prefix field-display-name lib/visible-columns))
+
+(defn- filterable-field-id [query field-id-prefix field-display-name]
+  (query-field-id query field-id-prefix field-display-name lib/filterable-columns))
+
+(deftest field-values-table-test
+  (ensure-fresh-field-values! (mt/id :people :state))
+  (ensure-fresh-field-values! (mt/id :products :category))
+  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+        people-id (mt/id :people)
+        people-query (table-query mp people-id)
+        birth-date-id (visible-field-id people-query (metabot-v3.tools.u/table-field-id-prefix people-id) "Birth Date")
+        state-id (visible-field-id people-query (metabot-v3.tools.u/table-field-id-prefix people-id) "State")
+        orders-id (mt/id :orders)
+        orders-query (table-query mp orders-id)
+        category-id (visible-field-id orders-query (metabot-v3.tools.u/table-field-id-prefix orders-id) "Category")]
+    (testing "No read permission results in an error."
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that."
+                            (metabot-v3.tools.field-stats/field-values
+                             {:entity-type "table", :entity-id people-id, :field-id state-id, :limit 5}))))
+    (testing "Getting statistics and values for table fields works."
+      (mt/as-admin
+        (are [table-id field-id output]
+             (= {:structured-output output}
+                (metabot-v3.tools.field-stats/field-values
+                 {:entity-type "table", :entity-id table-id, :field-id field-id, :limit 5}))
+          people-id birth-date-id {:statistics
+                                   {:distinct-count 2308
+                                    :percent-null   0.0
+                                    :earliest       "1958-04-26"
+                                    :latest         "2000-04-03"}}
+          people-id state-id      {:statistics {:distinct-count 49
+                                                :percent-null   0.0
+                                                :percent-json   0.0
+                                                :percent-url    0.0
+                                                :percent-email  0.0
+                                                :percent-state  1.0
+                                                :average-length 2.0}
+                                   :values     ["AK" "AL" "AR" "AZ" "CA"]}
+          orders-id category-id   {:statistics {:distinct-count 4
+                                                :percent-null   0.0
+                                                :percent-json   0.0
+                                                :percent-url    0.0
+                                                :percent-email  0.0
+                                                :percent-state  0.0
+                                                :average-length 6.375}
+                                   :values     ["Doohickey" "Gadget" "Gizmo" "Widget"]})))))
+
+(deftest field-values-model-test
+  (ensure-fresh-field-values! (mt/id :people :state))
+  (ensure-fresh-field-values! (mt/id :products :category))
+  (mt/with-temp [:model/Card {model-id :id} {:dataset_query (mt/mbql-query orders)
+                                             :type :model}]
+    (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+          model-query (lib/query mp (lib.metadata/card mp model-id))
+          field-id-prefix (metabot-v3.tools.u/card-field-id-prefix model-id)
+          birth-date-id (visible-field-id model-query field-id-prefix "Birth Date")
+          state-id (visible-field-id model-query field-id-prefix "State")
+          category-id (visible-field-id model-query field-id-prefix "Category")]
+      (testing "No read permission results in an error."
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that."
+                              (metabot-v3.tools.field-stats/field-values
+                               {:entity-type "model", :entity-id model-id, :field-id state-id, :limit 5}))))
+      (testing "Getting statistics and values for model fields works."
+        (mt/as-admin
+          (are [field-id output]
+               (= {:structured-output output}
+                  (metabot-v3.tools.field-stats/field-values
+                   {:entity-type "model", :entity-id model-id, :field-id field-id, :limit 5}))
+            birth-date-id {:statistics
+                           {:distinct-count 2308
+                            :percent-null   0.0
+                            :earliest       "1958-04-26"
+                            :latest         "2000-04-03"}}
+            state-id      {:statistics {:distinct-count 49
+                                        :percent-null   0.0
+                                        :percent-json   0.0
+                                        :percent-url    0.0
+                                        :percent-email  0.0
+                                        :percent-state  1.0
+                                        :average-length 2.0}
+                           :values     ["AK" "AL" "AR" "AZ" "CA"]}
+            category-id   {:statistics {:distinct-count 4
+                                        :percent-null   0.0
+                                        :percent-json   0.0
+                                        :percent-url    0.0
+                                        :percent-email  0.0
+                                        :percent-state  0.0
+                                        :average-length 6.375}
+                           :values     ["Doohickey" "Gadget" "Gizmo" "Widget"]}))))))
+
+(deftest ^:parallel field-values-metric-test
+  (mt/with-temp [:model/Card {metric-id :id} {:dataset_query (mt/mbql-query orders
+                                                               {:aggregation [[:count]]
+                                                                :breakout    [!year.user_id->people.birth_date]})
+                                              :type :metric}]
+    (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+          metric-query (lib/query mp (lib.metadata/metric mp metric-id))
+          field-id-prefix (metabot-v3.tools.u/card-field-id-prefix metric-id)
+          birth-date-id (filterable-field-id metric-query field-id-prefix "Birth Date")]
+      (testing "No read permission results in an error."
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that."
+                              (metabot-v3.tools.field-stats/field-values
+                               {:entity-type "metric", :entity-id metric-id, :field-id birth-date-id, :limit 5}))))
+      (testing "Getting statistics and values for metric fields works."
+        (mt/as-admin
+          (are [field-id output]
+               (= {:structured-output output}
+                  (metabot-v3.tools.field-stats/field-values
+                   {:entity-type "metric", :entity-id metric-id, :field-id field-id, :limit 5}))
+            birth-date-id {:statistics
+                           {:distinct-count 2308
+                            :percent-null   0.0
+                            :earliest       "1958-04-26"
+                            :latest         "2000-04-03"}}))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -287,10 +287,10 @@
 
 (deftest ^:parallel filter-records-table-test
   (testing "User has to have execution rights, otherwise the table should be invisible."
-    (is (= {:output (str "No table found with table_id " (mt/id :orders))}
-           (metabot-v3.tools.filters/filter-records
-            {:data-source {:table-id (mt/id :orders)}
-             :filters []}))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that."
+                          (metabot-v3.tools.filters/filter-records
+                           {:data-source {:table-id (mt/id :orders)}
+                            :filters []}))))
   (mt/with-current-user (mt/user->id :crowberto)
     (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
           table-id (mt/id :orders)
@@ -334,9 +334,9 @@
                              :operation :number-greater-than
                              :value 3}]})))))
     (testing "Missing table results in an error."
-      (is (= {:output (str "No table found with table_id " Integer/MAX_VALUE)}
-             (metabot-v3.tools.filters/filter-records
-              {:data-source {:table-id Integer/MAX_VALUE}}))))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Not found."
+                            (metabot-v3.tools.filters/filter-records
+                             {:data-source {:table-id Integer/MAX_VALUE}}))))))
 
 (deftest ^:parallel filter-records-model-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))


### PR DESCRIPTION
Closes BOT-164

### Description

Add a basic `field-values` tool API endpoint. This provides information based on the app DB, so the values are the same as the ones provided by the entity details endpoints. The fingerprinting statistics are new and are the same as the fingerprints created at sync time for the fields. The limit on the values returned just prevents returning more elements than requested. There are no guarantees as to the choice of which values are returned.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
