### PR TITLE
Skip uploading test results to Trunk.io for draft PRs

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -48,7 +48,7 @@ runs:
         aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/
 
     - name: Upload results to Trunk
-      if: ${{ always() }}
+      if: ${{ always() && !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: ${{ inputs.input-path }}


### PR DESCRIPTION
We're uploading nearly 1 million test results per day to Trunk.io. We're probably getting limited signal from the results on draft PRs, so let's reduce the data load by skipping the upload for draft PRs.
