### PR TITLE
Add team names to backend modules config

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1,4 +1,16 @@
+;;
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+;; !!                                                                                       !!
+;; !!  PRO TIP! Run the tests in [[metabase.core.modules-test]] when you change this file!  !!
+;; !!                                                                                       !!
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+;;
 ;; A "module" is any `metabase.<module>.core` namespace in `src`.
+;;
+;; ## `team`:
+;;
+;; The team that owns this module. This has to match one of the team names in `.github/team.json` EXACTLY. You can
+;; run [metabase.core.modules-test/all-modules-have-teams-test]] to make sure you did this correctly.
 ;;
 ;; ## `api`:
 ;;
@@ -34,7 +46,8 @@
 ;; you need to make
 {:metabase/modules
  {actions
-  {:api  #{metabase.actions.api
+  {:team "Workflows"
+   :api  #{metabase.actions.api
            metabase.actions.core
            metabase.actions.init}
    :uses #{analytics
@@ -54,7 +67,8 @@
            util}}
 
   activity-feed
-  {:api  #{metabase.activity-feed.api metabase.activity-feed.init}
+  {:team "Admin Webapp"
+   :api  #{metabase.activity-feed.api metabase.activity-feed.init}
    :uses #{api
            app-db
            collections
@@ -63,20 +77,16 @@
            models
            util}}
 
-  appearance
-  {:api  #{metabase.appearance.core
-           metabase.appearance.init}
-   :uses #{settings util}}
-
   analytics
-  {:api  #{metabase.analytics.api
+  {:team "Admin Webapp"
+   :api  #{metabase.analytics.api
            metabase.analytics.core
            metabase.analytics.init
            metabase.analytics.prometheus
            metabase.analytics.snowplow}
-   :uses #{appearance
-           api
+   :uses #{api
            app-db
+           appearance
            channel
            config
            driver
@@ -95,7 +105,8 @@
            version}}
 
   analyze
-  {:api  #{metabase.analyze.core
+  {:team "Semantic Layer"
+   :api  #{metabase.analyze.core
            metabase.analyze.query-results}
    :uses #{config
            driver
@@ -107,7 +118,8 @@
 
   ;; TODO -- consolidate these into a `.core` API namespace.
   api
-  {:api #{metabase.api.common
+  {:team "DevEx"
+   :api #{metabase.api.common
           metabase.api.common.internal
           metabase.api.docs
           metabase.api.init
@@ -125,7 +137,8 @@
            util}}
 
   api-keys
-  {:api  #{metabase.api-keys.api
+  {:team "Admin Webapp"
+   :api  #{metabase.api-keys.api
            metabase.api-keys.core}
    :uses #{api
            app-db
@@ -136,11 +149,13 @@
            util}}
 
   api-routes
-  {:api  #{metabase.api-routes.core}
+  {:team "Admin Webapp"
+   :api  #{metabase.api-routes.core}
    :uses :any}
 
   app-db
-  {:api  #{metabase.app-db.cluster-lock ; TODO FIXME
+  {:team "Admin Webapp"
+   :api  #{metabase.app-db.cluster-lock ; TODO FIXME
            metabase.app-db.core
            metabase.app-db.init
            metabase.app-db.setup}
@@ -151,8 +166,15 @@
            task
            util}}
 
+  appearance
+  {:team "Admin Webapp"
+   :api  #{metabase.appearance.core
+           metabase.appearance.init}
+   :uses #{settings util}}
+
   audit-app
-  {:api  #{metabase.audit-app.core
+  {:team "Admin Webapp"
+   :api  #{metabase.audit-app.core
            metabase.audit-app.init}
    :uses #{api
            app-db
@@ -165,25 +187,29 @@
            util}}
 
   auth-provider
-  {:api  #{metabase.auth-provider.core}
+  {:team "Admin Webapp"
+   :api  #{metabase.auth-provider.core}
    :uses #{premium-features}}
 
   batch-processing
-  {:api  #{metabase.batch-processing.core
+  {:team "Admin Webapp"
+   :api  #{metabase.batch-processing.core
            metabase.batch-processing.init}
    :uses #{app-db
            settings
            util}}
 
   bookmarks
-  {:api  #{metabase.bookmarks.api}
+  {:team "Admin Webapp"
+   :api  #{metabase.bookmarks.api}
    :uses #{api
            app-db
            queries
            util}}
 
   bug-reporting
-  {:api  #{metabase.bug-reporting.api
+  {:team "Admin Webapp"
+   :api  #{metabase.bug-reporting.api
            metabase.bug-reporting.init}
    :uses #{analytics
            api
@@ -196,7 +222,8 @@
            util}}
 
   cache
