### PR TITLE
Bulk Action execution API

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
@@ -9,18 +9,18 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
 
-(derive :data-grid/create :data-grid/common)
-(derive :data-grid/update :data-grid/common)
-(derive :data-grid/delete :data-grid/common)
+(derive :data-grid.row/create :data-grid.row/common)
+(derive :data-grid.row/update :data-grid.row/common)
+(derive :data-grid.row/delete :data-grid.row/common)
 
 (s/def :actions.args.data-grid/common
   :actions.args.crud.table/row)
 
-(defmethod actions/action-arg-map-spec :data-grid/common
+(defmethod actions/action-arg-map-spec :data-grid.row/common
   [_action]
   :actions.args.data-grid/common)
 
-(defmethod actions/normalize-action-arg-map :data-grid/common
+(defmethod actions/normalize-action-arg-map :data-grid.row/common
   [_action input]
   (update-keys input u/qualified-name))
 
@@ -28,7 +28,7 @@
   (u/prog1 (-> context :scope :table-id)
     (when-not <>
       (throw (ex-info "Cannot perform data-grid actions without a table in scope."
-                      {:error :data-grid/unknown-table})))))
+                      {:error :data-grid.row/unknown-table})))))
 
 (defn- map-inputs [table-id inputs]
   (for [row (data-editing/apply-coercions table-id inputs)]
@@ -53,15 +53,15 @@
         next-inputs  (map-inputs table-id inputs)]
     (perform-table-row-action! action-kw context next-inputs post-process)))
 
-(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid/create]
+(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/create]
   [_action context inputs :- [:sequential ::lib.schema.actions/row]]
   (perform! :table.row/create context inputs))
 
-(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid/update]
+(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/update]
   [_action context inputs :- [:sequential ::lib.schema.actions/row]]
   (perform! :table.row/update context inputs))
 
-(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid/delete]
+(mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/delete]
   [_action context inputs :- [:sequential ::lib.schema.actions/row]]
   (perform! :table.row/delete context inputs))
 

