### PR TITLE
Remove force-broken-id-refs

### DIFF
--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -80,7 +80,6 @@
   accept both `card-id` and `card`."
   [col
    card-id
-   card
    field]
   (let [col (-> col
                 (update-keys u/->kebab-case-en))
@@ -116,11 +115,10 @@
     cols                  :- [:sequential :map]]
    (let [metadata-provider (lib.metadata/->metadata-provider metadata-providerable)
          card-id           (when card-or-id (u/the-id card-or-id))
-         card              (when card-id (lib.metadata/card metadata-providerable card-id))
          field-ids         (keep :id cols)
          fields            (lib.metadata.protocols/metadatas metadata-provider :metadata/column field-ids)
          field-id->field   (m/index-by :id fields)]
-     (mapv #(->card-metadata-column % card-id card (get field-id->field (:id %))) cols))))
+     (mapv #(->card-metadata-column % card-id (get field-id->field (:id %))) cols))))
 
 (def ^:private CardColumnMetadata
   [:merge

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -75,13 +75,6 @@
    {:error/message "Card with :dataset-query"}
    [:dataset-query :map]])
 
-(def ^:dynamic *force-broken-card-refs*
-  "Things are fundamentally broken because of #29763, and every time I try to fix this is ends up being a giant mess to
-  untangle. The FE currently ignores results metadata for ad-hoc queries, and thus cannot match up 'correct' Field
-  refs like 'Products__CATEGORY'... for the time being we'll have to force ID refs even when we should be using
-  nominal refs so as to not completely destroy the FE. Once we port more stuff over maybe we can fix this."
-  false)
-
 (defn- ->card-metadata-column
   "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata. Note that `card` might be unavailable so we
   accept both `card-id` and `card`."

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -104,15 +104,6 @@
                    (:metabase.lib.field/temporal-unit col)
                    (assoc :inherited-temporal-unit (:metabase.lib.field/temporal-unit col))
 
-                   (and *force-broken-card-refs*
-                        ;; never force broken refs for Models, because Models can have give columns with completely
-                        ;; different names the Field ID of a different column, somehow. See #22715
-                        (or
-                         ;; we can only do this check if `card-id` is passed in.
-                         (not card-id)
-                         (not= (:type card) :model)))
-                   (assoc ::force-broken-id-refs true)
-
                    ;; If the incoming col doesn't have `:semantic-type :type/FK`, drop `:fk-target-field-id`.
                    ;; This comes up with metadata on SQL cards, which might be linked to their original DB field but should not be
                    ;; treated as FKs unless the metadata is configured accordingly.

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -4,7 +4,6 @@
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.binning :as lib.binning]
-   [metabase.lib.card :as lib.card]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.expression :as lib.expression]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -453,8 +453,7 @@
 
 (defn- column-metadata->field-ref
   [metadata]
-  (let [inherited-column? (when-not (::lib.card/force-broken-id-refs metadata)
-                            (#{:source/card :source/native :source/previous-stage} (:lib/source metadata)))
+  (let [inherited-column? (#{:source/card :source/native :source/previous-stage} (:lib/source metadata))
         options           (merge {:lib/uuid       (str (random-uuid))
                                   :base-type      (:base-type metadata)
                                   :effective-type (column-metadata-effective-type metadata)}

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -894,12 +894,7 @@
                     (m/distinct-by #(-> % ::target :id))
                     not-empty))
              (filter-clause [x y]
-               ;; DO NOT force broken refs for fields that come from Cards (broken refs in this case means use Field
-               ;; ID refs instead of nominal field literal refs), that will break things if a Card returns the same
-               ;; Field more than once (there would be no way to disambiguate). See #34227 for more info
-               (let [x (dissoc x ::lib.card/force-broken-id-refs)
-                     y (dissoc y ::lib.card/force-broken-id-refs)]
-                 (lib.filter/filter-clause (lib.filter.operator/operator-def :=) x y)))]
+               (lib.filter/filter-clause (lib.filter.operator/operator-def :=) x y))]
        (or
         ;; find cases where we have FK(s) pointing to joinable. Our column goes on the LHS.
         (when-let [fks (fks stage joinable)]

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -150,9 +150,7 @@
             col
             {:lib/source               :source/previous-stage
              :lib/source-column-alias  source-alias
-             :lib/desired-column-alias (unique-name-fn source-alias)}
-            (when (:metabase.lib.card/force-broken-id-refs col)
-              (select-keys col [:metabase.lib.card/force-broken-id-refs])))
+             :lib/desired-column-alias (unique-name-fn source-alias)})
            ;; do not retain `:temporal-unit`; it's not like we're doing a extract(month from <x>) twice, in both
            ;; stages of a query. It's a little hacky that we're manipulating `::lib.field` keys directly here since
            ;; they're presumably supposed to be private-ish, but I don't have a more elegant way of solving this sort

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -4,7 +4,6 @@
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
    [metabase.lib.breakout :as lib.breakout]
-   [metabase.lib.card :as lib.card]
    [metabase.lib.core :as lib]
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -482,22 +482,21 @@
   (testing "A column that comes from a source Card (Saved Question/Model/etc) can be broken out by."
     (let [query (lib.tu/query-with-source-card)]
       (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
-        (binding [lib.card/*force-broken-card-refs* false]
-          (let [name-col (m/find-first #(= (:name %) "USER_ID")
-                                       (lib/breakoutable-columns query))]
-            (is (=? {:name      "USER_ID"
-                     :base-type :type/Integer}
-                    name-col))
-            (let [query' (lib/breakout query name-col)]
-              (is (=? {:stages
-                       [{:source-card 1
-                         :breakout    [[:field {:base-type :type/Integer} "USER_ID"]]}]}
-                      query'))
-              (is (= "My Card, Grouped by User ID"
-                     (lib/describe-query query')))
-              (is (= ["User ID"]
-                     (for [breakout (lib/breakouts query')]
-                       (lib/display-name query' breakout)))))))))))
+        (let [name-col (m/find-first #(= (:name %) "USER_ID")
+                                     (lib/breakoutable-columns query))]
+          (is (=? {:name      "USER_ID"
+                   :base-type :type/Integer}
+                  name-col))
+          (let [query' (lib/breakout query name-col)]
+            (is (=? {:stages
+                     [{:source-card 1
+                       :breakout    [[:field {:base-type :type/Integer} "USER_ID"]]}]}
+                    query'))
+            (is (= "My Card, Grouped by User ID"
+                   (lib/describe-query query')))
+            (is (= ["User ID"]
+                   (for [breakout (lib/breakouts query')]
+                     (lib/display-name query' breakout))))))))))
 
 (deftest ^:parallel breakoutable-columns-expression-e2e-test
   (let [query (-> (lib.tu/venues-query)

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -254,7 +254,6 @@
                :name "count"
                :lib/source :source/aggregations}
           card-id 176
-          card {:type :model}
           field nil
           expected-col {:lib/type :metadata/column
                         :base-type :type/Integer
@@ -266,7 +265,7 @@
                         :lib/source-column-alias "count"
                         :fk-target-field-id nil}]
       (is (=? expected-col
-              (#'lib.card/->card-metadata-column col card-id card field))))))
+              (#'lib.card/->card-metadata-column col card-id field))))))
 
 (deftest ^:parallel source-card-type-test
   (is (= :model (lib.card/source-card-type (lib.tu/query-with-source-model))))

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -143,44 +143,42 @@
 
 (deftest ^:parallel returned-columns-31769-source-card-test
   (testing "Queries with `:source-card`s with joins should return correct column metadata/refs (#31769)"
-    (binding [lib.card/*force-broken-card-refs* false]
-      (let [metadata-provider (lib.tu.mocks-31769/mock-metadata-provider)
-            card              (lib.metadata/card metadata-provider 1)
-            q                 (lib/query metadata-provider card)
-            cols              (lib/returned-columns q)]
-        (is (=? [{:name                     "CATEGORY"
-                  :lib/source               :source/card
-                  :lib/source-column-alias  "CATEGORY"
-                  :lib/desired-column-alias "Products__CATEGORY"}
-                 {:name                     "count"
-                  :lib/source               :source/card
-                  :lib/source-column-alias  "count"
-                  :lib/desired-column-alias "count"}]
-                cols))
-        (is (=? [[:field {:base-type :type/Text} "Products__CATEGORY"]
-                 [:field {:base-type :type/Integer} "count"]]
-                (map lib.ref/ref cols)))))))
+    (let [metadata-provider (lib.tu.mocks-31769/mock-metadata-provider)
+          card              (lib.metadata/card metadata-provider 1)
+          q                 (lib/query metadata-provider card)
+          cols              (lib/returned-columns q)]
+      (is (=? [{:name                     "CATEGORY"
+                :lib/source               :source/card
+                :lib/source-column-alias  "CATEGORY"
+                :lib/desired-column-alias "Products__CATEGORY"}
+               {:name                     "count"
+                :lib/source               :source/card
+                :lib/source-column-alias  "count"
+                :lib/desired-column-alias "count"}]
+              cols))
+      (is (=? [[:field {:base-type :type/Text} "Products__CATEGORY"]
+               [:field {:base-type :type/Integer} "count"]]
+              (map lib.ref/ref cols))))))
 
 (deftest ^:parallel returned-columns-31769-source-card-previous-stage-test
   (testing "Queries with `:source-card`s with joins in the previous stage should return correct column metadata/refs (#31769)"
-    (binding [lib.card/*force-broken-card-refs* false]
-      (let [metadata-provider (lib.tu.mocks-31769/mock-metadata-provider)
-            card              (lib.metadata/card metadata-provider 1)
-            q                 (-> (lib/query metadata-provider card)
-                                  lib/append-stage)
-            cols              (lib/returned-columns q)]
-        (is (=? [{:name                     "CATEGORY"
-                  :lib/source               :source/previous-stage
-                  :lib/source-column-alias  "Products__CATEGORY"
-                  :lib/desired-column-alias "Products__CATEGORY"}
-                 {:name                     "count"
-                  :lib/source               :source/previous-stage
-                  :lib/source-column-alias  "count"
-                  :lib/desired-column-alias "count"}]
-                cols))
-        (is (=? [[:field {:base-type :type/Text} "Products__CATEGORY"]
-                 [:field {:base-type :type/Integer} "count"]]
-                (map lib.ref/ref cols)))))))
+    (let [metadata-provider (lib.tu.mocks-31769/mock-metadata-provider)
+          card              (lib.metadata/card metadata-provider 1)
+          q                 (-> (lib/query metadata-provider card)
+                                lib/append-stage)
+          cols              (lib/returned-columns q)]
+      (is (=? [{:name                     "CATEGORY"
+                :lib/source               :source/previous-stage
+                :lib/source-column-alias  "Products__CATEGORY"
+                :lib/desired-column-alias "Products__CATEGORY"}
+               {:name                     "count"
+                :lib/source               :source/previous-stage
+                :lib/source-column-alias  "count"
+                :lib/desired-column-alias "count"}]
+              cols))
+      (is (=? [[:field {:base-type :type/Text} "Products__CATEGORY"]
+               [:field {:base-type :type/Integer} "count"]]
+              (map lib.ref/ref cols))))))
 
 (deftest ^:parallel card-source-query-visible-columns-test
   (testing "Explicitly joined fields do not also appear as implictly joinable"

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -27,8 +27,7 @@
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (use-fixtures :each (fn [thunk]
-                      (binding [lib.card/*force-broken-card-refs* false]
-                        (thunk))))
+                      (thunk)))
 
 (defn- grandparent-parent-child-id [field]
   (+ (meta/id :venues :id)

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -4,7 +4,6 @@
    [clojure.test :refer [are deftest is testing use-fixtures]]
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
-   [metabase.lib.card :as lib.card]
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.field :as lib.field]

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -3,7 +3,6 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as m]
-   [metabase.lib.card :as lib.card]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.join :as lib.join]

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1442,21 +1442,16 @@
 
 (deftest ^:parallel join-source-card-with-in-previous-stage-with-joins-test
   (testing "Make sure we generate correct join conditions when joining source cards with joins (#31769)"
-    (doseq [broken-refs? [true false]]
-      (testing (str "\nbroken-refs? = " (pr-str broken-refs?))
-        (binding [lib.card/*force-broken-card-refs* broken-refs?]
-          (is (=? {:stages [{:source-card 1}
-                            {:joins [{:stages     [{:source-card 2}]
-                                      :fields     :all
-                                      :conditions [[:=
-                                                    {}
-                                                    (if broken-refs?
-                                                      [:field {} (meta/id :products :category)]
-                                                      [:field {:base-type :type/Text} "Products__CATEGORY"])
-                                                    [:field {:join-alias "Card 2 - Category"} (meta/id :products :category)]]]
-                                      :alias      "Card 2 - Category"}]
-                             :limit 2}]}
-                  (lib.tu.mocks-31769/query))))))))
+    (is (=? {:stages [{:source-card 1}
+                      {:joins [{:stages     [{:source-card 2}]
+                                :fields     :all
+                                :conditions [[:=
+                                              {}
+                                              [:field {:base-type :type/Text} "Products__CATEGORY"]
+                                              [:field {:join-alias "Card 2 - Category"} (meta/id :products :category)]]]
+                                :alias      "Card 2 - Category"}]
+                       :limit 2}]}
+            (lib.tu.mocks-31769/query)))))
 
 (deftest ^:parallel suggested-name-include-joins-test
   (testing "Include the names of joined tables in suggested query names (#24703)"

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -487,27 +487,26 @@
                   (lib/order-bys query'))))))))
 
 (deftest ^:parallel orderable-columns-with-source-card-e2e-test
-  (binding [lib.card/*force-broken-card-refs* false]
-    (testing "Make sure you can order by a column that comes from a source Card (Saved Question/Model/etc)"
-      (let [query (lib.tu/query-with-source-card)]
-        (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
-          (let [name-col (m/find-first #(= (:name %) "USER_ID")
-                                       (lib/orderable-columns query))]
-            (is (=? {:name      "USER_ID"
-                     :base-type :type/Integer}
-                    name-col))
-            (let [query' (lib/order-by query name-col)]
-              (is (=? {:stages
-                       [{:source-card 1
-                         :order-by    [[:asc
-                                        {}
-                                        [:field {:base-type :type/Integer} "USER_ID"]]]}]}
-                      query'))
-              (is (= "My Card, Sorted by User ID ascending"
-                     (lib/describe-query query')))
-              (is (= ["User ID ascending"]
-                     (for [order-by (lib/order-bys query')]
-                       (lib/display-name query' order-by)))))))))))
+  (testing "Make sure you can order by a column that comes from a source Card (Saved Question/Model/etc)"
+    (let [query (lib.tu/query-with-source-card)]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (let [name-col (m/find-first #(= (:name %) "USER_ID")
+                                     (lib/orderable-columns query))]
+          (is (=? {:name      "USER_ID"
+                   :base-type :type/Integer}
+                  name-col))
+          (let [query' (lib/order-by query name-col)]
+            (is (=? {:stages
+                     [{:source-card 1
+                       :order-by    [[:asc
+                                      {}
+                                      [:field {:base-type :type/Integer} "USER_ID"]]]}]}
+                    query'))
+            (is (= "My Card, Sorted by User ID ascending"
+                   (lib/describe-query query')))
+            (is (= ["User ID ascending"]
+                   (for [order-by (lib/order-bys query')]
+                     (lib/display-name query' order-by))))))))))
 
 (deftest ^:parallel orderable-columns-with-join-test
   (is (=? [{:name                     "ID"

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -3,7 +3,6 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as m]
-   [metabase.lib.card :as lib.card]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -4,7 +4,6 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is]]
    [medley.core :as m]
-   [metabase.lib.card :as lib.card]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -362,9 +362,7 @@
                        (throw (ex-info (str "No column named " (pr-str column-name) "; found: " (pr-str col-names))
                                        {:column column-name
                                         :found  col-names}))))]
-    (lib/ref (cond-> metadata
-               ;; This forces a string column in the presence of force-broken-id-refs
-               (::lib.card/force-broken-id-refs metadata) (dissoc :id)))))
+    (lib/ref metadata)))
 
 (mu/defn query-with-stage-metadata-from-card :- ::lib.schema/query
   "Convenience for creating a query that has `:lib/metadata` stage metadata attached to it from a Card. Note that this

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -3,7 +3,6 @@
    [clojure.test :refer :all]
    [malli.error :as me]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
-   [metabase.lib.card :as lib.card]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -92,68 +92,67 @@
               (lib.metadata.calculation/returned-columns mlv2-query))))))
 
 (deftest ^:synchronized with-temp-source-question-metadata-test
-  (binding [lib.card/*force-broken-card-refs* false]
-    #_{:clj-kondo/ignore [:discouraged-var]}
-    (mt/with-temp [:model/Card card {:dataset_query
-                                     (mt/mbql-query venues
-                                       {:joins
-                                        [{:source-table $$categories
-                                          :condition    [:= $category_id &c.categories.id]
-                                          :fields       :all
-                                          :alias        "c"}]})}]
-      (let [query      {:database (mt/id)
-                        :type     :query
-                        :query    {:source-card (u/the-id card)}}
-            mlv2-query (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-                                  (lib.convert/->pMBQL query))
-            breakouts  (lib/breakoutable-columns mlv2-query)
-            agg-query  (-> mlv2-query
-                           (lib/breakout (second breakouts))
-                           (lib/breakout (peek breakouts)))]
-        (is (=? [{:display-name      "ID"
-                  :long-display-name "ID"
-                  :effective-type    :type/BigInteger
-                  :semantic-type     :type/PK}
-                 {:display-name      "Name"
-                  :long-display-name "Name"
-                  :effective-type    :type/Text
-                  :semantic-type     :type/Name}
-                 {:display-name      "Category ID"
-                  :long-display-name "Category ID"
-                  :effective-type    :type/Integer
-                  :semantic-type     :type/FK}
-                 {:display-name      "Latitude"
-                  :long-display-name "Latitude"
-                  :effective-type    :type/Float
-                  :semantic-type     :type/Latitude}
-                 {:display-name      "Longitude"
-                  :long-display-name "Longitude"
-                  :effective-type    :type/Float
-                  :semantic-type     :type/Longitude}
-                 {:display-name      "Price"
-                  :long-display-name "Price"
-                  :effective-type    :type/Integer
-                  :semantic-type     :type/Category}
-                 {:display-name      "c → ID"
-                  :long-display-name "c → ID"
-                  :effective-type    :type/BigInteger
-                  :semantic-type     :type/PK}
-                 {:display-name      "c → Name"
-                  :long-display-name "c → Name"
-                  :effective-type    :type/Text
-                  :semantic-type     :type/Name}]
-                (map #(lib/display-info mlv2-query %)
-                     (lib.metadata.calculation/returned-columns mlv2-query))))
-        (is (=? [{:display-name      "Name"
-                  :long-display-name "Name"
-                  :effective-type    :type/Text
-                  :semantic-type     :type/Name}
-                 {:display-name      "c → Name"
-                  :long-display-name "c → Name"
-                  :effective-type    :type/Text
-                  :semantic-type     :type/Name}]
-                (map #(lib/display-info agg-query %)
-                     (lib.metadata.calculation/returned-columns agg-query))))))))
+  #_{:clj-kondo/ignore [:discouraged-var]}
+  (mt/with-temp [:model/Card card {:dataset_query
+                                   (mt/mbql-query venues
+                                     {:joins
+                                      [{:source-table $$categories
+                                        :condition    [:= $category_id &c.categories.id]
+                                        :fields       :all
+                                        :alias        "c"}]})}]
+    (let [query      {:database (mt/id)
+                      :type     :query
+                      :query    {:source-card (u/the-id card)}}
+          mlv2-query (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                                (lib.convert/->pMBQL query))
+          breakouts  (lib/breakoutable-columns mlv2-query)
+          agg-query  (-> mlv2-query
+                         (lib/breakout (second breakouts))
+                         (lib/breakout (peek breakouts)))]
+      (is (=? [{:display-name      "ID"
+                :long-display-name "ID"
+                :effective-type    :type/BigInteger
+                :semantic-type     :type/PK}
+               {:display-name      "Name"
+                :long-display-name "Name"
+                :effective-type    :type/Text
+                :semantic-type     :type/Name}
+               {:display-name      "Category ID"
+                :long-display-name "Category ID"
+                :effective-type    :type/Integer
+                :semantic-type     :type/FK}
+               {:display-name      "Latitude"
+                :long-display-name "Latitude"
+                :effective-type    :type/Float
+                :semantic-type     :type/Latitude}
+               {:display-name      "Longitude"
+                :long-display-name "Longitude"
+                :effective-type    :type/Float
+                :semantic-type     :type/Longitude}
+               {:display-name      "Price"
+                :long-display-name "Price"
+                :effective-type    :type/Integer
+                :semantic-type     :type/Category}
+               {:display-name      "c → ID"
+                :long-display-name "c → ID"
+                :effective-type    :type/BigInteger
+                :semantic-type     :type/PK}
+               {:display-name      "c → Name"
+                :long-display-name "c → Name"
+                :effective-type    :type/Text
+                :semantic-type     :type/Name}]
+              (map #(lib/display-info mlv2-query %)
+                   (lib.metadata.calculation/returned-columns mlv2-query))))
+      (is (=? [{:display-name      "Name"
+                :long-display-name "Name"
+                :effective-type    :type/Text
+                :semantic-type     :type/Name}
+               {:display-name      "c → Name"
+                :long-display-name "c → Name"
+                :effective-type    :type/Text
+                :semantic-type     :type/Name}]
+              (map #(lib/display-info agg-query %)
+                   (lib.metadata.calculation/returned-columns agg-query)))))))
 
 (deftest ^:synchronized external-remap-metadata-test
   (mt/with-column-remappings [venues.id categories.name]


### PR DESCRIPTION
`force-broken-id-refs` is no longer used, so let's remove it to simplify things