### PR TITLE
Disallow aggregations in filters and custom columns

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -203,6 +203,12 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     H.CustomExpressionEditor.get().findByText('"baz"').click();
     verifyHelptextPosition('"baz"');
   });
+
+  it("should not show helptext for functions that are not supported by the expression mode", () => {
+    addCustomColumn();
+    H.CustomExpressionEditor.type("Average([Price]){leftarrow}{leftarrow}");
+    H.CustomExpressionEditor.helpText().should("not.exist");
+  });
 });
 
 const addCustomColumn = () => {

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -2023,3 +2023,36 @@ describe.skip("issue 58371", () => {
     );
   });
 });
+
+describe("Issue 58230", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.openOrdersTable({ mode: "notebook" });
+  });
+
+  it("should display an error when using an aggregation function in a custom column (metabase#58230)", () => {
+    H.getNotebookStep("data").button("Custom column").click();
+    H.CustomExpressionEditor.type("Average([Total])");
+    H.popover().findByText(
+      "Aggregations like Average are not allowed when building a custom expression",
+    );
+  });
+
+  it("should display an error when using an aggregation function in a custom filter (metabase#58230)", () => {
+    H.filter({ mode: "notebook" });
+    H.popover().findByText("Custom Expression").click();
+    H.CustomExpressionEditor.type("Average([Total])");
+    H.popover().findByText(
+      "Aggregations like Average are not allowed when building a custom filter",
+    );
+  });
+
+  it("should not display an error when using an aggregation function in a custom aggregation (metabase#58230)", () => {
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Custom Expression").click();
+    H.CustomExpressionEditor.type("Average([Total])");
+    H.CustomExpressionEditor.nameInput().type("Foo");
+    H.popover().button("Done").should("be.enabled");
+  });
+});

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -407,6 +407,104 @@ describe("diagnostics", () => {
         );
       });
     });