-  {:api  #{metabase.cache.api
+  {:team "Admin Webapp"
+   :api  #{metabase.cache.api
            metabase.cache.core
            metabase.cache.init}
    :uses #{api
@@ -210,7 +237,8 @@
 
   ;; TODO -- way too many API namespaces.
   channel
-  {:api  #{metabase.channel.api
+  {:team "Workflows"
+   :api  #{metabase.channel.api
            metabase.channel.core
            metabase.channel.email
            metabase.channel.email.messages
@@ -247,12 +275,14 @@
            util}}
 
   classloader
-  {:api  #{metabase.classloader.core
+  {:team "DevEx"
+   :api  #{metabase.classloader.core
            metabase.classloader.init}
    :uses #{util}}
 
   cloud-migration
-  {:api  #{metabase.cloud-migration.api
+  {:team "Admin Webapp"
+   :api  #{metabase.cloud-migration.api
            metabase.cloud-migration.core
            metabase.cloud-migration.init}
    :uses #{api
@@ -265,15 +295,9 @@
            task
            util}}
 
-  content-verification
-  {:api  #{metabase.content-verification.core
-           metabase.content-verification.init}
-   :uses #{app-db
-           models
-           util}}
-
   cmd
-  {:api  #{metabase.cmd.copy
+  {:team "Admin Webapp"
+   :api  #{metabase.cmd.copy
            metabase.cmd.core
            metabase.cmd.dump-to-h2}
    :uses #{api
@@ -290,7 +314,8 @@
            util}}
 
   collections
-  {:api  #{metabase.collections.api
+  {:team "Admin Webapp"
+   :api  #{metabase.collections.api
            metabase.collections.models.collection
            metabase.collections.models.collection.root}
    :uses #{api
@@ -315,20 +340,32 @@
   ;; technically this 'uses' `enterprise/core` and `test` since it tries to load them to see if they exists so we know
   ;; if EE/test code is available; however we can ignore them since they're not real usages.
   config
-  {:api  #{metabase.config.core}
+  {:team "DevEx"
+   :api  #{metabase.config.core}
    :uses #{}}
 
   ;; this is not actually a real module, but comes from one of our libraries.
   connection-pool
-  {:api  #{metabase.connection-pool}
+  {:team "Admin Webapp"
+   :api  #{metabase.connection-pool}
    :uses #{}}
 
+  content-verification
+  {:team "Admin Webapp"
+   :api  #{metabase.content-verification.core
+           metabase.content-verification.init}
+   :uses #{app-db
+           models
+           util}}
+
   core
-  {:api  #{metabase.core.initialization-status}
+  {:team "Admin Webapp"
+   :api  #{metabase.core.initialization-status}
    :uses :any}
 
   dashboards
-  {:api  #{metabase.dashboards.api
+  {:team "DashViz"
+   :api  #{metabase.dashboards.api
            metabase.dashboards.autoplace
            metabase.dashboards.constants
            metabase.dashboards.models.dashboard
@@ -362,11 +399,13 @@
            xrays}}
 
   database-routing
-  {:api  #{metabase.database-routing.core}
+  {:team "Admin Webapp"
+   :api  #{metabase.database-routing.core}
    :uses #{premium-features}}
 
   driver
-  {:api #{metabase.driver
+  {:team "Drivers"
+   :api #{metabase.driver
           metabase.driver.common
           metabase.driver.common.parameters
           metabase.driver.common.parameters.dates
@@ -412,12 +451,13 @@
            sync
            system
            upload
+           util
            warehouse-schema
-           warehouses
-           util}}
+           warehouses}}
 
   eid-translation
-  {:api  #{metabase.eid-translation.api
+  {:team "Admin Webapp"
+   :api  #{metabase.eid-translation.api
            metabase.eid-translation.core
            metabase.eid-translation.init}
    :uses #{api
@@ -425,7 +465,8 @@
            util}}
 
   embedding
-  {:api  #{metabase.embedding.api
+  {:team "Embedding"
+   :api  #{metabase.embedding.api
            metabase.embedding.init
            metabase.embedding.settings
            metabase.embedding.validation}
@@ -447,22 +488,25 @@
            util}}
 
   events
-  {:api  #{metabase.events.core
+  {:team "DevEx"
+   :api  #{metabase.events.core
            metabase.events.init}
    :uses #{models
            util}}
 
   formatter
-  {:api  #{metabase.formatter.core}
+  {:team "DashViz"
+   :api  #{metabase.formatter.core}
    :uses #{appearance
            models
-           system
            query-processor
+           system
            types
            util}}
 
   geojson
-  {:api  #{metabase.geojson.api
+  {:team "Admin Webapp"
+   :api  #{metabase.geojson.api
            metabase.geojson.init}
    :uses #{api
            permissions
@@ -470,7 +514,8 @@
            util}}
 
   indexed-entities
-  {:api  #{metabase.indexed-entities.api
+  {:team "Admin Webapp"
+   :api  #{metabase.indexed-entities.api
            metabase.indexed-entities.init}
    :uses #{analytics
            api
@@ -485,12 +530,14 @@
            util}}
 
   internal-stats
