### PR TITLE
Closes VIZ-192: Goal line tooltip formatting does not match ticks formatting

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -964,4 +964,22 @@ describe("scenarios > visualizations > bar chart", () => {
     H.otherSeriesChartPaths().first().realHover();
     H.assertEChartsTooltip({ rows: [{ name: "Max", value: "3" }] });
   });
+
+  it("should format goal tooltip value as a percent when the Stacking option is 'Stack - 100%'", () => {
+    H.visitQuestionAdhoc({
+      ...breakoutBarChart,
+      visualization_settings: {
+        "graph.goal_value": 87.5,
+        "graph.show_goal": true,
+        "stackable.stack_type": "normalized",
+      },
+    });
+
+    H.echartsContainer().findByText("Goal").trigger("mousemove");
+
+    H.popover().within(() => {
+      cy.findByText("Goal:").should("exist");
+      cy.findByText("87.5%").should("exist");
+    });
+  });
 });

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -672,4 +672,65 @@ describe("scenarios > visualizations > line chart", () => {
       cy.findByText(X_AXIS_VALUE);
     });
   });
+
+  it("should format goal tooltip value to match y-axis tick formatting", () => {
+    H.visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ],
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "line",
+      visualization_settings: {
+        "graph.goal_value": 5000,
+        "graph.show_goal": true,
+        "graph.label_value_formatting": "compact",
+        column_settings: {
+          '["name","sum"]': {
+            number_style: "currency",
+            currency: "USD",
+          },
+        },
+      },
+    });
+
+    H.echartsContainer().findByText("$50.0k").should("exist");
+    H.echartsContainer().findByText("Goal").trigger("mousemove");
+
+    H.popover().within(() => {
+      cy.findByText("Goal:").should("exist");
+      cy.findByText("$5,000.00").should("exist");
+    });
+  });
+
+  it("should support formatting goal tooltip value as a percent", () => {
+    H.visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "line",
+      visualization_settings: {
+        "graph.goal_value": 123.4567,
+        "graph.show_goal": true,
+        "graph.label_value_formatting": "compact",
+        column_settings: {
+          '["name","count"]': {
+            number_style: "percent",
+          },
+        },
+      },
+    });
+
+    H.echartsContainer().findByText("50.0k%").should("exist");
+    H.echartsContainer().findByText("Goal").trigger("mousemove");
+
+    H.popover().within(() => {
+      cy.findByText("Goal:").should("exist");
+      cy.findByText("12,345.67%").should("exist");
+    });
+  });
 });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -547,6 +547,10 @@ export function getYAxisModel(
     stackType,
     formattingOptions,
   );
