### PR TITLE
fix: data perms test to set schemas for tables

### DIFF
--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -720,11 +720,13 @@
           table-id     (t2/insert-returning-pk! :metabase_table {:name       "orders"
                                                                  :active     true
                                                                  :db_id      db-id
+                                                                 :schema     "test-schema"
                                                                  :created_at #t "2020"
                                                                  :updated_at #t "2020"})
           _other-table (t2/insert-returning-pk! :metabase_table {:name       "other"
                                                                  :active     true
                                                                  :db_id      db-id
+                                                                 :schema     "test-schema"
                                                                  :created_at #t "2020"
                                                                  :updated_at #t "2020"})
           group-id     (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "Test Group"})]


### PR DESCRIPTION
### Description

Had to add these to a backport to get tests to work since rolling back a download-result perm expects schema to be set. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
