### PR TITLE
Improve Editable action init hook

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -873,20 +873,20 @@
                                                             :card_id        (:id model)
                                                             :visualization_settings
                                                             {:editableTable.enabledActions
-                                                             [{:actual_id #_:id "dashcard:unknown:abcdef"
-                                                               :id #_:action_id (:id action)
-                                                               :type            "row-action"
-                                                               :enabled         true}
-                                                              {:actual_id #_:id   "dashcard:unknown:fedcba"
-                                                               :id #_:action_id   "table.row/update"
-                                                               :type              "row-action"
+                                                             [{:id         "dashcard:unknown:abcdef"
+                                                               :actionId   (:id action)
+                                                               :actionType "data-grid/row-action"
+                                                               :enabled    true}
+                                                              {:id                "dashcard:unknown:fedcba"
+                                                               :actionId          "table.row/update"
+                                                               :actionType        "data-grid/row-action"
                                                                :parameterMappings {:table-id @test-table
                                                                                    :row      "::root"}
                                                                :enabled           true}
-                                                              {:actual_id #_:id "dashcard:unknown:xyzabc"
-                                                               :id #_:action_id (#'actions/encoded-action-id :table.row/update @test-table)
-                                                               :type            "row-action"
-                                                               :enabled         true}]}}]
+                                                              {:id         "dashcard:unknown:xyzabc"
+                                                               :actionId   (#'actions/encoded-action-id :table.row/update @test-table)
+                                                               :actionType "data-grid/row-action"
+                                                               :enabled    true}]}}]
                 (testing "no access to the model"
                   (is (= 403 (:status (req {:user      :rasta
                                             :action_id (:id action)

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -967,7 +967,7 @@
    (partial map
             (fn [grid-action]
               (-> grid-action
-                  (update :id (partial create-or-fix-action-id dashcards))
+                  (update :id (partial create-or-fix-action-id dashcard))
                   ;; At the time of writing, the FE only allows the creation of row actions. Make this explicit.
                   (update :actionType #(or % "data-grid/row-action"))
                   ;; By default actions are enabled.

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5155,3 +5155,23 @@
                                     :base_type :type/Text}]}
                 (:param_fields (mt/with-test-user :crowberto
                                  (#'api.dashboard/get-dashboard (:id dashboard))))))))))
+
+(deftest create-or-fix-action-id-test
+  (let [f       #'api.dashboard/create-or-fix-action-id
+        unsaved {}
+        saved   {:id 1337}]
+    (mt/with-dynamic-fn-redefs [u/generate-nano-id (fn [] "rAnDoM")]
+      (testing "leaves valid ids alone"
+        (is (= 1
+               (f saved 1)))
+        (is (= "dashcard:7331:unique"
+               (f saved "dashcard:7331:unique"))))
+      (testing "creates useful and unique ids"
+        (is (= "dashcard:1337:rAnDoM"
+               (f saved nil))))
+      (testing "does its best without a parent"
+        (is (= "dashcard:unknown:rAnDoM"
+               (f unsaved nil))))
+      (testing "accepts its new parent"
+        (is (= "dashcard:1337:SAVE_ME"
+               (f saved "dashcard:unknown:SAVE_ME")))))))


### PR DESCRIPTION
Improves the documentation and tracks some renames made to the keys on the FE.

Keeps the "unique" part of the id when doing a chicken-and-egg fix.