### PR TITLE
ci(sdk): bump package.json to 0.56.0-nightly

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.55.5-metabot",
+  "version": "0.56.0-nightly",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Bumps the package.json to 56-nightly, since we have cut 55 beta already.