### PR TITLE
revert default required logic

### DIFF
--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -238,6 +238,17 @@ describe("scenarios > question > native", () => {
         );
 
         H.runNativeQuery();
+        cy.findByTestId("query-visualization-root").should(
+          "contain",
+          "April 30, 2022, 6:56 PM",
+        );
+
+        H.rightSidebar()
+          .findByLabelText("Always require a value")
+          .parent()
+          .click();
+
+        H.runNativeQuery();
 
         cy.findByTestId("query-visualization-root").should(
           "contain",
@@ -245,10 +256,6 @@ describe("scenarios > question > native", () => {
         );
 
         H.rightSidebar().within(() => {
-          cy.findByLabelText("Always require a value")
-            .should("be.disabled")
-            .should("be.checked");
-
           cy.findByText("Enter a default value…").click();
         });
 

--- a/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
+++ b/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
@@ -10,18 +10,10 @@ interface RequiredParamToggleProps {
   value: boolean;
   onChange: (value: boolean) => void;
   disabledTooltip: React.ReactNode;
-  showTooltip?: boolean;
 }
 
 export function RequiredParamToggle(props: RequiredParamToggleProps) {
-  const {
-    disabled,
-    value,
-    onChange,
-    uniqueId,
-    disabledTooltip,
-    showTooltip = true,
-  } = props;
+  const { disabled, value, onChange, uniqueId, disabledTooltip } = props;
   const id = `required_param_toggle_${uniqueId}`;
 
   return (
@@ -35,7 +27,7 @@ export function RequiredParamToggle(props: RequiredParamToggleProps) {
       <div>
         <label className={S.SettingRequiredLabel} htmlFor={id}>
           {t`Always require a value`}
-          {disabled && showTooltip && (
+          {disabled && (
             <HoverCard position="top-end" shadow="xs">
               <HoverCard.Target>
                 <Icon name="info_filled" />

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -106,11 +106,6 @@ class TagEditorParamInner extends Component<
       // Field values might already have been loaded so force the load of other field information too
       fetchField(fieldId, true);
     }
-
-    // temporal unit tag is required by default, it can't be changed by user
-    if (tag.type === "temporal-unit") {
-      this.setRequired(true);
-    }
   }
 
   getTemplateTagConfigAfterTypeChange = (
@@ -404,9 +399,7 @@ class TagEditorParamInner extends Component<
 
         {parameter && (
           <DefaultRequiredValueControl
-            tag={isTemporalUnit ? { ...tag, required: true } : tag}
-            disabled={isTemporalUnit}
-            showTooltip={!isTemporalUnit}
+            tag={tag}
             parameter={parameter}
             isEmbeddedDisabled={embeddedParameterVisibility === "disabled"}
             onChangeDefaultValue={(value) => {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
@@ -14,16 +14,12 @@ export function DefaultRequiredValueControl({
   tag,
   parameter,
   isEmbeddedDisabled,
-  disabled = false,
-  showTooltip = false,
   onChangeDefaultValue,
   onChangeRequired,
 }: {
   tag: TemplateTag;
   parameter: Parameter;
   isEmbeddedDisabled: boolean;
-  disabled?: boolean;
-  showTooltip?: boolean;
   onChangeDefaultValue: (value: any) => void;
   onChangeRequired: (value: boolean) => void;
 }) {
@@ -52,10 +48,9 @@ export function DefaultRequiredValueControl({
 
         <RequiredParamToggle
           uniqueId={tag.id}
-          disabled={disabled || isEmbeddedDisabled}
+          disabled={isEmbeddedDisabled}
           value={tag.required ?? false}
           onChange={onChangeRequired}
-          showTooltip={showTooltip}
           disabledTooltip={
             <>
               <Text lh={1.4}>


### PR DESCRIPTION
as per [message](https://metaboat.slack.com/archives/C0645JP1W81/p1748012677503079?thread_ts=1747907392.466059&cid=C0645JP1W81), we need to use the same logic for required checkbox like for other variables in time grouping