--- a/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
@@ -45,13 +45,16 @@
   (for [[table-id diffs] (u/group-by :table-id identity outputs)
         :let [pretty-rows (data-editing/invalidate-and-present! table-id (map :row diffs))]
         [op pretty-row] (map vector (map :op diffs) pretty-rows)]
-    {:table-id table-id, :op op, :row pretty-row}))
+    {:op op, :table-id table-id, :row pretty-row}))
 
 (defn- perform! [action-kw context inputs]
   ;; We could enhance this in future to work more richly with multi-table editable models.
   (let [table-id     (scope->table-id context)
         next-inputs  (map-inputs table-id inputs)]
-    (perform-table-row-action! action-kw context next-inputs post-process)))
+    (perform-table-row-action! action-kw context next-inputs
+                               (if (= :table.row/delete action-kw)
+                                 identity
+                                 post-process))))
 
 (mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/create]
   [_action context inputs :- [:sequential ::lib.schema.actions/row]]

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -258,17 +258,19 @@
 
 (defn- execute-dashcard-row-action-on-saved-action!
   "Implementation handling a sub-sub-case."
-  [action-id dashcard-id pk params & [_mapping]]
-  (let [action (-> (actions/select-action :id action-id :archived false)
-                   (t2/hydrate :creator)
-                   api/read-check)
+  [action-id dashcard-id pks inputs & [_mapping]]
+  (let [action      (-> (actions/select-action :id action-id :archived false)
+                        (t2/hydrate :creator)
+                        api/read-check)
         ;; TODO flatten this into a single query
         card-id     (api/check-404 (t2/select-one-fn :card_id [:model/DashboardCard :card_id] dashcard-id))
         table-id    (api/check-404 (t2/select-one-fn :table_id [:model/Card :table_id] card-id))
         fields      (t2/select [:model/Field :id :name :semantic_type] :table_id table-id)
         field-names (set (map :name fields))
         pk-fields   (filter #(= :type/PK (:semantic_type %)) fields)
-        [row]       (data-editing/query-db-rows table-id pk-fields [pk])
+        _           (assert (= 1 (count pks)) "Further work needed to handle matching up database to input rows")
+        params      (first inputs)
+        [row]       (data-editing/query-db-rows table-id pk-fields pks)
         _           (api/check-404 row)
         row-params  (->> (:parameters action)
                          (keep (fn [{:keys [id slug]}]
@@ -278,23 +280,24 @@
                          (into {}))
         param-id    (u/index-by (some-fn :slug :id) :id (:parameters action))
         provided    (update-keys params #(api/check-400 (param-id (name %)) "Unexpected parameter provided"))]
-    (actions/execute-action! action (merge row-params provided))))
+    [(actions/execute-action! action (merge row-params provided))]))
 
 (defn- execute-dashcard-row-action-on-primitive-action!
   "Implementation handling a sub-sub-case."
-  [action-kw scope dashcard-id pk input _mapping]
+  [action-kw scope dashcard-id pks inputs _mapping]
   ;; TODO flatten this into a single query
   (let [card-id   (api/check-404 (t2/select-one-fn :card_id [:model/DashboardCard :card_id] dashcard-id))
         table-id  (api/check-404 (t2/select-one-fn :table_id [:model/Card :table_id] card-id))
         pk-fields (t2/select [:model/Field :id :name :semantic_type] :table_id table-id :semantic_type :type/PK)
-        [row]     (data-editing/query-db-rows table-id pk-fields [pk])
+        _         (assert (= 1 (count pks)) "Further work needed to handle matching up database to input rows")
+        [row]     (data-editing/query-db-rows table-id pk-fields pks)
         _         (api/check-404 row)
         ;; TODO handle custom mapping
-        input     (if (:row input)
-                    (assoc input :row (merge row (:row input)))
-                    (merge row input))]
-    ;; TODO collapse if multiple outputs
-    (first (:outputs (actions/perform-action! action-kw scope [input])))))
+        inputs    (for [input inputs]
+                    (if (:row input)
+                      (assoc input :row (merge row (:row input)))
+                      (merge row input)))]
+    (:outputs (actions/perform-action! action-kw scope inputs))))
 
 (api.macros/defendpoint :post "/row-action/:action-id/execute"
   "Executes an action as a row action. The allows action parameters sharing a name with column names to be derived from a specific row.
@@ -305,7 +308,7 @@
    {:keys [pk params]}   :- [:map
                              [:pk :any]
                              [:params :any]]]
-  (execute-dashcard-row-action-on-saved-action! (parse-long action-id) dashcard-id pk params))
+  (first (execute-dashcard-row-action-on-saved-action! (parse-long action-id) dashcard-id [pk] [params])))
 
 (api.macros/defendpoint :get "/tmp-action"
   "Returns all actions across all tables and models"
@@ -397,27 +400,21 @@
     :else
     (throw (ex-info "Unexpected id value" {:status 400, :action-id raw-id}))))
 
