### PR TITLE
fix: set download-results to no on table block

### DIFF
--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -57,7 +57,7 @@ describe("scenarios > admin > permissions > view data > blocked", () => {
 
     H.assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Granular", false);
     H.assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", false);
-    H.assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "1 million rows", false);
+    H.assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "Granular", false);
 
     H.modifyPermission(g, DATA_ACCESS_PERM_IDX, "Blocked");
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10274,6 +10274,39 @@ databaseChangeLog:
       rollback: # not needed
 
   - changeSet:
+      id: v52.2025-05-28T00:00:01
+      author: edpaget
+      comment: set perms/download-results to no when a table has perms/view-data blocked
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            sqlCheck:
+              expectedResult: 0
+              sql: >-
+                SELECT count(*) FROM (
+                    SELECT group_id, db_id, table_id
+                    FROM data_permissions
+                    WHERE (perm_type = 'perms/view-data' AND perm_value = 'blocked')
+                        OR (perm_type = 'perms/download-results' AND perm_value <> 'no')
+                    GROUP BY group_id, db_id, table_id
+                    HAVING count(*) = 2
+                )
+      changes:
+        - sql: >-
+            UPDATE data_permissions as update_dp SET perm_value = 'no'
+            WHERE EXISTS (
+                SELECT 1 FROM data_permissions as dp
+                WHERE dp.group_id = update_dp.group_id
+                    AND dp.db_id = update_dp.db_id
+                    AND dp.table_id = update_dp.table_id
+                    AND dp.perm_type = 'perms/view-data'
+                    AND dp.perm_value = 'blocked'
+                    AND update_dp.perm_type = 'perms/download-results'
+                    AND update_dp.perm_value <> 'no'
+            )
+      rollback: # not needed
+
+  - changeSet:
       id: v53.2024-12-02T16:21:15
       author: noahmoss
       comment: Add cache_config.refresh_automatically column

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10280,17 +10280,15 @@ databaseChangeLog:
       preConditions: # change is safe to run regardless
       changes:
         - sql: >-
-            UPDATE data_permissions as update_dp SET perm_value = 'no'
-            WHERE EXISTS (
-                SELECT 1 FROM data_permissions as dp
-                WHERE dp.group_id = update_dp.group_id
-                    AND dp.db_id = update_dp.db_id
-                    AND dp.table_id = update_dp.table_id
-                    AND dp.perm_type = 'perms/view-data'
-                    AND dp.perm_value = 'blocked'
-                    AND update_dp.perm_type = 'perms/download-results'
-                    AND update_dp.perm_value <> 'no'
-            )
+            UPDATE data_permissions SET perm_value = 'no'
+            JOIN data_permissions as dp
+                ON dp.group_id = group_id
+                AND dp.db_id = db_id
+                AND dp.table_id = table_id
+                AND dp.perm_type = 'perms/view-data'
+                AND dp.perm_value = 'blocked'
+            WHERE update_dp.perm_type = 'perms/download-results'
+                AND update_dp.perm_value <> 'no'
       rollback: # not needed
 
   - changeSet:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10279,16 +10279,33 @@ databaseChangeLog:
       comment: set perms/download-results to no when a table has perms/view-data blocked
       preConditions: # change is safe to run regardless
       changes:
-        - sql: >-
-            UPDATE data_permissions SET perm_value = 'no'
-            JOIN data_permissions as dp
-                ON dp.group_id = group_id
-                AND dp.db_id = db_id
-                AND dp.table_id = table_id
-                AND dp.perm_type = 'perms/view-data'
-                AND dp.perm_value = 'blocked'
-            WHERE update_dp.perm_type = 'perms/download-results'
-                AND update_dp.perm_value <> 'no'
+         - sql:
+            dbms: postgresql,h2
+            sql: >-
+              UPDATE data_permissions as update_dp SET perm_value = 'no'
+              WHERE update_dp.perm_type = 'perms/download-results'
+                  AND update_dp.perm_value <> 'no'
+                  AND EXISTS (
+                  SELECT 1 FROM data_permissions as dp
+                  WHERE dp.group_id = update_dp.group_id
+                      AND dp.db_id = update_dp.db_id
+                      AND dp.table_id = update_dp.table_id
+                      AND dp.perm_type = 'perms/view-data'
+                      AND dp.perm_value = 'blocked'
+                  )
+         - sql:
+            dbms: mariadb,mysql
+            sql: >-
+              UPDATE data_permissions as update_dp
+              INNER JOIN data_permissions as dp
+                  ON dp.group_id = update_dp.group_id
+                  AND dp.db_id = update_dp.db_id
+                  AND dp.table_id = update_dp.table_id
+                  AND dp.perm_type = 'perms/view-data'
+                  AND dp.perm_value = 'blocked'
+              SET update_dp.perm_value = 'no'
+              WHERE update_dp.perm_type = 'perms/download-results'
+                  AND update_dp.perm_value <> 'no'
       rollback: # not needed
 
   - changeSet:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10277,20 +10277,7 @@ databaseChangeLog:
       id: v52.2025-05-28T00:00:01
       author: edpaget
       comment: set perms/download-results to no when a table has perms/view-data blocked
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            sqlCheck:
-              expectedResult: 0
-              sql: >-
-                SELECT count(*) FROM (
-                    SELECT group_id, db_id, table_id
-                    FROM data_permissions
-                    WHERE (perm_type = 'perms/view-data' AND perm_value = 'blocked')
-                        OR (perm_type = 'perms/download-results' AND perm_value <> 'no')
-                    GROUP BY group_id, db_id, table_id
-                    HAVING count(*) = 2
-                )
+      preConditions: # change is safe to run regardless
       changes:
         - sql: >-
             UPDATE data_permissions as update_dp SET perm_value = 'no'

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -787,6 +787,14 @@
                                             keys
                                             (zipmap (repeat :unrestricted)))]
               (set-table-permissions! group-or-id :perms/view-data view-data-table-perms)))
