### PR TITLE
fix: audit adjust to source handles nil schemas

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -107,7 +107,11 @@
                                                                :from [[(t2/table-name :model/Table) :self_table]]
                                                                :where [:and
                                                                        [:= :self_table.db_id :table.db_id]
-                                                                       [:= :self_table.schema :table.schema]
+                                                                       [:or
+                                                                        [:= :self_table.schema :table.schema]
+                                                                        [:and
+                                                                         [:= :self_table.schema [:inline "public"]]
+                                                                         [:= :table.schema nil]]]
                                                                        [:= :self_table.name [:lower :table.name]]]}]]]})]
     (when (seq table-ids-to-update)
       (t2/update! :model/Table :id [:in (map :id table-ids-to-update)]
@@ -124,7 +128,11 @@
                                                                             [:= :self_table.id :self_field.table_id]]
                                                                :where [:and
                                                                        [:= :self_table.db_id :table.db_id]
-                                                                       [:= :self_table.schema :table.schema]
+                                                                       [:or
+                                                                        [:= :self_table.schema :table.schema]
+                                                                        [:and
+                                                                         [:= :self_table.schema [:inline "public"]]
+                                                                         [:= :table.schema nil]]]
                                                                        [:= :self_field.name [:lower :field.name]]]}]]]})]
     (when (seq field-ids-to-update)
       (t2/update! :model/Field :id [:in (map :id field-ids-to-update)]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
@@ -187,6 +187,21 @@
                    :model/Table {single-table-id :id} {:db_id audit-db-id
                                                        :schema "public"
                                                        :name "ORDERS"}
+
+                   ;; Create another table that has a two lower case versions
+                   ;; one without a nil schema
+                   :model/Table _ {:db_id audit-db-id
+                                   :schema "public"
+                                   :name "accounts"}
+
+                   :model/Table _ {:db_id audit-db-id
+                                   :schema nil
+                                   :name "accounts"}
+
+                   :model/Table {no-schema-table :id} {:db_id audit-db-id
+                                                       :schema nil
+                                                       :name "products"}
+
                    ;; Create fields with both uppercase and lowercase names
                    :model/Field {upper-field-id :id} {:table_id upper-table-id
                                                       :name "EMAIL"}
@@ -212,6 +227,14 @@
       (testing "Tables without lowercase versions should be converted to lowercase"
         (is (= "orders"
                (t2/select-one-fn :name :model/Table :id single-table-id))))
+
+      (testing "Tables with nil schemas should not be changed if a table with a schema exists"
+        (is (= 2
+               (t2/count :model/Table {:where [:= :name "accounts"]}))))
+
+      (testing "Tables with nil schemas have their schema set to \"public\""
+        (is (= "public"
+               (t2/select-one-fn :schema :model/Table :id no-schema-table))))
 
       (testing "Fields with existing lowercase versions should not be modified"
         (is (= "EMAIL"


### PR DESCRIPTION
### Description

Some mysql -> postgresql migrated users still had adjust to source failing because they had two tables with downcased names but one with a "public" schema column and the other with a null schema column. This handles that case by only selecting tables if there is not already a table with a "public" schema column.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
