### PR TITLE
Render Metabot generated get-year filters friendlier in the FE

### DIFF
--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -89,7 +89,8 @@
                            u/lower-case-en)
         ->unit {:get-hour :hour-of-day
                 :get-month :month-of-year
-                :get-quarter :quarter-of-year}]
+                :get-quarter :quarter-of-year
+                :get-year :year-of-era}]
     (lib.util.match/match-one expr
       [(_ :guard #{:= :in}) _ [:get-hour _ (a :guard temporal?)] (b :guard int?)]
       (i18n/tru "{0} is at {1}" (->unbucketed-display-name a) (u.time/format-unit b :hour-of-day))
@@ -117,7 +118,7 @@
                 (count args)
                 (-> :day-of-week lib.temporal-bucket/describe-temporal-unit u/lower-case-en))
 
-      [(_ :guard #{:= :in}) _ [(f :guard #{:get-month :get-quarter}) _ (a :guard temporal?)] (b :guard int?)]
+      [(_ :guard #{:= :in}) _ [(f :guard #{:get-month :get-quarter :get-year}) _ (a :guard temporal?)] (b :guard int?)]
       (i18n/tru "{0} is in {1}" (->unbucketed-display-name a) (u.time/format-unit b (->unit f)))
 
       [(_ :guard #{:!= :not-in}) _ [:get-month _ (a :guard temporal?)] (b :guard int?)]
@@ -126,13 +127,16 @@
       [(_ :guard #{:!= :not-in}) _ [:get-quarter _ (a :guard temporal?)] (b :guard int?)]
       (i18n/tru "{0} excludes {1} each year" (->unbucketed-display-name a) (u.time/format-unit b :quarter-of-year))
 
-      [(_ :guard #{:= :in}) _ [(f :guard #{:get-hour :get-month :get-quarter}) _ (a :guard temporal?)] & (args :guard #(every? int? %))]
+      [(_ :guard #{:!= :not-in}) _ [:get-year _ (a :guard temporal?)] (b :guard int?)]
+      (i18n/tru "{0} excludes {1}" (->unbucketed-display-name a) (u.time/format-unit b :year))
+
+      [(_ :guard #{:= :in}) _ [(f :guard #{:get-hour :get-month :get-quarter :get-year}) _ (a :guard temporal?)] & (args :guard #(every? int? %))]
       (i18n/tru "{0} is one of {1} {2} selections"
                 (->unbucketed-display-name a)
                 (count args)
                 (-> f ->unit lib.temporal-bucket/describe-temporal-unit u/lower-case-en))
 
-      [(_ :guard #{:!= :not-in}) _ [(f :guard #{:get-hour :get-month :get-quarter}) _ (a :guard temporal?)] & (args :guard #(every? int? %))]
+      [(_ :guard #{:!= :not-in}) _ [(f :guard #{:get-hour :get-month :get-quarter :get-year}) _ (a :guard temporal?)] & (args :guard #(every? int? %))]
       (i18n/tru "{0} excludes {1} {2} selections"
                 (->unbucketed-display-name a)
                 (count args)

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -157,4 +157,4 @@
           (cond-> (:name opts) (assoc :name (:name opts)))))
     {:lib/type :metadata/metric
      :id metric-id
-     :display-name (i18n/tru "Unknown Metric")}))
+     :display-name (fallback-display-name)}))

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -641,6 +641,17 @@
       {:clause [:not-in (lib/get-quarter created-at) 1 2 3]
        :name "Created At excludes 3 quarter of year selections"}
 
+      {:clause [:= (lib/get-year created-at) 2001]
+       :name "Created At is in 2001"}
+      {:clause [:= (lib/get-year created-at) 2001 2002 2003]
+       :name "Created At is one of 3 year of era selections"}
+      {:clause [:!= (lib/get-year created-at) 2001]
+       :name "Created At excludes 2001"}
+      {:clause [:!= (lib/get-year created-at) 2001 2002 2003]
+       :name "Created At excludes 3 year of era selections"}
+      {:clause [:not-in (lib/get-year created-at) 2001 2002 2003]
+       :name "Created At excludes 3 year of era selections"}
+
       {:clause [:is-null created-at]
        :name "Created At is empty"}
       {:clause [:not-null created-at]


### PR DESCRIPTION
### Description

Metabot generates some filters that have no pretty formatting support yet. This PR adds handling for `get-year` filters with equality and unequality.

### Demo

Before:
<img width="408" alt="image" src="https://github.com/user-attachments/assets/d2e70bfc-fdfe-4565-b501-19791a61dde0" />


After: 
<img width="413" alt="image" src="https://github.com/user-attachments/assets/14ed198a-840f-42e2-a66a-2f1b7ed0a21a" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