-(api.macros/defendpoint :post "/action/v2/execute"
-  " ** The Grand Unification ** "
-  [{}
-   {}
-   {:keys [action-id scope input]}
-   :- [:map
-       [:action-id [:or :string ms/NegativeInt ms/PositiveInt]]
-       [:scope     ::types/scope.raw]
-       [:input     :map]]]
+(defn- execute!* [action-id scope inputs]
   (let [scope   (actions/hydrate-scope scope)
         unified (fetch-unified-action scope action-id)]
     (cond
       (:action-id unified)
       (let [action (api/read-check (actions/select-action :id (:action-id unified) :archived false))]
-        (execute-saved-action! action input))
+        (api/check-400 (= 1 (count inputs)) "Saved actions currently only support a single input")
+        [(execute-saved-action! action (first inputs))])
       (:action-kw unified)
-      (let [action-kw (keyword (:action-kew unified))]
-        ;; Weird magic currying we've been doing implicitly.
-        (if (and (isa? action-kw :table.row/common) (:table-id unified))
-          (actions/perform-action! action-kw scope {:table-id (:table-id unified), :row input})
-          (actions/perform-action! action-kw scope input)))
+      (let [action-kw (keyword (:action-kw unified))]
+        (:outputs
+         ;; Weird magic currying we've been doing implicitly.
+         (if (and (isa? action-kw :table.row/common) (:table-id unified))
+           (actions/perform-action! action-kw scope (for [i inputs] {:table-id (:table-id unified), :row i}))
+           (actions/perform-action! action-kw scope inputs))))
       (:row-action unified)
       ;; use flat namespace for now, probably want to separate form inputs from pks
       (let [row-action  (:row-action unified)
@@ -427,23 +424,45 @@
             saved-id    (:action-id row-action)
             action-kw   (:action-kw row-action)
             ;; TODO probably take the row separately from inputs
-            pk          input
-            input       (if (seq mapping)
-                          (walk/postwalk-replace {"::root" input} mapping)
-                          input)]
+            pks         inputs
+            inputs      (for [input inputs]
+                          (if (seq mapping)
+                            (walk/postwalk-replace {"::root" input} mapping)
+                            input))]
         (cond
           saved-id
-          (execute-dashcard-row-action-on-saved-action! saved-id dashcard-id pk input mapping)
+          (execute-dashcard-row-action-on-saved-action! saved-id dashcard-id pks inputs mapping)
           action-kw
           (let [table-id (:table-id row-action)]
             ;; Weird magic currying we've been doing implicitly.
             (if (and table-id (isa? action-kw :table.row/common))
-              (let [pk    input
-                    input {:table-id table-id, :row input}]
-                (execute-dashcard-row-action-on-primitive-action! action-kw scope dashcard-id pk input mapping))
-              (execute-dashcard-row-action-on-primitive-action! action-kw scope dashcard-id pk input mapping)))))
+              (let [inputs (for [input inputs] {:table-id table-id, :row input})]
+                (execute-dashcard-row-action-on-primitive-action! action-kw scope dashcard-id pks inputs mapping))
+              (execute-dashcard-row-action-on-primitive-action! action-kw scope dashcard-id pks inputs mapping)))))
       :else
       (throw (ex-info "Not able to execute given action yet" {:status-code 500, :scope scope, :unified unified})))))