+  const formatGoal = getYAxisFormatter(column, settings, stackType, {
+    ...formattingOptions,
+    compact: false,
+  });
 
   return {
     seriesKeys,
@@ -554,6 +558,7 @@ export function getYAxisModel(
     column,
     label,
     formatter,
+    formatGoal,
     isNormalized: stackType === "normalized",
     splitNumber:
       settings["graph.y_axis.split_number"] > 0

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -422,6 +422,7 @@ const getYAxisFormatter = (
         formatValue(value, {
           column,
           number_style: "percent",
+          scale: formattingOptions?.scale,
         }),
       );
   }
@@ -550,6 +551,10 @@ export function getYAxisModel(
   const formatGoal = getYAxisFormatter(column, settings, stackType, {
     ...formattingOptions,
     compact: false,
+    scale:
+      stackType === "normalized"
+        ? 1 / 100 // Users enter "50" for "50%" but visualizations use decimals (e.g. 0.5 = 50%) so we need to convert "50" -> 0.5 for percentage-based goals to be displayed correctly
+        : formattingOptions?.scale,
   });
 
   return {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -179,6 +179,7 @@ export type YAxisModel = {
   column: DatasetColumn;
   label?: string;
   formatter: AxisFormatter;
+  formatGoal: AxisFormatter;
   splitNumber?: number;
   isNormalized?: boolean;
 };

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -33,6 +33,7 @@ import {
 } from "metabase/visualizations/echarts/cartesian/model/guards";
 import { getOtherSeriesAggregationLabel } from "metabase/visualizations/echarts/cartesian/model/other-series";
 import type {
+  AxisFormatter,
   BaseCartesianChartModel,
   BaseSeriesModel,
   ChartDataset,
@@ -816,7 +817,7 @@ export const getTimelineEventsHoverData = (
 export const getGoalLineHoverData = (
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
-  chartModel: BaseCartesianChartModel,
+  formatGoal?: AxisFormatter,
 ) => {
   const element = event.event.event.target as Element;
 
@@ -824,7 +825,7 @@ export const getGoalLineHoverData = (
     return null;
   }
 
-  const formatGoal = chartModel.leftAxisModel?.formatGoal || _.identity;
+  const goalValue = settings["graph.goal_value"] ?? "";
 
   return {
     element,
@@ -832,7 +833,7 @@ export const getGoalLineHoverData = (
       {
         col: null,
         key: settings["graph.goal_label"] ?? "",
-        value: formatGoal(settings["graph.goal_value"] ?? ""),
+        value: formatGoal ? formatGoal(goalValue) : goalValue,
       },
     ],
   };

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -816,6 +816,7 @@ export const getTimelineEventsHoverData = (
 export const getGoalLineHoverData = (
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
+  chartModel: BaseCartesianChartModel,
 ) => {
   const element = event.event.event.target as Element;
 
@@ -823,13 +824,15 @@ export const getGoalLineHoverData = (
     return null;
   }
 
+  const formatGoal = chartModel.leftAxisModel?.formatGoal || _.identity;
+
   return {
     element,
     data: [
       {
         col: null,
         key: settings["graph.goal_label"] ?? "",
-        value: settings["graph.goal_value"] ?? "",
+        value: formatGoal(settings["graph.goal_value"] ?? ""),
       },
     ],
   };

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -156,7 +156,7 @@ export const useChartEvents = (
           }
 
           if (event.seriesId === GOAL_LINE_SERIES_ID) {
-            const eventData = getGoalLineHoverData(settings, event);
+            const eventData = getGoalLineHoverData(settings, event, chartModel);
 
             onHoverChange?.(eventData);
             return;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -156,7 +156,11 @@ export const useChartEvents = (
           }
 
           if (event.seriesId === GOAL_LINE_SERIES_ID) {
-            const eventData = getGoalLineHoverData(settings, event, chartModel);
+            const eventData = getGoalLineHoverData(
+              settings,
+              event,
+              chartModel.leftAxisModel?.formatGoal,
+            );
 
             onHoverChange?.(eventData);
             return;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48473
Closes VIZ-192

### Description

Updates Goal tooltip to use the same formatting as the y-axis (but ignores compact/auto formatting to ensure the goal value is represented accurately).

### How to verify

**Base case**
1. Add a visualization with a Goal line, e.g. line chart + Settings > Display > Goal line
2. Hover over the "Goal" label
3. Verify the goal value is formatted the same way as the y-axis labels (but ignores compact/auto formatting to ensure the goal value is represented accurately)

**Normalized case**
1. Add a visualization with percentage-based values, e.g. bar chart + Settings > Display > "Stack - 100%"
2. Hover over the "Goal" label
3. Verify the goal value matches what's in the "Goal value" field prefixed with a % sign

### Demo

| **BEFORE (master)** | **AFTER (this branch)** |
| -------- | ------- |
| ![before-base](https://github.com/user-attachments/assets/2391cf31-cec9-4517-8e25-9a163ed97888)  | ![after-base](https://github.com/user-attachments/assets/72395569-b379-4463-a620-18fa0f7ed92e) |
| ![before-pct](https://github.com/user-attachments/assets/a6ef1f3a-bd85-42b5-b58f-964284c37895) | ![after-pct](https://github.com/user-attachments/assets/1b30b413-34a9-4b65-aef4-a2645a774daf) |