### PR TITLE
Quick fix for locale in public/embedded dashboards

### DIFF
--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/PublicOrEmbeddedDashboardPage.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/PublicOrEmbeddedDashboardPage.tsx
@@ -8,6 +8,7 @@ import { useDashboardUrlQuery } from "metabase/dashboard/hooks/use-dashboard-url
 import { getDashboardComplete } from "metabase/dashboard/selectors";
 import { SetTitle } from "metabase/hoc/Title";
 import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
 
 import { PublicOrEmbeddedDashboard } from "../PublicOrEmbeddedDashboard";
@@ -48,6 +49,9 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
 
   const dashboard = useSelector(getDashboardComplete);
 
+  const shouldPassLocale =
+    canWhitelabel || PLUGIN_CONTENT_TRANSLATION.isEnabled;
+
   return (
     <>
       <SetTitle title={dashboard?.name} />
@@ -69,7 +73,7 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
         titled={titled}
         parameterQueryParams={parameterQueryParams}
         cardTitled={true}
-        locale={canWhitelabel ? locale : undefined}
+        locale={shouldPassLocale ? locale : undefined}
         withFooter={true}
       />
     </>


### PR DESCRIPTION
Pass the locale in public/embedded dashboards if user can whitelabel, or if content translation is enabled

Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1746626569296449?thread_ts=1746469768.417679&channel=C063Q3F1HPF&message_ts=1746626569.296449