### PR TITLE
fix: prevent empty updated_at updates

### DIFF
--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -16,8 +16,6 @@
    [metabase.parameters.schema :as parameters.schema]
    [metabase.permissions.core :as perms]
    [metabase.public-sharing.core :as public-sharing]
-   ^{:clj-kondo/ignore [:deprecated-namespace]}
-   [metabase.pulse.core :as pulse]
    [metabase.queries.core :as queries]
    [metabase.query-processor.metadata :as qp.metadata]
    [metabase.search.core :as search]
@@ -100,11 +98,6 @@
       (collection/check-collection-namespace :model/Dashboard (:collection_id dashboard))
       (when (:archived changes)
         (t2/delete! :model/Pulse :dashboard_id (u/the-id dashboard))))))
-
-(t2/define-after-update :model/Dashboard
-  [dashboard]
-  ; TODO -- should this be done on `:event/dashboard-update` ?
-  (pulse/update-dashboard-subscription-pulses! dashboard))
 
 (defn- migrate-parameter [p]
   (cond-> p

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -501,7 +501,7 @@
         ; don't stomp on `:updated_at` if it's already explicitly specified.
         changes-already-include-updated-at? (some #{:updated_at} changed-fields)
         has-non-ignored-fields? (seq (set/difference changed-fields (non-timestamped-fields obj)))
-        should-set-updated-at? (or (empty? changed-fields) (and has-non-ignored-fields? (not changes-already-include-updated-at?)))]
+        should-set-updated-at? (and has-non-ignored-fields? (not changes-already-include-updated-at?))]
     (cond-> obj
       should-set-updated-at? (assoc :updated_at (now)))))
 

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -28,12 +28,11 @@
     (collection/check-collection-namespace :model/NativeQuerySnippet (:collection_id snippet))))
 
 (t2/define-before-update :model/NativeQuerySnippet
-  [{:keys [id], :as snippet}]
-  (u/prog1 (t2/changes snippet)
+  [snippet]
+  (u/prog1 snippet
     ;; throw an Exception if someone tries to update creator_id
-    (when (contains? <> :creator_id)
-      (when (not= (:creator_id <>) (t2/select-one-fn :creator_id :model/NativeQuerySnippet :id id))
-        (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a NativeQuerySnippet.")))))
+    (when (contains? (t2/changes <>) :creator_id)
+      (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a NativeQuerySnippet."))))
     (collection/check-collection-namespace :model/NativeQuerySnippet (:collection_id snippet))))
 
 (defmethod serdes/hash-fields :model/NativeQuerySnippet

--- a/src/metabase/pulse/core.clj
+++ b/src/metabase/pulse/core.clj
@@ -3,19 +3,15 @@
 
   This namespace is deprecated, soon everything will be migrated to notifications."
   (:require
-   [metabase.pulse.dashboard-subscription]
    [metabase.pulse.models.pulse]
    [metabase.pulse.update-alerts]
    [potemkin :as p]))
 
 (comment
-  metabase.pulse.dashboard-subscription/keep-me
   metabase.pulse.models.pulse/keep-me
   metabase.pulse.update-alerts/keep-me)
 
 (p/import-vars
- [metabase.pulse.dashboard-subscription
-  update-dashboard-subscription-pulses!]
  [metabase.pulse.models.pulse
   card->ref
   create-pulse!

--- a/src/metabase/pulse/events/dashboard_subscription.clj
+++ b/src/metabase/pulse/events/dashboard_subscription.clj
@@ -1,21 +1,25 @@
-(ns metabase.pulse.dashboard-subscription
+(ns metabase.pulse.events.dashboard-subscription
   (:require
    [clojure.set :as set]
    [metabase.app-db.core :as app-db]
+   [metabase.events.core :as events]
    [metabase.pulse.models.pulse :as models.pulse]
    [metabase.pulse.models.pulse-card :as pulse-card]
    [metabase.util :as u]
+   [methodical.core :as m]
    [toucan2.core :as t2]))
 
-;; TODO -- should this be done on `:event/dashboard-update` ??
-(defn update-dashboard-subscription-pulses!
+(derive ::dashboard-update :metabase/event)
+(derive :event/dashboard-update ::dashboard-update)
+
+(m/defmethod events/publish-event! ::dashboard-update
   "Updates the pulses' names and collection IDs, and syncs the PulseCards"
-  [dashboard]
+  [_ {dashboard :object}]
   (let [dashboard-id (u/the-id dashboard)
         affected     (app-db/query
                       {:select-distinct [[:p.id :pulse-id] [:pc.card_id :card-id]]
                        :from            [[:pulse :p]]
-                       :join            [[:pulse_card :pc] [:= :p.id :pc.pulse_id]]
+                       :left-join       [[:pulse_card :pc] [:= :p.id :pc.pulse_id]]
                        :where           [:= :p.dashboard_id dashboard-id]})]
     (when-let [pulse-ids (seq (distinct (map :pulse-id affected)))]
       (let [correct-card-ids     (->> (app-db/query

--- a/src/metabase/pulse/init.clj
+++ b/src/metabase/pulse/init.clj
@@ -1,5 +1,6 @@
 (ns metabase.pulse.init
   (:require
+   [metabase.pulse.events.dashboard-subscription]
    [metabase.pulse.events.report-timezone-updated]
    [metabase.pulse.task.email-remove-legacy-pulse]
    [metabase.pulse.task.send-pulses]))

--- a/src/metabase/pulse/models/pulse.clj
+++ b/src/metabase/pulse/models/pulse.clj
@@ -95,7 +95,7 @@
                (contains? notification :dashboard_id)
                (not= (:dashboard_id notification) dashboard_id))
       (throw (ex-info (tru "dashboard ID of a dashboard subscription cannot be modified") notification))))
-  (u/prog1 (t2/changes notification)
+  (u/prog1 notification
     (assert-valid-parameters notification)
     (collection/check-collection-namespace :model/Pulse (:collection_id notification))))
 

--- a/src/metabase/queries/models/parameter_card.clj
+++ b/src/metabase/queries/models/parameter_card.clj
@@ -35,8 +35,8 @@
 
 (t2/define-before-update :model/ParameterCard
   [pc]
-  (u/prog1 (t2/changes pc)
-    (when (:parameterized_object_type <>)
+  (u/prog1 pc
+    (when (:parameterized_object_type (t2/changes <>))
       (validate-parameterized-object-type <>))))
 
 (defn delete-all-for-parameterized-object!

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -80,12 +80,11 @@
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 
-(t2/define-before-update :model/Segment  [{:keys [id], :as segment}]
-  (u/prog1 (t2/changes segment)
-    ;; throw an Exception if someone tries to update creator_id
-    (when (contains? <> :creator_id)
-      (when (not= (:creator_id <>) (t2/select-one-fn :creator_id :model/Segment :id id))
-        (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Segment.")))))))
+(t2/define-before-update :model/Segment  [segment]
+  ;; throw an Exception if someone tries to update creator_id
+  (when (contains? (t2/changes segment) :creator_id)
+    (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Segment."))))
+  segment)
 
 (defmethod mi/perms-objects-set :model/Segment
   [segment read-or-write]

--- a/src/metabase/view_log/events/view_log.clj
+++ b/src/metabase/view_log/events/view_log.clj
@@ -16,6 +16,18 @@
    [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
 
+(def ^:private dashboard-statistics-lock
+  "keyword to use for locking dashboard updates that can deadlock"
+  ::dashboard-statistics-lock)
+
+(defn- view-count-lock
+  [model]
+  (case model
+    :model/Card cluster-lock/card-statistics-lock
+    :model/Dashboard dashboard-statistics-lock
+    (keyword "metabase.events.view_log"
+             (str (name (t2/table-name model)) "-view-count"))))
+
 (defn- group-by-frequency
   "Given a list of items, returns a map of frequencies to items.
     (group-by-frequency [:a :a :b :b :c :c :c])
@@ -36,10 +48,7 @@
                              items)]
       (doseq [[model ids] model->ids]
         (let [cnt->ids (group-by-frequency ids)
-              lock-name (if (= model :model/Card)
-                          cluster-lock/card-statistics-lock ;; need to use a shared lock for all updates to the card table
-                          (keyword "metabase.events.view_log"
-                                   (str (name (t2/table-name model)) "-view-count")))]
+              lock-name (view-count-lock model)]
           (log/debugf "Writing %d items to %s view counts with lock %s" (count ids) model lock-name)
           (cluster-lock/with-cluster-lock lock-name
             (t2/query {:update (t2/table-name model)
@@ -108,11 +117,13 @@
   (let [dashboard-id->timestamp (update-vals (group-by :id dashboard-id-timestamps)
                                              (fn [xs] (apply t/max (map :timestamp xs))))]
     (try
-      (t2/update! :model/Dashboard :id [:in (keys dashboard-id->timestamp)]
-                  {:last_viewed_at (into [:case]
-                                         (mapcat (fn [[id timestamp]]
-                                                   [[:= :id id] [:greatest [:coalesce :last_viewed_at (t/offset-date-time 0)] timestamp]])
-                                                 dashboard-id->timestamp))})
+      (cluster-lock/with-cluster-lock dashboard-statistics-lock
+        (t2/update! :model/Dashboard :id [:in (keys dashboard-id->timestamp)]
+                    {:last_viewed_at (into [:case]
+                                           (mapcat (fn [[id timestamp]]
+                                                     [[:= :id id] [:greatest [:coalesce :last_viewed_at (t/offset-date-time 0)] timestamp]])
+                                                   dashboard-id->timestamp))
+                     :updated_at :updated_at})) ;; setting last_viewed_at should not update the updated_at column
       (catch Exception e
         (log/error e "Failed to update dashboard last_viewed_at")))))
 

--- a/src/metabase/warehouse_schema/api/table.clj
+++ b/src/metabase/warehouse_schema/api/table.clj
@@ -98,7 +98,7 @@
   (when-let [changes (not-empty (u/select-keys-when body
                                                     :non-nil [:display_name :show_in_getting_started :entity_type :field_order]
                                                     :present [:description :caveats :points_of_interest :visibility_type]))]
-    (api/check-500 (pos? (t2/update! :model/Table id changes))))
+    (t2/update! :model/Table id changes))
   (let [updated-table        (t2/select-one :model/Table :id id)
         changed-field-order? (not= (:field_order updated-table) (:field_order existing-table))]
     (if changed-field-order?

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -133,8 +133,8 @@
 
 (t2/define-before-update :model/Field
   [field]
-  (u/prog1 (t2/changes field)
-    (when (false? (:active <>))
+  (u/prog1 field
+    (when (false? (:active (t2/changes <>)))
       (t2/update! :model/Field {:fk_target_field_id (:id field)} {:semantic_type      nil
                                                                   :fk_target_field_id nil}))))
 

--- a/test/metabase/channel/models/channel_test.clj
+++ b/test/metabase/channel/models/channel_test.clj
@@ -23,7 +23,7 @@
                                          :enabled true}]
     (testing "do not try to delete pulse-channel if active doesn't change"
       (is (pos? (t2/update! :model/Channel id {:name "New name"})))
-      (is (pos? (t2/update! :model/Channel id {:active true})))
+      (is (zero? (t2/update! :model/Channel id {:active true})))
       (is (t2/exists? :model/PulseChannel pc-id)))
 
     (testing "deactivate channel"

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5058,3 +5058,37 @@
                                     :base_type :type/Text}]}
                 (:param_fields (mt/with-test-user :crowberto
                                  (#'api.dashboard/get-dashboard (:id dashboard))))))))))
+
+(deftest post-update-test
+  (mt/with-temp [:model/Collection    {collection-id-1 :id} {}
+                 :model/Collection    {collection-id-2 :id} {}
+                 :model/Dashboard     {dashboard-id :id}    {:name "Lucky the Pigeon's Lucky Stuff", :collection_id collection-id-1}
+                 :model/Card          {card-id :id}         {}
+                 :model/Pulse         {pulse-id :id}        {:dashboard_id dashboard-id, :collection_id collection-id-1}
+                 :model/DashboardCard {dashcard-id :id}     {:dashboard_id dashboard-id, :card_id card-id}
+                 :model/PulseCard     _                     {:pulse_id pulse-id, :card_id card-id, :dashboard_card_id dashcard-id}]
+    (testing "Pulse name and collection-id updates"
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id)
+                            {:name "Lucky's Close Shaves" :collection_id collection-id-2})
+      (is (= "Lucky's Close Shaves"
+             (t2/select-one-fn :name :model/Pulse :id pulse-id)))
+      (is (= collection-id-2
+             (t2/select-one-fn :collection_id :model/Pulse :id pulse-id))))))
+
+(deftest post-update-card-sync-test
+  (mt/with-temp [:model/Collection    {collection-id-1 :id} {}
+                 :model/Dashboard     {dashboard-id :id}    {:name "Lucky the Pigeon's Lucky Stuff", :collection_id collection-id-1}
+                 :model/Card          {card-id :id}         {}
+                 :model/Card          {new-card-id :id}     {}
+                 :model/Pulse         {pulse-id :id}        {:dashboard_id dashboard-id, :collection_id collection-id-1}
+                 :model/DashboardCard {dashcard-id :id}     {:dashboard_id dashboard-id, :card_id card-id}
+                 :model/PulseCard     _                     {:pulse_id pulse-id, :card_id card-id, :dashboard_card_id dashcard-id}]
+    (testing "PulseCard syncing"
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id)
+                            {:dashcards [{:id 100
+                                          :card_id new-card-id
+                                          :row     0
+                                          :col     0
+                                          :size_x  4
+                                          :size_y  4}]})
+      (is (not (nil? (t2/select-one :model/PulseCard :card_id new-card-id)))))))

--- a/test/metabase/dashboards/models/dashboard_test.clj
+++ b/test/metabase/dashboards/models/dashboard_test.clj
@@ -99,30 +99,6 @@
         (is (nil? (t2/select-one :model/Pulse pulse-id)))
         (is (= 0 (count (pulse-channel-test/send-pulse-triggers pulse-id))))))))
 
-(deftest post-update-test
-  (mt/with-temp [:model/Collection    {collection-id-1 :id} {}
-                 :model/Collection    {collection-id-2 :id} {}
-                 :model/Dashboard     {dashboard-id :id}    {:name "Lucky the Pigeon's Lucky Stuff", :collection_id collection-id-1}
-                 :model/Card          {card-id :id}         {}
-                 :model/Pulse         {pulse-id :id}        {:dashboard_id dashboard-id, :collection_id collection-id-1}
-                 :model/DashboardCard {dashcard-id :id}     {:dashboard_id dashboard-id, :card_id card-id}
-                 :model/PulseCard     _                     {:pulse_id pulse-id, :card_id card-id, :dashboard_card_id dashcard-id}]
-    (testing "Pulse name and collection-id updates"
-      (t2/update! :model/Dashboard dashboard-id {:name "Lucky's Close Shaves" :collection_id collection-id-2})
-      (is (= "Lucky's Close Shaves"
-             (t2/select-one-fn :name :model/Pulse :id pulse-id)))
-      (is (= collection-id-2
-             (t2/select-one-fn :collection_id :model/Pulse :id pulse-id))))
-    (testing "PulseCard syncing"
-      (mt/with-temp [:model/Card {new-card-id :id}]
-        (dashboard/add-dashcards! dashboard-id [{:card_id new-card-id
-                                                 :row     0
-                                                 :col     0
-                                                 :size_x  4
-                                                 :size_y  4}])
-        (t2/update! :model/Dashboard dashboard-id {:name "Lucky's Close Shaves"})
-        (is (not (nil? (t2/select-one :model/PulseCard :card_id new-card-id))))))))
-
 (deftest parameter-card-test
   (testing "A new dashboard creates a new ParameterCard"
     (mt/with-temp [:model/Card      {card-id :id}      {}

--- a/test/metabase/segments/models/segment_test.clj
+++ b/test/metabase/segments/models/segment_test.clj
@@ -44,7 +44,7 @@
              (t2/update! :model/Segment id {:creator_id nil}))))
 
       (testing "calling `update!` with a value that is the same as the current value shouldn't throw an Exception"
-        (is (= 1
+        (is (= 0
                (t2/update! :model/Segment id {:creator_id (mt/user->id :rasta)})))))))
 
 (deftest identity-hash-test

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -351,7 +351,9 @@
               (t2/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
                 ;; 1. delete the fields that were just synced
                 (t2/delete! :model/Field :table_id [:in (map :id tables)])
-                ;; 2. sync the metadata for each table
+                ;; 2. reset the sync status for each table
+                (t2/update! :model/Table :id [:in (map :id tables)] {:initial_sync_status "incomplete"})
+                ;; 3. sync the metadata for each table
                 (if (= "for entire DB" message)
                   (let [tables-updated (atom nil)
                         original-set-initial-table-sync-complete-for-db! sync-util/set-initial-table-sync-complete-for-db!]

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -1140,19 +1140,19 @@
 (deftest field-ordering-test
   (let [original-field-order (t2/select-one-fn :field_order :model/Table :id (mt/id :venues))]
     (try
-      (testing "Cane we set alphabetical field ordering?"
+      (testing "Can we set alphabetical field ordering?"
         (is (= ["CATEGORY_ID" "ID" "LATITUDE" "LONGITUDE" "NAME" "PRICE"]
                (->> (mt/user-http-request :crowberto :put 200 (format "table/%s" (mt/id :venues))
                                           {:field_order :alphabetical})
                     :fields
                     (map :name)))))
-      (testing "Cane we set smart field ordering?"
+      (testing "Can we set smart field ordering?"
         (is (= ["ID" "NAME" "CATEGORY_ID" "LATITUDE" "LONGITUDE" "PRICE"]
                (->> (mt/user-http-request :crowberto :put 200 (format "table/%s" (mt/id :venues))
                                           {:field_order :smart})
                     :fields
                     (map :name)))))
-      (testing "Cane we set database field ordering?"
+      (testing "Can we set database field ordering?"
         (is (= ["ID" "NAME" "CATEGORY_ID" "LATITUDE" "LONGITUDE" "PRICE"]
                (->> (mt/user-http-request :crowberto :put 200 (format "table/%s" (mt/id :venues))
                                           {:field_order :database})


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #58802

### Description

Fixes the updated-at timestamp hook to not generate an `updated_at = now()` sql statement when there are no changes. This prevents us from sending spurious updates which can cause database deadlocks in conjunction with other bulk updates like the last_viewed_at and view_count updates. 

As part of that this fixes bugs where we were returning the value of `t2/changes` from before-update calls rather than just returning the provided value (or the provided value with whatever other changes we wanted). 

Moves the dashboard to pulse sync function to use the dashboard-updated event and fixes a bug in it where we would not create new PulseCards if an API request completely replaced dashcards in a dashboard. 

Also uses cluster locking around both last_viewed_at and view_count updates for report_dashboard models.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
