### PR TITLE
Explicitly disallow using API keys in production for new iframe embedding

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -184,24 +184,18 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
     });
   });
 
-  it("does not show an error if the token features are available and the parent page is not localhost", () => {
+  it("shows an error if we are using an API key in production", () => {
     cy.log("restore the current page's domain");
     cy.visit("http://localhost:4000");
 
-    cy.log("visit a test page with an origin of example.com");
+    cy.log("visit a test page with an origin of example.com using api keys");
     const frame = H.loadSdkIframeEmbedTestPage({
       origin: "http://example.com",
       template: "exploration",
     });
 
     frame
-      .findByText("A valid license is required for embedding.")
-      .should("not.exist");
-
-    frame.within(() => {
-      H.assertSdkNotebookEditorUsable(frame);
-    });
-
-    frame.findByTestId("sdk-usage-problem-indicator").should("not.exist");
+      .findByText("Using an API key in production is not allowed.")
+      .should("exist");
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -183,4 +183,25 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
       cy.get("iframe").invoke("attr", "src").should("eq", originalSrc);
     });
   });
+
+  it("does not show an error if the token features are available and the parent page is not localhost", () => {
+    cy.log("restore the current page's domain");
+    cy.visit("http://localhost:4000");
+
+    cy.log("visit a test page with an origin of example.com");
+    const frame = H.loadSdkIframeEmbedTestPage({
+      origin: "http://example.com",
+      template: "exploration",
+    });
+
+    frame
+      .findByText("A valid license is required for embedding.")
+      .should("not.exist");
+
+    frame.within(() => {
+      H.assertSdkNotebookEditorUsable(frame);
+    });
+
+    frame.findByTestId("sdk-usage-problem-indicator").should("not.exist");
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -12,7 +12,10 @@ import { Box } from "metabase/ui";
 import { useSdkIframeEmbedEventBus } from "../hooks/use-sdk-iframe-embed-event-bus";
 import type { SdkIframeEmbedSettings } from "../types/embed";
 
-import { SdkIframeInvalidLicenseError } from "./SdkIframeError";
+import {
+  SdkIframeApiKeyInProductionError,
+  SdkIframeInvalidLicenseError,
+} from "./SdkIframeError";
 
 export const SdkIframeEmbedRoute = () => {
   const { embedSettings } = useSdkIframeEmbedEventBus();
@@ -29,6 +32,11 @@ export const SdkIframeEmbedRoute = () => {
   // the token feature is not present, we show an error message
   if (!embedSettings._isLocalhost && !hasEmbedTokenFeature) {
     return <SdkIframeInvalidLicenseError />;
+  }
+
+  // Using API keys in production is not allowed. SSO is required.
+  if (!embedSettings._isLocalhost && embedSettings.apiKey) {
+    return <SdkIframeApiKeyInProductionError />;
   }
 
   const { theme, locale } = embedSettings;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeError.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeError.tsx
@@ -1,20 +1,26 @@
 import noResultsSource from "assets/img/no_results.svg";
 import { Center, Image, Stack, Text, ThemeProvider } from "metabase/ui";
 
-// Only shown when the app is running on production yet the license is invalid.
-const INVALID_LICENSE_ERROR_MESSAGE =
-  "A valid license is required for embedding.";
-
-export const SdkIframeInvalidLicenseError = () => (
+export const SdkIframeError = ({ message }: { message: string }) => (
   <ThemeProvider>
     <Center h="100%" mih="100vh">
       <Stack align="center">
         <Image w={120} h={120} src={noResultsSource} />
 
         <Text fw={500} ff="sans-serif" fz="lg">
-          {INVALID_LICENSE_ERROR_MESSAGE}
+          {message}
         </Text>
       </Stack>
     </Center>
   </ThemeProvider>
+);
+
+// Only shown when the app is running on production yet the license is invalid.
+export const SdkIframeInvalidLicenseError = () => (
+  <SdkIframeError message="A valid license is required for embedding." />
+);
+
+// Only shown when the app is running on production yet the license is invalid.
+export const SdkIframeApiKeyInProductionError = () => (
+  <SdkIframeError message="Using an API key in production is not allowed." />
 );


### PR DESCRIPTION
If a user tries to use `apiKey: (your-api-key)` in a non-localhost domain even with a valid license, we show an explicit error "Using an API key in production is not allowed". This error is intentionally not translated/localized as the localization is not yet available on the app-embed-sdk entry point.

### Wait, why do we need a separate check? We already check this in the SDK right?

The usage problem logic uses the `getIsLocalhost()` method and it only knows the Metabase instance's url, not the parent who actually renders it in an iframe. The Metabase instance might be hosted on `http://localhost:4000`, but the domain might be `https://foobar.com`, which is admittedly rare but having an explicit check makes it easier to test for this important case.