### PR TITLE
Fix hive-like trivy warnings

### DIFF
--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -2,10 +2,10 @@
  ["src" "resources"]
 
  :deps
-  {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}
-   com.google.guava/guava {:mvn/version "32.0.0-jre"}
-   org.apache.hadoop.thirdparty/hadoop-shaded-guava {:mvn/version "1.4.0"}
-   org.apache.commons/commons-configuration2 {:mvn/version "2.12.0"}
-   org.apache.zookeeper/zookeeper {:mvn/version "3.9.3"}
-   io.netty/netty-common {:mvn/version "4.2.1.Final"}
-   io.netty/netty-handler {:mvn/version "4.2.1.Final"}}}
+ {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}
+  com.google.guava/guava {:mvn/version "32.0.0-jre"}
+  org.apache.hadoop.thirdparty/hadoop-shaded-guava {:mvn/version "1.4.0"}
+  org.apache.commons/commons-configuration2 {:mvn/version "2.12.0"}
+  org.apache.zookeeper/zookeeper {:mvn/version "3.9.3"}
+  io.netty/netty-common {:mvn/version "4.2.1.Final"}
+  io.netty/netty-handler {:mvn/version "4.2.1.Final"}}}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -3,9 +3,7 @@
 
  :deps
  {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}
-  com.google.guava/guava {:mvn/version "32.0.0-jre"}
   org.apache.hadoop.thirdparty/hadoop-shaded-guava {:mvn/version "1.4.0"}
   org.apache.commons/commons-configuration2 {:mvn/version "2.12.0"}
   org.apache.zookeeper/zookeeper {:mvn/version "3.9.3"}
-  io.netty/netty-common {:mvn/version "4.2.1.Final"}
   io.netty/netty-handler {:mvn/version "4.2.1.Final"}}}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -2,9 +2,17 @@
  ["src" "resources"]
 
  :deps
- {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}
-  ;; The dependencies below are just to resolve security warnings
-  org.apache.hadoop.thirdparty/hadoop-shaded-guava {:mvn/version "1.4.0"}
-  org.apache.commons/commons-configuration2 {:mvn/version "2.12.0"}
+ {org.apache.hive/hive-jdbc {:mvn/version "4.0.1"}
+  org.apache.hive/hive-service {:mvn/version "4.0.1"
+                                :exclusions [org.apache.hadoop.thirdparty/hadoop-shaded-protobuf_3_7
+                                             org.apache.hadoop/hadoop-client-api
+                                             org.pac4j/pac4j-saml-opensamlv3
+                                             org.apache.hive/hive-exec
+                                             org.eclipse.jetty/jetty-runner]}
   org.apache.zookeeper/zookeeper {:mvn/version "3.9.3"}
-  io.netty/netty-handler {:mvn/version "4.2.1.Final"}}}
+  com.cedarsoftware/json-io {:mvn/version "4.54.0"}
+  commons-beanutils/commons-beanutils {:mvn/version "1.11.0"}
+  io.netty/netty-codec-haproxy {:mvn/version "4.2.1.Final"}
+  io.netty/netty-codec-http2 {:mvn/version "4.2.1.Final"}
+  org.apache.avro/avro {:mvn/version "1.12.0"}
+  org.apache.hadoop/hadoop-common {:mvn/version "3.4.1"}}}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -3,6 +3,7 @@
 
  :deps
  {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}
+  ;; The dependencies below are just to resolve security warnings
   org.apache.hadoop.thirdparty/hadoop-shaded-guava {:mvn/version "1.4.0"}
   org.apache.commons/commons-configuration2 {:mvn/version "2.12.0"}
   org.apache.zookeeper/zookeeper {:mvn/version "3.9.3"}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -2,4 +2,10 @@
  ["src" "resources"]
 
  :deps
- {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}}}
+  {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}
+   com.google.guava/guava {:mvn/version "32.0.0-jre"}
+   org.apache.hadoop.thirdparty/hadoop-shaded-guava {:mvn/version "1.4.0"}
+   org.apache.commons/commons-configuration2 {:mvn/version "2.12.0"}
+   org.apache.zookeeper/zookeeper {:mvn/version "3.9.3"}
+   io.netty/netty-common {:mvn/version "4.2.1.Final"}
+   io.netty/netty-handler {:mvn/version "4.2.1.Final"}}}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DRI-310/migrate-from-hive-jdbcdollarstandalone-to-hive-jdbc-dependency

### Description

Redo of https://github.com/metabase/metabase/pull/58655

Based on my testing, removing any of the exclusions or explicit dependencies results in trivy warnings. 

### How to verify

```bash
$ docker pull metabase/metabase-dev:remove-hive-jdbc-standalone
$ trivy image metabase/metabase-dev:remove-hive-jdbc-standalone
```

or get the jar from [here](https://github.com/metabase/metabase/actions/runs/15448917156) and run `trivy rootfs metabase.jar`

or build the `hive-like` driver locally and run `trivy rootfs hive-like.metabase-driver.jar`

There should be no warnings

### Demo

<details>

<summary>simple spark usage</summary>

https://github.com/user-attachments/assets/a64f4650-6658-444c-ae74-ef8177e00841

</details>

Did more manual testing for spark and databricks

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
