### PR TITLE
URL-encode parameters substituted into link & iframe cards

### DIFF
--- a/frontend/src/metabase/visualizations/shared/utils/parameter-substitution.js
+++ b/frontend/src/metabase/visualizations/shared/utils/parameter-substitution.js
@@ -9,6 +9,7 @@ export function fillParametersInText({
   parameterValues,
   text,
   escapeMarkdown = false,
+  urlEncode = false,
 }) {
   const parametersByTag = dashcard?.parameter_mappings?.reduce(
     (acc, mapping) => {
@@ -18,7 +19,10 @@ export function fillParametersInText({
       );
 
       if (parameter) {
-        const parameterValue = parameterValues[parameter.id];
+        const rawParameterValue = parameterValues[parameter.id];
+        const parameterValue = urlEncode
+          ? encodeURIComponent(rawParameterValue)
+          : rawParameterValue;
         return {
           ...acc,
           [tagId]: { ...parameter, value: parameterValue },

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
@@ -78,6 +78,7 @@ export function IFrameViz({
         dashboard,
         parameterValues,
         text: allowedIframeAttributes?.src,
+        urlEncode: true,
       }),
     [dashcard, dashboard, parameterValues, allowedIframeAttributes?.src],
   );

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
@@ -409,5 +409,22 @@ describe("IFrameViz", () => {
         screen.getByText("There was a problem rendering this content."),
       ).toBeInTheDocument();
     });
+
+    it("should URL-encode parameter values", () => {
+      const parameter = createMockParameter({
+        id: "1",
+        name: "Parameter 1",
+        slug: "param1",
+      });
+
+      const iframe = setupParameterTest({
+        parameters: [parameter],
+        iframeContent: "https://example.com/{{param1}}",
+        parameterValues: { param1: "pb&j" },
+      });
+
+      expect(iframe).toBeInTheDocument();
+      expect(iframe).toHaveAttribute("src", "https://example.com/pb%26j");
+    });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -109,6 +109,7 @@ function LinkVizInner({
         dashboard,
         parameterValues,
         text: url,
+        urlEncode: true,
       }),
     [dashboard, dashcard, parameterValues, url],
   );

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -531,5 +531,25 @@ describe("LinkViz", () => {
         screen.getByText("https://example.com/foo?q=bar"),
       ).toBeInTheDocument();
     });
+
+    it("should URL-encode parameter values", () => {
+      const parameters = [
+        createMockParameter({
+          id: "1",
+          name: "Parameter 1",
+          slug: "param1",
+        }),
+      ];
+
+      setupParameterTest({
+        parameters,
+        linkUrl: "https://example.com/{{param1}}",
+        parameterValues: { param1: "pb&j" },
+      });
+
+      expect(
+        screen.getByText("https://example.com/pb%26j"),
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/58386

Pretty straightforward, see the issue for a repro