### PR TITLE
fix a tiny flake

### DIFF
--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -116,7 +116,9 @@
 
 (def ^:private ^:dynamic ^Long *query-execution-delay-ms* 10)
 
-(def ^:private ^:dynamic *query-caching-min-ttl* 1)
+(def ^:private ^:dynamic *query-caching-min-ttl*
+  "Set this to zero to prevent flakes - we don't want a query to slip under the wire here."
+  0)
 
 (defn ^:private ttl-strategy []
   {:type             :ttl


### PR DESCRIPTION
Fix a tiny cache flake. Sometimes a query would slip under this wire and execute in less than 1ms (which, wow! impressive!) and the cache tests would get unexpected results (e.g. something wasn't cached that should have been).