### PR TITLE
Auto-backport workflow improvements

### DIFF
--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -23,7 +23,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         COMMIT: ${{ inputs.backport-commit }}
       shell: bash
-      run: |
+      run: | # bash
         git config --global user.email "metabase-bot@metabase.com"
         git config --global user.name "Metabase bot"
 
@@ -34,6 +34,8 @@ runs:
         git fetch --all
         git checkout -b ${BACKPORT_BRANCH}
         git cherry-pick ${COMMIT} || true
+
+        CONFLICT_LIST=$(git ls-files -u)
 
         CONFLICTS=$(git ls-files -u | wc -l)
         if [ "$CONFLICTS" -gt 0 ]; then
@@ -55,7 +57,14 @@ runs:
           #${ORIGINAL_PULL_REQUEST_NUMBER}
           > [!IMPORTANT]
           > Manual conflict resolution is required.
-          Checkout the branch and run \`./backport.sh\` script. Force push your changes after cherry-picking.
+          > Checkout the branch and run \`./backport.sh\` script. Force push your changes after cherry-picking. Check the box below when done.
+
+          Conflicts:
+          \`\`\`shell
+          ${CONFLICT_LIST}
+          \`\`\`
+
+          - [ ] Conflicts resolved
         END
           )
         else

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -1,18 +1,16 @@
 name: Auto-backport
+run-name: Auto Backport ${{ github.event.pull_request.title }}
 on:
   pull_request:
     types: [closed, labeled]
 
 jobs:
   create-backport:
-    if: | # the PR must be closed and have a backport label
-      (github.event.pull_request.merged == true || github.event.action == 'closed') && (
+    if: | # the PR must be merged and have a backport label
+      github.event.pull_request.merged == true && (
         contains(github.event.pull_request.labels.*.name, 'backport') ||
         contains(github.event.pull_request.labels.*.name, 'double-backport') ||
-        contains(github.event.pull_request.labels.*.name, 'triple-backport') ||
-        github.event.label.name == 'backport' ||
-        github.event.label.name == 'double-backport' ||
-        github.event.label.name == 'triple-backport'
+        contains(github.event.pull_request.labels.*.name, 'triple-backport')
       )
     runs-on: ubuntu-latest
     steps:
@@ -76,7 +74,7 @@ jobs:
           github-token-2: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Double Backport
-        if: ${{ fromJson(steps.how-many-backports.outputs.result) >= 2 }}
+        if: ${{ always() && fromJson(steps.how-many-backports.outputs.result) >= 2 }}
         uses: ./.github/actions/create-backport
         with:
           target-version: ${{ fromJson(steps.get-latest-release-version.outputs.result).secondLatest }}
@@ -85,7 +83,7 @@ jobs:
           github-token-2: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Triple Backport
-        if: ${{ fromJson(steps.how-many-backports.outputs.result) >= 3 }}
+        if: ${{ always() && fromJson(steps.how-many-backports.outputs.result) >= 3 }}
         uses: ./.github/actions/create-backport
         with:
           target-version: ${{ fromJson(steps.get-latest-release-version.outputs.result).thirdLatest }}


### PR DESCRIPTION
Closes DEV-521
Closes DEV-422

### Description

- Won't attempt backports on unmerged PRs
- If one backport fails, will keep trying the others
- Shows conflicted files in the PR body


![Screenshot 2025-06-04 at 9 18 25 AM](https://github.com/user-attachments/assets/15f7a29c-bf4c-4217-a592-3b7fcb372e7e)