+
+(api.macros/defendpoint :post "/action/v2/execute"
+  " ** The Grand Unification ** "
+  [{}
+   {}
+   {:keys [action_id scope input]}
+   :- [:map
+       [:action_id [:or :string ms/NegativeInt ms/PositiveInt]]
+       [:scope     ::types/scope.raw]
+       [:input     :map]]]
+  {:outputs (execute!* action_id scope [input])})
+
+(api.macros/defendpoint :post "/action/v2/execute-bulk"
+  " ** The Grand Unification ** "
+  [{}
+   {}
+   {:keys [action_id scope inputs]}
+   :- [:map
+       [:action_id [:or :string ms/NegativeInt ms/PositiveInt]]
+       [:scope     ::types/scope.raw]
+       [:inputs    [:sequential :map]]]]
+  {:outputs (execute!* action_id scope inputs)})
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -42,7 +42,7 @@
   (let [;; This is a bit unfortunate... we ignore the table-id in the path when called with a custom scope...
         ;; The solution is to stop accepting custom scope once we migrate the data grid to action/execute
         scope (or scope {:table-id table-id})]
-    {:created-rows (map :row (:outputs (actions/perform-action! :data-grid/create scope rows)))}))
+    {:created-rows (map :row (:outputs (actions/perform-action! :data-grid.row/create scope rows)))}))
 
 (api.macros/defendpoint :put "/table/:table-id"
   "Update row(s) within the given table."
@@ -71,7 +71,7 @@
                       ;; For now, it's just a shim, because we haven't implemented an efficient bulk update action yet.
                       ;; This is a dumb shim; we're not checking that the pk maps are really (just) the pks.
                       (map #(merge % updates) pks))]
-      {:updated (map :row (:outputs (actions/perform-action! :data-grid/update scope rows)))})))
+      {:updated (map :row (:outputs (actions/perform-action! :data-grid.row/update scope rows)))})))
 
 ;; This is a POST instead of DELETE as not all web proxies pass on the body of DELETE requests.
 (api.macros/defendpoint :post "/table/:table-id/delete"
@@ -86,7 +86,7 @@
   ;; This is a bit unfortunate... we ignore the table-id in the path when called with a custom scope...
   ;; The solution is to stop accepting custom scope once we migrate the data grid to action/execute
   (let [scope (or scope {:table-id table-id})]
-    (actions/perform-action! :data-grid/delete scope rows)
+    (actions/perform-action! :data-grid.row/delete scope rows)
     {:success true}))
 
 ;; might later be changed, or made driver specific, we might later drop the requirement depending on admin trust

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -443,7 +443,12 @@
       (throw (ex-info "Not able to execute given action yet" {:status-code 500, :scope scope, :unified unified})))))
 
 (api.macros/defendpoint :post "/action/v2/execute"
-  " ** The Grand Unification ** "
+  "The One True API for invoking actions.
+  It doesn't care whether the action is saved or primitive, and whether it has been placed.
+  In particular, it supports:
+  - Custom model actions as well as primitive actions, and encoded hack actions which use negative ids.
+  - Stand-alone actions, Dashboard actions, Row actions, and whatever else comes along.
+  Since actions are free to return multiple outputs even for a single output, the response is always plural."
   [{}
    {}
    {:keys [action_id scope input]}
@@ -454,7 +459,7 @@
   {:outputs (execute!* action_id scope [input])})
 
 (api.macros/defendpoint :post "/action/v2/execute-bulk"
-  " ** The Grand Unification ** "
+  "The *other* One True API for invoking actions. The only difference is that it accepts multiple inputs."
   [{}
    {}
    {:keys [action_id scope inputs]}

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -102,6 +102,79 @@
             (is (= [[3 "Farfetch'd" "The land of lisp"]]
                    (table-rows table-id)))))))))
 
