### PR TITLE
Make string matching functions case insensitive

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -11,6 +11,7 @@
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
    [metabase-enterprise.metabot-v3.envelope :as envelope]
+   [metabase-enterprise.metabot-v3.reactions]
    [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
     :as metabot-v3.tools.create-dashboard-subscription]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -116,30 +116,46 @@
                       :group-by [{:field-id (->field-id "Created At")
                                   :field-granularity :week}]}))))
           (testing "Multi-value filtering works"
-            (is (=? {:structured-output {:type :query,
-                                         :query-id string?
-                                         :query {:database (mt/id)
-                                                 :type :query
-                                                 :query {:source-table (mt/id :orders)
-                                                         :aggregation [[:metric metric-id]]
-                                                         :filter
-                                                         [:and
-                                                          [:starts-with {}
-                                                           [:field (mt/id :people :state)
-                                                            {:base-type :type/Text
-                                                             :source-field (mt/id :orders :user_id)}]
-                                                           "A" "G"]
-                                                          [:!=
-                                                           [:field (mt/id :orders :discount) {:base-type :type/Float}]
-                                                           3 42]]}}}}
-                    (metabot-v3.tools.filters/query-metric
-                     {:metric-id metric-id
-                      :filters [{:field-id (->field-id ["User" "State"])
-                                 :operation :string-starts-with
-                                 :values ["A" "G"]}
-                                {:field-id (->field-id "Discount")
-                                 :operation :not-equals
-                                 :values [3 42]}]})))))
+            (let [state-id (->field-id ["User" "State"])
+                  stat-field-clause [:field (mt/id :people :state)
+                                     {:base-type :type/Text
+                                      :source-field (mt/id :orders :user_id)}]]
+              (is (=? {:structured-output {:type :query,
+                                           :query-id string?
+                                           :query {:database (mt/id)
+                                                   :type :query
+                                                   :query {:source-table (mt/id :orders)
+                                                           :aggregation [[:metric metric-id]]
+                                                           :filter
+                                                           [:and
+                                                            [:contains {:case-sensitive false}
+                                                             stat-field-clause "o" "e"]
+                                                            [:does-not-contain
+                                                             stat-field-clause "y" {:case-sensitive false}]
+                                                            [:starts-with {:case-sensitive false}
+                                                             stat-field-clause "A" "G"]
+                                                            [:ends-with {:case-sensitive false}
+                                                             stat-field-clause "e" "f" "i" "T" "x"]
+                                                            [:!=
+                                                             [:field (mt/id :orders :discount) {:base-type :type/Float}]
+                                                             3 42]]}}}}
+                      (metabot-v3.tools.filters/query-metric
+                       {:metric-id metric-id
+                        :filters [{:field-id state-id
+                                   :operation :string-contains
+                                   :values ["o" "e"]}
+                                  {:field-id state-id
+                                   :operation :string-not-contains
+                                   :value "y"}
+                                  {:field-id state-id
+                                   :operation :string-starts-with
+                                   :values ["A" "G"]}
+                                  {:field-id state-id
+                                   :operation :string-ends-with
+                                   :values ["e" "f" "i" "T" "x"]}
+                                  {:field-id (->field-id "Discount")
+                                   :operation :not-equals
+                                   :values [3 42]}]}))))))
         (testing "Missing metric results in an error."
           (is (= {:output (str "No metric found with metric_id " Integer/MAX_VALUE)}
                  (metabot-v3.tools.filters/query-metric {:metric-id Integer/MAX_VALUE}))))


### PR DESCRIPTION
Closes BOT-121

### Description

Make string matching filters (`string-contains`, `string-not-contains`, `string-starts-with`, `string-ends-with`) case insensitive.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