-  {:api #{metabase.internal-stats.core}
+  {:team "Admin Webapp"
+   :api #{metabase.internal-stats.core}
    :uses #{app-db
            models}}
 
   legacy-mbql
-  {:api #{metabase.legacy-mbql.normalize
+  {:team "Querying"
+   :api #{metabase.legacy-mbql.normalize
           metabase.legacy-mbql.predicates
           metabase.legacy-mbql.schema
           metabase.legacy-mbql.schema.helpers
@@ -501,7 +548,8 @@
            util}}
 
   lib
-  {:api #{metabase.lib.binning
+  {:team "Querying"
+   :api #{metabase.lib.binning
           metabase.lib.binning.util
           metabase.lib.card
           metabase.lib.core
@@ -545,7 +593,8 @@
            util}}
 
   lib-be
-  {:api #{metabase.lib-be.core
+  {:team "Querying"
+   :api #{metabase.lib-be.core
           metabase.lib-be.init
           metabase.lib-be.metadata.jvm}
    :uses #{lib
@@ -554,7 +603,8 @@
            util}}
 
   logger
-  {:api  #{metabase.logger.api
+  {:team "DevEx"
+   :api  #{metabase.logger.api
            metabase.logger.core
            metabase.logger.init}
    :uses #{analytics
@@ -565,7 +615,8 @@
            util}}
 
   login-history
-  {:api #{metabase.login-history.api
+  {:team "Admin Webapp"
+   :api #{metabase.login-history.api
           metabase.login-history.core
           metabase.login-history.init}
    :uses #{analytics
@@ -576,7 +627,8 @@
            util}}
 
   model-persistence
-  {:api #{metabase.model-persistence.api
+  {:team "Querying"
+   :api #{metabase.model-persistence.api
           metabase.model-persistence.core
           metabase.model-persistence.init}
    :uses #{api
@@ -587,17 +639,18 @@
            models
            permissions
            premium-features
-           settings
            queries
            query-processor
            request
+           settings
            system
            task
            task-history
            util}}
 
   models
-  {:api #{metabase.models.dispatch
+  {:team "DevEx"
+   :api #{metabase.models.dispatch
           metabase.models.humanization
           metabase.models.init
           metabase.models.interface
@@ -615,7 +668,8 @@
            util}}
 
   native-query-snippets
-  {:api  #{metabase.native-query-snippets.api
+  {:team "Querying"
+   :api  #{metabase.native-query-snippets.api
            metabase.native-query-snippets.core}
    :uses #{api
            collections
@@ -625,7 +679,8 @@
            util}}
 
   notification
-  {:api  #{metabase.notification.api
+  {:team "Workflows"
+   :api  #{metabase.notification.api
            metabase.notification.core
            metabase.notification.init
            metabase.notification.models
@@ -655,7 +710,8 @@
 
   ;; TODO -- too many API namespaces
   parameters
-  {:api  #{metabase.parameters.chain-filter
+  {:team "Querying"
+   :api  #{metabase.parameters.chain-filter
            metabase.parameters.custom-values
            metabase.parameters.dashboard
            metabase.parameters.field
@@ -678,7 +734,8 @@
            warehouses}}
 
   permissions
-  {:api  #{metabase.permissions.api
+  {:team "Admin Webapp"
+   :api  #{metabase.permissions.api
            metabase.permissions.core
            metabase.permissions.init
            ;; TODO -- move these into the API namespace.
@@ -704,19 +761,22 @@
            enterprise/advanced-permissions}}
 
   pivot
-  {:api #{metabase.pivot.core}
+  {:team "DashViz"
+   :api #{metabase.pivot.core}
    :uses #{models
            util}}
 
   plugins
-  {:api  #{metabase.plugins.core}
+  {:team "DevEx"
+   :api  #{metabase.plugins.core}
    :uses #{classloader
            config
            driver
            util}}
 
   premium-features
-  {:api  #{metabase.premium-features.api
+  {:team "Admin Webapp"
+   :api  #{metabase.premium-features.api
            metabase.premium-features.core
            metabase.premium-features.init}
    :uses #{api
@@ -728,7 +788,8 @@
            util}}
 
   product-feedback
-  {:api  #{metabase.product-feedback.api
+  {:team "Admin Webapp"
+   :api  #{metabase.product-feedback.api
            metabase.product-feedback.init}
    :uses #{analytics
            api
@@ -742,7 +803,8 @@
            util}}
 
   public-sharing
-  {:api  #{metabase.public-sharing.api
+  {:team "Admin Webapp"
+   :api  #{metabase.public-sharing.api
            metabase.public-sharing.core
            metabase.public-sharing.init
            metabase.public-sharing.validation}
@@ -763,7 +825,8 @@
            util}}
 
   pulse
