### PR TITLE
Routes for new picker

### DIFF
--- a/src/metabase/actions/api.clj
+++ b/src/metabase/actions/api.clj
@@ -77,6 +77,34 @@
                                             (collection/visible-collection-filter-clause)]}))]
       (actions-for models))))
 
+(api.macros/defendpoint :get "/v2/"
+  "TODO describe new picker"
+  [_route-params
+   {:keys [model-id table-id] :- [:map
+                                  [:model-id {:optional true} ms/PositiveInt]
+                                  [:table-id {:optional true} ms/PositiveInt]]}
+   _body-params]
+  ;API should not return the list of tables in OSS instances, since for now we are keeping table actions feature not available on OSS
+  ;Do not return models without actions
+  ;Do not return DBs that don't have data editing enabled
+  ;When listing the models we also want to display information about the collection they are saved to
+  ;Search - aside from the list of tables and models should also return information about the db/schema the table belongs to or the collection_name for models (no collection hierarchy needed for models, just the collection name they are saved to).
+
+  {:models  [{:id 2
+              :name "blah"
+              :collection {:id nil
+                           :name "blah"}}]
+   :tables  []
+   :actions [{:id 2
+              :parameters [{:display-name "Name",
+                            :id "name",
+                            :is-auto-increment false,
+                            :required false,
+                            :target ("variable" ("template-tag" "name")),
+                            :type "type/Text"}]}]}
+
+  nil)
+
 (api.macros/defendpoint :get "/public"
   "Fetch a list of Actions with public UUIDs. These actions are publicly-accessible *if* public sharing is enabled."
   []

--- a/src/metabase/actions/api.clj
+++ b/src/metabase/actions/api.clj
@@ -77,73 +77,6 @@
                                             (collection/visible-collection-filter-clause)]}))]
       (actions-for models))))
 
-(api.macros/defendpoint :get "/v2/database"
-  "Databases which contain actions"
-  [_ _ _]
-  (let [non-empty-dbs      (t2/select-fn-set :db_id [:model/Table :db_id])
-        databases          (when non-empty-dbs
-                             (t2/select [:model/Database :id :name :description :settings] :id [:in non-empty-dbs]))
-        editable-database? (comp boolean :database-enable-table-editing :settings)
-        editable-databases (filter editable-database? databases)]
-    {:databases (for [db editable-databases]
-                  (select-keys db [:id :name :description]))}))
-
-(api.macros/defendpoint :get "/v2/database/:database-id/table"
-  "Tables which contain actions"
-  [{:keys [database-id]} :- [:map [:database-id ms/PositiveInt]] _ _]
-  (let [database           (api/check-404 (t2/select-one :model/Database :id database-id))
-        _                  (when-not (get-in database [:settings :database-enable-table-editing])
-                             (throw (ex-info "Table editing is not enabled for this database"
-                                             {:status-code 400})))
-        tables             (t2/select [:model/Table :id :display_name :name :description :schema] :db_id database-id)]
-    {:tables tables}))
-
-(api.macros/defendpoint :get "/v2/model"
-  "Models which contain actions"
-  [_ _ _]
-  (let [model-ids    (t2/select-fn-set :model_id [:model/Action :model_id] :archived false)
-        models       (when model-ids
-                       (t2/select [:model/Card :id :name :description :collection_position :collection_id] :id [:in model-ids]))
-        coll-ids     (into #{} (keep :collection_id) models)
-        collections  (when (seq coll-ids)
-                       (t2/select [:model/Collection :id :name] :id [:in coll-ids]))
-        ->collection (comp (u/index-by :id :name collections) :collection_id)]
-    {:models (for [m models] (assoc m :collection_name (->collection m)))}))
-
-(api.macros/defendpoint :get "/v2/"
-  "Returns actions with id and name only. Requires either model-id or table-id parameter."
-  [_route-params
-   {:keys [model-id table-id]} :- [:map
-                                   [:model-id {:optional true} ms/PositiveInt]
-                                   [:table-id {:optional true} ms/PositiveInt]]
-   _body-params]
-  (when-not (or model-id table-id)
-    (throw (ex-info "Either model-id or table-id parameter is required"
-                    {:status-code 400})))
-  (when (and model-id table-id)
-    (throw (ex-info "Cannot specify both model-id and table-id parameters"
-                    {:status-code 400})))
-  (cond
-    model-id
-    (do (api/read-check :model/Card model-id)
-        {:actions (t2/select [:model/Action :id :name :description]
-                             :model_id model-id
-                             :archived false)})
-
-    table-id
-    (let [table    (api/read-check :model/Table table-id)
-          database (t2/select-one :model/Database :id (:db_id table))
-          _        (when-not (get-in database [:settings :database-enable-table-editing])
-                     (throw (ex-info "Table editing is not enabled for this database"
-                                     {:status-code 400})))
-          fields   (t2/select :model/Field :table_id table-id)
-          actions  (for [op [:table.row/create :table.row/update :table.row/delete]
-                         :let [action (action/table-primitive-action table fields op)]]
-                     {:id          (:id action)
-                      :name        (:name action)
-                      :description (get-in action [:visualization_settings :description] "")})]
-      {:actions actions})))
-
 (api.macros/defendpoint :get "/public"
   "Fetch a list of Actions with public UUIDs. These actions are publicly-accessible *if* public sharing is enabled."
   []
@@ -302,3 +235,72 @@
                              :type      type
                              :action_id id})
     (actions.execution/execute-action! action (update-keys parameters name))))
