### PR TITLE
Auto-Rerun CI for PRs with auto-merge enabled

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -4,14 +4,51 @@ on:
   workflow_run:
     workflows: [Run tests]
     types: [completed]
-    branches: [master, 'release-x.**', 'backport-**']
 
 jobs:
-  rerun-on-failure:
-    name: 'Re-run ''${{ github.event.workflow_run.name }}'' workflow'
-    runs-on: ubuntu-22.04
+  should-rerun:
+    name: Check if re-run is needed
     # Do not re-run scheduled workflow runs
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      should-rerun: ${{ steps.check.outputs.result }}
+    steps:
+    - uses: actions/github-script@v7
+      id: check
+      with:
+        result-encoding: string
+        script: | # js
+          const RERUN_BRANCHES = ["master", "release-x"];
+          const branchName = context.payload.workflow_run.head_branch;
+
+          console.log({ branchName });
+
+          const isRerunBranch = RERUN_BRANCHES.some(branch => branchName.startsWith(branch));
+
+          if (isRerunBranch) {
+            console.log(`Re-running workflow for branch: ${branchName}`);
+            return true;
+          }
+
+          // check if there are any open pull requests for the branch
+          const { data: pullRequests } = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo : context.repo.repo,
+            state: "open",
+            head: `${context.owner.repo}:${branchName}`,
+          });
+
+          // if auto-merge is enabled, let's auto-rerun
+          const hasAutoMergeEnabled = pullRequests.some(pr => !!pr.auto_merge);
+
+          return hasAutoMergeEnabled;
+
+  rerun-on-failure:
+    needs: [should-rerun]
+    if: needs.should-rerun.outputs.should-rerun == 'true'
+    name: 'Re-run ''${{ github.event.workflow_run.name }}'' workflow'
+    runs-on: ubuntu-22.04
     env:
       BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
       AUTHOR_NAME: ${{ github.event.workflow_run.head_commit.author.name }}
@@ -45,7 +82,7 @@ jobs:
                 repo: context.repo.repo,
                 run_id: ${{ github.event.workflow_run.id }},
               });
-            } else if (!BRANCH.includes('backport-')) {
+            } else if (BRANCH.includes('master') || BRANCH.includes('release-x')) {
               // notify slack of repeated failure
               const { WebClient } = require('@slack/web-api');
               const slack = new WebClient('${{ secrets.SLACK_BOT_TOKEN }}');


### PR DESCRIPTION
> [!note] 
> I have mixed feelings about this, I'd rather address the root issue: flaky tests, but I also want to be realistic, but mostly I want my goshdarn PRs to merge

### Description

Presumably, when you enable auto-merge on a PR, it's "ready to go" and tests shouldn't fail, and any failures should be flakes. So let's help people out and auto-retry failing tests for PRs in this state.

