### PR TITLE
Correct datetime() helper text.

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -329,7 +329,7 @@ const CONVERSION = defineClauses(
           name: t`value`,
           type: "expression",
           description: t`The string to convert to a datetime.`,
-          example: "2025-03-20 12:45:04.55",
+          example: "2025-03-20 12:45:04",
         },
       ],
     },


### PR DESCRIPTION
The text was incorrect. We caught it. So I'm making a quick PR to correct it.