### PR TITLE
Closes viz-1053 UI polish on download popover

### DIFF
--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -81,12 +81,17 @@ export const ExportSettingsWidget = ({
   }));
 
   return (
-    <Stack gap="lg">
+    <Stack style={{ gap: 24 }}>
       <SegmentedControl
         w="100%"
         data={formatOptions}
         value={selectedFormat}
         onChange={onChangeFormat}
+        styles={{
+          root: {
+            backgroundColor: "var(--mb-color-background-light)",
+          },
+        }}
       />
 
       {canConfigureFormatting ? (
@@ -96,7 +101,15 @@ export const ExportSettingsWidget = ({
           checked={isFormattingEnabled}
           onChange={() => onToggleFormatting()}
           description={formattingLabel}
-          styles={{ inner: { alignSelf: "flex-start" } }}
+          styles={{
+            inner: { alignSelf: "flex-start" },
+            label: {
+              color: "var(--mb-color-text-primary)",
+            },
+            description: {
+              color: "var(--mb-color-text-secondary)",
+            },
+          }}
         />
       ) : null}
       {arePivotedExportsEnabled && canConfigurePivoting ? (
@@ -105,6 +118,11 @@ export const ExportSettingsWidget = ({
           label={t`Keep the data pivoted`}
           checked={isPivotingEnabled}
           onChange={() => onTogglePivoting()}
+          styles={{
+            label: {
+              color: "var(--mb-color-text-primary)",
+            },
+          }}
         />
       ) : null}
     </Stack>

--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -81,7 +81,7 @@ export const ExportSettingsWidget = ({
   }));
 
   return (
-    <Stack style={{ gap: 24 }}>
+    <Stack gap="lg">
       <SegmentedControl
         w="100%"
         data={formatOptions}

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
@@ -8,6 +8,7 @@ import type {
   TableExportFormat,
 } from "metabase/common/types/export";
 import Link from "metabase/core/components/Link";
+import CS from "metabase/css/core/index.css";
 import { exportFormatPng, exportFormats } from "metabase/lib/urls";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import {
@@ -132,14 +133,7 @@ export const QuestionDownloadWidget = ({
     showMetabaseLinks;
 
   return (
-    <Stack
-      {...stackProps}
-      style={{
-        padding: "0.75rem",
-        width: 336,
-        gap: 24,
-      }}
-    >
+    <Stack {...stackProps} w={336} p="0.75rem" gap="lg">
       <Title order={5}>{t`Download data`}</Title>
       <ExportSettingsWidget
         selectedFormat={format}
@@ -158,9 +152,7 @@ export const QuestionDownloadWidget = ({
           bg="var(--mb-color-background-light)"
           align="center"
           justify="space-between"
-          style={{
-            borderRadius: 8,
-          }}
+          className={CS.rounded}
         >
           <Text fz="12px" lh="16px" c="text-medium">
             {t`Trying to pivot this data in Excel? You should download the raw data instead.`}{" "}

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
@@ -130,8 +130,16 @@ export const QuestionDownloadWidget = ({
     isPivoted &&
     !dismissedExcelPivotExportsBanner &&
     showMetabaseLinks;
+
   return (
-    <Stack w={336} p="0.75rem" gap="md" {...stackProps}>
+    <Stack
+      {...stackProps}
+      style={{
+        padding: "0.75rem",
+        width: 336,
+        gap: 24,
+      }}
+    >
       <Title order={5}>{t`Download data`}</Title>
       <ExportSettingsWidget
         selectedFormat={format}
@@ -150,6 +158,9 @@ export const QuestionDownloadWidget = ({
           bg="var(--mb-color-background-light)"
           align="center"
           justify="space-between"
+          style={{
+            borderRadius: 8,
+          }}
         >
           <Text fz="12px" lh="16px" c="text-medium">
             {t`Trying to pivot this data in Excel? You should download the raw data instead.`}{" "}


### PR DESCRIPTION
Closes [VIZ-1053: Polish on download popover](https://linear.app/metabase/issue/VIZ-1053/polish-on-download-popover)

### Description

 - changed some backgrounds so they match
 - changed checkboxes labels' colors
 - added a border radius to the dismissible box
 - tweaked spacing

### Demo

#### Before
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/0ad07870-6d9d-43e5-89e1-8197a95ca830" />


#### After
<img width="1608" alt="image" src="https://github.com/user-attachments/assets/faa73538-cdf6-442b-957c-a0be131eee7c" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