-  {:api  #{metabase.pulse.api
+  {:team "Workflows"
+   :api  #{metabase.pulse.api
            metabase.pulse.core
            metabase.pulse.init}
    :uses #{api
@@ -787,7 +850,8 @@
            enterprise/sandbox}}
 
   queries
-  {:api  #{metabase.queries.api
+  {:team "Querying"
+   :api  #{metabase.queries.api
            metabase.queries.core
            metabase.queries.init
            metabase.queries.models.query ; TODO FIXME
@@ -825,7 +889,8 @@
            warehouse-schema}}
 
   query-analysis
-  {:api  #{metabase.query-analysis.core
+  {:team "Querying"
+   :api  #{metabase.query-analysis.core
            metabase.query-analysis.init}
    :uses #{config
            driver
@@ -837,7 +902,8 @@
            util}}
 
   query-permissions
-  {:api  #{metabase.query-permissions.core}
+  {:team "Admin Webapp"
+   :api  #{metabase.query-permissions.core}
    :uses #{api
            legacy-mbql
            lib
@@ -848,7 +914,8 @@
            util}}
 
   query-processor
-  {:api #{metabase.query-processor
+  {:team "Querying"
+   :api #{metabase.query-processor
           metabase.query-processor.api
           metabase.query-processor.card
           metabase.query-processor.compile
@@ -904,29 +971,31 @@
            permissions
            pivot
            premium-features
-           query-permissions
            queries
+           query-permissions
            request
+           server
            settings
            system
-           server
            types
            users
            util}}
 
   request
-  {:api  #{metabase.request.core
+  {:team "Admin Webapp"
+   :api  #{metabase.request.core
            metabase.request.init}
    :uses #{api
            config
-           permissions ; FIXME
+           permissions                  ; FIXME
            session
            settings
            users
            util}}
 
   revisions
-  {:api  #{metabase.revisions.api
+  {:team "Admin Webapp"
+   :api  #{metabase.revisions.api
            metabase.revisions.core
            metabase.revisions.init}
    :uses #{api
@@ -938,7 +1007,8 @@
            util}}
 
   sample-data
-  {:api  #{metabase.sample-data.core
+  {:team "Admin Webapp"
+   :api  #{metabase.sample-data.core
            metabase.sample-data.init}
    :uses #{plugins
            settings
@@ -946,7 +1016,8 @@
            util}}
 
   search
-  {:api #{metabase.search.api
+  {:team "Admin Webapp"
+   :api #{metabase.search.api
           metabase.search.appdb.scoring
           metabase.search.config
           metabase.search.core
@@ -975,11 +1046,13 @@
            warehouses}}
 
   secrets
-  {:api  #{metabase.secrets.core}
+  {:team "Drivers"
+   :api  #{metabase.secrets.core}
    :uses #{api driver models premium-features util}}
 
   segments
-  {:api  #{metabase.segments.api}
+  {:team "Querying"
+   :api  #{metabase.segments.api}
    :uses #{api
            events
            legacy-mbql
@@ -992,7 +1065,8 @@
            xrays}}
 
   server
-  {:api #{metabase.server.core
+  {:team "Admin Webapp"
+   :api #{metabase.server.core
           metabase.server.init
           metabase.server.middleware.session
           metabase.server.streaming-response} ; TODO -- too many API namespaces
@@ -1015,8 +1089,9 @@
            enterprise/sso}}
 
   session
-  {:api  #{metabase.session.core
-           metabase.session.api
+  {:team "Admin Webapp"
+   :api  #{metabase.session.api
+           metabase.session.core
            metabase.session.init
            metabase.session.models.session ; TODO -- shouldn't be exposed as an API namespace
            metabase.session.settings}      ; TODO -- shouldn't be exposed as an API namespace
@@ -1036,7 +1111,8 @@
            util}}
 
   settings
-  {:api  #{metabase.settings.api
+  {:team "DevEx"
+   :api  #{metabase.settings.api
            metabase.settings.core
            metabase.settings.init}
    :uses #{api
@@ -1050,7 +1126,8 @@
            enterprise/advanced-permissions}}
 
   setup
-  {:api  #{metabase.setup.api
+  {:team "Admin Webapp"
+   :api  #{metabase.setup.api
            metabase.setup.core
            metabase.setup.init}
    :uses #{analytics
@@ -1069,7 +1146,8 @@
            util}}
 
   sso
-  {:api  #{metabase.sso.api
+  {:team "Admin Webapp"
+   :api  #{metabase.sso.api
            metabase.sso.core
            metabase.sso.init}
    :uses #{api
@@ -1081,11 +1159,13 @@
            util}}
 
   startup
