### PR TITLE
Fix flaky visualizer test

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -197,12 +197,17 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
     });
 
     H.saveDashcardVisualizerModal("create");
-    cy.wait("@cardQuery");
-    cy.wait("@cardQuery");
-    cy.wait("@cardQuery");
+    // Wait for card queries before saving the dashboard
+    H.getDashboardCard(0).within(() => {
+      cy.findByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
+        "exist",
+      );
+      cy.findByText("Created At: Month").should("exist");
+    });
+
     H.saveDashboard();
 
-    // Making sure the card renders
+    // Making sure the card renders after saving the dashboard
     H.getDashboardCard(0).within(() => {
       cy.findByText(`Count (${PRODUCTS_COUNT_BY_CREATED_AT.name})`).should(
         "exist",

--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -197,6 +197,9 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
     });
 
     H.saveDashcardVisualizerModal("create");
+    cy.wait("@cardQuery");
+    cy.wait("@cardQuery");
+    cy.wait("@cardQuery");
     H.saveDashboard();
 
     // Making sure the card renders


### PR DESCRIPTION
Fixes a flaky visualizer test. Saving visualizer dashcard changes reruns its queries and seems like trying to save dashboard changes immediately causes a race condition. Fixed by awaiting dashcard queries before saving the dashboard

Stress tested here: https://github.com/metabase/metabase/actions/runs/15299510400