### PR TITLE
SEM-363 Data model - Field and table name/description inputs should be sticky and have icons

### DIFF
--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -11,6 +11,7 @@
 }
 
 .nameInput {
+  padding-left: 44px !important; /* override mantine styles */
   border-end-start-radius: 0;
   border-end-end-radius: 0;
 }
@@ -20,6 +21,6 @@
   border-start-end-radius: 0;
 }
 
-.rightSection {
-  display: none;
+.iconContainer {
+  border-radius: 6px;
 }

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -13,34 +13,13 @@
 .nameInput {
   border-end-start-radius: 0;
   border-end-end-radius: 0;
-
-  &:hover:not(:focus) {
-    background-color: var(--mb-base-color-orion-5);
-  }
 }
 
 .descriptionInput {
   border-start-start-radius: 0;
   border-start-end-radius: 0;
-
-  &:hover:not(:focus) {
-    background-color: var(--mb-base-color-orion-5);
-
-    .rightSection {
-      display: flex;
-    }
-  }
 }
 
 .rightSection {
   display: none;
-}
-
-.name,
-.description {
-  &:hover {
-    .rightSection {
-      display: flex;
-    }
-  }
 }

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -7,7 +7,7 @@
 
 .description {
   position: relative;
-  top: -2px; /* imitate collapsed borders */
+  top: -2px; /* Imitate collapsed borders. -1px does not seem to do the trick on Mac. */
 }
 
 .nameInput {

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -45,16 +45,16 @@ export const NameDescriptionInput = ({
       />
 
       <Textarea
+        autosize
         classNames={{
           input: S.descriptionInput,
           root: S.description,
         }}
+        maxRows={4}
+        minRows={2}
         placeholder={descriptionPlaceholder}
         value={description}
         onChange={onDescriptionChange}
-        autosize
-        minRows={2}
-        maxRows={4}
       />
     </Box>
   );

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -1,4 +1,4 @@
-import { Box } from "metabase/ui";
+import { Box, Flex, Icon, type IconName } from "metabase/ui";
 
 import { Input } from "./Input";
 import S from "./NameDescriptionInput.module.css";
@@ -8,6 +8,7 @@ interface Props {
   description: string;
   descriptionPlaceholder: string;
   name: string;
+  nameIcon: IconName;
   namePlaceholder: string;
   onDescriptionChange: (description: string) => void;
   onNameChange: (name: string) => void;
@@ -17,6 +18,7 @@ export const NameDescriptionInput = ({
   description,
   descriptionPlaceholder,
   name,
+  nameIcon,
   namePlaceholder,
   onDescriptionChange,
   onNameChange,
@@ -29,6 +31,18 @@ export const NameDescriptionInput = ({
           root: S.name,
         }}
         fw="bold"
+        leftSection={
+          <Flex
+            align="center"
+            bg="brand"
+            className={S.iconContainer}
+            h={24}
+            justify="center"
+            w={24}
+          >
+            <Icon c="white" name={nameIcon} size={12} />
+          </Flex>
+        }
         normalize={(newValue) => {
           if (typeof newValue !== "string") {
             return name;

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -1,7 +1,8 @@
 import { Box } from "metabase/ui";
 
-import { Input, Textarea } from "./Input";
+import { Input } from "./Input";
 import S from "./NameDescriptionInput.module.css";
+import { Textarea } from "./Textarea";
 
 interface Props {
   description: string;

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.unit.spec.tsx
@@ -18,6 +18,7 @@ function setup({ description = "", name = "" }: Partial<SetupOpts> = {}) {
       description={description}
       descriptionPlaceholder="Enter description"
       name={name}
+      nameIcon="table2"
       namePlaceholder="Enter name"
       onDescriptionChange={onDescriptionChange}
       onNameChange={onNameChange}

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/Textarea.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/Textarea.tsx
@@ -1,11 +1,8 @@
-import {
-  TextInputBlurChange,
-  type TextInputBlurChangeProps,
-} from "metabase/ui";
+import { TextareaBlurChange, type TextareaBlurChangeProps } from "metabase/ui";
 
 interface Props
   extends Omit<
-    TextInputBlurChangeProps,
+    TextareaBlurChangeProps,
     "normalize" | "value" | "onBlurChange" | "onChange"
   > {
   normalize?: (
@@ -15,7 +12,7 @@ interface Props
   onChange: (value: string) => void;
 }
 
-export const Input = ({
+export const Textarea = ({
   normalize,
   required,
   value,
@@ -23,7 +20,7 @@ export const Input = ({
   ...props
 }: Props) => {
   return (
-    <TextInputBlurChange
+    <TextareaBlurChange
       normalize={normalize}
       required={required}
       value={value}

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
@@ -18,23 +18,3 @@
 .footer {
   border-top: 1px solid var(--mb-color-border);
 }
-
-.segmentsLink {
-  border-radius: 8px;
-  cursor: pointer;
-
-  &:hover,
-  &.active {
-    background-color: var(--mb-color-brand-lighter);
-    color: var(--mb-color-brand);
-
-    .segmentsIcon {
-      opacity: 1;
-    }
-  }
-}
-
-.segmentsIcon {
-  opacity: 0.5;
-  flex-shrink: 0;
-}

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.module.css
@@ -1,18 +1,9 @@
-.sidebar {
+.column {
+  overflow: auto;
+}
+
+.rightBorder {
   border-right: 1px solid var(--mb-color-border);
-  overflow: auto;
-
-  &.noBorder {
-    border-right: none;
-  }
-}
-
-.tableSectionContainer {
-  overflow: auto;
-}
-
-.contentLoadingAndErrorWrapper {
-  height: 100%;
 }
 
 .footer {

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -32,10 +32,11 @@ export const DataModel = ({
   children: ReactNode;
 }) => {
   const { databaseId, tableId, schemaId } = parseRouteParams(params);
+
   return (
     <Flex h="100%" bg="bg-light">
       <Stack
-        className={S.sidebar}
+        className={S.column}
         flex="0 0 25%"
         miw="320px"
         gap={0}
@@ -87,22 +88,25 @@ export function DataModelEditor({ params }: { params: RouteParams }) {
   return (
     <>
       {tableId && (
-        <Box className={S.sidebar} flex="0 0 25%" h="100%" miw="400px">
-          <Box p="xl" pb="lg">
-            <LoadingAndErrorWrapper error={error} loading={isLoading}>
-              {table && (
-                <TableSection
-                  /**
-                   * Make sure internal component state is reset when changing tables.
-                   * This is to avoid state mix-up with optimistic updates.
-                   */
-                  key={table.id}
-                  params={params}
-                  table={table}
-                />
-              )}
-            </LoadingAndErrorWrapper>
-          </Box>
+        <Box
+          className={cx(S.column, S.rightBorder)}
+          flex="0 0 25%"
+          h="100%"
+          miw="400px"
+        >
+          <LoadingAndErrorWrapper error={error} loading={isLoading}>
+            {table && (
+              <TableSection
+                /**
+                 * Make sure internal component state is reset when changing tables.
+                 * This is to avoid state mix-up with optimistic updates.
+                 */
+                key={table.id}
+                params={params}
+                table={table}
+              />
+            )}
+          </LoadingAndErrorWrapper>
         </Box>
       )}
 
@@ -128,41 +132,30 @@ export function DataModelEditor({ params }: { params: RouteParams }) {
 
       {!isEmptyStateShown && (
         <>
-          <Box
-            flex="0 0 25%"
-            h="100%"
-            miw="400px"
-            className={cx(S.sidebar, S.noBorder)}
-          >
-            <Box p="xl" pb="lg">
-              <LoadingAndErrorWrapper
-                className={S.contentLoadingAndErrorWrapper}
-                error={error}
-                loading={isLoading}
-              >
-                {field && (
-                  <FieldSection
-                    databaseId={databaseId}
-                    field={field}
-                    /**
-                     * Make sure internal component state is reset when changing fields.
-                     * This is to avoid state mix-up with optimistic updates.
-                     */
-                    key={getRawTableFieldId(field)}
-                  />
-                )}
-              </LoadingAndErrorWrapper>
-            </Box>
+          <Box className={S.column} flex="0 0 25%" h="100%" miw="400px">
+            <LoadingAndErrorWrapper error={error} loading={isLoading}>
+              {field && (
+                <FieldSection
+                  databaseId={databaseId}
+                  field={field}
+                  /**
+                   * Make sure internal component state is reset when changing fields.
+                   * This is to avoid state mix-up with optimistic updates.
+                   */
+                  key={getRawTableFieldId(field)}
+                />
+              )}
+            </LoadingAndErrorWrapper>
           </Box>
 
           {field && (
-            <Box flex="1 1 200px" p="xl" pl={0} miw={0}>
+            <Box flex="1 1 200px" miw={0} p="xl">
               <PreviewSection
                 databaseId={databaseId}
-                tableId={tableId}
-                fieldId={fieldId}
                 field={field}
+                fieldId={fieldId}
                 previewType={previewType}
+                tableId={tableId}
                 onPreviewTypeChange={setPreviewType}
               />
             </Box>

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -6,16 +6,16 @@ import EmptyDashboardBot from "assets/img/dashboard-empty.svg";
 import { skipToken, useGetTableQueryMetadataQuery } from "metabase/api";
 import EmptyState from "metabase/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
-import Link from "metabase/core/components/Link";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import { Box, Flex, Icon, Stack } from "metabase/ui";
+import { Box, Flex, Stack } from "metabase/ui";
 
 import S from "./DataModel.module.css";
 import {
   FieldSection,
   PreviewSection,
   RouterTablePicker,
+  SegmentsLink,
   TableSection,
   usePreviewType,
 } from "./components";
@@ -47,8 +47,15 @@ export const DataModel = ({
           schemaId={schemaId}
           tableId={tableId}
         />
+
         <Box mx="xl" py="sm" className={S.footer}>
-          <SegmentsLink location={location} />
+          <SegmentsLink
+            active={
+              location.pathname.startsWith("/admin/datamodel/segments") ||
+              location.pathname.startsWith("/admin/datamodel/segment/")
+            }
+            to="/admin/datamodel/segments"
+          />
         </Box>
       </Stack>
 
@@ -56,25 +63,6 @@ export const DataModel = ({
     </Flex>
   );
 };
-
-function SegmentsLink({ location }: { location: Location }) {
-  const isActive =
-    location?.pathname?.startsWith("/admin/datamodel/segments") ||
-    location?.pathname?.startsWith("/admin/datamodel/segment/");
-
-  return (
-    <Flex
-      component={Link}
-      to="/admin/datamodel/segments"
-      className={cx(S.segmentsLink, { [S.active]: isActive })}
-      gap="sm"
-      p="sm"
-    >
-      <Icon name="pie" className={S.segmentsIcon} />
-      {t`Segments`}
-    </Flex>
-  );
-}
 
 export function DataModelEditor({ params }: { params: RouteParams }) {
   const { databaseId, tableId, fieldId } = parseRouteParams(params);
@@ -95,6 +83,7 @@ export function DataModelEditor({ params }: { params: RouteParams }) {
   );
   const field = table?.fields?.find((field) => field.id === fieldId);
   const [previewType, setPreviewType] = usePreviewType();
+
   return (
     <>
       {tableId && (

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection.tsx
@@ -24,17 +24,13 @@ interface Props {
 }
 
 export const BehaviorSection = ({ databaseId, field }: Props) => {
+  const id = getRawTableFieldId(field);
   const { data: database } = useGetDatabaseQuery({
     id: databaseId,
     ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
   });
   const [updateField] = useUpdateFieldMutation();
-  const id = getRawTableFieldId(field);
-
   const [sendToast] = useToast();
-  function confirm(message: string) {
-    sendToast({ message, icon: "check" });
-  }
 
   return (
     <Stack gap="md">
@@ -51,7 +47,11 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
             id,
             visibility_type: visibilityType,
           });
-          confirm(t`Visibility for ${field.display_name} updated`);
+
+          sendToast({
+            icon: "check",
+            message: t`Visibility for ${field.display_name} updated`,
+          });
         }}
       />
 
@@ -64,7 +64,11 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
             id,
             has_field_values: hasFieldValues,
           });
-          confirm(t`Filtering for ${field.display_name} updated`);
+
+          sendToast({
+            icon: "check",
+            message: t`Filtering for ${field.display_name} updated`,
+          });
         }}
       />
 
@@ -78,11 +82,13 @@ export const BehaviorSection = ({ databaseId, field }: Props) => {
               id,
               json_unfolding: jsonUnfolding,
             });
-            if (jsonUnfolding) {
-              confirm(t`JSON unfloding for ${field.display_name} enabled`);
-            } else {
-              confirm(t`JSON unfloding for ${field.display_name} disabled`);
-            }
+
+            sendToast({
+              icon: "check",
+              message: jsonUnfolding
+                ? t`JSON unfloding for ${field.display_name} enabled`
+                : t`JSON unfloding for ${field.display_name} disabled`,
+            });
           }}
         />
       )}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/DataSection.tsx
@@ -22,15 +22,12 @@ interface Props {
 }
 
 export const DataSection = ({ field }: Props) => {
-  const [updateField] = useUpdateFieldMutation();
+  const id = getRawTableFieldId(field);
   const [isCasting, setIsCasting] = useState(
     field ? field.coercion_strategy != null : false,
   );
-  const id = getRawTableFieldId(field);
+  const [updateField] = useUpdateFieldMutation();
   const [sendToast] = useToast();
-  function confirm(message: string) {
-    sendToast({ message, icon: "check" });
-  }
 
   useEffect(() => {
     setIsCasting(field.coercion_strategy != null);
@@ -81,7 +78,11 @@ export const DataSection = ({ field }: Props) => {
 
                   if (!event.target.checked) {
                     await updateField({ id, coercion_strategy: null });
-                    confirm(t`Casting disabled for ${field.display_name}`);
+
+                    sendToast({
+                      icon: "check",
+                      message: t`Casting disabled for ${field.display_name}`,
+                    });
                   }
                 }}
               />
@@ -96,7 +97,11 @@ export const DataSection = ({ field }: Props) => {
                     id,
                     coercion_strategy: coercionStrategy,
                   });
-                  confirm(t`Casting enabled for ${field.display_name}`);
+
+                  sendToast({
+                    icon: "check",
+                    message: t`Casting enabled for ${field.display_name}`,
+                  });
                 }}
               />
             )}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.module.css
@@ -1,0 +1,3 @@
+.header {
+  z-index: 3;
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
@@ -25,27 +25,32 @@ interface Props {
 }
 
 export const FieldSection = ({ databaseId, field }: Props) => {
-  const [updateField] = useUpdateFieldMutation();
   const id = getRawTableFieldId(field);
+  const [updateField] = useUpdateFieldMutation();
   const [sendToast] = useToast();
-  function confirm(message: string) {
-    sendToast({ message });
-  }
 
   return (
     <Stack gap="lg" h="100%">
       <NameDescriptionInput
         name={field.display_name}
         namePlaceholder={t`Give this field a name`}
-        onNameChange={async (display_name) => {
-          await updateField({ id, display_name });
-          confirm(t`Display name for ${display_name} updated`);
+        onNameChange={async (name) => {
+          await updateField({ id, display_name: name });
+
+          sendToast({
+            icon: "check",
+            message: t`Display name for ${name} updated`,
+          });
         }}
         description={field.description ?? ""}
         descriptionPlaceholder={t`Give this field a description`}
         onDescriptionChange={async (description) => {
           await updateField({ id, description });
-          confirm(t`Description for ${getFieldDisplayName(field)} updated`);
+
+          sendToast({
+            icon: "check",
+            message: t`Description for ${getFieldDisplayName(field)} updated`,
+          });
         }}
       />
 

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
@@ -81,6 +81,3 @@ export const FieldSection = ({ databaseId, field }: Props) => {
     </Stack>
   );
 };
-{
-  /* <Box className={S.container} h="100%" pb="lg" px="xl"> */
-}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
@@ -11,11 +11,12 @@ import {
   getFieldDisplayName,
   getRawTableFieldId,
 } from "metabase/metadata/utils/field";
-import { Stack } from "metabase/ui";
+import { Box, Stack } from "metabase/ui";
 import type { DatabaseId, Field } from "metabase-types/api";
 
 import { BehaviorSection } from "./BehaviorSection";
 import { DataSection } from "./DataSection";
+import S from "./FieldSection.module.css";
 import { FormattingSection } from "./FormattingSection";
 import { MetadataSection } from "./MetadataSection";
 
@@ -30,29 +31,38 @@ export const FieldSection = ({ databaseId, field }: Props) => {
   const [sendToast] = useToast();
 
   return (
-    <Stack gap="lg" h="100%">
-      <NameDescriptionInput
-        name={field.display_name}
-        namePlaceholder={t`Give this field a name`}
-        onNameChange={async (name) => {
-          await updateField({ id, display_name: name });
+    <Stack gap={0} p="xl" pt={0}>
+      <Box
+        bg="accent-gray-light"
+        className={S.header}
+        pb="lg"
+        pos="sticky"
+        pt="xl"
+        top={0}
+      >
+        <NameDescriptionInput
+          name={field.display_name}
+          namePlaceholder={t`Give this field a name`}
+          onNameChange={async (name) => {
+            await updateField({ id, display_name: name });
 
-          sendToast({
-            icon: "check",
-            message: t`Display name for ${name} updated`,
-          });
-        }}
-        description={field.description ?? ""}
-        descriptionPlaceholder={t`Give this field a description`}
-        onDescriptionChange={async (description) => {
-          await updateField({ id, description });
+            sendToast({
+              icon: "check",
+              message: t`Display name for ${name} updated`,
+            });
+          }}
+          description={field.description ?? ""}
+          descriptionPlaceholder={t`Give this field a description`}
+          onDescriptionChange={async (description) => {
+            await updateField({ id, description });
 
-          sendToast({
-            icon: "check",
-            message: t`Description for ${getFieldDisplayName(field)} updated`,
-          });
-        }}
-      />
+            sendToast({
+              icon: "check",
+              message: t`Description for ${getFieldDisplayName(field)} updated`,
+            });
+          }}
+        />
+      </Box>
 
       <Stack gap="xl">
         <DataSection field={field} />
@@ -68,3 +78,6 @@ export const FieldSection = ({ databaseId, field }: Props) => {
     </Stack>
   );
 };
+{
+  /* <Box className={S.container} h="100%" pb="lg" px="xl"> */
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
@@ -2,6 +2,7 @@ import { t } from "ttag";
 
 import { useUpdateFieldMutation } from "metabase/api";
 import { useToast } from "metabase/common/hooks";
+import { getColumnIcon } from "metabase/common/utils/columns";
 import {
   DiscardFieldValuesButton,
   NameDescriptionInput,
@@ -12,6 +13,7 @@ import {
   getRawTableFieldId,
 } from "metabase/metadata/utils/field";
 import { Box, Stack } from "metabase/ui";
+import * as Lib from "metabase-lib";
 import type { DatabaseId, Field } from "metabase-types/api";
 
 import { BehaviorSection } from "./BehaviorSection";
@@ -42,6 +44,7 @@ export const FieldSection = ({ databaseId, field }: Props) => {
       >
         <NameDescriptionInput
           name={field.display_name}
+          nameIcon={getColumnIcon(Lib.legacyColumnTypeInfo(field))}
           namePlaceholder={t`Give this field a name`}
           onNameChange={async (name) => {
             await updateField({ id, display_name: name });

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FormattingSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FormattingSection.tsx
@@ -20,18 +20,15 @@ interface Props {
 }
 
 export const FormattingSection = ({ field }: Props) => {
-  const [updateField] = useUpdateFieldMutation();
   const id = getRawTableFieldId(field);
+  const [updateField] = useUpdateFieldMutation();
+  const [sendToast] = useToast();
+  const inheritedSettings = useMemo(() => getGlobalSettingsForColumn(), []);
   const denyList = useMemo(() => {
     return isCurrency(field)
       ? new Set(["column_title", "number_style"])
       : new Set(["column_title"]);
   }, [field]);
-  const inheritedSettings = useMemo(() => getGlobalSettingsForColumn(), []);
-  const [sendToast] = useToast();
-  function confirm(message: string) {
-    sendToast({ message, icon: "check" });
-  }
 
   return (
     <Stack gap="md">
@@ -48,7 +45,11 @@ export const FormattingSection = ({ field }: Props) => {
         value={field.settings ?? {}}
         onChange={async (settings: FieldSettings) => {
           await updateField({ id, settings });
-          confirm(t`Field formatting for ${field.display_name} updated`);
+
+          sendToast({
+            icon: "check",
+            message: t`Field formatting for ${field.display_name} updated`,
+          });
         }}
       />
     </Stack>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/MetadataSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/MetadataSection.tsx
@@ -19,15 +19,13 @@ interface Props {
 }
 
 export const MetadataSection = ({ databaseId, field }: Props) => {
+  const id = getRawTableFieldId(field);
   const { data: idFields = [] } = useListDatabaseIdFieldsQuery({
     id: databaseId,
     ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
   });
   const [updateField] = useUpdateFieldMutation();
   const [sendToast] = useToast();
-  function confirm(message: string) {
-    sendToast({ message, icon: "check" });
-  }
 
   return (
     <Stack gap="md">
@@ -42,9 +40,12 @@ export const MetadataSection = ({ databaseId, field }: Props) => {
         label={t`Semantic type`}
         onUpdateField={async (field, updates) => {
           const { id: _id, ...fieldAttributes } = field;
-          const id = getRawTableFieldId(field);
           await updateField({ id, ...fieldAttributes, ...updates });
-          confirm(t`Semantic type for ${field.display_name} updated`);
+
+          sendToast({
+            icon: "check",
+            message: t`Semantic type for ${field.display_name} updated`,
+          });
         }}
       />
     </Stack>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/SegmentsLink/SegmentsLink.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/SegmentsLink/SegmentsLink.module.css
@@ -1,0 +1,19 @@
+.segmentsLink {
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:hover,
+  &.active {
+    background-color: var(--mb-color-brand-lighter);
+    color: var(--mb-color-brand);
+
+    .segmentsIcon {
+      opacity: 1;
+    }
+  }
+}
+
+.segmentsIcon {
+  opacity: 0.5;
+  flex-shrink: 0;
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/SegmentsLink/SegmentsLink.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/SegmentsLink/SegmentsLink.tsx
@@ -1,0 +1,28 @@
+import cx from "classnames";
+import { t } from "ttag";
+
+import Link from "metabase/core/components/Link";
+import { Flex, Icon } from "metabase/ui";
+
+import S from "./SegmentsLink.module.css";
+
+interface Props {
+  active: boolean;
+  to: string;
+}
+
+export const SegmentsLink = ({ active, to }: Props) => {
+  return (
+    <Flex
+      className={cx(S.segmentsLink, { [S.active]: active })}
+      component={Link}
+      gap="sm"
+      p="sm"
+      to={to}
+    >
+      <Icon name="pie" className={S.segmentsIcon} />
+
+      {t`Segments`}
+    </Flex>
+  );
+};

--- a/frontend/src/metabase/metadata/pages/DataModel/components/SegmentsLink/index.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/SegmentsLink/index.ts
@@ -1,0 +1,1 @@
+export * from "./SegmentsLink";

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.module.css
@@ -1,0 +1,3 @@
+.header {
+  z-index: 3;
+}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -45,6 +45,7 @@ export const TableSection = ({ params, table }: Props) => {
           description={table.description ?? ""}
           descriptionPlaceholder={t`Give this table a description`}
           name={table.display_name}
+          nameIcon="table2"
           namePlaceholder={t`Give this table a name`}
           onDescriptionChange={async (description) => {
             await updateTable({ id: table.id, description });

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -12,11 +12,13 @@ import {
   RescanTableFieldsButton,
   SortableFieldList,
 } from "metabase/metadata/components";
-import { Flex, Stack, Switch, Text } from "metabase/ui";
+import { Box, Flex, Stack, Switch, Text } from "metabase/ui";
 import type { FieldId, Table } from "metabase-types/api";
 
 import type { RouteParams } from "../../types";
 import { getUrl, parseRouteParams } from "../../utils";
+
+import S from "./TableSection.module.css";
 
 interface Props {
   params: RouteParams;
@@ -30,62 +32,91 @@ export const TableSection = ({ params, table }: Props) => {
   const [sendToast] = useToast();
 
   return (
-    <Stack gap="lg">
-      <NameDescriptionInput
-        description={table.description ?? ""}
-        descriptionPlaceholder={t`Give this table a description`}
-        name={table.display_name}
-        namePlaceholder={t`Give this table a name`}
-        onDescriptionChange={async (description) => {
-          await updateTable({ id: table.id, description });
-
-          sendToast({
-            icon: "check",
-            message: t`Table description updated`,
-          });
-        }}
-        onNameChange={async (name) => {
-          await updateTable({ id: table.id, display_name: name });
-
-          sendToast({
-            icon: "check",
-            message: t`Table name updated`,
-          });
-        }}
-      />
-
-      <Stack gap="sm">
-        <Text fw="bold" size="sm">{t`Table visibility`}</Text>
-
-        <Switch
-          checked={table.visibility_type === "hidden"}
-          label={t`Hide this table`}
-          size="sm"
-          onChange={async (event) => {
-            const visibilityType = event.target.checked ? "hidden" : null;
-            await updateTable({
-              id: table.id,
-              visibility_type: visibilityType,
-            });
+    <Stack gap={0} p="xl" pt={0}>
+      <Box
+        bg="accent-gray-light"
+        className={S.header}
+        pb="lg"
+        pos="sticky"
+        pt="xl"
+        top={0}
+      >
+        <NameDescriptionInput
+          description={table.description ?? ""}
+          descriptionPlaceholder={t`Give this table a description`}
+          name={table.display_name}
+          namePlaceholder={t`Give this table a name`}
+          onDescriptionChange={async (description) => {
+            await updateTable({ id: table.id, description });
 
             sendToast({
               icon: "check",
-              message: t`Table visibility updated`,
+              message: t`Table description updated`,
+            });
+          }}
+          onNameChange={async (name) => {
+            await updateTable({ id: table.id, display_name: name });
+
+            sendToast({
+              icon: "check",
+              message: t`Table name updated`,
             });
           }}
         />
-      </Stack>
+      </Box>
 
-      <Stack gap="sm">
-        <Flex align="flex-end" gap="md" justify="space-between">
-          <Text fw="bold" size="sm">{t`Fields`}</Text>
+      <Stack gap="lg">
+        <Stack gap="sm">
+          <Text fw="bold" size="sm">{t`Table visibility`}</Text>
 
-          <FieldOrderPicker
-            value={table.field_order}
-            onChange={async (fieldOrder) => {
+          <Switch
+            checked={table.visibility_type === "hidden"}
+            label={t`Hide this table`}
+            size="sm"
+            onChange={async (event) => {
+              const visibilityType = event.target.checked ? "hidden" : null;
               await updateTable({
                 id: table.id,
-                field_order: fieldOrder,
+                visibility_type: visibilityType,
+              });
+
+              sendToast({
+                icon: "check",
+                message: t`Table visibility updated`,
+              });
+            }}
+          />
+        </Stack>
+
+        <Stack gap="sm">
+          <Flex align="flex-end" gap="md" justify="space-between">
+            <Text fw="bold" size="sm">{t`Fields`}</Text>
+
+            <FieldOrderPicker
+              value={table.field_order}
+              onChange={async (fieldOrder) => {
+                await updateTable({
+                  id: table.id,
+                  field_order: fieldOrder,
+                });
+
+                sendToast({
+                  icon: "check",
+                  message: t`Field order updated`,
+                });
+              }}
+            />
+          </Flex>
+
+          <SortableFieldList
+            activeFieldId={fieldId}
+            getFieldHref={(fieldId) => getUrl({ ...parsedParams, fieldId })}
+            table={table}
+            onChange={async (fieldOrder) => {
+              await updateTableFieldsOrder({
+                id: table.id,
+                // in this context field id will never be a string because it's a raw table field, so it's ok to cast
+                field_order: fieldOrder as FieldId[],
               });
 
               sendToast({
@@ -94,36 +125,18 @@ export const TableSection = ({ params, table }: Props) => {
               });
             }}
           />
-        </Flex>
+        </Stack>
 
-        <SortableFieldList
-          activeFieldId={fieldId}
-          getFieldHref={(fieldId) => getUrl({ ...parsedParams, fieldId })}
-          table={table}
-          onChange={async (fieldOrder) => {
-            await updateTableFieldsOrder({
-              id: table.id,
-              // in this context field id will never be a string because it's a raw table field, so it's ok to cast
-              field_order: fieldOrder as FieldId[],
-            });
+        <Stack gap="sm">
+          <Text c="text-secondary" mb="md" mt="lg" size="sm" ta="center">
+            {/* eslint-disable-next-line no-literal-metabase-strings -- Admin settings */}
+            {t`Metabase can scan the values in this table to enable checkbox filters in dashboards and questions.`}
+          </Text>
 
-            sendToast({
-              icon: "check",
-              message: t`Field order updated`,
-            });
-          }}
-        />
-      </Stack>
+          <RescanTableFieldsButton tableId={table.id} />
 
-      <Stack gap="sm">
-        <Text c="text-secondary" mb="md" mt="lg" size="sm" ta="center">
-          {/* eslint-disable-next-line no-literal-metabase-strings -- Admin settings */}
-          {t`Metabase can scan the values in this table to enable checkbox filters in dashboards and questions.`}
-        </Text>
-
-        <RescanTableFieldsButton tableId={table.id} />
-
-        <DiscardTableFieldValuesButton tableId={table.id} />
+          <DiscardTableFieldValuesButton tableId={table.id} />
+        </Stack>
       </Stack>
     </Stack>
   );

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -12,7 +12,7 @@ import {
   RescanTableFieldsButton,
   SortableFieldList,
 } from "metabase/metadata/components";
-import { Card, Flex, Stack, Switch, Text } from "metabase/ui";
+import { Flex, Stack, Switch, Text } from "metabase/ui";
 import type { FieldId, Table } from "metabase-types/api";
 
 import type { RouteParams } from "../../types";
@@ -57,25 +57,23 @@ export const TableSection = ({ params, table }: Props) => {
       <Stack gap="sm">
         <Text fw="bold" size="sm">{t`Table visibility`}</Text>
 
-        <Card bg="accent-gray-light" p="sm" radius="md" shadow="none">
-          <Switch
-            checked={table.visibility_type === "hidden"}
-            label={t`Hide this table`}
-            size="sm"
-            onChange={async (event) => {
-              const visibilityType = event.target.checked ? "hidden" : null;
-              await updateTable({
-                id: table.id,
-                visibility_type: visibilityType,
-              });
+        <Switch
+          checked={table.visibility_type === "hidden"}
+          label={t`Hide this table`}
+          size="sm"
+          onChange={async (event) => {
+            const visibilityType = event.target.checked ? "hidden" : null;
+            await updateTable({
+              id: table.id,
+              visibility_type: visibilityType,
+            });
 
-              sendToast({
-                icon: "check",
-                message: t`Table visibility updated`,
-              });
-            }}
-          />
-        </Card>
+            sendToast({
+              icon: "check",
+              message: t`Table visibility updated`,
+            });
+          }}
+        />
       </Stack>
 
       <Stack gap="sm">

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -28,9 +28,6 @@ export const TableSection = ({ params, table }: Props) => {
   const [updateTable] = useUpdateTableMutation();
   const [updateTableFieldsOrder] = useUpdateTableFieldsOrderMutation();
   const [sendToast] = useToast();
-  function confirm(message: string) {
-    sendToast({ message, icon: "check" });
-  }
 
   return (
     <Stack gap="lg">
@@ -41,11 +38,19 @@ export const TableSection = ({ params, table }: Props) => {
         namePlaceholder={t`Give this table a name`}
         onDescriptionChange={async (description) => {
           await updateTable({ id: table.id, description });
-          confirm(t`Table description updated`);
+
+          sendToast({
+            icon: "check",
+            message: t`Table description updated`,
+          });
         }}
         onNameChange={async (name) => {
           await updateTable({ id: table.id, display_name: name });
-          confirm(t`Table name updated`);
+
+          sendToast({
+            icon: "check",
+            message: t`Table name updated`,
+          });
         }}
       />
 
@@ -63,7 +68,11 @@ export const TableSection = ({ params, table }: Props) => {
                 id: table.id,
                 visibility_type: visibilityType,
               });
-              confirm(t`Table visibility updated`);
+
+              sendToast({
+                icon: "check",
+                message: t`Table visibility updated`,
+              });
             }}
           />
         </Card>
@@ -75,9 +84,16 @@ export const TableSection = ({ params, table }: Props) => {
 
           <FieldOrderPicker
             value={table.field_order}
-            onChange={(fieldOrder) => {
-              updateTable({ id: table.id, field_order: fieldOrder });
-              confirm(t`Field order updated`);
+            onChange={async (fieldOrder) => {
+              await updateTable({
+                id: table.id,
+                field_order: fieldOrder,
+              });
+
+              sendToast({
+                icon: "check",
+                message: t`Field order updated`,
+              });
             }}
           />
         </Flex>
@@ -92,7 +108,11 @@ export const TableSection = ({ params, table }: Props) => {
               // in this context field id will never be a string because it's a raw table field, so it's ok to cast
               field_order: fieldOrder as FieldId[],
             });
-            confirm(t`Field order updated`);
+
+            sendToast({
+              icon: "check",
+              message: t`Field order updated`,
+            });
           }}
         />
       </Stack>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/index.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./FieldSection";
 export * from "./PreviewSection";
-export * from "./TableSection";
+export * from "./SegmentsLink";
 export * from "./TablePicker";
+export * from "./TableSection";


### PR DESCRIPTION
Closes [SEM-363](https://linear.app/metabase/issue/SEM-363/data-model-field-and-table-namedescription-inputs-should-be-sticky-and)

### Description

Hiding whitespace changes recommended.

- makes name + description inputs sticky (both in Table column and Field column)
- adds icons to name input (both in Table column and Field column)
- removes `Card` around "Table visibility" toggle
  - `Card` was useful when it had a different background than the rest of UI - now the background is the same, and the Card was resulting in redundant padding
- drops `confirm` wrapper around `showToast`
  - fixes missing `icon` param in one of the components
  - fixes missing `await` before showing toast in one of the components
- extracts `SegmentsLink` component
- moves `Textarea` to a separate file

### How to verify

1. Go to http://localhost:3000/admin/datamodel/database/1/schema/1:PUBLIC/table/6/field/37
2. Change viewport size so that columns with table name input and field name input are scrollable
3. Scroll down both columns - name/description inputs should be sticky
4. There should be icons in name inputs

### Demo


https://github.com/user-attachments/assets/c59127b3-ce52-4f50-b029-222e9fbdad2d

