### PR TITLE
New v2 execution API for actions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -79,7 +79,7 @@
   hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.14.2"}             ; Clojure/Script library used for prularizing words
   instaparse/instaparse                     {:mvn/version "1.5.0"}              ; Make your own parser
-  io.github.camsaul/toucan2                 {:mvn/version "1.0.564"}
+  io.github.camsaul/toucan2                 {:mvn/version "1.0.565"}
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "4998a1fdd9d3713d7034d04509e9212204773bf2"
                                              :git/url "https://github.com/eerohele/pp"}

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.data-editing.api
   (:require
-   [clojure.string :as str]
    [metabase-enterprise.data-editing.data-editing :as data-editing]
    [metabase-enterprise.data-editing.undo :as undo]
    [metabase.actions.core :as actions]
@@ -290,7 +289,7 @@
         [row]     (data-editing/query-db-rows table-id pk-fields [pk])
         _         (api/check-404 row)
         ;; TODO handle custom mapping
-        input     (merge row (merge input row))]
+        input     (merge row input)]
     (actions/perform-action! action-kw scope [input])))
 
 (api.macros/defendpoint :post "/row-action/:action-id/execute"
@@ -428,7 +427,7 @@
           saved-id
           (execute-dashcard-row-action-on-saved-action! saved-id dashcard-id pk input mapping)
           action-kw
-          (let [table-id (:table-id)]
+          (let [table-id (:table-id input)]
             ;; Weird magic currying we've been doing implicitly.
             (if (and table-id (isa? action-kw :table.row/common))
               (let [input {:table-id table-id, :row input}

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -238,6 +238,7 @@
   (let [action      (-> (actions/select-action :id (parse-long action-id) :archived false)
                         (t2/hydrate :creator)
                         api/read-check)
+        ;; TODO flatten this into a single query
         card-id     (api/check-404 (t2/select-one-fn :card_id [:model/DashboardCard :card_id] dashcard-id))
         table-id    (api/check-404 (t2/select-one-fn :table_id [:model/Card :table_id] card-id))
         fields      (t2/select [:model/Field :name] :table_id table-id)

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -787,7 +787,7 @@
                                                  :status "approved"}})
                                (select-keys [:status :body]))))))
                 (testing "dashcard row action modifying a row"
-                  (let [action-id (str "dashcard:unknown:abcdef")]
+                  (let [action-id "dashcard:unknown:abcdef"]
                     (testing "underlying row does not exist, action not executed"
                       (is (= 404 (:status (req {:action-id action-id
                                                 :scope     {:dashcard-id (:id dashcard)}

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -713,8 +713,7 @@
                                                  (merge {:scope {:unknown :legacy-action} :input {}}
                                                         (dissoc % :user-id)))]
     (mt/with-premium-features #{:table-data-editing}
-      ;; H2 does not support DDL operations, so this query action will fail.
-      (mt/test-drivers #{#_:h2 :postgres}
+      (mt/test-drivers #{:h2 :postgres}
         (data-editing.tu/toggle-data-editing-enabled! true)
         (mt/with-actions-enabled
           (testing "no dashcard"

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -727,8 +727,8 @@
               (is (= 404 (:status (req {:action-id 999999
                                         :scope     {:dashcard-id (:id dashcard)}
                                         :input     {}}))))
-              (testing "no dashcard still results in 400"
-                (is (= 400 (:status (req {:action-id 999999, :input {}})))))))
+              (testing "no dashcard still results in 404"
+                (is (= 404 (:status (req {:action-id 999999, :input {}})))))))
           (mt/with-non-admin-groups-no-root-collection-perms
             (with-open [test-table (data-editing.tu/open-test-table! {:id 'auto-inc-type
                                                                       :name [:text]

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -48,7 +48,7 @@
   select-action
   select-actions
   table-primitive-action
-  unpack-table-primitive-action-id]
+  unpack-encoded-action-id]
  [metabase.actions.events
   publish-action-success!]
  [metabase.actions.scope

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -203,7 +203,7 @@
       (execute-implicit-action! action request-parameters)
       (:query :http)
       (execute-custom-action! action request-parameters)
-      (throw (ex-info (tru "Unknown action type {0}." (name (:type action))) action)))))
+      (throw (ex-info (tru "Unknown action type {0}." (name (:type action :unknown))) action)))))
 
 (defn- execute-table-action! [action-kw table-id request-parameters]
   (actions/perform-action-with-single-input-and-output action-kw {:table-id table-id :arg request-parameters}))
@@ -222,7 +222,7 @@
       (let [{:keys [kind table_id]} table-action]
         ;; avoiding snowplow for now, to avoid adding new actions into their schema
         (execute-table-action! (keyword kind) table_id request-parameters))
-      (let [action (api/check-404 (action/select-action :id action-id))]
+      (let [action (api/check-404 (action/select-action :id action-id :archived false))]
         (analytics/track-event! :snowplow/action
                                 {:event     :action-executed
                                  :source    :dashboard

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -205,16 +205,8 @@
       (execute-custom-action! action request-parameters)
       (throw (ex-info (tru "Unknown action type {0}." (name (:type action))) action)))))
 
-(defn- execute-table-action!
-  [kind table-id request-parameters]
-  (let [args
-        {:table-id table-id
-         :database (t2/select-one-fn :db_id [:model/Table :db_id] table-id)
-         :arg      request-parameters}
-
-        opts
-        {:policy :data-editing}]
-    (actions/perform-action-with-single-input-and-output kind args opts)))
+(defn- execute-table-action! [kind table-id request-parameters]
+  (actions/perform-action-with-single-input-and-output kind {:table-id table-id :arg request-parameters}))
 
 (mu/defn execute-dashcard!
   "Execute the given action in the dashboard/dashcard context with the given parameters

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -205,8 +205,8 @@
       (execute-custom-action! action request-parameters)
       (throw (ex-info (tru "Unknown action type {0}." (name (:type action))) action)))))
 
-(defn- execute-table-action! [kind table-id request-parameters]
-  (actions/perform-action-with-single-input-and-output kind {:table-id table-id :arg request-parameters}))
+(defn- execute-table-action! [action-kw table-id request-parameters]
+  (actions/perform-action-with-single-input-and-output action-kw {:table-id table-id :arg request-parameters}))
 
 (mu/defn execute-dashcard!
   "Execute the given action in the dashboard/dashcard context with the given parameters
@@ -214,15 +214,13 @@
   [dashboard-id       :- ::lib.schema.id/dashboard
    dashcard-id        :- ::lib.schema.id/dashcard
    request-parameters :- [:maybe [:map-of :string :any]]]
-  (let [dashcard     (api/check-404 (t2/select-one :model/DashboardCard
-                                                   :id dashcard-id
-                                                   :dashboard_id dashboard-id))
+  (let [dashcard     (api/check-404 (t2/select-one :model/DashboardCard :id dashcard-id :dashboard_id dashboard-id))
         action-id    (:action_id dashcard)
         table-action (-> dashcard :visualization_settings :table_action)]
     (api/check-404 (or action-id table-action))
     (if table-action
       (let [{:keys [kind table_id]} table-action]
-        ;; avoiding snowplow for now, to avoid adding new actions into schema
+        ;; avoiding snowplow for now, to avoid adding new actions into their schema
         (execute-table-action! (keyword kind) table_id request-parameters))
       (let [action (api/check-404 (action/select-action :id action-id))]
         (analytics/track-event! :snowplow/action

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -337,13 +337,9 @@
 ;; we will use an integer with an op (15 bits) and param (32 bits)
 ;; to start with table actions, the param is the table-id.
 (def ^:private primitive-action-kind->int
-  {:table.row/create       0
-   :table.row/update       1
-   :table.row/delete       2
-   ;; not kinds, strictly speaking. id namespaces.
-   :dashcard/card-action   3
-   :dashcard/header-action 4
-   :dashcard/row-action    5})
+  {:table.row/create 0
+   :table.row/update 1
+   :table.row/delete 2})
 
 (def ^:private int->primitive-action-kind (set/map-invert primitive-action-kind->int))
 

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -336,7 +336,15 @@
 ;; parameter as an integer. The frontend picker can when creating the dashcard pass the negative action_id.
 ;; we will use an integer with an op (15 bits) and param (32 bits)
 ;; to start with table actions, the param is the table-id.
-(def ^:private primitive-action-kind->int {:table.row/create 0 :table.row/update 1 :table.row/delete 2})
+(def ^:private primitive-action-kind->int
+  {:table.row/create       0
+   :table.row/update       1
+   :table.row/delete       2
+   ;; not kinds, strictly speaking. id namespaces.
+   :dashcard/card-action   3
+   :dashcard/header-action 4
+   :dashcard/row-action    5})
+
 (def ^:private int->primitive-action-kind (set/map-invert primitive-action-kind->int))
 
 (defn unpack-table-primitive-action-id

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -258,7 +258,8 @@
         model-id->implicit-parameters (when (seq implicit-action-models)
                                         (implicit-action-parameters implicit-action-models))]
     (for [action actions]
-      (if (= (:type action) :implicit)
+      (case (:type action)
+        :implicit
         (let [model-id        (:model_id action)
               saved-params    (m/index-by :id (:parameters action))
               action-kind     (:kind action)
@@ -302,6 +303,7 @@
                                            (assoc acc param-id {:id param-id, :hidden false})))
                                        fields
                                        param-ids)))))))
+        (:query :http)
         action))))
 
 (defn select-action
@@ -336,31 +338,31 @@
 ;; parameter as an integer. The frontend picker can when creating the dashcard pass the negative action_id.
 ;; we will use an integer with an op (15 bits) and param (32 bits)
 ;; to start with table actions, the param is the table-id.
-(def ^:private primitive-action-kind->int
+(def ^:private primitive-action->int
   {:table.row/create 0
    :table.row/update 1
    :table.row/delete 2})
 
-(def ^:private int->primitive-action-kind (set/map-invert primitive-action-kind->int))
+(def ^:private int->primitive-action (set/map-invert primitive-action->int))
 
-(defn unpack-table-primitive-action-id
-  "Return an [kind table-id] vector given the negative action id."
+(defn unpack-encoded-action-id
+  "Return an [action-kw table-id] vector given the negative action id."
   [^long encoded-id]
   (let [pos-id     (bit-and (Math/abs encoded-id) 0xFFFFFFFFFFFF)
         param-bits (bit-and pos-id 0xFFFFFFFF)
         op-bits    (bit-and (bit-shift-right pos-id 32) 0xFFFF)]
-    [(int->primitive-action-kind op-bits) param-bits]))
+    [(int->primitive-action op-bits) param-bits]))
 
-(defn- table-primitive-action-id ^long [kind ^long param]
-  (let [op-bits (primitive-action-kind->int kind)
+(defn- encoded-action-id ^long [action-kw ^long param]
+  (let [op-bits (primitive-action->int action-kw)
         packed  (bit-or (bit-shift-left op-bits 32) (bit-and param 0xFFFFFFFF))]
     (- packed)))
 
 (defn table-primitive-action
-  "Return an action map for a table edit action for the primitive action kind.
+  "Return an action map for a table edit action for the primitive action.
   Such an action is only valid if data editing is enabled for the database."
-  [table fields kind]
-  (let [field-param? (case kind
+  [table fields action-kw]
+  (let [field-param? (case action-kw
                        :table.row/create
                        #(not (:database_is_auto_increment %))
                        :table.row/delete
@@ -370,51 +372,45 @@
                           (filter field-param?)
                           (sort-by :position))]
     {:database_id (:database_id table)
-     :name        (name kind)
-     :kind        (u/qualified-name kind)
+     :name        (name action-kw)
+     :kind        (u/qualified-name action-kw)
      :table_id    (:id table)
-     :id          (table-primitive-action-id kind (:id table))
+     :id          (encoded-action-id action-kw (:id table))
      ;; true for all databases with data_editing_enabled
      ;; it is expected this fn will not be called if this is not the case
      :database_enabled_actions true
      :visualization_settings
-     {:name ""
-      :type "button"
+     {:name        ""
+      :type        "button"
       :description ""
-      :fields
-      (u/for-map [field field-params
-                  :let [field-name (:name field)]]
-        [field-name
-         {:hidden      false
-          :id          field-name}])}
+      :fields      (u/for-map [field field-params
+                               :let [field-name (:name field)]]
+                     [field-name {:id field-name, :hidden false}])}
      :parameters
      (->> (for [field field-params
                 :let [field-name (:name field)]]
-            {:id    field-name
-             :display-name (:display_name field)
-             :type (:base_type field)
-             :target [:variable [:template-tag field-name]]
-             :slug  field-name
-             :required (or (= :type/PK (:semantic_type field))
-                           (:database_required field))
+            {:id                field-name
+             :display-name      (:display_name field)
+             :type              (:base_type field)
+             :target            [:variable [:template-tag field-name]]
+             :slug              field-name
+             :required          (or (= :type/PK (:semantic_type field))
+                                    (:database_required field))
              :is-auto-increment (:database_is_auto_increment field)})
           vec)}))
 
 (defn select-primitive-action
-  "Returns the primitive action (map) for the given kind (operation, e.g :row/create) and table-id."
+  "Returns the primitive action (map) for the given kind (operation, e.g., :row/create) and table-id."
   [table-id kind]
-  (let [table      (t2/select-one :model/Table table-id)
-        fields     (t2/select :model/Field :table_id table-id)]
+  (let [table  (t2/select-one :model/Table table-id)
+        fields (t2/select :model/Field :table_id table-id)]
     (table-primitive-action table fields kind)))
 
 (defn dashcard->action
   "Get the action associated with a dashcard if exists, return `nil` otherwise."
   [dashcard-id]
-  (let [{:keys [action_id
-                visualization_settings]}
-        (t2/select-one [:model/DashboardCard :action_id :visualization_settings] dashcard-id)
-        {:keys [table_action]}
-        visualization_settings]
+  (let [{:keys [action_id] {:keys [table_action]} :visualization_settings}
+        (t2/select-one [:model/DashboardCard :action_id :visualization_settings] dashcard-id)]
     (cond
       action_id (select-action :id action_id)
       table_action
@@ -445,6 +441,7 @@
           :let [action-id (:action_id dashcard)
                 action
                 (or (get actions-by-id action-id)
+                    ;; Create a (fictitious) saved action that calls the given table action.
                     (when-some [{:keys [table_id kind]} (:table_action (:visualization_settings dashcard))]
                       (when-some [table (get table-by-id table_id)]
                         (table-primitive-action table (get fields-by-id table_id []) (keyword kind)))))]]

--- a/src/metabase/actions/types.clj
+++ b/src/metabase/actions/types.clj
@@ -1,20 +1,26 @@
 (ns metabase.actions.types
   (:require
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]))
 
 ;; Maybe we want to add an origin? e.g., CRUD API versus action execute API versus v2 API. YAGNI for now.
 
+(mr/def ::missing-id
+  [:int {:min -1, :max -1}])
+
+(mr/def ::fk-or-missing-id [:or ::missing-id ms/PositiveInt])
+
 (def ^:private raw-scope-types
-  [[:map [:dashboard-id pos-int?]]
-   [:map [:dashcard-id pos-int?]]
-   [:map [:card-id pos-int?]]
+  [[:map [:dashboard-id ms/PositiveInt]]
+   [:map [:dashcard-id ms/PositiveInt]]
+   [:map [:card-id ms/PositiveInt]]
   ;; We represent legacy-actions, which get called against a model, distinctly.
   ;; Treated the same as card-id, mostly.
   ;; Might end up always assigning the key according to the card type, or always use card-id, but either way we would
   ;; then need some way to tell legacy-action invocations apart.
-   [:map [:model-id pos-int?]]
-   [:map [:table-id pos-int?]]
-   [:map [:webhook-id pos-int?]]
+   [:map [:model-id ms/PositiveInt]]
+   [:map [:table-id ms/PositiveInt]]
+   [:map [:webhook-id ms/PositiveInt]]
    [:map [:unknown [:enum :legacy-action]]]])
 
 ;; Relaxed, as we support it being
@@ -36,31 +42,31 @@
    [:dashboard
     [:map {:closed true}
      [:type          [:enum :dashboard]]
-     [:dashboard-id  pos-int?]
-     [:collection-id pos-int?]]]
+     [:dashboard-id  ms/PositiveInt]
+     [:collection-id ::fk-or-missing-id]]]
    ;; table - unified type that handles both regular and CRUD cases
    [:table
     [:map {:closed true}
      [:type                         [:enum :table]]
-     [:table-id                     pos-int?]
-     [:database-id                  pos-int?]
+     [:table-id                     ms/PositiveInt]
+     [:database-id                  ::fk-or-missing-id]
      [:rest-api    {:optional true} [:enum :table]]]]
    ;; card - unified type that handles both with and without table cases
    [:card
     [:map {:closed true}
      [:type                           [:enum :card]]
-     [:card-id                        pos-int?]
-     [:collection-id {:optional true} pos-int?]
-     [:table-id      {:optional true} pos-int?]
-     [:database-id                    pos-int?]]]
+     [:card-id                        ms/PositiveInt]
+     [:collection-id {:optional true} ::fk-or-missing-id]
+     [:table-id      {:optional true} ::fk-or-missing-id]
+     [:database-id                    ::fk-or-missing-id]]]
    ;; model - unified type that handles both with and without table cases
    [:model
     [:map {:closed true}
      [:type                           [:enum :model]]
-     [:model-id                       pos-int?]
-     [:collection-id {:optional true} pos-int?]
-     [:table-id      {:optional true} pos-int?]
-     [:database-id                    pos-int?]]]
+     [:model-id                       ms/PositiveInt]
+     [:collection-id {:optional true} ::fk-or-missing-id]
+     [:table-id      {:optional true} ::fk-or-missing-id]
+     [:database-id                    ::fk-or-missing-id]]]
    ;; dashcard - unified type that handles all cases:
    ;; 1. dashcard with both card and table (has card-id, table-id, database-id)
    ;; 2. dashcard with card but no table (has card-id, no table-id)
@@ -68,17 +74,17 @@
    [:dashcard
     [:map {:closed true}
      [:type                           [:enum :dashcard]]
-     [:dashcard-id                    pos-int?]
-     [:dashboard-id                   pos-int?]
-     [:collection-id                  pos-int?]
-     [:card-id       {:optional true} pos-int?]
-     [:table-id      {:optional true} pos-int?]
-     [:database-id   {:optional true} pos-int?]]]
+     [:dashcard-id                    ms/PositiveInt]
+     [:dashboard-id                   ::fk-or-missing-id]
+     [:collection-id                  ::fk-or-missing-id]
+     [:card-id       {:optional true} ::fk-or-missing-id]
+     [:table-id      {:optional true} ::fk-or-missing-id]
+     [:database-id   {:optional true} ::fk-or-missing-id]]]
    ;; for now, webhooks can only point at tables, not editables
    [:webhook
     [:map {:closed false}
      [:type        [:enum :webhook]]
-     [:webhook-id  pos-int?]
-     [:table-id    pos-int?]
-     [:database-id pos-int?]]]
+     [:webhook-id  ms/PositiveInt]
+     [:table-id    ::fk-or-missing-id]
+     [:database-id ::fk-or-missing-id]]]
    [:unknown any?]])

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -1011,12 +1011,24 @@
                                                                         (pos-int? (:action_id dashcard))
                                                                         (u/update-if-exists dashcard :visualization_settings dissoc :table_action)
                                                                         (neg-int? (:action_id dashcard))
-                                                                        (let [[op table-id] (actions/unpack-table-primitive-action-id (:action_id dashcard))]
-                                                                          (-> dashcard
-                                                                              (assoc-in [:visualization_settings :table_action]
-                                                                                        {:kind (u/qualified-name op)
-                                                                                         :table_id table-id})
-                                                                              (dissoc :action_id)))
+                                                                        (let [[op param] (actions/unpack-table-primitive-action-id (:action_id dashcard))]
+                                                                          (cond
+                                                                            (= "table.row" (namespace op))
+                                                                            (-> dashcard
+                                                                                (assoc-in [:visualization_settings :table_action]
+                                                                                          {:kind     (u/qualified-name op)
+                                                                                           :table_id param})
+                                                                                (dissoc :action_id))
+                                                                            :else
+                                                                            ;; FE should not be able to create these,
+                                                                            ;; and won't handle them either,
+                                                                            ;; but return the unpacking anyway for
+                                                                            ;; easy debugging.
+                                                                            (-> dashcard
+                                                                                (assoc-in [:visualization_settings :_action]
+                                                                                          {:type  (u/qualified-name op)
+                                                                                           :param param})
+                                                                                (dissoc :action_id))))
                                                                         :else
                                                                         dashcard))))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -943,7 +943,10 @@
                     identity
                     ;; Generate initial ids in the BE, preparing for a time when these are first-class db records.
                     ;; FE needs to rename "id" to "action_id", and then this can be renamed to "id"
