### PR TITLE
feat: edit table filters before saving a dashcard

### DIFF
--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -510,25 +510,37 @@ export const updateEditableTableCardQueryInEditMode = createThunkAction(
     cardId: DashboardCard["card_id"];
     newCard: Card;
   }) =>
-    async (dispatch: Dispatch) => {
+    async (dispatch: Dispatch, getState: GetState) => {
       // set data override to null to show loading state
       dispatch(setEditingDashcardData(dashcardId, cardId, null));
 
+      const dashcard = getDashCardById(getState(), dashcardId);
+      const isSavedDashcard = dashcard.id > 0;
+
       // Non-saved cards (temporary ID < 0) do not require sync with the server, since there's no card ID to update.
       // The `isDirty` flag is used to determine if the existing card local state is different from the server state.
-      const isDirty = newCard.id > 0 ? true : false;
+      const isDirty = isSavedDashcard ? true : false;
       const card: Card = {
         ...newCard,
         // @ts-expect-error - we don't have a type for Store card with additional state
         isDirty,
       };
 
+      const newDashcardAttributes: Partial<DashboardCard> = { card };
+
+      // For new cards we also need to copy card dataset_query to dashcard visualization_settings
+      // To preserve edited filters upon saving the dashboard and creating a new card
+      if (!isSavedDashcard) {
+        newDashcardAttributes.visualization_settings = {
+          ...dashcard.visualization_settings,
+          initial_dataset_query: newCard.dataset_query,
+        };
+      }
+
       dispatch(
         setDashCardAttributes({
           id: dashcardId,
-          attributes: {
-            card: card,
-          },
+          attributes: newDashcardAttributes,
         }),
       );
 

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableSidebar.tsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import { useSelector } from "metabase/lib/redux";
-import { ActionIcon, Box, Flex, Icon, Tabs, Tooltip } from "metabase/ui";
+import { ActionIcon, Box, Flex, Icon, Tabs } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
 
 import { getDashCardById, getSidebar } from "../../selectors";
@@ -30,23 +30,13 @@ export function ConfigureEditableTableSidebar({
     return null;
   }
 
-  const isUnsavedDashcard = dashcard.id < 0;
-
   return (
     <>
       <Sidebar data-testid="add-table-sidebar">
         <Tabs defaultValue="columns">
           <Tabs.List px="md" pt="sm">
             <Tabs.Tab value="columns">{t`Columns`}</Tabs.Tab>
-            <Tabs.Tab value="filters" disabled={isUnsavedDashcard}>
-              {isUnsavedDashcard ? (
-                <Tooltip label={t`Please save the card to modify filters`}>
-                  <span>{t`Filters`}</span>
-                </Tooltip>
-              ) : (
-                t`Filters`
-              )}
-            </Tabs.Tab>
+            <Tabs.Tab value="filters">{t`Filters`}</Tabs.Tab>
             <Tabs.Tab value="actions">{t`Actions`}</Tabs.Tab>
 
             <Flex flex="1" justify="flex-end" align="center">


### PR DESCRIPTION
Resolves [WRK-434](https://linear.app/metabase/issue/WRK-434/filters-are-not-accessible-before-you-save-dashcard-in-a-dashboard)
