### PR TITLE
Optimize delete children

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -45,6 +45,7 @@
            events
            legacy-mbql
            lib
+           lib-be
            model-persistence
            models
            permissions

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -200,16 +200,7 @@
                     2 98}
                    (children-count))))
           (testing "delete without delete-children param will return errors with children count"
-            (is (=? {:errors [{:index     0
-                               :type      "metabase.actions.error/violate-foreign-key-constraint"
-                               :message  "Other tables rely on this row so it cannot be deleted."
-                               :errors   {}
-                               :children {(mt/id :orders) 93}}
-                              {:index    1
-                               :type     "metabase.actions.error/violate-foreign-key-constraint"
-                               :message  "Other tables rely on this row so it cannot be deleted."
-                               :errors   {}
-                               :children {(mt/id :orders) 98}}]}
+            (is (=? {:errors {:type "metabase.actions.error/children-exist", :children-count {(mt/id :orders) 191}}}
                     (mt/user-http-request :crowberto :post 400 execute-v2-url
                                           body))))
 

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -9,6 +9,7 @@
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.store :as qp.store]
@@ -170,28 +171,29 @@
    ;; Since the inner map shape will depend on action-kw, we will need to dynamically validate it.
    inputs    :- [:sequential :map]
    & {:as _opts}]
