### PR TITLE
Select fields with parent-ids and hide parents by default

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -318,10 +318,10 @@
                                         nested-fields (get-in nested-column-lookup [(:table-name col) new-path])]
                                     (cond-> (assoc col :database-position root-database-position)
                                       (and (= :type/Dictionary (:base-type col)) nested-fields)
-                                      (-> (assoc :nested-fields (into #{}
-                                                                      (map #(maybe-add-nested-fields % new-path root-database-position))
-                                                                      nested-fields))
-                                          (assoc :visibility-type :details-only)))))
+                                      (assoc :nested-fields (into #{}
+                                                                  (map #(maybe-add-nested-fields % new-path root-database-position))
+                                                                  nested-fields)
+                                             :visibility-type :details-only))))
         max-position-per-table (reduce
                                 (fn [accum {table-name :table_name pos :ordinal_position}]
                                   (if (> (or pos 0) (get accum table-name -1))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -318,9 +318,10 @@
                                         nested-fields (get-in nested-column-lookup [(:table-name col) new-path])]
                                     (cond-> (assoc col :database-position root-database-position)
                                       (and (= :type/Dictionary (:base-type col)) nested-fields)
-                                      (assoc :nested-fields (into #{}
-                                                                  (map #(maybe-add-nested-fields % new-path root-database-position))
-                                                                  nested-fields)))))
+                                      (-> (assoc :nested-fields (into #{}
+                                                                      (map #(maybe-add-nested-fields % new-path root-database-position))
+                                                                      nested-fields))
+                                          (assoc :visibility-type :details-only)))))
         max-position-per-table (reduce
                                 (fn [accum {table-name :table_name pos :ordinal_position}]
                                   (if (> (or pos 0) (get accum table-name -1))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -853,7 +853,8 @@
                                     :database-type "STRING",
                                     :base-type :type/Text,
                                     :nfc-path ["primary"],
-                                    :database-position 2}}}
+                                    :database-position 2}}
+                                 :visibility-type :details-only}
                                 {:name "participants",
                                  :table-name tbl-nm
                                  :table-schema test-db-name

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -392,9 +392,12 @@
                   (assoc-in acc (interpose :nested-fields (:path field)) (dissoc field :path)))
                 {}
                 fields)
