### PR TITLE
Update Malli to 0.18

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -84,7 +84,8 @@
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "4998a1fdd9d3713d7034d04509e9212204773bf2"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.25"}             ; Parse native SQL queries
+  ;; TODO: replace back to normal artifact
+  io.github.metabase/macaw                  {:mvn/version "0.2.27"}             ; Parse native SQL queries
   io.github.resilience4j/resilience4j-retry ^:antq/exclude                      ; 2.x do not support Java 8
                                             {:mvn/version "1.7.1"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
@@ -102,7 +103,7 @@
                                                           org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   methodical/methodical                     {:mvn/version "1.0.127"}            ; drop-in replacements for Clojure multimethods and adds several advanced features
-  metosin/malli                             {:mvn/version "0.17.0"}             ; Data-driven Schemas for Clojure/Script and babashka
+  metosin/malli                             {:mvn/version "0.18.0"}             ; Data-driven Schemas for Clojure/Script and babashka
   nano-id/nano-id                           {:mvn/version "1.1.0"}              ; NanoID generator for generating entity_ids
   net.cgrand/macrovich                      {:mvn/version "0.2.2"}              ; utils for writing macros for both Clojure & ClojureScript
   net.clojars.wkok/openai-clojure           {:mvn/version "0.22.0"

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -78,7 +78,7 @@
                                                    [(u/qualified-name k) (fix-json-schema v)]))
                                             properties))))
 
-        (= (:type schema) :array)
+        (and (= (:type schema) :array) (:items schema))
         (update schema :items (fn [items]
                                 ;; apparently `:tuple` creates multiple `:items` entries... I don't think this is
                                 ;; correct. I think we're supposed to use `:prefixItems` instead. See
@@ -86,6 +86,9 @@
                                 (if (sequential? items)
                                   (mapv fix-json-schema items)
                                   (fix-json-schema items))))
