### PR TITLE
Fix SDK cross version tests getting version number from other prerelease labels

### DIFF
--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -214,7 +214,7 @@ export async function getLastEmbeddingSdkReleaseTag({
   });
 
   const lastRelease = getLastReleaseFromTags({
-    tags: tags.filter(filterOutNonSupportedPrereleaseIdentifiers),
+    tags: tags.filter(filterOutNonSupportedPrereleaseIdentifier),
   });
 
   return lastRelease;
@@ -222,9 +222,9 @@ export async function getLastEmbeddingSdkReleaseTag({
 
 /**
  *
- * @param tag a GitHub tag objects
+ * @param tag a GitHub tag object
  */
-export function filterOutNonSupportedPrereleaseIdentifiers(tag: Tag) {
+export function filterOutNonSupportedPrereleaseIdentifier(tag: Tag) {
   const prereleaseIdentifier = /\d+\.\d+\.\d+-(?<prerelease>\w+)$/.exec(tag.ref)
     ?.groups?.prerelease;
 

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -228,8 +228,6 @@ export function filterOutNonSupportedPrereleaseIdentifier(tag: Tag) {
   const prereleaseIdentifier = /\d+\.\d+\.\d+-(?<prerelease>\w+)$/.exec(tag.ref)
     ?.groups?.prerelease;
 
-  console.log("prereleaseIdentifier", prereleaseIdentifier, tag.ref);
-
   return (
     !prereleaseIdentifier ||
     ALLOWED_SDK_PRERELEASE_IDENTIFIERS.includes(prereleaseIdentifier)

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -94,8 +94,15 @@ export const getVersionFromReleaseBranch = (branch: string) => {
   return `v0.${majorVersion}.0`;
 };
 
+const ALLOWED_SDK_PRERELEASE_IDENTIFIERS = ["nightly"];
+const SDK_TAG_REGEXP = new RegExp(
+  `embedding-sdk-(0\\.\\d+\\.\\d+(-(${ALLOWED_SDK_PRERELEASE_IDENTIFIERS.join(
+    "|",
+  )}))?)$`,
+);
+
 export const getSdkVersionFromReleaseTagName = (tagName: string) => {
-  const match = /embedding-sdk-(0\.\d+\.\d+(-nightly)?)/.exec(tagName);
+  const match = SDK_TAG_REGEXP.exec(tagName);
 
   if (!match) {
     throw new Error(`Invalid sdk release tag: ${tagName}`);
@@ -207,10 +214,21 @@ export async function getLastEmbeddingSdkReleaseTag({
   });
 
   const lastRelease = getLastReleaseFromTags({
-    tags,
+    tags: filterAllowedPrereleaseIdentifiers(tags),
   });
 
   return lastRelease;
+}
+
+export function filterAllowedPrereleaseIdentifiers(tags: Tag[]) {
+  return tags.filter((tag) => {
+    const areJustNumbers = tag.ref.match(/\d+\.\d+\.\d+$/);
+    if (areJustNumbers) {
+      return true;
+    }
+
+    return SDK_TAG_REGEXP.exec(tag.ref);
+  });
 }
 
 export const getMajorVersionNumberFromReleaseBranch = (branch: string) => {
@@ -225,7 +243,7 @@ export const getMajorVersionNumberFromReleaseBranch = (branch: string) => {
 
 export const versionRequirements: Record<
   number,
-  { java: number; node: number, platforms: string }
+  { java: number; node: number; platforms: string }
 > = {
   43: { java: 8, node: 14, platforms: "linux/amd64" },
   44: { java: 11, node: 14, platforms: "linux/amd64" },
@@ -349,10 +367,10 @@ export function getLastReleaseFromTags({
   ignorePreReleases?: boolean;
 }) {
   return tags
-    .map(tag => tag.ref.replace("refs/tags/", ""))
-    .filter(tag => !tag.includes(".x"))
-    .filter(ignorePreReleases ? tag => !isPreReleaseVersion(tag) : () => true)
-    .filter(ignorePatches ? v => !isPatchVersion(v) : () => true)
+    .map((tag) => tag.ref.replace("refs/tags/", ""))
+    .filter((tag) => !tag.includes(".x"))
+    .filter(ignorePreReleases ? (tag) => !isPreReleaseVersion(tag) : () => true)
+    .filter(ignorePatches ? (v) => !isPatchVersion(v) : () => true)
     .sort(versionSort)
     .reverse()[0];
 }

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -94,12 +94,7 @@ export const getVersionFromReleaseBranch = (branch: string) => {
   return `v0.${majorVersion}.0`;
 };
 
-const ALLOWED_SDK_PRERELEASE_IDENTIFIERS = ["nightly"];
-const SDK_TAG_REGEXP = new RegExp(
-  `embedding-sdk-(0\\.\\d+\\.\\d+(-(${ALLOWED_SDK_PRERELEASE_IDENTIFIERS.join(
-    "|",
-  )}))?)$`,
-);
+const SDK_TAG_REGEXP = /embedding-sdk-(0\.\d+\.\d+(-\w+)?)$/;
 
 export const getSdkVersionFromReleaseTagName = (tagName: string) => {
   const match = SDK_TAG_REGEXP.exec(tagName);
@@ -220,6 +215,7 @@ export async function getLastEmbeddingSdkReleaseTag({
   return lastRelease;
 }
 
+const ALLOWED_SDK_PRERELEASE_IDENTIFIERS = ["nightly"];
 /**
  *
  * @param tag a GitHub tag object

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import type { GithubProps, Tag } from "./types";
 
 // https://regexr.com/7l1ip
@@ -214,40 +213,27 @@ export async function getLastEmbeddingSdkReleaseTag({
     ref: `tags/embedding-sdk-0.${majorVersion}`,
   });
 
-  const versions = _.compose(
-    filterOutNonSupportedPrereleaseIdentifiers,
-    getVersionsFromTags,
-  )(tags);
-
   const lastRelease = getLastReleaseFromTags({
-    tags: versions,
+    tags: tags.filter(filterOutNonSupportedPrereleaseIdentifiers),
   });
 
   return lastRelease;
 }
 
 /**
- * This function takes a list of GitHub tag objects and return a list of semver version strings
- */
-function getVersionsFromTags(tags: Tag[]) {
-  return tags.map((tag) => tag.ref.replace("refs/tags/embedding-sdk-", ""));
-}
-
-/**
  *
- * @param versions a list of semver version for example ["0.55.1-nightly", "0.55.3", "0.55.5-metabot"]
+ * @param tag a GitHub tag objects
  */
-export function filterOutNonSupportedPrereleaseIdentifiers(versions: string[]) {
-  return versions.filter((version) => {
-    const versionContainsOnlyNumbers = /\d+\.\d+\.\d+$/.exec(version);
+export function filterOutNonSupportedPrereleaseIdentifiers(tag: Tag) {
+  const prereleaseIdentifier = /\d+\.\d+\.\d+-(?<prerelease>\w+)$/.exec(tag.ref)
+    ?.groups?.prerelease;
 
-    return (
-      versionContainsOnlyNumbers ||
-      ALLOWED_SDK_PRERELEASE_IDENTIFIERS.some((allowedPrereleaseIdentifier) =>
-        version.endsWith(`-${allowedPrereleaseIdentifier}`),
-      )
-    );
-  });
+  console.log("prereleaseIdentifier", prereleaseIdentifier, tag.ref);
+
+  return (
+    !prereleaseIdentifier ||
+    ALLOWED_SDK_PRERELEASE_IDENTIFIERS.includes(prereleaseIdentifier)
+  );
 }
 
 export const getMajorVersionNumberFromReleaseBranch = (branch: string) => {

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -779,7 +779,7 @@ describe("version-helpers", () => {
     });
   });
 
-  describe("filterAllowedPrereleaseIdentifiers", () => {
+  describe("filterOutNonSupportedPrereleaseIdentifiers", () => {
     function createTags(tags: string[]): string[] {
       return tags.map((tag) => `refs/tags/embedding-sdk-${tag}`);
     }

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -780,28 +780,14 @@ describe("version-helpers", () => {
   });
 
   describe("filterOutNonSupportedPrereleaseIdentifiers", () => {
-    function createTags(tags: string[]): string[] {
-      return tags.map((tag) => `refs/tags/embedding-sdk-${tag}`);
+    function createTags(versions: string[]): Tag[] {
+      return versions.map(
+        (tag) => ({ ref: `refs/tags/embedding-sdk-${tag}` }) as Tag,
+      );
     }
 
     it("should ignore prerelease labels that are not `nightly` when passing refs", () => {
-      const filteredTags = filterOutNonSupportedPrereleaseIdentifiers(
-        createTags([
-          "0.55.0",
-          "0.55.0-nightly",
-          "0.55.0-rc1",
-          "0.55.0-rc2",
-          "0.55.0-beta",
-          "0.55.0-alpha",
-          "0.55.5-metabot",
-        ]),
-      );
-
-      expect(filteredTags).toEqual(createTags(["0.55.0", "0.55.0-nightly"]));
-    });
-
-    it("should ignore prerelease labels that are not `nightly` when passing versions", () => {
-      const filteredTags = filterOutNonSupportedPrereleaseIdentifiers([
+      const filteredTags = createTags([
         "0.55.0",
         "0.55.0-nightly",
         "0.55.0-rc1",
@@ -809,9 +795,9 @@ describe("version-helpers", () => {
         "0.55.0-beta",
         "0.55.0-alpha",
         "0.55.5-metabot",
-      ]);
+      ]).filter(filterOutNonSupportedPrereleaseIdentifiers);
 
-      expect(filteredTags).toEqual(["0.55.0", "0.55.0-nightly"]);
+      expect(filteredTags).toEqual(createTags(["0.55.0", "0.55.0-nightly"]));
     });
   });
 });

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -1,6 +1,6 @@
 import type { Tag } from "./types";
 import {
-  filterOutNonSupportedPrereleaseIdentifiers,
+  filterOutNonSupportedPrereleaseIdentifier,
   findNextPatchVersion,
   getBuildRequirements,
   getDotXs,
@@ -779,7 +779,7 @@ describe("version-helpers", () => {
     });
   });
 
-  describe("filterOutNonSupportedPrereleaseIdentifiers", () => {
+  describe("filterOutNonSupportedPrereleaseIdentifier", () => {
     function createTags(versions: string[]): Tag[] {
       return versions.map(
         (tag) => ({ ref: `refs/tags/embedding-sdk-${tag}` }) as Tag,
@@ -795,7 +795,7 @@ describe("version-helpers", () => {
         "0.55.0-beta",
         "0.55.0-alpha",
         "0.55.5-metabot",
-      ]).filter(filterOutNonSupportedPrereleaseIdentifiers);
+      ]).filter(filterOutNonSupportedPrereleaseIdentifier);
 
       expect(filteredTags).toEqual(createTags(["0.55.0", "0.55.0-nightly"]));
     });

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -1,5 +1,6 @@
 import type { Tag } from "./types";
 import {
+  filterAllowedPrereleaseIdentifiers,
   findNextPatchVersion,
   getBuildRequirements,
   getDotXs,
@@ -18,7 +19,7 @@ import {
   isEnterpriseVersion,
   isPreReleaseVersion,
   isValidVersionString,
-  versionSort
+  versionSort,
 } from "./version-helpers";
 
 describe("version-helpers", () => {
@@ -42,7 +43,7 @@ describe("version-helpers", () => {
       "v0.11.0-RC7", // legacy RC format
     ];
 
-    validCases.forEach(input => {
+    validCases.forEach((input) => {
       it(`should recognize ${input} as valid`, () => {
         expect(isValidVersionString(input)).toEqual(true);
       });
@@ -71,7 +72,7 @@ describe("version-helpers", () => {
       "v0.11-RC7",
     ];
 
-    invalidCases.forEach(input => {
+    invalidCases.forEach((input) => {
       it(`should recognize ${input} as invalid`, () => {
         expect(isValidVersionString(input)).toEqual(false);
       });
@@ -85,7 +86,7 @@ describe("version-helpers", () => {
         "v0.3.4-alpha",
       ];
 
-      cases.forEach(input => {
+      cases.forEach((input) => {
         expect(isValidVersionString(input)).toEqual(true);
       });
     });
@@ -132,7 +133,7 @@ describe("version-helpers", () => {
     it("should correctly identify non-enterprise version numbers", () => {
       const cases = ["v0.12", "v0.1.0", "v0.1.2.0", "v0.50", "v0.54.2-beta"];
 
-      cases.forEach(input => {
+      cases.forEach((input) => {
         expect(isEnterpriseVersion(input)).toEqual(false);
       });
     });
@@ -145,31 +146,33 @@ describe("version-helpers", () => {
 
   describe("isPreReleaseVersion", () => {
     it("should correctly identify RC version numbers", () => {
-      ["v0.75.0-RC", "v1.75.0-RC", "v0.75.2.9.7-rc"].forEach(input => {
+      ["v0.75.0-RC", "v1.75.0-RC", "v0.75.2.9.7-rc"].forEach((input) => {
         expect(isPreReleaseVersion(input)).toEqual(true);
       });
     });
 
     it("should correctly identify alpha version numbers", () => {
-      ["v0.75.0-alpha", "v1.75.0-alpha", "v0.75.2.9.7-alpha"].forEach(input => {
-        expect(isPreReleaseVersion(input)).toEqual(true);
-      });
+      ["v0.75.0-alpha", "v1.75.0-alpha", "v0.75.2.9.7-alpha"].forEach(
+        (input) => {
+          expect(isPreReleaseVersion(input)).toEqual(true);
+        },
+      );
     });
 
     it("should correctly identify beta version numbers", () => {
-      ["v0.75.0-beta", "v1.75.0-beta", "v0.75.2.9.7-beta"].forEach(input => {
+      ["v0.75.0-beta", "v1.75.0-beta", "v0.75.2.9.7-beta"].forEach((input) => {
         expect(isPreReleaseVersion(input)).toEqual(true);
       });
     });
 
     it("should correctly identify non-RC version numbers", () => {
-      ["v0.75", "v1.2"].forEach(input => {
+      ["v0.75", "v1.2"].forEach((input) => {
         expect(isPreReleaseVersion(input)).toEqual(false);
       });
     });
 
     it("should return false for invalid versions", () => {
-      ["123", "foo", "rc", "parc", "v9.9-rc2"].forEach(input => {
+      ["123", "foo", "rc", "parc", "v9.9-rc2"].forEach((input) => {
         expect(isPreReleaseVersion(input)).toEqual(false);
       });
     });
@@ -214,7 +217,7 @@ describe("version-helpers", () => {
       "v1.75.2.3.4",
     ];
 
-    cases.forEach(input => {
+    cases.forEach((input) => {
       it(`should return release-x.75.x for ${input}`, () => {
         expect(getReleaseBranch(input)).toEqual(`release-x.75.x`);
       });
@@ -249,7 +252,7 @@ describe("version-helpers", () => {
         "release-x.75.x-test",
         "refs/heads/release-x",
       ];
-      cases.forEach(input => {
+      cases.forEach((input) => {
         expect(() => getVersionFromReleaseBranch(input)).toThrow();
       });
     });
@@ -686,7 +689,7 @@ describe("version-helpers", () => {
     });
   });
 
-  describe("getDotXs", ()=> {
+  describe("getDotXs", () => {
     it("should return the correct major dot Xs", () => {
       expect(getDotXs("v1.75.0", 1)).toEqual("v1.75.x");
       expect(getDotXs("v1.75.2", 1)).toEqual("v1.75.x");
@@ -773,6 +776,30 @@ describe("version-helpers", () => {
         "v0.75.1.x",
         "v1.75.1.x",
       ]);
+    });
+  });
+
+  describe("filterAllowedPrereleaseIdentifiers", () => {
+    function createTags(tags: string[]): Tag[] {
+      return tags.map(
+        (tag) => ({ ref: `refs/tags/embedding-sdk-${tag}` }) as Tag,
+      );
+    }
+
+    it("should ignore prerelease labels that are not `nightly`", () => {
+      const filteredTags = filterAllowedPrereleaseIdentifiers(
+        createTags([
+          "0.55.0",
+          "0.55.0-nightly",
+          "0.55.0-rc1",
+          "0.55.0-rc2",
+          "0.55.0-beta",
+          "0.55.0-alpha",
+          "0.55.5-metabot",
+        ]),
+      );
+
+      expect(filteredTags).toEqual(createTags(["0.55.0", "0.55.0-nightly"]));
     });
   });
 });

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -1,6 +1,6 @@
 import type { Tag } from "./types";
 import {
-  filterAllowedPrereleaseIdentifiers,
+  filterOutNonSupportedPrereleaseIdentifiers,
   findNextPatchVersion,
   getBuildRequirements,
   getDotXs,
@@ -780,14 +780,12 @@ describe("version-helpers", () => {
   });
 
   describe("filterAllowedPrereleaseIdentifiers", () => {
-    function createTags(tags: string[]): Tag[] {
-      return tags.map(
-        (tag) => ({ ref: `refs/tags/embedding-sdk-${tag}` }) as Tag,
-      );
+    function createTags(tags: string[]): string[] {
+      return tags.map((tag) => `refs/tags/embedding-sdk-${tag}`);
     }
 
-    it("should ignore prerelease labels that are not `nightly`", () => {
-      const filteredTags = filterAllowedPrereleaseIdentifiers(
+    it("should ignore prerelease labels that are not `nightly` when passing refs", () => {
+      const filteredTags = filterOutNonSupportedPrereleaseIdentifiers(
         createTags([
           "0.55.0",
           "0.55.0-nightly",
@@ -800,6 +798,20 @@ describe("version-helpers", () => {
       );
 
       expect(filteredTags).toEqual(createTags(["0.55.0", "0.55.0-nightly"]));
+    });
+
+    it("should ignore prerelease labels that are not `nightly` when passing versions", () => {
+      const filteredTags = filterOutNonSupportedPrereleaseIdentifiers([
+        "0.55.0",
+        "0.55.0-nightly",
+        "0.55.0-rc1",
+        "0.55.0-rc2",
+        "0.55.0-beta",
+        "0.55.0-alpha",
+        "0.55.5-metabot",
+      ]);
+
+      expect(filteredTags).toEqual(["0.55.0", "0.55.0-nightly"]);
     });
   });
 });


### PR DESCRIPTION
### Description

I open this PR directly to the release branch to test out the new fixed function.

### How to verify

This PR should have green checks

### Demo
See the step to resolve the [latest SDK version.](https://github.com/metabase/metabase/actions/runs/15326103201/job/43120934361?pr=58638#step:4:27)

(Learn the hard way that, in months, the log will disappear)
```
Run actions/github-script@v7
Resolved latest major release version - 55
Looking for git tag - "embedding-sdk-0.55.*"
Resolved SDK latest release tag for v55 - embedding-sdk-0.55.2-nightly
Resolved SDK latest release version for v55 - 0.55.2-nightly
```

Here is the list of the tags for 55
```
embedding-sdk-0.55.1-metabot
embedding-sdk-0.55.1-nightly
embedding-sdk-0.55.2-metabot
embedding-sdk-0.55.2-nightly
embedding-sdk-0.55.3-metabot
embedding-sdk-0.55.4-metabot
embedding-sdk-0.55.5-metabot
```

Previously, it would resolve to `embedding-sdk-0.55.5` which would fail the [sparse checkout](https://github.com/metabase/metabase/actions/runs/15321587222/job/43106783743?pr=58624) since the tag won't exist.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
