### PR TITLE
Load prettier/standalone lazily for SDK

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
+++ b/frontend/src/metabase-lib/v1/expressions/formatter/formatter.ts
@@ -1,6 +1,6 @@
 import type { AstPath, Doc, ParserOptions, Plugin } from "prettier";
 import { builders } from "prettier/doc";
-import { format as pformat } from "prettier/standalone";
+import { format as staticPrettierFormat } from "prettier/standalone";
 
 import { parseNumber } from "metabase/lib/number";
 import * as Lib from "metabase-lib";
@@ -39,6 +39,7 @@ export async function format(
   // the root option.
   const { query, stageIndex } = options;
   const parts = Lib.expressionParts(query, stageIndex, expression);
+
   return formatExpressionParts(parts, options);
 }
 
@@ -54,10 +55,20 @@ export async function formatExpressionParts(
   root: Lib.ExpressionParts | Lib.ExpressionArg,
   options: FormatOptions = {},
 ) {
+  let prettierFormat: typeof staticPrettierFormat;
+
+  if (!process.env.IS_EMBEDDING_SDK) {
+    prettierFormat = staticPrettierFormat;
+  } else {
+    prettierFormat = await import("prettier/standalone").then(
+      ({ format }) => format,
+    );
+  }
+
   // prettier expects us to pass a string, but we have the AST already
   // so we pass a bogus string and ignore it. The actual ast is passed via
   // the root option.
-  return pformat("__not_used__", {
+  return prettierFormat("__not_used__", {
     parser: PRETTIER_PLUGIN_NAME,
     plugins: [plugin({ ...options, root })],
     printWidth: options.printWidth ?? 80,


### PR DESCRIPTION
Load prettier/standalone lazily for SDK.

We need it to reduce SDK bundle size a bit by extracting the prettier that is used in a single place to the lazy loaded chunk

How to verify:
- CI should pass
