### PR TITLE
Remove redundant sdk-ee-plugins import from the SDK in new iframe embedding

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/lib/sdk-specific-imports.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/sdk-specific-imports.ts
@@ -5,9 +5,6 @@
  * This is aliased as `sdk-specific-imports` in the SDK's webpack config.
  */
 
-// Import the EE plugins required by the embedding sdk.
-import "sdk-ee-plugins";
-
 // Polyfills useSyncExternalStore for React 17 for backwards compatibility.
 import "./polyfill/use-sync-external-store";
 


### PR DESCRIPTION
Removes the `import "sdk-ee-plugins";` from `sdk-specific-imports`, because of Tim's changes that adds `"sdk-ee-plugins"` to the SDK's entry point. That means it is safe to import `sdk-ee-plugins` from the SDK directly now, and we don't need this redundant import. This PR targets the new-iframe-embedding only.