### PR TITLE
sdk(docs): Export `UserBackendJwtResponse` from SDK

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -55,6 +55,7 @@ export type {
 } from "./types";
 
 export type {
+  UserBackendJwtResponse,
   MetabaseFetchRequestTokenFn,
   MetabaseEmbeddingSessionToken,
 } from "./types/refresh-token";


### PR DESCRIPTION
It fixes API docs generation