### PR TITLE
Draft: Move TableDataEditing API to OSS. Minor refactoring

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/index.ts
@@ -8,7 +8,6 @@ export * from "./metabot";
 export * from "./gdrive";
 export * from "./db-routing";
 export * from "./query-validation";
-export * from "./table-data-edit";
 export * from "./scim";
 export * from "./tags";
 export * from "./upload-management";

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
@@ -19,13 +19,14 @@ import type {
   DatasetData,
   Field,
   FieldWithMetadata,
+  RowPkValue,
   RowValue,
   RowValues,
+  UpdateCellValueHandlerParams,
   WritebackAction,
 } from "metabase-types/api";
 
 import { canEditField } from "../../helpers";
-import type { RowPkValue, UpdateCellValueHandlerParams } from "../types";
 
 import S from "./EditTableData.module.css";
 import { EditingBodyCellWrapper } from "./EditingBodyCell";

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditingBodyCell.tsx
@@ -6,9 +6,8 @@ import type {
   FieldWithMetadata,
   RowValue,
   RowValues,
+  UpdateCellValueHandlerParams,
 } from "metabase-types/api";
-
-import type { UpdateCellValueHandlerParams } from "../types";
 
 import S from "./EditingBodyCell.module.css";
 import { EditingBodyCellConditional } from "./inputs";

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditBulkRowsModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditBulkRowsModal.tsx
@@ -13,9 +13,9 @@ import type {
   FieldWithMetadata,
   RowValue,
   Table,
+  UpdatedRowBulkHandlerParams,
 } from "metabase-types/api";
 
-import type { UpdatedRowBulkHandlerParams } from "../../types";
 import { EditingBodyCellConditional } from "../inputs";
 import type { EditableTableColumnConfig } from "../use-editable-column-config";
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/EditingBaseRowModal.tsx
@@ -22,9 +22,9 @@ import type {
   RowValue,
   RowValues,
   Table,
+  UpdatedRowHandlerParams,
 } from "metabase-types/api";
 
-import type { UpdatedRowHandlerParams } from "../../types";
 import { EditingBodyCellConditional } from "../inputs";
 import type { EditableTableColumnConfig } from "../use-editable-column-config";
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-crud-optimistic-update.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-crud-optimistic-update.tsx
@@ -2,8 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import { useDispatch } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
-
-import type { CellUniqKey, RowPkValue } from "../types";
+import type { CellUniqKey, RowPkValue } from "metabase-types/api";
 
 import { ErrorUpdateToast } from "./ErrorUpdateToast";
 import type { OptimisticUpdatePatchResult } from "./use-table-state-update-strategy";

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-crud.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-crud.tsx
@@ -1,30 +1,27 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
-import { useGetTableQueryMetadataQuery } from "metabase/api";
-import { useDispatch } from "metabase/lib/redux";
-import { addUndo } from "metabase/redux/undo";
 import {
   useDeleteTableRowsMutation,
+  useGetTableQueryMetadataQuery,
   useInsertTableRowsMutation,
   useUpdateTableRowsMutation,
-} from "metabase-enterprise/api";
+} from "metabase/api";
+import { useDispatch } from "metabase/lib/redux";
+import { addUndo } from "metabase/redux/undo";
 import { isPK } from "metabase-lib/v1/types/utils/isa";
 import type {
   ConcreteTableId,
   DatasetData,
   FieldWithMetadata,
-  RowValue,
-} from "metabase-types/api";
-
-import type {
   RowCellsWithPkValue,
   RowPkValue,
+  RowValue,
   TableEditingScope,
   UpdateCellValueHandlerParams,
   UpdatedRowBulkHandlerParams,
   UpdatedRowHandlerParams,
-} from "../types";
+} from "metabase-types/api";
 
 import { useTableCrudOptimisticUpdate } from "./use-table-crud-optimistic-update";
 import type { TableEditingStateUpdateStrategy } from "./use-table-state-update-strategy";

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-undo-redo.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-undo-redo.ts
@@ -1,16 +1,15 @@
 import { useCallback } from "react";
 import { t } from "ttag";
 