+          (when (= :perms/view-data perm-type)
+            ;; if we are setting the view data permissions to blocked update create-queries and download-results to also
+            ;; mark them as no. This conforms with the behaviour of the set-database-permissions! function
+            (let [no-permissions (-> (filter (fn [[_ value]] (= value :blocked)) table-perms)
+                                     keys
+                                     (zipmap (repeat :no)))]
+              (set-table-permissions! group-or-id :perms/create-queries no-permissions)
+              (set-table-permissions! group-or-id :perms/download-results no-permissions)))
           (if existing-db-perm
             (when (not= values #{existing-db-perm-value})
               ;; If we're setting any table permissions to a value that is different from the database-level permission,

--- a/src/metabase/permissions/models/data_permissions/graph.clj
+++ b/src/metabase/permissions/models/data_permissions/graph.clj
@@ -368,13 +368,17 @@
   ([graph]
    (doseq [[group-id group-changes] graph]
      (doseq [[db-id db-changes] group-changes
-             [perm-type new-perms] db-changes]
-       (case perm-type
-         :view-data      (update-db-level-view-data-permissions! group-id db-id new-perms)
-         :create-queries (update-db-level-create-queries-permissions! group-id db-id new-perms)
-         :download       (update-db-level-download-permissions! group-id db-id new-perms)
-         :data-model     (update-db-level-metadata-permissions! group-id db-id new-perms)
-         :details        (update-details-perms! group-id db-id new-perms)))))
+             ;; instead of iterating the provided cb-changes object we need to go in a specific order
+             ;; so backend consistency rules like setting create-queries and download to no when view-data
+             ;; is blocked can happen in the correct order despite what may come in the API request
+             perm-type [:details :data-model :download :create-queries :view-data]]
+       (when-let [new-perms (perm-type db-changes)]
+         (case perm-type
+           :view-data      (update-db-level-view-data-permissions! group-id db-id new-perms)
+           :create-queries (update-db-level-create-queries-permissions! group-id db-id new-perms)
+           :download       (update-db-level-download-permissions! group-id db-id new-perms)
+           :data-model     (update-db-level-metadata-permissions! group-id db-id new-perms)
+           :details        (update-details-perms! group-id db-id new-perms))))))
 
   ;; The following arity is provided soley for convenience for tests/REPL usage
   ([ks :- [:vector :any] new-value]

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2756,3 +2756,24 @@
         (t2/update! (t2/table-name :model/User) user-id {:locale "zh"})
         (migrate!)
         (is (= "zh_CN" (t2/select-one-fn :locale (t2/table-name :model/User) :id user-id)))))))
+
+(deftest migrate-download-results-perms-test
+  (testing "Download results are set to no if view-data for a table is blocked"
+    (impl/test-migrations "v52.2025-05-28T00:00:01" [migrate!]
+      (let [db-id (t2/insert-returning-pk! (t2/table-name :model/Database) {:details   "{}"
+                                                                            :engine    "h2"
+                                                                            :is_sample false
+                                                                            :name      "populate-collection-created-at-test-db"})
+            table-id-1 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id db-id :name "test-table-1" :active true
+                                                                              :created_at :%now
+                                                                              :updated_at :%now})
+            table-id-2 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id db-id :name "test-table-2" :active true
+                                                                              :created_at :%now
+                                                                              :updated_at :%now})
+            pg-id (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "test-group"})]
+        (t2/insert! (t2/table-name :model/DataPermissions) [{:group_id pg-id :db_id db-id :table_id table-id-1 :perm_type "perms/view-data" :perm_value "blocked"}
+                                                            {:group_id pg-id :db_id db-id :table_id table-id-1 :perm_type "perms/download-results" :perm_value "one-million-rows"}
+                                                            {:group_id pg-id :db_id db-id :table_id table-id-2 :perm_type "perms/view-data" :perm_value "unrestricted"}
+                                                            {:group_id pg-id :db_id db-id :table_id table-id-2 :perm_type "perms/download-results" :perm_value "one-million-rows"}])
+        (migrate!)
+        (is (t2/exists? :model/DataPermissions :table_id table-id-1 :perm_value "no"))))))

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2741,6 +2741,29 @@
 ;;; 53+ tests should go below this line please <3
 ;;;
 
