### PR TITLE
Fix flaky visualizer tests

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -42,7 +42,7 @@ export function getDashboardCardMenu(index = 0) {
 }
 
 export function showDashboardCardActions(index = 0) {
-  getDashboardCard(index).realHover({ scrollBehavior: "bottom" });
+  return getDashboardCard(index).realHover({ scrollBehavior: "bottom" });
 }
 
 /**
@@ -90,6 +90,9 @@ export function saveDashboard({
     "saveDashboard-saveDashboardCards",
   );
   cy.intercept("GET", "/api/dashboard/*").as("saveDashboard-getDashboard");
+  cy.intercept("GET", "/api/dashboard/*/query_metadata*").as(
+    "saveDashboard-getDashboardMetadata",
+  );
 
   cy.findByText(editBarText).should("be.visible");
   cy.button(buttonLabel).click();
@@ -97,6 +100,7 @@ export function saveDashboard({
   if (awaitRequest) {
     cy.wait("@saveDashboard-saveDashboardCards");
     cy.wait("@saveDashboard-getDashboard");
+    cy.wait("@saveDashboard-getDashboardMetadata");
   }
 
   cy.findByText(editBarText).should("not.exist");

--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -1,6 +1,9 @@
 import type { VisualizationDisplay } from "metabase-types/api";
 
-import { getDashboardCard } from "./e2e-dashboard-helpers";
+import {
+  getDashboardCard,
+  showDashboardCardActions,
+} from "./e2e-dashboard-helpers";
 import { modal, sidebar } from "./e2e-ui-elements-helpers";
 
 export function clickVisualizeAnotherWay(name: string) {
@@ -238,11 +241,11 @@ export function chartLegendItem(name: string) {
 }
 
 export function showDashcardVisualizerModal(index = 0) {
+  showDashboardCardActions(index);
+
   getDashboardCard(index)
-    .realHover()
-    .within(() => {
-      cy.findByLabelText("Edit visualization").click({ force: true });
-    });
+    .findByLabelText("Edit visualization")
+    .click({ force: true });
 
   modal().within(() => {
     cy.findByTestId("visualization-canvas-loader").should("not.exist");

--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -10,7 +10,11 @@ export function clickVisualizeAnotherWay(name: string) {
       .findByLabelText("Visualize another way")
       .click({ force: true });
   });
-  cy.findByTestId("visualization-canvas-loader").should("not.exist");
+
+  modal().within(() => {
+    cy.findByTestId("visualization-canvas-loader").should("not.exist");
+    dataImporter().findByTestId("loading-indicator").should("not.exist");
+  });
 }
 
 export function dataImporter() {
@@ -234,11 +238,16 @@ export function chartLegendItem(name: string) {
 }
 
 export function showDashcardVisualizerModal(index = 0) {
-  return getDashboardCard(index)
+  getDashboardCard(index)
     .realHover()
     .within(() => {
       cy.findByLabelText("Edit visualization").click({ force: true });
     });
+
+  modal().within(() => {
+    cy.findByTestId("visualization-canvas-loader").should("not.exist");
+    dataImporter().findByTestId("loading-indicator").should("not.exist");
+  });
 }
 
 export function showDashcardVisualizerModalSettings(index = 0) {

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -202,17 +202,22 @@ function visitDashboardById(dashboard_id, config) {
     if (canViewDashboard && validQuestions) {
       // If dashboard has valid questions (GUI or native),
       // we need to alias each request and wait for their reponses
-      const aliases = validQuestions.flatMap((dashcard) => {
-        const { series = [], card: mainCard } = dashcard;
-        return [mainCard, ...series].map((card) =>
-          interceptCardQueryRequest(
-            dashboard_id,
-            dashcard.id,
-            card.id,
-            card.display,
-          ),
-        );
-      });
+      const aliases = validQuestions.map(
+        ({ id, card_id, card: { display } }) => {
+          const baseUrl =
+            display === "pivot"
+              ? `/api/dashboard/pivot/${dashboard_id}`
+              : `/api/dashboard/${dashboard_id}`;
+
+          const interceptUrl = `${baseUrl}/dashcard/${id}/card/${card_id}/query`;
+
+          const alias = "dashcardQuery" + id;
+
+          cy.intercept("POST", interceptUrl).as(alias);
+
+          return `@${alias}`;
+        },
+      );
 
       cy.visit({
         url: `/dashboard/${dashboard_id}`,
@@ -230,18 +235,6 @@ function visitDashboardById(dashboard_id, config) {
       cy.wait(`@${dashboardAlias}`);
     }
   });
-}
-
-function interceptCardQueryRequest(dashboardId, dashcardId, cardId, display) {
-  const baseUrl =
-    display === "pivot"
-      ? `/api/dashboard/pivot/${dashboardId}`
-      : `/api/dashboard/${dashboardId}`;
-
-  const interceptUrl = `${baseUrl}/dashcard/${dashcardId}/card/${cardId}/query`;
-  const alias = `dashcardQuery${dashcardId}_${cardId}`;
-  cy.intercept("POST", interceptUrl).as(alias);
-  return `@${alias}`;
 }
 
 function hasAccess(statusCode) {

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -291,7 +291,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     );
   });
 
-  it("should rename a dashboard card", { tags: "@flaky" }, () => {
+  it("should rename a dashboard card", () => {
     createDashboardWithVisualizerDashcards();
     H.editDashboard();
 

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -290,6 +290,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       cy.findByDisplayValue("My chart").clear().type("Renamed chart").blur();
     });
     H.saveDashcardVisualizerModal();
+    H.getDashboardCard(0).findByText("Created At: Month").should("exist"); // wait for query rerun
     H.assertDashboardCardTitle(0, "Renamed chart");
 
     // Rename the third card and check
@@ -302,6 +303,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
         .blur();
     });
     H.saveDashcardVisualizerModal();
+    H.getDashboardCard(3).findByText("Created At: Month").should("exist"); // wait for query rerun
     H.assertDashboardCardTitle(3, "Another chart");
 
     // Clear the second card title
@@ -311,6 +313,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       cy.findByTestId("visualizer-title").clear().blur();
     });
     H.saveDashcardVisualizerModal();
+    H.getDashboardCard(1).findByText("Product → Category").should("exist"); // wait for query rerun
     H.assertDashboardCardTitle(1, "");
 
     // Save the dashboard


### PR DESCRIPTION
Closes [VIZ-1046](https://linear.app/metabase/issue/VIZ-1046/flaky-test-e2e-tests-scenarios-dashboard-visualizer-basics-scenarios), closes [VIZ-1047](https://linear.app/metabase/issue/VIZ-1047/flaky-test-e2e-tests-scenarios-dashboard-visualizer-cartesian)

There are two race conditions in the visualizer tests that cause flakiness:

1. Saving visualizer changes often reruns card queries, and it seems to be canceling an attempt to save the dashboard right after that
2. After we save dashboard changes, we turn off dashboard editing mode. In E2E tests, the edit mode is sometimes turned off after `H.saveDashboard` is called for some reason. If we call `H.editDashboard` right after saving, there's a chance that editing mode will be turned off, causing errors.

I'm not sure exactly what is causing this issue, and I'm unsure why other tests are not failing due to 2. The PR fixes flakiness by adding several `cy.wait` calls for now + adds several more assertions:

- extended `H.saveDashboard` to wait for a dashboard metadata response
- added assertions to make sure the visualizer is loaded correctly before trying to do anything

Stress tests for flaky tests

- https://github.com/metabase/metabase/actions/runs/15399373220
- https://github.com/metabase/metabase/actions/runs/15399337463
- https://github.com/metabase/metabase/actions/runs/15399332746