### PR TITLE
[HOTFIX] Metabot requests causing interactive embedding to improperly redirect

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -50,7 +50,7 @@ export const Metabot = (props: MetabotProps) => {
 
   // NOTE: do not render Metabot if the user is not authenticated.
   // doing so will cause a redirect for unauthenticated requests
-  // which will break interactive embedding.
+  // which will break interactive embedding. See (metabase#58687).
   if (!currentUser) {
     return null;
   }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -48,6 +48,9 @@ export const MetabotAuthenticated = ({ hide }: MetabotProps) => {
 export const Metabot = (props: MetabotProps) => {
   const currentUser = useSelector(getUser);
 
+  // NOTE: do not render Metabot if the user is not authenticated.
+  // doing so will cause a redirect for unauthenticated requests
+  // which will break interactive embedding.
   if (!currentUser) {
     return null;
   }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { tinykeys } from "tinykeys";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useSelector } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
 
 import { useMetabotAgent } from "../hooks";
 
@@ -13,23 +13,17 @@ export interface MetabotProps {
   hide?: boolean;
 }
 
-export const Metabot = ({ hide }: MetabotProps) => {
-  const currentUser = useSelector(getCurrentUser);
-
+export const MetabotAuthenticated = ({ hide }: MetabotProps) => {
   const { visible, setVisible } = useMetabotAgent();
 
   useEffect(() => {
-    if (!currentUser) {
-      return () => {};
-    }
-
     return tinykeys(window, {
       "$mod+b": (e) => {
         e.preventDefault(); // prevent FF from opening bookmark menu
         setVisible(!visible);
       },
     });
-  }, [visible, setVisible, currentUser]);
+  }, [visible, setVisible]);
 
   useEffect(
     function closeViaPropChange() {
@@ -49,4 +43,14 @@ export const Metabot = ({ hide }: MetabotProps) => {
       <MetabotChat />
     </ErrorBoundary>
   );
+};
+
+export const Metabot = (props: MetabotProps) => {
+  const currentUser = useSelector(getUser);
+
+  if (!currentUser) {
+    return null;
+  }
+
+  return <MetabotAuthenticated {...props} />;
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useMetabotContext } from "metabase/metabot";
+import { getUser } from "metabase/selectors/user";
 import {
   METABOT_TAG,
   useGetSuggestedMetabotPromptsQuery,
@@ -23,7 +24,7 @@ export const useMetabotAgent = () => {
   const dispatch = useDispatch();
   const { getChatContext } = useMetabotContext();
 
-  const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery();
+  const currentUser = useSelector(getUser);
 
   // TODO: create an enterprise useSelector
   const messages = useSelector(getMessages as any) as ReturnType<
@@ -35,6 +36,11 @@ export const useMetabotAgent = () => {
 
   const [, sendMessageReq] = useMetabotAgentMutation({
     fixedCacheKey: METABOT_TAG,
+  });
+
+  const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery(undefined, {
+    // NOTE: running the request with no user breaks embedding (metaboase#????)
+    skip: !currentUser,
   });
 
   return {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useMetabotContext } from "metabase/metabot";
-import { getUser } from "metabase/selectors/user";
 import {
   METABOT_TAG,
   useGetSuggestedMetabotPromptsQuery,
@@ -24,8 +23,6 @@ export const useMetabotAgent = () => {
   const dispatch = useDispatch();
   const { getChatContext } = useMetabotContext();
 
-  const currentUser = useSelector(getUser);
-
   // TODO: create an enterprise useSelector
   const messages = useSelector(getMessages as any) as ReturnType<
     typeof getMessages
@@ -38,10 +35,7 @@ export const useMetabotAgent = () => {
     fixedCacheKey: METABOT_TAG,
   });
 
-  const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery(undefined, {
-    // NOTE: running the request with no user breaks embedding (metaboase#????)
-    skip: !currentUser,
-  });
+  const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery();
 
   return {
     visible: useSelector(getMetabotVisible as any) as ReturnType<

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -23,6 +23,8 @@ export const useMetabotAgent = () => {
   const dispatch = useDispatch();
   const { getChatContext } = useMetabotContext();
 
+  const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery();
+
   // TODO: create an enterprise useSelector
   const messages = useSelector(getMessages as any) as ReturnType<
     typeof getMessages
@@ -34,8 +36,6 @@ export const useMetabotAgent = () => {
   const [, sendMessageReq] = useMetabotAgentMutation({
     fixedCacheKey: METABOT_TAG,
   });
-
-  const suggestedPromptsReq = useGetSuggestedMetabotPromptsQuery();
 
   return {
     visible: useSelector(getMetabotVisible as any) as ReturnType<


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

**This is a p0 bug.**
Full slack thread for context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1748543205951849

**TL:DR;**
Most of our components are rendered as a child our Routes in `frontend/src/metabase/routes.jsx` with most components being wrapped in a `IsAuthenticated` route guard. However, Metabot was rendered within `frontend/src/metabase/App.tsx` placing it outside of our Routes for layout reasons. A recent change in #58059 would issue a network request for suggested prompts, and was the first request by Metabot to get automatically issued on mount. For unauthorized users, this is causing a redirect to authenticate to occur, which in an embedded context was dropping the `return_to` query param for auth redirects.

### How to verify

- Setup interactive embedding
- Run this simple JWT provider
```js
const http = require("http");

const server = http.createServer((req, res) => {
  console.log(
    new Date().toISOString(),
    `[${req.method}]`,
    "RAW req.url received by server:",
    req.url,
  );
  res.write(req.url);
  return res.end();
});

server.listen(8888, () => {
  console.log("Server is running on port 8888");
});
```
- Configure your JWT auth to point to `http://localhost:8888/auth/sso`
- Serve this simple webpage via `npx serve`
```html
<h1>Simple embed for interactive embedding</h1>

<iframe
  src="http://localhost:3000/dashboard/1"
  width="100%"
  height="100%"
></iframe>
```
- Visit the served webpage in an incognito tab (this is to avoid picking up authenticate locally if you're already signed in elsewhere)
- You should now see `/auth/sso?return_to=/dashboard/1` again, having see `/auth/sso` before the ifx

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