-        ;; replace maps from name to field with sets of fields
+        ;; replace maps from name to field with sets of fields and set visibility-type for parent fields
         fields (walk/postwalk (fn [x]
                                 (cond-> x
+                                  (and (map? x) (:nested-fields x))
+                                  (assoc :visibility-type :details-only)
+
                                   (map? x)
                                   (m/update-existing :nested-fields #(set (vals %)))))
                               (set (vals fields)))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1396,42 +1396,51 @@
 
 ;;; ---------------------------------------------------- order-by ----------------------------------------------------
 
-(defn- remove-path-collisions
-  "When `fields` contains both a field and its parent, removes one or the other based on `to-remove`.
-
-  This is necessary because as of MongoDB 4.4, including both will result in an error (see:
+(defn- remove-parent-fields
+  "Removes any and all entries in `fields` that are parents of another field in `fields`. This is necessary because as
+  of MongoDB 4.4, including both will result in an error (see:
   `https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#path-collision-errors-in-embedded-fields`).
 
-  This can be asked to keep either side, because when selecting fields, we want to keep the parents (because the
-  parents include the children), but when we are sorting, we want to keep the children (because leaf nodes sort)."
-  [fields to-remove]
-  (let [collision-map (reduce (fn [acc [agg-type field-id & _]]
-                                (if (and (= agg-type :field)
-                                         (integer? field-id))
-                                  (let [{:keys [parent-id], :as field} (lib.metadata/field (qp.store/metadata-provider) field-id)]
-                                    (cond
-                                      (not parent-id)
-                                      acc
-
-                                      (= to-remove :parent)
-                                      (update acc parent-id conj (u/the-id field))
-
-                                      (= to-remove :child)
-                                      (update acc (u/the-id field) conj parent-id)
-
-                                      :else
-                                      (throw (ex-info "Invalid to-remove passed to remove-path-collisions"
-                                                      {:to-remove to-remove}))))
-                                  acc))
-                              {}
-                              fields)]
+  Removing parents is useful when sorting, because leaf fields sort."
+  [fields]
+  (let [parent->child-id (reduce (fn [acc [agg-type field-id & _]]
+                                   (if (and (= agg-type :field)
+                                            (integer? field-id))
+                                     (let [{:keys [parent-id], :as field} (lib.metadata/field (qp.store/metadata-provider) field-id)]
+                                       (if parent-id
+                                         (update acc parent-id conj (u/the-id field))
+                                         acc))
+                                     acc))
+                                 {}
+                                 fields)]
     (remove (fn [[_ field-id & _]]
-              (and (integer? field-id) (contains? collision-map field-id)))
+              (and (integer? field-id) (contains? parent->child-id field-id)))
+            fields)))
+
+(defn- remove-child-fields
+  "Removes any and all entries in `fields` that are children of another field in `fields`. This is necessary because as
+  of MongoDB 4.4, including both will result in an error (see:
+  `https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#path-collision-errors-in-embedded-fields`).
+
+  Removing children is useful when projecting, because the return value of a mongo query is json, and so a parent
+  includes all of its children."
+  [fields]
+  (let [field-ids (into #{}
+                        (map (fn [[agg-type field-id]]
+                               (when (and (= agg-type :field)
+                                          (integer? field-id))
+                                 field-id)))
+                        fields)]
+    (remove (fn [[agg-type field-id]]
+              (when (and (= agg-type :field)
+                         (integer? field-id))
+                (let [{:keys [parent-id]} (lib.metadata/field (qp.store/metadata-provider) field-id)]
+                  (contains? field-ids parent-id))))
             fields)))
 
 (defn- handle-order-by [{:keys [order-by breakout aggregation]} pipeline-ctx]
   (let [breakout-fields (set breakout)
-        sort-fields (for [field (remove-path-collisions (map second order-by) :parent)
+        sort-fields (for [field (remove-parent-fields (map second order-by))
                           ;; We only care about expressions and bucketing not added as breakout
                           :when (and (not (contains? breakout-fields field))
                                      (let [dispatch-value
@@ -1479,7 +1488,7 @@
 (defn- handle-fields [{:keys [fields]} pipeline-ctx]
   (if-not (seq fields)
     pipeline-ctx
-    (let [new-projections (for [field (remove-path-collisions fields :child)]
+    (let [new-projections (for [field (remove-child-fields fields)]
                             [(field-alias field) (->rvalue field)])]
       (-> pipeline-ctx
           ;; we can't ask mongo for both a parent field and its child at the same time, because mongo will throw an

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1434,8 +1434,8 @@
     (remove (fn [[agg-type field-id]]
               (when (and (= agg-type :field)
                          (integer? field-id))
-                (let [{:keys [parent-id]} (lib.metadata/field (qp.store/metadata-provider) field-id)]
-                  (contains? field-ids parent-id))))
+                (let [{:keys [parent-id] :as field} (lib.metadata/field (qp.store/metadata-provider) field-id)]
+                  (and parent-id (contains? field-ids parent-id)))))
             fields)))
 
 (defn- handle-order-by [{:keys [order-by breakout aggregation]} pipeline-ctx]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1434,7 +1434,7 @@
     (remove (fn [[agg-type field-id]]
               (when (and (= agg-type :field)
                          (integer? field-id))
-                (let [{:keys [parent-id] :as field} (lib.metadata/field (qp.store/metadata-provider) field-id)]
+                (let [{:keys [parent-id]} (lib.metadata/field (qp.store/metadata-provider) field-id)]
                   (and parent-id (contains? field-ids parent-id)))))
             fields)))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1494,8 +1494,7 @@
           ;; we can't ask mongo for both a parent field and its child at the same time, because mongo will throw an
           ;; error. It's also unnecessary, because the parent includes the child. However, we need to list all fields
           ;; we think we want in :projections so that we know to look for them all once we get data back.
-          (assoc :projections (for [field fields]
-                                (field-alias field)))
+          (assoc :projections (map field-alias fields))
           ;; add project _id = false to keep _id from getting automatically returned unless explicitly specified
           (update :query conj {$project (into
                                          (ordered-map/ordered-map "_id" false)

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.mongo.query-processor-test
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -13,9 +12,7 @@
    [metabase.query-processor-test.date-time-zone-functions-test :as qp.datetime-test]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.timezone :as qp.timezone]
-   [metabase.test :as mt]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -245,19 +245,6 @@
                   (mt/mbql-query tips
                     {:aggregation [[:count]]
                      :breakout    [$tips.source.username]}))))
-          (testing "Parent fields are removed from projections when child fields are included (#19135)"
-            (let [table       (t2/select-one :model/Table :db_id (mt/id))
-                  fields      (t2/select :model/Field :table_id (u/the-id table))
-                  projections (-> (mongo.qp/mbql->native
-                                   (mt/mbql-query tips {:fields (mapv (fn [f]
-                                                                        [:field (u/the-id f) nil])
-                                                                      fields)}))
-                                  :projections
-                                  set)]
-              ;; the "source", "url", and "venue" fields should NOT have been chosen as projections, since they have
-              ;; at least one child field selected as a projection, which is not allowed as of MongoDB 4.4
-              ;; see docstring on mongo.qp/remove-parent-fields for full details
-              (is (empty? (set/intersection projections #{"source" "url" "venue"})))))
           (testing "Nested fields in join condition aliases are transformed to use `_` instead of a `.` (#32182)"
             (let [query (mt/mbql-query tips
                           {:joins [{:alias "Tips"

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -338,9 +338,11 @@
                           {:name "mixed_uuid", :database-type "binData", :base-type :type/MongoBinData, :database-position 7}
                           {:name "mixed_not_uuid", :database-type "binData", :base-type :type/MongoBinData, :database-position 6}
                           {:name "nested_mixed_uuid", :database-type "object", :base-type :type/Dictionary, :database-position 8,
-                           :nested-fields #{{:name "nested_data", :database-type "binData", :base-type :type/MongoBinData, :database-position 9}}}
+                           :nested-fields #{{:name "nested_data", :database-type "binData", :base-type :type/MongoBinData, :database-position 9}}
+                           :visibility-type :details-only}
                           {:name "nested_mixed_not_uuid", :database-type "object", :base-type :type/Dictionary, :database-position 4,
-                           :nested-fields #{{:name "nested_data_2", :database-type "binData", :base-type :type/MongoBinData, :database-position 5}}}}}
+                           :nested-fields #{{:name "nested_data_2", :database-type "binData", :base-type :type/MongoBinData, :database-position 5}}
+                           :visibility-type :details-only}}}
                (driver/describe-table :mongo (mt/db) (t2/select-one :model/Table :id (mt/id :nested-bindata)))))))))
 
 ;; Index sync is turned off across the application as it is not used ATM.
@@ -911,7 +913,11 @@
         (mt/with-temp [:model/Card card {:display       :table
                                          :dataset_query {:database (mt/id)
                                                          :type     :query
-                                                         :query    {:source-table (mt/id :coll)}}}]
+                                                         :query    {:source-table (mt/id :coll)
+                                                                    :fields [(mt/id :coll :id)
+                                                                             (mt/id :coll :a)
+                                                                             (mt/id :coll :b)
+                                                                             (mt/id :coll :c)]}}}]
           (let [results (downloads-test/card-download card {:export-format :csv :format-rows true})]
             (is (= [["ID" "A" "B" "C"]
                     ["1"

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -22,7 +22,6 @@
   "Return a sequence of all Fields for table that we'd normally include in the equivalent of a `SELECT *`."
   [table-id]
   (->> (lib.metadata/fields (qp.store/metadata-provider) table-id)
-       (remove :parent-id)
        (remove #(#{:sensitive :retired} (:visibility-type %)))
        (sort-by (juxt :position (comp u/lower-case-en :name)))))
 

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -189,11 +189,11 @@
                   "categories" ["Pizza" "Liquor Store"],
                   "phone" "415-969-7474",
                   "id" "7b9c7dc3-d8f1-498d-843a-e62360449892"}]]
-               (mt/formatted-rows [str cheshire.core/parse-string]
-                                  (mt/run-mbql-query tips
-                                    {:fields   [$tips.venue.name $tips.venue]
-                                     :order-by [[:asc $id]]
-                                     :limit    10}))))))))
+               (mt/rows
+                (mt/run-mbql-query tips
+                  {:fields   [$tips.venue.name $tips.venue]
+                   :order-by [[:asc $id]]
+                   :limit    10}))))))))
 
 (deftest ^:parallel order-by-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -61,7 +61,7 @@
                  {:phone "415-901-6541", :name "Pacific Heights Free-Range Eatery", :categories ["Free-Range" "Eatery"], :id "88b361c8-ce69-4b2e-b0f2-9deedd574af6"}]]
                (mt/rows
                 (mt/run-mbql-query tips
-                  {:fields   [$tips.id $tips.text $tips.url $tips.venue]
+                  {:fields   [$tips.id $tips.source $tips.text $tips.url $tips.venue]
                    :filter   [:and
                               [:= $tips.source.service "twitter"]
                               [:= $tips.source.username "kyle"]]

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -18,13 +18,13 @@
                 [417 "Kyle's Low-Carb Grill"]
                 [426 "Kyle's Low-Carb Grill"]
                 [470 "Kyle's Low-Carb Grill"]]
-               (mapv
-                (fn [[id _ _ _ {venue-name :name}]] [id venue-name])
-                (mt/rows
-                 (mt/run-mbql-query tips
-                   {:filter   [:= $tips.venue.name "Kyle's Low-Carb Grill"]
-                    :order-by [[:asc $id]]
-                    :limit    10})))))))))
+               (mt/formatted-rows
+                [int str]
+                (mt/run-mbql-query tips
+                  {:fields   [$tips.id $tips.venue.name]
+                   :filter   [:= $tips.venue.name "Kyle's Low-Carb Grill"]
+                   :order-by [[:asc $id]]
+                   :limit    10}))))))))
 
 (deftest ^:parallel order-by-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
@@ -61,7 +61,8 @@
                  {:phone "415-901-6541", :name "Pacific Heights Free-Range Eatery", :categories ["Free-Range" "Eatery"], :id "88b361c8-ce69-4b2e-b0f2-9deedd574af6"}]]
                (mt/rows
                 (mt/run-mbql-query tips
-                  {:filter   [:and
+                  {:fields   [$tips.id $tips.text $tips.url $tips.venue]
+                   :filter   [:and
                               [:= $tips.source.service "twitter"]
                               [:= $tips.source.username "kyle"]]
                    :order-by [[:asc $tips.venue.name]]}))))))))

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -140,55 +140,55 @@
       (mt/dataset geographical-tips
         ;; Return the first 10 tips with just tip.venue.name
         (is (= [["Lucky's Gluten-Free Café"
-                 {"name" "Lucky's Gluten-Free Café",
-                  "categories" ["Gluten-Free" "Café"],
-                  "phone" "415-740-2328",
-                  "id" "379af987-ad40-4a93-88a6-0233e1c14649"}]
+                 {:name "Lucky's Gluten-Free Café",
+                  :categories ["Gluten-Free" "Café"],
+                  :phone "415-740-2328",
+                  :id "379af987-ad40-4a93-88a6-0233e1c14649"}]
                 ["Joe's Homestyle Eatery"
-                 {"name" "Joe's Homestyle Eatery",
-                  "categories" ["Homestyle" "Eatery"],
-                  "phone" "415-950-1337",
-                  "id" "5cc18489-dfaf-417b-900f-5d1d61b961e8"}]
+                 {:name "Joe's Homestyle Eatery",
+                  :categories ["Homestyle" "Eatery"],
+                  :phone "415-950-1337",
+                  :id "5cc18489-dfaf-417b-900f-5d1d61b961e8"}]
                 ["Lower Pac Heights Cage-Free Coffee House"
-                 {"name" "Lower Pac Heights Cage-Free Coffee House",
-                  "categories" ["Cage-Free" "Coffee House"],
-                  "phone" "415-697-9309",
-                  "id" "02b1f618-41a0-406b-96dd-1a017f630b81"}]
+                 {:name "Lower Pac Heights Cage-Free Coffee House",
+                  :categories ["Cage-Free" "Coffee House"],
+                  :phone "415-697-9309",
+                  :id "02b1f618-41a0-406b-96dd-1a017f630b81"}]
                 ["Oakland European Liquor Store"
-                 {"name" "Oakland European Liquor Store",
-                  "categories" ["European" "Liquor Store"],
-                  "phone" "415-559-1516",
-                  "id" "e342e7b7-e82d-475d-a822-b2df9c84850d"}]
+                 {:name "Oakland European Liquor Store",
+                  :categories ["European" "Liquor Store"],
+                  :phone "415-559-1516",
+                  :id "e342e7b7-e82d-475d-a822-b2df9c84850d"}]
                 ["Tenderloin Gormet Restaurant"
-                 {"name" "Tenderloin Gormet Restaurant",
-                  "categories" ["Gormet" "Restaurant"],
-                  "phone" "415-127-4197",
-                  "id" "54a9eac8-d80d-4af8-b6d7-34651a60e59c"}]
+                 {:name "Tenderloin Gormet Restaurant",
+                  :categories ["Gormet" "Restaurant"],
+                  :phone "415-127-4197",
+                  :id "54a9eac8-d80d-4af8-b6d7-34651a60e59c"}]
                 ["Marina Modern Sushi"
-                 {"name" "Marina Modern Sushi",
-                  "categories" ["Modern" "Sushi"],
-                  "phone" "415-393-7672",
-                  "id" "21807c63-ca4c-4468-9844-d0c2620fbdfc"}]
+                 {:name "Marina Modern Sushi",
+                  :categories ["Modern" "Sushi"],
+                  :phone "415-393-7672",
+                  :id "21807c63-ca4c-4468-9844-d0c2620fbdfc"}]
                 ["Sunset Homestyle Grill"
-                 {"name" "Sunset Homestyle Grill",
-                  "categories" ["Homestyle" "Grill"],
-                  "phone" "415-356-7052",
-                  "id" "c57673cd-f2d0-4bbc-aed0-6c166d7cf2c3"}]
+                 {:name "Sunset Homestyle Grill",
+                  :categories ["Homestyle" "Grill"],
+                  :phone "415-356-7052",
+                  :id "c57673cd-f2d0-4bbc-aed0-6c166d7cf2c3"}]
                 ["Kyle's Low-Carb Grill"
-                 {"name" "Kyle's Low-Carb Grill",
-                  "categories" ["Low-Carb" "Grill"],
-                  "phone" "415-992-8278",
-                  "id" "b27f50c6-55eb-48b0-9fee-17a6ef5243bd"}]
+                 {:name "Kyle's Low-Carb Grill",
+                  :categories ["Low-Carb" "Grill"],
+                  :phone "415-992-8278",
+                  :id "b27f50c6-55eb-48b0-9fee-17a6ef5243bd"}]
                 ["Mission Homestyle Churros"
-                 {"name" "Mission Homestyle Churros",
-                  "categories" ["Homestyle" "Churros"],
-                  "phone" "415-343-4489",
-                  "id" "21d903d3-8bdb-4b7d-b288-6063ad48af44"}]
+                 {:name "Mission Homestyle Churros",
+                  :categories ["Homestyle" "Churros"],
+                  :phone "415-343-4489",
+                  :id "21d903d3-8bdb-4b7d-b288-6063ad48af44"}]
                 ["Sameer's Pizza Liquor Store"
-                 {"name" "Sameer's Pizza Liquor Store",
-                  "categories" ["Pizza" "Liquor Store"],
-                  "phone" "415-969-7474",
-                  "id" "7b9c7dc3-d8f1-498d-843a-e62360449892"}]]
+                 {:name "Sameer's Pizza Liquor Store",
+                  :categories ["Pizza" "Liquor Store"],
+                  :phone "415-969-7474",
+                  :id "7b9c7dc3-d8f1-498d-843a-e62360449892"}]]
                (mt/rows
                 (mt/run-mbql-query tips
                   {:fields   [$tips.venue.name $tips.venue]

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.query-processor-test.nested-field-test
   "Tests for nested field access."
   (:require
-   [cheshire.core]
    [clojure.test :refer :all]
    [metabase.test :as mt]))
 

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/driver-tests metabase.query-processor-test.nested-field-test
   "Tests for nested field access."
   (:require
+   [cheshire.core]
    [clojure.test :refer :all]
    [metabase.test :as mt]))
 
@@ -132,6 +133,67 @@
                   {:fields   [$tips.venue.name]
                    :order-by [[:asc $id]]
                    :limit    10}))))))))