+
+;; new picker
+
+(api.macros/defendpoint :get "/v2/database"
+  "Databases which contain actions"
+  [_ _ _]
+  (let [non-empty-dbs      (t2/select-fn-set :db_id [:model/Table :db_id])
+        databases          (when non-empty-dbs
+                             (t2/select [:model/Database :id :name :description :settings] :id [:in non-empty-dbs]))
+        editable-database? (comp boolean :database-enable-table-editing :settings)
+        editable-databases (filter editable-database? databases)]
+    {:databases (for [db editable-databases]
+                  (select-keys db [:id :name :description]))}))
+
+(api.macros/defendpoint :get "/v2/database/:database-id/table"
+  "Tables which contain actions"
+  [{:keys [database-id]} :- [:map [:database-id ms/PositiveInt]] _ _]
+  (let [database           (api/check-404 (t2/select-one :model/Database :id database-id))
+        _                  (when-not (get-in database [:settings :database-enable-table-editing])
+                             (throw (ex-info "Table editing is not enabled for this database"
+                                             {:status-code 400})))
+        tables             (t2/select [:model/Table :id :display_name :name :description :schema] :db_id database-id)]
+    {:tables tables}))
+
+(api.macros/defendpoint :get "/v2/model"
+  "Models which contain actions"
+  [_ _ _]
+  (let [model-ids    (t2/select-fn-set :model_id [:model/Action :model_id] :archived false)
+        models       (when model-ids
+                       (t2/select [:model/Card :id :name :description :collection_position :collection_id] :id [:in model-ids]))
+        coll-ids     (into #{} (keep :collection_id) models)
+        collections  (when (seq coll-ids)
+                       (t2/select [:model/Collection :id :name] :id [:in coll-ids]))
+        ->collection (comp (u/index-by :id :name collections) :collection_id)]
+    {:models (for [m models] (assoc m :collection_name (->collection m)))}))
+
+(api.macros/defendpoint :get "/v2/"
+  "Returns actions with id and name only. Requires either model-id or table-id parameter."
+  [_route-params
+   {:keys [model-id table-id]} :- [:map
+                                   [:model-id {:optional true} ms/PositiveInt]
+                                   [:table-id {:optional true} ms/PositiveInt]]
+   _body-params]
+  (when-not (or model-id table-id)
+    (throw (ex-info "Either model-id or table-id parameter is required"
+                    {:status-code 400})))
+  (when (and model-id table-id)
+    (throw (ex-info "Cannot specify both model-id and table-id parameters"
+                    {:status-code 400})))
+  (cond
+    model-id
+    (do (api/read-check :model/Card model-id)
+        {:actions (t2/select [:model/Action :id :name :description]
+                             :model_id model-id
+                             :archived false)})
+
+    table-id
+    (let [table    (api/read-check :model/Table table-id)
+          database (t2/select-one :model/Database :id (:db_id table))
+          _        (when-not (get-in database [:settings :database-enable-table-editing])
+                     (throw (ex-info "Table editing is not enabled for this database"
+                                     {:status-code 400})))
+          fields   (t2/select :model/Field :table_id table-id)
+          actions  (for [op [:table.row/create :table.row/update :table.row/delete]
+                         :let [action (action/table-primitive-action table fields op)]]
+                     {:id          (:id action)
+                      :name        (:name action)
+                      :description (get-in action [:visualization_settings :description] "")})]
+      {:actions actions})))

--- a/src/metabase/actions/api.clj
+++ b/src/metabase/actions/api.clj
@@ -97,7 +97,7 @@
   ;; ... why on FE? because some databases don't have a notion of schema
   ;; filter everything or return error if data editing is not enabled
   (let [settings           (when true #_(premium-features.settings/table-data-editing?)
-                                 (t2/select-one-fn :settings [:model/Database :settings] #p database-id))
+                                 (t2/select-one-fn :settings [:model/Database :settings] database-id))
         _                  (api/check-404 settings)
         ;; This code / message could be improved.
         _                  (api/check-400 (:database-enable-table-editing settings))

--- a/src/metabase/actions/api.clj
+++ b/src/metabase/actions/api.clj
@@ -10,7 +10,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.validation :as validation]
-   [metabase.premium-features.settings :as premium-features.settings]
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.queries.core :as queries]
    [metabase.util :as u]
@@ -140,8 +139,9 @@
           fields   (t2/select :model/Field :table_id table-id)
           actions  (for [op [:table.row/create :table.row/update :table.row/delete]
                          :let [action (action/table-primitive-action table fields op)]]
-                     {:id   (:id action)
-                      :name (:name action)})]
+                     {:id          (:id action)
+                      :name        (:name action)
+                      :description (get-in action [:visualization_settings :description] "")})]
       {:actions actions})))
 
 (api.macros/defendpoint :get "/public"

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -770,35 +770,28 @@
 
             (testing "Returns models that have actions"
               (let [response (mt/user-http-request :crowberto :get 200 "action/v2/model")]
-                (is (map? response))
-                (is (contains? response :models))
-                (is (= 2 (count (:models response))))
-                (let [model-ids (set (map :id (:models response)))]
-                  (is (contains? model-ids model-id-1))
-                  (is (contains? model-ids model-id-2)))
-                (let [model-1 (first (filter #(= (:id %) model-id-1) (:models response)))
-                      model-2 (first (filter #(= (:id %) model-id-2) (:models response)))]
-                  (is (= "Test Model 1" (:name model-1)))
-                  (is (= "First test model" (:description model-1)))
-                  (is (= coll-id (:collection_id model-1)))
-                  (is (= 1 (:collection_position model-1)))
-                  (is (= "Test Collection" (:collection_name model-1)))
-
-                  (is (= "Test Model 2" (:name model-2)))
-                  (is (= "Second test model" (:description model-2)))
-                  (is (nil? (:collection_id model-2)))
-                  (is (= 2 (:collection_position model-2)))
-                  (is (nil? (:collection_name model-2))))))
+                (is (=? {:models [{:id model-id-1
+                                   :name "Test Model 1"
+                                   :description "First test model"
+                                   :collection_id coll-id
+                                   :collection_position 1
+                                   :collection_name "Test Collection"}
+                                  {:id model-id-2
+                                   :name "Test Model 2"
+                                   :description "Second test model"
+                                   :collection_id nil
+                                   :collection_position 2
+                                   :collection_name nil}]}
+                        response))))
 
             (testing "Does not return models with only archived actions"
               (t2/update! :model/Action action-id-1 {:archived true})
               (t2/update! :model/Action action-id-2 {:archived true})
-              (let [response (mt/user-http-request :crowberto :get 200 "action/v2/model")]
-                (is (= {:models []} response))))
+              (is (=? {:models []}
+                      (mt/user-http-request :crowberto :get 200 "action/v2/model"))))
 
             (testing "Returns empty list when no models have actions"
               (t2/delete! :model/Action action-id-1)
               (t2/delete! :model/Action action-id-2)
-              (t2/delete! :model/Action archived-action-id)
-              (let [response (mt/user-http-request :crowberto :get 200 "action/v2/model")]
-                (is (= {:models []} response))))))))))
+              (is (=? {:models []}
+                      (mt/user-http-request :crowberto :get 200 "action/v2/model"))))))))))

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -724,11 +724,11 @@
                                                     :description  "Premium leather side table"
                                                     :schema       "public"
                                                     :db_id        db-id-2}]