+
+        (and (= (:type schema) :array) (false? (:items schema)))
+        (dissoc schema :items)
 
         :else
         schema))

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -155,12 +155,12 @@
    [:map
 
     [:type        [:= :array]]
-    [:items       [:multi
-                   {:dispatch map?}
-                   [true [:ref ::parameter.schema]]
-                   ;; for a tuple. I don't think this is correct, I think you're supposed to use `prefixItems` -- see
-                   ;; https://stackoverflow.com/questions/57464633/how-to-define-a-json-array-with-concrete-item-definition-for-every-index-i-e-a
-                   [false [:sequential [:ref ::parameter.schema]]]]]
+    [:items           {:optional true} [:multi
+                                        {:dispatch map?}
+                                        [true [:ref ::parameter.schema]]
+                                        ;; for a tuple. I don't think this is correct, I think you're supposed to use `prefixItems` -- see
+                                        ;; https://stackoverflow.com/questions/57464633/how-to-define-a-json-array-with-concrete-item-definition-for-every-index-i-e-a
+                                        [false [:sequential [:ref ::parameter.schema]]]]]
     [:uniqueItems     {:optional true} :boolean]
     [:additionalItems {:optional true} :boolean] ; for tuples
     [:minItems        {:optional true} integer?]

--- a/src/metabase/models/visualization_settings.cljc
+++ b/src/metabase/models/visualization_settings.cljc
@@ -139,10 +139,10 @@
   (let [parsed (mc/parse db-column-ref-vec-schema column-ref-vec)]
     (if (= parsed ::mc/invalid)
       (throw (ex-info "Invalid input" (mr/explain db-column-ref-vec-schema column-ref-vec)))
-      (let [[m parts] parsed]
+      (let [{m :key, parts :value} parsed]
         (case m
           :field
-          (let [[_ [_ [_ [id-or-str v] [_ field-md]]]] parsed]
+          (let [[_ [_ {id-or-str :key, v :value} {field-md :value}]] parts]
             (cond-> (case id-or-str
                       :field-id {::field-id v}
                       :field-str {::field-str v})
@@ -150,7 +150,7 @@
           :column-name
           {::column-name (nth parts 1)}
           :expression
-          (let [[_expression [_ref [_expression column-name]]] parsed]
+          (let [[_ref [_expression column-name]] parts]
             {::column-name column-name}))))))
 
 (mu/defn parse-db-column-ref :- column-ref-schema
@@ -176,11 +176,11 @@
   (let [parsed (mc/parse db-column-ref-schema column-ref)]
     (if (= parsed ::mc/invalid)
       (throw (ex-info "Invalid input" (mr/explain db-column-ref-schema column-ref)))
-      (let [[k v]    parsed
-            ref->vec (case k
-                       :string?  (comp vec parse-json-string)
-                       :keyword? (comp vec parse-json-string keyname)
-                       :vector?  identity)]
+      (let [{k :key, v :value} parsed
+            ref->vec           (case k
+                                 :string?  (comp vec parse-json-string)
+                                 :keyword? (comp vec parse-json-string keyname)
+                                 :vector?  identity)]
         (db->norm-column-ref (ref->vec v))))))
 
 ;;; ------------------------------------------------ Builder fns ------------------------------------------------

--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -30,32 +30,34 @@
                      (cond-> args-meta
                        resolved-tag (assoc :tag resolved-tag)))))))
 
-(core/defn- deparameterized-arglists [{:keys [arities], :as _parsed}]
-  (let [[arities-type arities-value] arities]
+(core/defn- deparameterized-arglists [parsed]
+  (let [{:keys [arities]} (:values parsed)
+        arities-type (:key arities)
+        arities-value (:values (:value arities))]
     (case arities-type
       :single   (list (deparameterized-arglist arities-value))
-      :multiple (map deparameterized-arglist (:arities arities-value)))))
+      :multiple (map #(deparameterized-arglist (:values %)) (:arities arities-value)))))
 
 (core/defn- annotated-docstring
   "Generate a docstring with additional information about inputs and return type using a parsed fn tail (as parsed
   by [[mx/SchematizedParams]])."
-  [{original-docstring           :doc
-    [arities-type arities-value] :arities
-    :keys                        [return]
-    :as                          _parsed}]
-  (str/trim
-   (str "Inputs: " (case arities-type
-                     :single   (pr-str (:args arities-value))
-                     :multiple (str "("
-                                    (str/join "\n           "
-                                              (map (comp pr-str :args)
-                                                   (:arities arities-value)))
-                                    ")"))
-        "\n  Return: " (str/replace (u/pprint-to-str (:schema return :any))
-                                    "\n"
-                                    "\n          ")
-        (when (not-empty original-docstring)
-          (str "\n\n  " original-docstring)))))
+  [parsed]
+  (let [{:keys [doc arities return]} (:values parsed)
+        arities-type (:key arities)
+        arities-value (:values (:value arities))]
+    (str/trim
+     (str "Inputs: " (case arities-type
+                       :single   (pr-str (:args arities-value))
+                       :multiple (str "("
+                                      (str/join "\n           "
+                                                (map (comp pr-str :args :values)
+                                                     (:arities arities-value)))
+                                      ")"))
+          "\n  Return: " (str/replace (u/pprint-to-str (:schema (:values return) :any))
+                                      "\n"
+                                      "\n          ")
+          (when (not-empty doc)
+            (str "\n\n  " doc))))))
 
 (defmacro defn
   "Implementation of [[metabase.util.malli/defn]]. Like [[schema.core/defn]], but for Malli.
@@ -87,7 +89,7 @@
   [& [fn-name :as fn-tail]]
   (let [parsed           (mu.fn/parse-fn-tail fn-tail)
         cosmetic-name    (gensym (munge (str fn-name)))
-        {attr-map :meta} parsed
+        {attr-map :meta} (:values parsed)
         attr-map         (merge
                           {:arglists (list 'quote (deparameterized-arglists parsed))
                            :schema   (mu.fn/fn-schema parsed {:target :target/metadata})}

--- a/test/metabase/api/macros/defendpoint/open_api_test.clj
+++ b/test/metabase/api/macros/defendpoint/open_api_test.clj
@@ -18,8 +18,8 @@
 
 (deftest ^:parallel json-schema-conversion-2
   (testing ":json-schema basically works (see definition of :metabase.lib.schema.common/non-blank-string)"
-    (is (=? {:$ref        "#/definitions/metabase.lib.schema.common~1non-blank-string"
-             :definitions {"metabase.lib.schema.common/non-blank-string" {:type "string", :minLength 1}}}
+    (is (=? {:$ref        "#/definitions/metabase.lib.schema.common.non-blank-string"
+             :definitions {"metabase.lib.schema.common.non-blank-string" {:type "string", :minLength 1}}}
             (mjs/transform ::lib.schema.common/non-blank-string)))))
 
 (mr/def ::non-blank-string
@@ -28,12 +28,12 @@
 
 (deftest ^:parallel json-schema-conversion-2b
   (testing ":json-schema basically works (nested ref)"
-    (is (=? {:$ref "#/definitions/metabase.api.macros.defendpoint.open-api-test~1non-blank-string",
-             :definitions {"metabase.api.macros.defendpoint.open-api-test/non-blank-string"
+    (is (=? {:$ref "#/definitions/metabase.api.macros.defendpoint.open-api-test.non-blank-string",
+             :definitions {"metabase.api.macros.defendpoint.open-api-test.non-blank-string"
                            {:description "Non-blank string."
-                            :$ref "#/definitions/metabase.lib.schema.common~1non-blank-string"}
+                            :$ref "#/definitions/metabase.lib.schema.common.non-blank-string"}
 
-                           "metabase.lib.schema.common/non-blank-string"
+                           "metabase.lib.schema.common.non-blank-string"
                            {:type "string", :minLength 1}}}
             (mjs/transform ::non-blank-string)))))
 
@@ -59,7 +59,7 @@
 
 (deftest ^:parallel collect-definitions-test
   (binding [defendpoint.open-api/*definitions* (atom [])]
-    (is (=? {:properties {:value {:$ref "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}}}
+    (is (=? {:properties {:value {:$ref "#/components/schemas/metabase.lib.schema.common.non-blank-string"}}}
             (#'defendpoint.open-api/mjs-collect-definitions [:map [:value ::lib.schema.common/non-blank-string]])))
-    (is (= [{"metabase.lib.schema.common/non-blank-string" {:type :string, :minLength 1}}]
+    (is (= [{"metabase.lib.schema.common.non-blank-string" {:type :string, :minLength 1}}]
            @@#'defendpoint.open-api/*definitions*))))

--- a/test/metabase/api/open_api_test.clj
+++ b/test/metabase/api/open_api_test.clj
@@ -93,7 +93,7 @@
                          {:in       :query
                           :name     "value"
                           :required true
-                          :schema   {:$ref "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}}]}}
+                          :schema   {:$ref "#/components/schemas/metabase.lib.schema.common.non-blank-string"}}]}}
           (-> (open-api/open-api-spec (api.macros/ns-handler 'metabase.api.open-api-test) "")
               (get-in [:paths "/{id}"])))))
 
@@ -162,7 +162,7 @@
                  {:type     :object
                   :required ["dashcards"]
                   :properties
-                  {"name"      {:$ref "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}
+                  {"name"      {:$ref "#/components/schemas/metabase.lib.schema.common.non-blank-string"}
                    "dashcards" {:type :array
                                 :description string?
                                 :items       {:type       :object
@@ -180,7 +180,7 @@
   (is (=? {:paths      {"/{id}/upload" {:post {}}
                         "/{id}"        {:get  {}
                                         :post {}}}
-           :components {:schemas {"metabase.lib.schema.common/non-blank-string" {:type :string, :minLength 1}}}}
+           :components {:schemas {"metabase.lib.schema.common.non-blank-string" {:type :string, :minLength 1}}}}
           (open-api/open-api-spec (api.macros/ns-handler 'metabase.api.open-api-test) ""))))
 
 (deftest ^:parallel openapi-all-routes

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -161,9 +161,7 @@
 
 (deftest ^:parallel preserve-arglists-metadata-test
   (is (= 'java.lang.Integer
-         (-> '{:arities [:single {:args    ^{:tag Integer} [x :- :int y :- :int]
-                                  :prepost nil
-                                  :body    [(+ x y)]}]}
+         (-> (mu.fn/parse-fn-tail '[^Integer [x :- :int y :- :int] (+ x y)])
              (#'mu.defn/deparameterized-arglists)
              first
              meta

--- a/test/metabase/util/malli/fn_test.clj
+++ b/test/metabase/util/malli/fn_test.clj
@@ -274,8 +274,10 @@
   (is (= 'Integer
          (-> '(^{:private true} add-ints :- :int ^{:tag Integer} [x :- :int y :- :int] (+ x y))
              mu.fn/parse-fn-tail
+             :values
              :arities
-             second
+             :value
+             :values
              :args
              meta
              :tag))))


### PR DESCRIPTION
Malli making some pretty nasty breaking changes in 0.18 (https://github.com/metosin/malli/blob/master/CHANGELOG.md#0180-2025-05-12) requires updating the defn wrappers we have in Metabase. I hope I cleared all of them, at least the project loads, but tests will show more.

- [x] This PR depends on https://github.com/metabase/macaw/pull/116 to be merged first (and then bump the Macaw version too).

**Update**
Finally got the tests to pass. Except for breaking how parsing works, the new Malli also upgraded to OpenAPI spec 3.1 (if I understand correctly) which also broke some of our openapi-related tests. I only made those tests pass by changing them but I have no idea what the preferred behavior is.
