### PR TITLE
Extend tmp-modal to existing viz-action mappings

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -466,7 +466,7 @@
   such that they can be presented correctly in a modal ahead of execution."
   [{}
    {}
-   {:keys [action_id scope #_input]}]
+   {:keys [action_id scope input]}]
   (let [scope   (actions/hydrate-scope scope)
         unified
         ;; this mess can go once callers are on new listing API, leaving only the unified-action call.
@@ -486,36 +486,54 @@
           (let [{:keys [dashcard-id]} scope
                 {:keys [dashboard_id visualization_settings]} (t2/select-one :model/DashboardCard dashcard-id)]
             (api/read-check (t2/select-one :model/Dashboard dashboard_id))
-            {:action-kw (keyword action_id)
-             :mapping {:table-id (:table_id visualization_settings)
-                       :row ::root}})
+            {:row-action {:action-kw (keyword action_id)
+                          :mapping {:table-id (:table_id visualization_settings)
+                                    :row ::root}}
+             :mapping   (->> visualization_settings
+                             :editableTable.enabledActions
+                             (some (fn [{:keys [id parameterMappings]}]
+                                     (when (= id action_id)
+                                       parameterMappings))))})
           :else
           (throw (ex-info "Using table.row/* actions require either a table-id or dashcard-id in the scope"
                           {:status-code 400
                            :scope scope
                            :action_id action_id})))
 
-        ;; todo mapping support
+        param-value
+        (fn [param-mapping row-delay]
+          (case (:sourceType param-mapping)
+            "constant" (:value param-mapping)
+            "row-data" (when row-delay (get @row-delay (keyword (:sourceValueTarget param-mapping))))
+            nil))
+
         describe-saved-action
-        (fn [& {:keys [action-id _row-action-dashcard-id _mapping]}]
+        (fn [& {:keys [action-id
+                       row-action-mapping
+                       row-delay]}]
           (let [action (-> (actions/select-action :id action-id
                                                   :archived false
                                                   {:where [:not [:= nil :model_id]]})
 
                            api/read-check
                            api/check-404)
-                param-id->viz-field (-> action :visualization_settings (:fields {}))]
+                param-id->viz-field (-> action :visualization_settings (:fields {}))
+                param-id->mapping   (u/index-by :parameterId row-action-mapping)]
+
             {:title (:name action)
              :parameters
              (->> (for [param (:parameters action)
                         ;; query type actions store most stuff in viz settings rather than the
                         ;; parameter
-                        :let [viz-field (param-id->viz-field (:id param))]
-                        :when (not (:hidden viz-field))]
+                        :let [viz-field (param-id->viz-field (:id param))
+                              param-mapping (param-id->mapping (:id param))]
+                        :when (and (not (:hidden viz-field))
+                                   (not= "hidden" (:visibility param-mapping)))]
                     (u/remove-nils
                       ;; todo dropdown options
                      {:id (:id param)
                       :display_name (or (:display-name param) (:name param))
+                      :mapping param-mapping
                       :type (case (:type param)
                               :string/=    :type/Text
                               :number/=    :type/Number
@@ -528,19 +546,26 @@
                                            :param-type (:type param)
                                            :scope scope
                                            :unified unified}))))
-                      :optional (and (not (:required param)) (not (:required viz-field)))}))
+                      :optional (and (not (:required param)) (not (:required viz-field)))
+                      :nullable true ; is there a way to know this?
+                      :readonly (= "readonly" (:visibility param-mapping))
+                      :value    (param-value param-mapping row-delay)}))
                   vec)}))
 
-        ;; todo mapping support
         describe-table-action