-  {:api  #{metabase.startup.core}
+  {:team "DevEx"
+   :api  #{metabase.startup.core}
    :uses #{util}}
 
   sync
-  {:api #{metabase.sync.api
+  {:team "Semantic Layer"
+   :api #{metabase.sync.api
           metabase.sync.core
           metabase.sync.init
           metabase.sync.schedules
@@ -1109,19 +1189,22 @@
            warehouses}}
 
   system
-  {:api  #{metabase.system.core
+  {:team "Admin Webapp"
+   :api  #{metabase.system.core
            metabase.system.init}
    :uses #{appearance settings util}}
 
   task
-  {:api #{metabase.task.bootstrap
+  {:team "Admin Webapp"
+   :api #{metabase.task.bootstrap
           metabase.task.core}
    :uses #{app-db
            classloader
            util}}
 
   task-history
-  {:api  #{metabase.task-history.api
+  {:team "Admin Webapp"
+   :api  #{metabase.task-history.api
            metabase.task-history.core
            metabase.task-history.init}
    :uses #{api
@@ -1133,7 +1216,8 @@
            util}}
 
   testing-api
-  {:api  #{metabase.testing-api.api
+  {:team "DevEx"
+   :api  #{metabase.testing-api.api
            metabase.testing-api.core
            metabase.testing-api.init}
    :uses #{analytics
@@ -1145,7 +1229,8 @@
            util}}
 
   tiles
-  {:api  #{metabase.tiles.api
+  {:team "DashViz"
+   :api  #{metabase.tiles.api
            metabase.tiles.init}
    :uses #{api
            legacy-mbql
@@ -1154,7 +1239,8 @@
            util}}
 
   timeline
-  {:api  #{metabase.timeline.api
+  {:team "Admin Webapp"
+   :api  #{metabase.timeline.api
            metabase.timeline.core}
    :uses #{analytics
            api
@@ -1163,17 +1249,19 @@
            util}}
 
   types
-  {:api  #{metabase.types.core
+  {:team "Semantic Layer"
+   :api  #{metabase.types.core
            metabase.types.init}
    :uses #{util}}
 
   upload
-  {:api  #{metabase.upload.api
+  {:team "Semantic Layer"
+   :api  #{metabase.upload.api
            metabase.upload.core
            metabase.upload.init}
    :uses #{analytics
-           appearance
            api
+           appearance
            collections
            driver
            events
@@ -1189,7 +1277,8 @@
            warehouse-schema}}
 
   user-key-value
-  {:api  #{metabase.user-key-value.api
+  {:team "Admin Webapp"
+   :api  #{metabase.user-key-value.api
            metabase.user-key-value.init}
    :uses #{api
            config
@@ -1197,7 +1286,8 @@
            util}}
 
   users
-  {:api  #{metabase.users.api
+  {:team "Admin Webapp"
+   :api  #{metabase.users.api
            metabase.users.init
            metabase.users.models.user
            metabase.users.models.user-parameter-value}
@@ -1222,14 +1312,16 @@
            enterprise/advanced-permissions}}
 
   util
-  {:api :any
+  {:team "DevEx"
+   :api  :any
    :uses #{classloader
            config
            settings
            system}}
 
   version
-  {:api  #{metabase.version.core
+  {:team "Admin Webapp"
+   :api  #{metabase.version.core
            metabase.version.init}
    :uses #{config
            settings
@@ -1238,7 +1330,8 @@
            util}}
 
   view-log
-  {:api  #{metabase.view-log.core
+  {:team "Admin Webapp"
+   :api  #{metabase.view-log.core
            metabase.view-log.init}
    :uses #{analytics
            api
@@ -1252,7 +1345,8 @@
            util}}
 
   warehouse-schema
-  {:api  #{metabase.warehouse-schema.api
+  {:team "Admin Webapp"
+   :api  #{metabase.warehouse-schema.api
            metabase.warehouse-schema.field
            metabase.warehouse-schema.metadata-from-qp
            metabase.warehouse-schema.metadata-queries
@@ -1283,7 +1377,8 @@
            xrays}}
 
   warehouses
-  {:api  #{metabase.warehouses.api
+  {:team "Admin Webapp"
+   :api  #{metabase.warehouses.api
            metabase.warehouses.core
            metabase.warehouses.init
            metabase.warehouses.models.database}
@@ -1315,29 +1410,31 @@
            enterprise/advanced-permissions}}
 
   xrays
-  {:api  #{metabase.xrays.api
+  {:team "Querying"
+   :api  #{metabase.xrays.api
            metabase.xrays.core
            metabase.xrays.init}
    :uses #{analyze
-           appearance
            api
+           appearance
            collections
            dashboards
            driver
            legacy-mbql
            lib
            models
-           settings
            queries
            query-permissions
            query-processor
+           settings
            util
            warehouse-schema}}
 
   enterprise/advanced-config
-  {:api  #{metabase-enterprise.advanced-config.api.logs
-           metabase-enterprise.advanced-config.init
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.advanced-config.api.logs
            metabase-enterprise.advanced-config.file
+           metabase-enterprise.advanced-config.init
            metabase-enterprise.advanced-config.settings}
    :uses #{api
            api-keys
