### PR TITLE
Fix currency formatting settings bug

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -32,6 +32,11 @@ const DEFAULT_FORMATTING_SETTINGS: FormattingSettings = {
   },
 };
 
+const mapNameToLabel = (option: { name: string; value: any }) => ({
+  label: option.name,
+  value: option.value,
+});
+
 export function FormattingWidget() {
   const {
     value: initialValue,
@@ -43,10 +48,6 @@ export function FormattingWidget() {
     ...DEFAULT_FORMATTING_SETTINGS,
     ...initialValue,
   });
-
-  if (isLoading) {
-    return null;
-  }
 
   const {
     date_style: dateStyle,
@@ -60,9 +61,20 @@ export function FormattingWidget() {
   const { currency, currency_style: currencyStyle } =
     localValue?.["type/Currency"] || {};
 
+  const [currencyOptions, currencyStyleOptions] = useMemo(() => {
+    const currencyOptions = (
+      getCurrencyOptions() as { name: string; value: string }[]
+    ).map(mapNameToLabel);
+    const currencyStyleOptions =
+      getCurrencyStyleOptions(currency).map(mapNameToLabel);
+    return [currencyOptions, currencyStyleOptions];
+  }, [currency]);
+
+  if (isLoading) {
+    return null;
+  }
+
   const dateStyleOptions = getDateStyleOptionsForUnit("default", dateAbreviate);
-  const currencyOptions: { name: string; value: string }[] =
-    getCurrencyOptions();
 
   const handleChange = (newValue: FormattingSettings) => {
     if (_.isEqual(newValue, localValue)) {
@@ -170,10 +182,7 @@ export function FormattingWidget() {
               label={t`Unit of currency`}
               value={currency}
               inputType="select"
-              options={currencyOptions.map(({ name, value }) => ({
-                label: name,
-                value,
-              }))}
+              options={currencyOptions}
               onChange={(newValue) =>
                 handleChange({
                   ...localValue,
@@ -189,7 +198,7 @@ export function FormattingWidget() {
               label={t`Currency label style`}
               value={currencyStyle}
               inputType="radio"
-              options={getCurrencyStyleOptions(currency)}
+              options={currencyStyleOptions}
               onChange={(newValue) =>
                 handleChange({
                   ...localValue,

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import { act } from "react-dom/test-utils";
 
 import {
   findRequests,
@@ -39,11 +38,13 @@ const setup = async () => {
       },
     },
   );
+
+  await screen.findByText("Localization options");
 };
 
 describe("PublicSharingSettingsPage", () => {
   it("should render a FormattingWidget", async () => {
-    await act(() => setup());
+    await setup();
     [
       "Dates and Times",
       "Date style",
@@ -98,38 +99,38 @@ describe("PublicSharingSettingsPage", () => {
   });
 
   it("should update multiple settings", async () => {
-    setup();
+    await setup();
     const blur = async () => {
       const elementOutside = screen.getByText("Dates and Times");
       await userEvent.click(elementOutside); // blur
     };
 
     const dateStyleInput = await screen.findByLabelText("Date style");
-    dateStyleInput.click();
+    await userEvent.click(dateStyleInput);
     await userEvent.click(await screen.findByText("31/1/2018"));
-    blur();
+    await blur();
 
     const dateAbbreviateToggle = await screen.findByRole("switch");
-    dateAbbreviateToggle.click();
-    blur();
+    await userEvent.click(dateAbbreviateToggle);
+    await blur();
 
     const timeStyle24HourRadio = await screen.findByLabelText(/24-hour/i);
-    timeStyle24HourRadio.click();
-    blur();
+    await userEvent.click(timeStyle24HourRadio);
+    await blur();
 
     const seperatorStyleInput = await screen.findByLabelText("Separator style");
     await userEvent.click(seperatorStyleInput);
     await userEvent.click(await screen.findByText("100000.00"));
-    blur();
+    await blur();
 
     const currencyInput = await screen.findByLabelText("Unit of currency");
     await userEvent.click(currencyInput);
     await userEvent.click(await screen.findByText("New Zealand Dollar"));
-    blur();
+    await blur();
 
     const currencyStyleNameRadio = await screen.findByLabelText(/name/i);
     await userEvent.click(currencyStyleNameRadio);
-    blur();
+    await blur();
 
     await waitFor(async () => {
       const puts = await findRequests("PUT");

--- a/frontend/src/metabase/lib/formatting/currency.js
+++ b/frontend/src/metabase/lib/formatting/currency.js
@@ -28,31 +28,35 @@ export function getCurrencyStyleOptions(currency = "USD") {
     ...(symbol !== code
       ? [
           {
-            label: t`Symbol` + ` ` + `(${symbol})`,
+            name: t`Symbol` + ` ` + `(${symbol})`,
             value: "symbol",
           },
         ]
       : []),
     {
-      label: t`Code` + ` ` + `(${code})`,
+      name: t`Code` + ` ` + `(${code})`,
       value: "code",
     },
     {
-      label: t`Name` + ` ` + `(${name})`,
+      name: t`Name` + ` ` + `(${name})`,
       value: "name",
     },
   ];
 }
 
 export function getCurrency(currency, currencyStyle) {
-  return (0)
-    .toLocaleString("en", {
-      style: "currency",
-      currency: currency,
-      currencyDisplay: currencyStyle,
-    })
-    .replace(/0([.,]0+)?/, "")
-    .trim(); // strip off actual number
+  try {
+    return (0)
+      .toLocaleString("en", {
+        style: "currency",
+        currency: currency,
+        currencyDisplay: currencyStyle,
+      })
+      .replace(/0([.,]0+)?/, "")
+      .trim(); // strip off actual number
+  } catch (e) {
+    return currency;
+  }
 }
 
 export function getCurrencyOptions() {

--- a/frontend/src/metabase/lib/formatting/currency.unit.spec.js
+++ b/frontend/src/metabase/lib/formatting/currency.unit.spec.js
@@ -1,0 +1,29 @@
+import { getCurrencyStyleOptions } from "./currency";
+
+describe("getCurrencyStyleOptions", () => {
+  it("should get currency options - USD", () => {
+    const options = getCurrencyStyleOptions("USD");
+    expect(options).toEqual([
+      { name: "Symbol ($)", value: "symbol" },
+      { name: "Code (USD)", value: "code" },
+      { name: "Name (US dollars)", value: "name" },
+    ]);
+  });
+
+  it("should get currency options - NZD", () => {
+    const options = getCurrencyStyleOptions("NZD");
+    expect(options).toEqual([
+      { name: "Symbol (NZ$)", value: "symbol" },
+      { name: "Code (NZD)", value: "code" },
+      { name: "Name (New Zealand dollars)", value: "name" },
+    ]);
+  });
+
+  it("should get currency options - invalid", () => {
+    const options = getCurrencyStyleOptions("PKMN");
+    expect(options).toEqual([
+      { name: "Code (PKMN)", value: "code" },
+      { name: "Name (PKMN)", value: "name" },
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #58727

Closes adm-858

### Description

Moving this code into a shared directory to be used by both viz settings and admin settings caused a bug where we mixed up label/name keys. Would be nice if this was in typescript 😢  but I added some tests to give us safety going forward.

Admin settings:
![Screenshot 2025-05-30 at 1 08 49 PM](https://github.com/user-attachments/assets/d91a64b2-f48a-47c2-87bd-769c75cbd92b)

Viz Settings
![Screenshot 2025-05-30 at 1 08 25 PM](https://github.com/user-attachments/assets/79902351-d813-4b47-8381-7c2c8977f406)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
