### PR TITLE
Fix underlying records drill for question with multiple breakouts on the same column

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -1383,7 +1383,7 @@ describe("issue 53604 - nested native question with multiple breakouts on same c
     });
   }
 
-  function testUnderlyingRecordsDrillThrough() {
+  function testUnderlyingRecordsDrillThru() {
     cy.intercept("POST", "/api/dataset").as("dataset");
     H.visitQuestion("@nestedQuestionId");
 
@@ -1412,12 +1412,12 @@ describe("issue 53604 - nested native question with multiple breakouts on same c
 
   it("Underlying records drill-through should work on nested native question (metabase#53604)", () => {
     createNestedQuestion();
-    testUnderlyingRecordsDrillThrough();
+    testUnderlyingRecordsDrillThru();
   });
 
   it("Underlying records drill-through should work on nested native model (metabase#53604)", () => {
     createNestedQuestion({ turnIntoModel: true });
-    testUnderlyingRecordsDrillThrough();
+    testUnderlyingRecordsDrillThru();
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -1335,6 +1335,92 @@ describe("issue 53556 - nested question based on native model with remapped valu
   });
 });
 
+describe("issue 53604 - nested native question with multiple breakouts on same column", () => {
+  const questionDetails = {
+    name: "53604 base",
+    type: "question",
+    native: {
+      query: "select ID, CREATED_AT from ORDERS",
+      "template-tags": {},
+    },
+  };
+
+  function createNestedQuestion({
+    turnIntoModel: shouldTurnIntoModel = false,
+  } = {}) {
+    H.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
+      if (shouldTurnIntoModel) {
+        H.visitQuestion(id);
+        turnIntoModel();
+      }
+      H.createQuestion(
+        {
+          type: "question",
+          name: "53604",
+          query: {
+            "source-table": `card__${id}`,
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "field",
+                "CREATED_AT",
+                { "temporal-unit": "month", "base-type": "type/DateTime" },
+              ],
+              [
+                "field",
+                "CREATED_AT",
+                { "temporal-unit": "year", "base-type": "type/DateTime" },
+              ],
+            ],
+          },
+          display: "line",
+        },
+        {
+          wrapId: true,
+          idAlias: "nestedQuestionId",
+        },
+      );
+    });
+  }
+
+  function testUnderlyingRecordsDrillThrough() {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    H.visitQuestion("@nestedQuestionId");
+
+    // We can click on any circle; this index was chosen randomly
+    H.cartesianChartCircle().eq(25).click({ force: true });
+    H.popover()
+      .findByText(/^See these/)
+      .click();
+    cy.wait("@dataset");
+
+    cy.findByTestId("qb-filters-panel").findByText(
+      "CREATED_AT is May 1–31, 2024",
+    );
+
+    cy.findByTestId("qb-filters-panel").findByText(
+      "CREATED_AT is Jan 1 – Dec 31, 2024",
+    );
+
+    H.assertQueryBuilderRowCount(520);
+  }
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("Underlying records drill-through should work on nested native question (metabase#53604)", () => {
+    createNestedQuestion();
+    testUnderlyingRecordsDrillThrough();
+  });
+
+  it("Underlying records drill-through should work on nested native model (metabase#53604)", () => {
+    createNestedQuestion({ turnIntoModel: true });
+    testUnderlyingRecordsDrillThrough();
+  });
+});
+
 describe("issue 54108 - nested question broken out by day", () => {
   const questionDetails = {
     name: "54108 base",

--- a/src/metabase/lib/drill_thru/column_filter.cljc
+++ b/src/metabase/lib/drill_thru/column_filter.cljc
@@ -25,9 +25,7 @@
   Question transformation:
   - None"
   (:require
-   [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
-   [metabase.lib.equality :as lib.equality]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.filter.operator :as lib.filter.operator]
    [metabase.lib.schema :as lib.schema]
@@ -79,12 +77,8 @@
                         ;; And if there isn't a later stage, add one.
                         :else      {:query        (lib.stage/append-stage query)
                                     :stage-number -1})
-        columns       (lib.filter/filterable-columns (:query base) (:stage-number base))
-        filter-column (or (lib.equality/find-matching-column
-                           (:query base) (:stage-number base) column-ref columns)
-                          (and (:lib/source-uuid column)
-                               (m/find-first #(= (:lib/source-uuid %) (:lib/source-uuid column))
-                                             columns)))]
+        filter-column (lib.drill-thru.common/matching-filterable-column
+                       (:query base) (:stage-number base) column-ref column)]
     ;; If we cannot find the matching column, don't allow to drill
     (when filter-column
       (assoc base :column filter-column))))

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -69,7 +69,7 @@
     (not-empty (filterv #(lib.underlying/breakout-sourced? query (:column %))
                         row))))
 
