### PR TITLE
Show loader every time the generated sql is fetched

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-generation/components/GenerateSqlQueryButton/GenerateSqlQueryButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-generation/components/GenerateSqlQueryButton/GenerateSqlQueryButton.tsx
@@ -12,7 +12,7 @@ export function GenerateSqlQueryButton({
   selectedQueryText,
   onGenerateQuery,
 }: GenerateSqlQueryButtonProps) {
-  const [generateSql, { isLoading }] = useLazyGenerateSqlQueryQuery();
+  const [generateSql, { isFetching }] = useLazyGenerateSqlQueryQuery();
   const request = getRequest(query, selectedQueryText);
 
   const handleClick = async () => {
@@ -32,7 +32,7 @@ export function GenerateSqlQueryButton({
         className={className}
         variant="subtle"
         leftSection={<Icon name="metabot" />}
-        loading={isLoading}
+        loading={isFetching}
         disabled={request == null}
         aria-label={t`Generate SQL based on the prompt`}
         onClick={handleClick}


### PR DESCRIPTION
We need to show the loader every time we fetch the generated SQL, and not just the first time