+(deftest migrate-download-results-perms-test
+  (testing "Download results are set to no if view-data for a table is blocked"
+    (impl/test-migrations "v52.2025-05-28T00:00:01" [migrate!]
+      (let [db-id (t2/insert-returning-pk! (t2/table-name :model/Database) {:details   "{}"
+                                                                            :engine    "h2"
+                                                                            :is_sample false
+                                                                            :name      "populate-collection-created-at-test-db"
+                                                                            :created_at :%now
+                                                                            :updated_at :%now})
+            table-id-1 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id db-id :name "test-table-1" :active true
+                                                                              :created_at :%now
+                                                                              :updated_at :%now})
+            table-id-2 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id db-id :name "test-table-2" :active true
+                                                                              :created_at :%now
+                                                                              :updated_at :%now})
+            pg-id (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "test-group"})]
+        (t2/insert! (t2/table-name :model/DataPermissions) [{:group_id pg-id :db_id db-id :table_id table-id-1 :perm_type "perms/view-data" :perm_value "blocked"}
+                                                            {:group_id pg-id :db_id db-id :table_id table-id-1 :perm_type "perms/download-results" :perm_value "one-million-rows"}
+                                                            {:group_id pg-id :db_id db-id :table_id table-id-2 :perm_type "perms/view-data" :perm_value "unrestricted"}
+                                                            {:group_id pg-id :db_id db-id :table_id table-id-2 :perm_type "perms/download-results" :perm_value "one-million-rows"}])
+        (migrate!)
+        (is (t2/exists? :model/DataPermissions :table_id table-id-1 :perm_value "no"))))))
+
 (deftest chinese-site-locale-migration-test
   (testing "Site locale is migrated from zh to zh_CN"
     (impl/test-migrations "v54.2025-03-17T18:52:44" [migrate!]
@@ -2756,24 +2779,3 @@
         (t2/update! (t2/table-name :model/User) user-id {:locale "zh"})
         (migrate!)
         (is (= "zh_CN" (t2/select-one-fn :locale (t2/table-name :model/User) :id user-id)))))))
-
-(deftest migrate-download-results-perms-test
-  (testing "Download results are set to no if view-data for a table is blocked"
-    (impl/test-migrations "v52.2025-05-28T00:00:01" [migrate!]
-      (let [db-id (t2/insert-returning-pk! (t2/table-name :model/Database) {:details   "{}"
-                                                                            :engine    "h2"
-                                                                            :is_sample false
-                                                                            :name      "populate-collection-created-at-test-db"})
-            table-id-1 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id db-id :name "test-table-1" :active true
-                                                                              :created_at :%now
-                                                                              :updated_at :%now})
-            table-id-2 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id db-id :name "test-table-2" :active true
-                                                                              :created_at :%now
-                                                                              :updated_at :%now})
-            pg-id (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "test-group"})]
-        (t2/insert! (t2/table-name :model/DataPermissions) [{:group_id pg-id :db_id db-id :table_id table-id-1 :perm_type "perms/view-data" :perm_value "blocked"}
-                                                            {:group_id pg-id :db_id db-id :table_id table-id-1 :perm_type "perms/download-results" :perm_value "one-million-rows"}
-                                                            {:group_id pg-id :db_id db-id :table_id table-id-2 :perm_type "perms/view-data" :perm_value "unrestricted"}
-                                                            {:group_id pg-id :db_id db-id :table_id table-id-2 :perm_type "perms/download-results" :perm_value "one-million-rows"}])
-        (migrate!)
-        (is (t2/exists? :model/DataPermissions :table_id table-id-1 :perm_value "no"))))))

