### PR TITLE
Restore some excluded from package.json SDK dependencies that may cause @types/react conflicts

### DIFF
--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -4,32 +4,30 @@
 const fs = require("fs");
 const path = require("path");
 
-const IGNORED_PACKAGES = [
-  "react",
-  "react-dom",
+const IGNORED_REACT_PACKAGES = ["react", "react-dom"];
+const IGNORED_TYPES_DEPENDENCIES = [
   "@types/react",
   "@types/react-dom",
   "@types/react-router",
   "@types/redux-auth-wrapper",
-  "@visx/axis",
-  "@visx/clip-path",
-  "@visx/grid",
-  "@visx/group",
-  "@visx/shape",
-  "@visx/text",
-  "formik",
-  "react-beautiful-dnd",
-
+];
+const IGNORED_NOT_USED_BY_SDK_PACKAGES = [
   // Not used in the SDK, and triggers code-scanning errors
   "react-ansi-style",
 ];
+const IGNORED_DEPENDENCIES = [
+  ...IGNORED_REACT_PACKAGES,
+  ...IGNORED_TYPES_DEPENDENCIES,
+  ...IGNORED_NOT_USED_BY_SDK_PACKAGES,
+];
+
 const SDK_DIST_DIR = path.resolve("./resources/embedding-sdk");
 
 function filterOuDependencies(object) {
   const result = {};
 
   Object.entries(object).forEach(([packageName, version]) => {
-    if (!IGNORED_PACKAGES.includes(packageName)) {
+    if (!IGNORED_DEPENDENCIES.includes(packageName)) {
       result[packageName] = version;
     }
   });

--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -50,6 +50,32 @@ or with yarn:
 yarn add @metabase/embedding-sdk-react@53-stable
 ```
 
+### Resolving `@types/react` version mismatches
+
+In rare scenarios, the Embedding SDK and your application may use different major versions of `@types/react`, causing TypeScript conflicts.
+
+To enforce a single `@types/react` version across all dependencies, add an `overrides` (npm) or `resolutions` (Yarn) section to your `package.json` and specify the `@types/react` version your application uses.
+
+#### NPM set @types/react version
+
+```json
+{
+  "overrides": {
+    "@types/react": "..."
+  }
+}
+```
+
+#### Yarn set @types/react version
+
+```json
+{
+  "resolutions": {
+    "@types/react": "..."
+  }
+}
+```
+
 ## Developing with the Embedded analytics SDK
 
 Start with one of the quickstarts, then see these pages for more info on components, theming, and more.


### PR DESCRIPTION
Restore some excluded from package.json SDK dependencies that may cause @types/react conflicts.

Closes https://linear.app/metabase/issue/EMB-437/restore-some-sdk-dependencies-back-to-packagejson

Initially these dependencies were excluded from `package.json` because they **may** install a different version of `@types/react` compared to the version that is installed on a Host App at the root `node_modules/@types/react`

Seems we have a very few such cases (1 or 2) yet, so
after discussion, we decided just to restore these deps and provide a documentation section that mentions how to solve `@types/react` type conflicts

Context https://metaboat.slack.com/archives/C063Q3F1HPF/p1748954667873549

How to test:
- CI should be green