-(mu/defn- nested-name-based-breakout-column? :- :boolean
+(mu/defn- card-sourced-name-based-breakout-column? :- :boolean
   [query  :- ::lib.schema/query
    column :- ::lib.schema.metadata/column]
   (let [breakout-sourced? (= :source/breakouts (:lib/source column))
@@ -147,7 +147,7 @@
   ;; this function once the field refs overhaul lands.
   ;;
   ;; https://github.com/metabase/metabase/issues/53604
-  (if-not (or (nested-name-based-breakout-column? query column)
+  (if-not (or (card-sourced-name-based-breakout-column? query column)
               (possible-model-mapped-breakout-column? query column)
               (day-bucketed-breakout-column? column))
     column

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -2,11 +2,14 @@
   (:require
    [medley.core :as m]
    [metabase.lib.card :as lib.card]
+   [metabase.lib.equality :as lib.equality]
+   [metabase.lib.filter :as lib.filter]
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
@@ -66,19 +69,39 @@
     (not-empty (filterv #(lib.underlying/breakout-sourced? query (:column %))
                         row))))
 
+(mu/defn- nested-name-based-breakout-column? :- :boolean
+  [query  :- ::lib.schema/query
+   column :- ::lib.schema.metadata/column]
+  (let [breakout-sourced? (= :source/breakouts (:lib/source column))
+        card-sourced? (boolean (lib.util/source-card-id query))
+        has-id? (boolean (:id column))]
+    (and breakout-sourced? card-sourced? (not has-id?))))
+
 (mu/defn- possible-model-mapped-breakout-column? :- :boolean
   [query  :- ::lib.schema/query
    column :- ::lib.schema.metadata/column]
   (let [breakout-sourced? (= :source/breakouts (:lib/source column))
         model-sourced? (lib.card/source-card-is-model? query)
-        has-id? (:id column)]
-    (and breakout-sourced? model-sourced? (boolean has-id?))))
+        has-id? (boolean (:id column))]
+    (and breakout-sourced? model-sourced? has-id?)))
 
 (mu/defn- day-bucketed-breakout-column? :- :boolean
   [column :- ::lib.schema.metadata/column]
   (let [breakout-sourced? (= :source/breakouts (:lib/source column))
         day-bucketed? (= (:metabase.lib.field/temporal-unit column) :day)]
     (and breakout-sourced? day-bucketed?)))
+
+(mu/defn matching-filterable-column :- [:maybe ::lib.schema.metadata/column]
+  "Return the matching column found in the stage's [[lib.filter/filterable-columns]]."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column-ref   :- ::lib.schema.ref/ref
+   column       :- ::lib.schema.metadata/column]
+  (let [columns (lib.filter/filterable-columns query stage-number)]
+    (or (lib.equality/find-matching-column query stage-number column-ref columns)
+        (and (:lib/source-uuid column)
+             (m/find-first #(= (:lib/source-uuid %) (:lib/source-uuid column))
+                           columns)))))
 
 (mu/defn breakout->resolved-column :- ::lib.schema.metadata/column
   "Given a breakout sourced column, return the resolved metadata for the column in this stage."
@@ -111,8 +134,22 @@
      column
      (let [field-ref (cond-> (lib.ref/ref column)
                        (not preserve-type?) (update 1 dissoc :base-type :effective-type))
-           resolved-column  (lib.metadata.calculation/metadata query stage-number field-ref)
-           underlying-unit  (::lib.underlying/temporal-unit column)
-           matching-column  (some-> resolved-column
-                                    (m/assoc-some ::lib.underlying/temporal-unit underlying-unit))]
-       (or matching-column column)))))
+           resolved-column  (lib.metadata.calculation/metadata query stage-number field-ref)]
+       (or resolved-column column)))))
+
+(mu/defn breakout->filterable-column :- ::lib.schema.metadata/column
+  "Given a breakout sourced column, return the matching filterable-column in this stage."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column-ref   :- ::lib.schema.ref/ref
+   column       :- ::lib.schema.metadata/column]
+  ;; TODO: This is a hack to workaround field refs confusion that should be fixed by the field refs overhaul. Remove
+  ;; this function once the field refs overhaul lands.
+  ;;
+  ;; https://github.com/metabase/metabase/issues/53604
+  (if-not (or (nested-name-based-breakout-column? query column)
+              (possible-model-mapped-breakout-column? query column)
+              (day-bucketed-breakout-column? column))
+    column
+    (let [filterable-column (matching-filterable-column query stage-number column-ref column)]
+      (or filterable-column column))))

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -38,7 +38,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
-   [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.schema.metadata :as lib.schema.metadata]

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -38,9 +38,11 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
@@ -119,10 +121,11 @@
   [query        :- ::lib.schema/query
    stage-number :- :int
    column       :- ::lib.schema.metadata/column
+   column-ref   :- ::lib.schema.ref/ref
    value        :- :any]
