### PR TITLE
Update SDK release workflow after 55 gold

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -16,7 +16,6 @@ on:
           - release-x.53.x
           - release-x.54.x
           - release-x.55.x
-          - metabot-v3-main
           - esbuild-main
 
 concurrency:
@@ -394,7 +393,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "release-x.55.x": "55-nightly", "metabot-v3-main": "55-metabot", "esbuild-main": "56-esbuild"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "release-x.55.x": "55-stable", "esbuild-main": "56-esbuild"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.54.x`) deployment
         if: ${{ inputs.branch == 'release-x.54.x' }}


### PR DESCRIPTION
Please refer to this [checklist](https://www.notion.so/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d)

This is the first step for gold release
