### PR TITLE
Avoid doing quadratic search in FkTargetPicker

### DIFF
--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -44,7 +44,7 @@ export const FkTargetPicker = ({
       return { comparableIdFields, hasIdFields, data, optionsByFieldId };
     }, [field, idFields]);
 
-  const getField = (fieldId: string | null) => {
+  const getFieldFromValue = (fieldId: string | null) => {
     if (fieldId == null) {
       return null;
     }
@@ -52,8 +52,8 @@ export const FkTargetPicker = ({
     return option?.field;
   };
 
-  const getValue = (fieldId: string | null): FieldId => {
-    const field = getField(fieldId);
+  const getFieldIdFromValue = (fieldId: string | null): FieldId => {
+    const field = getFieldFromValue(fieldId);
     if (field?.id === undefined || typeof field.id === "object") {
       // this code is unreachable since we don't expect field references here
       throw new Error("unreachable");
@@ -62,7 +62,7 @@ export const FkTargetPicker = ({
   };
 
   const handleChange = (value: string) => {
-    const fieldId = getValue(value);
+    const fieldId = getFieldIdFromValue(value);
     onChange(fieldId);
   };
 
@@ -90,7 +90,7 @@ export const FkTargetPicker = ({
             return false;
           }
 
-          const field = getField(option.value);
+          const field = getFieldFromValue(option.value);
           if (!field) {
             return false;
           }
@@ -105,8 +105,8 @@ export const FkTargetPicker = ({
       nothingFoundMessage={t`Didn't find any results`}
       placeholder={getFkFieldPlaceholder(field, comparableIdFields)}
       renderOption={(item) => {
-        const field = getField(item.option.value);
-        const selected = getValue(item.option.value) === value;
+        const field = getFieldFromValue(item.option.value);
+        const selected = getFieldIdFromValue(item.option.value) === value;
 
         return (
           <SelectItem selected={selected}>

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { t } from "ttag";
 
 import {
@@ -28,15 +29,26 @@ export const FkTargetPicker = ({
   onChange,
   ...props
 }: Props) => {
-  const comparableIdFields = idFields.filter((idField) => {
-    return idField.isComparableWith(field);
-  });
-  const hasIdFields = comparableIdFields.length > 0;
-  const includeSchema = hasMultipleSchemas(comparableIdFields);
-  const data = getData(comparableIdFields, includeSchema);
+  const { comparableIdFields, hasIdFields, data, optionsByFieldId } =
+    useMemo(() => {
+      const comparableIdFields = idFields.filter((idField) => {
+        return idField.isComparableWith(field);
+      });
+      const hasIdFields = comparableIdFields.length > 0;
+      const includeSchema = hasMultipleSchemas(comparableIdFields);
+      const data = getData(comparableIdFields, includeSchema);
+      const optionsByFieldId = Object.fromEntries(
+        data.map((option) => [option.value, option]),
+      );
 
-  const getField = (fieldId: FieldId | null) => {
-    const option = data.find((option) => parseValue(option.value) === fieldId);
+      return { comparableIdFields, hasIdFields, data, optionsByFieldId };
+    }, [field, idFields]);
+
+  const getField = (fieldId: FieldId | string | null) => {
+    if (fieldId == null) {
+      return null;
+    }
+    const option = optionsByFieldId[String(fieldId)];
     return option?.field;
   };
 
@@ -69,8 +81,7 @@ export const FkTargetPicker = ({
             return false;
           }
 
-          const field = getField(parseValue(option.value));
-
+          const field = getField(option.value);
           if (!field) {
             return false;
           }

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -44,11 +44,11 @@ export const FkTargetPicker = ({
       return { comparableIdFields, hasIdFields, data, optionsByFieldId };
     }, [field, idFields]);
 
-  const getField = (fieldId: FieldId | string | null) => {
+  const getField = (fieldId: string | null) => {
     if (fieldId == null) {
       return null;
     }
-    const option = optionsByFieldId[String(fieldId)];
+    const option = optionsByFieldId[fieldId];
     return option?.field;
   };
 
@@ -96,7 +96,7 @@ export const FkTargetPicker = ({
       nothingFoundMessage={t`Didn't find any results`}
       placeholder={getFkFieldPlaceholder(field, comparableIdFields)}
       renderOption={(item) => {
-        const field = getField(parseValue(item.option.value));
+        const field = getField(item.option.value);
         const selected = parseValue(item.option.value) === value;
 
         return (

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -52,9 +52,20 @@ export const FkTargetPicker = ({
     return option?.field;
   };
 
+  const getValue = (fieldId: string | null) => {
+    const field = getField(fieldId);
+    if (field?.id === undefined || typeof field.id === "object") {
+      // this code is unreachable since we don't expect field references here
+      return;
+    }
+    return field.id;
+  };
+
   const handleChange = (value: string) => {
-    const parsedValue = parseValue(value);
-    onChange(parsedValue);
+    const fieldId = getValue(value);
+    if (fieldId) {
+      onChange(fieldId);
+    }
   };
 
   return (
@@ -97,7 +108,7 @@ export const FkTargetPicker = ({
       placeholder={getFkFieldPlaceholder(field, comparableIdFields)}
       renderOption={(item) => {
         const field = getField(item.option.value);
-        const selected = parseValue(item.option.value) === value;
+        const selected = getValue(item.option.value) === value;
 
         return (
           <SelectItem selected={selected}>
@@ -136,10 +147,6 @@ function getData(comparableIdFields: Field[], includeSchema: boolean) {
           : stringifyValue(field.id),
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
-}
-
-function parseValue(value: string): FieldId | null {
-  return value === "" ? null : JSON.parse(value);
 }
 
 function stringifyValue(value: FieldId | null): string {

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -52,20 +52,18 @@ export const FkTargetPicker = ({
     return option?.field;
   };
 
-  const getValue = (fieldId: string | null) => {
+  const getValue = (fieldId: string | null): FieldId => {
     const field = getField(fieldId);
     if (field?.id === undefined || typeof field.id === "object") {
       // this code is unreachable since we don't expect field references here
-      return;
+      throw new Error("unreachable");
     }
     return field.id;
   };
 
   const handleChange = (value: string) => {
     const fieldId = getValue(value);
-    if (fieldId) {
-      onChange(fieldId);
-    }
+    onChange(fieldId);
   };
 
   return (


### PR DESCRIPTION
The current implementation of the `FkTargetPicker` has quadratic complexity. 

For a small number of fields that is managable, but with a lot of fields, the picker becomes sluggish.

This PR removes the quadratic behavior and also removes the need for calling `JSON.parse` inside the component at all.

<img width="1030" alt="Screenshot 2025-05-23 at 19 36 05" src="https://github.com/user-attachments/assets/3fea8682-41d7-4f1f-b927-740aa83957fd" />
