### PR TITLE
Ignore CSS import order warnings from new iframe embedding

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -270,6 +270,11 @@ const config = {
     new rspack.CssExtractRspackPlugin({
       filename: devMode ? "[name].css" : "[name].[contenthash].css",
       chunkFilename: devMode ? "[id].css" : "[id].[contenthash].css",
+
+      // We use CSS modules to scope styles, so this is safe to ignore according to the docs:
+      // https://webpack.js.org/plugins/mini-css-extract-plugin/#remove-order-warnings
+      // This is needed due to app-embed-sdk importing the sdk, so the style order is different than the main app.
+      ignoreOrder: true,
     }),
     new OnScriptError(),
     new HtmlWebpackPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -294,6 +294,11 @@ const config = {
     new MiniCssExtractPlugin({
       filename: devMode ? "[name].css" : "[name].[contenthash].css",
       chunkFilename: devMode ? "[id].css" : "[id].[contenthash].css",
+
+      // We use CSS modules to scope styles, so this is safe to ignore according to the docs:
+      // https://webpack.js.org/plugins/mini-css-extract-plugin/#remove-order-warnings
+      // This is needed due to app-embed-sdk importing the sdk, so the style order is different than the main app.
+      ignoreOrder: true,
     }),
     new OnScriptError(),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
The `app-embed-sdk` entry point imports the sdk and has a completely different CSS requirements (as it only imports just the SDK styles), so the style order is totally different than the main app. We use CSS modules to scope styles, so this is safe to ignore according to the documentation at https://webpack.js.org/plugins/mini-css-extract-plugin/#remove-order-warnings

Before:

![CleanShot 2568-05-23 at 21 26 10@2x](https://github.com/user-attachments/assets/128a8652-5929-448e-abae-77a2de377509)

After:

![CleanShot 2568-05-23 at 21 25 04@2x](https://github.com/user-attachments/assets/7ebcc9d4-6a5f-4a2a-9e5d-fbaebbd571db)

