### PR TITLE
Fix 3 flaky tests

### DIFF
--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -4,6 +4,7 @@
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.query :as mdb.query]
    [metabase.app-db.query-cancelation :as app-db.query-cancelation]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.retry :as retry]
    [toucan2.core :as t2])
@@ -56,6 +57,7 @@
         (t2/query-one {:insert-into [:metabase_cluster_lock]
                        :columns [:lock_name]
                        :values [[lock-name-str]]})))
+    (log/info "Obtained cluster lock")
     (thunk)))
 
 (mu/defn do-with-cluster-lock

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -9,7 +9,7 @@
    [metabase.util.retry :as retry]
    [toucan2.core :as t2])
   (:import
-   (java.sql Connection PreparedStatement SQLIntegrityConstraintViolationException)))
+   (java.sql Connection PreparedStatement SQLIntegrityConstraintViolationException SQLException)))
 
 (set! *warn-on-reflection* true)
 
@@ -20,8 +20,8 @@
   ;; We can retry getting the cluster lock if either we tried to concurrently insert the pk
   ;; for the lock resulting in a SQLIntegrityConstraintViolationException or if the query
   ;; was cancelled via timeout waiting to get the SELECT FOR UPDATE lock
-  (or (instance? SQLIntegrityConstraintViolationException e)
-      (instance? SQLIntegrityConstraintViolationException (ex-cause e))
+  (or (instance? SQLException e)
+      (instance? SQLException (ex-cause e))
       (app-db.query-cancelation/query-canceled-exception? (mdb.connection/db-type) e)))
 
 (def ^:private default-retry-config

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -29,18 +29,17 @@
       (t2/with-connection [_conn]
         ;; need to use a shared lock for all updates to the card table
         (cluster-lock/with-cluster-lock cluster-lock/card-statistics-lock
-          (t2/update! :model/Card :id [:in (keys card-id->timestamp)]
-                      {:last_used_at (into [:case]
-                                           (mapcat (fn [[id timestamp]]
-                                                     [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
-                                                   card-id->timestamp))
-                       ;; Set updated_at to its current value to prevent it from updating automatically
-                       :updated_at :updated_at})))
+          (t2/query {:update [(t2/table-name :model/Card)]
+                     :where  [:in :id (keys card-id->timestamp)]
+                     :set    {:last_used_at (into [:case]
+                                                  (mapcat (fn [[id timestamp]]
+                                                            [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
+                                                          card-id->timestamp))
+                              :updated_at :updated_at}})))
       (catch Throwable e
         (log/error e "Error updating used cards")))))
 
