### PR TITLE
Fix disappearing padding on filter

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1591,3 +1591,38 @@ describe("issue 50731", () => {
       });
   });
 });
+
+describe("issue 58923", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    cy.viewport(800, 800);
+  });
+
+  it("it should not lose padding when switching filter types (metabase#58923)", () => {
+    H.openPeopleTable();
+    H.tableHeaderClick("Name");
+
+    H.popover().findByText("Filter by this column").click();
+    H.popover().findByText("Is").click();
+    H.popover().should("have.length", 2).last().findByText("Contains").click();
+
+    H.popover().findByText("Contains").click();
+    H.popover().should("have.length", 2).last().findByText("Is").click();
+
+    H.popover()
+      .first()
+      .within(() => {
+        cy.findByPlaceholderText("Search by Name").then((input) => {
+          cy.button("Add filter")
+            .parent()
+            .then((footer) => {
+              const { bottom } = input[0].getBoundingClientRect();
+              const { top } = footer[0].getBoundingClientRect();
+
+              cy.wrap(top - bottom).should("be.gt", 16);
+            });
+        });
+      });
+  });
+});

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -134,7 +134,7 @@ function StringValueInput({
 }: StringValueInputProps) {
   if (type === "exact") {
     return (
-      <Box p="md" mah="25vh" style={{ overflow: "auto" }}>
+      <Box p="md" pb={0} mah="25vh" style={{ overflow: "auto" }}>
         <StringFilterValuePicker
           query={query}
           stageIndex={stageIndex}
@@ -144,6 +144,7 @@ function StringValueInput({
           autoFocus
           onChange={onChange}
         />
+        <Box pt="md" />
       </Box>
     );
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58923

## To verify 

1. New > Question > People > Vizualize
2. Click on "Name" table header
3. Click "Filter by this column"
4. Change operator to "Contains"
5. Change operator back to "Is"

The padding should not disappear and there should be no error in the console.