### PR TITLE
Short circuit on sync error

### DIFF
--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -196,12 +196,11 @@
   (if-let [fields (fields-to-fingerprint table)]
     (do
       (log/infof "Fingerprinting %s fields in table %s" (count fields) (sync-util/name-for-logging table))
-      (let [stats (sync-util/with-error-handling
-                   (format "Error fingerprinting %s" (sync-util/name-for-logging table))
-                    (fingerprint-fields! table fields))]
-        (if (instance? Exception stats)
-          (assoc (empty-stats-map 0)
-                 :throwable stats)
+      (let [stats
+            (sync-util/with-returning-throwable (format "Error fingerprinting %s" (sync-util/name-for-logging table))
+              (fingerprint-fields! table fields))]
+        (if (:throwable stats)
+          (merge (empty-stats-map 0) stats)
           stats)))
     (empty-stats-map 0)))
 

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -204,15 +204,32 @@
          (throw e))))))
 
 (defmacro with-error-handling
-  "Execute `body` in a way that catches and logs any Exceptions thrown, and returns `nil` if they do so. Pass a
-  `message` to help provide information about what failed for the log message.
+  "Execute `body` in a way that catches and logs any Exceptions thrown, and returns the exception itself if they do so.
+  Pass a `message` to help provide information about what failed for the log message.
 
   The exception classes deriving from `:metabase.sync.util/exception-class-not-to-retry` are a list of classes tested
   against exceptions thrown. If there is a match found, the sync is aborted as that error is not considered
   recoverable for this sync run."
   {:style/indent 1}
   [message & body]
-  `(do-with-error-handling ~message (fn [] ~@body)))
+  `(do-with-error-handling ~message (^:once fn* [] ~@body)))
+
+(defn do-with-returning-throwable
+  "Internal implementation of [[with-returning-throwable]]; use that instead of calling this directly."
+  [message f]
+  (try (f)
+       (catch Throwable e
+         (if *log-exceptions-and-continue?*
+           (do
+             (log/warn e message)
+             {:throwable e})
+           (throw e)))))
+
+(defmacro with-returning-throwable
+  "Execute `body`, catching any exception and returning it as `{:throwable e}`"
+  {:style/indent 1}
+  [message & body]
+  `(do-with-returning-throwable ~message (^:once fn* [] ~@body)))
 
 (mu/defn do-sync-operation
   "Internal implementation of [[sync-operation]]; use that instead of calling this directly."
@@ -503,7 +520,7 @@
                             step-name
                             (name-for-logging database))
                     (fn [& args]
-                      (try
+                      (with-returning-throwable (format "Error running step ''%s'' for %s" step-name (name-for-logging database))
                         (task-history/with-task-history
                           {:task            step-name
                            :db_id           (u/the-id database)
@@ -511,13 +528,7 @@
                                               (if (instance? Throwable result)
                                                 (throw result)
                                                 (assoc update-map :task_details (dissoc result :start-time :end-time :log-summary-fn))))}
-                          (apply sync-fn database args))
-                        (catch Throwable e
-                          (if *log-exceptions-and-continue?*
-                            (do
-                              (log/warnf e "Error running step ''%s'' for %s" step-name (name-for-logging database))
-                              {:throwable e})
-                            (throw e))))))
+                          (apply sync-fn database args)))))
         end-time   (t/zoned-date-time)]
     [step-name (assoc results
                       :start-time start-time

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -13,6 +13,8 @@
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (defn- venues-price-field-values []
   (t2/select-one-fn :values :model/FieldValues, :field_id (mt/id :venues :price), :type :full))
 
@@ -270,3 +272,19 @@
                   :has_more_values       true}
                  (into {} (t2/select-one [:model/FieldValues :values :human_readable_values :has_more_values]
                                          :field_id (mt/id :blueberries_consumed :str))))))))))
+
+(deftest sync-aborts-on-non-recoverable-error-test
+  (testing "Make sure sync aborts on non-recoverable errors"
+    (one-off-dbs/with-blueberries-db
+      ;; insert 50 rows & sync
+      (one-off-dbs/insert-rows-and-sync! [(str/join (repeat 50 "A"))])
+      ;; Manually activate Field values since they are not created during sync (#53387)
+      (field-values/get-or-create-full-field-values! (t2/select-one :model/Field (mt/id :blueberries_consumed :str)))
+      ;; we throw ConnectException, which is a non-recoverable exception
+      (with-redefs [field-values/create-or-update-full-field-values! (fn [& _] (throw (java.net.ConnectException.)))]
+        (is (->> (sync/update-field-values! (data/db))
+                 :steps
+                 (filter (fn [[k _]] (= k "update-field-values")))
+                 first
+                 second
+                 :throwable))))))

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -282,9 +282,7 @@
       (field-values/get-or-create-full-field-values! (t2/select-one :model/Field (mt/id :blueberries_consumed :str)))
       ;; we throw ConnectException, which is a non-recoverable exception
       (with-redefs [field-values/create-or-update-full-field-values! (fn [& _] (throw (java.net.ConnectException.)))]
-        (is (->> (sync/update-field-values! (data/db))
-                 :steps
-                 (filter (fn [[k _]] (= k "update-field-values")))
-                 first
-                 second
-                 :throwable))))))
+        (is (=?
+             {:steps [["delete-expired-advanced-field-values" {}]
+                      ["update-field-values" {:throwable #(instance? Exception %)}]]}
+             (sync/update-field-values! (data/db))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #51683
Closes https://linear.app/metabase/issue/SEM-13/field-values-must-short-circuit-on-sync-ending-errors

# Description
Let sync's `with-error-handling` respect `::exception-class-not-to-retry` as its docstring actually promises.

This allows the entire sync pipeline to avoid doing needless work once one such exception is thrown, which is the goal of the original ticket