### PR TITLE
Unskip skipped embedding SDK test

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -141,12 +141,17 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     getSdkRoot().contains("My Orders");
   });
 
-  it.skip("should respect `entityTypes` prop", () => {
+  it("should respect `entityTypes` prop", () => {
     cy.signOut();
     mockAuthProviderAndJwtSignIn();
     cy.intercept("POST", "/api/card").as("createCard");
 
-    const MODEL_COUNT = 14;
+    /**
+     * We have changed the default MB_SEARCH_ENGINE from "in-place" to "appdb", and it affects the results here.
+     * Previously, when the engine was "in-place", we'll get models from the "Usage Analytics" collection as well,
+     * so the number was different.
+     */
+    const MODEL_COUNT = 1;
     const TABLE_COUNT = 4;
 
     cy.log('1. `entityTypes` = ["table"]');


### PR DESCRIPTION
Closes EMB-447
> [!note]
> For the fix on the release branch, I need to wait for https://github.com/metabase/metabase/pull/58891 to land first, then update the test to `const MODEL_COUNT = 1`.
> After that PR is merged, then I will make a new SDK release and remove `MB_SEACH_ENGINE` in the workflow `e2e-component-tests-embedding-sdk-cross-version.yml`

### Backport reason
I'm not going to backport this one, as I'll be creating a separate fix for the 55 branch. It will contain some intermediary fix in the workflow too.

### Description

The test behavior changes since https://github.com/metabase/metabase/pull/58718

https://github.com/metabase/metabase/blob/4305019588ea2178bc599c717d99f9fa202be862/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx#L150-L154
### How to verify

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
