### PR TITLE
fix(sdk): wait for locales to be loaded before rendering SDK components

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Visualization.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Visualization.tsx
@@ -39,6 +39,7 @@ export const QuestionVisualization = ({
     question,
     queryResults,
     mode,
+    isLocaleLoading,
     isQuestionLoading,
     isQueryRunning,
     navigateToNewCard,
@@ -52,7 +53,7 @@ export const QuestionVisualization = ({
   const isQueryResultLoading =
     question && shouldRunCardQuery(question) && !queryResults;
 
-  if (isQuestionLoading || isQueryResultLoading) {
+  if (isLocaleLoading || isQuestionLoading || isQueryResultLoading) {
     return <SdkLoader />;
   }
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Visualization.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Visualization.tsx
@@ -9,6 +9,7 @@ import {
   SdkLoader,
 } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { shouldRunCardQuery } from "embedding-sdk/lib/interactive-question";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import CS from "metabase/css/core/index.css";
 import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
 import type Question from "metabase-lib/v1/Question";
@@ -35,11 +36,11 @@ export const QuestionVisualization = ({
   className,
   style,
 }: InteractiveQuestionQuestionVisualizationProps) => {
+  const { isLocaleLoading } = useLocale();
   const {
     question,
     queryResults,
     mode,
-    isLocaleLoading,
     isQuestionLoading,
     isQueryRunning,
     navigateToNewCard,

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -6,7 +6,6 @@ import { transformSdkQuestion } from "embedding-sdk/lib/transform-question";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import { getPlugins } from "embedding-sdk/store/selectors";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
-import { useLocale } from "metabase/common/hooks/use-locale";
 import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import { useCreateQuestion } from "metabase/query_builder/containers/use-create-question";
 import { useSaveQuestion } from "metabase/query_builder/containers/use-save-question";
@@ -48,8 +47,6 @@ export const InteractiveQuestionProvider = ({
   withDownloads,
   variant,
 }: InteractiveQuestionProviderProps) => {
-  const { isLocaleLoading } = useLocale();
-
   const handleCreateQuestion = useCreateQuestion();
   const handleSaveQuestion = useSaveQuestion();
 
@@ -124,7 +121,6 @@ export const InteractiveQuestionProvider = ({
 
   const questionContext: InteractiveQuestionContextType = {
     originalId: questionId,
-    isLocaleLoading,
     isQuestionLoading,
     isQueryRunning,
     resetQuestion: loadAndQueryQuestion,

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -6,6 +6,7 @@ import { transformSdkQuestion } from "embedding-sdk/lib/transform-question";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import { getPlugins } from "embedding-sdk/store/selectors";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import { useCreateQuestion } from "metabase/query_builder/containers/use-create-question";
 import { useSaveQuestion } from "metabase/query_builder/containers/use-save-question";
@@ -47,6 +48,8 @@ export const InteractiveQuestionProvider = ({
   withDownloads,
   variant,
 }: InteractiveQuestionProviderProps) => {
+  const { isLocaleLoading } = useLocale();
+
   const handleCreateQuestion = useCreateQuestion();
   const handleSaveQuestion = useSaveQuestion();
 
@@ -121,7 +124,8 @@ export const InteractiveQuestionProvider = ({
 
   const questionContext: InteractiveQuestionContextType = {
     originalId: questionId,
-    isQuestionLoading: isQuestionLoading,
+    isLocaleLoading,
+    isQuestionLoading,
     isQueryRunning,
     resetQuestion: loadAndQueryQuestion,
     onReset: loadAndQueryQuestion,

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -88,7 +88,6 @@ export type InteractiveQuestionContextType = Omit<
     "onNavigateBack" | "isSaveEnabled" | "targetCollection" | "withDownloads"
   > &
   Pick<InteractiveQuestionProviderProps, "variant"> & {
-    isLocaleLoading: boolean;
     plugins: InteractiveQuestionConfig["componentPlugins"] | null;
     mode: Mode | null | undefined;
     originalId: SdkQuestionId | null;

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -88,12 +88,12 @@ export type InteractiveQuestionContextType = Omit<
     "onNavigateBack" | "isSaveEnabled" | "targetCollection" | "withDownloads"
   > &
   Pick<InteractiveQuestionProviderProps, "variant"> & {
+    isLocaleLoading: boolean;
     plugins: InteractiveQuestionConfig["componentPlugins"] | null;
     mode: Mode | null | undefined;
+    originalId: SdkQuestionId | null;
     resetQuestion: () => void;
     onReset: () => void;
     onCreate: (question: Question) => Promise<Question>;
     onSave: (question: Question) => Promise<void>;
-  } & {
-    originalId: SdkQuestionId | null;
   };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -11,6 +11,7 @@ import {
 import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import { shouldRunCardQuery } from "embedding-sdk/lib/interactive-question";
 import type { SdkQuestionTitleProps } from "embedding-sdk/types/question";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import { SaveQuestionModal } from "metabase/containers/SaveQuestionModal";
 import {
   Box,
@@ -58,11 +59,11 @@ export const InteractiveQuestionDefaultView = ({
   withResetButton,
   withChartTypeSelector,
 }: InteractiveQuestionDefaultViewProps): ReactElement => {
+  const { isLocaleLoading } = useLocale();
   const {
     originalId,
     question,
     queryResults,
-    isLocaleLoading,
     isQuestionLoading,
     originalQuestion,
     isSaveEnabled,

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -62,6 +62,7 @@ export const InteractiveQuestionDefaultView = ({
     originalId,
     question,
     queryResults,
+    isLocaleLoading,
     isQuestionLoading,
     originalQuestion,
     isSaveEnabled,
@@ -81,7 +82,10 @@ export const InteractiveQuestionDefaultView = ({
   const isQueryResultLoading =
     question && shouldRunCardQuery(question) && !queryResults;
 
-  if (!isEditorOpen && (isQuestionLoading || isQueryResultLoading)) {
+  if (
+    !isEditorOpen &&
+    (isLocaleLoading || isQuestionLoading || isQueryResultLoading)
+  ) {
     return <SdkLoader />;
   }
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -15,6 +15,7 @@ import type {
 import type { CommonStylingProps } from "embedding-sdk/types/props";
 import { COLLECTION_PAGE_SIZE } from "metabase/collections/components/CollectionContent";
 import { CollectionItemsTable } from "metabase/collections/components/CollectionContent/CollectionItemsTable";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import { isNotNull } from "metabase/lib/types";
 import CollectionBreadcrumbs from "metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs";
 import { Stack } from "metabase/ui";
@@ -156,11 +157,12 @@ const CollectionBrowserWrapper = ({
   collectionId = "personal",
   ...restProps
 }: CollectionBrowserProps) => {
+  const { isLocaleLoading } = useLocale();
   const { id, isLoading } = useTranslatedCollectionId({
     id: collectionId,
   });
 
-  if (isLoading) {
+  if (isLocaleLoading || isLoading) {
     return <SdkLoader />;
   }
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -2,7 +2,7 @@ import { withPublicComponentWrapper } from "embedding-sdk/components/private/Pub
 import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-translated-collection-id";
 import type { SdkCollectionId } from "embedding-sdk/types/collection";
 import type { MetabaseDashboard } from "embedding-sdk/types/dashboard";
-import { useCollectionQuery } from "metabase/common/hooks";
+import { useCollectionQuery, useLocale } from "metabase/common/hooks";
 import { CreateDashboardModal as CreateDashboardModalCore } from "metabase/dashboard/containers/CreateDashboardModal";
 
 /**
@@ -37,6 +37,7 @@ const CreateDashboardModalInner = ({
   onCreate,
   onClose,
 }: CreateDashboardModalProps) => {
+  const { isLocaleLoading } = useLocale();
   const { id, isLoading: isTranslateCollectionLoading } =
     useTranslatedCollectionId({
       id: initialCollectionId,
@@ -48,7 +49,7 @@ const CreateDashboardModalInner = ({
 
   const isLoading = isTranslateCollectionLoading && isCollectionQueryLoading;
 
-  if (isLoading) {
+  if (isLocaleLoading || isLoading) {
     return null;
   }
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -9,6 +9,7 @@ import { screen, waitFor } from "__support__/ui";
 import { getNextId } from "__support__/utils";
 import { renderWithSDKProviders } from "embedding-sdk/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk/test/mocks/config";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
 import {
   createMockCollection,
@@ -20,6 +21,12 @@ import {
   CreateDashboardModal,
   type CreateDashboardModalProps,
 } from "./CreateDashboardModal";
+
+jest.mock("metabase/common/hooks/use-locale", () => ({
+  useLocale: jest.fn(),
+}));
+
+const useLocaleMock = useLocale as jest.Mock;
 
 const CURRENT_USER = createMockUser({
   id: getNextId(),
@@ -43,7 +50,13 @@ const PERSONAL_COLLECTION = createMockCollection({
 const COLLECTIONS = [ROOT_COLLECTION, PERSONAL_COLLECTION];
 
 describe("CreateDashboardModal", () => {
-  it("should render", () => {
+  it("should render a loader when a locale is loading", async () => {
+    setup({ isLocaleLoading: true });
+
+    expect(screen.queryByText("New dashboard")).not.toBeInTheDocument();
+  });
+
+  it("should render", async () => {
     setup();
 
     expect(screen.getByText("New dashboard")).toBeInTheDocument();
@@ -120,7 +133,17 @@ describe("CreateDashboardModal", () => {
   });
 });
 
-function setup({ props }: { props?: Partial<CreateDashboardModalProps> } = {}) {
+function setup(
+  {
+    isLocaleLoading,
+    props,
+  }: {
+    isLocaleLoading?: boolean;
+    props?: Partial<CreateDashboardModalProps>;
+  } = { isLocaleLoading: false, props: {} },
+) {
+  useLocaleMock.mockReturnValue({ isLocaleLoading });
+
   setupCollectionByIdEndpoint({ collections: COLLECTIONS });
 
   return renderWithSDKProviders(

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
@@ -13,6 +13,7 @@ import {
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import {
   DASHBOARD_EDITING_ACTIONS,
   SDK_DASHBOARD_VIEW_ACTIONS,
@@ -73,6 +74,7 @@ export const EditableDashboard = ({
     plugins: plugins,
   },
 }: EditableDashboardProps) => {
+  const { isLocaleLoading } = useLocale();
   const {
     ref,
     isFullscreen,
@@ -112,7 +114,7 @@ export const EditableDashboard = ({
     }
   }, [dispatch, dashboardId]);
 
-  if (isLoading) {
+  if (isLocaleLoading || isLoading) {
     return <SdkLoader />;
   }
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -3,7 +3,11 @@ import { t } from "ttag";
 
 import { InteractiveAdHocQuestion } from "embedding-sdk/components/private/InteractiveAdHocQuestion";
 import { InteractiveQuestionDefaultView } from "embedding-sdk/components/private/InteractiveQuestionDefaultView";
-import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
+import {
+  SdkLoader,
+  withPublicComponentWrapper,
+} from "embedding-sdk/components/private/PublicComponentWrapper";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import { Flex, Icon, Paper, Stack, Text } from "metabase/ui";
 import { getErrorMessage } from "metabase-enterprise/metabot/constants";
 
@@ -12,8 +16,13 @@ import { QuestionDetails } from "./QuestionDetails";
 import { QuestionTitle } from "./QuestionTitle";
 
 const MetabotQuestionInner = () => {
+  const { isLocaleLoading } = useLocale();
   const [redirectUrl, setRedirectUrl] = useState<string>("");
   const [messages, setMessages] = useState<string[]>([]);
+
+  if (isLocaleLoading) {
+    return <SdkLoader />;
+  }
 
   return (
     <Flex direction="column" align="center" gap="md">

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -13,6 +13,7 @@ import {
 } from "embedding-sdk/hooks/private/use-sdk-dashboard-params";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
+import { useLocale } from "metabase/common/hooks/use-locale";
 import CS from "metabase/css/core/index.css";
 import { useEmbedTheme } from "metabase/dashboard/hooks";
 import type { EmbedDisplayParams } from "metabase/dashboard/types";
@@ -101,6 +102,7 @@ export const StaticDashboardInner = ({
  */
 const StaticDashboard = withPublicComponentWrapper<StaticDashboardProps>(
   ({ dashboardId: initialDashboardId, ...rest }) => {
+    const { isLocaleLoading } = useLocale();
     const { isLoading, id: resolvedDashboardId } = useValidatedEntityId({
       type: "dashboard",
       id: initialDashboardId,
@@ -114,7 +116,7 @@ const StaticDashboard = withPublicComponentWrapper<StaticDashboardProps>(
       }
     }, [dispatch, resolvedDashboardId]);
 
-    if (isLoading) {
+    if (isLocaleLoading || isLoading) {
       return <SdkLoader />;
     }
 

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
@@ -21,7 +21,10 @@ export const useLocale = () => {
     useSelector(getCurrentUser)?.locale || undefined;
 
   // locale used in the sdk and in public/static from the #locale parameter
-  const frontendLocale = useContext(FrontendLocaleContext);
+  const { locale: frontendLocale, ...rest } = useContext(FrontendLocaleContext);
 
-  return frontendLocale || userLocale || instanceLocale;
+  return {
+    locale: frontendLocale || userLocale || instanceLocale,
+    ...rest,
+  };
 };

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
@@ -21,10 +21,12 @@ export const useLocale = () => {
     useSelector(getCurrentUser)?.locale || undefined;
 
   // locale used in the sdk and in public/static from the #locale parameter
-  const { locale: frontendLocale, ...rest } = useContext(FrontendLocaleContext);
+  const { locale: frontendLocale, isLocaleLoading } = useContext(
+    FrontendLocaleContext,
+  );
 
   return {
     locale: frontendLocale || userLocale || instanceLocale,
-    ...rest,
+    isLocaleLoading,
   };
 };

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
 import { useLocale } from "./use-locale";
 
 const TestComponent = () => {
-  const locale = useLocale();
+  const { locale } = useLocale();
   return <div data-testid="locale">{`${locale}`}</div>;
 };
 

--- a/frontend/src/metabase/public/LocaleProvider.tsx
+++ b/frontend/src/metabase/public/LocaleProvider.tsx
@@ -1,4 +1,5 @@
 import {
+  type Context,
   type PropsWithChildren,
   createContext,
   useEffect,
@@ -16,7 +17,10 @@ interface LocaleProviderProps {
 }
 
 /** context for the locale used in the sdk and in public/static from the #locale parameter  */
-export const FrontendLocaleContext = createContext<string | null>(null);
+export const FrontendLocaleContext = createContext({}) as unknown as Context<{
+  locale: string | null;
+  isLocaleLoading: boolean;
+}>;
 
 export const LocaleProvider = ({
   children,
@@ -54,7 +58,12 @@ export const LocaleProvider = ({
   }
 
   return (
-    <FrontendLocaleContext.Provider value={contextLocale}>
+    <FrontendLocaleContext.Provider
+      value={{
+        locale: contextLocale,
+        isLocaleLoading,
+      }}
+    >
       {/* The `DatesProvider` wrapping the app is not re-rendered when the locale changes
       so we need to wrap the children in another `DatesProvider` to ensure the locale is updated */}
       <DatesProvider>

--- a/frontend/src/metabase/public/LocaleProvider.unit.spec.tsx
+++ b/frontend/src/metabase/public/LocaleProvider.unit.spec.tsx
@@ -124,7 +124,7 @@ describe("LocaleProvider", () => {
 
   it("should make useLocale return the correct locale", async () => {
     const TestComponent = () => {
-      const locale = useLocale();
+      const { locale } = useLocale();
       return <div>{locale}</div>;
     };
 


### PR DESCRIPTION
Wait for locales to be loaded before rendering SDK components

Context https://metaboat.slack.com/archives/C063Q3F1HPF/p1748429665732379
Updated context https://metaboat.slack.com/archives/C063Q3F1HPF/p1748937923820109

Closes https://linear.app/metabase/issue/EMB-472/wait-while-locales-are-loaded-before-rendering-sdk-components

Our locales are loaded via a request.
And it causes or may cause some race conditions between a locale loading and the rendering of children.
Especially for components that don't perform a request but have translated strings, the current approach may display untranslated strings.

The solution is to wait for locales being loaded until rendering components, but also because it's done on a per-component level, we can load some component requests in parallel with locales.

Some components that don't perform requests still have to load until a locale is loaded until they are rendered (MetabotQuestion)

How to test:
- CI should be green.
