### PR TITLE
CI debugging improvements

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -38,3 +38,10 @@ runs:
         list-suites: failed
         list-tests: failed
         fail-on-error: false
+    - name: Upload Logs on Failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-logs-${{ github.job }}
+        path: logs/test.log
+        retention-days: 1

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -43,5 +43,5 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: test-logs-${{ github.job }}
-        path: logs/test.log
+        path: logs/test-log.json
         retention-days: 1

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -153,6 +153,14 @@ jobs:
           list-tests: failed
           fail-on-error: false
 
+      - name: Upload Logs on Failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ matrix.java-version }}-${{ matrix.job.edition }}-${{ github.job }}
+          path: logs/test.log
+          retention-days: 1
+
   # checks that all the namespaces we actually ship can be compiled, without any dependencies that we don't ship (such
   # as `:dev` dependencies). See #27009 for more context.
   be-check:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -158,7 +158,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.java-version }}-${{ matrix.job.edition }}-${{ github.job }}
-          path: logs/test.log
+          path: logs/test-log.json
           retention-days: 1
 
   # checks that all the namespaces we actually ship can be compiled, without any dependencies that we don't ship (such

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -28,6 +28,7 @@
    [potemkin :as p]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]
+   [toucan2.pipeline :as t2.pipeline]
    [toucan2.protocols :as t2.protocols]
    [toucan2.tools.before-insert :as t2.before-insert]
    [toucan2.tools.hydrate :as t2.hydrate]
@@ -835,3 +836,11 @@
 (defmethod exclude-internal-content-hsql :default
   [_model & _]
   [:= [:inline 1] [:inline 1]])
+
+(methodical/defmethod t2.pipeline/compile
+  [:default
+   :metabase/model
+   clojure.lang.IPersistentMap]
+  [query-type model query]
+  (log/info query-type model query)
+  (next-method query-type model query))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -836,11 +836,3 @@
 (defmethod exclude-internal-content-hsql :default
   [_model & _]
   [:= [:inline 1] [:inline 1]])
-
-(methodical/defmethod t2.pipeline/compile
-  [:default
-   :metabase/model
-   clojure.lang.IPersistentMap]
-  [query-type model query]
-  (log/info query-type model query)
-  (next-method query-type model query))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -28,7 +28,6 @@
    [potemkin :as p]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]
