### PR TITLE
Closes VIZ-1051 no title menu for single source cards

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -341,6 +341,10 @@ export function assertDashboardCardTitle(index: number, title: string) {
     .should("have.text", title);
 }
 
+export function clickOnCardTitle(index: number) {
+  getDashboardCard(index).findByTestId("legend-caption-title").click();
+}
+
 export const dashboardHeader = () => {
   return cy.findByTestId("dashboard-header");
 };

--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -266,13 +266,19 @@ export function toggleVisualizerSettingsSidebar() {
 }
 
 export function saveDashcardVisualizerModal(
-  mode: "create" | "update" = "update",
+  options: {
+    mode?: "create" | "update";
+    waitMs?: number;
+  } = {},
 ) {
+  const { mode = "update", waitMs = 1 } = options;
+
   modal().within(() => {
     cy.findByText(mode === "create" ? "Add to dashboard" : "Save").click();
   });
 
   modal({ timeout: 6000 }).should("not.exist");
+  cy.wait(waitMs); // Wait for the modal to close and the dashboard to update
 }
 
 export function closeDashcardVisualizerModal() {

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -229,12 +229,10 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     // Click on both series of the first chart
     // Series 1
     H.showUnderlyingQuestion(0, ORDERS_COUNT_BY_CREATED_AT.name);
-
     cy.get("@ordersCountByCreatedAtQuestionId").then((id) =>
       cy.url().should("contain", `${id}-orders-by-created-at-month`),
     );
     cy.findByLabelText("Back to Test Dashboard").click();
-
     // Series 2
     H.showUnderlyingQuestion(0, PRODUCTS_COUNT_BY_CREATED_AT.name);
     cy.get("@productsCountByCreatedAtQuestionId").then((id) =>
@@ -242,10 +240,47 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     );
     cy.findByLabelText("Back to Test Dashboard").click();
 
-    // Click on the third chart (a pie)
+    // Click on the third chart (a pie with a single series)
+    H.clickOnCardTitle(2);
+    cy.get("@productsCountByCategoryQuestionId").then((id) =>
+      cy.url().should("contain", `${id}-products-by-category`),
+    );
+    cy.findByLabelText("Back to Test Dashboard").click();
+
+    // make the pie a two series pie and check that the title is still clickable
+    H.editDashboard();
+    H.showDashcardVisualizerModal(2);
+    H.modal().within(() => {
+      H.switchToAddMoreData();
+      H.selectDataset(PRODUCTS_COUNT_BY_CATEGORY.name);
+      H.assertWellItems({
+        vertical: ["Count"],
+        horizontal: ["Category"],
+      });
+      H.addDataset(PRODUCTS_COUNT_BY_CATEGORY_PIE.name);
+      H.assertWellItems({
+        vertical: ["Count", "Count (Products by Category (Pie))"],
+        horizontal: ["Category"],
+      });
+      H.selectVisualization("pie");
+      H.assertWellItems({
+        pieMetric: ["Count"],
+        pieDimensions: ["Category", "Category (Products by Category (Pie))"],
+      });
+    });
+
+    H.saveDashcardVisualizerModal({ waitMs: 500 });
+    H.saveDashboard({ waitMs: 2000 });
+
     H.showUnderlyingQuestion(2, PRODUCTS_COUNT_BY_CATEGORY.name);
     cy.get("@productsCountByCategoryQuestionId").then((id) =>
       cy.url().should("contain", `${id}-products-by-category`),
+    );
+    cy.findByLabelText("Back to Test Dashboard").click();
+
+    H.showUnderlyingQuestion(2, PRODUCTS_COUNT_BY_CATEGORY_PIE.name);
+    cy.get("@productsCountByCategoryPieQuestionId").then((id) =>
+      cy.url().should("contain", `${id}-products-by-category-pie`),
     );
     cy.findByLabelText("Back to Test Dashboard").click();
 
@@ -556,7 +591,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.openQuestionsSidebar();
     H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
 
-    H.saveDashcardVisualizerModal("create");
+    H.saveDashcardVisualizerModal({ mode: "create" });
     H.getDashboardCard(0).within(() => {
       cy.wait("@cardQuery");
       cy.findByText(ORDERS_COUNT_BY_CREATED_AT.name).should("exist");
@@ -618,7 +653,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
           vertical: ["Count", "Count (Products by Created At (Month))"],
         });
       });
