### PR TITLE
ci(sdk): skip broken create question test temporarily

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -141,7 +141,7 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     getSdkRoot().contains("My Orders");
   });
 
-  it("should respect `entityTypes` prop", () => {
+  it.skip("should respect `entityTypes` prop", () => {
     cy.signOut();
     mockAuthProviderAndJwtSignIn();
     cy.intercept("POST", "/api/card").as("createCard");


### PR DESCRIPTION
Temporarily skips a broken test while we look into what broke it.