### PR TITLE
Add text comparison support for ClickHouse UUIDs

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -55,7 +55,7 @@
                               :left-join                       (not config/is-test?)
                               :describe-fks                    false
                               :actions                         false
-                              :uuid-type true
+                              :uuid-type                       true
                               :metadata/key-constraints        (not config/is-test?)}]
   (defmethod driver/database-supports? [:clickhouse feature] [_driver _feature _db] supported?))
 

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -55,6 +55,7 @@
                               :left-join                       (not config/is-test?)
                               :describe-fks                    false
                               :actions                         false
+                              :uuid-type true
                               :metadata/key-constraints        (not config/is-test?)}]
   (defmethod driver/database-supports? [:clickhouse feature] [_driver _feature _db] supported?))
 

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -338,33 +338,32 @@
 
 (deftest clickhouse-native-query-with-uuid-filter-test
   (mt/test-driver :clickhouse
-    (let [uuid-1 (random-uuid)
-          uuid-2 (random-uuid)]
-      (mt/dataset
-        (mt/dataset-definition "uuid_filter_db"
-                               ["uuid_filter_table"
-                                [{:field-name "uuid"
-                                  :base-type {:native "UUID"}
-                                  :semantic-type :type/PK}
-                                 {:field-name "value"
-                                  :base-type :type/Integer}]
-                                [[uuid-1 10]
-                                 [uuid-2 20]]])
-        (let [query {:database   (mt/id)
-                     :type       :native
-                     :native     {:query         "select sum(value) from `uuid_filter_db`.`uuid_filter_table` where {{uuid}}"
-                                  :template-tags {"uuid" {:type         :dimension
-                                                          :dimension    ["field" (mt/id :uuid_filter_table :uuid) nil]
-                                                          :default      [(str uuid-2)]
-                                                          :name         "uuid"
-                                                          :display-name "UUID"
-                                                          :widget-type  "id"}}}
-                     :parameters [{:type   "id"
-                                   :target [:dimension [:template-tag "uuid"]]
-                                   :value  [(str uuid-2)]}]}]
-          (is (= [[20]]
-                 (mt/formatted-rows [int]
-                                    (qp/process-query query))))
-          (is (= (str "select sum(value) from `uuid_filter_db`.`uuid_filter_table` "
-                      (format "where `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('%s' AS UUID))" uuid-2))
-                 (:query (qp.compile/compile-with-inline-parameters query)))))))))
+    (mt/dataset
+      (mt/dataset-definition "uuid_filter_db"
+                             ["uuid_filter_table"
+                              [{:field-name "uuid"
+                                :base-type {:native "UUID"}
+                                :semantic-type :type/PK}
+                               {:field-name "value"
+                                :base-type :type/Integer}]
+                              [[#uuid "89c77143-0c9a-4686-b241-5b21b9ab44f1" 10]
+                               [#uuid "89c77143-0c9a-4686-b241-5b21b9ab44f2" 20]]])
+      (let [query {:database   (mt/id)
+                   :type       :native
+                   :native     {:query         "select sum(value) from `uuid_filter_db`.`uuid_filter_table` where {{uuid}}"
+                                :template-tags {"uuid" {:type         :dimension
+                                                        :dimension    ["field" (mt/id :uuid_filter_table :uuid) nil]
+                                                        :default      ["89c77143-0c9a-4686-b241-5b21b9ab44f2"]
+                                                        :name         "uuid"
+                                                        :display-name "UUID"
+                                                        :widget-type  "id"}}}
+                   :parameters [{:type   "id"
+                                 :target [:dimension [:template-tag "uuid"]]
+                                 :value  ["89c77143-0c9a-4686-b241-5b21b9ab44f2"]}]}]
+        (is (= [[20]]
+               (mt/formatted-rows [int]
+                                  (qp/process-query query))))
+        (is (= (str "select sum(value) from `uuid_filter_db`.`uuid_filter_table` "
+                    "where `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('89c77143-0c9a-4686-b241-5b21b9ab44f2' AS UUID))")
+               (:query (qp.compile/compile-with-inline-parameters query))))))))
+

--- a/test/metabase/query_processor_test/uuid_test.clj
+++ b/test/metabase/query_processor_test/uuid_test.clj
@@ -27,7 +27,7 @@
                             "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]}))))))))
 
 (deftest ^:parallel joined-uuid-query-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :uuid-type ::uuids-in-create-table-statements)
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :uuid-type ::uuids-in-create-table-statements)
     (testing "Query with joins"
       (mt/dataset uuid-dogs
         (is (= [[#uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859" "Tim"]]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58579

### Description

Adds text comparison support for ClickHouse UUIDs

### How to verify

1. Create a clickhouse table with UUID columns
2. You should be able to filter these columns with the standard text comparison operators, similar to postgres. 

### Demo

<details>

<summary>demo</summary>

https://github.com/user-attachments/assets/83dd752e-a6fa-4769-94a4-9c1a1e302bf5

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
