### PR TITLE
Revert "Make snowflake not required (#58815)"

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1097,7 +1097,7 @@ jobs:
       - be-tests-postgres
       - be-tests-presto-jdbc-ee
       - be-tests-redshift-ee
-      # - be-tests-snowflake-ee FIXME temporarily disabled DRI-325
+      - be-tests-snowflake-ee
       - be-tests-sparksql-ee
       - be-tests-sqlite-ee
       - be-tests-sqlserver


### PR DESCRIPTION
This reverts commit 9dcbcba3f66235cba151ab6e9d040f518dd12899.

snowflake is now fixed from being flaky and is now required again

the fix was in checking old dataset names to prune. Shared databases like cloud databases don't get destroyed when docker terminates, so we have to remove old databases. The way we did it in the past would error if more than 10,000 rows were returned. The fix is the following from https://github.com/metabase/metabase/pull/58818 :

```clojure
(defn- old-dataset-names
  "Return a collection of all dataset names that are old -- prefixed with a date two days ago or older?"
  []
  ;; modified the query from the snowflake driver:
  ;; https://github.com/snowflakedb/snowflake-jdbc/blob/fa58e3496809395d039ee4d8fb2cf2767997cdd4/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1644C21-L1644C90
  ;; We run into issues where this returns more than 10,000 items and we get an error: "The result set size exceeded
  ;; the max number of rows(10000) supported for SHOW statements. Use LIMIT option to limit result set"
  (let [query "show /* JDBC:DatabaseMetaData.getCatalogs() with limit */ databases in account limit 10000"]
    (into []
          (comp (map :name)
                (filter sql.tu.unique-prefix/old-dataset-name?))
          (jdbc/reducible-query (no-db-connection-spec) [query] {:raw?
          true}))))
```