-   [toucan2.pipeline :as t2.pipeline]
    [toucan2.protocols :as t2.protocols]
    [toucan2.tools.before-insert :as t2.before-insert]
    [toucan2.tools.hydrate :as t2.hydrate]

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -223,7 +223,7 @@
    ThreadContext will contain: {\"notification_id\" \"1\"} and stack \"Notification 1\""
   [context-map & body]
   (macros/case
-    :clj `(let [ctx-map# ~(update-keys context-map #(str "mb-" (u.format/qualified-name %)))
+    :clj `(let [ctx-map# (update-keys ~context-map #(str "mb-" (u.format/qualified-name %)))
                 ctx-keys# (keys ctx-map#)
                 ;; Store original values before modifying
                 original-values# (into {}

--- a/test/metabase/logger/core_test.clj
+++ b/test/metabase/logger/core_test.clj
@@ -66,7 +66,7 @@
       (let [f (io/file filename)]
         (with-open [_ (logger/for-ns f 'metabase.logger.core-test {:additive false})]
           (log/info "just a test"))
-        (is (=? [#".*just a test$"]
+        (is (=? [#".*just a test.+"]
                 (line-seq (io/reader f))))))))
 
 (deftest fork-logs-test-2
@@ -76,7 +76,7 @@
         (log/info "just a test"))
       (log/info "this line is not going into our stream")
       (testing "We catched the line we needed and did not catch the other one"
-        (is (=? [#".*just a test$"]
+        (is (=? [#".*just a test.+"]
                 (line-seq (io/reader (.toByteArray baos)))))))))
 
 (deftest fork-logs-test-3
@@ -90,8 +90,8 @@
           (log/log 'metabase.unknown :info nil "separate test")
           (testing "Check that `for-ns` will skip non-specified namespaces"
             (log/log 'metabase.unknown2 :info nil "this one going into standard log")))
-        (is (=? [#".*just a test$"
-                 #".*separate test$"]
+        (is (=? [#".*just a test.+"
+                 #".*separate test.+"]
                 (line-seq (io/reader f))))))))
 
 (deftest level-enabled?-test

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -357,7 +357,7 @@
   it thread safe. If it is wrapped in a call to [[metabase.test/test-helpers-set-global-values!]], it will affect the
   global state of the application database.")
 
-(def ^:private original-test-var clojure.test/test-var)
+(defonce ^:private original-test-var clojure.test/test-var)
 
 (defn- test-var-with-context
   "A modified version of `clojure.test/test-var` that:

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -372,12 +372,12 @@
 
 (alter-var-root #'clojure.test/test-var (constantly test-var-with-context))
 
-(methodical/defmethod t2.pipeline/compile
+(methodical/defmethod t2.pipeline/compile :after
   [#_query-type  :default
    #_model       :default
    #_built-query :default]
   [query-type model built-query]
-  (u/prog1 (next-method query-type model built-query)
+  (u/prog1 built-query
     (let [compiled-query-arg-map (into {} (map-indexed (fn [i v] [(str "compiled-query-arg-" i) v]) (rest <>)))]
       (log/with-context (merge {:query-type query-type
                                 :model model

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -378,9 +378,11 @@
    #_built-query :default]
   [query-type model built-query]
   (u/prog1 (next-method query-type model built-query)
-    (log/with-context {:query-type query-type
-                       :model model
-                       :compiled-query (first <>)
-                       :compiled-query-args (rest <>)}
-      (when config/is-test?
-        (log/info "Compiled query")))))
+    (let [compiled-query-arg-map (into {} (map-indexed (fn [i v] [(str "compiled-query-arg-" i) v]) (rest <>)))]
+      (log/with-context (merge {:query-type query-type
+                                :model model
+                                :compiled-query (first <>)
+                                :compiled-query-args (rest <>)}
+                               compiled-query-arg-map)
+        (when config/is-test?
+          (log/info "Compiled query"))))))

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -3,13 +3,13 @@
    [clojure.test :refer :all]
    [metabase.util.log :as log])
   (:import
-   (org.apache.logging.log4j ThreadContext)
-   (org.apache.logging.log4j.util ReadOnlyStringMap)))
+   (java.util Map)
+   (org.apache.logging.log4j ThreadContext)))
 
 (set! *warn-on-reflection* true)
 
 (defn- to-map [immutable-context]
-  (into {} (.toMap ^ReadOnlyStringMap immutable-context)))
+  (into {} immutable-context))
 
 (defn- get-context-fn
   []

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -3,48 +3,55 @@
    [clojure.test :refer :all]
    [metabase.util.log :as log])
   (:import
-   (org.apache.logging.log4j ThreadContext)))
+   (org.apache.logging.log4j ThreadContext)
+   (org.apache.logging.log4j.util ReadOnlyStringMap)))
 
 (set! *warn-on-reflection* true)
 
-(defn- get-context
+(defn- to-map [immutable-context]
+  (into {} (.toMap ^ReadOnlyStringMap immutable-context)))
+
+(defn- get-context-fn
   []
-  (ThreadContext/getImmutableContext))
+  (let [original-context (to-map (ThreadContext/getImmutableContext))]
+    (fn []
+      (let [new-context (to-map (ThreadContext/getImmutableContext))]
+        (apply dissoc new-context (keys original-context))))))
 
 (deftest with-context-test
-  (testing "with-context should set and reset context correctly"
-    (is (empty? (get-context)))  ; Initially context should be nil
-
-    (log/with-context {:user-id 123 :action "test"}
-      (is (= {"mb-user-id" "123" "mb-action" "test"}
-             (get-context))
-          "Context should be set inside macro"))
-
-    (is (empty? (get-context))
-        "Context should be reset to nil after macro"))
-
-  (testing "with-context should handle nested contexts"
-    (log/with-context {:outer "value" :empty "" :false false}
-      (is (= {"mb-outer" "value" "mb-empty" "" "mb-false" "false"}
-             (get-context))
-          "Outer context should be set")
-
-      (log/with-context {:inner "nested"}
-        (is (= {"mb-outer" "value" "mb-inner" "nested" "mb-empty" "" "mb-false" "false"}
+  (let [get-context (get-context-fn)
+        original-context (get-context)]
+    (testing "with-context should set and reset context correctly"
+      (log/with-context {:user-id 123 :action "test"}
+        (is (= {"mb-user-id" "123" "mb-action" "test"}
                (get-context))
-            "Inner context should replace outer context"))
+            "Context should be set inside macro"))
 
-      (is (= {"mb-outer" "value" "mb-empty" "" "mb-false" "false"}
-             (get-context))
-          "Outer context should be restored after nested macro")))
+      (is (= original-context (get-context))
+          "Context should be reset after macro"))
 
-  (testing "with-context should reset context even if exception occurs"
-    (is (empty? (get-context)))
+    (testing "with-context should handle nested contexts"
+      (log/with-context {:outer "value" :empty "" :false false}
+        (is (= {"mb-outer" "value" "mb-empty" "" "mb-false" "false"}
+               (get-context))
+            "Outer context should be set")
 
-    (try
-      (log/with-context {:error "test"}
-        (throw (Exception. "Test exception")))
-      (catch Exception _))
+        (log/with-context {:inner "nested"}
+          (is (= {"mb-outer" "value" "mb-inner" "nested" "mb-empty" "" "mb-false" "false"}
+                 (get-context))
+              "Inner context should replace outer context"))
 
-    (is (empty? (get-context))
-        "Context should be reset after exception")))
+        (is (= {"mb-outer" "value" "mb-empty" "" "mb-false" "false"}
+               (get-context))
+            "Outer context should be restored after nested macro")))
+
+    (testing "with-context should reset context even if exception occurs"
+      (is (= original-context (get-context)))
+
+      (try
+        (log/with-context {:error "test"}
+          (throw (Exception. "Test exception")))
+        (catch Exception _))
+
+      (is (= original-context (get-context))
+          "Context should be reset after exception"))))

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -3,7 +3,6 @@
    [clojure.test :refer :all]
    [metabase.util.log :as log])
   (:import
-   (java.util Map)
    (org.apache.logging.log4j ThreadContext)))
 
 (set! *warn-on-reflection* true)

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -14,7 +14,7 @@
       </Filters>
     </Console>
     <File name="File" fileName="logs/test-log.json" append="false">
-      <JsonLayout locationInfo="false" properties="true" />
+      <JsonLayout locationInfo="false" properties="true" compact="true" />
       <Filters>
         <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -3,16 +3,37 @@
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">
       <PatternLayout pattern="[%t] %-5level %logger{36} - %msg%n"/>
+      <Filters>
+        <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
     </Console>
+    <Console name="ConsoleInfoLevel" target="SYSTEM_OUT" follow="true">
+      <PatternLayout pattern="[%t] %-5level %logger{36} - %msg%n"/>
+      <Filters>
+        <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+    </Console>
+    <File name="File" fileName="logs/test.log" append="false">
+      <PatternLayout pattern="[%d{HH:mm:ss}] %-5level %logger{36} - %msg%n"/>
+      <Filters>
+        <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+    </File>
   </Appenders>
   <Loggers>
-    <Logger name="liquibase" level="FATAL"/>
-    <Logger name="metabase" level="FATAL"/>
-    <Logger name="metabase-enterprise" level="FATAL"/>
-    <Logger name="metabase.test.gentest" level="INFO"/>
+    <Logger name="liquibase" level="INFO"/>
+    <Logger name="metabase" level="INFO"/>
+    <Logger name="metabase-enterprise" level="INFO"/>
 
-    <Root level="FATAL">
+    <Logger name="metabase.test.gentest" level="INFO" additivity="false">
+      <AppenderRef ref="ConsoleInfoLevel"/>
       <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+    </Logger>
+
+    <Root level="INFO">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -2,19 +2,19 @@
 <Configuration>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="[%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="[%t] %-5level %logger{36} - %msg %notEmpty{%X}%n"/>
       <Filters>
         <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
     </Console>
     <Console name="ConsoleInfoLevel" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="[%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="[%t] %-5level %logger{36} - %msg %notEmpty{%X}%n"/>
       <Filters>
         <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
     </Console>
     <File name="File" fileName="logs/test.log" append="false">
-      <PatternLayout pattern="[%d{HH:mm:ss}] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="[%d{HH:mm:ss}] %-5level %logger{36} - %msg %notEmpty{%X}%n"/>
       <Filters>
         <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -13,8 +13,8 @@
         <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
     </Console>
-    <File name="File" fileName="logs/test.log" append="false">
-      <PatternLayout pattern="[%d{HH:mm:ss}] %-5level %logger{36} - %msg %notEmpty{%X}%n"/>
+    <File name="File" fileName="logs/test-log.json" append="false">
+      <JsonLayout locationInfo="false" properties="true" />
       <Filters>
         <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>


### PR DESCRIPTION
When running tests, output logs to a file that is uploaded as an artifact (retention 1 day).

The file contains very detailed logs - INFO level, JSON formatted, with all the log context.

Also hack `clojure.test/test-var` to add context to any logs emitted during the test with the name of the test - this way if parallel tests are interfering with each other you can see which did what when.

Also, hackily add a log every time we compile a toucan query. Probably we should just always emit this, and do it with log level `DEBUG` or something, and have the CI log file contain `DEBUG` logs. Not totally sure, maybe we can do that, but `DEBUG` emits like 50MB of JSON logs while `INFO` emits ~2MB, so maybe we should move some `DEBUG` down to `TRACE` before we want to do this.