+
+(deftest ^:parallel children-and-parents-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
+    (testing "Can select both a child and its parent"
+      (mt/dataset geographical-tips
+        ;; Return the first 10 tips with just tip.venue.name
+        (is (= [["Lucky's Gluten-Free Café"
+                 {"name" "Lucky's Gluten-Free Café",
+                  "categories" ["Gluten-Free" "Café"],
+                  "phone" "415-740-2328",
+                  "id" "379af987-ad40-4a93-88a6-0233e1c14649"}]
+                ["Joe's Homestyle Eatery"
+                 {"name" "Joe's Homestyle Eatery",
+                  "categories" ["Homestyle" "Eatery"],
+                  "phone" "415-950-1337",
+                  "id" "5cc18489-dfaf-417b-900f-5d1d61b961e8"}]
+                ["Lower Pac Heights Cage-Free Coffee House"
+                 {"name" "Lower Pac Heights Cage-Free Coffee House",
+                  "categories" ["Cage-Free" "Coffee House"],
+                  "phone" "415-697-9309",
+                  "id" "02b1f618-41a0-406b-96dd-1a017f630b81"}]
+                ["Oakland European Liquor Store"
+                 {"name" "Oakland European Liquor Store",
+                  "categories" ["European" "Liquor Store"],
+                  "phone" "415-559-1516",
+                  "id" "e342e7b7-e82d-475d-a822-b2df9c84850d"}]
+                ["Tenderloin Gormet Restaurant"
+                 {"name" "Tenderloin Gormet Restaurant",
+                  "categories" ["Gormet" "Restaurant"],
+                  "phone" "415-127-4197",
+                  "id" "54a9eac8-d80d-4af8-b6d7-34651a60e59c"}]
+                ["Marina Modern Sushi"
+                 {"name" "Marina Modern Sushi",
+                  "categories" ["Modern" "Sushi"],
+                  "phone" "415-393-7672",
+                  "id" "21807c63-ca4c-4468-9844-d0c2620fbdfc"}]
+                ["Sunset Homestyle Grill"
+                 {"name" "Sunset Homestyle Grill",
+                  "categories" ["Homestyle" "Grill"],
+                  "phone" "415-356-7052",
+                  "id" "c57673cd-f2d0-4bbc-aed0-6c166d7cf2c3"}]
+                ["Kyle's Low-Carb Grill"
+                 {"name" "Kyle's Low-Carb Grill",
+                  "categories" ["Low-Carb" "Grill"],
+                  "phone" "415-992-8278",
+                  "id" "b27f50c6-55eb-48b0-9fee-17a6ef5243bd"}]
+                ["Mission Homestyle Churros"
+                 {"name" "Mission Homestyle Churros",
+                  "categories" ["Homestyle" "Churros"],
+                  "phone" "415-343-4489",
+                  "id" "21d903d3-8bdb-4b7d-b288-6063ad48af44"}]
+                ["Sameer's Pizza Liquor Store"
+                 {"name" "Sameer's Pizza Liquor Store",
+                  "categories" ["Pizza" "Liquor Store"],
+                  "phone" "415-969-7474",
+                  "id" "7b9c7dc3-d8f1-498d-843a-e62360449892"}]]
+               (mt/formatted-rows [str cheshire.core/parse-string]
+                                  (mt/run-mbql-query tips
+                                    {:fields   [$tips.venue.name $tips.venue]
+                                     :order-by [[:asc $id]]
+                                     :limit    10}))))))))
 
 (deftest ^:parallel order-by-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47146

### Description

In postgres, json fields are hidden by default, and we just show their children instead.  However, mongo fields and bigquery struct fields work differently -- we default to just showing the parent, even though the ui claims that all fields are selected.  This makes mongo and bigquery work like postgres.

In addition, this fixes a presumably-longstanding bug where mongo had incorrect column names when selecting both a parent and its child.  Basically, you can't ask mongo for both a parent and its child.  The returned data is just json, so asking for the parent field includes all of its children.  Instead, mongo just errors when you try to make a request like that.  As a workaround, the mongo driver was just requesting and returning the child fields.  This meant that it was returning a different number of fields than expected, which confused annotate.

Now, the mongo query processor only selects for parent fields, because as mentioned, parent fields include their children.  However, it also keeps track of all the fields we asked for in :projections, so when we get data back, we know to pull all of those fields out of the returned data.

### How to verify

1. Sync your mongo or bigquery db
2. Make a mongo or bigquery query against a table with child cols
3. Verify that you got the child cols back in the query, while the parent col is hidden by default
4. With mongo, verify that the col labels are correct

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
