### PR TITLE
Fix auto-approve on translation update workflow

### DIFF
--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Auto approve PR
         uses: juliangruber/approve-pull-request-action@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           number: ${{ steps.create_pr.outputs.pr_number }}
 
       - name: Enable Pull Request Automerge


### PR DESCRIPTION

Closes dev-583

### Description

Translations updates were not auto-approving. this swaps the token to enable it and fix this error:

```
Error: Unprocessable Entity: "Can not approve your own pull request"
```

