### PR TITLE
Improve Gsheets Error Message UI

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.tsx
@@ -4,15 +4,16 @@ import { useLocation } from "react-use";
 import { t } from "ttag";
 
 import { skipToken, useGetDatabaseQuery } from "metabase/api";
-import { Button, Flex, Icon, Loader, Menu, Text, Tooltip } from "metabase/ui";
+import { Button, Flex, Icon, Loader, Menu, Text } from "metabase/ui";
 import {
   useGetGsheetsFolderQuery,
   useSyncGsheetsFolderMutation,
 } from "metabase-enterprise/api";
 
 import { GdriveConnectionModal } from "./GdriveConnectionModal";
+import { GdriveErrorMenuItem } from "./GdriveErrorMenuItem";
 import { trackSheetConnectionClick } from "./analytics";
-import { getErrorMessage, getStatus, useShowGdrive } from "./utils";
+import { getStatus, useShowGdrive } from "./utils";
 
 export function GdriveDbMenu() {
   const [showModal, setShowModal] = useState(false);
@@ -78,7 +79,6 @@ export function GdriveDbMenu() {
           <Menu.Item
             leftSection={<Icon name="close" />}
             fw="bold"
-            disabled={status === "syncing"}
             onClick={() => setShowModal(true)}
           >
             {t`Disconnect`}
@@ -143,21 +143,11 @@ function MenuSyncStatus() {
     : t`soon` + "™";
 
   if (folderStatus === "error") {
-    const errorMessage = getErrorMessage(
-      folderError,
-      // eslint-disable-next-line no-literal-metabase-strings -- admin UI
-      t`Please check that the folder is shared with the Metabase Service Account.`,
-    );
-
     return (
-      <Tooltip label={errorMessage} position="bottom" maw="20rem">
-        <Flex align="center" gap="md">
-          <Icon name="warning" c="error" />
-          <Text fz="sm" c="error">
-            {t`Error syncing`}
-          </Text>
-        </Flex>
-      </Tooltip>
+      <GdriveErrorMenuItem
+        error={folderError ?? folderInfo}
+        hasDivider={false}
+      />
     );
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveDbMenu.unit.spec.tsx
@@ -104,7 +104,11 @@ describe("Google Drive > DB Menu", () => {
     setup({ status: "error" });
 
     await openMenu();
-    expect(await screen.findByText("Error syncing")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Please check that the folder is shared with the Metabase Service Account.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows a menu when loading", async () => {
@@ -133,7 +137,7 @@ describe("Google Drive > DB Menu", () => {
     expect(disconnectButton).toBeEnabled();
   });
 
-  it("disables disconnect button when loading", async () => {
+  it("enables disconnect button when loading", async () => {
     setup({
       status: "syncing",
     });
@@ -142,7 +146,7 @@ describe("Google Drive > DB Menu", () => {
     const disconnectButton = await screen.findByRole("menuitem", {
       name: /close icon disconnect/i,
     });
-    expect(disconnectButton).toBeDisabled();
+    expect(disconnectButton).toBeEnabled();
   });
 
   it("should show last sync time", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveErrorMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveErrorMenuItem.tsx
@@ -1,0 +1,34 @@
+import { t } from "ttag";
+
+import { Box, Flex, Icon, Menu, Text } from "metabase/ui";
+
+import { getErrorMessage } from "./utils";
+
+export function GdriveErrorMenuItem({
+  error,
+  hasDivider = true,
+}: {
+  error: any;
+  hasDivider?: boolean;
+}) {
+  if (!error) {
+    return null;
+  }
+
+  return (
+    <>
+      {hasDivider && <Menu.Divider />}
+      <Menu.Label>
+        <Flex>
+          <Icon name="warning" c="error" mt="xs" mr="sm" />
+          <Box>
+            <Text fw="bold">{t`Couldn't sync Google Sheets`}</Text>
+            <Text size="sm" c="text-medium" maw="16rem">
+              {getErrorMessage(error)}
+            </Text>
+          </Box>
+        </Flex>
+      </Menu.Label>
+    </>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSidebarMenuItem.tsx
@@ -2,11 +2,12 @@ import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { skipToken } from "metabase/api";
-import { Button, Flex, Icon, Menu, Text, Tooltip } from "metabase/ui";
+import { Button, Flex, Icon, Menu, Text } from "metabase/ui";
 import { useGetGsheetsFolderQuery } from "metabase-enterprise/api";
 
+import { GdriveErrorMenuItem } from "./GdriveErrorMenuItem";
 import { trackSheetConnectionClick } from "./analytics";
-import { getErrorMessage, getStatus, useShowGdrive } from "./utils";
+import { getStatus, useShowGdrive } from "./utils";
 
 export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
   const showGdrive = useShowGdrive();
@@ -33,53 +34,37 @@ export function GdriveSidebarMenuItem({ onClick }: { onClick: () => void }) {
     .otherwise(() => t`Google Sheets`);
 
   const helperText = match(status)
-    .with("error", () => t`Connection error`)
     .with("not-connected", () => null)
     .with("syncing", () => t`Syncing files...`)
     .with("active", () => t`Connected`)
     .otherwise(() => null);
 
-  const errorMessage = getErrorMessage(error);
-
-  const MaybeTooltip = ({ children }: { children: React.ReactNode }) =>
-    status === "error" ? (
-      <Tooltip label={errorMessage} position="bottom" maw="20rem">
-        {children}
-      </Tooltip>
-    ) : (
-      <>{children}</>
-    );
-
   return (
-    <Menu.Item onClick={handleClick} disabled={status === "syncing"}>
-      <Flex gap="sm" align="flex-start" justify="space-between" w="100%">
-        <Flex>
-          <Icon name="google_sheet" mt="xs" mr="sm" />
-          <div>
-            <Text
-              fw="bold"
-              c={status === "syncing" ? "text-light" : "text-dark"}
-            >
-              {buttonText}
-            </Text>
-            {helperText && (
-              <MaybeTooltip>
+    <>
+      <Menu.Item onClick={handleClick}>
+        <Flex gap="sm" align="flex-start" justify="space-between" w="100%">
+          <Flex>
+            <Icon name="google_sheet" mt="xs" mr="sm" />
+            <div>
+              <Text fw="bold">{buttonText}</Text>
+              {helperText && (
                 <Text
                   size="sm"
                   c={status === "error" ? "error" : "text-medium"}
                 >
                   {helperText}
                 </Text>
-              </MaybeTooltip>
-            )}
-          </div>
+              )}
+            </div>
+          </Flex>
+          {status === "active" && (
+            <Button variant="subtle" onClick={handleClick}>
+              {t`Add New`}
+            </Button>
+          )}
         </Flex>
-        {status === "active" && (
-          <Button variant="subtle" onClick={handleClick}>
-            {t`Add New`}
-          </Button>
-        )}
-      </Flex>
-    </Menu.Item>
+      </Menu.Item>
+      {status === "error" && <GdriveErrorMenuItem error={error ?? folder} />}
+    </>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
@@ -8,6 +8,13 @@ import { getUserIsAdmin } from "metabase/selectors/user";
 import { useGetServiceAccountQuery } from "metabase-enterprise/api";
 import type { GdrivePayload } from "metabase-types/api";
 
+export type ErrorPayload =
+  | unknown
+  | string
+  | { data: { message: string } | { error_message: string } | string }
+  | { message: string }
+  | { error_message: string };
+
 export function useShowGdrive() {
   const gSheetsEnabled = useSetting("show-google-sheets-integration");
   const hasDwh = useHasTokenFeature("attached_dwh");
@@ -40,13 +47,9 @@ export const getStatus = ({
     .otherwise(() => "not-connected");
 
 export const getErrorMessage = (
-  payload:
-    | unknown
-    | string
-    | { data: { message: string } | { error_message: string } | string }
-    | { message: string }
-    | { error_message: string },
-  fallback: string = t`Something went wrong`,
+  payload: ErrorPayload,
+  // eslint-disable-next-line no-literal-metabase-strings -- admin UI
+  fallback: string = t`Please check that the folder is shared with the Metabase Service Account.`,
 ): string => {
   if (typeof payload === "string") {
     return payload;

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.unit.spec.ts
@@ -99,7 +99,9 @@ describe("google_drive > getStatus", () => {
 
     it("should return a default fallback message if payload is null", () => {
       const result = getErrorMessage(null);
-      expect(result).toEqual("Something went wrong");
+      expect(result).toEqual(
+        "Please check that the folder is shared with the Metabase Service Account.",
+      );
     });
   });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DwhUpload/DwhUpload.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DwhUpload/DwhUpload.tsx
@@ -74,7 +74,7 @@ export const DwhUploadMenu = () => {
 
   return (
     <Box data-testid="dwh-upload" mt="md" px="md">
-      <Menu position="right">
+      <Menu position="right-start">
         <Menu.Target>
           <Button
             fullWidth


### PR DESCRIPTION
Closes ADM-799

depends on https://github.com/metabase/metabase/pull/58439

### Description

Adds nicer UI for displaying error messages, both in the sidebar upload menu:
![Screenshot 2025-05-28 at 10 31 18 AM](https://github.com/user-attachments/assets/5f0b8996-1762-4492-92bd-1e1028f6a015)

and the browse database menu
![Screenshot 2025-05-28 at 12 25 56 PM](https://github.com/user-attachments/assets/dad83135-b6ee-4455-9f84-16df10af75bc)


### How to verify

Easiest way to trigger an error state:
1. connect a google drive/sheet
2. Revoke access from the metabase service account
3. trigger a resync
4. you should see an error 🎈 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
