### PR TITLE
Execute dashcard actions via unified API

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -342,8 +342,8 @@
                            "row-action" {:row-action unified, :mapping mapping, :dashcard-id dashcard-id}))
                        (if-let [[_ dashcard-id] (re-matches #"^dashcard:(\d+)$" raw-id)]
                          ;; Dashboard buttons can only be invoked from dashboards
-                         ;; We're not checking that the scope has the correct dashboard, but if it's incorrect.
-                         ;; There will be a 404 thrown when we try to execute the action.
+                         ;; We're not checking that the scope has the correct dashboard, but if it's incorrect, there
+                         ;; will be a 404 thrown when we try to execute the action.
                          ;; This 404 here is not the best error to return, but we can polish this later.
                          (let [dashboard-id (api/check-404 (:dashboard-id scope))]
                            (api/read-check :model/Dashboard dashboard-id)

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -303,6 +303,8 @@
   [:or
    ::unified-action.base
    [:map {:closed true}
+    [:dashboard-action ms/PositiveInt]]
+   [:map {:closed true}
     [:row-action ::unified-action.base]
     ;; TODO type our mappings
     [:mapping :map]
@@ -311,7 +313,7 @@
 
 (mu/defn- fetch-unified-action :- ::unified-action
   "Resolve various types of action id into a semantic map which is easier to dispatch on."
-  [scope :- ::types/scope.raw
+  [scope :- ::types/scope.hydrated
    raw-id :- [:or :string ms/NegativeInt ms/PositiveInt]]
   (cond
     (pos-int? raw-id) {:action-id raw-id}
@@ -338,8 +340,16 @@
                          (assert (:enabled viz-action) "Cannot call disabled actions")
                          (case action-type
                            "row-action" {:row-action unified, :mapping mapping, :dashcard-id dashcard-id}))
-                       ;; Not a fancy encoded string, it must refer directly to a primitive.
-                       {:action-kw (keyword raw-id)})
+                       (if-let [[_ dashcard-id] (re-matches #"^dashcard:(\d+)$" raw-id)]
+                         ;; Dashboard buttons can only be invoked from dashboards
+                         ;; We're not checking that the scope has the correct dashboard, but if it's incorrect.
+                         ;; There will be a 404 thrown when we try to execute the action.
+                         ;; This 404 here is not the best error to return, but we can polish this later.
+                         (let [dashboard-id (api/check-404 (:dashboard-id scope))]
+                           (api/read-check :model/Dashboard dashboard-id)
+                           {:dashboard-action (parse-long dashcard-id)})
+                         ;; Not a fancy encoded string, it must refer directly to a primitive.
+                         {:action-kw (keyword raw-id)}))
     :else
     (throw (ex-info "Unexpected id value" {:status 400, :action-id raw-id}))))
 
@@ -358,6 +368,12 @@
          (if (and (isa? action-kw :table.row/common) (:table-id unified))
            (actions/perform-action! action-kw scope (for [i inputs] {:table-id (:table-id unified), :row i}))
            (actions/perform-action! action-kw scope inputs))))
+      (:dashboard-action unified)
+      (do
+        (api/check-400 (= 1 (count inputs)) "Saved actions currently only support a single input")
+        [(actions/execute-dashcard! (:dashboard-id scope)
+                                    (:dashboard-action unified)
+                                    (walk/stringify-keys (first inputs)))])
       (:row-action unified)
       ;; use flat namespace for now, probably want to separate form inputs from pks
       (let [row-action  (:row-action unified)

--- a/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/undo.clj
@@ -170,7 +170,7 @@
    :update :update
    :delete :create})
 
-(def category->op
+(def ^:private category->op
   {:create :created
    :update :updated
    :delete :deleted})

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1155,3 +1155,36 @@
                            :type "type/BigInteger"}]
                          (->> (:parameters body)
                               (map #(select-keys % [:id :display_name :type]))))))))))))))
+
+;; Taken from metabase-enterprise.data-editing.api-test.
+;; When we deprecate that API, we should move all the sibling tests here as well.
+(deftest dashcard-implicit-action-execution-insert-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+    (mt/with-actions-test-data-and-actions-enabled
+      (testing "Executing dashcard insert"
+        (mt/with-actions [{:keys [action-id model-id]} {:type :implicit :kind "row/create"}]
+          (mt/with-temp [:model/Dashboard     {dashboard-id :id} {}
+                         :model/DashboardCard {dashcard-id :id}  {:dashboard_id dashboard-id
+                                                                  :card_id      model-id
+                                                                  :action_id    action-id}]
+            (let [execute-path "/ee/data-editing/action/v2/execute"
+                  body         {:action_id (str "dashcard:" dashcard-id)
+                                :scope     {:dashboard-id dashboard-id}
+                                :input     {"name" "Birds"}}
+                  new-row      (-> (mt/user-http-request :crowberto :post 200 execute-path body)
+                                   :outputs
+                                   first
+                                   :created-row
+                                   (update-keys (comp keyword u/lower-case-en name)))]
+              (testing "Should be able to insert"
+                (is (pos? (:id new-row)))
+                (is (partial= {:name "Birds"}
+                              new-row)))
+              (testing "Extra parameter should fail gracefully"
+                (is (partial= {:message "No destination parameter found for #{\"extra\"}. Found: #{\"name\"}"}
+                              (mt/user-http-request :crowberto :post 400 execute-path
+                                                    (assoc-in body [:input :extra] 1)))))
+              (testing "Missing other parameters should fail gracefully"
+                (is (partial= "Implicit parameters must be provided."
+                              (mt/user-http-request :crowberto :post 400 execute-path
+                                                    (assoc body :input {}))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.data-editing.api-test
+(ns ^:mb/driver-tests metabase-enterprise.data-editing.api-test
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/undo_test.clj
@@ -5,7 +5,6 @@
    [metabase-enterprise.data-editing.undo :as undo]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
-   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (deftest diff-keys-test

--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -233,7 +233,7 @@
                        {:emailType    "notification"
                         :logoHeader   true
                         :heading      (trs "We hope you''ve been enjoying Metabase.")
-                        :callToAction (trs "Would you mind taking a quick 5 minute survey to tell us how it's going?")
+                        :callToAction (trs "Would you mind taking a quick 5 minute survey to tell us how it''s going?")
                         :link         "https://metabase.com/feedback/active"})
         email {:subject      (trs "[{0}] Tell us how things are going." (app-name-trs))
                :recipients   [email]

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -3824,6 +3824,8 @@
                      (mt/user-http-request :crowberto :post 400 execute-path
                                            {:parameters {"id" "BAD"}})))))))))))
 
+;; Mirrored in test for unified API in metabase-enterprise.data-editing.api-test.
+;; When we deprecate that API, we should move all the sibling tests there as well.
 (deftest dashcard-implicit-action-execution-insert-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)
     (mt/with-actions-test-data-and-actions-enabled

--- a/test/metabase/notification/seed_test.clj
+++ b/test/metabase/notification/seed_test.clj
@@ -31,7 +31,7 @@
                (notification.seed/seed-notification!))))
       (let [before (get-notifications-data)]
         (testing "skip all since none of the notifications were changed"
-          (is (= {:skip 3}
+          (is (= {:skip 4}
                  (notification.seed/seed-notification!))))
         (testing "it equals to the data before "
           (is (= before (get-notifications-data))))))))


### PR DESCRIPTION
Missed an important case - executing dashcard actions.

Haven't tried to make it beautiful yet - when we make row-actions into first class entities we can do the same for these actions. Since these actions already exist in master though we'll need a migration strategy.