### PR TITLE
Ensure display-info returns correct :long-display-name for aggregations from a previous stage

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -2071,8 +2071,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         "Product → Created At",
         // 1st stage - Aggregations & breakouts
         "Created At: Month",
-        "Category",
-        "Created At: Year",
+        "Product → Category",
+        "User → Created At: Year",
         "Count",
         "Sum of Total",
         // 2nd stage - Custom columns
@@ -2085,10 +2085,10 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         "Reviews - Created At: Month → Body",
         "Reviews - Created At: Month → Created At",
         // 2nd stage - Aggregations & breakouts
-        "Category",
-        "Created At",
+        "Product → Category",
+        "Reviews - Created At: Month → Created At",
         "Count",
-        "Sum of Rating",
+        "Sum of Reviews - Created At: Month → Rating",
       ]);
 
       // 1st stage - Orders
@@ -2117,7 +2117,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       H.popover().findByText("Product → Category").click();
 
       // 1st stage - Aggregations & breakouts
-      getClickMapping("Category").first().click();
+      getClickMapping("Product → Category").eq(2).click();
       H.popover().findByText("Product → Category").click();
 
       // 2nd stage - Custom columns

--- a/e2e/test/scenarios/filters/filter-sources.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-sources.cy.spec.js
@@ -619,7 +619,7 @@ describe("scenarios > filters > filter sources", () => {
         cy.findByPlaceholderText("Enter a number").type("350");
         cy.button("Add filter").click();
       });
