### PR TITLE
Use NULL in place of optional SQL parameters

### DIFF
--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -34,6 +34,7 @@
     (let [parameters (for [parameter (:parameters action)]
                        (assoc parameter
                               :value (get request-parameters (:id parameter))
+                              ;; Fetch an important property that's not really a visualization setting...
                               :required (if-let [f (get-in action [:visualization_settings :fields (:id parameter)])]
                                           (:required f)
                                           ;; if we can't find the settings, treat it as required

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -32,7 +32,12 @@
   (log/tracef "Executing action\n\n%s" (u/pprint-to-str action))
   (try
     (let [parameters (for [parameter (:parameters action)]
-                       (assoc parameter :value (get request-parameters (:id parameter))))
+                       (assoc parameter
+                              :value (get request-parameters (:id parameter))
+                              :required (if-let [f (get-in action [:visualization_settings :fields (:id parameter)])]
+                                          (:required f)
+                                          ;; if we can't find the settings, treat it as required
+                                          true)))
           query (-> dataset_query
                     (update :type keyword)
                     (assoc :parameters parameters))]

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -56,16 +56,21 @@
 
 (mu/defmethod driver/substitute-native-parameters :sql
   [_driver {:keys [query] :as inner-query} :- [:and [:map-of :keyword :any] [:map {:query ::lib.schema.common/non-blank-string}]]]
-  (let [params-map          (params.values/query->params-map inner-query)
-        referenced-card-ids (params.values/referenced-card-ids params-map)
-        [query params]      (-> query
-                                params.parse/parse
-                                (sql.params.substitute/substitute params-map))]
-    (cond-> (assoc inner-query
-                   :query  query
-                   :params params)
-      (seq referenced-card-ids)
-      (update :metabase.permissions.models.query.permissions/referenced-card-ids set/union referenced-card-ids))))
+  (binding [sql.params.substitute/*optional-params* (set (for [p (:parameters inner-query)
+                                                               :when (not (:required p))
+                                                               :when (and (= :variable (first (:target p)))
+                                                                          (= :template-tag (first (second (:target p)))))]
+                                                           (get-in p [:target 1 1])))]
+    (let [params-map          (params.values/query->params-map inner-query)
+          referenced-card-ids (params.values/referenced-card-ids params-map)
+          [query params] (-> query
+                             params.parse/parse
+                             (sql.params.substitute/substitute params-map))]
+      (cond-> (assoc inner-query
+                     :query query
+                     :params params)
+        (seq referenced-card-ids)
+        (update :metabase.permissions.models.query.permissions/referenced-card-ids set/union referenced-card-ids)))))
 
 (defmulti json-field-length
   "Return a HoneySQL expression that calculates the number of characters in a JSON field for a given driver.

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -10,6 +10,10 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]))
 
+(def ^:dynamic *optional-params*
+  "YES I TOOK A SHORTCUT"
+  #{})
+
 (defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [_field value], :as v}]
   (if (and (= params/no-value value) in-optional?)
     ;; no-value field filters inside optional clauses are ignored, and eventually emitted entirely
@@ -42,12 +46,13 @@
         (params/ReferencedQuerySnippet? v)
         (substitute-native-query-snippet [sql args missing] v)
 
-        (= params/no-value v)
+        (and (= params/no-value v) (not (contains? #p *optional-params* #p k)))
         [sql args (conj missing k)]
 
         :else
-        (let [{:keys [replacement-snippet prepared-statement-args]}
-              (sql.params.substitution/->replacement-snippet-info driver/*driver* v)]
+        (let [value (when (not= params/no-value v) v)
+              {:keys [replacement-snippet prepared-statement-args]}
+              (sql.params.substitution/->replacement-snippet-info driver/*driver* value)]
           [(str sql replacement-snippet) (concat args prepared-statement-args) missing])))))
 
 (declare substitute*)

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -46,7 +46,7 @@
         (params/ReferencedQuerySnippet? v)
         (substitute-native-query-snippet [sql args missing] v)
 
-        (and (= params/no-value v) (not (contains? #p *optional-params* #p k)))
+        (and (= params/no-value v) (not (contains? *optional-params* k)))
         [sql args (conj missing k)]
 
         :else


### PR DESCRIPTION
This fixes the obnoxious case where an action fails because an **optional** parameter was omitted.

Hacky fix for now, and only tested manually.