### PR TITLE
Browser nav for model editor

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1563,9 +1563,6 @@ describe("issue 55486", () => {
   function checkIsShowingMetadataEditorTab() {
     cy.findByTestId("editor-tabs-metadata").should("be.checked");
     cy.findByTestId("visualization-root").should("be.visible");
-    cy.findByTestId("visualization-root")
-      .findByText("Loading...")
-      .should("not.exist");
   }
 
   function checkIsShowingQueryEditorTab() {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1588,5 +1588,13 @@ describe("issue 55486", () => {
     cy.log("Back button should show the query editor");
     cy.go("back");
     checkIsShowingQueryEditorTab();
+
+    cy.log("Forward button should show the query editor");
+    cy.go("forward");
+    checkIsShowingMetadataEditorTab();
+
+    cy.log("Forward button should show the query editor");
+    cy.go("forward");
+    checkIsShowingQueryEditorTab();
   });
 });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1553,6 +1553,7 @@ describe("issue 55486", () => {
         name: MODEL_NAME,
         query: {
           "source-table": PRODUCTS_ID,
+          limit: 5,
         },
       },
       { visitQuestion: true },

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1562,7 +1562,9 @@ describe("issue 55486", () => {
   function checkIsShowingMetadataEditorTab() {
     cy.findByTestId("editor-tabs-metadata").should("be.checked");
     cy.findByTestId("visualization-root").should("be.visible");
-    cy.findByText("Loading...").should("not.exist");
+    cy.findByTestId("visualization-root")
+      .findByText("Loading...")
+      .should("not.exist");
   }
 
   function checkIsShowingQueryEditorTab() {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1540,3 +1540,51 @@ describe("issue 56775", () => {
     H.getNotebookStep("data").findByText("Products").should("be.visible");
   });
 });
+
+describe("issue 55486", () => {
+  const MODEL_NAME = "Model 55486";
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createQuestion(
+      {
+        type: "model",
+        name: MODEL_NAME,
+        query: {
+          "source-table": PRODUCTS_ID,
+        },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  function checkIsShowingMetadataEditorTab() {
+    cy.findByTestId("editor-tabs-metadata").should("be.checked");
+    cy.findByTestId("visualization-root").should("be.visible");
+    cy.findByText("Loading...").should("not.exist");
+  }
+
+  function checkIsShowingQueryEditorTab() {
+    cy.findByTestId("editor-tabs-query").should("be.checked");
+    H.getNotebookStep("data").should("be.visible");
+  }
+
+  it("should render the correct query after using the back button in a model (metabase#56775)", () => {
+    H.openQuestionActions("Edit query definition");
+
+    H.datasetEditBar().findByText("Metadata").click();
+    checkIsShowingMetadataEditorTab();
+
+    H.datasetEditBar().findByText("Query").click();
+    checkIsShowingQueryEditorTab();
+
+    cy.log("Back button should show the metadata editor");
+    cy.go("back");
+    checkIsShowingMetadataEditorTab();
+
+    cy.log("Back button should show the query editor");
+    cy.go("back");
+    checkIsShowingQueryEditorTab();
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/navigation.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.ts
@@ -78,14 +78,21 @@ export const popState = createThunkAction(
       }
     }
 
-    const { queryBuilderMode: queryBuilderModeFromURL, ...uiControls } =
-      getQueryBuilderModeFromLocation(location);
+    const {
+      queryBuilderMode: queryBuilderModeFromURL,
+      datasetEditorTab: datasetEditorTabFromURL,
+      ...uiControls
+    } = getQueryBuilderModeFromLocation(location);
 
-    if (getQueryBuilderMode(getState()) !== queryBuilderModeFromURL) {
+    if (
+      getQueryBuilderMode(getState()) !== queryBuilderModeFromURL ||
+      getDatasetEditorTab(getState()) !== datasetEditorTabFromURL
+    ) {
       await dispatch(
         setQueryBuilderMode(queryBuilderModeFromURL, {
+          datasetEditorTab: datasetEditorTabFromURL,
           ...uiControls,
-          shouldUpdateUrl: queryBuilderModeFromURL === "dataset",
+          shouldUpdateUrl: false,
         }),
       );
     }

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
@@ -243,9 +243,7 @@ const _DatasetEditorInner = (props) => {
     });
   }, [question, height]);
 
-  const [editorHeight, setEditorHeight] = useState(
-    isEditingQuery ? initialEditorHeight : 0,
-  );
+  const [editorHeight, setEditorHeight] = useState(initialEditorHeight);
 
   const [focusedFieldName, setFocusedFieldName] = useState();
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55486

Allows using browser buttons to navigate the editor tabs.


### To verify


1. Go to a model -> actions menu -> Edit Metadata
3. Click Query in the Edit bar
4. Click the back button in the browser, you should see the metadata editor
5. Click the forward button in the browser, you should see the query editor