### PR TITLE
Closes VIZ-181: Negative values overlap with x-axis labels, making them unreadable

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -19,10 +19,12 @@ import type {
 import type { TimelineEventId } from "metabase-types/api";
 
 import type { ChartMeasurements } from "../chart-measurements/types";
+import { CHART_STYLE } from "../constants/style";
 import { getBarSeriesDataLabelKey } from "../model/util";
 
 import { getGoalLineSeriesOption } from "./goal-line";
 import { getTrendLinesOption } from "./trend-line";
+import type { EChartsSeriesOption } from "./types";
 
 export const getSharedEChartsOptions = (isAnimated: boolean) => ({
   useUTC: true,
@@ -38,6 +40,40 @@ export const getSharedEChartsOptions = (isAnimated: boolean) => ({
     throttleType: "debounce" as const,
     throttleDelay: 200,
   },
+});
+
+type Axes = ReturnType<typeof buildAxes>;
+
+const ensureRoomForLabels = (
+  axes: Axes,
+  { leftAxisModel, rightAxisModel }: CartesianChartModel,
+  chartMeasurements: ChartMeasurements,
+  seriesOption: EChartsSeriesOption[],
+): Axes => ({
+  ...axes,
+  yAxis: axes.yAxis.map((axis) => {
+    const axisModel = axis.position === "left" ? leftAxisModel : rightAxisModel;
+    if (!axisModel) {
+      return axis;
+    }
+    const isAxisUsedForBarChart = axisModel.seriesKeys.some((key) => {
+      return seriesOption.some((o) => o.id === key && o.type === "bar");
+    });
+    if (!isAxisUsedForBarChart) {
+      return axis;
+    }
+    const [min] = axisModel.extent;
+    if (min < 0) {
+      const { bounds } = chartMeasurements;
+      const innerHeight = Math.abs(bounds.bottom - bounds.top);
+      const textPct = CHART_STYLE.seriesLabels.size / innerHeight;
+      return {
+        ...axis,
+        boundaryGap: [textPct, 0],
+      };
+    }
+    return axis;
+  }),
 });
 
 export const getCartesianChartOption = (
@@ -123,13 +159,18 @@ export const getCartesianChartOption = (
     },
     dataset: echartsDataset,
     series: seriesOption,
-    ...buildAxes(
+    ...ensureRoomForLabels(
+      buildAxes(
+        chartModel,
+        chartWidth,
+        chartMeasurements,
+        settings,
+        hasTimelineEvents,
+        renderingContext,
+      ),
       chartModel,
-      chartWidth,
       chartMeasurements,
-      settings,
-      hasTimelineEvents,
-      renderingContext,
+      seriesOption,
     ),
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -170,7 +170,7 @@ export const getCartesianChartOption = (
       ),
       chartModel,
       chartMeasurements,
-      seriesOption,
+      dataSeriesOptions,
     ),
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -66,11 +66,9 @@ const ensureRoomForLabels = (
     if (min < 0) {
       const { bounds } = chartMeasurements;
       const innerHeight = Math.abs(bounds.bottom - bounds.top);
-      const textPct = CHART_STYLE.seriesLabels.size / innerHeight;
-      return {
-        ...axis,
-        boundaryGap: [textPct, 0],
-      };
+      const labelPct = CHART_STYLE.seriesLabels.size / innerHeight;
+      const lowerBoundaryGap = labelPct / 2; // `/ 2` because it's okay if the bar label overlaps the axis *line*, we just don't want it to overlap the axis *labels*
+      return { ...axis, boundaryGap: [lowerBoundaryGap, 0] };
     }
     return axis;
   }),

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -44,7 +44,7 @@ export const getSharedEChartsOptions = (isAnimated: boolean) => ({
 
 type Axes = ReturnType<typeof buildAxes>;
 
-const ensureRoomForLabels = (
+export const ensureRoomForLabels = (
   axes: Axes,
   { leftAxisModel, rightAxisModel }: CartesianChartModel,
   chartMeasurements: ChartMeasurements,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.unit.spec.ts
@@ -1,0 +1,144 @@
+import type { XAXisOption, YAXisOption } from "echarts/types/dist/shared";
+
+import { DEFAULT_VISUALIZATION_THEME } from "metabase/visualizations/shared/utils/theme";
+import type { RenderingContext } from "metabase/visualizations/types";
+import type { RawSeries, SingleSeries } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
+
+import { getChartMeasurements } from "../chart-measurements";
+import { getCartesianChartModel } from "../model";
+
+import { buildAxes } from "./axis";
+import { buildEChartsSeries } from "./series";
+
+import { ensureRoomForLabels } from "./index";
+
+const chartWidth = 480;
+const chartHeight = 274;
+const hasTimelineEvents = false;
+const hiddenSeries: string[] = [];
+
+const mockRenderingContext: RenderingContext = {
+  getColor: (name) => name,
+  measureText: () => 0,
+  measureTextHeight: () => 0,
+  fontFamily: "",
+  theme: DEFAULT_VISUALIZATION_THEME,
+};
+
+const seriesFn = jest.fn();
+
+const mockSettings = createMockVisualizationSettings({
+  "graph.dimensions": ["Month created"],
+  "graph.metrics": ["count"],
+  series: seriesFn,
+});
+
+const mockSeries: SingleSeries = {
+  card: createMockCard(),
+  data: createMockDatasetData({
+    rows: [
+      [1, 200],
+      [2, 300],
+      [3, 400],
+      [4, 500],
+    ],
+    cols: [
+      createMockColumn({ name: "Month created" }),
+      createMockColumn({ name: "count" }),
+    ],
+  }),
+};
+
+const mockSeriesWithNegative: SingleSeries = {
+  ...mockSeries,
+  data: {
+    ...mockSeries.data,
+    rows: [
+      [1, 200],
+      [2, 300],
+      [3, -150],
+      [4, 500],
+    ],
+  },
+};
+
+describe("ensureRoomForLabels", () => {
+  const getArgs = (
+    rawSeries: RawSeries,
+  ): Parameters<typeof ensureRoomForLabels> => {
+    const chartModel = getCartesianChartModel(
+      rawSeries,
+      mockSettings,
+      hiddenSeries,
+      mockRenderingContext,
+    );
+
+    const chartMeasurements = getChartMeasurements(
+      chartModel,
+      mockSettings,
+      hasTimelineEvents,
+      chartWidth,
+      chartHeight,
+      mockRenderingContext,
+    );
+
+    const axes = buildAxes(
+      chartModel,
+      chartWidth,
+      chartMeasurements,
+      mockSettings,
+      hasTimelineEvents,
+      mockRenderingContext,
+    );
+
+    const dataSeriesOptions = buildEChartsSeries(
+      chartModel,
+      mockSettings,
+      chartWidth,
+      chartMeasurements,
+      mockRenderingContext,
+    );
+
+    return [axes, chartModel, chartMeasurements, dataSeriesOptions] as const;
+  };
+
+  const getBoundaryGap = (axis: YAXisOption | XAXisOption) =>
+    "boundaryGap" in axis ? axis.boundaryGap : undefined;
+
+  beforeEach(() => {
+    seriesFn.mockReturnValue({ display: "bar" });
+  });
+
+  it("does not alter the axes if there are no negative values", () => {
+    const args = getArgs([mockSeries]);
+    const [originalAxes] = args;
+    const axes = ensureRoomForLabels(...args);
+    expect(axes.xAxis).toBe(originalAxes.xAxis);
+    expect(getBoundaryGap(axes.xAxis)).toBe(undefined);
+    expect(axes.yAxis.map(getBoundaryGap)).toEqual([undefined]);
+  });
+
+  it("does not alter the axes for non-bar charts", () => {
+    seriesFn.mockReturnValue({ display: "line" });
+    const args = getArgs([mockSeriesWithNegative]);
+    const [originalAxes] = args;
+    const axes = ensureRoomForLabels(...args);
+    expect(axes.xAxis).toBe(originalAxes.xAxis);
+    expect(getBoundaryGap(axes.xAxis)).toBe(undefined);
+    expect(axes.yAxis.map(getBoundaryGap)).toEqual([undefined]);
+  });
+
+  it("adds a lower boundaryGap to the y-axis if there are negative values and it's a bar chart", () => {
+    const args = getArgs([mockSeriesWithNegative]);
+    const [originalAxes] = args;
+    const axes = ensureRoomForLabels(...args);
+    expect(axes.xAxis).toBe(originalAxes.xAxis);
+    expect(axes.yAxis.map(getBoundaryGap)).toEqual([[0.024, 0]]);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48130
Closes VIZ-181

### Description

Adds boundaryGap to bar chart y-axis if it has negative values to ensure bar labels don’t overlap axis labels

### How to verify

**Base case**
1. Create a bar chart with at least one bar having a negative value

**Stress tests**
1. Create a bar chart with a VERY negative value and make the chart very short
2. Brush-select only positive bars
3. Create a visualization with multiple kinds of charts (e.g. bar + line)

**Regression tests**
1. Make a bar chart where all the bars have positive values
2. Make a cartesian chart (e.g. line, waterfall, etc) that doesn't have any bars
3. Make a bar chart with negative values and there's already enough room to display the labels

**EXPECTED BEHAVIOR**
* Negative bars' labels should not overlap x-axis labels (within reason)
* Charts with only positive values should start at 0 on the y-axis
* Other kinds of charts should be unaffected by this PR

### Demo

**BEFORE (master)**
![before](https://github.com/user-attachments/assets/f92f4a49-1f54-4f8a-bed5-dc7e20c2a903)

**AFTER (this branch)**
![after](https://github.com/user-attachments/assets/c774b3ea-48a8-43b6-921f-b4037aa7fd18)