-  (let [column         (lib.drill-thru.common/breakout->resolved-column query stage-number column)
+  (let [filter-column  (lib.drill-thru.common/breakout->filterable-column query stage-number column-ref column)
         filter-clauses (or (when (lib.binning/binning column)
-                             (let [unbinned-column (lib.binning/with-binning column nil)]
+                             (let [unbinned-column (lib.binning/with-binning filter-column nil)]
                                (if (some? value)
                                  (when-let [{:keys [min-value max-value]} (lib.binning/resolve-bin-width query column value)]
                                    [(lib.filter/>= unbinned-column min-value)
@@ -136,9 +139,10 @@
                            ;; instead of
                            ;;
                            ;;    month(col) = March 2023
-                           (let [column (if-let [temporal-unit (::lib.underlying/temporal-unit column)]
-                                          (lib.temporal-bucket/with-temporal-bucket column temporal-unit)
-                                          column)]
+                           (let [column (if-let [temporal-unit (or (::lib.underlying/temporal-unit column)
+                                                                   (lib.temporal-bucket/temporal-bucket column))]
+                                          (lib.temporal-bucket/with-temporal-bucket filter-column temporal-unit)
+                                          filter-column)]
                              (if (some? value)
                                [(lib.filter/= column value)]
                                [(lib.filter/is-null column)])))]
@@ -159,8 +163,8 @@
         base-query  (lib.util/update-query-stage query -1 dissoc :aggregation :breakout :order-by :limit :fields)
         ;; Turn any non-aggregation dimensions into filters.
         ;; eg. if we drilled into a temporal bucket, add a filter for the [:= breakout-column that-month].
-        filtered    (reduce (fn [q {:keys [column value]}]
-                              (drill-filter q -1 column value))
+        filtered    (reduce (fn [q {:keys [column column-ref value]}]
+                              (drill-filter q -1 column column-ref value))
                             base-query
                             (for [dimension dimensions
                                   :when (-> dimension :column :lib/source (not= :source/aggregations))]


### PR DESCRIPTION
Closes #53604

### Description

Add `lib.drill-thru.common/breakout->filterable-column` and call it in `lib.drill-thru.underlying-records/drill-filter` to get the filterable column.

### How to verify

See repo steps in #53604 or included e2e test

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
