### PR TITLE
Don't Require tech-writer review for developers guide docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@ src/metabase/analytics/prometheus.clj @metabase/cloud-ops
 deps.edn @metabase/backend-developers
 
 docs @metabase/tech-writers
+docs/developers-guide # exclude from tech-writer ownership
 
 #
 # Backend modules <=> teams that own them


### PR DESCRIPTION
adding a directory without an owner after a parent directory with an owner should exclude it from code ownership

