### PR TITLE
Content translation: localize tab names in statically embedded dashboards

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboard-tab-names.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboard-tab-names.cy.spec.ts
@@ -1,0 +1,33 @@
+import {
+  NORMAL_USER_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
+import type { DictionaryArray } from "metabase/i18n/types";
+
+import { uploadTranslationDictionary } from "./helpers/e2e-content-translation-helpers";
+
+const { H } = cy;
+
+describe("scenarios > content translation > dashboard tab names", () => {
+  const textCardTranslations: DictionaryArray = [
+    { locale: "de", msgid: "Tab 1", msgstr: "Reiter 1" },
+  ];
+
+  beforeEach(() => {
+    cy.intercept("POST", "api/ee/content-translation/upload-dictionary").as(
+      "uploadDictionary",
+    );
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+    uploadTranslationDictionary(textCardTranslations);
+    cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, { locale: "de" });
+  });
+
+  it("should translate text in dashboard tab names", () => {
+    H.visitDashboardAndCreateTab({
+      dashboardId: ORDERS_DASHBOARD_ID,
+    });
+    cy.findByRole("tab", { name: "Reiter 1" });
+  });
+});

--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboard-tab-names.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboard-tab-names.cy.spec.ts
@@ -28,6 +28,7 @@ describe("scenarios > content translation > dashboard tab names", () => {
     H.visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
     });
+    cy.signInAsNormalUser();
     cy.findByRole("tab", { name: "Reiter 1" });
   });
 });

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -21,6 +21,7 @@ import {
 import { t } from "ttag";
 
 import ControlledPopoverWithTrigger from "metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { lighten } from "metabase/lib/colors";
 
 import type { TabContextType } from "../Tab";
@@ -218,17 +219,23 @@ export function RenameableTabButton({
   tabIndex,
   ...props
 }: RenameableTabButtonProps) {
+  const tc = useTranslateContent();
+
   const { value: selectedValue } = useContext(TabContext);
   const isSelected = props.value === selectedValue;
 
+  // Only translate the label if it is not editable
+  const maybeTranslatedLabelProp = canRename ? labelProp : tc(labelProp);
+
   const [label, setLabel] = useState(labelProp);
+
   const [prevLabel, setPrevLabel] = useState(label);
   const [isRenaming, setIsRenaming] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    setLabel(labelProp);
-  }, [labelProp]);
+    setLabel(maybeTranslatedLabelProp);
+  }, [maybeTranslatedLabelProp]);
 
   useEffect(() => {
     if (isRenaming) {


### PR DESCRIPTION
The goal is to localize the tab name in statically embedded dashboards, but by design this will also cause the tab names to localize in the normal app as well.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/a239d9dd-a791-4234-a281-13f46b5e429f.png)

To test:
* In Admin / Settings / Localization, upload a CSV with lines like `de,First tab,Erster tab`.
* Check how a dashboard with a tab named "First tab" looks when your locale is set to German
* Create a public link for the dashboard and check that "First tab" is localized when you add `#locale=de` to the end of the link.