### PR TITLE
Update adminAppState mock to remove isNoticeEnabled

### DIFF
--- a/frontend/src/metabase-types/store/admin.ts
+++ b/frontend/src/metabase-types/store/admin.ts
@@ -51,6 +51,5 @@ export interface AdminState {
 }
 
 export interface AdminAppState {
-  isNoticeEnabled: boolean;
   paths: AdminPath[];
 }

--- a/frontend/src/metabase-types/store/mocks/admin.ts
+++ b/frontend/src/metabase-types/store/mocks/admin.ts
@@ -16,7 +16,6 @@ export const createMockAdminState = (
 export const createMockAdminAppState = (
   opts?: Partial<AdminAppState>,
 ): AdminAppState => ({
-  isNoticeEnabled: false,
   paths: [],
   ...opts,
 });


### PR DESCRIPTION
follow up to https://github.com/metabase/metabase/pull/58001

## Description

I removed `isNoticeEnabled` as a property from the redux store, but failed to remove it in a couple places for test setup, that was throwing errors

```
Unexpected key "isNoticeEnabled" found in preloadedState argument passed to createStore. Expected to find one of the known reducer keys instead: "paths". Unexpected keys will be ignored.
```