### PR TITLE
feat: kondo linter enforcing i18n of ex-info msgs

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -483,6 +483,7 @@
    cljs.test/is                                                                                                              hooks.clojure.test/is
    cljs.test/use-fixtures                                                                                                    hooks.clojure.test/use-fixtures
    clojure.core/defmulti                                                                                                     hooks.clojure.core.defmulti/lint-defmulti
+   clojure.core/ex-info                                                                                                      hooks.clojure.core.ex-info/ex-info
    clojure.core/ns                                                                                                           hooks.clojure.core.ns/lint-ns
    clojure.core/require                                                                                                      hooks.clojure.core.require/lint-require
    clojure.core/requiring-resolve                                                                                            hooks.clojure.core.require/lint-requiring-resolve
@@ -720,6 +721,7 @@
   {:linters
    {:metabase/validate-escaped-single-quotes-in-i18n {:level :warning}
     :metabase/validate-string-or-str-args-to-i18n {:level :warning}
+    :metabase/i18n-ex-info {:level :warning}
     :discouraged-var
     {clojure.core/with-redefs {:message "Don't use with-redefs outside of tests"}
      clojure.core/eval        {:message "Don't use eval outside of tests"}}}}

--- a/.clj-kondo/src/hooks/clojure/core/ex_info.clj
+++ b/.clj-kondo/src/hooks/clojure/core/ex_info.clj
@@ -1,0 +1,61 @@
+(ns hooks.clojure.core.ex-info
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(def ^:private i18n-macros #{'tru
+                             'deferred-tru
+                             'deferred-trs
+                             'trs
+                             'trun
+                             'deferred-trun
+                             'deferred-trsn
+                             'trsn
+                             'tru-clj
+                             'deferred-tru-clj
+                             'deferred-trs-clj
+                             'trs-clj
+                             'trun-clj
+                             'deferred-trun-clj
+                             'deferred-trsn-clj
+                             'trsn-clj})
+;; allow ex-infos that are just rethrowing other messages with
+;; additional data
+(def ^:private ex-message #{'ex-message})
+
+(defn- is-i18n-wrapped? [message-expr]
+  (and (seq? message-expr)
+       (let [{:keys [name ns]} (api/resolve {:name (first message-expr)})]
+         (or (and (= 'metabase.util.i18n ns)
+                  (contains? i18n-macros name))
+             (and (= 'clojure.core ns)
+                  (contains? ex-message name))))))
+
+(defn- is-i18n-var? [message-expr]
+  (boolean
+   (and (symbol? message-expr)
+        (get (api/env) message-expr))))
+
+(defn ex-info
+  "Checks if the first argument to ex-info (the message) is properly wrapped in an i18n macro.
+  This ensures all exception messages are internationalized.
+
+  Validates that:
+  1. The message is wrapped in an i18n macro like tru/trs
+  2. Or the message is a variable
+  3. Or that we are rethrowing a message using ex-message
+
+  Reports a linting error if these conditions aren't met.
+
+  TODO: Is is possible to check at least for a local variable if it was defined using a i18n macro  "
+  [{:keys [node]}]
+  (let [args (rest (:children node))
+        message-node (first args)]
+    (when message-node
+      (let [message-expr (api/sexpr message-node)]
+        (when-not (or (is-i18n-wrapped? message-expr)
+                      (is-i18n-var? message-expr))
+          (api/reg-finding!
+           {:message "ex-info message should be wrapped in tru/trs or deferred-tru/trs for i18n"
+            :type :metabase/i18n-ex-info
+            :node message-node}))))
+    {:node node}))

--- a/.clj-kondo/test/hooks/clojure/core/ex_info_test.clj
+++ b/.clj-kondo/test/hooks/clojure/core/ex_info_test.clj
@@ -1,0 +1,29 @@
+(ns hooks.clojure.core.ex-info-test
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clj-kondo.impl.utils]
+   [clojure.test :refer [deftest are testing]]
+   [hooks.clojure.core.ex-info :as sut]))
+
+(defn- warnings
+  [form]
+  (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/i18n-ex-info {:level :warning}}}
+                                        :ignores    (atom nil)
+                                        :findings   (atom [])
+                                        :namespaces (atom {})}]
+    (sut/ex-info {:node (api/parse-string (pr-str form))})
+    (mapv :message @(:findings clj-kondo.impl.utils/*ctx*))))
+
+(deftest ^:parallel ex-info-test-pass
+  (are [form] (= []
+                 (warnings (quote form)))
+    (ex-info (metabase.util.i18n/deferred-tru "message"))
+    (ex-info (metabase.util.i18n/tru "message"))
+    (ex-info (tru "message") {})
+    (ex-info (deferred-tru "message") {})))
+
+(deftest ^:parallel ex-info-test-warns
+  (are [form] (= ["ex-info message should be wrapped in tru/trs or deferred-tru/trs for i18n"]
+                 (warnings (quote form)))
+    (ex-info (other-fn "plain-string") {})
+    (ex-info "plain-string" {})))

--- a/.clj-kondo/test/hooks/metabase/util/i18n_test.clj
+++ b/.clj-kondo/test/hooks/metabase/util/i18n_test.clj
@@ -1,9 +1,9 @@
 (ns hooks.metabase.util.i18n-test
-  (:require [clj-kondo.hooks-api :as api]
-            [clj-kondo.impl.utils]
-            [clojure.string :as str]
-            [clojure.test :refer [deftest testing is are]]
-            [hooks.metabase.util.i18n]))
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clj-kondo.impl.utils]
+   [clojure.test :refer [deftest are]]
+   [hooks.metabase.util.i18n]))
 
 (defn- warnings
   [form]

--- a/src/metabase/util/time.cljc
+++ b/src/metabase/util/time.cljc
@@ -5,6 +5,7 @@
   (:require
    [clojure.string :as str]
    [metabase.util :as u]
+   [metabase.util.i18n :as i18n]
    [metabase.util.namespaces :as shared.ns]
    [metabase.util.time.impl :as internal]
    [metabase.util.time.impl-common :as common]))
@@ -78,7 +79,7 @@
   (cond
     (internal/time? value) value
     (string? value) (-> value common/drop-trailing-time-zone internal/parse-time-string)
-    :else           (throw (ex-info "Unknown input to coerce-to-time; expecting a string"
+    :else           (throw (ex-info (i18n/tru "Unknown input to coerce-to-time; expecting a string")
                                     {:value value}))))
 
 (defn format-unit

--- a/src/metabase/util/time/impl.clj
+++ b/src/metabase/util/time/impl.clj
@@ -150,7 +150,7 @@
                      (catch Exception _
                        (try (t/day-of-week "EEEE" value)
                             (catch Exception _
-                              (throw (ex-info (str "Failed to coerce '" value "' to day-of-week")
+                              (throw (ex-info (i18n/tru "Failed to coerce '''{value}''' to day-of-week" value)
                                               {:value value}))))))]
         (-> (now)
             (t/truncate-to :days)

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -177,16 +177,16 @@
   (cond
     (nil? type)
     (when (some? hash_key)
-      (throw (ex-info "Invalid query - cannot specify a hash_key without specifying the type"
+      (throw (ex-info (tru "Invalid query - cannot specify a hash_key without specifying the type")
                       {:field-values field-values})))
 
     (= :full (keyword type))
     (when (some? hash_key)
-      (throw (ex-info "Invalid query - :full FieldValues cannot have a hash_key"
+      (throw (ex-info (tru "Invalid query - :full FieldValues cannot have a hash_key")
                       {:field-values field-values})))
 
     (and (contains? field-values :hash_key) (nil? hash_key))
-    (throw (ex-info "Invalid query - Advanced FieldValues can only specify a non-empty hash_key"
+    (throw (ex-info (tru "Invalid query - Advanced FieldValues can only specify a non-empty hash_key")
                     {:field-values field-values}))))
 
 (defn- add-mismatched-hash-filter [{:keys [type] :as field-values}]

--- a/src/metabase/xrays/automagic_dashboards/dashboard_templates.clj
+++ b/src/metabase/xrays/automagic_dashboards/dashboard_templates.clj
@@ -396,7 +396,7 @@
             (let [template (try
                              (yaml/load (partial make-dashboard-template entity-type) f)
                              (catch Throwable e
-                               (throw (ex-info (format "Error loading template %s: %s" (str f) (ex-message e))
+                               (throw (ex-info (i18n/tru "Error loading template %s: %s" (str f) (ex-message e))
                                                {:path path, :f f}
                                                e))))]
               (assoc-in acc (concat path [entity-type ::leaf]) template))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #27998
### Description

Kondo linter that checks that the message string passed to ex-info throwable has been wrapped in tru or deferred-tru or other i18n macro to support i18n of the message. There are exceptions for passing in a variable and simply unwrapping another Throwable with ex-message.
