### PR TITLE
validate time unit parameters and fix bug

### DIFF
--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -247,6 +247,11 @@
      {:snippet-id (:id snippet)
       :content    (:content snippet)})))
 
+(def #^:private valid-temporal-units
+  #{"minute" "hour" "day" "week" "month" "quarter" "year"
+    "minute-of-hour" "hour-of-day" "day-of-month" "day-of-year" "month-of-year" "quarter-of-year"
+    nil})
+
 (defmethod parse-tag :temporal-unit
   [{:keys [name required] :as tag} params]
   (let [matching-param (when-let [matching-params (not-empty (tag-params tag params))]
@@ -258,6 +263,10 @@
                          (first matching-params))
         nil-value?     (and matching-param
                             (nil? (:value matching-param)))]
+    (when (not (valid-temporal-units (:value matching-param)))
+      (throw (ex-info (tru "Error: invalid value specified for temporal-unit parameter.")
+                      {:value (:value matching-param)
+                       :expected valid-temporal-units})))
     (params/map->TemporalUnit
      {:name name
       :value (or (:value matching-param)

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -55,7 +55,7 @@
   (if (and (params/TemporalUnit? v) (string? k) (string? column))
     (let [{:keys [replacement-snippet prepared-statement-args]}
           (sql.params.substitution/time-grouping->replacement-snippet-info driver/*driver* column v)]
-      [(str sql replacement-snippet) (concat args prepared-statement-args args) missing])
+      [(str sql replacement-snippet) (concat args prepared-statement-args) missing])
     [sql args (conj missing k)]))
 
 (defn- substitute-function-param [param->value [sql args missing] {[k] :args :keys [function-name] :as param}]

--- a/test/metabase/driver/common/parameters/temporal_units_test.clj
+++ b/test/metabase/driver/common/parameters/temporal_units_test.clj
@@ -99,5 +99,6 @@
                                        :target [:variable [:template-tag "time-unit"]]
                                        :value  "foo"}])]
         (mt/with-native-query-testing-context query
-          (is (thrown? clojure.lang.ExceptionInfo
-                       (run-sample-query query))))))))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"invalid value specified for temporal-unit parameter"
+                                (run-sample-query query))))))))


### PR DESCRIPTION
### Description

Fixes a bug that caused query-processor errors when you had a time grouping parameter after a normal parameter and validates time grouping parameters

### How to verify

Run
```
select {{mb.time_grouping("var", "orders.created_at")}}, sum(total) 
from orders 
join products on orders.product_id = products.id
where {{cat}}
group by {{mb.time_grouping("var", "orders.created_at")}}
```
and verify that the query runs

also, try to pass in "foo" as a temporal unit and verify that you get a reasonable error message.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