+import { useTableRedoMutation, useTableUndoMutation } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { useDispatch } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
-import {
-  useTableRedoMutation,
-  useTableUndoMutation,
-} from "metabase-enterprise/api/table-data-edit";
-import type { ConcreteTableId, RowValue } from "metabase-types/api";
-
-import type { TableEditingScope } from "../types";
+import type {
+  ConcreteTableId,
+  RowValue,
+  TableEditingScope,
+} from "metabase-types/api";
 
 import type { TableEditingStateUpdateStrategy } from "./use-table-state-update-strategy";
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/utils.ts
@@ -3,9 +3,13 @@ import { t } from "ttag";
 import { b64hash_to_utf8, utf8_to_b64url } from "metabase/lib/encoding";
 import type { GenericErrorResponse } from "metabase/lib/errors";
 import { isPK } from "metabase-lib/v1/types/utils/isa";
-import type { DatasetData, Filter, OrderBy } from "metabase-types/api";
-
-import type { CellUniqKey, RowPkValue } from "../types";
+import type {
+  CellUniqKey,
+  DatasetData,
+  Filter,
+  OrderBy,
+  RowPkValue,
+} from "metabase-types/api";
 
 export const serializeMbqlParam = (filterMbql: Array<any>): string => {
   return utf8_to_b64url(JSON.stringify(filterMbql));

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/execution/TableActionExecuteModalContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/execution/TableActionExecuteModalContent.tsx
@@ -6,14 +6,17 @@ import {
   getActionErrorMessage,
   getActionExecutionMessage,
 } from "metabase/actions/utils";
-import { skipToken, useGetActionQuery } from "metabase/api";
+import {
+  skipToken,
+  useExecuteActionMutation,
+  useGetActionQuery,
+} from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import ModalContent from "metabase/components/ModalContent";
 import { useDispatch } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import { addUndo } from "metabase/redux/undo";
 import type { TableActionsExecuteFormVizOverride } from "metabase/visualizations/types/table-actions";
-import { useExecuteActionMutation } from "metabase-enterprise/api";
 import type {
   ParametersForActionExecution,
   WritebackAction,

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
+import { useGetActionsQuery } from "metabase/api";
 import { uuid } from "metabase/lib/uuid";
 import { Button, Modal, Stack } from "metabase/ui";
 import type { BasicTableViewColumn } from "metabase/visualizations/types/table-actions";
-import { useGetActionsQuery } from "metabase-enterprise/api";
 import type {
   RowActionFieldSettings,
   TableAction,

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -44,6 +44,7 @@ export * from "./snippets";
 export * from "./store";
 export * from "./subscription";
 export * from "./table";
+export * from "./table-data-editing";
 export * from "./task";
 export * from "./timeline";
 export * from "./user";

--- a/frontend/src/metabase-types/api/table-data-editing.ts
+++ b/frontend/src/metabase-types/api/table-data-editing.ts
@@ -7,11 +7,11 @@ import type {
   WritebackActionId,
 } from "metabase-types/api";
 
-export type RowCellsWithPkValue = Record<DatasetColumn["name"], RowValue>;
-
 export type RowPkValue = string | number;
 
 export type CellUniqKey = string;
+
+export type RowCellsWithPkValue = Record<DatasetColumn["name"], RowValue>;
 
 export type TableEditingScope =
   | { "table-id": ConcreteTableId }
@@ -70,8 +70,6 @@ export type TableUndoRedoRequest = {
   tableId: ConcreteTableId;
   scope?: TableEditingScope;
 };
-
-export type TableOperation = [string, Record<string, RowValue>];
 
 export type TableUndoRedoResponse = {
   outputs?: ExecuteOutput<"created" | "updated" | "deleted">[];

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
@@ -2,14 +2,12 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker";
+import { useGetActionsQuery } from "metabase/api";
 import EmptyState from "metabase/components/EmptyState";
 import Button from "metabase/core/components/Button";
 import CS from "metabase/css/core/index.css";
 import { setActionForDashcard } from "metabase/dashboard/actions";
 import { connect } from "metabase/lib/redux";
-// TODO: Remove this once we have a proper API for actions.
-// eslint-disable-next-line no-restricted-imports
-import { useGetActionsQuery } from "metabase-enterprise/api";
 import type {
   ActionDashboardCard,
   Dashboard,

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -31,6 +31,7 @@ export * from "./settings";
 export * from "./snippet";
 export * from "./subscription";
 export * from "./table";
+export * from "./table-data-editing";
 export * from "./task";
 export * from "./timeline";
 export * from "./timeline-event";

--- a/frontend/src/metabase/api/table-data-editing.ts
+++ b/frontend/src/metabase/api/table-data-editing.ts
@@ -1,3 +1,4 @@
+import type { TableAction, WritebackAction } from "metabase-types/api/actions";
 import type {
   TableDeleteRowsRequest,
   TableDeleteRowsResponse,
@@ -9,12 +10,13 @@ import type {
   TableUndoRedoResponse,
   TableUpdateRowsRequest,
   TableUpdateRowsResponse,
-} from "metabase-enterprise/data_editing/tables/types";
-import type { TableAction, WritebackAction } from "metabase-types/api/actions";
+} from "metabase-types/api/table-data-editing";
 
-import { EnterpriseApi } from "./api";
+import { Api } from "./api";
 
-export const tableDataEditApi = EnterpriseApi.injectEndpoints({
+const API_PATH = `/api/ee/data-editing`;
+
+export const tableDataEditingApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     insertTableRows: builder.mutation<
       TableInsertRowsResponse,
@@ -22,7 +24,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
     >({
       query: ({ rows, scope }) => ({
         method: "POST",
-        url: `/api/ee/data-editing/action/v2/execute-bulk`,
+        url: `${API_PATH}/action/v2/execute-bulk`,
         body: { inputs: rows, scope, action_id: "data-grid.row/create" },
       }),
     }),
@@ -32,7 +34,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
     >({
       query: ({ rows, scope }) => ({
         method: "POST",
-        url: `/api/ee/data-editing/action/v2/execute-bulk`,
+        url: `${API_PATH}/action/v2/execute-bulk`,
         body: { inputs: rows, scope, action_id: "data-grid.row/update" },
       }),
     }),
@@ -42,14 +44,14 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
     >({
       query: ({ rows, scope }) => ({
         method: "POST",
-        url: `/api/ee/data-editing/action/v2/execute-bulk`,
+        url: `${API_PATH}/action/v2/execute-bulk`,
         body: { inputs: rows, scope, action_id: "data-grid.row/delete" },
       }),
     }),
     tableUndo: builder.mutation<TableUndoRedoResponse, TableUndoRedoRequest>({
       query: ({ tableId, scope }) => ({
         method: "POST",
-        url: `/api/ee/data-editing/action/v2/execute`,
+        url: `${API_PATH}/action/v2/execute`,
         body: {
           input: {
             "table-id": tableId,
@@ -62,7 +64,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
     tableRedo: builder.mutation<TableUndoRedoResponse, TableUndoRedoRequest>({
       query: ({ tableId, scope }) => ({
         method: "POST",
-        url: `/api/ee/data-editing/action/v2/execute`,
+        url: `${API_PATH}/action/v2/execute`,
         body: {
           input: {
             "table-id": tableId,
@@ -75,7 +77,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
     getActions: builder.query<Array<WritebackAction | TableAction>, void>({
       query: () => ({
         method: "GET",
-        url: `/api/ee/data-editing/tmp-action`,
+        url: `${API_PATH}/tmp-action`,
       }),
       transformResponse: (response: {
         actions: Array<WritebackAction | TableAction>;
@@ -87,7 +89,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
     >({
       query: ({ actionId, parameters }) => ({
         method: "POST",
-        url: `/api/ee/data-editing/action/v2/execute`,
+        url: `${API_PATH}/action/v2/execute`,
         body: {
           input: parameters,
           // Here we pass a dummy table id, because the BE doesn't allow scope to be optional,
@@ -113,4 +115,4 @@ export const {
   useTableRedoMutation,
   useGetActionsQuery,
   useExecuteActionMutation,
-} = tableDataEditApi;
+} = tableDataEditingApi;


### PR DESCRIPTION
### Description

Move updated API to OSS to be able to use it with dashcards. The path will be renamed to `/action/v2` soon.