### PR TITLE
Remove package prerelease identifier after 55 gold

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.55.1-nightly",
+  "version": "0.55.1",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Please refer to this [checklist](https://www.notion.so/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d)

This is the second task after gold.
