### PR TITLE
ci(sdk): restore package.json version to 0.55.1-nightly

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.55.5-metabot",
+  "version": "0.55.1-nightly",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
We merged the Metabot PoC branch which makes the version in the 55 branch "0.55.5-metabot", where in reality it should've been `0.55.1-nightly` as we did a nightly release once for 55.

![CleanShot 2568-05-29 at 17 14 29@2x](https://github.com/user-attachments/assets/76d8d2ea-ba65-494d-9055-13662ce60d8f)
