### PR TITLE
fix: proper input/param mappings for execution endpoints

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
@@ -30,10 +30,10 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
       TableUpdateRowsResponse,
       TableUpdateRowsRequest
     >({
-      query: ({ rows, scope }) => ({
+      query: ({ inputs, params, scope }) => ({
         method: "POST",
         url: `/api/ee/data-editing/action/v2/execute-bulk`,
-        body: { inputs: rows, scope, action_id: "data-grid.row/update" },
+        body: { inputs, params, scope, action_id: "data-grid.row/update" },
       }),
     }),
     deleteTableRows: builder.mutation<
@@ -90,11 +90,12 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
       TableExecuteActionResponse,
       TableExecuteActionRequest
     >({
-      query: ({ actionId, parameters }) => ({
+      query: ({ actionId, input, params }) => ({
         method: "POST",
         url: `/api/ee/data-editing/action/v2/execute`,
         body: {
-          input: parameters,
+          input,
+          params,
           // Here we pass a dummy table id, because the BE doesn't allow scope to be optional,
           // but it's not actually used for this case.
           scope: { "table-id": 1 },

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-crud.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-crud.tsx
@@ -19,7 +19,6 @@ import type {
 } from "metabase-types/api";
 
 import type {
-  RowCellsWithPkValue,
   RowPkValue,
   TableEditingScope,
   UpdateCellValueHandlerParams,
@@ -102,7 +101,8 @@ export const useTableCRUD = ({
 
       try {
         const response = await updateTableRows({
-          rows: [updatedRowWithPk],
+          inputs: [pkRecord],
+          params: updatedData,
           scope,
         });
 
@@ -160,19 +160,13 @@ export const useTableCRUD = ({
         return false;
       }
 
-      const updatedRows: RowCellsWithPkValue[] = [];
-
-      for (const rowIndex of rowIndices) {
-        const pkRecord = getRowPkKeyValue(datasetData, rowIndex);
-
-        updatedRows.push({
-          ...updatedData,
-          ...pkRecord,
-        });
-      }
+      const inputs = rowIndices.map((rowIndex) =>
+        getRowPkKeyValue(datasetData, rowIndex),
+      );
 
       const response = await updateTableRows({
-        rows: updatedRows,
+        inputs,
+        params: updatedData,
         scope,
       });
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
@@ -33,7 +33,8 @@ export type TableInsertRowsResponse = {
 };
 
 export type TableUpdateRowsRequest = {
-  rows: RowCellsWithPkValue[];
+  inputs: RowCellsWithPkValue[];
+  params: Record<DatasetColumn["name"], RowValue>;
   scope?: TableEditingScope;
 };
 
@@ -80,7 +81,8 @@ export type TableUndoRedoResponse = {
 
 export type TableExecuteActionRequest = {
   actionId: WritebackActionId;
-  parameters: ParametersForActionExecution;
+  input: ParametersForActionExecution;
+  params: ParametersForActionExecution;
 };
 
 export type TableExecuteActionResponse = {

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/execution/TableActionExecuteModalContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/execution/TableActionExecuteModalContent.tsx
@@ -59,14 +59,10 @@ export const TableActionExecuteModalContent = ({
 
   const handleSubmit = useCallback(
     async (parameters: ParametersForActionExecution) => {
-      const fullParameters = {
-        ...initialValues,
-        ...parameters,
-      };
-
       const result = await executeAction({
         actionId: actionId as number,
-        parameters: fullParameters,
+        input: initialValues,
+        params: parameters,
       });
       if (!result.error) {
         const message = getActionExecutionMessage(


### PR DESCRIPTION
As Chris requested, in some cases we should split `input` (lookup info for rows) and `params` (actual changed data) for `execute`-like endpoints, since BE does parameter merging itself.
