### PR TITLE
Fix for Column Formatting: number 1e-18 cannot be converted to a BigInt because it is not an integer. 

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -331,6 +331,13 @@ function abs(a: number | bigint) {
   return a < 0 ? -a : a;
 }
 
+/**
+ * Multiplies two numbers, handling bigints and floats safely.
+ */
 function multiply(a: number | bigint, b: number) {
-  return typeof a === "bigint" ? a * BigInt(b) : a * b;
+  if (typeof a === "bigint" && Number.isSafeInteger(b)) {
+    return a * BigInt(b);
+  } else {
+    return Number(a) * b;
+  }
 }

--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -335,7 +335,7 @@ function abs(a: number | bigint) {
  * Multiplies two numbers, handling bigints and floats safely.
  */
 function multiply(a: number | bigint, b: number) {
-  if (typeof a === "bigint" && Number.isSafeInteger(b)) {
+  if (typeof a === "bigint" && Number.isInteger(b)) {
     return a * BigInt(b);
   } else {
     return Number(a) * b;


### PR DESCRIPTION
Fixes #57884

I cannot run the tests locally because I have no experience with clojure, but this should fix the bug.
Lets see if the tests pass :)

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/57884

### Description

`BigInt` cannot handle decimals such as `0.1`, so falling back to regular Number multiplication if thats the received value.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
