### PR TITLE
Avoid timeouts during sync with snowflake

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -767,7 +767,7 @@
     (and ((get-method driver/can-connect? :sql-jdbc) driver details)
          (sql-jdbc.conn/with-connection-spec-for-testing-connection [spec [driver details]]
            ;; jdbc/query is used to see if we throw, we want to ignore the results
-           (jdbc/query spec (format "SHOW OBJECTS IN DATABASE \"%s\";" db))
+           (jdbc/query spec (format "SHOW SCHEMAS IN DATABASE \"%s\";" db))
            true))))
 
 (defmethod driver/normalize-db-details :snowflake


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #41964
Closes https://linear.app/metabase/issue/SEM-179/sync-schema-endpoint-is-synchronous-when-it-should-be-asynchronous


# Description
It appears that the snowflake driver is using an expensive `SHOW OBJECTS IN DATABASE` query in its implementation of `can-connect`. This can lead to api timeouts as `driver.u/can-connect-with-details?` is generally assumed to be very fast and done in sync code throughout the codebase. 
This PR replaces that expensive query with a less expensive `SHOW SCHEMAS IN DATABASE`.