+
+    it("should reject aggregations functions in expression mode", () => {
+      const mode = "expression";
+      expect(err("CumulativeCount([Total])", mode)).toBe(
+        "Aggregations like CumulativeCount are not allowed when building a custom expression",
+      );
+      expect(err("CumulativeSum([Total])", mode)).toBe(
+        "Aggregations like CumulativeSum are not allowed when building a custom expression",
+      );
+      expect(err("Count([Total])", mode)).toBe(
+        "Aggregations like Count are not allowed when building a custom expression",
+      );
+      expect(err("Sum([Total])", mode)).toBe(
+        "Aggregations like Sum are not allowed when building a custom expression",
+      );
+      expect(err("Distinct([Total])", mode)).toBe(
+        "Aggregations like Distinct are not allowed when building a custom expression",
+      );
+      expect(err("Average([Total])", mode)).toBe(
+        "Aggregations like Average are not allowed when building a custom expression",
+      );
+      expect(err("Median([Total])", mode)).toBe(
+        "Aggregations like Median are not allowed when building a custom expression",
+      );
+      expect(err("Min([Total])", mode)).toBe(
+        "Aggregations like Min are not allowed when building a custom expression",
+      );
+      expect(err("Max([Total])", mode)).toBe(
+        "Aggregations like Max are not allowed when building a custom expression",
+      );
+      expect(err("Share([Total] = 10)", mode)).toBe(
+        "Aggregations like Share are not allowed when building a custom expression",
+      );
+      expect(err("CountIf([Total] = 10)", mode)).toBe(
+        "Aggregations like CountIf are not allowed when building a custom expression",
+      );
+      expect(err("DistinctIf([Total], [Tax] = 10)", mode)).toBe(
+        "Aggregations like DistinctIf are not allowed when building a custom expression",
+      );
+      expect(err("SumIf([Total], [Tax] = 10)", mode)).toBe(
+        "Aggregations like SumIf are not allowed when building a custom expression",
+      );
+      expect(err("Variance([Total])", mode)).toBe(
+        "Aggregations like Variance are not allowed when building a custom expression",
+      );
+      expect(err("Percentile([Total], 0.9)", mode)).toBe(
+        "Aggregations like Percentile are not allowed when building a custom expression",
+      );
+    });
+
+    it("should reject aggregations functions in filter mode", () => {
+      const mode = "filter";
+      expect(err("CumulativeCount([Total] > 1)", mode)).toBe(
+        "Aggregations like CumulativeCount are not allowed when building a custom filter",
+      );
+      expect(err("CumulativeSum([Total] > 1)", mode)).toBe(
+        "Aggregations like CumulativeSum are not allowed when building a custom filter",
+      );
+      expect(err("Count([Total] > 1)", mode)).toBe(
+        "Aggregations like Count are not allowed when building a custom filter",
+      );
+      expect(err("Sum([Total])", mode)).toBe(
+        "Aggregations like Sum are not allowed when building a custom filter",
+      );
+      expect(err("Distinct([Total])", mode)).toBe(
+        "Aggregations like Distinct are not allowed when building a custom filter",
+      );
+      expect(err("Average([Total])", mode)).toBe(
+        "Aggregations like Average are not allowed when building a custom filter",
+      );
+      expect(err("Median([Total])", mode)).toBe(
+        "Aggregations like Median are not allowed when building a custom filter",
+      );
+      expect(err("Min([Total])", mode)).toBe(
+        "Aggregations like Min are not allowed when building a custom filter",
+      );
+      expect(err("Max([Total])", mode)).toBe(
+        "Aggregations like Max are not allowed when building a custom filter",
+      );
+      expect(err("Share([Total] = 10)", mode)).toBe(
+        "Aggregations like Share are not allowed when building a custom filter",
+      );
+      expect(err("CountIf([Total] = 10)", mode)).toBe(
+        "Aggregations like CountIf are not allowed when building a custom filter",
+      );
+      expect(err("DistinctIf([Total], [Tax] = 10)", mode)).toBe(
+        "Aggregations like DistinctIf are not allowed when building a custom filter",
+      );
+      expect(err("SumIf([Total], [Tax] = 10)", mode)).toBe(
+        "Aggregations like SumIf are not allowed when building a custom filter",
+      );
+      expect(err("Variance([Total])", mode)).toBe(
+        "Aggregations like Variance are not allowed when building a custom filter",
+      );
+      expect(err("Percentile([Total], 0.9)", mode)).toBe(
+        "Aggregations like Percentile are not allowed when building a custom filter",
+      );
+    });
   });
 
   describe("diagnoseAndCompile", () => {

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
@@ -1,9 +1,7 @@
 import * as Lib from "metabase-lib";
 
-import { ExpressionError } from "../../errors";
-import { assertModeSupportsClause } from "../../mode";
+import { checkExpressionModeSupportsClause } from "../../mode";
 import { visit } from "../../visitor";
-import { error } from "../utils";
 
 export function checkFunctionsForExpressionMode({
   expressionParts,
@@ -21,13 +19,12 @@ export function checkFunctionsForExpressionMode({
       return;
     }
 
-    try {
-      assertModeSupportsClause(expressionMode, node.operator);
-    } catch (err) {
-      if (err instanceof ExpressionError) {
-        error(node, err.message);
-      }
-      throw err;
+    const error = checkExpressionModeSupportsClause(
+      expressionMode,
+      node.operator,
+    );
+    if (error !== null) {
+      throw error;
     }
   });
 }

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
@@ -1,8 +1,7 @@
-import { t } from "ttag";
-
 import * as Lib from "metabase-lib";
 
-import { getClauseDefinition } from "../../clause";
+import { ExpressionError } from "../../errors";
+import { assertModeSupportsClause } from "../../mode";
 import { visit } from "../../visitor";
 import { error } from "../utils";
 
@@ -18,20 +17,13 @@ export function checkFunctionsForExpressionMode({
       return;
     }
 
-    if (expressionMode === "aggregation") {
-      return;
-    }
-
-    const { operator } = node;
-    const clause = getClauseDefinition(operator);
-    if (!clause) {
-      return;
-    }
-
-    if (clause.type === "aggregation") {
-      error(
-        t`Aggregations like ${clause.displayName} are not allowed when building a custom ${expressionMode}`,
-      );
+    try {
+      assertModeSupportsClause(expressionMode, node.operator);
+    } catch (err) {
+      if (err instanceof ExpressionError) {
+        error(node, err.message);
+      }
+      throw err;
     }
   });
 }

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
@@ -1,0 +1,37 @@
+import { t } from "ttag";
+
+import * as Lib from "metabase-lib";
+
+import { getClauseDefinition } from "../../clause";
+import { visit } from "../../visitor";
+import { error } from "../utils";
+
+export function checkFunctionsForExpressionMode({
+  expressionParts,
+  expressionMode,
+}: {
+  expressionParts: Lib.ExpressionParts | Lib.ExpressionArg;
+  expressionMode: Lib.ExpressionMode;
+}) {
+  visit(expressionParts, (node) => {
+    if (!Lib.isExpressionParts(node)) {
+      return;
+    }
+
+    if (expressionMode === "aggregation") {
+      return;
+    }
+
+    const { operator } = node;
+    const clause = getClauseDefinition(operator);
+    if (!clause) {
+      return;
+    }
+
+    if (clause.type === "aggregation") {
+      error(
+        t`Aggregations like ${clause.displayName} are not allowed when building a custom ${expressionMode}`,
+      );
+    }
+  });
+}

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-functions-for-expression-mode.ts
@@ -17,6 +17,10 @@ export function checkFunctionsForExpressionMode({
       return;
     }
 
+    if (node.operator === "value") {
+      return;
+    }
+
     try {
       assertModeSupportsClause(expressionMode, node.operator);
     } catch (err) {

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/index.ts
@@ -5,6 +5,7 @@ import { checkArgCount } from "./check-arg-count";
 import { checkArgValidators } from "./check-arg-validators";
 import { checkCaseOrIfArgCount } from "./check-case-or-if-arg-count";
 import { checkComparisonOperatorArgs } from "./check-comparison-operator-args";
+import { checkFunctionsForExpressionMode } from "./check-functions-for-expression-mode";
 import { checkKnownFunctions } from "./check-known-functions";
 import { checkLibDiagnostics } from "./check-lib-diagnostics";
 import { checkSupportedFunctions } from "./check-supported-functions";
@@ -12,6 +13,7 @@ import { checkSupportedFunctions } from "./check-supported-functions";
 const expressionChecks = [
   checkKnownFunctions,
   checkSupportedFunctions,
+  checkFunctionsForExpressionMode,
   checkArgValidators,
   checkArgCount,
   checkComparisonOperatorArgs,

--- a/frontend/src/metabase-lib/v1/expressions/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/index.ts
@@ -6,4 +6,5 @@ export * from "./diagnostics";
 export * from "./position";
 export * from "./errors";
 export * from "./clause";
+export * from "./mode";
 export * from "./help-text";

--- a/frontend/src/metabase-lib/v1/expressions/mode.ts
+++ b/frontend/src/metabase-lib/v1/expressions/mode.ts
@@ -5,6 +5,16 @@ import type * as Lib from "metabase-lib";
 import { getClauseDefinition, isDefinedClause } from "./clause";
 import { DiagnosticError } from "./errors";
 
+const MODE_DISPLAY_NAMES: Record<Lib.ExpressionMode, () => string> = {
+  expression: () => t`expression`,
+  filter: () => t`filter`,
+  aggregation: () => t`aggregation`,
+};
+
+export function expressionModeDisplayName(expressionMode: Lib.ExpressionMode) {
+  return MODE_DISPLAY_NAMES[expressionMode]();
+}
+
 export function expressionModeSupportsClause(
   expressionMode: Lib.ExpressionMode,
   operator: string,
@@ -27,8 +37,8 @@ export function assertModeSupportsClause(
 
   const clause = getClauseDefinition(operator);
   if (clause.type === "aggregation" && expressionMode !== "aggregation") {
-    throw new DiagnosticError(
-      t`Aggregations like ${clause.displayName} are not allowed when building a custom ${expressionMode}`,
+    return new DiagnosticError(
+      t`Aggregations like ${clause.displayName} are not allowed when building a custom ${expressionModeDisplayName(expressionMode)}`,
     );
   }
 }

--- a/frontend/src/metabase-lib/v1/expressions/mode.ts
+++ b/frontend/src/metabase-lib/v1/expressions/mode.ts
@@ -1,0 +1,34 @@
+import { t } from "ttag";
+
+import type * as Lib from "metabase-lib";
+
+import { getClauseDefinition, isDefinedClause } from "./clause";
+import { DiagnosticError } from "./errors";
+
+export function expressionModeSupportsClause(
+  expressionMode: Lib.ExpressionMode,
+  operator: string,
+) {
+  try {
+    assertModeSupportsClause(expressionMode, operator);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function assertModeSupportsClause(
+  expressionMode: Lib.ExpressionMode,
+  operator: string,
+) {
+  if (!isDefinedClause(operator)) {
+    throw new DiagnosticError(t`Unknown operator ${operator}`);
+  }
+
+  const clause = getClauseDefinition(operator);
+  if (clause.type === "aggregation" && expressionMode !== "aggregation") {
+    throw new DiagnosticError(
+      t`Aggregations like ${clause.displayName} are not allowed when building a custom ${expressionMode}`,
+    );
+  }
+}

--- a/frontend/src/metabase-lib/v1/expressions/mode.ts
+++ b/frontend/src/metabase-lib/v1/expressions/mode.ts
@@ -19,15 +19,11 @@ export function expressionModeSupportsClause(
   expressionMode: Lib.ExpressionMode,
   operator: string,
 ) {
-  try {
-    assertModeSupportsClause(expressionMode, operator);
-    return true;
-  } catch {
-    return false;
-  }
+  const error = checkExpressionModeSupportsClause(expressionMode, operator);
+  return error === null;
 }
 
-export function assertModeSupportsClause(
+export function checkExpressionModeSupportsClause(
   expressionMode: Lib.ExpressionMode,
   operator: string,
 ) {
@@ -41,4 +37,6 @@ export function assertModeSupportsClause(
       t`Aggregations like ${clause.displayName} are not allowed when building a custom ${expressionModeDisplayName(expressionMode)}`,
     );
   }
+
+  return null;
 }

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -107,6 +107,7 @@ export function Editor(props: EditorProps) {
         stageIndex={stageIndex}
         metadata={metadata}
         reportTimezone={reportTimezone}
+        expressionMode={expressionMode}
         {...props}
       />
     ),

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.stories.tsx
@@ -29,6 +29,7 @@ const Template: StoryFn<typeof HelpText> = () => {
           arg: null,
         }}
         reportTimezone="America/Los_Angeles"
+        expressionMode="expression"
       />
     </ReduxProvider>
   );

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.tsx
@@ -15,6 +15,7 @@ import { Box, Flex, Icon, UnstyledButton } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import {
   type HelpText,
+  expressionModeSupportsClause,
   getClauseDefinition,
   getHelpText,
 } from "metabase-lib/v1/expressions";
@@ -47,6 +48,7 @@ export type HelpTextProps = {
   query: Lib.Query;
   metadata: Metadata;
   reportTimezone?: string;
+  expressionMode: Lib.ExpressionMode;
 };
 
 function getDatabase(query: Lib.Query, metadata: Metadata) {
@@ -78,6 +80,7 @@ export function HelpText({
   query,
   metadata,
   reportTimezone,
+  expressionMode,
 }: HelpTextProps) {
   const database = getDatabase(query, metadata);
   const helpText =
@@ -86,7 +89,10 @@ export function HelpText({
       : null;
 
   const clause = helpText && getClauseDefinition(helpText.name);
-  const isSupported = clause && database?.hasFeature(clause?.requiresFeature);
+  const isSupported =
+    clause &&
+    database?.hasFeature(clause?.requiresFeature) &&
+    expressionModeSupportsClause(expressionMode, clause.name);
 
   const { url: docsUrl, showMetabaseLinks } = useDocsUrl(
     helpText?.docsUrl ?? "",

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/tests/common.unit.spec.tsx
@@ -37,6 +37,7 @@ describe("HelpText (OSS)", () => {
       enclosingFunction: {
         name: "cum-count",
       },
+      expressionMode: "aggregation",
     });
 
     const exampleCodeEl = screen.getByTestId(

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/tests/setup.tsx
@@ -3,6 +3,7 @@ import { createMockMetadata } from "__support__/metadata";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
+import type * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
 import { getHelpText } from "metabase-lib/v1/expressions";
 import type { TokenFeatures } from "metabase-types/api";
@@ -22,6 +23,7 @@ export interface SetupOpts {
   showMetabaseLinks?: boolean;
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
+  expressionMode?: Lib.ExpressionMode;
 }
 
 export async function setup({
@@ -30,6 +32,7 @@ export async function setup({
   showMetabaseLinks = true,
   hasEnterprisePlugins,
   tokenFeatures = {},
+  expressionMode = "expression",
 }: SetupOpts) {
   const state = createMockState({
     settings: mockSettings({
@@ -53,6 +56,7 @@ export async function setup({
     query,
     metadata,
     reportTimezone,
+    expressionMode,
   };
 
   if (hasEnterprisePlugins) {

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Tooltip/Tooltip.tsx
@@ -24,6 +24,7 @@ export function Tooltip({
   metadata,
   reportTimezone,
   tooltipRef,
+  expressionMode,
 
   state,
   view,
@@ -32,6 +33,7 @@ export function Tooltip({
   stageIndex: number;
   metadata: Metadata;
   reportTimezone?: string;
+  expressionMode: Lib.ExpressionMode;
 
   // from tooltip extension
   tooltipRef: RefObject<HTMLDivElement>;
@@ -104,6 +106,7 @@ export function Tooltip({
             reportTimezone={reportTimezone}
             open={shouldShowHelpText}
             onToggle={handleToggleHelpText}
+            expressionMode={expressionMode}
           />
           {shouldShowCompletions && (
             <Listbox


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58230

- Adds a validator that will show an error when using an aggregation in an expression that does not support aggregations.
- Avoid showing helptext for aggregations when editing an expression that does not support them


### To verify
1. New -> Question -> Sample Database -> Orders
2. Add Custom Column (or a Custom filter)
3. Type `Average([Total])`
4. The help text popover should not appear
5. An error should be displayed


<img width="743" alt="Screenshot 2025-06-03 at 11 55 12" src="https://github.com/user-attachments/assets/aa532ea6-76fa-449e-a076-8a90f3c51ea6" />
