### PR TITLE
Add Clickhouse UUID cast implementation for native filtering

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -6,6 +6,7 @@
    [metabase.driver.clickhouse-nippy]
    [metabase.driver.clickhouse-version :as clickhouse-version]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
    [metabase.driver.sql.query-processor :as sql.qp :refer [add-interval-honeysql-form]]
    [metabase.driver.sql.util :as sql.u]
    [metabase.legacy-mbql.util :as mbql.u]
@@ -23,7 +24,7 @@
     OffsetDateTime
     OffsetTime
     ZonedDateTime]
-   java.util.Arrays))
+   [java.util Arrays UUID]))
 
 ;; (set! *warn-on-reflection* true) ;; isn't enabled because of Arrays/toString call
 
@@ -598,3 +599,7 @@
 (defmethod sql.qp/inline-value [:clickhouse ZonedDateTime]
   [_ t]
   (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSSZZZZZ" t)))
+
+(defmethod sql.params.substitution/->replacement-snippet-info [:clickhouse UUID]
+  [_driver this]
+  {:replacement-snippet (format "CAST('%s' AS UUID)" (str this))})

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -338,31 +338,33 @@
 
 (deftest clickhouse-native-query-with-uuid-filter-test
   (mt/test-driver :clickhouse
-    (mt/dataset
-      (mt/dataset-definition "uuid_filter_db"
-                             ["uuid_filter_table"
-                              [{:field-name "uuid"
-                                :base-type {:native "UUID"}
-                                :semantic-type :type/PK}
-                               {:field-name "value"
-                                :base-type :type/Integer}]
-                              [[#uuid "e8670ee0-3f9f-4324-8f37-3dc5f7703f41" 10]
-                               [#uuid "e8670ee0-3f9f-4324-8f37-3dc5f7703f42" 20]]])
-      (let [query {:database   (mt/id)
-                   :type       :native
-                   :native     {:query         "select sum(value) from `uuid_filter_db`.`uuid_filter_table` where {{uuid}}"
-                                :template-tags {"uuid" {:type         :dimension
-                                                        :dimension    ["field" (mt/id :uuid_filter_table :uuid) nil]
-                                                        :default      ["e8670ee0-3f9f-4324-8f37-3dc5f7703f42"]
-                                                        :name         "uuid"
-                                                        :display-name "UUID"
-                                                        :widget-type  "id"}}}
-                   :parameters [{:type   "id"
-                                 :target [:dimension [:template-tag "uuid"]]
-                                 :value  ["e8670ee0-3f9f-4324-8f37-3dc5f7703f42"]}]}]
-        (is (= [[20]]
-               (mt/formatted-rows [int]
-                                  (qp/process-query query))))
-        (is (= (str "select sum(value) from `uuid_filter_db`.`uuid_filter_table` "
-                    "where `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('e8670ee0-3f9f-4324-8f37-3dc5f7703f42' AS UUID))")
-               (:query (qp.compile/compile-with-inline-parameters query))))))))
+    (let [uuid-1 (random-uuid)
+          uuid-2 (random-uuid)]
+      (mt/dataset
+        (mt/dataset-definition "uuid_filter_db"
+                               ["uuid_filter_table"
+                                [{:field-name "uuid"
+                                  :base-type {:native "UUID"}
+                                  :semantic-type :type/PK}
+                                 {:field-name "value"
+                                  :base-type :type/Integer}]
+                                [[uuid-1 10]
+                                 [uuid-2 20]]])
+        (let [query {:database   (mt/id)
+                     :type       :native
+                     :native     {:query         "select sum(value) from `uuid_filter_db`.`uuid_filter_table` where {{uuid}}"
+                                  :template-tags {"uuid" {:type         :dimension
+                                                          :dimension    ["field" (mt/id :uuid_filter_table :uuid) nil]
+                                                          :default      [(str uuid-2)]
+                                                          :name         "uuid"
+                                                          :display-name "UUID"
+                                                          :widget-type  "id"}}}
+                     :parameters [{:type   "id"
+                                   :target [:dimension [:template-tag "uuid"]]
+                                   :value  [(str uuid-2)]}]}]
+          (is (= [[20]]
+                 (mt/formatted-rows [int]
+                                    (qp/process-query query))))
+          (is (= (str "select sum(value) from `uuid_filter_db`.`uuid_filter_table` "
+                      (format "where `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('%s' AS UUID))" uuid-2))
+                 (:query (qp.compile/compile-with-inline-parameters query)))))))))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
    [metabase.test.data.clickhouse :as ctd]
    [metabase.util :as u]
@@ -334,3 +335,34 @@
                                         :value "Gizmo"
                                         :target ["variable" ["template-tag" "x"]]
                                         :id uuid}]}))))))))
+
+(deftest clickhouse-native-query-with-uuid-filter-test
+  (mt/test-driver :clickhouse
+    (mt/dataset
+      (mt/dataset-definition "uuid_filter_db"
+                             ["uuid_filter_table"
+                              [{:field-name "uuid"
+                                :base-type {:native "UUID"}
+                                :semantic-type :type/PK}
+                               {:field-name "value"
+                                :base-type :type/Integer}]
+                              [[#uuid "e8670ee0-3f9f-4324-8f37-3dc5f7703f41" 10]
+                               [#uuid "e8670ee0-3f9f-4324-8f37-3dc5f7703f42" 20]]])
+      (let [query {:database   (mt/id)
+                   :type       :native
+                   :native     {:query         "select sum(value) from `uuid_filter_db`.`uuid_filter_table` where {{uuid}}"
+                                :template-tags {"uuid" {:type         :dimension
+                                                        :dimension    ["field" (mt/id :uuid_filter_table :uuid) nil]
+                                                        :default      ["e8670ee0-3f9f-4324-8f37-3dc5f7703f42"]
+                                                        :name         "uuid"
+                                                        :display-name "UUID"
+                                                        :widget-type  "id"}}}
+                   :parameters [{:type   "id"
+                                 :target [:dimension [:template-tag "uuid"]]
+                                 :value  ["e8670ee0-3f9f-4324-8f37-3dc5f7703f42"]}]}]
+        (is (= [[20]]
+               (mt/formatted-rows [int]
+                                  (qp/process-query query))))
+        (is (= (str "select sum(value) from `uuid_filter_db`.`uuid_filter_table` "
+                    "where `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('e8670ee0-3f9f-4324-8f37-3dc5f7703f42' AS UUID))")
+               (:query (qp.compile/compile-with-inline-parameters query))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58461
Closes https://github.com/metabase/metabase/issues/58398

### Description

Adds a ClickHouse implementation for `sql.params.substitution/->replacement-snippet-info`

### How to verify

1. Follow the repro steps in https://github.com/metabase/metabase/issues/58461
2. It should work as expected

### Demo

<details>

<summary>
demo
</summary>

https://github.com/user-attachments/assets/e7678162-9e49-43f8-ba1c-0dea63c7f0df

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