-        (testing "Returns only tables from the specified database"
-          (is (=? {:tables [{:id table-id-1 :name "oak_dining_table" :display_name "Oak Dining Table"
-                             :description "Elegant oak dining furniture" :schema "public"}
-                            {:id table-id-2 :name "mahogany_coffee_table" :display_name "Mahogany Coffee Table"
-                             :description "Luxurious mahogany coffee table" :schema "public"}]}
+        (testing "Returns only tables from the specified database, in alphabetical order"
+          (is (=? {:tables [{:id table-id-2 :name "mahogany_coffee_table" :display_name "Mahogany Coffee Table"
+                             :description "Luxurious mahogany coffee table" :schema "public"}
+                            {:id table-id-1 :name "oak_dining_table" :display_name "Oak Dining Table"
+                             :description "Elegant oak dining furniture" :schema "public"}]}
                   (mt/user-http-request :crowberto :get 200 (format "action/v2/database/%d/table" db-id-1))))
           (testing "Does not include tables from other databases"
             (let [tables (:tables (mt/user-http-request :crowberto :get 200 (format "action/v2/database/%d/table" db-id-1)))]

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -681,7 +681,7 @@
                                                     :description "Luxury fashion database"
                                                     :engine      "h2"
                                                     :settings    {:database-enable-table-editing true}}
-                       :model/Table {table-id :id} {:name "runway_table" :db_id db-id}]
+                       :model/Table _ {:name "runway_table" :db_id db-id}]
           (is (some #(= % {:id db-id :name "Versace Mansion" :description "Luxury fashion database"})
                     (:databases (mt/user-http-request :crowberto :get 200 "action/v2/database"))))))
 
@@ -690,7 +690,7 @@
                                                     :description "Disabled fashion database"
                                                     :engine      "h2"
                                                     :settings    {:database-enable-table-editing false}}
