### PR TITLE
Localize content of dashboard text cards

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/text-cards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/text-cards.cy.spec.ts
@@ -6,67 +6,73 @@ import { uploadTranslationDictionary } from "./helpers/e2e-content-translation-h
 const { H } = cy;
 
 describe("scenarios > dashboard > content translation of text cards and headings", () => {
-  const textCardTranslations: DictionaryArray = [
-    { locale: "de", msgid: "Sample Text", msgstr: "Beispieltext" },
-    { locale: "de", msgid: "Sample Heading", msgstr: "Beispielüberschrift" },
-    {
-      locale: "de",
-      msgid: "Category is {{category}}",
-      msgstr: "Kategorie ist {{category}}",
-    },
-  ];
+  describe("ee", () => {
+    const textCardTranslations: DictionaryArray = [
+      { locale: "de", msgid: "Sample Text", msgstr: "Beispieltext" },
+      { locale: "de", msgid: "Sample Heading", msgstr: "Beispielüberschrift" },
+      {
+        locale: "de",
+        msgid: "Category is {{category}}",
+        msgstr: "Kategorie ist {{category}}",
+      },
+    ];
+    before(() => {
+      H.restore();
+      cy.intercept("POST", "api/ee/content-translation/upload-dictionary").as(
+        "uploadDictionary",
+      );
+      cy.signInAsAdmin();
+      H.setTokenFeatures("all");
 
-  beforeEach(() => {
-    cy.intercept("POST", "api/ee/content-translation/upload-dictionary").as(
-      "uploadDictionary",
-    );
-    H.restore();
-    cy.signInAsAdmin();
-    H.setTokenFeatures("all");
+      cy.log("Upload sample translation dictionary");
+      uploadTranslationDictionary(textCardTranslations);
 
-    cy.log("Upload sample translation dictionary");
-    uploadTranslationDictionary(textCardTranslations);
-
-    cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, { locale: "de" });
-  });
-
-  it("should translate text in dashboard text cards", () => {
-    H.createDashboard().then(({ body: { id: dashboardId } }) => {
-      H.visitDashboard(dashboardId);
-
-      H.editDashboard();
-      H.addTextBoxWhileEditing("Sample Text", {
-        parseSpecialCharSequences: false,
-      });
-
-      H.saveDashboard();
-
-      H.getDashboardCard(0).findByText("Beispieltext").should("be.visible");
-
-      H.editDashboard();
-      H.getDashboardCard(0).click();
-      cy.get("textarea").should("have.value", "Category");
+      cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, { locale: "de" });
+      H.snapshot("translations-uploaded");
     });
-  });
 
-  it("should translate text in dashboard heading cards", () => {
-    H.createDashboard().then(({ body: { id: dashboardId } }) => {
-      H.visitDashboard(dashboardId);
+    beforeEach(() => {
+      H.restore("translations-uploaded" as any);
+    });
 
-      H.editDashboard();
-      H.addHeadingWhileEditing("Sample Heading", {
-        parseSpecialCharSequences: false,
+    it("should translate text in dashboard text cards", () => {
+      H.createDashboard().then(({ body: { id: dashboardId } }) => {
+        H.visitDashboard(dashboardId);
+
+        H.editDashboard();
+        H.addTextBoxWhileEditing("Sample Text", {
+          parseSpecialCharSequences: false,
+        });
+
+        H.saveDashboard();
+
+        H.getDashboardCard(0).findByText("Beispieltext").should("be.visible");
+
+        H.editDashboard();
+        H.getDashboardCard(0).click();
+        cy.get("textarea").should("have.value", "Category");
       });
+    });
 
-      H.saveDashboard();
+    it("should translate text in dashboard heading cards", () => {
+      H.createDashboard().then(({ body: { id: dashboardId } }) => {
+        H.visitDashboard(dashboardId);
 
-      H.getDashboardCard(0)
-        .findByText("Beispielüberschrift")
-        .should("be.visible");
+        H.editDashboard();
+        H.addHeadingWhileEditing("Sample Heading", {
+          parseSpecialCharSequences: false,
+        });
 
-      H.editDashboard();
-      H.getDashboardCard(0).click();
-      cy.get("input").should("have.value", "Sample Heading");
+        H.saveDashboard();
+
+        H.getDashboardCard(0)
+          .findByText("Beispielüberschrift")
+          .should("be.visible");
+
+        H.editDashboard();
+        H.getDashboardCard(0).click();
+        cy.get("input").should("have.value", "Sample Heading");
+      });
     });
   });
 });

--- a/e2e/test/scenarios/admin/i18n/content-translation/text-cards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/text-cards.cy.spec.ts
@@ -1,21 +1,17 @@
 import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
-import type { DictionaryArray } from "metabase/i18n/types";
+import type { DictionaryArray } from "metabase-types/api";
 
 import { uploadTranslationDictionary } from "./helpers/e2e-content-translation-helpers";
 
 const { H } = cy;
 
+const textCardTranslations: DictionaryArray = [
+  { locale: "de", msgid: "Sample Text", msgstr: "Beispieltext" },
+  { locale: "de", msgid: "Sample Heading", msgstr: "Beispielüberschrift" },
+];
+
 describe("scenarios > dashboard > content translation of text cards and headings", () => {
   describe("ee", () => {
-    const textCardTranslations: DictionaryArray = [
-      { locale: "de", msgid: "Sample Text", msgstr: "Beispieltext" },
-      { locale: "de", msgid: "Sample Heading", msgstr: "Beispielüberschrift" },
-      {
-        locale: "de",
-        msgid: "Category is {{category}}",
-        msgstr: "Kategorie ist {{category}}",
-      },
-    ];
     before(() => {
       H.restore();
       cy.intercept("POST", "api/ee/content-translation/upload-dictionary").as(

--- a/e2e/test/scenarios/admin/i18n/content-translation/text-cards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/text-cards.cy.spec.ts
@@ -1,0 +1,72 @@
+import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
+import type { DictionaryArray } from "metabase/i18n/types";
+
+import { uploadTranslationDictionary } from "./helpers/e2e-content-translation-helpers";
+
+const { H } = cy;
+
+describe("scenarios > dashboard > content translation of text cards and headings", () => {
+  const textCardTranslations: DictionaryArray = [
+    { locale: "de", msgid: "Sample Text", msgstr: "Beispieltext" },
+    { locale: "de", msgid: "Sample Heading", msgstr: "Beispielüberschrift" },
+    {
+      locale: "de",
+      msgid: "Category is {{category}}",
+      msgstr: "Kategorie ist {{category}}",
+    },
+  ];
+
+  beforeEach(() => {
+    cy.intercept("POST", "api/ee/content-translation/upload-dictionary").as(
+      "uploadDictionary",
+    );
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+
+    cy.log("Upload sample translation dictionary");
+    uploadTranslationDictionary(textCardTranslations);
+
+    cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, { locale: "de" });
+  });
+
+  it("should translate text in dashboard text cards", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+
+      H.editDashboard();
+      H.addTextBoxWhileEditing("Sample Text", {
+        parseSpecialCharSequences: false,
+      });
+
+      H.saveDashboard();
+
+      H.getDashboardCard(0).findByText("Beispieltext").should("be.visible");
+
+      H.editDashboard();
+      H.getDashboardCard(0).click();
+      cy.get("textarea").should("have.value", "Category");
+    });
+  });
+
+  it("should translate text in dashboard heading cards", () => {
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.visitDashboard(dashboardId);
+
+      H.editDashboard();
+      H.addHeadingWhileEditing("Sample Heading", {
+        parseSpecialCharSequences: false,
+      });
+
+      H.saveDashboard();
+
+      H.getDashboardCard(0)
+        .findByText("Beispielüberschrift")
+        .should("be.visible");
+
+      H.editDashboard();
+      H.getDashboardCard(0).click();
+      cy.get("input").should("have.value", "Sample Heading");
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -4,8 +4,10 @@ import { t } from "ttag";
 
 import { getParameterValues } from "metabase/dashboard/selectors";
 import { useToggle } from "metabase/hooks/use-toggle";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { isEmpty } from "metabase/lib/validate";
+import { TextInput } from "metabase/ui";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 import type {
   Dashboard,
@@ -17,7 +19,6 @@ import {
   HeadingContainer,
   HeadingContent,
   InputContainer,
-  TextInput,
 } from "./Heading.styled";
 
 interface HeadingProps {
@@ -38,6 +39,8 @@ export function Heading({
   const parameterValues = useSelector(getParameterValues);
   const justAdded = useMemo(() => dashcard?.justAdded || false, [dashcard]);
 
+  const tc = useTranslateContent();
+
   const [isFocused, { turnOn: toggleFocusOn, turnOff: toggleFocusOff }] =
     useToggle(justAdded);
   const isPreviewing = !isFocused;
@@ -45,6 +48,8 @@ export function Heading({
   const [textValue, setTextValue] = useState(settings.text);
   const preventDragging = (e: MouseEvent<HTMLInputElement>) =>
     e.stopPropagation();
+
+  const translatedText = useMemo(() => tc(settings.text), [settings.text, tc]);
 
   // handles a case when settings are updated externally
   useEffect(() => {
@@ -57,9 +62,9 @@ export function Heading({
         dashcard,
         dashboard,
         parameterValues,
-        text: settings.text,
+        text: translatedText,
       }),
-    [dashcard, dashboard, parameterValues, settings.text],
+    [dashcard, dashboard, parameterValues, translatedText],
   );
 
   const hasContent = !isEmpty(settings.text);

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -9,15 +9,16 @@ import { t } from "ttag";
 import CS from "metabase/css/core/index.css";
 import { getParameterValues } from "metabase/dashboard/selectors";
 import { useToggle } from "metabase/hooks/use-toggle";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { isEmpty } from "metabase/lib/validate";
+import { TextInput } from "metabase/ui";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 
 import {
   DisplayContainer,
   EditModeContainer,
   ReactMarkdownStyleWrapper,
-  TextInput,
 } from "./Text.styled";
 
 const getSettingsStyle = (settings) => ({
@@ -46,6 +47,9 @@ export function Text({
   const justAdded = useMemo(() => dashcard?.justAdded || false, [dashcard]);
   const [textValue, setTextValue] = useState(settings.text);
 
+  const tc = useTranslateContent();
+  const translatedText = useMemo(() => tc(settings.text), [settings.text, tc]);
+
   const [isFocused, { turnOn: toggleFocusOn, turnOff: toggleFocusOff }] =
     useToggle(justAdded);
   const isPreviewing = !isFocused;
@@ -65,10 +69,10 @@ export function Text({
         dashcard,
         dashboard,
         parameterValues,
-        text: settings.text,
+        text: translatedText,
         escapeMarkdown: true,
       }),
-    [dashcard, dashboard, parameterValues, settings.text],
+    [dashcard, dashboard, parameterValues, translatedText],
   );
 
   const hasContent = !isEmpty(settings.text);

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -12,13 +12,13 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import { useTranslateContent } from "metabase/i18n/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { isEmpty } from "metabase/lib/validate";
-import { TextInput } from "metabase/ui";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 
 import {
   DisplayContainer,
   EditModeContainer,
   ReactMarkdownStyleWrapper,
+  TextInput,
 } from "./Text.styled";
 
 const getSettingsStyle = (settings) => ({


### PR DESCRIPTION
This PR localizes user-generated content in dashboard text cards and titles

On the left is the original text. On the right is a translation into German.
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/5b25bd59-9fbd-4300-b218-483ae76e16ee" />

To set up the translation, I uploaded the following dictionary in Admin / Settings / Localization:

```
"Language","String","Translation"
"de","Insights","Einblicke"
"de","It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of light, it was the season of darkness, it was the spring of hope, it was the winter of despair.","Es war die beste Zeit, es war die schlimmste Zeit, es war das Zeitalter der Weisheit, es war das Zeitalter der Dummheit, es war die Epoche des Glaubens, es war die Epoche des Unglaubens, es war die Jahreszeit des Lichts, es war die Jahreszeit der Dunkelheit, es war der Frühling der Hoffnung, es war der Winter der Verzweiflung."
```