### PR TITLE
Respect `is_active` on JWT/SAML logins

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -32,7 +32,7 @@
               :email            email
               :sso_source       :jwt
               :login_attributes user-attributes}]
-    (or (sso-utils/fetch-and-update-login-attributes! user)
+    (or (sso-utils/fetch-and-update-login-attributes! user (sso-settings/jwt-user-provisioning-enabled?))
         (sso-utils/check-user-provisioning :jwt)
         (sso-utils/create-new-sso-user! user))))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -98,7 +98,7 @@
                   :email            email
                   :sso_source       :saml
                   :login_attributes user-attributes}]
-    (when-let [user (or (sso-utils/fetch-and-update-login-attributes! new-user)
+    (when-let [user (or (sso-utils/fetch-and-update-login-attributes! new-user (sso-settings/saml-user-provisioning-enabled?))
                         (sso-utils/check-user-provisioning :saml)
                         (sso-utils/create-new-sso-user! new-user))]
       (sync-groups! user group-names)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -74,19 +74,28 @@
       (throw (ex-info (trs "Error creating new SSO user")
                       {:user user})))))
 
-(defn fetch-and-update-login-attributes!
-  "Update `:first_name`, `:last_name`, and `:login_attributes` for the user at `email`.
-  This call is a no-op if the mentioned key values are equal."
-  [{:keys [email] :as user-from-sso}]
-  (when-let [{:keys [id] :as user} (t2/select-one :model/User :%lower.email (u/lower-case-en email))]
-    (let [user-keys (keys user-from-sso)
-          ;; remove keys with `nil` values
-          user-data (into {} (filter second user-from-sso))]
-      (if (= (select-keys user user-keys) user-data)
-        user
-        (do
-          (t2/update! :model/User id user-data)
-          (t2/select-one :model/User :id id))))))
+(mu/defn fetch-and-update-login-attributes!
+  "Updates `UserAttributes` for the user at `email`, if they exist, returning the user afterwards.
+  Only updates if the `UserAttributes` are unequal to the current values.
+
+  If a user exists but `is_active` is `false`, will return the user only if `reactivate?` is `true`. Otherwise it will
+  be as if this user does not exist."
+  [{:keys [email] :as user-from-sso} :- UserAttributes
+   reactivate? :- ms/BooleanValue]
+  (let [;; if the user is not active, we will want to mark them as active if they are actually reactivated.
+        new-user-data (merge user-from-sso {:is_active true})
+        user-keys (keys new-user-data)]
+    (when-let [{:keys [id] :as user} (t2/select-one (into [:model/User :id] user-keys)
+                                                    :%lower.email (u/lower-case-en email))]
+      (when (or (:is_active user)
+                reactivate?)
+        (let [;; remove keys with `nil` values
+              user-data (into {} (filter second new-user-data))]
+          (if (= (select-keys user user-keys) user-data)
+            user
+            (do
+              (t2/update! :model/User id user-data)
+              (t2/select-one :model/User :id id))))))))
 
 (defn relative-uri?
   "Checks that given `uri` is not an absolute (so no scheme and no host)."


### PR DESCRIPTION
Currently, if a user is set to `is_active: false`, we still allow them to create a session via JWT or SAML (though **note that this session cannot be actually used to log in**).

After this change, the behavior when discovering an existing user upon login is:

- if `is_active` is `false` and JWT/SAML user provisioning is on, we'll log the user in and set `is_active` to `true`. The user will be allowed to log in.

- if `is_active` is `false` and JWT/SAML user provisioning is off, we'll give the user an error and not change the existing user.

- if `is_active` is `true`, we'll log the user in like normal.

Fixes [ADM-842: Existing bug? JWT login should respect and update `is_active` field](https://linear.app/metabase/issue/ADM-842/existing-bug-jwt-login-should-respect-and-update-is-active-field)