### PR TITLE
Content translation cleanup

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -67,7 +67,7 @@
 
 (defn import-translations!
   "Import translations from CSV and insert or update rows in the content_translation table."
-  [{:keys [file]}]
+  [file]
   (with-open [reader (io/reader file)]
     ; Validate all rows before proceeding
     (let [csv-data (read-csv-file reader)

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -7,28 +7,33 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private http-status-unprocessable 422)
+(defn- translation-key
+  "The identity of a translation. It's locale and source string so we can identify if the same translation is present
+  multiple times."
+  [t]
+  (select-keys t [:locale :msgid]))
 
-(defn- collect-row-format-error
-  "Returns an error message if a row does not have the expected format."
-  [row-index row]
-  (when-not (= (count row) 3)
-    (tru "Row {0}: Invalid format. Expected exactly 3 columns (Language, String, Translation)" (+ row-index 2))))
+(defn- adjust-index
+  "Adjust index: increment once for the header row that was chopped off and again to go to 1-based indexing for human
+  consumption."
+  [i]
+  (+ i 2))
 
 (defn- collect-locale-error
   "Returns an error message if a row does not have a valid locale."
-  [row-index locale]
+  [_state index {:keys [locale]}]
   (when (not (i18n/available-locale? locale))
-    (tru "Row {0}: Invalid locale: {1}" (+ row-index 2) locale)))
+    (tru "Row {0}: Invalid locale: {1}" (adjust-index index) locale)))
 
 (defn- collect-duplication-error
-  "Returns an error message if this translation key has already been seen in the file. A translation key is a string like 'de,Category'"
-  [seen-keys translation-key row-index locale trimmed-msgid]
-  (when (contains? seen-keys translation-key)
+  "Returns an error message if this translation key has already been seen in the file. A translation key is a string
+  like 'de,Category'"
+  [{:keys [seen] :as _state} index {:keys [msgid locale] :as translation}]
+  (when (-> translation translation-key seen)
     (tru "Row {0}: The string \"{1}\" is translated into locale \"{2}\" earlier in the file"
-         (+ row-index 2) trimmed-msgid locale)))
+         (adjust-index index) msgid locale)))
 
