### PR TITLE
Adjust external column type sync

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -178,7 +178,7 @@
 
 ;; custom Redshift type handling
 
-(defn- external-datbaase-type->base-type
+(defn- external-database-type->base-type
   "Additional type mappings of external columns. Return nil when no matching type is found."
   [database-type]
   (when (or (string? database-type)
@@ -236,7 +236,7 @@
       (let [assumed-type ((get-method sql-jdbc.sync/database-type->base-type :postgres) driver column-type)]
         (if-not (contains? #{nil :type/*} assumed-type)
           assumed-type
-          (if-some [external-assumed-type (external-datbaase-type->base-type column-type)]
+          (if-some [external-assumed-type (external-database-type->base-type column-type)]
             external-assumed-type
             assumed-type)))))
 

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -178,6 +178,47 @@
 
 ;; custom Redshift type handling
 
+(defn- external-datbaase-type->base-type
+  "Additional type mappings of external columns. Return nil when no matching type is found to avoid short circuit
+  in `sql-jdbc.sync/database-type->base-type :redshift`."
+  [database-type]
+  (when (or (string? database-type)
+            (instance? clojure.lang.Named database-type))
+    (let [stn  (-> (name database-type) ; sanitized-type-name
+                   (u/lower-case-en))]
+      ;; Following is inspired by mysql docs and redshift jdbc driver code: https://github.com/aws/amazon-redshift-jdbc-driver/blob/master/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java#L3414-L3448
+      (cond
+        (str/starts-with? stn "tinyint")   :type/Integer
+        (str/starts-with? stn "smallint")  :type/Integer
+        (str/starts-with? stn "mediumint") :type/Integer
+        (str/starts-with? stn "int")       :type/Integer
+        (str/starts-with? stn "bigint")    :type/BigInteger
+
+        (str/starts-with? stn "float")     :type/Float
+        (str/starts-with? stn "double")    :type/Float
+
+        (and (or (str/starts-with? stn "char")
+                 (str/starts-with? stn "varchar")
+                 (str/starts-with? stn "text"))
+             (re-find #"character set binary" stn))         :type/*
+
+        (str/starts-with? stn "char")                       :type/Text
+        (str/starts-with? stn "varchar")                    :type/Text
+        (str/starts-with? stn "text")                       :type/Text
+        ;; https://dev.mysql.com/doc/refman/8.4/en/charset-national.html
+        (str/starts-with? stn "national varchar")           :type/Text
+        (str/starts-with? stn "nvarchar")                   :type/Text
+        (str/starts-with? stn "nchar varchar")              :type/Text
+        (str/starts-with? stn "national character varying") :type/Text
+        (str/starts-with? stn "national char varying")      :type/Text
+
+        (str/starts-with? stn "tinytext")   :type/Text
+        (str/starts-with? stn "mediumtext") :type/Text
+        (str/starts-with? stn "longtext")   :type/Text
+
+        (= stn "datetime")                  :type/DateTime
+        (= stn "year")                      :type/Integer))))
+
 (def ^:private database-type->base-type
   (some-fn (sql-jdbc.sync/pattern-based-database-type->base-type
             [[#"(?i)CHARACTER VARYING" :type/Text]       ; Redshift uses CHARACTER VARYING (N) as a synonym for VARCHAR(N)
@@ -187,7 +228,9 @@
             :geometry    :type/*    ; spatial data
             :geography   :type/*    ; spatial data
             :intervaly2m :type/*    ; interval literal
-            :intervald2s :type/*})) ; interval literal
+            :intervald2s :type/*}   ; interval literal
+           ;; external tables types
+           external-datbaase-type->base-type))
 
 (defmethod sql-jdbc.sync/database-type->base-type :redshift
   [driver column-type]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -525,7 +525,9 @@
                                          ["double(10,20)" :type/Float]
                                          ["float(10)" :type/Float]
                                          ["datetime" :type/DateTime]
-                                         ["year" :type/Integer]]]
+                                         ["year" :type/Integer]
+                                         ;; nonsense
+                                         ["fadlsjfldskajfl" nil]]]
     (testing (format "database-type %s" (pr-str database-type))
       (is (= exp-base-type
              (sql-jdbc.sync/database-type->base-type :redshift database-type))))))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -7,6 +7,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
+   [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.plugins.jdbc-proxy :as jdbc-proxy]
    [metabase.query-processor :as qp]
@@ -505,3 +506,26 @@
                   qp/process-query
                   mt/rows
                   count))))))
+
+(deftest database-type->base-type-external-table-types-test
+  (doseq [[database-type exp-base-type] [["tinyint" :type/Integer]
+                                         ["smallint" :type/Integer]
+                                         ["mediumint" :type/Integer]
+                                         [:mediumint :type/Integer]
+                                         [:MEDIUMINT :type/Integer]
+                                         ["tinytext" :type/Text]
+                                         ["mediumtext" :type/Text]
+                                         ["longtext" :type/Text]
+                                         ["varchar(100)" :type/Text]
+                                         ["varchar(100)" :type/Text]
+                                         ["int(11) unsigned" :type/Integer]
+                                         ["int(10)" :type/Integer]
+                                         ["tinyint(1)" :type/Integer]
+                                         ["BIGINTEGER" :type/BigInteger]
+                                         ["double(10,20)" :type/Float]
+                                         ["float(10)" :type/Float]
+                                         ["datetime" :type/DateTime]
+                                         ["year" :type/Integer]]]
+    (testing (format "database-type %s" (pr-str database-type))
+      (is (= exp-base-type
+             (sql-jdbc.sync/database-type->base-type :redshift database-type))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41788

### Description

This PR makes updates database type to base types mapping for Redshift external columns.

I've attempted to find a way of mapping the external type to rs database type. I've also checked whether system tables (eg. svv_external_columns, svv_external_schemas...) wouldn't offer rs type info. I've checked whether mysql data-type->base-type implementation could not be re-used.

As former didn't work, I've resorted to consulting mysql docs and redshift jdbc driver.

This PR does not implement support for set and enum rs types. That should be handled separately I believe.

### How to verify

Run new tests or follow repro from issue comments.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
