### PR TITLE
Make snowflake tests not required (temporarily)

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1097,7 +1097,7 @@ jobs:
       - be-tests-postgres
       - be-tests-presto-jdbc-ee
       - be-tests-redshift-ee
-      - be-tests-snowflake-ee
+      # - be-tests-snowflake-ee FIXME temporarily disabled DRI-325
       - be-tests-sparksql-ee
       - be-tests-sqlite-ee
       - be-tests-sqlserver


### PR DESCRIPTION
See https://metaboat.slack.com/archives/C5XHN8GLW/p1748897622247079
ticket to re-enable: DRI-325