-      assertFilterName("Sum of QUANTITY is less than 350", { stage: 1 });
+      assertFilterName("Sum of Quantity is less than 350", { stage: 1 });
       H.visualize();
       H.assertQueryBuilderRowCount(115);
     });

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
@@ -301,8 +301,8 @@ describe("parameters/utils/targets", () => {
             ...withColumnsStage(0, productsColumns),
             ...withColumnsStage(1, [
               ["Orders", "Created At: Month"],
-              ["Products", "Created At: Year"],
-              ["Reviews", "Created At: Quarter"],
+              ["Products", "Product → Created At: Year"],
+              ["Reviews", "Reviews - Product → Created At: Quarter"],
               [undefined, "User's 18th birthday"],
               [undefined, "Count"],
               [undefined, "Sum of Total"],
@@ -324,8 +324,8 @@ describe("parameters/utils/targets", () => {
             ...withColumnsStage(0, productsColumns),
             ...withColumnsStage(1, [
               ["Orders", "Created At: Month"],
-              ["Products", "Created At: Year"],
-              ["Reviews", "Created At: Quarter"],
+              ["Products", "Product → Created At: Year"],
+              ["Reviews", "Reviews - Product → Created At: Quarter"],
               [undefined, "User's 18th birthday"],
               [undefined, "Count"],
               [undefined, "Sum of Total"],

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -248,6 +248,8 @@
                        parent-id           :parent-id
                        simple-display-name ::simple-display-name
                        hide-bin-bucket?    :lib/hide-bin-bucket?
+                       source              :lib/source
+                       source-uuid         :lib/source-uuid
                        :as                 field-metadata} style]
   (let [humanized-name (u.humanization/name->human-readable-name :simple field-name)
         field-display-name (or simple-display-name
@@ -256,6 +258,23 @@
                                           (or (nil? field-display-name)
                                               (= field-display-name humanized-name)))
                                  (nest-display-name query field-metadata))
+                               (when-let [[source-index source-clause]
+                                          (and source-uuid
+                                               field-display-name
+                                               (= style :long)
+                                               (= source :source/previous-stage)
+                                               (not (or fk-field-id join-alias))
+                                               (not (str/includes? field-display-name " → "))
+                                               (lib.util/find-stage-index-and-clause-by-uuid
+                                                query
+                                                (dec stage-number)
+                                                source-uuid))]
+                                 ;; The :display-name from the field metadata is probably not a :long display name, so
+                                 ;; if the caller requested a :long name and we can lookup the original clause by the
+                                 ;; source-uuid, use that to get the :long name. This allows display-info to get the
+                                 ;; long display-name with join info included for aggregations over a joined field
+                                 ;; from the previous stage, like "Max of Products -> ID" rather than "Max of ID".
+                                 (lib.metadata.calculation/display-name query source-index source-clause style))
                                field-display-name
                                (if (string? field-name)
                                  humanized-name

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -583,13 +583,16 @@
           (update :stages #(into [] (take (inc (canonical-stage-index query stage-number))) %)))
       new-query)))
 
-(defn find-clause-by-uuid
-  "Find a clause in `query` with the given `lib-uuid`."
+(defn find-stage-index-and-clause-by-uuid
+  "Find the clause in `query` with the given `lib-uuid`. Return a [stage-index clause] pair, if found."
   ([query lib-uuid]
-   (find-clause-by-uuid query -1 lib-uuid))
+   (find-stage-index-and-clause-by-uuid query -1 lib-uuid))
   ([query stage-number lib-uuid]
-   (lib.util.match/match-one (drop-later-stages query stage-number)
-     (_ :guard #(= lib-uuid (lib.options/uuid %))))))
+   (first (keep-indexed (fn [idx stage]
+                          (lib.util.match/match-one stage
+                            (clause :guard #(= lib-uuid (lib.options/uuid %)))
+                            [idx clause]))
+                        (:stages (drop-later-stages query stage-number))))))
 
 (defn fresh-uuids
   "Recursively replace all the :lib/uuids in `x` with fresh ones. Useful if you need to attach something to a query more

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -336,7 +336,8 @@
 (defn last-stage?
   "Whether a `stage-number` is referring to the last stage of a query or not."
   [query stage-number]
-  (not (next-stage-number query stage-number)))
+  ;; Call canonical-stage-index to ensure this throws when given an invalid stage-number.
+  (not (next-stage-number query (canonical-stage-index query stage-number))))
 
 (mu/defn query-stage :- [:maybe ::lib.schema/stage]
   "Fetch a specific `stage` of a query. This handles negative indices as well, e.g. `-1` will return the last stage of

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -392,7 +392,7 @@
   (is (= 2 (lib/stage-count (lib.util/drop-later-stages two-stage-query -1))))
   (is (= two-stage-query (lib.util/drop-later-stages two-stage-query -1))))
 
-(deftest ^:parallel find-clause-by-uuid-test
+(deftest ^:parallel find-stage-index-and-clause-by-uuid-test
   (let [query {:database 1
                :lib/type :mbql/query
                :stages   [{:lib/type     :mbql.stage/mbql
@@ -403,16 +403,16 @@
                                        {:lib/uuid "a1898aa6-4928-4e97-837d-e440ce21085e"}
                                        [:field {:lib/uuid "1cb2a996-6ba1-45fb-8101-63dc3105c311"} 3]
                                        "wow"]]}]}]
-    (is (= [:count {:lib/uuid "00000000-0000-0000-0000-000000000001"}]
-           (lib.util/find-clause-by-uuid query "00000000-0000-0000-0000-000000000001")))
-    (is (= [:count {:lib/uuid "00000000-0000-0000-0000-000000000001"}]
-           (lib.util/find-clause-by-uuid query 0 "00000000-0000-0000-0000-000000000001")))
-    (is (= [:field {:lib/uuid "1cb2a996-6ba1-45fb-8101-63dc3105c311"} 3]
-           (lib.util/find-clause-by-uuid query "1cb2a996-6ba1-45fb-8101-63dc3105c311")))
-    (is (= [:=
-            {:lib/uuid "a1898aa6-4928-4e97-837d-e440ce21085e"}
-            [:field {:lib/uuid "1cb2a996-6ba1-45fb-8101-63dc3105c311"} 3]
-            "wow"]
-           (lib.util/find-clause-by-uuid query "a1898aa6-4928-4e97-837d-e440ce21085e")))
-    (is (nil? (lib.util/find-clause-by-uuid query "00000000-0000-0000-0000-000000000002")))
-    (is (nil? (lib.util/find-clause-by-uuid query 0 "a1898aa6-4928-4e97-837d-e440ce21085e")))))
+    (is (= [0 [:count {:lib/uuid "00000000-0000-0000-0000-000000000001"}]]
+           (lib.util/find-stage-index-and-clause-by-uuid query "00000000-0000-0000-0000-000000000001")))
+    (is (= [0 [:count {:lib/uuid "00000000-0000-0000-0000-000000000001"}]]
+           (lib.util/find-stage-index-and-clause-by-uuid query 0 "00000000-0000-0000-0000-000000000001")))
+    (is (= [1 [:field {:lib/uuid "1cb2a996-6ba1-45fb-8101-63dc3105c311"} 3]]
+           (lib.util/find-stage-index-and-clause-by-uuid query "1cb2a996-6ba1-45fb-8101-63dc3105c311")))
+    (is (= [1 [:=
+               {:lib/uuid "a1898aa6-4928-4e97-837d-e440ce21085e"}
+               [:field {:lib/uuid "1cb2a996-6ba1-45fb-8101-63dc3105c311"} 3]
+               "wow"]]
+           (lib.util/find-stage-index-and-clause-by-uuid query "a1898aa6-4928-4e97-837d-e440ce21085e")))
+    (is (nil? (lib.util/find-stage-index-and-clause-by-uuid query "00000000-0000-0000-0000-000000000002")))
+    (is (nil? (lib.util/find-stage-index-and-clause-by-uuid query 0 "a1898aa6-4928-4e97-837d-e440ce21085e")))))

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -372,17 +372,34 @@
     (is (lib.util/first-stage? single-stage-query 0))
     (is (lib.util/first-stage? two-stage-query 0)))
   (testing "should return false for the second stage"
-    (is (not (lib.util/first-stage? two-stage-query 1)))))
+    (is (not (lib.util/first-stage? two-stage-query 1))))
+  (testing "should throw for invalid index"
+    (are [form] (thrown-with-msg?
+                 #?(:clj Throwable :cljs js/Error)
+                 #"Stage .* does not exist"
+                 form)
+      (lib.util/first-stage? single-stage-query 1)
+      (lib.util/first-stage? single-stage-query -2)
+      (lib.util/first-stage? two-stage-query 2)
+      (lib.util/first-stage? two-stage-query -3))))
 
 (deftest ^:parallel last-stage?-test
   (testing "should return true for the last stage"
     (is (lib.util/last-stage? single-stage-query 0))
     (is (lib.util/last-stage? two-stage-query 1)))
   (testing "should return false for a non-last stage"
-    (is (not (lib.util/last-stage? two-stage-query 0)))))
+    (is (not (lib.util/last-stage? two-stage-query 0))))
+  (testing "should throw for invalid index"
+    (are [form] (thrown-with-msg?
+                 #?(:clj Throwable :cljs js/Error)
+                 #"Stage .* does not exist"
+                 form)
+      (lib.util/last-stage? single-stage-query 1)
+      (lib.util/last-stage? single-stage-query -2)
+      (lib.util/last-stage? two-stage-query 2)
+      (lib.util/last-stage? two-stage-query -3))))
 
 (deftest ^:parallel drop-later-stages-test
-  (is (= 1 (lib/stage-count single-stage-query)))
   (is (= 1 (lib/stage-count (lib.util/drop-later-stages single-stage-query 0))))
   (is (= 1 (lib/stage-count (lib.util/drop-later-stages single-stage-query -1))))
   (is (= single-stage-query (lib.util/drop-later-stages single-stage-query 0)))

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -370,10 +370,10 @@
 
 (deftest ^:parallel first-stage?-test
   (testing "should return true for the first stage"
-    (is (lib.util/first-stage? single-stage-query 0))
-    (is (lib.util/first-stage? two-stage-query 0)))
+    (is (true? (lib.util/first-stage? single-stage-query 0)))
+    (is (true? (lib.util/first-stage? two-stage-query 0))))
   (testing "should return false for the second stage"
-    (is (not (lib.util/first-stage? two-stage-query 1))))
+    (is (false? (lib.util/first-stage? two-stage-query 1))))
   (testing "should throw for invalid index"
     (are [form] (thrown-with-msg?
                  #?(:clj Throwable :cljs js/Error)
@@ -386,10 +386,10 @@
 
 (deftest ^:parallel last-stage?-test
   (testing "should return true for the last stage"
-    (is (lib.util/last-stage? single-stage-query 0))
-    (is (lib.util/last-stage? two-stage-query 1)))
+    (is (true? (lib.util/last-stage? single-stage-query 0)))
+    (is (true? (lib.util/last-stage? two-stage-query 1))))
   (testing "should return false for a non-last stage"
-    (is (not (lib.util/last-stage? two-stage-query 0))))
+    (is (false? (lib.util/last-stage? two-stage-query 0))))
   (testing "should throw for invalid index"
     (are [form] (thrown-with-msg?
                  #?(:clj Throwable :cljs js/Error)

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -5,6 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]))
 
@@ -361,7 +362,7 @@
     (is (lib.equality/= query fresh-query))))
 
 (def ^:private single-stage-query
-  (lib/query meta/metadata-provider (meta/table-metadata :venues)))
+  (lib.tu/venues-query))
 
 (def ^:private two-stage-query
   (-> (lib/append-stage single-stage-query)


### PR DESCRIPTION
Closes #50308

Slack thread: https://metaboat.slack.com/archives/C0645JP1W81/p1748378579884869

### Description

Ensure `display-info` returns the `:long` display-name for aggregations from a previous stage.  In `display-name-method`, if a `:long` name is requested and the column has a `:lib/source-uuid` and comes from a previous stage, lookup the source clause by uuid and use that to generate the long `display-name`, including join info, if present.

Previously, both the `:display-name` and the `:long-display-name` returned by `display-info` would be something like `"Max of ID"` rather than `"Max of Products → ID"` for an aggregation over a joined column. In such cases, the FE cannot distinguish the columns, so only the first appears in the completion popover.

### How to verify

See repro steps in #50308 or new `display-name` test.

### Demo

**Before: only `Max of ID` appears in completion list**

![Screenshot 2025-05-29 at 5 53 54 PM](https://github.com/user-attachments/assets/010aa1df-74b7-4a95-8b8b-f083607e0020)

**After: both `Max of ID` and `Max of Products → ID` are selectable**

![Screenshot 2025-05-29 at 5 52 34 PM](https://github.com/user-attachments/assets/8220cb34-ff3a-4e74-b2a7-c2f17d547145)

![Screenshot 2025-05-29 at 5 53 22 PM](https://github.com/user-attachments/assets/b710c540-6edc-4b32-b56e-612223e673df)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
