### PR TITLE
Only run escape-join-aliases on mongo

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -416,6 +416,7 @@
                               :test/jvm-timezone-setting       false
                               :identifiers-with-spaces         true
                               :saved-question-sandboxing       false
+                              :global-aliases                  true
                               :expressions/date                true
                               :expressions/text                true
                               :expressions/datetime            true

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -416,7 +416,7 @@
                               :test/jvm-timezone-setting       false
                               :identifiers-with-spaces         true
                               :saved-question-sandboxing       false
-                              :global-aliases                  true
+                              :global-join-aliases             true
                               :expressions/date                true
                               :expressions/text                true
                               :expressions/datetime            true

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -672,6 +672,9 @@
     ;; Does this driver support sandboxing with saved questions?
     :saved-question-sandboxing
 
+    ;; Are aliases in queries for this driver globally scoped (which means that names must be globally unique)?
+    :global-aliases
+
     ;; Does this driver support casting text and floats to integers? (`integer()` custom expression function)
     :expressions/integer
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -673,7 +673,7 @@
     :saved-question-sandboxing
 
     ;; Are aliases in queries for this driver globally scoped (which means that names must be globally unique)?
-    :global-aliases
+    :global-join-aliases
 
     ;; Does this driver support casting text and floats to integers? (`integer()` custom expression function)
     :expressions/integer

--- a/src/metabase/query_processor/middleware/escape_join_aliases.clj
+++ b/src/metabase/query_processor/middleware/escape_join_aliases.clj
@@ -169,7 +169,7 @@
   [query]
   ;; add logging around the steps to make this easier to debug.
   (log/debugf "Escaping join aliases\n%s" (u/pprint-to-str query))
-  (if (driver.u/supports? driver/*driver* :global-aliases (lib.metadata/database (qp.store/metadata-provider)))
+  (if (driver.u/supports? driver/*driver* :global-join-aliases (lib.metadata/database (qp.store/metadata-provider)))
     (letfn [(add-escaped-aliases* [query]
               (add-escaped-aliases query (driver->escape-fn driver/*driver*)))
             (add-original->escaped-alias-maps* [query]

--- a/src/metabase/query_processor/middleware/escape_join_aliases.clj
+++ b/src/metabase/query_processor/middleware/escape_join_aliases.clj
@@ -165,7 +165,8 @@
 (defn- replace-alias! [form key alias-store]
   (let [old-alias (key form)
         new-alias (driver/escape-alias driver/*driver* old-alias)]
-    (swap! alias-store assoc new-alias old-alias)
+    (when (not= old-alias new-alias)
+      (swap! alias-store assoc new-alias old-alias))
     (assoc form key new-alias)))
 
 (defn- simple-escape-aliases [query]

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -554,7 +554,7 @@
                   ((some-fn :source-query :source-table) form))
              (vary-meta (add-alias-info* form) assoc ::transformed true)
 
-             (:strategy form)
+             (and (:strategy form) (:alias form))
              (update form :alias (partial driver/escape-alias driver/*driver*))
 
              (:join-alias form)

--- a/test/metabase/query_processor/middleware/escape_join_aliases_test.clj
+++ b/test/metabase/query_processor/middleware/escape_join_aliases_test.clj
@@ -496,6 +496,7 @@
   (testing "Should ensure all join aliases are unique, ignoring case"
     ;; some Databases treat table/subquery aliases as case-insensitive and thus `Cat` and `cat` would be considered the
     ;; same thing. That's EVIL! Make sure we deduplicate.
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     (driver/with-driver :mongo
       (is (= {:database 1
               :type     :query
@@ -526,6 +527,7 @@
 
 (deftest ^:parallel deduplicate-alias-names-test-2
   (testing "no need to include alias info if they have not changed"
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     (driver/with-driver :mongo
       (let [query {:database 1
                    :type     :query
@@ -612,6 +614,7 @@
                                                  [:field 6 {:join-alias "Q2", :temporal-unit :month}]]}]
                   :order-by     [[:asc [:field 6 {:join-alias "Products", :temporal-unit :month}]]]}
           :info  {:alias/escaped->original {"Products_2" "Products"}}}
+         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
          (driver/with-driver :mongo
            (escape-join-aliases
             {:query {:source-query {:source-table 1
@@ -662,6 +665,7 @@
                                                      [:field 6 {:join-alias "Products", :temporal-unit :month}]
                                                      [:field 6 {:join-alias "Q2", :temporal-unit :month}]]}]}
               :info  {:alias/escaped->original {"Products_2" "Products"}}}
+             #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
              (driver/with-driver :mongo
                (escape-join-aliases
                 {:query {:source-query {:source-table 1
@@ -695,6 +699,7 @@
                                                                      [:field 4 nil]
                                                                      [:field 5 {:join-alias "Products_2"}]]}]}]}
               :info  {:alias/escaped->original {"Products_2" "Products"}}}
+             #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
              (driver/with-driver :mongo
                (escape-join-aliases
                 {:query {:source-query {:source-table 1


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Escape join aliases exists because aliases in mongo are effectively globally scoped and so need to be globally unique. In theory, this shouldn't cause issues for any driver, because globally unique aliases generally aren't a bad thing. However, the actual renaming process is buggy and causes issues with more complicated queries.  Given that, we only want to run the code where it is actually needed.  This should fix a number of bugs in non-mongo drivers.

### How to verify

1. Make and save query in a non-mongo driver that joins orders to itself
2. Make another query that joins the query from 1 to itself
3. Verify that the query runs correctly

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
