### PR TITLE
chore: replace moment-timezone with dayjs in cypress specs

### DIFF
--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 
 const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
@@ -277,7 +277,7 @@ function assertInputValue(labelText, value) {
 }
 
 function assertDateInputValue(labelText, value) {
-  const expectedValue = moment(value)
+  const expectedValue = dayjs(value)
     .format()
     .replace(/-\d\d:\d\d$/, "");
 

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 
 const { H } = cy;
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
@@ -1202,8 +1202,8 @@ describe("issue 22482", () => {
     cy.findByText("months").click();
 
     const expectedRange = getFormattedRange(
-      moment().startOf("month").add(-15, "month"),
-      moment().add(-1, "month").endOf("month"),
+      dayjs().startOf("month").add(-15, "month"),
+      dayjs().add(-1, "month").endOf("month"),
     );
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -1,5 +1,6 @@
-import "metabase/lib/dayjs";
 import dayjs from "dayjs";
+
+import "metabase/lib/dayjs";
 
 const { H } = cy;
 

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -1,4 +1,5 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import "metabase/lib/dayjs";
+import dayjs from "dayjs";
 
 const { H } = cy;
 
@@ -13,7 +14,7 @@ const STARTING_FROM_UNITS = [
 ];
 
 describe("scenarios > question > relative-datetime", () => {
-  const now = moment().utc();
+  const now = dayjs().utc();
 
   beforeEach(() => {
     H.restore();
@@ -237,7 +238,7 @@ const nativeSQL = (values) => {
   cy.intercept("POST", "/api/dataset").as("dataset");
 
   const queries = values.map((value) => {
-    const date = moment(value).utc();
+    const date = dayjs(value).utc();
     return `SELECT '${date.toISOString()}'::timestamp as "testcol"`;
   });
 


### PR DESCRIPTION
we used moment-timezone in cypress, we can replace it with dayjs easily