### PR TITLE
Generate valid multi arg string filters in parameter chaining

### DIFF
--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -1,11 +1,14 @@
 (ns metabase.parameters.chain-filter-test
   (:require
    [clojure.test :refer :all]
+   [malli.error :as me]
+   [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.field-values :as params.field-values]
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.malli.registry :as mr]
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2]))
 
@@ -48,6 +51,19 @@
       :has_more_values false}"
   [n result]
   (update result :values #(take n %)))
+
+(deftest ^:parallel special-form-filter-clause-test
+  (testing "Can handle multi-arg string filters when chaining (#57287)"
+    (doseq [value ["Omer" ["Omer"] ["Omer" "Clovis"]]]
+      (testing (str "with value " (pr-str value))
+        (are [op] (nil? (->> (#'chain-filter/filter-clause (mt/id :venues)
+                                                           {:field-id (mt/id :venues :name)
+                                                            :op op
+                                                            :value value
+                                                            :options nil})
+                             (mr/explain mbql.s/Filter)
+                             me/humanize))
+          :starts-with :ends-with :contains :does-not-contain)))))
 
 (deftest chain-filter-test
   (testing "Show me expensive restaurants"


### PR DESCRIPTION
Fixes #57287

### Description

Multi-arg string filters have a special legacy form which was not taken into account when generating filters for linked filters. Ideally filter generation should happen using the MBQL lib, but I didn't want to make this change bigger than necessary.

The multi-arg version was introduced with #41958, which was part of #41956, which was part of milestone [0.50](https://github.com/metabase/metabase/milestone/209).

### How to verify

The repro tests #57287 in should not result in an error. The new test verifies the string filter generation.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
