### PR TITLE
fix SSO login

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -85,7 +85,7 @@
   (let [;; if the user is not active, we will want to mark them as active if they are actually reactivated.
         new-user-data (merge user-from-sso {:is_active true})
         user-keys (keys new-user-data)]
-    (when-let [{:keys [id] :as user} (t2/select-one (into [:model/User :id] user-keys)
+    (when-let [{:keys [id] :as user} (t2/select-one (into [:model/User :id :last_login] user-keys)
                                                     :%lower.email (u/lower-case-en email))]
       (when (or (:is_active user)
                 reactivate?)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58872

getting a fast fix out. This was failing because we call

```
(session/create-session! :sso user (request/device-info request))
```

with the result of this function, and `session/create-session!` requires a user with at least `:id` and `:last_login`. We didn't have a `:last_login` in this case so `create-session!` was barfing.