-        (fn [& {:keys [action-kw mapping] :as _}]
-          (let [table-id (api/check-500 (:table-id mapping))
-                table (api/read-check (t2/select-one :model/Table :id table-id :active true))]
+        (fn [& {:keys [action-kw
+                       table-id
+                       ;; this has been written to work with the existing viz-settings mapping
+                       row-action-mapping
+                       row-delay]}]
+          (let [table-id            (or table-id (:table-id row-action-mapping))
+                table               (api/read-check (t2/select-one :model/Table :id table-id :active true))
+                field-name->mapping (u/index-by :parameterId row-action-mapping)]
             {:title (format "%s: %s" (:display_name table) (u/capitalize-en (name action-kw)))
              :parameters
-             (->> (for [field (->> (t2/select :model/Field :table_id table-id)
-                                   (sort-by :position))
-                        :let [pk (= :type/PK (:semantic_type field))]
+             (->> (for [field (t2/select :model/Field :table_id table-id {:order-by [[:position]]})
+                        :let [pk (= :type/PK (:semantic_type field))
+                              param-mapping (field-name->mapping (:name field))]
                         :when (case action-kw
                                 ;; create does not take pk cols if auto increment, todo generated cols?
                                 :table.row/create (not (:database_is_auto_increment field))
@@ -548,13 +573,16 @@
                                 :table.row/delete pk
                                 ;; update takes both the pk and field (if not a row action)
                                 :table.row/update true)
+                        :when (not= "hidden" (:visibility param-mapping))
                         :let [required (or pk (:database_required field))]]
                     (u/remove-nils
                      {:id (:name field)
                       :display_name (:display_name field)
                       :type (:base_type field)
                       :optional (not required)
-                      :nullable (:database_is_nullable field)}))
+                      :nullable (:database_is_nullable field)
+                      :readonly (= "readonly" (:visibility param-mapping))
+                      :value (param-value param-mapping row-delay)}))
 
                   vec)}))]
 
@@ -565,25 +593,40 @@
 
       ;; table action
       (:action-kw unified)
-      (describe-table-action unified)
+      (describe-table-action
+       :action-kw          (:action-kw unified)
+       :row-action-mapping (:mapping unified))
 
       (:row-action unified)
       (let [row-action  (:row-action unified)
             mapping     (:mapping unified)
             dashcard-id (:dashcard-id unified)
             saved-id    (:action-id row-action)
-            action-kw   (:action-kw row-action)]
+            action-kw   (:action-kw row-action)
+            table-id    (or (:table-id mapping)
+                            (:table-id (:mapping row-action))
+                            (:table-id scope))
+
+            row-delay
+            (delay
+              (when table-id
+                (let [pk-fields    (data-editing/select-table-pk-fields table-id)
+                      pk           (select-keys input (mapv (comp keyword :name) pk-fields))
+                      pk-satisfied (= (count pk) (count pk-fields))]
+                  (when pk-satisfied
+                    (first (data-editing/query-db-rows table-id pk-fields [pk]))))))]
         (cond
           saved-id
           (describe-saved-action :action-id saved-id
                                  :row-action-dashcard-id dashcard-id
-                                 :row-action-mapping mapping)
+                                 :row-action-mapping mapping
+                                 :row-delay row-delay)
 
           action-kw
-          (let [table-id (:table-id row-action)]
-            (describe-table-action :action-kw action-kw
-                                   :table-id table-id
-                                   :row-action-mapping mapping))
+          (describe-table-action :action-kw action-kw
+                                 :table-id table-id
+                                 :row-action-mapping mapping
+                                 :row-delay row-delay)
 
           :else (ex-info "Not a supported row action" {:status-code 500, :scope scope, :unified unified})))
       :else

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1070,7 +1070,59 @@
                          (->> (table-rows @test-table)
                               (sort-by first)))))))))))))
 
