### PR TITLE
Support empty column names in table viz

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1466,3 +1466,23 @@ WHERE NOT (
       .should("be.visible");
   });
 });
+
+describe("issue 57685", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createNativeQuestion(
+      {
+        display: "table",
+        native: {
+          query: 'SELECT id as "" FROM PRODUCTS',
+        },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("should handle empty column names without error (metabase#57685)", () => {
+    cy.findByTestId("visualization-root").icon("warning").should("not.exist");
+  });
+});

--- a/frontend/src/metabase/data-grid/components/HeaderCell/HeaderCell.tsx
+++ b/frontend/src/metabase/data-grid/components/HeaderCell/HeaderCell.tsx
@@ -7,7 +7,7 @@ import type {
   HeaderCellBaseProps,
   HeaderCellVariant,
 } from "metabase/data-grid/types";
-import { Icon } from "metabase/ui";
+import { Box, Icon, rem } from "metabase/ui";
 
 import S from "./HeaderCell.module.css";
 
@@ -34,7 +34,7 @@ export const HeaderCellPill = forwardRef<HTMLDivElement, HeaderCellBaseProps>(
     ref,
   ) {
     return (
-      <div
+      <Box
         ref={ref}
         data-grid-header-cell-content
         data-header-click-target
@@ -42,6 +42,8 @@ export const HeaderCellPill = forwardRef<HTMLDivElement, HeaderCellBaseProps>(
           [S.alignRight]: align === "right",
         })}
         data-testid="cell-data"
+        mih={rem(18)}
+        miw={rem(22)}
       >
         <Ellipsified tooltip={name}>{name}</Ellipsified>
         {sort != null ? (
@@ -52,7 +54,7 @@ export const HeaderCellPill = forwardRef<HTMLDivElement, HeaderCellBaseProps>(
             size={10}
           />
         ) : null}
-      </div>
+      </Box>
     );
   },
 );

--- a/frontend/src/metabase/data-grid/constants.ts
+++ b/frontend/src/metabase/data-grid/constants.ts
@@ -7,3 +7,4 @@ export const TRUNCATE_LONG_CELL_WIDTH = 780;
 export const PINNED_COLUMN_Z_INDEX = 1;
 export const DEFAULT_FONT_SIZE = "12.5px";
 export const FOOTER_HEIGHT = 30;
+export const FALLBACK_ID_FOR_EMPTY_COLUMN_NAME = "\0_EMPTY_COLUMN_ID";

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -23,6 +23,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import DashboardS from "metabase/css/dashboard.module.css";
 import { DataGrid, type DataGridStylesProps } from "metabase/data-grid";
 import {
+  FALLBACK_ID_FOR_EMPTY_COLUMN_NAME,
   FOOTER_HEIGHT,
   HEADER_HEIGHT,
   ROW_HEIGHT,
@@ -461,6 +462,10 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
         align = columnSettings["text_align"];
         id = col.name;
         sortDirection = getColumnSortDirection(columnIndex);
+      }
+
+      if (id === "") {
+        id = `${FALLBACK_ID_FOR_EMPTY_COLUMN_NAME}:${columnIndex}`;
       }
 
       const options: ColumnOptions<RowValues, RowValue> = {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57685

Tanstack Table throws an error when the id for a column is the empty string. This PR fixes that by adding a fallback id.

This allows the table to render when some column names are empty strings. This PR also fixes the styling of the header pill for empty column headers.

Note that this PR does not fix any of the myriad of other issues that stem from using empty strings as column names.

<img width="1474" alt="Screenshot 2025-05-29 at 11 35 12" src="https://github.com/user-attachments/assets/f2aa5fb4-bcca-4adf-aa1b-09eac7060255" />
