### PR TITLE
Closes VIZ-1035 silent error when converting certain models to viz cards

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -173,28 +173,36 @@ export function getInitialStateForCardDataSource(
       }
 
       if (Array.isArray(originalValue)) {
-        // When there're no sensibile metrics/dimensions,
+        // When there're no sensible metrics/dimensions,
         // "graph.dimensions" and "graph.metrics" are `[null]`
         if (originalValue.filter(Boolean).length === 0) {
           return;
         } else {
           return [
             setting,
-            originalValue.map((originalColumnName) => {
-              const index = columns.findIndex(
-                (col) => col.name === originalColumnName,
-              );
-              return state.columns[index].name;
-            }),
+            originalValue
+              .map((originalColumnName) => {
+                const index = columns.findIndex(
+                  (col) => col.name === originalColumnName,
+                );
+
+                if (index === -1 || !state.columns[index]) {
+                  return null;
+                }
+
+                return state.columns[index].name;
+              })
+              .filter(isNotNull),
           ];
         }
       } else {
         const index = columns.findIndex((col) => col.name === originalValue);
+
         if (!state.columns[index]) {
           return;
         }
 
-        return [setting, state.columns[index]?.name];
+        return [setting, state.columns[index].name];
       }
     })
     .filter(isNotNull);

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -55,6 +55,65 @@ describe("getInitialStateForCardDataSource", () => {
     expect(initialState.display).toEqual("bar");
   });
 
+  it("should ignore superfluous columns (VIZ-1035)", () => {
+    const dataset = createMockDataset({
+      data: createMockDatasetData({
+        cols: [
+          createMockColumn({
+            name: "CREATED_AT",
+            base_type: "type/DateTime",
+            effective_type: "type/DateTime",
+            semantic_type: null,
+            unit: "month",
+          }),
+          createMockColumn({
+            name: "SOME_METRIC",
+            database_type: "int8",
+            semantic_type: "type/Quantity",
+            base_type: "type/BigInteger",
+          }),
+          createMockColumn({
+            name: "SOME_OTHER_METRIC",
+            database_type: "int8",
+            semantic_type: "type/Quantity",
+            base_type: "type/BigInteger",
+          }),
+        ],
+      }),
+    });
+
+    const card = createMockCard({
+      display: "table",
+      name: "TablyMcTableface",
+      visualization_settings: {},
+    });
+
+    const state = getInitialStateForCardDataSource(card, dataset);
+
+    expect(state.columnValuesMapping).toEqual({
+      COLUMN_1: [
+        {
+          name: "COLUMN_1",
+          originalName: "CREATED_AT",
+          sourceId: "card:1",
+        },
+      ],
+      COLUMN_2: [
+        {
+          name: "COLUMN_2",
+          originalName: "SOME_METRIC",
+          sourceId: "card:1",
+        },
+      ],
+    });
+
+    expect(state.settings).toEqual({
+      "card.title": "TablyMcTableface",
+      "graph.dimensions": ["COLUMN_1"],
+      "graph.metrics": ["COLUMN_2"],
+    });
+  });
+
   it("should compute default viz settings when card's viz type isn't supported by the visualizer", () => {
     const dataset = createMockDataset({
       data: createMockDatasetData({


### PR DESCRIPTION
Closes [VIZ-1035: Pick a dataset empty state causes dead end for sources that aren't mapped](https://linear.app/metabase/issue/VIZ-1035/pick-a-dataset-empty-state-causes-dead-end-for-sources-that-arent)

### Description

Under certain conditions, the code to convert a question card into a visualizer card would silently error out. These conditions (a model with a single date time column and more than one numerical columns) are now properly handled.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