-(defonce ^:private
-  update-used-cards-queue
+(defonce ^:private update-used-cards-queue
   (delay
     (grouper/start!
      #'update-used-cards!*

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -2,8 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.parameters.custom-values :as custom-values]
-   [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 ;;; --------------------------------------------- source=card ----------------------------------------------
 
@@ -13,21 +12,21 @@
       (binding [custom-values/*max-rows* 3]
         (testing "with simple mbql"
           (mt/with-temp
-            [:model/Card {card-id :id} (merge (mt/card-with-source-metadata-for-query (mt/mbql-query venues))
-                                              {:database_id     (mt/id)
-                                               :type            (if model? :model :question)
-                                               :table_id        (mt/id :venues)})]
+            [:model/Card card (merge (mt/card-with-source-metadata-for-query (mt/mbql-query venues))
+                                     {:database_id     (mt/id)
+                                      :type            (if model? :model :question)
+                                      :table_id        (mt/id :venues)})]
             (testing "get values"
               (is (= {:has_more_values true
                       :values          [["20th Century Cafe"] ["25°"] ["33 Taps"]]}
                      (custom-values/values-from-card
-                      (t2/select-one :model/Card :id card-id)
+                      card
                       (mt/$ids $venues.name)))))
             (testing "case in-sensitve search test"
               (is (= {:has_more_values false
                       :values          [["Liguria Bakery"] ["Noe Valley Bakery"]]}
                      (custom-values/values-from-card
-                      (t2/select-one :model/Card :id card-id)
+                      card
                       (mt/$ids $venues.name)
                       {:query-string "bakery"}))))))))))
 
@@ -36,37 +35,37 @@
     (binding [custom-values/*max-rows* 3]
       (testing "has aggregation column"
         (mt/with-temp
-          [:model/Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
-                                             (mt/mbql-query venues
-                                               {:aggregation [[:sum $venues.price]]
-                                                :breakout    [[:field %categories.name {:source-field %venues.category_id}]]}))
-                                            {:database_id     (mt/id)
-                                             :type            :model
-                                             :table_id        (mt/id :venues)})]
+          [:model/Card card (merge (mt/card-with-source-metadata-for-query
+                                    (mt/mbql-query venues
+                                      {:aggregation [[:sum $venues.price]]
+                                       :breakout    [[:field %categories.name {:source-field %venues.category_id}]]}))
+                                   {:database_id     (mt/id)
+                                    :type            :model
+                                    :table_id        (mt/id :venues)})]
           (testing "get values from breakout columns"
             (is (= {:has_more_values true
                     :values          [["American"] ["Artisan"] ["Asian"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "NAME" {:base-type :type/Text}]))))
           (testing "get values from aggregation column"
             (is (= {:has_more_values true
                     :values          [[1] [2] [3]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "sum" {:base-type :type/Float}]))))
           (testing "can search on aggregation column"
             (is (= {:has_more_values false
                     :values          [[2]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "sum" {:base-type :type/Float}]
                     {:query-string 2}))))
           (testing "doing case in-sensitve search on breakout columns"
             (is (= {:has_more_values false
                     :values          [["Bakery"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "NAME" {:base-type :type/Text}]
                     {:query-string "bakery"}))))))))
 
@@ -74,24 +73,24 @@
     (binding [custom-values/*max-rows* 3]
       (testing "has aggregation column"
         (mt/with-temp
-          [:model/Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
-                                             (mt/mbql-query venues
-                                               {:aggregation [[:sum $venues.price]]
-                                                :breakout    [[:field %categories.name {:source-field %venues.category_id}]]}))
-                                            {:database_id     (mt/id)
-                                             :type            :question
-                                             :table_id        (mt/id :venues)})]
+          [:model/Card card (merge (mt/card-with-source-metadata-for-query
+                                    (mt/mbql-query venues
+                                      {:aggregation [[:sum $venues.price]]
+                                       :breakout    [[:field %categories.name {:source-field %venues.category_id}]]}))
+                                   {:database_id     (mt/id)
+                                    :type            :question
+                                    :table_id        (mt/id :venues)})]
           (testing "get values from breakout columns"
             (is (= {:has_more_values true
                     :values          [["American"] ["Artisan"] ["Asian"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field (mt/id :categories :name) {:source-field (mt/id :venues :category_id)}]))))
           (testing "doing case in-sensitve search on breakout columns"
             (is (= {:has_more_values false
                     :values          [["Bakery"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field (mt/id :categories :name) {:source-field (mt/id :venues :category_id)}]
                     {:query-string "bakery"})))))))))
 
@@ -102,23 +101,23 @@
         (testing "should disable remapping when getting fk columns"
           (mt/with-column-remappings [venues.category_id categories.name]
             (mt/with-temp
-              [:model/Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
-                                                 (mt/mbql-query venues
-                                                   {:joins [{:source-table $$categories
-                                                             :alias        "Categories"
-                                                             :condition    [:= $venues.category_id &Categories.categories.id]}]}))
-                                                {:type (if model? :model :question)})]
+              [:model/Card card (merge (mt/card-with-source-metadata-for-query
+                                        (mt/mbql-query venues
+                                          {:joins [{:source-table $$categories
+                                                    :alias        "Categories"
+                                                    :condition    [:= $venues.category_id &Categories.categories.id]}]}))
+                                       {:type (if model? :model :question)})]
               (testing "get values returns the value, not remapped values"
                 (is (= {:has_more_values true
                         :values          [[2] [3] [4]]}
                        (custom-values/values-from-card
-                        (t2/select-one :model/Card :id card-id)
+                        card
                         (mt/$ids $venues.category_id)))))
               (testing "search with  the value, not remapped values"
                 (is (= {:has_more_values false
                         :values          [[2]]}
                        (custom-values/values-from-card
-                        (t2/select-one :model/Card :id card-id)
+                        card
                         (mt/$ids $venues.category_id)
                         {:query-string 2})))))))))))
 
@@ -127,17 +126,17 @@
     (testing "should nest the query if the target stage is after the last stage"
       (mt/with-column-remappings [venues.category_id categories.name]
         (mt/with-temp
-          [:model/Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
-                                             (mt/mbql-query venues
-                                               {:joins [{:source-table $$categories
-                                                         :alias        "Categories"
-                                                         :fields       :all
-                                                         :condition    [:= $venues.category_id &Categories.categories.id]}]}))
-                                            {:type :question})]
+          [:model/Card card (merge (mt/card-with-source-metadata-for-query
+                                    (mt/mbql-query venues
+                                      {:joins [{:source-table $$categories
+                                                :alias        "Categories"
+                                                :fields       :all
+                                                :condition    [:= $venues.category_id &Categories.categories.id]}]}))
+                                   {:type :question})]
           (is (= {:values [["American"] ["Artisan"] ["Asian"]]
                   :has_more_values true}
                  (custom-values/values-from-card
-                  (t2/select-one :model/Card :id card-id)
+                  card
                   [:field "NAME_2" {:base_type :type/Text}]
                   {:stage-number 1}))))))))
 
@@ -146,22 +145,22 @@
     (testing (format "source card is a %s with native question" (if model? "model" "question"))
       (binding [custom-values/*max-rows* 3]
         (mt/with-temp
-          [:model/Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
-                                             (mt/native-query {:query "select * from venues where lower(name) like '%red%'"}))
-                                            {:database_id     (mt/id)
-                                             :type            (if model? :model :question)
-                                             :table_id        (mt/id :venues)})]
+          [:model/Card card (merge (mt/card-with-source-metadata-for-query
+                                    (mt/native-query {:query "select * from venues where lower(name) like '%red%'"}))
+                                   {:database_id     (mt/id)
+                                    :type            (if model? :model :question)
+                                    :table_id        (mt/id :venues)})]
           (testing "get values from breakout columns"
             (is (= {:has_more_values false
                     :values          [["Fred 62"] ["Red Medicine"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "NAME" {:base-type :type/Text}]))))
           (testing "doing case in-sensitve search on breakout columns"
             (is (= {:has_more_values false
                     :values          [["Red Medicine"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "NAME" {:base-type :type/Text}]
                     {:query-string "medicine"})))))))))
 
@@ -169,19 +168,19 @@
   (mt/dataset test-data
     (testing "the values list should not contains duplicated and empty values"
       (testing "with native query"
-        (mt/with-temp [:model/Card {card-id :id} (mt/card-with-source-metadata-for-query
-                                                  (mt/native-query {:query "select * from people"}))]
+        (mt/with-temp [:model/Card card (mt/card-with-source-metadata-for-query
+                                         (mt/native-query {:query "select * from people"}))]
           (testing "get values from breakout columns"
             (is (= {:has_more_values false
                     :values          [["Affiliate"] ["Facebook"] ["Google"] ["Organic"] ["Twitter"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "SOURCE" {:base-type :type/Text}]))))
           (testing "doing case in-sensitve search on breakout columns"
             (is (= {:has_more_values false
                     :values          [["Facebook"] ["Google"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     [:field "SOURCE" {:base-type :type/Text}]
                     {:query-string "oo"})))))))))
 
@@ -189,19 +188,19 @@
   (mt/dataset test-data
     (testing "the values list should not contains duplicated and empty values"
       (testing "with mbql query"
-        (mt/with-temp [:model/Card {card-id :id} (mt/card-with-source-metadata-for-query
-                                                  (mt/mbql-query people))]
+        (mt/with-temp [:model/Card card (mt/card-with-source-metadata-for-query
+                                         (mt/mbql-query people))]
           (testing "get values from breakout columns"
             (is (= {:has_more_values false
                     :values          [["Affiliate"] ["Facebook"] ["Google"] ["Organic"] ["Twitter"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     (mt/$ids $people.source)))))
           (testing "doing case in-sensitve search on breakout columns"
             (is (= {:has_more_values false
                     :values          [["Facebook"] ["Google"]]}
                    (custom-values/values-from-card
-                    (t2/select-one :model/Card :id card-id)
+                    card
                     (mt/$ids $people.source)
                     {:query-string "oo"})))))))))
 
@@ -271,19 +270,19 @@
     (doseq [model? [true false]]
       (testing (format "source card is a %s" (if model? "model" "question"))
         (mt/with-temp
-          [:model/Card {card-id :id} (merge (-> (mt/mbql-query
-                                                  products
-                                                  {:aggregation [[:count]]
-                                                   :breakout    [$category !month.created_at]
-                                                   :order-by    [[:asc [:aggregation 0]]]})
-                                                mt/card-with-source-metadata-for-query)
-                                            {:database_id     (mt/id)
-                                             :type            (if model? :model :question)
-                                             :table_id        (mt/id :products)})]
+          [:model/Card card (merge (-> (mt/mbql-query
+                                         products
+                                         {:aggregation [[:count]]
+                                          :breakout    [$category !month.created_at]
+                                          :order-by    [[:asc [:aggregation 0]]]})
+                                       mt/card-with-source-metadata-for-query)
+                                   {:database_id     (mt/id)
+                                    :type            (if model? :model :question)
+                                    :table_id        (mt/id :products)})]
           (is (= {:has_more_values false
                   :values          [["Doohickey"] ["Gadget"] ["Gizmo"] ["Widget"]]}
                  (custom-values/values-from-card
-                  (t2/select-one :model/Card :id card-id)
+                  card
                   (mt/$ids $products.category)))))))))
 
 (deftest pk-of-fk-pk-field-ids-test

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -1,28 +1,11 @@
 (ns metabase.parameters.custom-values-test
   (:require
    [clojure.test :refer :all]
-   [metabase.app-db.cluster-lock :as app-db.cluster-lock]
    [metabase.parameters.custom-values :as custom-values]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
-   [toucan2.core :as t2]))
+   [metabase.test.fixtures :as fixtures]))
 
-;; Create the lock before these fixtures run. On mysql and mariadb attempting to concurrently create
-;; this lock inside an extremely nested transaction can fail rolling back the rest of the transaction
-;; Outside of the test environment this is fine because we can retry just the transaction the cluster
-;; lock is used in
-(use-fixtures :once
-  (fixtures/initialize :db)
-  (fn [f]
-    (let [lock-name-str (str (namespace app-db.cluster-lock/card-statistics-lock)
-                             "/" (name app-db.cluster-lock/card-statistics-lock))]
-      ;; Create cluster lock row before running tests
-      (t2/query-one {:insert-into [:metabase_cluster_lock] :columns [:lock_name] :values [[lock-name-str]]})
-      (try
-        (f)
-        (finally
-          ;; Clean up cluster lock after tests
-          (t2/query-one {:delete-from [:metabase_cluster_lock] :where [:= :lock_name lock-name-str]}))))))
+(use-fixtures :once (fixtures/initialize :db :row-lock))
 
 ;;; --------------------------------------------- source=card ----------------------------------------------
 

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -152,16 +152,15 @@
                   (#'token-check/fetch-token-status* (random-token))))))
 
 (deftest fetch-token-does-not-call-db-when-cached
-  (testing "No DB calls are made for the user count when checking token status if the status is cached"
+  (testing "No DB calls are made when checking token status if the status is cached"
     (let [token (random-token)]
       (t2/with-call-count [call-count]
         ;; First fetch, should trigger a DB call to fetch user count and db calls for other stats
         (#'token-check/fetch-token-status token)
-        (is (= 6 (call-count)))
-
-        ;; Subsequent fetches with the same token should not trigger additional DB calls
-        (#'token-check/fetch-token-status token)
-        (is (= 6 (call-count)))))))
+        (let [prev-call-count (call-count)]
+          ;; Subsequent fetches with the same token should not trigger additional DB calls
+          (#'token-check/fetch-token-status token)
+          (is (= prev-call-count (call-count))))))))
 
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -118,6 +118,11 @@
   (initialize-if-needed! :db)
   (notification/seed-notification!))
 
+(define-initialization :row-lock
+  (initialize-if-needed! :db)
+  (classloader/require 'metabase.test.initialize.row-lock)
+  ((resolve 'metabase.test.initialize.row-lock/init!)))
+
 (defn- all-components
   "Set of all components/initialization steps that are defined."
   []

--- a/test/metabase/test/initialize/row_lock.clj
+++ b/test/metabase/test/initialize/row_lock.clj
@@ -12,4 +12,5 @@
   (let [lock-name-str (str (namespace app-db.cluster-lock/card-statistics-lock)
                            "/" (name app-db.cluster-lock/card-statistics-lock))]
       ;; Create cluster lock row before running tests
-    (t2/query-one {:insert-into [:metabase_cluster_lock] :columns [:lock_name] :values [[lock-name-str]]})))
+    (when-not (t2/exists? :metabase_cluster_lock :lock_name lock-name-str)
+      (t2/query-one {:insert-into [:metabase_cluster_lock] :columns [:lock_name] :values [[lock-name-str]]}))))

--- a/test/metabase/test/initialize/row_lock.clj
+++ b/test/metabase/test/initialize/row_lock.clj
@@ -1,0 +1,15 @@
+(ns metabase.test.initialize.row-lock
+  (:require
+   [metabase.app-db.cluster-lock :as app-db.cluster-lock]
+   [toucan2.core :as t2]))
+
+(defn init!
+  "Create the lock before these fixtures run. On mysql and mariadb attempting to concurrently create
+  this lock inside an extremely nested transaction can fail rolling back the rest of the transaction
+  Outside of the test environment this is fine because we can retry just the transaction the cluster
+  lock is used in"
+  []
+  (let [lock-name-str (str (namespace app-db.cluster-lock/card-statistics-lock)
+                           "/" (name app-db.cluster-lock/card-statistics-lock))]
+      ;; Create cluster lock row before running tests
+    (t2/query-one {:insert-into [:metabase_cluster_lock] :columns [:lock_name] :values [[lock-name-str]]})))

--- a/test/metabase/warehouses/api_test.clj
+++ b/test/metabase/warehouses/api_test.clj
@@ -47,7 +47,7 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once (fixtures/initialize :db :plugins :test-drivers))
+(use-fixtures :once (fixtures/initialize :db :plugins :test-drivers :row-lock))
 
 ;; HELPER FNS
 


### PR DESCRIPTION
The code here goes through tables and refingerprints them (with all their fields). After each table it checks the
`max-refingerprint-field-count` and stops if we've hit it.

The test gave some wiggle-room - we'd allow 10 extra fields. But in a fresh run of my tests, the biggest table has... 13 fields. So if the last table we hit before hitting the limit was *that* table, we exceed our wiggle-room and the test fails.

Instead, the test now actually looks to see what's the biggest table we have (in terms of number of fields), and asserts that the number of fields refingerprinted is, at the most, the max plus that number of fields.

Two more flaky test fixes in the second commit:

one is clearly a symptom of another test being super naughty but I can't
figure out which one. It's marked `parallel` and doing

```
(mt/with-temp [:model/Card {id :id} ...]
 (do-something-with (t2/select-one :model/Card id)))
```

which is failing because `(t2/select-one :model/Card id)` is returning
nil. We can just pass the card that was actually returned by
`mt/with-temp` here and that should be more resilient to horrible tests
being horrible.

the other is checking that we're caching something by checking the call
count to toucan on the first and subsequent call to a function. But it
asserts that the first call count is exactly 6, which isn't relevant.
If I start a fresh REPL I get more than 6 the first time. It doesn't
matter! Just assert that we don't get MORE than the first time on the
second run!

