### PR TITLE
chore: replace moment-timezone with dayjs when fromNow is used

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
@@ -1,5 +1,5 @@
+import dayjs from "dayjs";
 import fetchMock from "fetch-mock";
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
 import { createMockMetadata } from "__support__/metadata";
 import { setupModelPersistenceEndpoints } from "__support__/server-mocks/persist";
@@ -96,7 +96,7 @@ describe("ModelCacheManagementSection", () => {
 
   it("displays 'persisted' state correctly", async () => {
     const { modelCacheInfo } = await setup({ state: "persisted" });
-    const expectedTimestamp = moment(modelCacheInfo.refresh_end).fromNow();
+    const expectedTimestamp = dayjs(modelCacheInfo.refresh_end).fromNow();
     expect(
       await screen.findByText(`Model last cached ${expectedTimestamp}`),
     ).toBeInTheDocument();
@@ -115,7 +115,7 @@ describe("ModelCacheManagementSection", () => {
 
   it("displays 'error' state correctly", async () => {
     const { modelCacheInfo } = await setup({ state: "error" });
-    const expectedTimestamp = moment(modelCacheInfo.refresh_end).fromNow();
+    const expectedTimestamp = dayjs(modelCacheInfo.refresh_end).fromNow();
 
     expect(
       await screen.findByText("Failed to update model cache"),

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -1,5 +1,5 @@
+import dayjs from "dayjs";
 import { assoc } from "icepick";
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 import { t } from "ttag";
 
 import { humanize, titleize } from "metabase/lib/formatting";
@@ -126,7 +126,7 @@ export const getQuestionUrl = (getQuestionArgs) =>
 export const has = (entity) => entity && entity.length > 0;
 
 export const getDescription = (question) => {
-  const timestamp = moment(question.getCreatedAt()).fromNow();
+  const timestamp = dayjs(question.getCreatedAt()).fromNow();
   const author = question.getCreator().common_name;
   return t`Created ${timestamp} by ${author}`;
 };

--- a/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
@@ -1,4 +1,4 @@
-import moment from "moment"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 
 import {
   setupCollectionByIdEndpoint,
@@ -37,7 +37,7 @@ const MOCK_OTHER_USER = createMockUser({
 
 const CREATED_AT_TIME = "2022-01-01T00:00:00.000Z";
 const LAST_EDITED_TIME = "2023-01-01T00:00:00.000Z";
-const formatDuration = (timestamp: string) => moment(timestamp).fromNow();
+const formatDuration = (timestamp: string) => dayjs(timestamp).fromNow();
 
 const CREATED_AT_DURATION = formatDuration(CREATED_AT_TIME);
 const LAST_EDITED_DURATION = formatDuration(LAST_EDITED_TIME);


### PR DESCRIPTION
moment's `fromNow` is very easy to replace with dayjs's `fromNow`