### PR TITLE
Allow resetting a required filter to its default value

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -785,8 +785,9 @@ describe("scenarios > dashboard > filters > reset all filters", () => {
       filter(textFilter.name).click();
       H.popover().within(() => {
         cy.findByText("Select all").click();
-        cy.findByText("Update filter").click();
+        cy.findByText("Set to default").click();
       });
+      H.filterWidget().eq(0).should("contain.text", "4 selections");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -766,6 +766,29 @@ describe("scenarios > dashboard > filters > reset all filters", () => {
       cy.findByRole("dialog").should("not.exist");
     });
   });
+
+  describe("issue 57388", () => {
+    it("should be possible to reset a required text filter to it's default value (metabase#57388)", () => {
+      const textFilter = {
+        name: "Filter",
+        slug: "filter",
+        id: "75d67d39",
+        type: "string/=",
+        required: true,
+        sectionId: "string",
+        default: ["Gizmo", "Gadget", "Widget", "Doohickey"],
+      };
+      createDashboardWithParameters(ORDERS_QUESTION, PRODUCTS_CATEGORY_FIELD, [
+        textFilter,
+      ]);
+
+      filter(textFilter.name).click();
+      H.popover().within(() => {
+        cy.findByText("Select all").click();
+        cy.findByText("Update filter").click();
+      });
+    });
+  });
 });
 
 function createDashboardWithParameters(

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -68,6 +68,10 @@ describe("scenarios > filters > sql filters > field filter", () => {
         H.removeFieldValuesValue(0);
         cy.findByText("Set to default").click();
       });
+
+      cy.log("make sure the dialog is gone");
+      cy.findByRole("dialog").should("not.exist");
+
       H.filterWidget()
         .findByTestId("field-set-content")
         .should("have.text", "10");

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-values.js
@@ -158,3 +158,7 @@ export function getParameterValuesBySlug(parameters, parameterValuesById) {
 export function getIsMultiSelect(parameter) {
   return parameter.isMultiSelect ?? true;
 }
+
+export function hasValue(value) {
+  return Array.isArray(value) ? value.length > 0 : value != null;
+}

--- a/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
+++ b/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
@@ -31,7 +31,7 @@ export function getUpdateButtonProps(
     if (isDefaultValue || isEmpty) {
       return {
         label: getResetLabel(),
-        isDisabled: false,
+        isDisabled: isDefaultValue,
       };
     }
 

--- a/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
+++ b/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
@@ -28,9 +28,16 @@ export function getUpdateButtonProps(
   const isUnchanged = areParameterValuesIdentical(value, unsavedValue);
 
   if (required) {
+    if (isDefaultValue || isEmpty) {
+      return {
+        label: getResetLabel(),
+        isDisabled: false,
+      };
+    }
+
     return {
-      label: isDefaultValue ? getResetLabel() : getUpdateLabel(),
-      isDisabled: isEmpty || isUnchanged,
+      label: getUpdateLabel(),
+      isDisabled: isUnchanged,
     };
   }
 

--- a/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
+++ b/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
@@ -20,31 +20,30 @@ export function getUpdateButtonProps(
   defaultValue?: unknown,
   required?: boolean,
 ): { label: string; isDisabled: boolean } {
+  const isDefaultValue = areParameterValuesIdentical(
+    unsavedValue,
+    defaultValue,
+  );
+  const isEmpty = !hasValue(unsavedValue);
+  const isUnchanged = areParameterValuesIdentical(value, unsavedValue);
+
   if (required) {
     return {
-      label:
-        !hasValue(unsavedValue) ||
-        areParameterValuesIdentical(unsavedValue, defaultValue)
-          ? getResetLabel()
-          : getUpdateLabel(),
-      isDisabled:
-        areParameterValuesIdentical(unsavedValue, value) &&
-        hasValue(unsavedValue),
+      label: isDefaultValue ? getResetLabel() : getUpdateLabel(),
+      isDisabled: isEmpty || isUnchanged,
     };
   }
 
   if (hasValue(defaultValue)) {
     return {
-      label: areParameterValuesIdentical(unsavedValue, defaultValue)
-        ? getResetLabel()
-        : getUpdateLabel(),
-      isDisabled: areParameterValuesIdentical(value, unsavedValue),
+      label: isDefaultValue ? getResetLabel() : getUpdateLabel(),
+      isDisabled: isUnchanged,
     };
   }
 
   return {
     label: hasValue(value) ? getUpdateLabel() : getAddLabel(),
-    isDisabled: areParameterValuesIdentical(value, unsavedValue),
+    isDisabled: isUnchanged,
   };
 }
 

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -12,6 +12,7 @@ import {
   serializeNumberParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
 import { Box, type ComboboxItem, MultiAutocomplete } from "metabase/ui";
+import { hasValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
   Parameter,
   ParameterValue,
@@ -80,7 +81,14 @@ export function NumberInputWidget({
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    if (!isValid || (isRequired && isEmpty)) {
+    if (!isValid) {
+      return;
+    }
+
+    if (isRequired && isEmpty) {
+      if (hasValue(parameter.default)) {
+        setValue(parameter.default);
+      }
       return;
     }
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.tsx
@@ -14,6 +14,7 @@ import {
 } from "metabase-lib/v1/operators/utils";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import { deriveFieldOperatorFromParameter } from "metabase-lib/v1/parameters/utils/operators";
+import { hasValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type { Dashboard, RowValue } from "metabase-types/api";
 
 import { Footer } from "../Widget";
@@ -61,7 +62,14 @@ export function ParameterFieldWidget({
 
   const handleFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-    if (!isValid || (isRequired && isEmpty)) {
+    if (!isValid) {
+      return;
+    }
+
+    if (isRequired && isEmpty) {
+      if (hasValue(parameter.default)) {
+        setValue(parameter.default);
+      }
       return;
     }
 

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
 import { deserializeStringParameterValue } from "metabase/querying/parameters/utils/parsing";
 import { Box, MultiAutocomplete, TextInput } from "metabase/ui";
+import { hasValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type { Parameter, ParameterValueOrArray } from "metabase-types/api";
 
 import { Footer, WidgetLabel } from "../Widget";
@@ -48,6 +49,9 @@ export function StringInputWidget({
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     if (isRequired && isEmpty) {
+      if (hasValue(parameter.default)) {
+        setValue(parameter.default);
+      }
       return;
     }
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { t } from "ttag";
 
 import { RequiredParamToggle } from "metabase/parameters/components/RequiredParamToggle";
@@ -24,6 +25,10 @@ export function DefaultRequiredValueControl({
   onChangeRequired: (value: boolean) => void;
 }) {
   const isMissing = tag.required && !tag.default;
+  const parameterWithoutDefault = useMemo(
+    () => ({ ...parameter, default: null }),
+    [parameter],
+  );
 
   return (
     <div>
@@ -36,7 +41,7 @@ export function DefaultRequiredValueControl({
         {parameter && (
           <div aria-labelledby={`default-value-label-${tag.id}`}>
             <DefaultParameterValueWidget
-              parameter={parameter}
+              parameter={parameterWithoutDefault}
               value={tag.default}
               setValue={onChangeDefaultValue}
               isEditing


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58867

### To verify
1. Go to Our Analytics -> Examples -> E-commerce Insights
2. Try to unset all the values for the Product Category filter
3. You should see the correct button

<img width="367" alt="Screenshot 2025-06-03 at 18 07 04" src="https://github.com/user-attachments/assets/e7d9a5c6-5e80-4631-9c25-ebd5f7a34844" />
