### PR TITLE
add docs_merge_detected workflow

### DIFF
--- a/.github/workflows/docs_merge_detected.yml
+++ b/.github/workflows/docs_merge_detected.yml
@@ -1,0 +1,35 @@
+name: Docs Merge Detected
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+
+jobs:
+  push_workflow_to_docs_metabase_github_io_job_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report changed docs files exist
+        run: |
+          echo "A change in the docs directory was detected on merge."
+
+      - name: Trigger repo dispatch
+        uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref  }}
+        with:
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          script: | #js
+            if (process.env.BRANCH_NAME === "master" ||
+                /^release-x\.\d+\.x$/.test(process.env.BRANCH_NAME)) {
+              github.rest.repos.createDispatchEvent({
+                owner: "${{ github.repository_owner }}",
+                repo: "docs.metabase.github.io",
+                event_type: "docs_merge",
+                client_payload: { branch_name: process.env.BRANCH_NAME }
+              });
+            } else {
+              console.log("Branch name is not to be published: ", process.env.BRANCH_NAME);
+            }

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,4 +1,5 @@
 ---
+# bump in /docs/**
 layout: docs-api
 title: Metabase API documentation
 description: The official API documentation for Metabase.

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,5 +1,4 @@
 ---
-# bump in /docs/**
 layout: docs-api
 title: Metabase API documentation
 description: The official API documentation for Metabase.


### PR DESCRIPTION
resolves DEV-550

Adds a workflow that triggers a workflow in the docs repo whenever a change to /docs/** is *merged*. The triggered workflow will automatically build and merge the generated markdown files and exported html to the master branch of the docs repo.

Note: We already have a `Docs Bump Detected` workflow, which runs on any PR that touches /docs/**. That is for generating preview.