### PR TITLE
Surface Group API error messages, update components

### DIFF
--- a/frontend/src/metabase/admin/people/components/GroupsListing.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.tsx
@@ -1,9 +1,10 @@
 import { useDisclosure } from "@mantine/hooks";
-import { Component } from "react";
+import { useState } from "react";
 import { jt, t } from "ttag";
 import _ from "underscore";
 
 import { useListApiKeysQuery } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import { AdminContentTable } from "metabase/components/AdminContentTable";
 import { AdminPaneLayout } from "metabase/components/AdminPaneLayout";
 import Alert from "metabase/components/Alert";
@@ -374,95 +375,63 @@ interface GroupsListingProps {
   delete: (group: GroupInfo, groupCount: number) => Promise<void>;
 }
 
-interface GroupsListingState {
-  text: string;
-  showAddGroupRow: boolean;
-  groupBeingEdited: GroupInfo | null;
-  alertMessage: string | null;
-}
+export const GroupsListing = (props: GroupsListingProps) => {
+  const [text, setText] = useState("");
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
+  const [groupBeingEdited, setGroupBeingEdited] = useState<GroupInfo | null>(
+    null,
+  );
+  const [
+    isShowingAddGroupRow,
+    { open: showAddGroupRow, close: hideAddGroupRow },
+  ] = useDisclosure(false);
 
-export class GroupsListing extends Component<
-  GroupsListingProps,
-  GroupsListingState
-> {
-  constructor(props: GroupsListingProps, context: any) {
-    super(props, context);
-    this.state = {
-      text: "",
-      showAddGroupRow: false,
-      groupBeingEdited: null,
-      alertMessage: null,
-    };
-  }
+  const onAddGroupCanceled = () => {
+    hideAddGroupRow();
+  };
 
-  alert(alertMessage: string) {
-    this.setState({ alertMessage });
-  }
-
-  onAddGroupCanceled() {
-    this.setState({
-      showAddGroupRow: false,
-    });
-  }
-
-  async onAddGroupCreateButtonClicked() {
+  const onAddGroupCreateButtonClicked = async () => {
+    const { create } = props;
     try {
-      await this.props.create({ name: this.state.text.trim() });
-      this.setState({
-        showAddGroupRow: false,
-        text: "",
-      });
+      await create({ name: text.trim() });
+      hideAddGroupRow();
+      setText("");
     } catch (error: any) {
       console.error("Error creating group:", error);
-      if (error.data && typeof error.data === "string") {
-        this.alert(error.data);
+      if (error.data) {
+        const errorMessage = getErrorMessage(error);
+        setAlertMessage(errorMessage);
       }
     }
-  }
+  };
 
-  onAddGroupTextChanged(newText: string) {
-    this.setState({
-      text: newText,
-    });
-  }
+  const onCreateAGroupButtonClicked = () => {
+    setText("");
+    showAddGroupRow();
+    setGroupBeingEdited(null);
+  };
 
-  onCreateAGroupButtonClicked() {
-    this.setState({
-      text: "",
-      showAddGroupRow: true,
-      groupBeingEdited: null,
-    });
-  }
+  const onEditGroupClicked = (group: GroupInfo) => {
+    setGroupBeingEdited({ ...group });
+    setText("");
+    hideAddGroupRow();
+  };
 
-  onEditGroupClicked(group: GroupInfo) {
-    this.setState({
-      groupBeingEdited: { ...group },
-      text: "",
-      showAddGroupRow: false,
-    });
-  }
-
-  onEditGroupTextChange(newText: string) {
-    const { groupBeingEdited } = this.state;
-
+  const onEditGroupTextChange = (newText: string) => {
     if (!groupBeingEdited) {
       throw new Error("Group being edited not found");
     }
 
-    this.setState({
-      groupBeingEdited: { ...groupBeingEdited, name: newText },
-    });
-  }
+    setGroupBeingEdited({ ...groupBeingEdited, name: newText });
+  };
 
-  onEditGroupCancelClicked() {
-    this.setState({
-      groupBeingEdited: null,
-    });
-  }
+  const onEditGroupCancelClicked = () => {
+    setGroupBeingEdited(null);
+  };
 
-  async onEditGroupDoneClicked() {
-    const { groups } = this.props;
-    const group = this.state.groupBeingEdited;
+  const onEditGroupDoneClicked = async () => {
+    const { groups, update } = props;
+    const group = groupBeingEdited;
 
     if (!group) {
       throw new Error("There is currently no group being edited");
@@ -480,70 +449,61 @@ export class GroupsListing extends Component<
 
     // if name hasn't changed there is nothing to do
     if (originalGroup.name === group.name) {
-      this.setState({ groupBeingEdited: null });
+      setGroupBeingEdited(null);
     } else {
       // ok, fire off API call to change the group
       try {
-        await this.props.update({ id: group.id, name: group.name.trim() });
-        this.setState({ groupBeingEdited: null });
+        await update({ id: group.id, name: group.name.trim() });
+        setGroupBeingEdited(null);
       } catch (error: any) {
         console.error("Error updating group name:", error);
-        if (error.data && typeof error.data === "string") {
-          this.alert(error.data);
-        }
+        const errorMessage = getErrorMessage(error);
+
+        setAlertMessage(errorMessage);
       }
     }
-  }
+  };
 
-  async onDeleteGroupClicked(groups: GroupInfo[], group: GroupInfo) {
+  const onDeleteGroupClicked = async (
+    groups: GroupInfo[],
+    group: GroupInfo,
+  ) => {
     try {
-      await this.props.delete(group, groups.length);
+      await props.delete(group, groups.length);
     } catch (error: any) {
       console.error("Error deleting group: ", error);
-      if (error.data && typeof error.data === "string") {
-        this.alert(error.data);
-      }
+      const errorMessage = getErrorMessage(error);
+
+      setAlertMessage(errorMessage);
     }
-  }
+  };
 
-  render() {
-    const { groups, isAdmin } = this.props;
-    const { alertMessage } = this.state;
+  const { groups, isAdmin } = props;
 
-    return (
-      <AdminPaneLayout
-        title={t`Groups`}
-        buttonText={isAdmin ? t`Create a group` : undefined}
-        buttonAction={
-          this.state.showAddGroupRow
-            ? undefined
-            : this.onCreateAGroupButtonClicked.bind(this)
-        }
-        description={t`You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed.`}
-      >
-        <GroupsTable
-          groups={groups}
-          text={this.state.text}
-          showAddGroupRow={this.state.showAddGroupRow}
-          groupBeingEdited={this.state.groupBeingEdited}
-          onAddGroupCanceled={this.onAddGroupCanceled.bind(this)}
-          onAddGroupCreateButtonClicked={this.onAddGroupCreateButtonClicked.bind(
-            this,
-          )}
-          onAddGroupTextChanged={this.onAddGroupTextChanged.bind(this)}
-          onEditGroupClicked={this.onEditGroupClicked.bind(this)}
-          onEditGroupTextChange={this.onEditGroupTextChange.bind(this)}
-          onEditGroupCancelClicked={this.onEditGroupCancelClicked.bind(this)}
-          onEditGroupDoneClicked={this.onEditGroupDoneClicked.bind(this)}
-          onDeleteGroupClicked={(group) =>
-            this.onDeleteGroupClicked(groups, group)
-          }
-        />
-        <Alert
-          message={alertMessage}
-          onClose={() => this.setState({ alertMessage: null })}
-        />
-      </AdminPaneLayout>
-    );
-  }
-}
+  return (
+    <AdminPaneLayout
+      title={t`Groups`}
+      buttonText={isAdmin ? t`Create a group` : undefined}
+      buttonAction={
+        isShowingAddGroupRow ? undefined : onCreateAGroupButtonClicked
+      }
+      description={t`You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed.`}
+    >
+      <GroupsTable
+        groups={groups}
+        text={text}
+        showAddGroupRow={isShowingAddGroupRow}
+        groupBeingEdited={groupBeingEdited}
+        onAddGroupCanceled={onAddGroupCanceled}
+        onAddGroupCreateButtonClicked={onAddGroupCreateButtonClicked}
+        onAddGroupTextChanged={setText}
+        onEditGroupClicked={onEditGroupClicked}
+        onEditGroupTextChange={onEditGroupTextChange}
+        onEditGroupCancelClicked={onEditGroupCancelClicked}
+        onEditGroupDoneClicked={onEditGroupDoneClicked}
+        onDeleteGroupClicked={(group) => onDeleteGroupClicked(groups, group)}
+      />
+      <Alert message={alertMessage} onClose={() => setAlertMessage(null)} />
+    </AdminPaneLayout>
+  );
+};

--- a/frontend/src/metabase/admin/people/components/GroupsListing.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.tsx
@@ -7,7 +7,6 @@ import { useListApiKeysQuery } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { AdminContentTable } from "metabase/components/AdminContentTable";
 import { AdminPaneLayout } from "metabase/components/AdminPaneLayout";
-import Alert from "metabase/components/Alert";
 import { ConfirmModal } from "metabase/components/ConfirmModal";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import UserAvatar from "metabase/components/UserAvatar";
@@ -390,6 +389,10 @@ export const GroupsListing = (props: GroupsListingProps) => {
     hideAddGroupRow();
   };
 
+  const onDismissAlert = () => {
+    setAlertMessage(null);
+  };
+
   const onAddGroupCreateButtonClicked = async () => {
     const { create } = props;
     try {
@@ -503,7 +506,17 @@ export const GroupsListing = (props: GroupsListingProps) => {
         onEditGroupDoneClicked={onEditGroupDoneClicked}
         onDeleteGroupClicked={(group) => onDeleteGroupClicked(groups, group)}
       />
-      <Alert message={alertMessage} onClose={() => setAlertMessage(null)} />
+      <ConfirmModal
+        onClose={onDismissAlert}
+        onConfirm={onDismissAlert}
+        opened={!!alertMessage}
+        message={alertMessage}
+        closeButtonText={null}
+        withCloseButton={false}
+        confirmButtonText={t`Ok`}
+        confirmButtonProps={{ color: "brand" }}
+        data-testid="alert-modal"
+      />
     </AdminPaneLayout>
   );
 };

--- a/frontend/src/metabase/components/Alert/Alert.jsx
+++ b/frontend/src/metabase/components/Alert/Alert.jsx
@@ -2,18 +2,27 @@
 import cx from "classnames";
 import { t } from "ttag";
 
-import Modal from "metabase/components/Modal";
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";
+import { Button, Modal, Title } from "metabase/ui";
 
 const Alert = ({ message, onClose }) => (
-  <Modal small isOpen={!!message}>
+  <Modal
+    size="md"
+    opened={!!message}
+    withCloseButton={false}
+    padding="0"
+    data-testid="alert-modal"
+  >
     <div className={cx(CS.flex, CS.flexColumn, CS.layoutCentered, CS.p4)}>
-      <h3 className={CS.mb4}>{message}</h3>
-      <button
+      <Title order={3} className={cx(CS.mb2, CS.textWrap)}>
+        {message}
+      </Title>
+      <Button
         className={cx(ButtonsS.Button, ButtonsS.ButtonPrimary)}
+        variant="primary"
         onClick={onClose}
-      >{t`Ok`}</button>
+      >{t`Ok`}</Button>
     </div>
   </Modal>
 );

--- a/frontend/src/metabase/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/metabase/components/ConfirmModal/ConfirmModal.tsx
@@ -12,7 +12,7 @@ import {
 } from "metabase/ui";
 
 interface ConfirmModal extends ModalProps {
-  title: string | ReactNode;
+  title?: string | ReactNode;
   content?: string;
   message?: string | ReactNode;
   onConfirm?: () => void | Promise<void>;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52886

### Description
Surfaces the error messages returned by the groups API when greating / editing / deleting groups. These alerts always existed, but the error payload was different from what the components were expecting. This PR updates the top component to a functional component, and updates the `Alert` component to use the Mantine Modal.

### How to verify
1. Admin -> People -> Groups
2. Try to create a group with a super long name. eg: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` (more than 256 chars).
3. You should see an error pop up that you can dismiss.
4. Try editing an existing group with the same name, and you should also see an error

### Demo
<img width="961" alt="image" src="https://github.com/user-attachments/assets/f557912a-c479-4fd6-bc65-2b51d7b80a41" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