-                       :model/Table {table-id :id} {:name "disabled_table" :db_id db-id}]
+                       :model/Table _ {:name "disabled_table" :db_id db-id}]
           (is (not (some #(= (:id %) db-id) (:databases (mt/user-http-request :crowberto :get 200 "action/v2/database")))))))
 
       (testing "Excludes databases without tables"
@@ -752,10 +752,10 @@
                                                     :type     :implicit
                                                     :kind     "row/create"
                                                     :archived false}
-                          {archived-action-id :action-id} {:name     "Retired Supermodel"
-                                                           :type     :implicit
-                                                           :kind     "row/delete"
-                                                           :archived true}]
+                          _                        {:name     "Retired Supermodel"
+                                                    :type     :implicit
+                                                    :kind     "row/delete"
+                                                    :archived true}]
           (mt/with-actions [{model-id-2 :id} {:type :model, :dataset_query (mt/mbql-query venues)}
                             {action-id-2 :action-id} {:name     "Tyra Banks Strut"
                                                       :type     :implicit
@@ -817,11 +817,11 @@
                                          :type          :query
                                          :model_id      model-id
                                          :dataset_query (mt/mbql-query venues)}
-                            retired-action {:name          "Retired from Runway"
-                                            :type          :query
-                                            :model_id      model-id
-                                            :dataset_query (mt/mbql-query users)
-                                            :archived      true}]
+                            _           {:name          "Retired from Runway"
+                                         :type          :query
+                                         :model_id      model-id
+                                         :dataset_query (mt/mbql-query users)
+                                         :archived      true}]
             (testing "Requires either model-id or table-id parameter"
               (is (= "Either model-id or table-id parameter is required"
                      (mt/user-http-request :crowberto :get 400 "action/v2/"))))


### PR DESCRIPTION
Closes WRK-404 

Routes to support browsing through action-containing scopes, and to list the actions for each corresponding leaf node.

Very spartan for now, can expect more fields to be added, along with more flexibility.