### PR TITLE
Move segments to table picker

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.styled.tsx
@@ -9,6 +9,8 @@ import {
 
 export const FormRoot = styled.form`
   width: 100%;
+  height: 100%;
+  overflow: auto;
 `;
 
 export const FormSection = styled.div`

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.styled.tsx
@@ -11,6 +11,7 @@ export const FormRoot = styled.form`
   width: 100%;
   height: 100%;
   overflow: auto;
+  background-color: var(--mb-color-bg-white);
 `;
 
 export const FormSection = styled.div`

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -29,9 +29,12 @@ export default class RevisionHistory extends Component {
     }
 
     return (
-      <LoadingAndErrorWrapper loading={!segment || !revisions}>
+      <LoadingAndErrorWrapper
+        loading={!segment || !revisions}
+        className={CS.wrapper}
+      >
         {() => (
-          <div className={CS.wrapper}>
+          <>
             <Breadcrumbs
               className={CS.py4}
               crumbs={[
@@ -63,7 +66,7 @@ export default class RevisionHistory extends Component {
                 ))}
               </ol>
             </div>
-          </div>
+          </>
         )}
       </LoadingAndErrorWrapper>
     );

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -31,7 +31,7 @@ export default class RevisionHistory extends Component {
     return (
       <LoadingAndErrorWrapper
         loading={!segment || !revisions}
-        className={cx(CS.wrapper, CS.scrollY)}
+        className={cx(CS.wrapper, CS.scrollY, CS.bgWhite)}
       >
         {() => (
           <>

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -42,7 +42,7 @@ export default class RevisionHistory extends Component {
                   t`Segments`,
                   `/admin/datamodel/segments?table=${segment.table_id}`,
                 ],
-                [t`Segment` + t` History`],
+                [t`Segment History`],
               ]}
             />
             <div

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -31,7 +31,7 @@ export default class RevisionHistory extends Component {
     return (
       <LoadingAndErrorWrapper
         loading={!segment || !revisions}
-        className={CS.wrapper}
+        className={cx(CS.wrapper, CS.scrollY)}
       >
         {() => (
           <>

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -18,7 +18,10 @@ class SegmentListAppInner extends Component {
     const { segments, tableSelector, setArchived } = this.props;
 
     return (
-      <div className={cx(CS.px3, CS.pb2)} data-testid="segment-list-app">
+      <div
+        className={cx(CS.px3, CS.pb2, CS.wrapper)}
+        data-testid="segment-list-app"
+      >
         <div className={cx(CS.flex, CS.py2)}>
           {tableSelector}
           <Link to="/admin/datamodel/segment/create" className={CS.mlAuto}>

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -19,7 +19,7 @@ class SegmentListAppInner extends Component {
 
     return (
       <div
-        className={cx(CS.px3, CS.pb2, CS.wrapper)}
+        className={cx(CS.px3, CS.pb2, CS.wrapper, CS.scrollY)}
         data-testid="segment-list-app"
       >
         <div className={cx(CS.flex, CS.py2)}>

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -19,7 +19,7 @@ class SegmentListAppInner extends Component {
 
     return (
       <div
-        className={cx(CS.px3, CS.pb2, CS.wrapper, CS.scrollY)}
+        className={cx(CS.px3, CS.pb2, CS.wrapper, CS.scrollY, CS.bgWhite)}
         data-testid="segment-list-app"
       >
         <div className={cx(CS.flex, CS.py2)}>

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -117,10 +117,14 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
             from="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId/:section"
             to="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
           />
-          <Route path="segments" component={SegmentListApp} />
-          <Route path="segment/create" component={SegmentApp} />
-          <Route path="segment/:id" component={SegmentApp} />
-          <Route path="segment/:id/revisions" component={RevisionHistoryApp} />
+          <Route title={t`Segments`} path="segments" component={DataModel}>
+            <IndexRoute component={SegmentListApp} />
+          </Route>
+          <Route path="segment" component={DataModel}>
+            <Route path="create" component={SegmentApp} />
+            <Route path=":id" component={SegmentApp} />
+            <Route path=":id/revisions" component={RevisionHistoryApp} />
+          </Route>
         </Route>
       </Route>
       {/* PEOPLE */}

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -41,7 +41,7 @@ import CS from "metabase/css/core/index.css";
 import { withBackground } from "metabase/hoc/Background";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { Route } from "metabase/hoc/Title";
-import { DataModel } from "metabase/metadata/pages/DataModel";
+import { DataModel, DataModelEditor } from "metabase/metadata/pages/DataModel";
 import {
   PLUGIN_ADMIN_ROUTES,
   PLUGIN_ADMIN_TOOLS,
@@ -93,22 +93,26 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
         </Route>
       </Route>
       <Route path="datamodel" component={createAdminRouteGuard("data-model")}>
-        <Route title={t`Table Metadata`} component={DataModelApp}>
+        <Route title={t`Table Metadata`} component={DataModel}>
           <IndexRedirect to="database" />
-          <Route path="database" component={DataModel} />
-          <Route path="database/:databaseId" component={DataModel} />
+          <Route path="database" component={DataModelEditor} />
+          <Route path="database/:databaseId" component={DataModelEditor} />
           <Route
             path="database/:databaseId/schema/:schemaId"
-            component={DataModel}
+            component={DataModelEditor}
           />
           <Route
             path="database/:databaseId/schema/:schemaId/table/:tableId"
-            component={DataModel}
+            component={DataModelEditor}
           />
           <Route
             path="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
-            component={DataModel}
+            component={DataModelEditor}
           />
+          <Route path="segments" component={SegmentListApp} />
+          <Route path="segment/create" component={SegmentApp} />
+          <Route path="segment/:id" component={SegmentApp} />
+          <Route path="segment/:id/revisions" component={RevisionHistoryApp} />
           <Redirect
             from="database/:databaseId/schema/:schemaId/table/:tableId/settings"
             to="database/:databaseId/schema/:schemaId/table/:tableId"
@@ -117,14 +121,6 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
             from="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId/:section"
             to="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
           />
-          <Route title={t`Segments`} path="segments" component={DataModel}>
-            <IndexRoute component={SegmentListApp} />
-          </Route>
-          <Route path="segment" component={DataModel}>
-            <Route path="create" component={SegmentApp} />
-            <Route path=":id" component={SegmentApp} />
-            <Route path=":id/revisions" component={RevisionHistoryApp} />
-          </Route>
         </Route>
       </Route>
       {/* PEOPLE */}

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
@@ -14,3 +14,26 @@
 .contentLoadingAndErrorWrapper {
   height: 100%;
 }
+
+.footer {
+  border-top: 1px solid var(--mb-color-border);
+}
+
+.segmentsLink {
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--mb-color-brand-lighter);
+    color: var(--mb-color-brand);
+
+    .segmentsIcon {
+      opacity: 1;
+    }
+  }
+}
+
+.segmentsIcon {
+  opacity: 0.5;
+  flex-shrink: 0;
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
@@ -23,7 +23,8 @@
   border-radius: 8px;
   cursor: pointer;
 
-  &:hover {
+  &:hover,
+  &.active {
     background-color: var(--mb-color-brand-lighter);
     color: var(--mb-color-brand);
 

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -5,9 +5,10 @@ import EmptyDashboardBot from "assets/img/dashboard-empty.svg";
 import { skipToken, useGetTableQueryMetadataQuery } from "metabase/api";
 import EmptyState from "metabase/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
+import Link from "metabase/core/components/Link";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import { Box, Flex, Stack } from "metabase/ui";
+import { Box, Flex, Icon, Stack } from "metabase/ui";
 
 import S from "./DataModel.module.css";
 import {
@@ -61,6 +62,18 @@ export const DataModel = ({ params }: Props) => {
           schemaId={schemaId}
           tableId={tableId}
         />
+        <Box mx="xl" py="sm" className={S.footer}>
+          <Flex
+            component={Link}
+            to="/admin/datamodel/segments"
+            className={S.segmentsLink}
+            gap="sm"
+            p="sm"
+          >
+            <Icon name="pie" className={S.segmentsIcon} />
+            {t`Segments`}
+          </Flex>
+        </Box>
       </Stack>
 
       {tableId && (

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -1,4 +1,5 @@
 import cx from "classnames";
+import type { ReactNode } from "react";
 import { t } from "ttag";
 
 import EmptyDashboardBot from "assets/img/dashboard-empty.svg";
@@ -21,32 +22,16 @@ import {
 import type { RouteParams } from "./types";
 import { parseRouteParams } from "./utils";
 
-interface Props {
-  params: RouteParams;
-}
-
 const DATA_MODEL_APP_NAV_BAR_HEIGHT = 53;
 
-export const DataModel = ({ params }: Props) => {
-  const { databaseId, tableId, schemaId, fieldId } = parseRouteParams(params);
-  const isEmptyStateShown =
-    databaseId == null || tableId == null || fieldId == null;
-  const {
-    data: table,
-    error,
-    isLoading,
-  } = useGetTableQueryMetadataQuery(
-    tableId == null
-      ? skipToken
-      : {
-          id: tableId,
-          include_sensitive_fields: true,
-          ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-        },
-  );
-  const field = table?.fields?.find((field) => field.id === fieldId);
-  const [previewType, setPreviewType] = usePreviewType();
-
+export const DataModel = ({
+  params,
+  children,
+}: {
+  params: RouteParams;
+  children: ReactNode;
+}) => {
+  const { databaseId, tableId, schemaId } = parseRouteParams(params);
   return (
     <Flex h={`calc(100% - ${DATA_MODEL_APP_NAV_BAR_HEIGHT}px)`} bg="bg-light">
       <Stack
@@ -76,6 +61,32 @@ export const DataModel = ({ params }: Props) => {
         </Box>
       </Stack>
 
+      {children ?? <DataModelEditor params={params} />}
+    </Flex>
+  );
+};
+
+export function DataModelEditor({ params }: { params: RouteParams }) {
+  const { databaseId, tableId, fieldId } = parseRouteParams(params);
+  const isEmptyStateShown =
+    databaseId == null || tableId == null || fieldId == null;
+  const {
+    data: table,
+    error,
+    isLoading,
+  } = useGetTableQueryMetadataQuery(
+    tableId == null
+      ? skipToken
+      : {
+          id: tableId,
+          include_sensitive_fields: true,
+          ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+        },
+  );
+  const field = table?.fields?.find((field) => field.id === fieldId);
+  const [previewType, setPreviewType] = usePreviewType();
+  return (
+    <>
       {tableId && (
         <Box className={S.sidebar} flex="0 0 25%" h="100%" miw="400px">
           <Box p="xl" pb="lg">
@@ -159,6 +170,6 @@ export const DataModel = ({ params }: Props) => {
           )}
         </>
       )}
-    </Flex>
+    </>
   );
-};
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -26,9 +26,11 @@ const DATA_MODEL_APP_NAV_BAR_HEIGHT = 53;
 
 export const DataModel = ({
   params,
+  location,
   children,
 }: {
   params: RouteParams;
+  location: Location;
   children: ReactNode;
 }) => {
   const { databaseId, tableId, schemaId } = parseRouteParams(params);
@@ -48,16 +50,7 @@ export const DataModel = ({
           tableId={tableId}
         />
         <Box mx="xl" py="sm" className={S.footer}>
-          <Flex
-            component={Link}
-            to="/admin/datamodel/segments"
-            className={S.segmentsLink}
-            gap="sm"
-            p="sm"
-          >
-            <Icon name="pie" className={S.segmentsIcon} />
-            {t`Segments`}
-          </Flex>
+          <SegmentsLink location={location} />
         </Box>
       </Stack>
 
@@ -65,6 +58,25 @@ export const DataModel = ({
     </Flex>
   );
 };
+
+function SegmentsLink({ location }: { location: Location }) {
+  const isActive =
+    location?.pathname?.startsWith("/admin/datamodel/segments") ||
+    location?.pathname?.startsWith("/admin/datamodel/segment/");
+
+  return (
+    <Flex
+      component={Link}
+      to="/admin/datamodel/segments"
+      className={cx(S.segmentsLink, { [S.active]: isActive })}
+      gap="sm"
+      p="sm"
+    >
+      <Icon name="pie" className={S.segmentsIcon} />
+      {t`Segments`}
+    </Flex>
+  );
+}
 
 export function DataModelEditor({ params }: { params: RouteParams }) {
   const { databaseId, tableId, fieldId } = parseRouteParams(params);

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -22,8 +22,6 @@ import {
 import type { RouteParams } from "./types";
 import { parseRouteParams } from "./utils";
 
-const DATA_MODEL_APP_NAV_BAR_HEIGHT = 53;
-
 export const DataModel = ({
   params,
   location,
@@ -35,7 +33,7 @@ export const DataModel = ({
 }) => {
   const { databaseId, tableId, schemaId } = parseRouteParams(params);
   return (
-    <Flex h={`calc(100% - ${DATA_MODEL_APP_NAV_BAR_HEIGHT}px)`} bg="bg-light">
+    <Flex h="100%" bg="bg-light">
       <Stack
         className={S.sidebar}
         flex="0 0 25%"
@@ -54,7 +52,7 @@ export const DataModel = ({
         </Box>
       </Stack>
 
-      {children ?? <DataModelEditor params={params} />}
+      {children}
     </Flex>
   );
 };

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
@@ -21,7 +21,7 @@ export function TablePicker({
   const deferredQuery = useDeferredValue(query);
 
   return (
-    <Stack mih={200} h="100%">
+    <Stack mih={200}>
       <Box p="xl" pb={0}>
         <Input
           value={query}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
@@ -164,7 +164,7 @@ function Search({
 
 function EmptyState({ title }: { title: string }) {
   return (
-    <Stack pt="lg" align="center" className={S.emptyState} gap="md">
+    <Stack py="xl" align="center" className={S.emptyState} gap="md">
       <Flex className={S.empyIcon} p="lg" align="center" justify="center">
         <Icon name="table2" />
       </Flex>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/wrappers.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/wrappers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { push } from "react-router-redux";
 
 import { useDispatch } from "metabase/lib/redux";
@@ -9,13 +9,18 @@ import { getUrl } from "./utils";
 
 export function RouterTablePicker(props: TreePath) {
   const dispatch = useDispatch();
+  const [value, setValue] = useState(props);
   const onChange = useCallback(
     (value: TreePath) => {
+      setValue(value);
       dispatch(push(getUrl(value)));
     },
     [dispatch],
   );
-  return <TablePicker value={props} onChange={onChange} />;
+  useEffect(() => {
+    setValue(props);
+  }, [props]);
+  return <TablePicker value={value} onChange={onChange} />;
 }
 
 export function UncontrolledTablePicker({


### PR DESCRIPTION
Closes [SEM-340](https://linear.app/metabase/issue/SEM-340/move-segments-below-the-list-of-databases)

Moves the segments tab into the table picker sidebar and removes the top bar.

<img width="1474" alt="Screenshot 2025-05-23 at 16 42 48" src="https://github.com/user-attachments/assets/53bca2d2-9b01-468b-96b1-0a8a14059398" />

e2e tests will be updated in a follow up PR.