### PR TITLE
respect modularisation effort and use analytics.core

### DIFF
--- a/src/metabase/warehouse_schema/api/field.clj
+++ b/src/metabase/warehouse_schema/api/field.clj
@@ -1,6 +1,6 @@
 (ns metabase.warehouse-schema.api.field
   (:require
-   [metabase.analytics.snowplow :as snowplow]
+   [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
@@ -159,7 +159,7 @@
                  (t2/hydrate :dimensions :has_field_values)
                  (field/hydrate-target-with-write-perms))
       (when (not= effective-type (:effective_type field))
-        (snowplow/track-event! :snowplow/simple_event {:event "field_effective_type_change" :target_id id})
+        (analytics/track-event! :snowplow/simple_event {:event "field_effective_type_change" :target_id id})
         (quick-task/submit-task! (fn [] (sync/refingerprint-field! <>)))))))
 
 ;;; ------------------------------------------------- Field Metadata -------------------------------------------------
@@ -255,7 +255,7 @@
    FieldValues."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (snowplow/track-event! :snowplow/simple_event {:event "field_manual_scan" :target_id id})
+  (analytics/track-event! :snowplow/simple_event {:event "field_manual_scan" :target_id id})
   (let [field (api/write-check (t2/select-one :model/Field :id id))]
     ;; Grant full permissions so that permission checks pass during sync. If a user has DB detail perms
     ;; but no data perms, they should stll be able to trigger a sync of field values. This is fine because we don't

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.analytics.core :as analytics]
-   [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
@@ -1016,7 +1015,7 @@
                     e))]
       (throw (ex-info (ex-message ex) {:status-code 422}))
       (do
-        (snowplow/track-event! :snowplow/simple_event {:event "database_manual_sync" :target_id id})
+        (analytics/track-event! :snowplow/simple_event {:event "database_manual_sync" :target_id id})
         (quick-task/submit-task!
          (fn []
            (database-routing/with-database-routing-off
@@ -1055,7 +1054,7 @@
   ;; just wrap this is a future so it happens async
   (let [db (api/write-check (get-database id {:exclude-uneditable-details? true}))]
     (events/publish-event! :event/database-manual-scan {:object db :user-id api/*current-user-id*})
-    (snowplow/track-event! :snowplow/simple_event {:event "database_manual_scan" :target_id id})
+    (analytics/track-event! :snowplow/simple_event {:event "database_manual_scan" :target_id id})
     ;; Grant full permissions so that permission checks pass during sync. If a user has DB detail perms
     ;; but no data perms, they should stll be able to trigger a sync of field values. This is fine because we don't
     ;; return any actual field values from this API. (#21764)
@@ -1083,7 +1082,7 @@
                     [:id ms/PositiveInt]]]
   (let [db (api/write-check (get-database id {:exclude-uneditable-details? true}))]
     (events/publish-event! :event/database-discard-field-values {:object db :user-id api/*current-user-id*})
-    (snowplow/track-event! :snowplow/simple_event {:event "database_discard_field_values" :target_id id})
+    (analytics/track-event! :snowplow/simple_event {:event "database_discard_field_values" :target_id id})
     (delete-all-field-values-for-database! db))
   {:status :ok})
 


### PR DESCRIPTION
quick follow up to https://github.com/metabase/metabase/pull/58843 to consistently use `analytics.core` instead of `analytics.snowplow`