### PR TITLE
Add :params argument to v2/execute

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -153,7 +153,7 @@
 
 (api.macros/defendpoint :delete "/webhook/:token"
   "Deletes a webhook endpoint token."
-  [{:keys [token]}
+  [{:keys [token]} :- [:map [:token [:string {:api/regex #"[0-9a-zA-Z-_]+"}]]]
    _
    _]
   (check-permissions)

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -406,12 +406,14 @@
             action-kw   (:action-kw row-action)
             ;; TODO probably take the row separately from inputs
             pks         inputs
-            inputs      (apply-mapping (:mapping unified) (apply-mapping (:mapping row-action) inputs))]
+            inputs      (->> inputs
+                             (apply-mapping (:mapping row-action))
+                             (apply-mapping (:mapping unified)))]
         (cond
           saved-id
-          (execute-dashcard-row-action-on-saved-action! saved-id dashcard-id pks inputs ::row-mapping)
+          (execute-dashcard-row-action-on-saved-action! saved-id dashcard-id pks inputs ::mapping-placeholder)
           action-kw
-          (execute-dashcard-row-action-on-primitive-action! action-kw scope dashcard-id pks inputs ::row-mapping)))
+          (execute-dashcard-row-action-on-primitive-action! action-kw scope dashcard-id pks inputs ::mapping-placeholder)))
       :else
       (throw (ex-info "Not able to execute given action yet" {:status-code 500, :scope scope, :unified unified})))))
 

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -900,13 +900,14 @@
                   (is (= 403 (:status (req {:user      :rasta
                                             :action_id (:id action)
                                             :scope     {:dashcard-id (:id dashcard)}
-                                            :input     {:id 1 :status "approved"}})))))
+                                            :input     {:id 1}
+                                            :params    {:status "approved"}})))))
                 (testing "non-row action modifying a row"
                   (testing "underlying row does not exist, action not executed"
                     (is (= 400 (:status (req {:action_id (:id action)
                                               :scope     {:dashcard-id (:id dashcard)}
-                                              :input     {:id     1
-                                                          :status "approved"}})))))
+                                              :input     {:id 1}
+                                              :params    {:status "approved"}})))))
                   (testing "underlying row exists, action executed"
                     (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
                                           {:rows [{:name "Widgets", :status "waiting"}]})
@@ -914,16 +915,16 @@
                             :body   {:outputs [{:rows-updated 1}]}}
                            (-> (req {:action_id (:id action)
                                      :scope     {:dashcard-id (:id dashcard)}
-                                     :input     {:id     1
-                                                 :status "approved"}})
+                                     :input     {:id 1}
+                                     :params    {:status "approved"}})
                                (select-keys [:status :body]))))))
                 (testing "dashcard row action modifying a row - implicit action"
                   (let [action-id "dashcard:unknown:abcdef"]
                     (testing "underlying row does not exist, action not executed"
                       (is (= 404 (:status (req {:action_id action-id
                                                 :scope     {:dashcard-id (:id dashcard)}
-                                                :input     {:id     2
-                                                            :status "approved"}})))))
+                                                :input     {:id 2}
+                                                :params    {:status "approved"}})))))
                     (testing "underlying row exists, action executed"
                       (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
                                             {:rows [{:name "Sprockets", :status "waiting"}]})
@@ -931,16 +932,16 @@
                               :body   {:outputs [{:rows-updated 1}]}}
                              (-> (req {:action_id action-id
                                        :scope     {:dashcard-id (:id dashcard)}
-                                       :input     {:id     2
-                                                   :status "approved"}})
+                                       :input     {:id 2}
+                                       :params    {:status "approved"}})
                                  (select-keys [:status :body])))))))
                 (testing "dashcard row action modifying a row - primitive action"
                   (let [action-id "dashcard:unknown:fedcba"]
                     (testing "underlying row does not exist, action not executed"
                       (is (= 404 (:status (req {:action_id action-id
                                                 :scope     {:dashcard-id (:id dashcard)}
-                                                :input     {:id     3
-                                                            :status "approved"}})))))
+                                                :input     {:id 3}
+                                                :params    {:status "approved"}})))))
                     (testing "underlying row exists, action executed"
                       (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
                                             {:rows [{:name "Braai tongs", :status "waiting"}]})
@@ -950,8 +951,8 @@
                                                   :row      {:id 3, :name "Braai tongs", :status "approved"}}]}}
                              (-> (req {:action_id action-id
                                        :scope     {:dashcard-id (:id dashcard)}
-                                       :input     {:id     3
-                                                   :status "approved"}})
+                                       :input     {:id 3}
+                                       :params    {:status "approved"}})
                                  (select-keys [:status :body])))))))
                 (testing "dashcard row action modifying a row - encoded action"
                   (let [action-id "dashcard:unknown:xyzabc"]
@@ -969,8 +970,8 @@
                                                   :row      {:id 4, :name "Salad spinners", :status "approved"}}]}}
                              (-> (req {:action_id action-id
                                        :scope     {:dashcard-id (:id dashcard)}
-                                       :input     {:id     4
-                                                   :status "approved"}})
+                                       :input     {:id 4}
+                                       :params    {:status "approved"}})
                                  (select-keys [:status :body])))))))))))))))
 
 (deftest list-and-add-to-dashcard-test

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -788,6 +788,7 @@
         [errors results] (batch-execution-by-table-id!
                           {:inputs        inputs
                            :row-action    :model.row/delete
+                           ;; TODO :delete-children should get passed in as part of inputs, and we should get rid of *params*
                            :row-fn        (if (:delete-children actions/*params*) row-delete!*-with-children row-delete!*)
                            :validate-fn   (fn [database table-id rows]
                                             (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]


### PR DESCRIPTION
Even when you're executing bulk actions (e.g. bulk update rows), you'll still be served with single flat form for manual input. So, this starts out as convenience to have another (singular) slot to put values which should be implicitly repeated.

This manual input will also superseded data that comes from the underlying rows, so for row actions it also makes sense to separate it from the `:input` data which is taken verbatim from the visible rows in the given table.

This also introduces a generic `:mapping` notion which allows us to remove a bunch of hard coding for some magic behavior in a few places.

Update: Ngoc preempted my slightly in adding params himself. With `:mapping` we'll be able to get rid of his dynamic var hack in a subsequent PR!