-  (let [invocation-id  (nano-id/nano-id)
-        context-before (-> (assoc ctx :invocation-id invocation-id)
-                           (update :invocation-stack u/conjv [action-kw invocation-id]))]
-    (actions.events/publish-action-invocation! action-kw context-before inputs)
-    (try
-      (u/prog1 (perform-action!* action-kw context-before inputs)
-        (let [{context-after :context, :keys [outputs]} <>]
-          (doseq [k [:invocation-id :invocation-stack :user-id]]
-            (assert (= (k context-before) (k context-after)) (format "Output context must not change %s" k)))
-          ;; We might in future want effects to propagate all the up to the root scope ¯\_(ツ)_/¯
-          (handle-effects! context-after)
-          (actions.events/publish-action-success! action-kw context-after outputs)))
-      ;; Err on the side of visibility. We may want to handle Errors differently when we polish Internal Tools.
-      (catch Throwable e
-        (let [msg  (ex-message e)
-              ;; Can't be nil or adding metadata will NPE
-              info (or (ex-data e) {})
-              ;; TODO Why metadata? Not sure anything is reading this, and it'll get lost if we serialize error events.
-              info (with-meta info (merge (meta info) {:exception e}))]
-          ;; Need to think about how we learn about already performed effects this way, since we don't get a context.
-          (actions.events/publish-action-failure! action-kw context-before msg info)
-          (throw e))))))
+  (lib.metadata.jvm/with-metadata-provider-cache
+    (let [invocation-id  (nano-id/nano-id)
+          context-before (-> (assoc ctx :invocation-id invocation-id)
+                             (update :invocation-stack u/conjv [action-kw invocation-id]))]
+      (actions.events/publish-action-invocation! action-kw context-before inputs)
+      (try
+        (u/prog1 (perform-action!* action-kw context-before inputs)
+          (let [{context-after :context, :keys [outputs]} <>]
+            (doseq [k [:invocation-id :invocation-stack :user-id]]
+              (assert (= (k context-before) (k context-after)) (format "Output context must not change %s" k)))
+           ;; We might in future want effects to propagate all the up to the root scope ¯\_(ツ)_/¯
+            (handle-effects! context-after)
+            (actions.events/publish-action-success! action-kw context-after outputs)))
+       ;; Err on the side of visibility. We may want to handle Errors differently when we polish Internal Tools.
+        (catch Throwable e
+          (let [msg  (ex-message e)
+               ;; Can't be nil or adding metadata will NPE
+                info (or (ex-data e) {})
+               ;; TODO Why metadata? Not sure anything is reading this, and it'll get lost if we serialize error events.
+                info (with-meta info (merge (meta info) {:exception e}))]
+           ;; Need to think about how we learn about already performed effects this way, since we don't get a context.
+            (actions.events/publish-action-failure! action-kw context-before msg info)
+            (throw e)))))))
 
 (defn perform-nested-action!
   "Similar to [[perform-action!]] but taking an existing context.
@@ -223,7 +225,7 @@
   "Uses cache to prevent redundant look-ups with an action call chain."
   [table-id]
   (assert table-id "Id cannot be nil")
-  (cached-database (:db_id (cached-value [:table-by-db-ids table-id] #(t2/select-one [:model/Table :name :db_id] table-id)))))
+  (cached-database (:db_id (cached-value [:table-by-db-ids table-id] #(t2/select-one [:model/Table :db_id] table-id)))))
 
 (mu/defn perform-action!
   "Perform an *implicit* `action`. Invoke this function for performing actions, e.g. in API endpoints;

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -211,11 +211,19 @@
                 #(qp.store/with-metadata-provider db-id
                    (lib.metadata/database (qp.store/metadata-provider)))))
 
+(defn cached-table
+  "Uses cache to prevent redundant look-ups with an action call chain."
+  [db-id table-id]
+  (assert db-id "Id cannot be nil")
+  (cached-value [:tables table-id]
+                #(qp.store/with-metadata-provider db-id
+                   (lib.metadata/table (qp.store/metadata-provider) table-id))))
+
 (defn cached-database-via-table-id
   "Uses cache to prevent redundant look-ups with an action call chain."
   [table-id]
   (assert table-id "Id cannot be nil")
-  (cached-database (:db_id (cached-value [:tables table-id] #(t2/select-one [:model/Table :db_id] table-id)))))
+  (cached-database (:db_id (cached-value [:table-by-db-ids table-id] #(t2/select-one [:model/Table :name :db_id] table-id)))))
 
 (mu/defn perform-action!
   "Perform an *implicit* `action`. Invoke this function for performing actions, e.g. in API endpoints;

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -35,6 +35,7 @@
   action-arg-map-spec
   normalize-action-arg-map]
  [metabase.actions.error
+  children-exist
   incorrect-value-type
   violate-foreign-key-constraint
   violate-not-null-constraint

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -26,6 +26,7 @@
   check-data-editing-enabled-for-database!
   cached-database
   cached-database-via-table-id
+  cached-table
   handle-effects!*
   perform-action!
   ;; allow actions to be defined in the data-editing module

--- a/src/metabase/actions/error.clj
+++ b/src/metabase/actions/error.clj
@@ -15,3 +15,7 @@
 (def incorrect-value-type
   "Error type for SQL incorrect value type."
   ::incorrect-value-type)
+
+(def children-exist
+  "Error type for when trying to delete a row that has dependent children rows."
+  ::children-exist)

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.sql-jdbc.actions
+  #_{:clj-kondo/ignore [:discouraged-namespace]} ;; for using toucan2 in this ns
   (:require
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as str]

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -771,23 +771,23 @@
                                   field-name->id (table-id->pk-field-name->id (:id database) table-id)]
                               [table-id (keys field-name->id)]))
         delete-children?  (:delete-children actions/*params*)
-        [errors results] (batch-execution-by-table-id!
-                          {:inputs        inputs
-                           :row-action    :model.row/delete
-                           :row-fn        (if delete-children? row-delete!*-with-children row-delete!*)
-                           :validate-fn   (fn [database table-id rows]
-                                            (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]
-                                              (check-consistent-row-keys rows)
-                                              (check-rows-have-expected-columns-and-no-other-keys rows (keys pk-name->id))
-                                              (check-unique-rows rows)
-                                              (when-not delete-children?
-                                                (check-rows-have-no-children (:id database) table-id rows))))
-                           :input-fn      (fn [{db-id :id} table-id row]
-                                            {:database db-id
-                                             :type     :query
-                                             :query    {:source-table table-id
-                                                        :filter       (row->mbql-filter-clause
-                                                                       (table-id->pk-field-name->id db-id table-id) row)}})})]
+        [errors results]  (batch-execution-by-table-id!
+                           {:inputs        inputs
+                            :row-action    :model.row/delete
+                            :row-fn        (if delete-children? row-delete!*-with-children row-delete!*)
+                            :validate-fn   (fn [database table-id rows]
+                                             (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]
+                                               (check-consistent-row-keys rows)
+                                               (check-rows-have-expected-columns-and-no-other-keys rows (keys pk-name->id))
+                                               (check-unique-rows rows)
+                                               (when-not delete-children?
+                                                 (check-rows-have-no-children (:id database) table-id rows))))
+                            :input-fn      (fn [{db-id :id} table-id row]
+                                             {:database db-id
+                                              :type     :query
+                                              :query    {:source-table table-id
+                                                         :filter       (row->mbql-filter-clause
+                                                                        (table-id->pk-field-name->id db-id table-id) row)}})})]
     (when (seq errors)
       (throw (ex-info (tru "Error(s) deleting rows.")
                       {:status-code 400


### PR DESCRIPTION
- Optimized 
  - delete 1 row:  126ms (62 DB calls) vs 84ms (41 DB calls)
  - delete 3 rows: 294ms (137 DB calls) vs 90ms (55 DB calls)
  - I'm pretty sure others actions are benefited as well as one of the optimization was to cache metadata provider
    - update reduced from 51 to 39 calls for a single update
- Changed to check row descendants on normal deletion => even deleting rows from table with cascade delete will also be detected ( it was ignored before )
- New error response:
```json
{
  "errors": {
    "type": "metabase.actions.error/children-exist",
    "children-count": {
      "2": 98
    }
  }
}
```
