### PR TITLE
PRG-49  Add token missing banner

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -110,6 +110,11 @@ describe("snapshots", () => {
     updateSetting("enable-embedding-static", true).then(() => {
       updateSetting("embedding-secret-key", METABASE_SECRET_KEY);
     });
+    // dismiss the license token missing banner, not necessary to render it in every test
+    updateSetting(
+      "license-token-missing-banner-dismissal-timestamp",
+      new Date().toISOString(),
+    );
 
     // update the Sample db connection string so it is valid in both CI and locally
     cy.request("GET", `/api/database/${SAMPLE_DB_ID}`).then((response) => {

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -355,5 +355,6 @@ export const createMockSettings = (
   "check-for-updates": true,
   "update-channel": "latest",
   "trial-banner-dismissal-timestamp": null,
+  "license-token-missing-banner-dismissal-timestamp": [],
   ...opts,
 });

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -370,6 +370,7 @@ interface AdminSettings {
   "setup-license-active-at-setup": boolean;
   "store-url": string;
   gsheets: Partial<GdrivePayload>;
+  "license-token-missing-banner-dismissal-timestamp": Array<string>;
 }
 interface SettingsManagerSettings {
   "bcc-enabled?": boolean;
@@ -483,7 +484,6 @@ export type UserSettings = {
   "show-updated-permission-modal": boolean;
   "show-updated-permission-banner": boolean;
   "trial-banner-dismissal-timestamp"?: string | null;
-  "license-token-missing-banner-dismissal-timestamp": Array<string>;
 };
 
 /**

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -370,7 +370,7 @@ interface AdminSettings {
   "setup-license-active-at-setup": boolean;
   "store-url": string;
   gsheets: Partial<GdrivePayload>;
-  "license-token-missing-banner-dismissal-timestamp": Array<string>;
+  "license-token-missing-banner-dismissal-timestamp"?: Array<string>;
 }
 interface SettingsManagerSettings {
   "bcc-enabled?": boolean;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -483,6 +483,7 @@ export type UserSettings = {
   "show-updated-permission-modal": boolean;
   "show-updated-permission-banner": boolean;
   "trial-banner-dismissal-timestamp"?: string | null;
+  "license-token-missing-banner-dismissal-timestamp": Array<string>;
 };
 
 /**

--- a/frontend/src/metabase/components/AppBanner/AppBanner.tsx
+++ b/frontend/src/metabase/components/AppBanner/AppBanner.tsx
@@ -20,7 +20,8 @@ export const AppBanner = () => {
     "trial-banner-dismissal-timestamp",
   );
 
-  const { shouldShow, dismissBanner } = useLicenseTokenMissingBanner();
+  const { shouldShowLicenseTokenMissingBanner, dismissBanner } =
+    useLicenseTokenMissingBanner();
 
   const isAdmin = useSelector(getUserIsAdmin);
   const isHosted = useSelector(getIsHosted);
@@ -46,7 +47,7 @@ export const AppBanner = () => {
     return <ReadOnlyBanner />;
   }
 
-  if (shouldShow) {
+  if (shouldShowLicenseTokenMissingBanner) {
     return <LicenseTokenMissingBanner onClose={dismissBanner} />;
   }
 

--- a/frontend/src/metabase/components/AppBanner/AppBanner.tsx
+++ b/frontend/src/metabase/components/AppBanner/AppBanner.tsx
@@ -20,14 +20,14 @@ export const AppBanner = () => {
     "trial-banner-dismissal-timestamp",
   );
 
-  const { shouldShowLicenseTokenMissingBanner, dismissBanner } =
-    useLicenseTokenMissingBanner();
-
   const isAdmin = useSelector(getUserIsAdmin);
   const isHosted = useSelector(getIsHosted);
   const tokenStatus = useSetting("token-status");
   const readOnly = useSetting("read-only-mode");
   const isDevMode = useSetting("development-mode?");
+
+  const { shouldShowLicenseTokenMissingBanner, dismissBanner } =
+    useLicenseTokenMissingBanner(isAdmin);
 
   const tokenExpiryTimestamp = tokenStatus?.["valid-thru"];
   const isValidTrial = tokenExpiryTimestamp && tokenStatus?.trial && isHosted;

--- a/frontend/src/metabase/components/AppBanner/AppBanner.tsx
+++ b/frontend/src/metabase/components/AppBanner/AppBanner.tsx
@@ -3,6 +3,10 @@ import dayjs from "dayjs";
 import { useSetting, useUserSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { DevModeBanner } from "metabase/nav/components/DevModeBanner";
+import {
+  LicenseTokenMissingBanner,
+  useLicenseTokenMissingBanner,
+} from "metabase/nav/components/LicenseTokenMissingBanner";
 import { PaymentBanner } from "metabase/nav/components/PaymentBanner/PaymentBanner";
 import { ReadOnlyBanner } from "metabase/nav/components/ReadOnlyBanner";
 import { TrialBanner } from "metabase/nav/components/TrialBanner";
@@ -15,6 +19,8 @@ export const AppBanner = () => {
   const [lastDismissed, setLastDismissed] = useUserSetting(
     "trial-banner-dismissal-timestamp",
   );
+
+  const { shouldShow, dismissBanner } = useLicenseTokenMissingBanner();
 
   const isAdmin = useSelector(getUserIsAdmin);
   const isHosted = useSelector(getIsHosted);
@@ -38,6 +44,10 @@ export const AppBanner = () => {
 
   if (readOnly) {
     return <ReadOnlyBanner />;
+  }
+
+  if (shouldShow) {
+    return <LicenseTokenMissingBanner onClose={dismissBanner} />;
   }
 
   if (isValidTrial) {

--- a/frontend/src/metabase/components/Banner/Banner.stories.tsx
+++ b/frontend/src/metabase/components/Banner/Banner.stories.tsx
@@ -15,7 +15,7 @@ export const Default = {
   render: (args: BannerProps) => <Banner {...args} />,
   args: {
     icon: "warning_round_filled",
-    bg: "var(--mb-color-bg-black)",
+    bg: "var(--mb-color-background-inverse)",
     iconColor: "var(--mb-color-text-white)",
     body: (
       <Text lh="inherit" c="text-white">

--- a/frontend/src/metabase/components/Banner/Banner.stories.tsx
+++ b/frontend/src/metabase/components/Banner/Banner.stories.tsx
@@ -1,0 +1,35 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta } from "@storybook/react";
+
+import { Text } from "metabase/ui";
+
+import { Banner, type BannerProps } from "./Banner";
+
+export default {
+  title: "components/Banner",
+  component: Banner,
+  tags: ["autodocs"],
+} satisfies Meta<BannerProps>;
+
+export const Default = {
+  render: (args: BannerProps) => <Banner {...args} />,
+  args: {
+    icon: "warning_round_filled",
+    bg: "var(--mb-color-bg-black)",
+    iconColor: "var(--mb-color-text-white)",
+    body: (
+      <Text lh="inherit" c="text-white">
+        This is a banner
+      </Text>
+    ),
+    closable: true,
+    onClose: action("onClose"),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A banner with an icon, a body, and a close button.",
+      },
+    },
+  },
+};

--- a/frontend/src/metabase/components/Banner/Banner.stories.tsx
+++ b/frontend/src/metabase/components/Banner/Banner.stories.tsx
@@ -33,3 +33,17 @@ export const Default = {
     },
   },
 };
+
+export const NonClosable = {
+  render: (args: BannerProps) => <Banner {...args} />,
+  args: {
+    closable: false,
+    bg: "var(--mb-color-success)",
+    body: (
+      <Text lh="inherit" c="text-white">
+        This is a banner
+      </Text>
+    ),
+    py: "md",
+  },
+};

--- a/frontend/src/metabase/components/Banner/Banner.tsx
+++ b/frontend/src/metabase/components/Banner/Banner.tsx
@@ -6,15 +6,17 @@ import { Flex, Group, Icon } from "metabase/ui";
 
 interface BaseBannerProps extends FlexProps {
   icon?: IconName;
+  iconColor?: string;
   body: ReactNode;
 }
 
-type BannerProps =
+export type BannerProps =
   | (BaseBannerProps & { closable: true; onClose: () => void })
   | (BaseBannerProps & { closable?: false; onClose?: never });
 
 export const Banner = ({
   icon,
+  iconColor,
   body,
   closable,
   onClose,
@@ -33,7 +35,7 @@ export const Banner = ({
       {...flexProps}
     >
       <Group gap="xs">
-        {icon && <Icon name={icon} w={36} />}
+        {icon && <Icon name={icon} w={36} color={iconColor} />}
         {body}
       </Group>
       {closable && (
@@ -42,6 +44,7 @@ export const Banner = ({
           name="close"
           onClick={onClose}
           w={36}
+          color={iconColor}
         />
       )}
     </Flex>

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -92,3 +92,7 @@ export function dataModelFieldFormatting(
   const tableUrl = dataModelTable(databaseId, schemaId, tableId);
   return `${tableUrl}/field/${fieldId}/formatting`;
 }
+
+export function adminLicense() {
+  return `/admin/settings/license`;
+}

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -94,5 +94,5 @@ export function dataModelFieldFormatting(
 }
 
 export function adminLicense() {
-  return `/admin/settings/license`;
+  return "/admin/settings/license";
 }

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.module.css
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.module.css
@@ -1,0 +1,15 @@
+.BannerContainer {
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.BannerBody {
+  text-align: left;
+  flex-direction: column;
+  align-items: flex-start;
+
+  @media screen and (--breakpoint-min-sm) {
+    flex-direction: row;
+    align-items: center;
+  }
+}

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
@@ -17,7 +17,6 @@ export const LicenseTokenMissingBanner = ({
       iconColor="var(--mb-color-text-white)"
       className={styles.BannerContainer}
       bg="var(--mb-color-background-inverse)"
-      align="flex-start"
       aria-label={t`License activation notice`}
       aria-live="polite"
       role="status"

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
@@ -21,7 +21,7 @@ export const LicenseTokenMissingBanner = ({
       aria-live="polite"
       role="status"
       body={
-        <Flex align="" gap="xs" className={styles.BannerBody}>
+        <Flex gap="xs" className={styles.BannerBody}>
           <Text lh="inherit" c="text-white" ta={{ base: "left", sm: "center" }}>
             {t`Unlock the paid features included in your Pro or Enterprise plan.`}
           </Text>

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
@@ -1,0 +1,36 @@
+import { t } from "ttag";
+
+import { Banner } from "metabase/components/Banner";
+import Link from "metabase/core/components/Link";
+import { adminLicense } from "metabase/lib/urls";
+import { Flex, Text } from "metabase/ui";
+
+import styles from "./LicenseTokenMissingBanner.module.css";
+
+export const LicenseTokenMissingBanner = ({
+  onClose,
+}: {
+  onClose: () => void;
+}) => {
+  return (
+    <Banner
+      iconColor="var(--mb-color-text-white)"
+      className={styles.BannerContainer}
+      bg="var(--mb-color-background-inverse)"
+      align="flex-start"
+      body={
+        <Flex align="" gap="xs" className={styles.BannerBody}>
+          <Text lh="inherit" c="text-white" ta={{ base: "left", sm: "center" }}>
+            {t`Unlock the paid features included in your Pro or Enterprise plan.`}
+          </Text>
+          <Link to={adminLicense()} variant="brand">
+            {t`Activate your license`}
+          </Link>
+        </Flex>
+      }
+      closable
+      onClose={onClose}
+      py="md"
+    ></Banner>
+  );
+};

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/LicenseTokenMissingBanner.tsx
@@ -18,6 +18,9 @@ export const LicenseTokenMissingBanner = ({
       className={styles.BannerContainer}
       bg="var(--mb-color-background-inverse)"
       align="flex-start"
+      aria-label={t`License activation notice`}
+      aria-live="polite"
+      role="status"
       body={
         <Flex align="" gap="xs" className={styles.BannerBody}>
           <Text lh="inherit" c="text-white" ta={{ base: "left", sm: "center" }}>

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/index.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/index.ts
@@ -1,0 +1,2 @@
+export { LicenseTokenMissingBanner } from "./LicenseTokenMissingBanner";
+export { useLicenseTokenMissingBanner } from "./useLicenseTokenMissingBanner";

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.ts
@@ -1,7 +1,8 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 
-import { useSetting, useUserSetting } from "metabase/common/hooks";
+import { useAdminSetting } from "metabase/api/utils";
+import { useSetting } from "metabase/common/hooks";
 import { isEEBuild } from "metabase/lib/utils";
 import type { TokenStatus } from "metabase-types/api";
 
@@ -9,6 +10,7 @@ dayjs.extend(utc);
 
 const DAYS_BEFORE_REPEAT_BANNER = 14;
 const MAX_NUMBER_OF_DISMISSALS = 2;
+const SETTING_NAME = "license-token-missing-banner-dismissal-timestamp";
 
 export const getCurrentUTCTimestamp = () => {
   return dayjs.utc().toISOString();
@@ -52,13 +54,16 @@ export function shouldShowBanner({
 }
 
 export function useLicenseTokenMissingBanner() {
-  const [lastDismissed, setLastDismissed] = useUserSetting(
-    "license-token-missing-banner-dismissal-timestamp",
-  );
+  const { value: lastDismissed = [], updateSetting: setLastDismissed } =
+    useAdminSetting(SETTING_NAME);
 
   function dismissBanner() {
     // Keep only the last 2 dismissals
-    setLastDismissed([...lastDismissed, getCurrentUTCTimestamp()].slice(-2));
+    setLastDismissed({
+      key: SETTING_NAME,
+      value: [...lastDismissed, getCurrentUTCTimestamp()].slice(-2),
+      toast: false,
+    });
   }
 
   const tokenStatus = useSetting("token-status");

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.ts
@@ -7,6 +7,9 @@ import type { TokenStatus } from "metabase-types/api";
 
 dayjs.extend(utc);
 
+const DAYS_BEFORE_REPEAT_BANNER = 14;
+const MAX_NUMBER_OF_DISMISSALS = 2;
+
 export const getCurrentUTCTimestamp = () => {
   return dayjs.utc().toISOString();
 };
@@ -20,15 +23,14 @@ export function shouldShowBanner({
   lastDismissed: Array<string>;
   isEEBuild: boolean;
 }) {
-  const DAYS_BEFORE_REPEAT_BANNER = 14;
-
   if (!isEEBuild) {
     return false;
   }
   if (tokenStatus !== null) {
     return false;
   }
-  if (lastDismissed.length >= 2) {
+
+  if (lastDismissed.length >= MAX_NUMBER_OF_DISMISSALS) {
     return false;
   }
   if (lastDismissed.length === 0) {

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.ts
@@ -60,7 +60,7 @@ export function useLicenseTokenMissingBanner() {
   }
 
   const tokenStatus = useSetting("token-status");
-  const shouldShow = shouldShowBanner({
+  const shouldShowLicenseTokenMissingBanner = shouldShowBanner({
     tokenStatus,
     lastDismissed,
     isEEBuild: isEEBuild(),
@@ -68,6 +68,6 @@ export function useLicenseTokenMissingBanner() {
 
   return {
     dismissBanner,
-    shouldShow,
+    shouldShowLicenseTokenMissingBanner,
   };
 }

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
@@ -1,0 +1,72 @@
+import { shouldShowBanner } from "./useLicenseTokenMissingBanner";
+
+describe("shouldShowBanner works correctly", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2024-03-20T00:00:00.000Z"));
+  });
+
+  it("should return false when not running EE build", () => {
+    const result = shouldShowBanner({
+      tokenStatus: null,
+      lastDismissed: [],
+      isEEBuild: false,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when token status is not null", () => {
+    const result = shouldShowBanner({
+      tokenStatus: {
+        status: "valid",
+        valid: true,
+      },
+      lastDismissed: [],
+      isEEBuild: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when banner has been dismissed twice", () => {
+    const result = shouldShowBanner({
+      tokenStatus: null,
+      lastDismissed: ["2024-03-19T00:00:00.000Z", "2024-03-20T00:00:00.000Z"],
+      isEEBuild: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true when banner has never been dismissed", () => {
+    const result = shouldShowBanner({
+      tokenStatus: null,
+      lastDismissed: [],
+      isEEBuild: true,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false when banner was dismissed less than 14 days ago", () => {
+    const result = shouldShowBanner({
+      tokenStatus: null,
+      lastDismissed: ["2024-03-10T00:00:00.000Z"],
+      isEEBuild: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true when banner was dismissed more than 14 days ago", () => {
+    const result = shouldShowBanner({
+      tokenStatus: null,
+      lastDismissed: ["2024-03-01T00:00:00.000Z"],
+      isEEBuild: true,
+    });
+
+    expect(result).toBe(true);
+  });
+});

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
@@ -101,6 +101,8 @@ describe("shouldShowBanner works correctly", () => {
 });
 
 describe("useLicenseTokenMissingBanner", () => {
+  const NOW = new Date("2024-03-20T00:00:00.000Z");
+
   const setup = ({
     tokenStatus,
     dismissals,
@@ -112,11 +114,10 @@ describe("useLicenseTokenMissingBanner", () => {
       }),
     });
     setupEnterprisePlugins();
+    setupUpdateSettingEndpoint();
     setupPropertiesEndpoints(
       createMockSettings({
-        "license-token-missing-banner-dismissal-timestamp": [
-          "2024-03-20T00:00:00.000Z",
-        ],
+        "license-token-missing-banner-dismissal-timestamp": [NOW.toISOString()],
         "token-status": tokenStatus ?? null,
       }),
     );
@@ -125,13 +126,10 @@ describe("useLicenseTokenMissingBanner", () => {
     });
   };
 
-  const NOW = new Date("2024-03-20T00:00:00.000Z");
-
   beforeEach(() => {
     fetchMock.reset();
     jest.useFakeTimers();
     jest.setSystemTime(NOW);
-    setupUpdateSettingEndpoint();
   });
 
   describe("shouldShow", () => {

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
@@ -4,7 +4,7 @@ import fetchMock from "fetch-mock";
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupPropertiesEndpoints,
-  setupUpdateSettingsEndpoint,
+  setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
@@ -130,7 +130,7 @@ describe("useLicenseTokenMissingBanner", () => {
     fetchMock.reset();
     jest.useFakeTimers();
     jest.setSystemTime(NOW);
-    setupUpdateSettingsEndpoint();
+    setupUpdateSettingEndpoint();
   });
 
   describe("shouldShow", () => {
@@ -152,7 +152,6 @@ describe("useLicenseTokenMissingBanner", () => {
   describe("dismissBanner", () => {
     it("updates lastDismissed", async () => {
       const { result } = setup();
-      fetchMock.putOnce(SETTINGS_ENDPOINT, 204);
 
       expect(result.current.shouldShowLicenseTokenMissingBanner).toBe(true);
 
@@ -177,7 +176,6 @@ describe("useLicenseTokenMissingBanner", () => {
       ];
 
       const { result } = setup({ dismissals: existingDismissals });
-      fetchMock.put(SETTINGS_ENDPOINT, 204);
 
       act(() => {
         result.current.dismissBanner();

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
@@ -137,7 +137,7 @@ describe("useLicenseTokenMissingBanner", () => {
     it("is true when conditions are met", () => {
       const { result } = setup();
 
-      expect(result.current.shouldShow).toBe(true);
+      expect(result.current.shouldShowLicenseTokenMissingBanner).toBe(true);
     });
 
     it("is false when token status is valid", () => {
@@ -145,7 +145,7 @@ describe("useLicenseTokenMissingBanner", () => {
         tokenStatus: { status: "valid", valid: true },
       });
 
-      expect(result.current.shouldShow).toBe(false);
+      expect(result.current.shouldShowLicenseTokenMissingBanner).toBe(false);
     });
   });
 
@@ -154,7 +154,7 @@ describe("useLicenseTokenMissingBanner", () => {
       const { result } = setup();
       fetchMock.putOnce(SETTINGS_ENDPOINT, 204);
 
-      expect(result.current.shouldShow).toBe(true);
+      expect(result.current.shouldShowLicenseTokenMissingBanner).toBe(true);
 
       act(() => {
         result.current.dismissBanner();
@@ -164,7 +164,7 @@ describe("useLicenseTokenMissingBanner", () => {
         expect(fetchMock.called(SETTINGS_ENDPOINT)).toBe(true);
       });
       await waitFor(() => {
-        expect(result.current.shouldShow).toBe(false);
+        expect(result.current.shouldShowLicenseTokenMissingBanner).toBe(false);
       });
     });
 

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
@@ -192,17 +192,21 @@ describe("useLicenseTokenMissingBanner", () => {
         result.current.dismissBanner();
       });
 
+      let dismissalTimestamp;
+
       await waitFor(async () => {
-        const [{ url }] = await findRequests("PUT");
+        const [{ url, body }] = await findRequests("PUT");
         expect(url).toContain(SETTINGS_ENDPOINT);
+        dismissalTimestamp = body.value[1];
       });
 
       const puts = await findRequests("PUT");
       expect(puts).toHaveLength(1);
       const [{ url, body }] = puts;
       expect(url).toContain(SETTINGS_ENDPOINT);
-      expect(body.value).toHaveLength(2);
-      expect(body.value).toContain(SECOND_DISMISSAL.toISOString());
+      expect(body).toEqual({
+        value: [SECOND_DISMISSAL.toISOString(), dismissalTimestamp],
+      });
     });
   });
 });

--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -102,7 +102,7 @@
   :type       :string)
 
 (defsetting license-token-missing-banner-dismissal-timestamp
-  (deferred-tru "The ISO8601 date when a user last dismissed the banner.")
+  (deferred-tru "The array of last two ISO8601 dates when a user dismissed the license token missing banner.")
   :user-local :only
   :encryption :no
   :export?    false

--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -101,6 +101,15 @@
   :visibility :authenticated
   :type       :string)
 
+(defsetting license-token-missing-banner-dismissal-timestamp
+  (deferred-tru "The ISO8601 date when a user last dismissed the banner.")
+  :user-local :only
+  :encryption :no
+  :export?    false
+  :visibility :authenticated
+  :type       :csv
+  :default    [])
+
 (defsetting user-visibility
   (deferred-tru "Note: Sandboxed users will never see suggestions.")
   :visibility   :authenticated

--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -102,11 +102,10 @@
   :type       :string)
 
 (defsetting license-token-missing-banner-dismissal-timestamp
-  (deferred-tru "The array of last two ISO8601 dates when a user dismissed the license token missing banner.")
-  :user-local :only
+  (deferred-tru "The array of last two ISO8601 dates when an admin dismissed the license token missing banner.")
   :encryption :no
   :export?    false
-  :visibility :authenticated
+  :visibility :admin
   :type       :csv
   :default    [])
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-49/prgrowth-show-a-banner-for-pro-self-hosted-that-navigates-users-to

### Description

Banner consists of two parts: banner UI component and hook which contains the logic and data bindings to decide when to show the banner and to hide it.

I'm introducing new user setting: `"license-token-missing-banner-dismissal-timestamp"` which holds array of timestamps, which represent when the banner was dismissed. 

### How to verify

Test if the banner shows up on a new enterprise instance, whether it can be dismissed, also if entering the token hides the banner.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
