### PR TITLE
ci(sdk): add release-x.55.x branch to release workflow

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -394,7 +394,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "release-x.55.x": "55-stable", "metabot-v3-main": "55-metabot", "esbuild-main": "56-esbuild"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "release-x.55.x": "55-nightly", "metabot-v3-main": "55-metabot", "esbuild-main": "56-esbuild"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.54.x`) deployment
         if: ${{ inputs.branch == 'release-x.54.x' }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -15,6 +15,7 @@ on:
           - release-x.52.x
           - release-x.53.x
           - release-x.54.x
+          - release-x.55.x
           - metabot-v3-main
           - esbuild-main
 
@@ -393,7 +394,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "metabot-v3-main": "55-metabot", "esbuild-main": "56-esbuild"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "release-x.55.x": "55-stable", "metabot-v3-main": "55-metabot", "esbuild-main": "56-esbuild"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.54.x`) deployment
         if: ${{ inputs.branch == 'release-x.54.x' }}


### PR DESCRIPTION
Adds the `release-x.55.x` branch to the release workflow on master. It must be `55-nightly` as we are still haven't cut Gold.