### PR TITLE
Cleanup resolve-field-metadata

### DIFF
--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -161,7 +161,7 @@ describe("binning related reproductions", () => {
     });
 
     H.getNotebookStep("summarize").findByText(
-      "18646 - Product → Created At: Month",
+      "18646 - Product → CREATED_AT: Month",
     );
 
     H.visualize();

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -151,7 +151,7 @@ describe("scenarios > question > joined questions", () => {
     H.visualize();
 
     cy.findByTestId("qb-filters-panel")
-      .findByText("question b - PRODUCT_ID → Category is Gadget")
+      .findByText("question b - PRODUCT_ID → CATEGORY is Gadget")
       .should("be.visible");
     cy.findByTestId("scalar-value").contains("Gadget").should("be.visible");
   });

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -136,32 +136,29 @@
          (clojure.core/= source-field-join-alias (:fk-join-alias column)))
     ;; If it's not an implicit join, then either the join aliases must match for an explicit join, or both be nil for
     ;; an own column.
-    (clojure.core/= (column-join-alias column) join-alias)))
+    ;; TODO: If the target ref has no join-alias, AND the source is fields or card, the source
+    ;; alias on the column can be ignored. QP can set it when it shouldn't. See #33972.
+    (clojure.core/= join-alias (if (and (not join-alias)
+                                        (#{:source/fields :source/card} (:lib/source column)))
+                                 (:metabase.lib.join/join-alias column)
+                                 (column-join-alias column)))))
 
 (mu/defn- plausible-matches-for-name :- [:sequential ::lib.schema.metadata/column]
-  [[_ref-kind opts ref-name :as a-ref] :- ::lib.schema.ref/ref
+  [[_ref-kind _opts ref-name :as a-ref] :- ::lib.schema.ref/ref
    columns                              :- [:sequential ::lib.schema.metadata/column]]
   (or (not-empty (filter #(and (clojure.core/= (:lib/desired-column-alias %) ref-name)
                                (matching-join? a-ref %))
                          columns))
       (filter #(and (clojure.core/= (:name %) ref-name)
-                    ;; TODO: If the target ref has no join-alias, AND the source is fields or card, the join
-                    ;; alias on the column can be ignored. QP can set it when it shouldn't. See #33972.
-                    (or (and (not (:join-alias opts))
-                             (#{:source/fields :source/card} (:lib/source %)))
-                        (matching-join? a-ref %)))
+                    (matching-join? a-ref %))
               columns)))
 
 (mu/defn- plausible-matches-for-id :- [:sequential ::lib.schema.metadata/column]
-  [[_ref-kind opts ref-id :as a-ref] :- ::lib.schema.ref/ref
+  [[_ref-kind _opts ref-id :as a-ref] :- ::lib.schema.ref/ref
    columns                           :- [:sequential ::lib.schema.metadata/column]
    generous?                         :- [:maybe :boolean]]
   (or (not-empty (filter #(and (clojure.core/= (:id %) ref-id)
-                               ;; TODO: If the target ref has no join-alias, AND the source is fields or card, the join
-                               ;; alias on the column can be ignored. QP can set it when it shouldn't. See #33972.
-                               (or (and (not (:join-alias opts))
-                                        (#{:source/fields :source/card} (:lib/source %)))
-                                   (matching-join? a-ref %)))
+                               (matching-join? a-ref %))
                          columns))
       (when generous?
         (not-empty (filter #(clojure.core/= (:id %) ref-id) columns)))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -72,8 +72,8 @@
 (mu/defn- resolve-field-metadata :- ::lib.schema.metadata/column
   "Resolve metadata for a `:field` ref. This is part of the implementation
   for [[lib.metadata.calculation/metadata-method]] a `:field` clause."
-  [query                                                              :- ::lib.schema/query
-   stage-number                                                       :- :int
+  [query                                                                :- ::lib.schema/query
+   stage-number                                                         :- :int
    [_field {:keys [join-alias], :as opts} id-or-name, :as field-clause] :- :mbql.clause/field]
   (let [metadata (merge
                   (when-let [base-type (:base-type opts)]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1662,7 +1662,11 @@
                  :name            "12345"
                  :display-name    "Unknown Field"}
                 (lib.metadata.calculation/metadata (lib.tu/venues-query) -1
-                                                   [:field {:lib/uuid (str (random-uuid))} 12345])))))))
+                                                   [:field {:lib/uuid (str (random-uuid))} 12345]))))))
+  (testing "Should resolve joined fields correctly"
+    (let [query (lib.tu/query-with-self-join)]
+      (doseq [column (lib/visible-columns query)]
+        (= column (lib.metadata.calculation/metadata query -1 (lib/ref column)))))))
 
 (deftest ^:parallel field-values-search-info-test
   (testing "type/PK field remapped to a type/Name field within the same table"

--- a/test/metabase/query_processor_test/drill_thru_e2e_test.clj
+++ b/test/metabase/query_processor_test/drill_thru_e2e_test.clj
@@ -4,7 +4,6 @@
    [medley.core :as m]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
-   [metabase.lib.field :as lib.field]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.ref :as lib.ref]
@@ -64,7 +63,7 @@
                                           :dataset-query   card-query
                                           :result-metadata results-metadata}]})
             query              (lib/query metadata-provider (lib.metadata/card metadata-provider 1))
-            longitude          (lib.field/resolve-column-name-in-metadata "LATITUDE" (lib/returned-columns query))
+            longitude          (m/find-first (comp #{"LATITUDE"} :name) (lib/returned-columns query))
             _                  (is (=? {:name           "LATITUDE"
                                         :effective-type :type/Float
                                         :fingerprint    {:type {:type/Number {:min number?, :max number?}}}}


### PR DESCRIPTION
Some prep work to be able to use `:lib/desired-column-alias` for joins. Make sure that the same `lib/find-matching-column` function is used for resolving joined fields.