@@ -1345,14 +1442,15 @@
            driver
            permissions
            premium-features
-           setup
            settings
+           setup
            sync
            users
            util}}
 
   enterprise/advanced-permissions
-  {:api  #{metabase-enterprise.advanced-permissions.api.routes
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.advanced-permissions.api.routes
            metabase-enterprise.advanced-permissions.common
            metabase-enterprise.advanced-permissions.models.permissions.group-manager}
    :uses #{api
@@ -1366,30 +1464,35 @@
            enterprise/impersonation}}
 
   enterprise/ai-entity-analysis
-  {:api #{metabase-enterprise.ai-entity-analysis.api}
+  {:team "Metabot"
+   :api  #{metabase-enterprise.ai-entity-analysis.api}
    :uses #{api
            premium-features
            enterprise/metabot-v3}}
 
   enterprise/ai-sql-fixer
-  {:api #{metabase-enterprise.ai-sql-fixer.api}
+  {:team "Metabot"
+   :api  #{metabase-enterprise.ai-sql-fixer.api}
    :uses #{api
            driver
-           enterprise/metabot-v3
            query-analysis
            query-processor
-           util}}
+           util
+           enterprise/metabot-v3
+           }}
 
   enterprise/ai-sql-generation
-  {:api #{metabase-enterprise.ai-sql-generation.api}
+  {:team  "Metabot"
+   :api  #{metabase-enterprise.ai-sql-generation.api}
    :uses #{api
            driver
-           enterprise/metabot-v3
            models
-           util}}
+           util
+           enterprise/metabot-v3}}
 
   enterprise/analytics
-  {:api  #{}
+  {:team "Admin Webapp"
+   :api  #{}
    :uses #{driver
            premium-features
            enterprise/advanced-config
@@ -1397,12 +1500,14 @@
            enterprise/sso}}
 
   enterprise/api
-  {:api  #{metabase-enterprise.api.routes
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.api.routes
            metabase-enterprise.api.routes.common}
    :uses :any}
 
   enterprise/audit-app
-  {:api  #{metabase-enterprise.audit-app.api.routes
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.audit-app.api.routes
            metabase-enterprise.audit-app.init}
    :uses #{api
            app-db
@@ -1423,17 +1528,20 @@
            enterprise/serialization}}
 
   enterprise/auth-provider
-  {:api  #{}
+  {:team "Admin Webapp"
+   :api  #{}
    :uses #{premium-features
            util}}
 
   enterprise/billing
-  {:api  #{metabase-enterprise.billing.api.routes}
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.billing.api.routes}
    :uses #{api
            premium-features util}}
 
   enterprise/cache
-  {:api  #{metabase-enterprise.cache.init}
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.cache.init}
    :uses #{cache
            premium-features
            query-processor
@@ -1441,28 +1549,33 @@
            util}}
 
   enterprise/content-verification
-  {:api  #{metabase-enterprise.content-verification.api.routes}
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.content-verification.api.routes}
    :uses #{api
            content-verification
            util
            enterprise/api}}
 
   enterprise/core
-  {:api  #{metabase-enterprise.core.init}
+  {:team "DevEx"
+   :api  #{metabase-enterprise.core.init}
    :uses :any}
 
   enterprise/dashboard-subscription-filters
-  {:api  #{}
+  {:team "Workflows"
+   :api  #{}
    :uses #{premium-features}}
 
   enterprise/data-editing
-  {:api  #{metabase-enterprise.data-editing.api}
-   :uses #{api
-           actions
+  {:team "Workflows"
+   :api  #{metabase-enterprise.data-editing.api}
+   :uses #{actions
+           api
            util}}
 
   enterprise/database-routing
-  {:api #{metabase-enterprise.database-routing.api}
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.database-routing.api}
    :uses #{api
            config
            database-routing
@@ -1477,23 +1590,26 @@
            warehouses}}
 
   enterprise/gsheets
-  {:api  #{metabase-enterprise.gsheets.api
+  {:team  "Cloud"
+   :api  #{metabase-enterprise.gsheets.api
            metabase-enterprise.gsheets.init}
-   :uses #{api
-           analytics
+   :uses #{analytics
+           api
            premium-features
            settings
            util
            enterprise/harbormaster}}
 
   enterprise/harbormaster
-  {:api #{metabase-enterprise.harbormaster.client}
+  {:team "Cloud"
+   :api  #{metabase-enterprise.harbormaster.client}
    :uses #{api
            cloud-migration
            util}}
 
   enterprise/impersonation
-  {:api #{metabase-enterprise.impersonation.api}
+  {:team "Drivers"
+   :api  #{metabase-enterprise.impersonation.api}
    :uses #{api
            audit-app
            driver
@@ -1506,12 +1622,14 @@
            enterprise/sandbox}}
 
   enterprise/internal-stats