-      H.saveDashcardVisualizerModal("create");
+      H.saveDashcardVisualizerModal({ mode: "create" });
       H.saveDashboard();
 
       cy.intercept("GET", `/api/dashboard/${dashboardId}*`).as("dashboardLoad");

--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -193,7 +193,7 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
       H.assertWellItemsCount({ vertical: 3 });
     });
 
-    H.saveDashcardVisualizerModal("create");
+    H.saveDashcardVisualizerModal({ mode: "create" });
     // Wait for card queries before saving the dashboard
     H.getDashboardCard(0).within(() => {
       cy.findByText(PRODUCTS_COUNT_BY_CREATED_AT.name).should("exist");

--- a/e2e/test/scenarios/dashboard/visualizer/filters.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/filters.cy.spec.ts
@@ -46,7 +46,7 @@ describe("scenarios > dashboard > visualizer > filters", () => {
       });
     });
 
-    H.saveDashcardVisualizerModal("create");
+    H.saveDashcardVisualizerModal({ mode: "create" });
 
     H.setFilter("Text or Category", "Is");
 

--- a/e2e/test/scenarios/dashboard/visualizer/snowplow-tracking.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/snowplow-tracking.cy.spec.ts
@@ -134,7 +134,7 @@ describe("Snowplow tracking", () => {
       });
 
       // save the card