+(deftest table-operations-via-action-execute-test
+  (mt/with-premium-features #{:table-data-editing}
+    (mt/test-drivers #{:h2 :postgres}
+      (with-open [table-ref (data-editing.tu/open-test-table!)]
+        (let [table-id @table-ref
+              url      "ee/data-editing/action/v2/execute-bulk"]
+          (data-editing.tu/toggle-data-editing-enabled! true)
+          (testing "Initially the table is empty"
+            (is (= [] (table-rows table-id))))
+
+          (testing "POST should insert new rows"
+            (is (= #{{:op "created", :table-id table-id, :row {:id 1, :name "Pidgey", :song "Car alarms"}}
+                     {:op "created", :table-id table-id, :row {:id 2, :name "Spearow", :song "Hold music"}}
+                     {:op "created", :table-id table-id, :row {:id 3, :name "Farfetch'd", :song "The land of lisp"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/create"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:name "Pidgey" :song "Car alarms"}
+                                                        {:name "Spearow" :song "Hold music"}
+                                                        {:name "Farfetch'd" :song "The land of lisp"}]})))))
+
+            (is (= [[1 "Pidgey" "Car alarms"]
+                    [2 "Spearow" "Hold music"]
+                    [3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
+
+          (testing "PUT should update the relevant rows and columns"
+            (is (= #{{:op "updated", :table-id table-id :row {:id 1, :name "Pidgey",     :song "Join us now and share the software"}}
+                     {:op "updated", :table-id table-id :row {:id 2, :name "Speacolumn", :song "Hold music"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id 1 :song "Join us now and share the software"}
+                                                        {:id 2 :name "Speacolumn"}]}))))
+
+                (is (= #{[1 "Pidgey" "Join us now and share the software"]
+                         [2 "Speacolumn" "Hold music"]
+                         [3 "Farfetch'd" "The land of lisp"]}
+                       (set (table-rows table-id))))))
+
+          ;; Leaning against not adding this action.
+          #_(testing "PUT can also do bulk updates"
+              (is (= #{{:id 1, :name "Pidgey",     :song "The Star-Spangled Banner"}
+                       {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}
+                     (set
+                      (:updated
+                       (mt/user-http-request :crowberto :put 200 url
+                                             {:pks     [{:id 1}
+                                                        {:id 2}]
+                                              :updates {:song "The Star-Spangled Banner"}}))))
+
+                  (is (= #{[1 "Pidgey" "The Star-Spangled Banner"]
+                           [2 "Speacolumn" "The Star-Spangled Banner"]
+                           [3 "Farfetch'd" "The land of lisp"]}
+                         (set (table-rows table-id))))))
+
+          (testing "DELETE should remove the corresponding rows"
+            (is (= #{{:op "deleted", :table-id table-id, :row {:id 1}}
+                     {:op "deleted", :table-id table-id, :row {:id 2}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/delete"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id 1}
+                                                        {:id 2}]})))))
+            (is (= [[3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id)))))))))
+
 (deftest editing-allowed-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
@@ -722,17 +795,17 @@
         (data-editing.tu/toggle-data-editing-enabled! true)
         (mt/with-actions-enabled
           (testing "no dashcard"
-            (is (= 404 (:status (req {:action-id "dashcard:999999:1"
+            (is (= 404 (:status (req {:action_id "dashcard:999999:1"
                                       :scope     {:dashcard-id 999999}
                                       :input     {}})))))
           (testing "no action"
             (mt/with-temp [:model/Dashboard     dash {}
                            :model/DashboardCard dashcard {:dashboard_id (:id dash)}]
-              (is (= 404 (:status (req {:action-id 999999
+              (is (= 404 (:status (req {:action_id 999999
                                         :scope     {:dashcard-id (:id dashcard)}
                                         :input     {}}))))
               (testing "no dashcard still results in 404"
-                (is (= 404 (:status (req {:action-id 999999, :input {}})))))))
+                (is (= 404 (:status (req {:action_id 999999, :input {}})))))))
           (mt/with-non-admin-groups-no-root-collection-perms
             (with-open [test-table (data-editing.tu/open-test-table! {:id 'auto-inc-type
                                                                       :name [:text]
@@ -780,12 +853,12 @@
                                                                :enabled         true}]}}]
                 (testing "no access to the model"
                   (is (= 403 (:status (req {:user      :rasta
-                                            :action-id (:id action)
+                                            :action_id (:id action)
                                             :scope     {:dashcard-id (:id dashcard)}
                                             :input     {:id 1 :status "approved"}})))))
                 (testing "non-row action modifying a row"
                   (testing "underlying row does not exist, action not executed"
-                    (is (= 400 (:status (req {:action-id (:id action)
+                    (is (= 400 (:status (req {:action_id (:id action)
                                               :scope     {:dashcard-id (:id dashcard)}
                                               :input     {:id     1
                                                           :status "approved"}})))))
@@ -793,8 +866,8 @@
                     (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
                                           {:rows [{:name "Widgets", :status "waiting"}]})
                     (is (= {:status 200
-                            :body   {:rows-updated 1}}
-                           (-> (req {:action-id (:id action)
+                            :body   {:outputs [{:rows-updated 1}]}}
+                           (-> (req {:action_id (:id action)
                                      :scope     {:dashcard-id (:id dashcard)}
                                      :input     {:id     1
                                                  :status "approved"}})
@@ -802,7 +875,7 @@
                 (testing "dashcard row action modifying a row - implicit action"
                   (let [action-id "dashcard:unknown:abcdef"]
                     (testing "underlying row does not exist, action not executed"
-                      (is (= 404 (:status (req {:action-id action-id
+                      (is (= 404 (:status (req {:action_id action-id
                                                 :scope     {:dashcard-id (:id dashcard)}
                                                 :input     {:id     2
                                                             :status "approved"}})))))
@@ -810,8 +883,8 @@
                       (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
                                             {:rows [{:name "Sprockets", :status "waiting"}]})
                       (is (= {:status 200
-                              :body   {:rows-updated 1}}
-                             (-> (req {:action-id action-id
+                              :body   {:outputs [{:rows-updated 1}]}}
+                             (-> (req {:action_id action-id
                                        :scope     {:dashcard-id (:id dashcard)}
                                        :input     {:id     2
                                                    :status "approved"}})
@@ -819,7 +892,7 @@
                 (testing "dashcard row action modifying a row - primitive action"
                   (let [action-id "dashcard:unknown:fedcba"]
                     (testing "underlying row does not exist, action not executed"
-                      (is (= 404 (:status (req {:action-id action-id
+                      (is (= 404 (:status (req {:action_id action-id
                                                 :scope     {:dashcard-id (:id dashcard)}
                                                 :input     {:id     3
                                                             :status "approved"}})))))
@@ -827,10 +900,10 @@
                       (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
                                             {:rows [{:name "Braai tongs", :status "waiting"}]})
                       (is (= {:status 200
-                              :body   {:table-id @test-table
-                                       :op "updated"
-                                       :row {:id 3, :name "Braai tongs", :status "approved"}}}
-                             (-> (req {:action-id action-id
+                              :body   {:outputs [{:table-id @test-table
+                                                  :op       "updated"
+                                                  :row      {:id 3, :name "Braai tongs", :status "approved"}}]}}
+                             (-> (req {:action_id action-id
                                        :scope     {:dashcard-id (:id dashcard)}
                                        :input     {:id     3
                                                    :status "approved"}})
@@ -838,7 +911,7 @@
                 (testing "dashcard row action modifying a row - encoded action"
                   (let [action-id "dashcard:unknown:xyzabc"]
                     (testing "underlying row does not exist, action not executed"
-                      (is (= 404 (:status (req {:action-id action-id
+                      (is (= 404 (:status (req {:action_id action-id
                                                 :scope     {:dashcard-id (:id dashcard)}
                                                 :input     {:id     4
                                                             :status "approved"}})))))
@@ -846,10 +919,10 @@
                       (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
                                             {:rows [{:name "Salad spinners", :status "waiting"}]})
                       (is (= {:status 200
-                              :body   {:table-id @test-table
-                                       :op "updated"
-                                       :row {:id 4, :name "Salad spinners", :status "approved"}}}
-                             (-> (req {:action-id action-id
+                              :body   {:outputs [{:table-id @test-table
+                                                  :op       "updated"
+                                                  :row      {:id 4, :name "Salad spinners", :status "approved"}}]}}
+                             (-> (req {:action_id action-id
                                        :scope     {:dashcard-id (:id dashcard)}
                                        :input     {:id     4
                                                    :status "approved"}})

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -233,10 +233,10 @@
         arg-maps  (if (map? arg-map-or-maps) [arg-map-or-maps] arg-map-or-maps)
         policy    (or policy
                       (cond
-                        (:model-id scope)                        :model-action
-                        (= "data-grid" (namespace action-kw))    :data-editing
-                        (= "data-editing" (namespace action-kw)) :data-editing
-                        :else                                    :ad-hoc-invocation))
+                        (:model-id scope)                         :model-action
+                        (= "data-grid.row" (namespace action-kw)) :data-editing
+                        (= "data-editing" (namespace action-kw))  :data-editing
+                        :else                                     :ad-hoc-invocation))
         spec      (action-arg-map-spec action-kw)
         arg-maps  (map (partial normalize-action-arg-map action-kw) arg-maps)
         errors    (for [arg-map arg-maps

--- a/src/metabase/notification/settings.clj
+++ b/src/metabase/notification/settings.clj
@@ -6,6 +6,8 @@
   (:import
    (java.time ZonedDateTime)))
 
+(set! *warn-on-reflection* true)
+
 (defsetting notification-thread-pool-size
   "The size of the thread pool used to send notifications."
   :default    3


### PR DESCRIPTION
Somehow I forgot that we need both a singular and bulk execution API. This adds the latter, and uses it to drive the data grid scenario.

re: `data-grid.row/*` 

Denis made the good suggestion to add this suffix to the namespace:

1. Leaves room for other kinds of data grid actions.
2. More consistent with `table.row/*` and `model.row/*` actions.