-(deftest tmp-modal-test
+(deftest tmp-modal-saved-action-test
+  (let [req
+        #(mt/user-http-request-full-response
+          (:user % :crowberto)
+          :post
+          "ee/data-editing/tmp-modal"
+          (select-keys % [:action_id
+                          :scope
+                          :input]))]
+    (mt/with-premium-features #{:table-data-editing}
+      (mt/test-drivers #{:h2 :postgres}
+        (data-editing.tu/toggle-data-editing-enabled! true)
+        (testing "saved actions"
+          (mt/with-non-admin-groups-no-root-collection-perms
+            (mt/with-temp [:model/Table         table    {}
+                           :model/Card          model    {:type         :model
+                                                          :table_id     (:id table)}
+                           :model/Action        action   {:type         :query
+                                                          :name "Do cool thing"
+                                                          :model_id     (:id model)
+                                                          :parameters   [{:id "a"
+                                                                          :name "A"
+                                                                          :type "number/="}
+                                                                         {:id "b"
+                                                                          :name "B"
+                                                                          :type "date/single"}
+                                                                         {:id "c"
+                                                                          :name "C"
+                                                                          :type "string/="}
+                                                                         {:id "d"
+                                                                          :name "D"
+                                                                          :type "string/="}]}]
+              (let [{:keys [status, body]} (req {:scope {:model-id (:id model)
+                                                         :table-id (:id table)}
+                                                 :action_id (:id action)})]
+                (is (= 200 status))
+                (is (= "Do cool thing" (:title body)))
+                (is (= [{:id "a"
+                         :display_name "A"
+                         :type "type/Number"}
+                        {:id "b"
+                         :display_name "B"
+                         :type "type/Date"}
+                        {:id "c"
+                         :display_name "C"
+                         :type "type/Text"}
+                        {:id "d"
+                         :display_name "D"
+                         :type "type/Text"}]
+                       (->> (:parameters body)
+                            (map #(select-keys % [:id :display_name :type])))))))))))))
+
+(deftest tmp-modal-table-action-test
   (let [list-req
         #(mt/user-http-request-full-response
           (:user % :crowberto)
@@ -1093,45 +1145,6 @@
                                                                   :timestamp [:timestamp]
                                                                   :date      [:date]}
                                                                  {:primary-key [:id]})]
-          (testing "saved actions"
-            (mt/with-non-admin-groups-no-root-collection-perms
-              (mt/with-temp [:model/Table         table    {}
-                             :model/Card          model    {:type         :model
-                                                            :table_id     (:id table)}
-                             :model/Action        action   {:type         :query
-                                                            :name "Do cool thing"
-                                                            :model_id     (:id model)
-                                                            :parameters   [{:id "a"
-                                                                            :name "A"
-                                                                            :type "number/="}
-                                                                           {:id "b"
-                                                                            :name "B"
-                                                                            :type "date/single"}
-                                                                           {:id "c"
-                                                                            :name "C"
-                                                                            :type "string/="}
-                                                                           {:id "d"
-                                                                            :name "D"
-                                                                            :type "string/="}]}]
-                (let [{:keys [status, body]} (req {:scope {:model-id (:id model)
-                                                           :table-id (:id table)}
-                                                   :action_id (:id action)})]
-                  (is (= 200 status))
-                  (is (= "Do cool thing" (:title body)))
-                  (is (= [{:id "a"
-                           :display_name "A"
-                           :type "type/Number"}
-                          {:id "b"
-                           :display_name "B"
-                           :type "type/Date"}
-                          {:id "c"
-                           :display_name "C"
-                           :type "type/Text"}
-                          {:id "d"
-                           :display_name "D"
-                           :type "type/Text"}]
-                         (->> (:parameters body)
-                              (map #(select-keys % [:id :display_name :type])))))))))
 
           (testing "table actions"
             (let [{list-body :body} (list-req {})
@@ -1194,10 +1207,30 @@
                               (map #(select-keys % [:id :display_name :type])))))))))
 
           (mt/with-temp
-            [:model/Dashboard dashboard {}
-             :model/DashboardCard dashcard {:dashboard_id (:id dashboard)
-                                            :visualization_settings {:table_id @test-table}}]
-            (testing "table actions (old picker shim)"
+            [:model/Dashboard dashboard
+             {}
+             :model/DashboardCard dashcard
+             {:dashboard_id (:id dashboard)
+              :visualization_settings
+              {:table_id @test-table
+               :editableTable.enabledActions
+               [{:id "table.row/create"
+                 :parameterMappings [{:parameterId "int"
+                                      :sourceType  "const"
+                                      :value       42}
+                                     {:parameterId "text"
+                                      :sourceType  "row-data"
+                                      :sourceValueTarget "text"
+                                      :visibility  "readonly"}
+                                     {:parameterId "timestamp"
+                                      :visibility  "hidden"}]}]}}]
+
+            ;; insert a row for the row action
+            (mt/user-http-request :crowberto :post 200
+                                  (data-editing.tu/table-url @test-table)
+                                  {:rows [{:text "a very important string"}]})
+
+            (testing "table actions on a dashcard"
               (let [create-id "table.row/create"
                     update-id "table.row/update"
                     delete-id "table.row/delete"]
@@ -1205,9 +1238,20 @@
                                              ["dashcard scope" {:dashcard-id (:id dashcard)}]]]
                   (testing testing-msg
                     (testing "create"
-                      (let [{:keys [status]} (req {:scope scope
-                                                   :action_id create-id})]
-                        (is (= 200 status))))
+                      (let [{:keys [status
+                                    body]} (req {:scope     scope
+                                                 :action_id create-id
+                                                 :input     {:id 1}})]
+                        (is (= 200 status))
+                        (when (:dashcard-id scope)
+                          (is (= [{:id "text" :readonly true  :value "a very important string"}
+                                  {:id "int"  :readonly false}
+                                 ;; note that timestamp is now hidden
+                                  {:id "date" :readonly false}]
+                                 (map #(select-keys % [:id
+                                                       :readonly
+                                                       :value])
+                                      (:parameters body)))))))
 
                     (testing "update"
                       (let [{:keys [status]} (req {:scope scope
@@ -1218,6 +1262,8 @@
                       (let [{:keys [status]} (req {:scope scope
                                                    :action_id delete-id})]
                         (is (= 200 status))))))))))))))
+
+(deftest tmp-modal-test)
 
 ;; Taken from metabase-enterprise.data-editing.api-test.
 ;; When we deprecate that API, we should move all the sibling tests here as well.


### PR DESCRIPTION
- readonly support
- hidden params are hidden
- constant :value is returned (to show on screen)
- row :value is returned by lookup against the provided :input pk