-      H.saveDashcardVisualizerModal("create");
+      H.saveDashcardVisualizerModal({ mode: "create" });
       H.expectUnstructuredSnowplowEvent({
         event: "visualizer_save_clicked",
         triggered_from: "visualizer-modal",

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -348,10 +348,8 @@ export function DashCardVisualization({
 
   const titleMenuItems = useMemo(
     () =>
-      isVisualizerDashboardCard(dashcard) && rawSeries ? (
-        <>
-          <Menu.Label>{t`Questions in this card`}</Menu.Label>
-          {rawSeries.map((series, index) => (
+      isVisualizerDashboardCard(dashcard) && rawSeries
+        ? rawSeries.map((series, index) => (
             <Menu.Item
               key={index}
               onClick={() => {
@@ -360,9 +358,8 @@ export function DashCardVisualization({
             >
               {series.card.name}
             </Menu.Item>
-          ))}
-        </>
-      ) : undefined,
+          ))
+        : undefined,
     [dashcard, rawSeries, onOpenQuestion],
   );
 

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import type { IconProps } from "metabase/ui";
 import type { OnChangeCardAndRun } from "metabase/visualizations/types";
 import type {
+  RawSeries,
   Series,
   TransformedSeries,
   VisualizationSettings,
@@ -21,10 +22,12 @@ interface ChartCaptionProps {
   getHref?: () => string | undefined;
   titleMenuItems?: React.ReactNode;
   onChangeCardAndRun?: OnChangeCardAndRun | null;
+  visualizerRawSeries?: RawSeries;
 }
 
 const ChartCaption = ({
   series,
+  visualizerRawSeries,
   settings,
   icon,
   actionButtons,
@@ -36,7 +39,8 @@ const ChartCaption = ({
 }: ChartCaptionProps) => {
   const title = settings["card.title"] ?? series?.[0].card.name ?? "";
   const description = settings["card.description"];
-  const data = (series as TransformedSeries)._raw || series;
+  const data =
+    visualizerRawSeries ?? (series as TransformedSeries)._raw ?? series;
   const card = data[0].card;
   const cardIds = new Set(data.map((s) => s.card.id));
   const canSelectTitle = cardIds.size === 1 && onChangeCardAndRun;

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -9,6 +9,7 @@ import {
   type Ref,
   forwardRef,
 } from "react";
+import React from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -735,7 +736,9 @@ class Visualization extends PureComponent<
     // We can't navigate a user to a particular card from a visualizer viz,
     // so title selection is disabled in this case
     const canSelectTitle =
-      this.props.onChangeCardAndRun && !replacementContent && !isVisualizerViz;
+      this.props.onChangeCardAndRun &&
+      !replacementContent &&
+      (!isVisualizerViz || React.Children.count(titleMenuItems) === 1);
 
     return (
       <ErrorBoundary
@@ -755,6 +758,7 @@ class Visualization extends PureComponent<
             <VisualizationHeader>
               <ChartCaption
                 series={series}
+                visualizerRawSeries={visualizerRawSeries}
                 settings={settings}
                 icon={headerIcon}
                 actionButtons={extra}

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
@@ -88,8 +88,8 @@ export const LegendCaption = ({
         DashboardS.fullscreenNightText,
         EmbedFrameS.fullscreenNightText,
       )}
-      href={href}
-      onClick={onSelectTitle}
+      href={hasTitleMenuItems ? undefined : href}
+      onClick={hasTitleMenuItems ? undefined : onSelectTitle}
       onFocus={handleFocus}
       onMouseEnter={handleMouseEnter}
     >

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
-import { useCallback, useState } from "react";
+import React, { useCallback, useState } from "react";
+import { t } from "ttag";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Markdown from "metabase/core/components/Markdown";
@@ -77,6 +78,9 @@ export const LegendCaption = ({
     }
   }, [getHref]);
 
+  const hasTitleMenuItems =
+    titleMenuItems && React.Children.count(titleMenuItems) > 1;
+
   const titleElement = (
     <LegendLabel
       className={cx(
@@ -90,7 +94,7 @@ export const LegendCaption = ({
       onMouseEnter={handleMouseEnter}
     >
       <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>
-      {title && titleMenuItems && (
+      {title && hasTitleMenuItems && (
         <Icon
           style={{ flexShrink: 0, marginRight: 10 }}
           name="chevrondown"
@@ -104,10 +108,11 @@ export const LegendCaption = ({
   return (
     <LegendCaptionRoot className={className} data-testid="legend-caption">
       {icon && <LegendLabelIcon {...icon} />}
-      {titleMenuItems ? (
+      {hasTitleMenuItems ? (
         <Menu>
           <Menu.Target>{titleElement}</Menu.Target>
           <Menu.Dropdown data-testid="legend-caption-menu">
+            <Menu.Label>{t`Questions in this card`}</Menu.Label>
             {titleMenuItems}
           </Menu.Dropdown>
         </Menu>

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -224,7 +224,7 @@ export type VisualizationPassThroughProps = {
    * Items that will be shown in a menu when the title is clicked.
    * Used for visualizer cards to jump to underlying questions
    */
-  titleMenuItems?: React.ReactNode;
+  titleMenuItems?: React.ReactNode[];
 
   // frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.tsx
   isSettings?: boolean;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import React from "react";
 import { useSet } from "react-use";
 
 import { isWebkit } from "metabase/lib/browser";
@@ -134,7 +135,9 @@ function _CartesianChart(props: VisualizationProps) {
 
   // We can't navigate a user to a particular card from a visualizer viz,
   // so title selection is disabled in this case
-  const canSelectTitle = !!onChangeCardAndRun && !isVisualizerViz;
+  const canSelectTitle =
+    !!onChangeCardAndRun &&
+    (!isVisualizerViz || React.Children.count(titleMenuItems) === 1);
 
   const seriesColorsCss = useCartesianChartSeriesColorsClasses(
     chartModel,

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -1,4 +1,5 @@
 import cx from "classnames";
+import React from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -222,7 +223,9 @@ export function Funnel(props: VisualizationProps) {
 
   // We can't navigate a user to a particular card from a visualizer viz,
   // so title selection is disabled in this case
-  const canSelectTitle = !!onChangeCardAndRun && !isVisualizerViz;
+  const canSelectTitle =
+    !!onChangeCardAndRun &&
+    (!isVisualizerViz || React.Children.count(titleMenuItems) === 1);
 
   return (
     <div className={cx(className, CS.flex, CS.flexColumn, CS.p1)}>


### PR DESCRIPTION
Closes [VIZ-1051: Adjust entrypoint behavior for single source cards](https://linear.app/metabase/issue/VIZ-1051/adjust-entrypoint-behavior-for-single-source-cards)

### Description

For single source visualizer cards, we want the title to directly navigate to the question instead of showing a menu with a single item.

https://www.loom.com/share/8c7cf4cf711d4d4385b38ef09120aa3b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