-                    (update :actual_id #(or % (u/generate-nano-id)))
+                    ;; NOTE: it's possible that the dashcard has not been saved to the database yet, and there does not
+                    ;;       have an id. this will create a cosmetic blemish for now, but will cause more serious
+                    ;;       issues when we try to make these actions first-class database records. have fun!
+                    (update :actual_id #(or % (str "dashcard:" (:id dashcard) ":" (u/generate-nano-id))))
                     ;; At the time of writing, the FE only allows the creation of row actions.
                     (update :type #(or % "grid/row-action"))
                     ;; By default actions are enabled.


### PR DESCRIPTION
This API supports all the underlying action flavors:

- Saved actions (e.g. SQL and Basic Model Actions)
- Primitive actions (e.g. undo/redo, table actions)
- Encoded actions (via the picker hack)

It also supports calling actions 

- Dashboard buttons
- Editable row actions

It will not yet support "Question row actions", but that should be a fairly straight-forward extension. Likewise we should be able to add support for "header actions" as well.

This API will replace our usage of the following 8 APIs:

```
- POST /data-editing/table (create row)
- PUT  /data-editing/table (update row)
- POST /data-editing/table/delete (delete row)
- POST /data-editing/undo
- POST /data-editing/redo
- POST /data-editing/row-action/:id/execute
- POST /action/:id/execute (legacy model actions only)
- POST /dashboard/:id/dashcard/:id/execute
```

I suggest keeping the first three even after deprecation though, they're really nice APIs for 3rd party automation.