### PR TITLE
array-map for json export to preserve order

### DIFF
--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -63,19 +63,20 @@
             (when-not (zero? row-num)
               (.write writer ",\n"))
             (json/encode-to
-             (zipmap
-              @col-names
-              (map (fn [formatter r]
+             (apply array-map
+                    (interleave
+                     @col-names
+                     (map (fn [formatter r]
                      ;; NOTE: Stringification of formatted values ensures consistency with what is shown in the
                      ;; Metabase UI, especially numbers (e.g. percents, currencies, and rounding). However, this
                      ;; does mean that all JSON values are strings. Any other strategy requires some level of
                      ;; inference to know if we should or should not parse a string (or not stringify an object).
-                     (let [res (formatter (streaming.common/format-value r))]
-                       (cond
-                         (formatter/NumericWrapper? res) (:num-str res)
-                         (formatter/TextWrapper? res)    (:text-str res)
-                         :else                          res)))
-                   @ordered-formatters cleaned-row))
+                            (let [res (formatter (streaming.common/format-value r))]
+                              (cond
+                                (formatter/NumericWrapper? res) (:num-str res)
+                                (formatter/TextWrapper? res)    (:text-str res)
+                                :else                          res)))
+                          @ordered-formatters cleaned-row)))
              writer {})
             (.flush writer))))
 

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -67,10 +67,10 @@
                     (interleave
                      @col-names
                      (map (fn [formatter r]
-                     ;; NOTE: Stringification of formatted values ensures consistency with what is shown in the
-                     ;; Metabase UI, especially numbers (e.g. percents, currencies, and rounding). However, this
-                     ;; does mean that all JSON values are strings. Any other strategy requires some level of
-                     ;; inference to know if we should or should not parse a string (or not stringify an object).
+                            ;; NOTE: Stringification of formatted values ensures consistency with what is shown in the
+                            ;; Metabase UI, especially numbers (e.g. percents, currencies, and rounding). However, this
+                            ;; does mean that all JSON values are strings. Any other strategy requires some level of
+                            ;; inference to know if we should or should not parse a string (or not stringify an object).
                             (let [res (formatter (streaming.common/format-value r))]
                               (cond
                                 (formatter/NumericWrapper? res) (:num-str res)

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -63,6 +63,7 @@
             (when-not (zero? row-num)
               (.write writer ",\n"))
             (json/encode-to
+             ;; #12247 Use array-map instead of zipmap for preserving order in json export
              (apply array-map
                     (interleave
                      @col-names


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #12247
Closes VIZ-29

- Use `array-map` instead of `zipmap` when streaming the row results of json exports so that we avoid the hash map conversion that occurs for maps with 8+ key/values as this results in nondeterministic ordering

<details>
<summary>Before & After</summary>
<img width="801" alt="image" src="https://github.com/user-attachments/assets/0a0af1b9-ef8a-4ec1-826d-45d314480187" />
</details>
