### PR TITLE
Ensure we use a different connection per `have-select-privilege?` call

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -63,6 +63,10 @@ title: Driver interface changelog
   settings formerly in a `metabase.query-processor.*` namespace have been moved to
   `metabase.query-processor.settings`.
 
+## Metabase 0.54.11
+- The multimethods `metabase.driver.sql-jdbc.sync.interface/active-tables` and `metabase.driver.sql-jdbc.sync.interface/filtered-syncable-schemas`, aswell as the functions
+`metabase.driver.sql-jdbc.sync.describe_database/fast-active-tables`, `metabase.driver.sql-jdbc.sync.describe_database/have-select-privilege-fn` and `metabase.driver.sql-jdbc.sync.describe_database/db-tables` now take a database spec instead of a `java.sql.Connection` object.
+
 ## Metabase 0.54.10
 
 - Add `metabase.driver/table-known-to-not-exist?` for drivers to test if an exception is due to a query on a table that no longer exists

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -591,35 +591,30 @@
     (qp.store/with-metadata-provider (u/the-id database)
       (let [schema-patterns (driver.s/db-details->schema-filter-patterns "schema-filters" database)
             [inclusion-patterns exclusion-patterns] schema-patterns]
-        (sql-jdbc.execute/do-with-connection-with-options
-         driver
-         database
-         nil
-         ;; you know what, if we really wanted to make this efficient we would do
-         ;;
-         ;;    SHOW SCHEMAS IN DATABASE <db>
-         ;;
-         ;; first, and filter out the ones we're not interested in, and THEN do
-         ;;
-         ;;    SHOW OBJECTS IN SCHEMA <schema>
-         ;;
-         ;; for each of the schemas we wanted to sync. Right now we're fetching EVERY table, including ones from schemas
-         ;; we aren't interested in.
-         (fn [^Connection conn]
-           {:tables (into #{}
-                          (comp (filter (fn [{schema :schema table-name :name}]
-                                          (and (not (contains? excluded-schemas schema))
-                                               (sql-jdbc.describe-database/include-schema-logging-exclusion inclusion-patterns
-                                                                                                            exclusion-patterns
-                                                                                                            schema)
-                                               (sql-jdbc.sync/have-select-privilege? driver conn schema table-name))))
-                                (map #(dissoc % :type)))
-                          ;; The Snowflake JDBC drivers is dumb and broken, it will narrow the results to the current
-                          ;; session schema pass in `nil` for `schema-or-nil` to `getTables()`... `%` seems to fix it.
-                          ;; See [[metabase.driver.snowflake/describe-database-default-schema-test]] and
-                          ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1706220295862639?thread_ts=1706156558.940489&cid=C04DN5VRQM6
-                          ;; for more info.
-                          (sql-jdbc.describe-database/db-tables driver (.getMetaData conn) "%" db-name))}))))))
+        ;; you know what, if we really wanted to make this efficient we would do
+        ;;
+        ;;    SHOW SCHEMAS IN DATABASE <db>
+        ;;
+        ;; first, and filter out the ones we're not interested in, and THEN do
+        ;;
+        ;;    SHOW OBJECTS IN SCHEMA <schema>
+        ;;
+        ;; for each of the schemas we wanted to sync. Right now we're fetching EVERY table, including ones from schemas
+        ;; we aren't interested in.
+        {:tables (into #{}
+                       (comp (filter (fn [{schema :schema table-name :name}]
+                                       (and (not (contains? excluded-schemas schema))
+                                            (sql-jdbc.describe-database/include-schema-logging-exclusion inclusion-patterns
+                                                                                                         exclusion-patterns
+                                                                                                         schema)
+                                            (sql-jdbc.sync/have-select-privilege? driver database schema table-name))))
+                             (map #(dissoc % :type)))
+                       ;; The Snowflake JDBC drivers is dumb and broken, it will narrow the results to the current
+                       ;; session schema pass in `nil` for `schema-or-nil` to `getTables()`... `%` seems to fix it.
+                       ;; See [[metabase.driver.snowflake/describe-database-default-schema-test]] and
+                       ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1706220295862639?thread_ts=1706156558.940489&cid=C04DN5VRQM6
+                       ;; for more info.
+                       (sql-jdbc.describe-database/db-tables driver database "%" db-name))}))))
 
 (defmethod driver/describe-table :snowflake
   [driver database table]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -596,7 +596,7 @@
                                  (sql-jdbc.describe-database/include-schema-logging-exclusion inclusion-patterns
                                                                                               exclusion-patterns
                                                                                               schema)
-                                 (sql-jdbc.sync/have-select-privilege? driver database schema table-name)))]
+                                 (sql-jdbc.describe-database/have-select-privilege? driver database schema table-name)))]
         ;; you know what, if we really wanted to make this efficient we would do
         ;;
         ;;    SHOW SCHEMAS IN DATABASE <db>

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -269,29 +269,24 @@
   (sql-jdbc.execute/reducible-query database (get-tables-sql schemas tables)))
 
 (defn- describe-syncable-tables
-  [{driver :engine :as database}]
+  [driver database]
   (reify clojure.lang.IReduceInit
     (reduce [_ rf init]
-      (sql-jdbc.execute/do-with-connection-with-options
-       driver
-       database
-       nil
-       (fn [^Connection conn]
-         (reduce
-          rf
-          init
-          (when-let [syncable-schemas (seq (driver/syncable-schemas driver database))]
-            (let [have-select-privilege? (sql-jdbc.describe-database/have-select-privilege-fn driver conn)]
-              (eduction
-               (comp (filter have-select-privilege?)
-                     (map #(dissoc % :type)))
-               (get-tables database syncable-schemas nil))))))))))
+      (reduce
+       rf
+       init
+       (when-let [syncable-schemas (seq (driver/syncable-schemas driver database))]
+         (let [have-select-privilege? (sql-jdbc.describe-database/have-select-privilege-fn driver database)]
+           (eduction
+            (comp (filter have-select-privilege?)
+                  (map #(dissoc % :type)))
+            (get-tables database syncable-schemas nil))))))))
 
 (defmethod driver/describe-database :postgres
-  [_driver database]
+  [driver database]
   ;; TODO: we should figure out how to sync tables using transducer, this way we don't have to hold 100k tables in
   ;; memory in a set like this
-  {:tables (into #{} (describe-syncable-tables database))})
+  {:tables (into #{} (describe-syncable-tables driver database))})
 
 (defmethod sql-jdbc.sync/describe-fields-sql :postgres
   ;; The implementation is based on `getColumns` in https://github.com/pgjdbc/pgjdbc/blob/fcc13e70e6b6bb64b848df4b4ba6b3566b5e95a3/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -226,14 +226,8 @@
 
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver
-   database
-   nil
-   (fn [^java.sql.Connection conn]
-     (let [[inclusion-patterns
-            exclusion-patterns] (driver.s/db-details->schema-filter-patterns database)]
-       (into #{} (sql-jdbc.sync/filtered-syncable-schemas driver conn (.getMetaData conn) inclusion-patterns exclusion-patterns))))))
+  (let [[inclusion-patterns exclusion-patterns] (driver.s/db-details->schema-filter-patterns database)]
+    (sql-jdbc.sync/filtered-syncable-schemas driver database inclusion-patterns exclusion-patterns)))
 
 (defmethod driver/set-role! :sql-jdbc
   [driver conn role]

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -102,13 +102,13 @@
                       (pr-str table-name)))
       true
       (catch Throwable e
-        (let [allow? (driver/query-canceled? driver e)]
-          (log/infof (if allow?
-                       "%s: Assuming SELECT privileges: caught timeout exception"
-                       "%s: Assuming no SELECT privileges: caught exception")
-                     (str (when table-schema
-                            (str (pr-str table-schema) \.))
-                          (pr-str table-name)))
+        (let [allow? (driver/query-canceled? driver e)
+              table-str (str (when table-schema
+                               (str (pr-str table-schema) \.))
+                             (pr-str table-name))]
+          (if allow?
+            (log/infof "%s: Assuming SELECT privileges: caught timeout exception" table-str)
+            (log/infof e "%s: Assuming no SELECT privileges: caught exception" table-str))
           ;; if the connection was closed this will throw an error and fail the sync loop so we prevent this error from
           ;; affecting anything higher
           (try (when-not (.getAutoCommit conn)

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -103,12 +103,12 @@
       true
       (catch Throwable e
         (let [allow? (driver/query-canceled? driver e)]
-          (log/info (if allow?
-                      "%s: Assuming SELECT privileges: caught timeout exception"
-                      "%s: Assuming no SELECT privileges: caught exception")
-                    (str (when table-schema
-                           (str (pr-str table-schema) \.))
-                         (pr-str table-name)))
+          (log/infof (if allow?
+                       "%s: Assuming SELECT privileges: caught timeout exception"
+                       "%s: Assuming no SELECT privileges: caught exception")
+                     (str (when table-schema
+                            (str (pr-str table-schema) \.))
+                          (pr-str table-name)))
           ;; if the connection was closed this will throw an error and fail the sync loop so we prevent this error from
           ;; affecting anything higher
           (try (when-not (.getAutoCommit conn)

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -172,7 +172,9 @@
           (map (juxt :schema :table))
           set))))
 
-(defn- have-selected-privilege? [driver database schema table]
+(defn have-select-privilege?
+  "Wrapper over [[sql-jdbc.sync.interface/have-select-privilege?]] accepting a database instead of a Connection"
+  [driver database schema table]
   (sql-jdbc.execute/do-with-connection-with-options
    driver database nil
    (fn [^Connection conn]
@@ -198,10 +200,10 @@
         ;; TODO FIXME What the hecc!!! We should NOT be hardcoding driver-specific hacks in functions like this!!!!
         (if (#{[:postgres "FOREIGN TABLE"]}
              [driver ttype])
-          (have-selected-privilege? driver database schema table)
+          (have-select-privilege? driver database schema table)
           (contains? schema+table-with-select-privileges [schema table]))))
     (fn [{schema :schema table :name}]
-      (have-selected-privilege? driver database schema table))))
+      (have-select-privilege? driver database schema table))))
 
 (defn fast-active-tables
   "Default, fast implementation of `active-tables` best suited for DBs with lots of system tables (like Oracle). Fetch

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -39,12 +39,18 @@
       (log/infof "Skipping schema '%s' because it does not match the current schema filtering settings" table-schema)))
 
 (defmethod sql-jdbc.sync.interface/filtered-syncable-schemas :sql-jdbc
-  [driver _ metadata schema-inclusion-filters schema-exclusion-filters]
-  (eduction (remove (set (sql-jdbc.sync.interface/excluded-schemas driver)))
-            ;; remove the persisted_model schemas
-            (remove (fn [schema] (re-find #"^metabase_cache.*" schema)))
-            (filter #(include-schema-logging-exclusion schema-inclusion-filters schema-exclusion-filters %))
-            (all-schemas metadata)))
+  [driver database schema-inclusion-filters schema-exclusion-filters]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver database nil
+   (fn [^Connection conn]
+     (->>
+      (all-schemas (.getMetaData conn))
+      (eduction
+       (remove (set (sql-jdbc.sync.interface/excluded-schemas driver)))
+       ;; remove the persisted_model schemas
+       (remove (fn [schema] (re-find #"^metabase_cache.*" schema)))
+       (filter #(include-schema-logging-exclusion schema-inclusion-filters schema-exclusion-filters %)))
+      (into #{})))))
 
 (mu/defn simple-select-probe-query :- [:cat ::lib.schema.common/non-blank-string [:* :any]]
   "Simple (ie. cheap) SELECT on a given table to test for access and get column metadata. Doesn't return
@@ -139,24 +145,37 @@
 
 (defn db-tables
   "Fetch a JDBC Metadata ResultSet of tables in the DB, optionally limited to ones belonging to a given
-  schema. Returns a reducible sequence of results."
-  [driver ^DatabaseMetaData metadata ^String schema-or-nil ^String db-name-or-nil]
+  schema. Returns a set of results."
+  [driver database ^String schema-or-nil ^String db-name-or-nil]
   ;; seems like some JDBC drivers like Snowflake are dumb and still narrow the search results by the current session
   ;; schema if you pass in `nil` for `schema-or-nil`, which means not to narrow results at all... For Snowflake, I fixed
   ;; this by passing in `"%"` instead -- consider making this the default behavior. See this Slack thread
   ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1706220295862639?thread_ts=1706156558.940489&cid=C04DN5VRQM6 for
   ;; more info.
-  (jdbc-get-tables driver metadata db-name-or-nil schema-or-nil "%"
-                   ["TABLE" "PARTITIONED TABLE" "VIEW" "FOREIGN TABLE" "MATERIALIZED VIEW"
-                    "EXTERNAL TABLE" "DYNAMIC_TABLE"]))
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver database nil
+   (fn [^Connection conn]
+     (let [metadata (.getMetaData conn)]
+       (into #{}
+             (jdbc-get-tables driver metadata db-name-or-nil schema-or-nil "%"
+                              ["TABLE" "PARTITIONED TABLE" "VIEW" "FOREIGN TABLE" "MATERIALIZED VIEW"
+                               "EXTERNAL TABLE" "DYNAMIC_TABLE"]))))))
 
 (defn- schema+table-with-select-privileges
-  [driver conn]
-  (->> (sql-jdbc.sync.interface/current-user-table-privileges driver {:connection conn})
-       (filter #(true? (:select %)))
-       (map (fn [{:keys [schema table]}]
-              [schema table]))
-       set))
+  [driver database]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver database nil
+   (fn [^Connection conn]
+     (->> (sql-jdbc.sync.interface/current-user-table-privileges driver {:connection conn})
+          (filter #(true? (:select %)))
+          (map (juxt :schema :table))
+          set))))
+
+(defn- have-selected-privilege? [driver database schema table]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver database nil
+   (fn [^Connection conn]
+     (sql-jdbc.sync.interface/have-select-privilege? driver conn schema table))))
 
 (defn have-select-privilege-fn
   "Returns a function that take a map with 3 keys [:schema, :name, :type], return true if we can do a select query on the table.
@@ -166,11 +185,11 @@
     (let [have-select-privilege-fn* (have-select-privilege-fn driver database conn)
           tables                   ...]
       (filter have-select-privilege-fn* tables))"
-  [driver conn]
+  [driver database]
   ;; `sql-jdbc.sync.interface/have-select-privilege?` is slow because we're doing a SELECT query on each table
   ;; It's basically a N+1 operation where N is the number of tables in the database
   (if (driver/database-supports? driver :table-privileges nil)
-    (let [schema+table-with-select-privileges (schema+table-with-select-privileges driver conn)]
+    (let [schema+table-with-select-privileges (schema+table-with-select-privileges driver database)]
       (fn [{schema :schema table :name ttype :type}]
         ;; driver/current-user-table-privileges does not return privileges for external table on redshift, and foreign
         ;; table on postgres, so we need to use the select method on them
@@ -178,10 +197,10 @@
         ;; TODO FIXME What the hecc!!! We should NOT be hardcoding driver-specific hacks in functions like this!!!!
         (if (#{[:postgres "FOREIGN TABLE"]}
              [driver ttype])
-          (sql-jdbc.sync.interface/have-select-privilege? driver conn schema table)
+          (have-selected-privilege? driver database schema table)
           (contains? schema+table-with-select-privileges [schema table]))))
     (fn [{schema :schema table :name}]
-      (sql-jdbc.sync.interface/have-select-privilege? driver conn schema table))))
+      (have-selected-privilege? driver database schema table))))
 
 (defn fast-active-tables
   "Default, fast implementation of `active-tables` best suited for DBs with lots of system tables (like Oracle). Fetch
@@ -189,17 +208,15 @@
 
   This is as much as 15x faster for Databases with lots of system tables than `post-filtered-active-tables` (4 seconds
   vs 60)."
-  [driver ^Connection conn & [db-name-or-nil schema-inclusion-filters schema-exclusion-filters]]
-  {:pre [(instance? Connection conn)]}
-  (let [metadata                  (.getMetaData conn)
-        syncable-schemas          (sql-jdbc.sync.interface/filtered-syncable-schemas driver conn metadata
+  [driver database & [db-name-or-nil schema-inclusion-filters schema-exclusion-filters]]
+  (let [syncable-schemas          (sql-jdbc.sync.interface/filtered-syncable-schemas driver database
                                                                                      schema-inclusion-filters schema-exclusion-filters)
-        have-select-privilege-fn? (have-select-privilege-fn driver conn)]
+        have-select-privilege-fn? (have-select-privilege-fn driver database)]
     (eduction (mapcat (fn [schema]
                         (eduction
                          (comp (filter have-select-privilege-fn?)
                                (map #(dissoc % :type)))
-                         (db-tables driver metadata schema db-name-or-nil))))
+                         (db-tables driver database schema db-name-or-nil))))
               syncable-schemas)))
 
 (defmethod sql-jdbc.sync.interface/active-tables :sql-jdbc
@@ -209,9 +226,8 @@
 (defn post-filtered-active-tables
   "Alternative implementation of `active-tables` best suited for DBs with little or no support for schemas. Fetch *all*
   Tables, then filter out ones whose schema is in `excluded-schemas` Clojure-side."
-  [driver ^Connection conn & [db-name-or-nil schema-inclusion-filters schema-exclusion-filters]]
-  {:pre [(instance? Connection conn)]}
-  (let [have-select-privilege-fn? (have-select-privilege-fn driver conn)]
+  [driver database & [db-name-or-nil schema-inclusion-filters schema-exclusion-filters]]
+  (let [have-select-privilege-fn? (have-select-privilege-fn driver database)]
     (eduction
      (comp
       (filter (let [excluded (sql-jdbc.sync.interface/excluded-schemas driver)]
@@ -220,7 +236,7 @@
                        (include-schema-logging-exclusion schema-inclusion-filters schema-exclusion-filters table-schema)
                        (have-select-privilege-fn? table)))))
       (map #(dissoc % :type)))
-     (db-tables driver (.getMetaData conn) nil db-name-or-nil))))
+     (db-tables driver database nil db-name-or-nil))))
 
 (defn db-or-id-or-spec->database
   "Get database instance from `db-or-id-or-spec`."
@@ -240,14 +256,9 @@
   [driver           :- :keyword
    db-or-id-or-spec :- [:or :int :map]]
   {:tables
-   (sql-jdbc.execute/do-with-connection-with-options
-    driver
-    db-or-id-or-spec
-    nil
-    (fn [^Connection conn]
-      (let [schema-filter-prop   (driver.u/find-schema-filters-prop driver)
-            database             (db-or-id-or-spec->database db-or-id-or-spec)
-            [inclusion-patterns
-             exclusion-patterns] (when (some? schema-filter-prop)
-                                   (driver.s/db-details->schema-filter-patterns (:name schema-filter-prop) database))]
-        (into #{} (sql-jdbc.sync.interface/active-tables driver conn inclusion-patterns exclusion-patterns)))))})
+   (let [schema-filter-prop   (driver.u/find-schema-filters-prop driver)
+         database             (db-or-id-or-spec->database db-or-id-or-spec)
+         [inclusion-patterns
+          exclusion-patterns] (when (some? schema-filter-prop)
+                                (driver.s/db-details->schema-filter-patterns (:name schema-filter-prop) database))]
+     (into #{} (sql-jdbc.sync.interface/active-tables driver database inclusion-patterns exclusion-patterns)))})

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -15,7 +15,7 @@
   functions for more details on the differences."
   {:added "0.37.1"
    :arglists '([driver
-                ^java.sql.Connection connection
+                database
                 ^String schema-inclusion-filters
                 ^String schema-exclusion-filters])}
   driver/dispatch-on-initialized-driver
@@ -36,7 +36,7 @@
   :hierarchy #'driver/hierarchy)
 
 (defmulti filtered-syncable-schemas
-  "Return a reducible sequence of string names of schemas that should be synced for the given database. Schemas for
+  "Return a set of string names of schemas that should be synced for the given database. Schemas for
   which the current DB user has no `SELECT` permissions should be filtered out. The default implementation will fetch
   a sequence of all schema names from the JDBC database metadata and filter out any schemas in `excluded-schemas`, along
   with any that shouldn't be included based on the given inclusion and exclusion patterns (see the
@@ -44,8 +44,7 @@
   {:changelog-test/ignore true
    :added "0.43.0"
    :arglists '([driver
-                ^java.sql.Connection connection
-                ^java.sql.DatabaseMetaData metadata
+                database
                 ^String schema-inclusion-patterns
                 ^String schema-exclusion-patterns])}
   driver/dispatch-on-initialized-driver

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -250,7 +250,7 @@
                                    (filter #(not (driver/database-supports? % :table-privileges nil))))
                              (descendants driver/hierarchy :sql-jdbc))
         (let [closed-first (volatile! nil)
-              all-tables (sql-jdbc.describe-database/describe-database driver/*driver* (mt/id))]
+              all-tables (driver/describe-database driver/*driver* (mt/id))]
           (with-redefs [sql-jdbc.sync.interface/have-select-privilege?
                         (fn [driver ^Connection conn schema tbl-name]
                           (when-not @closed-first
@@ -258,6 +258,6 @@
                             (.close conn))
                           (have-select-privilege? driver conn schema tbl-name))]
             (let [table-names #(->> % :tables (map :name) set)
-                  all-tables-sans-first (table-names (sql-jdbc.describe-database/describe-database driver/*driver* (mt/id)))]
+                  all-tables-sans-first (table-names (driver/describe-database driver/*driver* (mt/id)))]
               (is (or (= (-> all-tables table-names (disj @closed-first)) all-tables-sans-first)
                       (= (-> all-tables table-names) all-tables-sans-first))))))))))

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -244,9 +244,11 @@
 (deftest resilient-to-conn-close?-test
   (testing "checking sync is resilient to connections being closed during [have-select-privilege?]"
     (let [have-select-privilege? (get-method sql-jdbc.sync.interface/have-select-privilege? :sql-jdbc)
-          default-have-select-privilege? #(identical? have-select-privilege? (get-method sql-jdbc.sync.interface/have-select-privilege? %))]
+          default-have-select-privilege? #(identical? have-select-privilege? (get-method sql-jdbc.sync.interface/have-select-privilege? %))
+          jdbc-describe-database #(identical? (get-method driver/describe-database :sql-jdbc) (get-method driver/describe-database %))]
       (mt/test-drivers (into #{}
                              (comp (filter default-have-select-privilege?)
+                                   (filter jdbc-describe-database)
                                    (filter #(not (driver/database-supports? % :table-privileges nil))))
                              (descendants driver/hierarchy :sql-jdbc))
         (let [closed-first (volatile! nil)

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -59,27 +59,16 @@
 
 (deftest fast-active-tables-test
   (is (= ["CATEGORIES" "CHECKINS" "ORDERS" "PEOPLE" "PRODUCTS" "REVIEWS" "USERS" "VENUES"]
-         (sql-jdbc.execute/do-with-connection-with-options
-          (or driver/*driver* :h2)
-          (mt/db)
-          nil
-          (fn [^java.sql.Connection conn]
-            ;; We have to mock this to make it work with all DBs
-            (with-redefs [sql-jdbc.describe-database/all-schemas (constantly #{"PUBLIC"})]
-              (->> (into [] (sql-jdbc.describe-database/fast-active-tables (or driver/*driver* :h2) conn nil nil))
-                   (map :name)
-                   sort)))))))
+         (with-redefs [sql-jdbc.describe-database/all-schemas (constantly #{"PUBLIC"})]
+           (->> (into [] (sql-jdbc.describe-database/fast-active-tables (or driver/*driver* :h2) (mt/db) nil nil))
+                (map :name)
+                sort)))))
 
 (deftest post-filtered-active-tables-test
   (is (= ["CATEGORIES" "CHECKINS" "ORDERS" "PEOPLE" "PRODUCTS" "REVIEWS" "USERS" "VENUES"]
-         (sql-jdbc.execute/do-with-connection-with-options
-          :h2
-          (mt/db)
-          nil
-          (fn [^java.sql.Connection conn]
-            (->> (into [] (sql-jdbc.describe-database/post-filtered-active-tables :h2 conn nil nil))
-                 (map :name)
-                 sort))))))
+         (->> (into [] (sql-jdbc.describe-database/post-filtered-active-tables :h2 (mt/db) nil nil))
+              (map :name)
+              sort))))
 
 (deftest describe-database-test
   (is (= {:tables #{{:name "USERS", :schema "PUBLIC", :description nil}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #58304
Closes: https://linear.app/metabase/issue/SEM-349/metabase-does-not-work-on-oracle-sync-fails-when-trying-to-sync-tables

# Description
In some permission-related error scenarios, certain databases may abruptly close a JDBC connection instead of simply throwing an exception. During sync, we check whether the current user has SELECT access to a table by issuing a probing SELECT quer. This can inadvertently trigger such connection closures.

Currently, the sync process uses a single database connection to probe all tables. If that connection is closed due to one of these permission errors, the entire sync fails.

This PR resolves the issue by executing each probing query using a separate database connection. This allows the connection pool to automatically handle reconnections if any are closed during the process.

As a result of scoping connections more narrowly, some functions needed to be updated to return concrete sequences instead of reducibles. This ensures that the data is materialized before the corresponding connection is closed. While this slightly changes how results are processed (e.g., mapping over sequences instead of reducibles), the memory footprint remains the same, and the performance impact should be minimal.
