### PR TITLE
PoC unique join alias

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -510,11 +510,16 @@
     (generator base-name)))
 
 (defn default-alias
-  "Generate a default `:alias` for a join clause. home-cols should be visible columns for the stage"
+  "Generate a default `:alias` for a join clause."
+  []
+  (u/generate-nano-id))
+
+(defn default-display-name
+  "Generate a default `:display-name` for a join clause. home-cols should be visible columns for the stage"
   ([query stage-number a-join]
    (let [stage (lib.util/query-stage query stage-number)
          home-cols (lib.metadata.calculation/visible-columns query stage-number stage)]
-     (default-alias query stage-number a-join stage home-cols)))
+     (default-display-name query stage-number a-join stage home-cols)))
   ([query _stage-number a-join stage home-cols]
    (let [home-cols   home-cols
          cond-fields (lib.util.match/match (:conditions a-join) :field)
@@ -540,7 +545,8 @@
                                                             %)
                                                          joins))))
           home-cols   (lib.metadata.calculation/visible-columns query stage-number stage)
-          join-alias  (default-alias query stage-number a-join stage home-cols)
+          join-alias  (default-alias)
+          join-name   (default-display-name query stage-number a-join stage home-cols)
           join-cols   (lib.metadata.calculation/returned-columns
                        (lib.query/query-with-stages query (:stages a-join)))]
       (cond-> a-join
@@ -549,7 +555,8 @@
                                 (fn [conditions]
                                   (mapv #(add-alias-to-condition query stage-number % join-alias home-cols join-cols)
                                         conditions)))
-        true (with-join-alias join-alias)))))
+        true (with-join-alias join-alias)
+        true (assoc :display-name join-name)))))
 
 (declare join-conditions
          joined-thing

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -459,13 +459,13 @@
               join-idx (peek join-loc)
               join (get (lib.join/joins query stage-number) join-idx)
               old-join (get (lib.join/joins unmodified-query stage-number) join-idx)
-              new-name (lib.join/default-alias query stage-number (dissoc join :alias))]
-          (if (and (not= new-name (:alias join))
+              new-alias (lib.join/default-alias)]
+          (if (and (not= new-alias (:alias join))
                    (conditions-changed-for-aliases? (:alias join) (:conditions join)
                                                     (:alias old-join) (:conditions old-join)))
             ;; TODO: This is pretty ugly and specific; this is an example of how hopelessly coupled and intricate
             ;; this namespace is.
-            (rename-join query stage-number (assoc join :ident (:ident old-join)) new-name)
+            (rename-join query stage-number (assoc join :ident (:ident old-join)) new-alias)
             query))
         query))))
 

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -459,13 +459,13 @@
               join-idx (peek join-loc)
               join (get (lib.join/joins query stage-number) join-idx)
               old-join (get (lib.join/joins unmodified-query stage-number) join-idx)
-              new-alias (lib.join/default-alias)]
-          (if (and (not= new-alias (:alias join))
+              new-name (lib.join/default-display-name query stage-number (dissoc join :alias))]
+          (if (and (not= new-name ((some-fn :display-name :alias) join))
                    (conditions-changed-for-aliases? (:alias join) (:conditions join)
                                                     (:alias old-join) (:conditions old-join)))
             ;; TODO: This is pretty ugly and specific; this is an example of how hopelessly coupled and intricate
             ;; this namespace is.
-            (rename-join query stage-number (assoc join :ident (:ident old-join)) new-alias)
+            (rename-join query stage-number (assoc join :ident (:ident old-join)) (lib.join/default-alias))
             query))
         query))))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -129,13 +129,13 @@
 (defn- display-name-for-joined-field
   "Return an appropriate display name for a joined field. For *explicitly* joined Fields, the qualifier is the join
   alias; for implicitly joined fields, it is the display name of the foreign key used to create the join."
-  [field-display-name {:keys [fk-field-id], join-alias :alias}]
+  [field-display-name {:keys [fk-field-id], join-alias :alias, join-display-name :display-name}]
   (let [qualifier (if fk-field-id
                     ;; strip off trailing ` id` from FK display name
                     (str/replace (:display-name (lib.metadata/field (qp.store/metadata-provider) fk-field-id))
                                  #"(?i)\sid$"
                                  "")
-                    join-alias)]
+                    (or join-display-name join-alias))]
     (format "%s → %s" qualifier field-display-name)))
 
 (defn- datetime-arithmetics?


### PR DESCRIPTION
Try to workaround QP bugs:
1. If a `join-alias` is not unique within the whole query, including nested cards, everything breaks
2. If a `join-alias` is changed by `driver/escape-alias`, everything breaks

So decouple the join identifier from the column display-name prefix:
1. Use a nano-id for `:alias`
2. Add a new join property `display-name` that is used to set `display-name` of joined columns.