-  {:api #{}
+  {:team "Admin Webapp"
+   :api  #{}
    :uses #{premium-features
            settings}}
 
   enterprise/llm
-  {:api  #{metabase-enterprise.llm.api
+  {:team "Metabot"
+   :api  #{metabase-enterprise.llm.api
            metabase-enterprise.llm.init}
    :uses #{analytics
            analyze
@@ -1522,7 +1640,8 @@
            util}}
 
   enterprise/metabot-v3
-  {:api #{metabase-enterprise.metabot-v3.api
+  {:team "Metabot"
+   :api #{metabase-enterprise.metabot-v3.api
           metabase-enterprise.metabot-v3.core
           metabase-enterprise.metabot-v3.init
           metabase-enterprise.metabot-v3.tools.api}
@@ -1546,12 +1665,14 @@
            warehouse-schema}}
 
   enterprise/premium-features
-  {:api  #{}
+  {:team "Admin Webapp"
+   :api  #{}
    :uses #{premium-features
            util}}
 
   enterprise/query-reference-validation
-  {:api  #{metabase-enterprise.query-reference-validation.api}
+  {:team "Querying"
+   :api  #{metabase-enterprise.query-reference-validation.api}
    :uses #{api
            collections
            query-analysis
@@ -1559,7 +1680,8 @@
            util}}
 
   enterprise/sandbox
-  {:api #{metabase-enterprise.sandbox.api.routes
+  {:team "Admin Webapp"
+   :api #{metabase-enterprise.sandbox.api.routes
           metabase-enterprise.sandbox.api.util}
    :uses #{api
            app-db
@@ -1581,7 +1703,8 @@
            enterprise/api}}
 
   enterprise/scim
-  {:api  #{metabase-enterprise.scim.core
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.scim.core
            metabase-enterprise.scim.init
            metabase-enterprise.scim.routes}
    :uses #{analytics
@@ -1589,20 +1712,22 @@
            api-keys
            models
            permissions
-           settings
            server
+           settings
            system
            users
            util
            enterprise/serialization}}
 
   enterprise/search
-  {:api  #{}
+  {:team "Admin Webapp"
+   :api  #{}
    :uses #{premium-features
            search}}
 
   enterprise/serialization
-  {:api #{metabase-enterprise.serialization.api
+  {:team "Workflows"
+   :api #{metabase-enterprise.serialization.api
           metabase-enterprise.serialization.cmd
           metabase-enterprise.serialization.v2.backfill-ids}
    :uses #{analytics
@@ -1623,7 +1748,8 @@
            warehouse-schema}}
 
   enterprise/snippet-collections
-  {:api  #{}
+  {:team "Querying"
+   :api  #{}
    :uses #{models
            native-query-snippets
            permissions
@@ -1631,7 +1757,8 @@
            util}}
 
   enterprise/sso
-  {:api #{metabase-enterprise.sso.api.routes
+  {:team "Admin Webapp"
+   :api #{metabase-enterprise.sso.api.routes
           metabase-enterprise.sso.init
           metabase-enterprise.sso.settings}
    :uses #{api
@@ -1651,7 +1778,8 @@
            enterprise/scim}}
 
   enterprise/stale
-  {:api  #{metabase-enterprise.stale.api
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.stale.api
            metabase-enterprise.stale.init}
    :uses #{analytics
            api
@@ -1664,7 +1792,8 @@
            util}}
 
   enterprise/upload-management
-  {:api  #{metabase-enterprise.upload-management.api}
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.upload-management.api}
    :uses #{api
            models
            premium-features
@@ -1684,3 +1813,9 @@
      "test\\.impl"                          ; anything that contains `test.impl`
      "test-setup"                           ; anything that contains `test-setup`
      "^metabase(?:-enterprise)?\\.test"}}}} ; anything starting with `metabase.test` or `metabase-enterprise.test`
+
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+;; !!                                                                                       !!
+;; !!  PRO TIP! Run the tests in [[metabase.core.modules-test]] when you change this file!  !!
+;; !!                                                                                       !!
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/.github/team.json
+++ b/.github/team.json
@@ -101,6 +101,11 @@
       "name": "Product Growth",
       "label": ".Team/ProductGrowth",
       "members": ["nemanjaglumac", "chodorowicz"]
+    },
+    {
+      "name": "Cloud",
+      "label": "cloud",
+      "members": []
     }
   ]
 }

