### PR TITLE
Fix brush filter for visualizer charts

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
@@ -198,7 +198,7 @@ describe("scenarios > dashboard > visualizer > drillthrough", () => {
     H.assertQueryBuilderRowCount(1);
   });
 
-  it("should allow brus filtering single-series timeseries charts (VIZ-979)", () => {
+  it("should allow brush filtering single-series timeseries charts (VIZ-979)", () => {
     createDashboardWithVisualizerDashcards();
 
     // Ensure the brush is disabled for multi-series charts

--- a/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
@@ -197,4 +197,42 @@ describe("scenarios > dashboard > visualizer > drillthrough", () => {
     H.tableInteractiveHeader().findByText("Views").should("exist");
     H.assertQueryBuilderRowCount(1);
   });
+
+  it("should allow brus filtering single-series timeseries charts (VIZ-979)", () => {
+    createDashboardWithVisualizerDashcards();
+
+    // Ensure the brush is disabled for multi-series charts
+    H.getDashboardCard(0).within(() => {
+      cy.findAllByText("Count").should("have.length", 2);
+      cy.findAllByText("Count (Products by Created At (Month))").should(
+        "have.length",
+        2,
+      );
+      applyBrush(200, 300);
+      cy.get("@dataset.all").should("have.length", 0);
+    });
+
+    H.getDashboardCard(3).within(() => {
+      applyBrush(200, 300);
+      cy.wait("@dataset");
+    });
+
+    H.queryBuilderFiltersPanel()
+      .findByText(/Created At is May 1/)
+      .should("exist");
+    H.assertQueryBuilderRowCount(9);
+    H.queryBuilderMain().within(() => {
+      cy.findByText("Count").should("exist"); // y-axis
+      cy.findByText("Created At: Month").should("exist"); // x-axis
+      cy.findByText("May 2023").should("exist");
+      cy.findByText("December 2023").should("exist");
+    });
+  });
 });
+
+function applyBrush(left: number, right: number) {
+  H.echartsContainer()
+    .trigger("mousedown", left, 100)
+    .trigger("mousemove", left, 100)
+    .trigger("mouseup", right, 100);
+}

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -223,7 +223,7 @@ export const useChartEvents = (
         eventName: "brushEnd",
         handler: (event: EChartsSeriesBrushEndEvent) => {
           const eventData = getBrushData(
-            rawSeries,
+            isVisualizerViz ? visualizerRawSeries : rawSeries,
             metadata,
             chartModel,
             event,
@@ -250,6 +250,8 @@ export const useChartEvents = (
       onDeselectTimelineEvents,
       onOpenQuestion,
       rawSeries,
+      visualizerRawSeries,
+      isVisualizerViz,
       metadata,
       onChangeCardAndRun,
     ],


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57899
Fixes brush filtering for cartesian charts made in the visualizer. It now works as expected for single-series charts and is disabled for multi-series charts (similarly to how it was handled for dashcards made with the "add series" modal).

### Demo

https://github.com/user-attachments/assets/225c1a2e-1dee-4e0b-a584-c2e2a34aaa15

