### PR TITLE
Closes VIZ-1021 message for empty results in dataset importer

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -559,4 +559,18 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       ensureVisualizerCardsAreRendered();
     });
   });
+
+  it("show a message when there are no search results", () => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.openQuestionsSidebar();
+    H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
+
+    H.modal().within(() => {
+      cy.findByText("Add more data").click();
+      cy.findByPlaceholderText("Search for something").type("non-existing");
+
+      cy.findByText("No results").should("exist");
+    });
+  });
 });

--- a/frontend/src/metabase/visualizer/components/DataImporter/DataImporter.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/DataImporter.tsx
@@ -95,23 +95,22 @@ export const DataImporter = ({ className }: { className?: string }) => {
             height: "100%",
           }}
         >
-          <Box>
-            <TextInput
-              m="xs"
-              variant="filled"
-              value={search}
-              onChange={handleSearchChange}
-              placeholder={t`Search for something`}
-              leftSection={<Icon name="search" />}
-              autoFocus
-            />
-          </Box>
+          <TextInput
+            m="xs"
+            variant="filled"
+            value={search}
+            onChange={handleSearchChange}
+            placeholder={t`Search for something`}
+            leftSection={<Icon name="search" />}
+            autoFocus
+          />
           <Flex
             direction="column"
             pt="sm"
             px="sm"
             style={{
               overflowY: "auto",
+              flex: 1,
             }}
           >
             <DatasetsList


### PR DESCRIPTION
Closes [VIZ-1021: Add empty state when there are no Recent search results](https://linear.app/metabase/issue/VIZ-1021/add-empty-state-when-there-are-no-recent-search-results)

### Description

https://www.loom.com/share/c8de58e54eac4180bd0f6088a701e640

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