--- a/test/metabase/permissions/api_test.clj
+++ b/test/metabase/permissions/api_test.clj
@@ -6,6 +6,7 @@
    [metabase.config.core :as config]
    [metabase.permissions.api :as api.permissions]
    [metabase.permissions.api-test-util :as perm-test-util]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -313,6 +314,55 @@
       (mt/with-premium-features #{}
         (mt/assert-has-premium-feature-error "Sandboxes" (mt/user-http-request :crowberto :put 402 "permissions/graph"
                                                                                (assoc (data-perms.graph/api-graph) :sandboxes [{:card_id 1}])))))))
+
+(deftest update-perms-graph-blocked-view-data-test
+  (testing "PUT /api/permissions/graph"
+    (testing "setting view-data to blocked automatically sets download-results to no, even if requested otherwise"
+      (mt/with-temp [:model/PermissionsGroup group       {}
+                     :model/Database         {db-id :id}  {}
+                     :model/Table            {table-id :id} {:db_id db-id, :schema "PUBLIC"}]
+        (mt/with-no-data-perms-for-all-users!
+          (perms/add-user-to-group! (mt/user->id :rasta) group)
+          ;; First set both permissions to unrestricted/full
+          (mt/user-http-request
+           :crowberto :put 200 "permissions/graph"
+           (-> (data-perms.graph/api-graph)
+               (assoc-in [:groups (u/the-id group) db-id :view-data]
+                         {"PUBLIC" {table-id :unrestricted}})
+               (assoc-in [:groups (u/the-id group) db-id :download :schemas]
+                         {"PUBLIC" {table-id :full}})))
+
+          ;; Verify initial state
+          (is (= :unrestricted
+                 (data-perms/table-permission-for-user (mt/user->id :rasta)
+                                                       :perms/view-data
+                                                       db-id
+                                                       table-id)))
+          (is (= :one-million-rows
+                 (data-perms/table-permission-for-user (mt/user->id :rasta)
+                                                       :perms/download-results
+                                                       db-id
+                                                       table-id)))
+          ;; Now try to set view-data to blocked while keeping download-results as full
+          (mt/user-http-request
+           :crowberto :put 200 "permissions/graph"
+           (-> (data-perms.graph/api-graph)
+               (assoc-in [:groups (u/the-id group) db-id :view-data]
+                         {"PUBLIC" {table-id :blocked}})
+               (assoc-in [:groups (u/the-id group) db-id :download :schemas]
+                         {"PUBLIC" {table-id :full}})))
+
+          ;; Verify that download-results was automatically set to no
+          (is (= :blocked
+                 (data-perms/table-permission-for-user (mt/user->id :rasta)
+                                                       :perms/view-data
+                                                       db-id
+                                                       table-id)))
+          (is (= :no
+                 (data-perms/table-permission-for-user (mt/user->id :rasta)
+                                                       :perms/download-results
+                                                       db-id
+                                                       table-id))))))))
 
 (deftest get-group-membership-test
   (testing "GET /api/permissions/membership"

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -127,7 +127,32 @@
           (is (= :no (create-queries-perm-value nil)))
           (is (nil?  (create-queries-perm-value table-id-1)))
           (is (nil?  (create-queries-perm-value table-id-2)))
-          (is (nil?  (create-queries-perm-value table-id-3))))))))
+          (is (nil?  (create-queries-perm-value table-id-3))))
+
+        (testing "Setting view-data to :blocked for tables also sets create-queries and download-results to :no"
+          (let [download-results-perm-value (fn [table-id] (t2/select-one-fn :perm_value :model/DataPermissions
+                                                                             :db_id     database-id
+                                                                             :group_id  group-id
+                                                                             :table_id  table-id
+                                                                             :perm_type :perms/download-results))]
+            ;; First set up some initial permissions
+            (data-perms/set-table-permissions! group-id :perms/view-data {table-id-1 :unrestricted
+                                                                          table-id-2 :unrestricted})
+            (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-1 :query-builder
+                                                                               table-id-2 :query-builder})
+            (data-perms/set-table-permissions! group-id :perms/download-results {table-id-1 :one-million-rows
+                                                                                 table-id-2 :one-million-rows})
+
+            ;; Now set view-data to :blocked for table-id-1 only
+            (data-perms/set-table-permissions! group-id :perms/view-data {table-id-1 :blocked})
+
+            ;; Verify that create-queries and download-results are set to :no for table-id-1
+            (is (= :no (create-queries-perm-value table-id-1)))
+            (is (= :no (download-results-perm-value table-id-1)))
+
+            ;; Verify that table-id-2 permissions are unchanged
+            (is (= :query-builder (create-queries-perm-value table-id-2)))
+            (is (= :one-million-rows (download-results-perm-value table-id-2)))))))))
 
 (deftest database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}


### PR DESCRIPTION
### Description

When a view-data permission for a table is set to blocked set the create-queries and download-results permissions to no. This makes set-table-permissions! behave in the same way as set-database-permissions! for these changes. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
