### PR TITLE
Follow-up validation improvements for new iframe embedding

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -144,7 +144,7 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
       });
   });
 
-  it("does not allow updating instanceUrl via embed.updateSettings", () => {
+  it("does not allow changing the value of instanceUrl via embed.updateSettings", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
       questionId: ORDERS_QUESTION_ID,
     });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -38,11 +38,6 @@ class MetabaseEmbed {
    * Merge these settings with the current settings.
    */
   public updateSettings(settings: Partial<SdkIframeEmbedSettings>) {
-    if (!this._isEmbedReady) {
-      warn("embed settings must be ready before updating the settings");
-      return;
-    }
-
     // The value of instanceUrl must be the same as the initial value used to create an embed.
     // This allows users to pass a complete settings object that includes all their settings.
     if (
@@ -50,6 +45,11 @@ class MetabaseEmbed {
       settings.instanceUrl !== this._settings.instanceUrl
     ) {
       raiseError("instanceUrl cannot be updated after the embed is created");
+    }
+
+    if (!this._isEmbedReady) {
+      warn("embed settings must be ready before updating the settings");
+      return;
     }
 
     this._setEmbedSettings(settings);
@@ -119,6 +119,12 @@ class MetabaseEmbed {
   private _validateEmbedSettings(settings: SdkIframeEmbedTagSettings) {
     if (!settings.apiKey || !settings.instanceUrl) {
       raiseError("API key and instance URL must be provided");
+    }
+
+    if (!settings.dashboardId && !settings.questionId && !settings.template) {
+      raiseError(
+        "either dashboardId, questionId, or template must be provided",
+      );
     }
 
     if (

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -43,7 +43,8 @@ class MetabaseEmbed {
       return;
     }
 
-    // The instanceUrl settings cannot be updated after the embed is created
+    // The value of instanceUrl must be the same as the initial value used to create an embed.
+    // This allows users to pass a complete settings object that includes all their settings.
     if (
       settings.instanceUrl &&
       settings.instanceUrl !== this._settings.instanceUrl

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -43,7 +43,11 @@ class MetabaseEmbed {
       return;
     }
 
-    if (settings.instanceUrl) {
+    // The instanceUrl settings cannot be updated after the embed is created
+    if (
+      settings.instanceUrl &&
+      settings.instanceUrl !== this._settings.instanceUrl
+    ) {
       raiseError("instanceUrl cannot be updated after the embed is created");
     }
 
@@ -126,7 +130,9 @@ class MetabaseEmbed {
     }
 
     if (settings.dashboardId && settings.questionId) {
-      raiseError("can't use both dashboardId and questionId at the same time");
+      raiseError(
+        "can't use both dashboardId and questionId at the same time. to change the question to a dashboard, set the questionId to null (and vice-versa)",
+      );
     }
 
     if (!settings.target) {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -12,14 +12,22 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   it("throws when target element is not found", () => {
     expect(() => {
-      new MetabaseEmbed({ ...defaultSettings, target: "#not-existent-target" });
+      new MetabaseEmbed({
+        ...defaultSettings,
+        questionId: 1,
+        target: "#not-existent-target",
+      });
     }).toThrow('cannot find embed container "#not-existent-target"');
   });
 
   it("throws when target element is undefined", () => {
     expect(() => {
-      // @ts-expect-error -- we are testing for incorrect configuration
-      new MetabaseEmbed({ ...defaultSettings, target: undefined });
+      new MetabaseEmbed({
+        ...defaultSettings,
+        questionId: 1,
+        // @ts-expect-error -- we are testing for incorrect configuration
+        target: undefined,
+      });
     }).toThrow("target must be provided");
   });
 
@@ -82,5 +90,11 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     }).toThrow(
       "the exploration template can't be used with dashboardId or questionId",
     );
+  });
+
+  it("throws when neither question id, dashboard id, or template are provided", () => {
+    expect(() => {
+      new MetabaseEmbed({ ...defaultSettings });
+    }).toThrow("either dashboardId, questionId, or template must be provided");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -47,6 +47,19 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     }).toThrow("can't use both dashboardId and questionId at the same time");
   });
 
+  it("does not throw an error when instanceUrl is updated to be the same", () => {
+    expect(() => {
+      const embed = new MetabaseEmbed({
+        ...defaultSettings,
+        instanceUrl: "https://foo-bar-baz.com",
+        questionId: 10,
+        target: document.createElement("div"),
+      });
+
+      embed.updateSettings({ instanceUrl: "https://foo-bar-baz.com" });
+    }).not.toThrow();
+  });
+
   it("throws when question id is provided in the exploration template", () => {
     expect(() => {
       new MetabaseEmbed({


### PR DESCRIPTION
Includes the following follow-up improvements based on your review comments (thanks!):

- Only raise an error when the `instanceUrl` has been changed from existing values. This helps people to use `updateSettings(settings)` where they have an existing object with all settings. ([Original comment](https://github.com/metabase/metabase/pull/58390#discussion_r2107488783))
- If `questionId` and `dashboardId` and `type` are all missing, throw an error. ([Original comment](https://github.com/metabase/metabase/pull/58390#issuecomment-2911770222))
- Add hints to the error message when someone tries to change a question to a dashboard, but fails because they forgot to set the previous questionId/dashboardId to null. ([Original comment](https://github.com/metabase/metabase/pull/58390#issuecomment-2912102097))