### PR TITLE
VIZ-327 Updates styling and text for cryptic "unknown map" error message

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -4,17 +4,19 @@ import Color from "color";
 import * as d3 from "d3";
 import { Component } from "react";
 import ss from "simple-statistics";
-import { t } from "ttag";
+import { jt, t } from "ttag";
 import _ from "underscore";
 
 // eslint-disable-next-line no-restricted-imports -- deprecated sdk import
 import { getMetabaseInstanceUrl } from "embedding-sdk/store/selectors";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
+import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import { formatValue } from "metabase/lib/formatting";
 import { connect } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
+import { Flex } from "metabase/ui";
 import { MinColumnsError } from "metabase/visualizations/lib/errors";
 import {
   computeMinimalBounds,
@@ -195,7 +197,22 @@ class ChoroplethMapInner extends Component {
   render() {
     const details = this._getDetails(this.props);
     if (!details) {
-      return <div>{t`unknown map`}</div>;
+      return (
+        <Flex direction="column" m="auto" maw="24rem">
+          <div className={cx(CS.textCentered, CS.mb4)}>
+            <p>
+              {t`Map not found. Please update the map used in this visualization's settings.`}
+            </p>
+            <p>
+              {jt`To add a new map, visit ${(
+                <Link to="/admin/settings/maps" className={CS.link}>
+                  {t`Admin settings > Maps`}
+                </Link>
+              )}.`}
+            </p>
+          </div>
+        </Flex>
+      );
     }
 
     const {

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -138,13 +138,13 @@ export function getMapUrl(details, props) {
 const MapNotFound = () => {
   const isAdmin = useSelector(getUserIsAdmin);
   return (
-    <Flex direction="column" m="auto" maw="24rem">
-      <div className={cx(CS.textCentered, CS.mb4)}>
-        <Text>
+    <Flex direction="column" m="auto" maw="25rem">
+      <div className={cx(CS.textCentered, CS.mb4, CS.px2)}>
+        <Text component="p">
           {t`Looks like this custom map is no longer available. Try using a different map to visualize this.`}
         </Text>
         {isAdmin && (
-          <Text>
+          <Text component="p" className={CS.mt1}>
             {jt`To add a new map, visit ${(
               <Link to="/admin/settings/maps" className={CS.link}>
                 {t`Admin settings > Maps`}

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -17,7 +17,7 @@ import { connect, useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { Flex } from "metabase/ui";
+import { Flex, Text } from "metabase/ui";
 import { MinColumnsError } from "metabase/visualizations/lib/errors";
 import {
   computeMinimalBounds,
@@ -140,17 +140,17 @@ const MapNotFound = () => {
   return (
     <Flex direction="column" m="auto" maw="24rem">
       <div className={cx(CS.textCentered, CS.mb4)}>
-        <p>
+        <Text>
           {t`Looks like this custom map is no longer available. Try using a different map to visualize this.`}
-        </p>
+        </Text>
         {isAdmin && (
-          <p>
+          <Text>
             {jt`To add a new map, visit ${(
               <Link to="/admin/settings/maps" className={CS.link}>
                 {t`Admin settings > Maps`}
               </Link>
             )}.`}
-          </p>
+          </Text>
         )}
       </div>
     </Flex>

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -13,9 +13,10 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import { formatValue } from "metabase/lib/formatting";
-import { connect } from "metabase/lib/redux";
+import { connect, useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Flex } from "metabase/ui";
 import { MinColumnsError } from "metabase/visualizations/lib/errors";
 import {
@@ -134,6 +135,28 @@ export function getMapUrl(details, props) {
   return new URL(mapUrl, ensureTrailingSlash(baseUrl)).href;
 }
 
+const MapNotFound = () => {
+  const isAdmin = useSelector(getUserIsAdmin);
+  return (
+    <Flex direction="column" m="auto" maw="24rem">
+      <div className={cx(CS.textCentered, CS.mb4)}>
+        <p>
+          {t`Looks like this custom map is no longer available. Try using a different map to visualize this.`}
+        </p>
+        {isAdmin && (
+          <p>
+            {jt`To add a new map, visit ${(
+              <Link to="/admin/settings/maps" className={CS.link}>
+                {t`Admin settings > Maps`}
+              </Link>
+            )}.`}
+          </p>
+        )}
+      </div>
+    </Flex>
+  );
+};
+
 class ChoroplethMapInner extends Component {
   static propTypes = {};
 
@@ -197,22 +220,7 @@ class ChoroplethMapInner extends Component {
   render() {
     const details = this._getDetails(this.props);
     if (!details) {
-      return (
-        <Flex direction="column" m="auto" maw="24rem">
-          <div className={cx(CS.textCentered, CS.mb4)}>
-            <p>
-              {t`Map not found. Please update the map used in this visualization's settings.`}
-            </p>
-            <p>
-              {jt`To add a new map, visit ${(
-                <Link to="/admin/settings/maps" className={CS.link}>
-                  {t`Admin settings > Maps`}
-                </Link>
-              )}.`}
-            </p>
-          </div>
-        </Flex>
-      );
+      return <MapNotFound />;
     }
 
     const {


### PR DESCRIPTION
Closes #39134
Closes [VIZ-327 Error message is ugly & unhelpful when rendering a map visualization where the custom geojson has been deleted](https://linear.app/metabase/issue/VIZ-327/error-message-is-ugly-and-unhelpful-when-rendering-a-map-visualization)

### Description

Replaced "unknown map" error message with a more descriptive and styled one. I came up with the text off the dome so please feel free to suggest different wording/CTAs.

### How to verify

1. Add a custom GeoJSON map in the admin panel
2. Create and save a question using the map
3. Delete the map from the admin panel
4. Reload the question and see the error
5. Verify the error message is styled and directs the user to change the map used or add a new one

### Demo

**BEFORE**
<img width="1592" alt="before" src="https://github.com/user-attachments/assets/98cc34e5-ef02-4935-9f64-4381bc7bc48f" />

**AFTER (Dashboard)**
![mapless-dashboard](https://github.com/user-attachments/assets/5d076325-b6b6-4a5d-94db-dea88978aaa4)

**AFTER (Question detail)**
![mapless-detail](https://github.com/user-attachments/assets/da5d9e26-1014-4e0d-99f1-29eccc150b60)

**AFTER (Non-admin)**
![mapless-non-admin](https://github.com/user-attachments/assets/8b18a0ad-664a-4b3f-89ff-d248f95f2895)

**POSSIBLY TMI**
There does already exist a "you haven't defined the map yet" state, and I can definitely just use that if desired. My thinking was it'd be good to have a fail-safe for unexpected errors (which is how this bug manifests) with a more general message/CTA, but let me know if you all would prefer to use that existing message instead:
<img width="557" alt="incomplete-map" src="https://github.com/user-attachments/assets/ba2616c0-e007-4d8c-aeeb-14b2c8482f51" />

