### PR TITLE
Don't show schemas for destination databases

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -402,18 +402,20 @@
 (defn- expand-schema-filters-prop [prop]
   (let [prop-name (:name prop)
         disp-name (or (:display-name prop) "")
+        visible-if (:visible-if prop)
         placeholder (or (:placeholder prop) "E.x. public,auth*")
         type-prop-nm (str prop-name "-type")]
-    [{:name type-prop-nm
-      :display-name disp-name
-      :type "select"
-      :options [{:name (trs "All")
-                 :value "all"}
-                {:name (trs "Only these...")
-                 :value "inclusion"}
-                {:name (trs "All except...")
-                 :value "exclusion"}]
-      :default "all"}
+    [(merge {:name type-prop-nm
+             :display-name disp-name
+             :type "select"
+             :options [{:name (trs "All")
+                        :value "all"}
+                       {:name (trs "Only these...")
+                        :value "inclusion"}
+                       {:name (trs "All except...")
+                        :value "exclusion"}]
+             :default "all"}
+            {:visible-if visible-if})
      {:name (str prop-name "-patterns")
       :type "text"
       :placeholder placeholder


### PR DESCRIPTION
We do some wacky expansion of `schema-filters` properties that wasn't respecting the `visible-if` property.

~Note that this isn't working E2E - not sure if maybe we need some FE work here?~ (This is working, I'm just dumb.)