### PR TITLE
Fix before-and-after :join generative test

### DIFF
--- a/test/metabase/lib/test_util/generators.cljc
+++ b/test/metabase/lib/test_util/generators.cljc
@@ -380,8 +380,8 @@
         (is (= (inc (count before-joins))
                (count after-joins)))
         (testing "at the end"
-          (let [summaries? (or (seq (lib/aggregations after))
-                               (seq (lib/breakouts after)))]
+          (let [summaries? (or (seq (lib/aggregations after stage-number))
+                               (seq (lib/breakouts after stage-number)))]
             (is (=? {:lib/type   :mbql/join
                      :strategy   strategy
                      :alias      string?
@@ -453,9 +453,10 @@
   (let [{after :query :as ctx'} (run-step ctx step)]
     ;; Run the before/after tests. Throws if the tests fail.
     (try
-      (testing (str "\n\nwith before query\n" (u/pprint-to-str before)
-                    "\n\nwith after  query\n" (u/pprint-to-str after)
-                    "\n\nwith steps\n" (str/join "\n" (map pr-str (step-seq ctx))))
+      (testing (str "\n\nwith before steps\n" (str/join "\n" (map pr-str (step-seq ctx)))
+                    "\n\nwith before query\n" (u/pprint-to-str before)
+                    "\n\nwith current step\n" (pr-str step)
+                    "\n\nwith after query\n"  (u/pprint-to-str after))
         (before-and-after before after step))
       ctx'
 

--- a/test/metabase/lib/test_util/generators.cljc
+++ b/test/metabase/lib/test_util/generators.cljc
@@ -423,6 +423,18 @@
       (is (empty? (all-stage-parts after -1))))))
 
 ;; Generator internals ===========================================================================
+(defn history-seq
+  "Returns the sequence of contexts, newest first."
+  [ctx]
+  (->> ctx
+       (iterate :previous)
+       (take-while some?)))
+
+(defn step-seq
+  "Returns the sequence of steps that brought about this query, oldest first."
+  [ctx]
+  (->> ctx history-seq reverse next (map :step)))
+
 (defn- run-step
   "Applies a step, returning the updated context."
   [{:keys [query] :as ctx} step]
@@ -441,7 +453,10 @@
   (let [{after :query :as ctx'} (run-step ctx step)]
     ;; Run the before/after tests. Throws if the tests fail.
     (try
-      (before-and-after before after step)
+      (testing (str "\n\nwith before query\n" (u/pprint-to-str before)
+                    "\n\nwith after  query\n" (u/pprint-to-str after)
+                    "\n\nwith steps\n" (str/join "\n" (map pr-str (step-seq ctx))))
+        (before-and-after before after step))
       ctx'
 
       (catch #?(:clj Throwable :cljs js/Error) e
@@ -449,18 +464,6 @@
                                                             (dissoc :query)
                                                             (assoc :before before, :after after, :step step))
                         e))))))
-
-(defn history-seq
-  "Returns the sequence of contexts, newest first."
-  [ctx]
-  (->> ctx
-       (iterate :previous)
-       (take-while some?)))
-
-(defn step-seq
-  "Returns the sequence of steps that brought about this query, oldest first."
-  [ctx]
-  (->> ctx history-seq reverse next (map :step)))
 
 (defn query->context
   "Retrieves the generator context from the metadata on a generated query."


### PR DESCRIPTION
Closes QUE-1316

### Description

Fix before-and-after :join in generative tests. Pass stage-number to check for aggregations and breakouts on the stage where the join was added rather than the final stage.

Add testing context around before-and-after gen tests to ensure you can see the before and after queries as well as the steps that produced them when a test fails.

### How to verify

Repeatedly run the `query-generator-test`. Previously, it would fail after 100 or so runs.

Alternatively, paste this test into the file and run it

```clojure
(deftest ^:parallel before-and-after-join-test
  (let [before (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                   (lib/aggregate (lib/count))
                   lib/append-stage)
        target (meta/table-metadata :products)
        condition (lib/= (meta/field-metadata :orders :product-id)
                         (meta/field-metadata :products :id))
        strategy :left-join
        step [:join 0 target condition strategy]
        after  (run-step* before step)]
    (testing "before-and-after for a join"
      (before-and-after before after step))))
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
