### PR TITLE
fix: include entity_id in default fields for user

### DIFF
--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -185,7 +185,7 @@
 
 (def ^:private default-user-columns
   "Sequence of columns that are normally returned when fetching a User from the DB."
-  [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_qbnewb :tenant_id])
+  [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_qbnewb :tenant_id :entity_id])
 
 (def admin-or-self-visible-columns
   "Sequence of columns that we can/should return for admins fetching a list of all Users, or for the current user


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #47081

### Description

Fixes the set of default columns for the user model to include entity_id. 