-(defn is-msgstr-usable
+(defn- is-msgstr-usable
   "Check if the translation string is usable. It should not be blank or contain only commas, whitespace, or semicolons."
   [msgstr]
   (not
@@ -36,44 +41,51 @@
     (str/blank? msgstr)
     (re-matches #"^[,;\s]*$" msgstr))))
 
-(defn- validate-row
-  "Validate a single row of CSV data, returning errors and the updated set of seen translation keys."
-  [row-index row seen-keys]
-  (let [[locale msgid _msgstr] row
-        trimmed-msgid (str/trim msgid)
-        translation-key (str locale "," trimmed-msgid)]
-    (if-let [format-error (collect-row-format-error row-index row)]
-      ;; If the row format is invalid, just return that error
-      {:errors [format-error] :seen-keys (conj seen-keys translation-key)}
-      ;; Otherwise check for other potential errors
-      (let [errors (remove nil?
-                           [(collect-duplication-error seen-keys translation-key row-index locale trimmed-msgid)
-                            (collect-locale-error row-index locale)])]
-        {:errors errors :seen-keys (conj seen-keys translation-key)}))))
+(defn- row-errors
+  [state index translation]
+  (keep (fn [f] (f state index translation))
+        [collect-duplication-error collect-locale-error]))
+
+(defn- wrong-row-shape
+  [index]
+  (tru "Row {0}: Invalid format. Expected exactly 3 columns (Language, String, Translation)"
+       (adjust-index index)))
+
+(defn- process-rows
+  "Format, trim, validate rows. Takes the vectors from a csv and returns a map with the shape
+  {:translations [{:locale :msgid :msgstr}]
+   :errors       [string]}.
+  The :seen set is returned but not meant for consumption."
+  [rows]
+  (reduce (fn [state [index row]]
+            (let [[locale msgid msgstr & extra] row
+                  translation                   {:locale locale
+                                                 :msgid  (str/trim msgid)
+                                                 :msgstr (str/trim msgstr)}
+                  errors                        (cond-> (row-errors state index translation)
+                                                  (seq extra) (conj (wrong-row-shape index)))]
+              (cond-> (-> state
+                          (update :seen conj (dissoc translation :msgstr))
+                          (update :translations conj translation))
+                (seq errors) (update :errors into errors))))
+          {:seen         #{}
+           :errors       []
+           :translations []}
+          (map-indexed vector rows)))
 
 (defn import-translations!
   "Import translations from CSV and insert or update rows in the content_translation table."
   [rows]
-  (let [errors (:errors (reduce (fn [{:keys [seen-keys] :as m} [row-index row]]
-                                  (let [{row-errors :errors updated-seen-keys :seen-keys} (validate-row row-index row seen-keys)]
-                                    (-> m
-                                        (update :seen-keys #(apply conj %1 %2) updated-seen-keys)
-                                        (update :errors #(apply conj %1 %2) row-errors))))
-                                {:seen-keys #{}
-                                 :errors []}
-                                (map-indexed vector rows)))
-        _ (when (seq errors)
-            (throw (ex-info (tru "The file could not be uploaded due to the following error(s):")
-                            {:status-code http-status-unprocessable
-                             :errors errors})))
-        usable-rows (for [[locale msgid msgstr] rows
-                          :let [trimmed-msgid (str/trim msgid)
-                                trimmed-msgstr (str/trim msgstr)]
-                          :when (is-msgstr-usable trimmed-msgstr)]
-                      {:locale locale :msgid trimmed-msgid :msgstr trimmed-msgstr})]
-    (t2/with-transaction [_tx]
-      ;; Replace all existing entries
-      (t2/delete! :model/ContentTranslation)
-      ;; Insert all usable rows at once
-      (when-not (empty? usable-rows)
-        (t2/insert! :model/ContentTranslation usable-rows)))))
+  (let [{:keys [translations errors]} (process-rows rows)]
+    (when (seq errors)
+      (throw (ex-info (tru "The file could not be uploaded due to the following error(s):")
+                      {:status-code 422
+                       :errors errors})))
+    ;; remove bad msgstrs after error generator for line number reporting reasons
+    (let [usable-rows (filter (comp is-msgstr-usable :msgstr) translations)]
+      (t2/with-transaction [_tx]
+        ;; Replace all existing entries
+        (t2/delete! :model/ContentTranslation)
+        ;; Insert all usable rows at once
+        (when-not (empty? usable-rows)
+          (t2/insert! :model/ContentTranslation usable-rows))))))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -4,10 +4,7 @@
    [metabase-enterprise.content-translation.dictionary :as dictionary]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
-   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]))
-
-(def ^:private http-status-ok 200)
 
 (api.macros/defendpoint :post
   "/upload-dictionary"
@@ -25,9 +22,7 @@
                                                     [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
   (dictionary/import-translations! {:filename (get-in multipart-params ["file" :filename])
                                     :file     (get-in multipart-params ["file" :tempfile])})
-  {:status http-status-ok
-   :headers {"Content-Type" "application/json"}
-   :body (json/encode {:success true})})
+  {:success true})
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/content-translation` routes."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -1,6 +1,8 @@
 (ns metabase-enterprise.content-translation.routes
   "Endpoints relating to the translation of user-generated content"
   (:require
+   [clojure.data.csv :as csv]
+   [clojure.java.io :as io]
    [metabase-enterprise.content-translation.dictionary :as dictionary]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -24,7 +26,9 @@
   (let [file (get-in multipart-params ["file" :tempfile])]
     (when-not (instance? java.io.File file)
       (throw (ex-info (tru "No file provided") {:status-code 400})))
-    (dictionary/import-translations! file))
+    (with-open [rdr (io/reader file)]
+      (let [[_header & rows] (csv/read-csv rdr)]
+        (dictionary/import-translations! rows))))
   {:success true})
 
 (def ^{:arglists '([request respond raise])} routes

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.content-translation.dictionary :as dictionary]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]))
 
 (api.macros/defendpoint :post
@@ -20,8 +21,10 @@
                                                    [:map
                                                     [:filename :string]
                                                     [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
-  (dictionary/import-translations! {:filename (get-in multipart-params ["file" :filename])
-                                    :file     (get-in multipart-params ["file" :tempfile])})
+  (let [file (get-in multipart-params ["file" :tempfile])]
+    (when-not (instance? java.io.File file)
+      (throw (ex-info (tru "No file provided") {:status-code 400})))
+    (dictionary/import-translations! file))
   {:success true})
 
 (def ^{:arglists '([request respond raise])} routes


### PR DESCRIPTION
some cleanup.
- don't pass a file into the dictionary creation, pass rows. this keeps the io and stuff out of there and its easier to test
- don't pass a filename to the importer. it didn't care
- clean up how we returned statuses. We can just return `{:success true}` and it will do the json conversion for us


Easy way to test things:

```clojure
(ns nocommit.doit
  (:require
   [cheshire.core :as json]
   [clj-http.client :as http]
   [clojure.java.io :as io]))

(defn send
  [csv-text]
  (let [url "http://localhost:3000/api/ee/content-translation/upload-dictionary"
        cookie "metabase.SESSION=de222745-e7f9-4691-94c3-dc784eac9b2f" ;; adjust for your own session here
        ^String file-content (format "locale,source,translated\n%s" csv-text)
        filename "dictionary.csv"]
    (let [response (http/post url
                              {:headers {"Cookie" cookie}
                               :multipart [{:name "file"
                                            :content (io/input-stream (.getBytes file-content "UTF-8"))
                                            :filename filename
                                            :content-type "text/csv"}]
                               :throw-exceptions false})] ; Set to true if you want exceptions on non-2xx responses
      (-> response :body json/parse-string))))

(defn replace
  []
  (send  "fr,Orders over time,l'orders sur temps
fr,Orders displayed over tim,Orders qui nous displayons sur temps
fr,super important,l'importance c'est tres grand
fr,foo,fooooooooooooo
fr,Count,le counte
fr,This is a text card,celui c'est un carde du texte!
fr,And this is a header!,Et bien sur celui-ca c'est un carte du text plus grande!
fr,Category Filter,le filter de chategoire
fr,tabs have names,les tabes soit des noms
fr,Created At,Immaculé par
fr,Doohickey,le doohick
fr,Gadget,le gadget
fr,Gizmo,le ghuize
fr,Widget,le grenouille"))

(defn errors
  []
  (send "fr,Orders over time,l'orders sur temps
fr,Orders over time,l'orders sur temps
fr,valid,also valid,extra column
not-found,Orders over time,l'orders sur temps"))
```

and then you can send things to a repl:
```clojure
doit=> (nocommit.doit/replace)
{"success" true}
doit=> (nocommit.doit/errors)
{"errors" ["Row 3: The string \"Orders over time\" is translated into locale \"fr\" earlier in the file"
           "Row 4: Invalid format. Expected exactly 3 columns (Language, String, Translation)"
           "Row 5: Invalid locale: not-found"]}
```