--- a/test/metabase/core/modules_test.clj
+++ b/test/metabase/core/modules_test.clj
@@ -1,0 +1,133 @@
+(ns metabase.core.modules-test
+  "Tests that the modules config file is configured correctly."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.util.json :as json]
+   [rewrite-clj.node :as n]
+   [rewrite-clj.parser :as r.parser]
+   [rewrite-clj.zip :as z]))
+
+(set! *warn-on-reflection* true)
+
+(defn- modules-config
+  "Kondo modules config."
+  []
+  (-> (slurp ".clj-kondo/config/modules/config.edn")
+      edn/read-string
+      :metabase/modules))
+
+(defn- teams
+  "Set of valid string team names."
+  []
+  (into (sorted-set)
+        (map :name)
+        (-> (slurp ".github/team.json")
+            (json/decode true)
+            :teams)))
+
+(deftest ^:parallel all-modules-have-teams-test
+  (testing "All modules should have a valid :team owner"
+    (let [teams (teams)]
+      (doseq [[module config] (modules-config)]
+        (testing (format "\n'%s' module" module)
+          (is (contains? teams (:team config))
+              "Should have a valid :team key"))))))
+
+(defn- modules-config-zipper
+  "Return a zipper pointing to the modules config map node (the value of the `:metabase/modules` key)."
+  []
+  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. ".clj-kondo/config/modules/config.edn"))]
+    (let [node               (r.parser/parse-all r)
+          forms-zloc         (z/of-node node)
+          top-level-map-zloc (z/find forms-zloc (fn [zloc]
+                                                  (= (z/tag zloc) :map)))
+          modules-key-zloc   (-> (z/down top-level-map-zloc)
+                                 (z/find (fn [zloc]
+                                           (and (n/keyword-node? (z/node zloc))
+                                                (= (z/sexpr zloc) :metabase/modules)))))
+          config-zloc       (z/find-next modules-key-zloc (fn [zloc]
+                                                            (= (z/tag zloc) :map)))]
+      config-zloc)))
+
+(defn- module-names-in-file-order
+  "Get the list of modules names as they appear in the config file."
+  []
+  (loop [modules [], zloc (z/down (modules-config-zipper))]
+    (let [modules' (conj modules (z/sexpr zloc))
+          zloc'    (-> zloc z/right z/right)]
+      (if zloc'
+        (recur modules' zloc')
+        modules'))))
+
+(defn- sort-module-names
+  "Sort module names in order but sort the `enterprise/` modules last."
+  [module-names]
+  (sort-by (fn [module-name]
+             [(if (str/starts-with? module-name "enterprise/")
+                1
+                0)
+              module-name])
+           module-names))
+
+(deftest ^:parallel modules-should-be-sorted-by-name-test
+  (testing "Modules configs should sorted by module name with enterprise/modules appearing last"
+    (let [actual   (module-names-in-file-order)
+          expected (sort-module-names actual)]
+      (is (= expected
+             actual)))))
+
+(defn- do-each-module-config
+  "Calls
+
+    (f module-symbol module-config-zloc)
+
+  For each module config in the Kondo module config file."
+  [f]
+  (loop [zloc (z/down (modules-config-zipper))]
+    (let [module (z/sexpr zloc)
+          config-zloc (z/right zloc)]
+      (f module config-zloc)
+      (when-let [zloc' (z/right config-zloc)]
+        (recur zloc')))))
+
+(deftest ^:parallel module-api-namespaces-should-be-sorted-test
+  (testing "Module :api namespaces should be sorted"
+    (do-each-module-config
+     (fn [module config-zloc]
+       (when-let [api-namespaces (-> config-zloc
+                                     ;; into the map
+                                     z/down
+                                     ;; find the `:api` key
+                                     (z/find (fn [zloc]
+                                               (and (n/keyword-node? (z/node zloc))
+                                                    (= (z/sexpr zloc) :api))))
+                                     ;; find the value for the `:api` key (set of namespaces)
+                                     z/right
+                                     ;; get the namespaces in the set
+                                     z/child-sexprs
+                                     not-empty)]
+         (testing (format "\n'%s' module" module)
+           (is (= (sort api-namespaces)
+                  api-namespaces))))))))
+
+(deftest ^:parallel module-uses-should-be-sorted-test
+  (testing "Module :uses namespaces should be sorted"
+    (do-each-module-config
+     (fn [module config-zloc]
+       (when-let [uses (-> config-zloc
+                           ;; into the map
+                           z/down
+                           ;; find the `:uses` key
+                           (z/find (fn [zloc]
+                                     (and (n/keyword-node? (z/node zloc))
+                                          (= (z/sexpr zloc) :uses))))
+                           ;; find the value for the `:uses` key (set of module names)
+                           z/right
+                           ;; get the namespaces in the set
+                           z/child-sexprs
+                           not-empty)]
+         (testing (format "\n'%s' module" module)
+           (is (= (sort-module-names uses)
+                  uses))))))))


### PR DESCRIPTION
- Add team names to the backend modules config file (I confirmed which team owns which module in a meeting with the EMs last week)
- Add a test to make sure each module in the config file has a valid team name matching one from the `.github/teams.json` file
- Add tests to make sure modules in config file are kept sorted and fix the ones that weren't

Resolves DEV-522