### PR TITLE
fix incorrect keyset not exists logging during metabase_metadata sync

### DIFF
--- a/src/metabase/sync/sync_metadata/metabase_metadata.clj
+++ b/src/metabase/sync/sync_metadata/metabase_metadata.clj
@@ -43,19 +43,19 @@
    {:keys [table-name field-name k]} :- KeypathComponents
    value]
   (boolean
-    ;; ignore legacy entries that try to set field_type since it's no longer part of Field
+   ;; ignore legacy entries that try to set field_type since it's no longer part of Field
    (when-not (= k :field_type)
-      ;; fetch the corresponding Table, then set the Table or Field property
+     ;; fetch the corresponding Table, then set the Table or Field property
      (if table-name
        (when-let [table-id (t2/select-one-pk :model/Table
-                                              ;; TODO: this needs to support schemas
+                                             ;; TODO: this needs to support schemas
                                              :db_id  (u/the-id database)
                                              :name   table-name
                                              :active true)]
          (if field-name
-           (pos? (t2/update! :model/Field {:name field-name, :table_id table-id} {k value}))
-           (pos? (t2/update! :model/Table table-id {k value}))))
-       (pos? (t2/update! :model/Database (u/the-id database) {k value}))))))
+           (t2/update! :model/Field {:name field-name, :table_id table-id} {k value})
+           (t2/update! :model/Table table-id {k value})))
+       (t2/update! :model/Database (u/the-id database) {k value})))))
 
 (mu/defn- sync-metabase-metadata-table!
   "Databases may include a table named `_metabase_metadata` (case-insentive) which includes descriptions or other


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-369/error-logging-during-sync-no-matching-keypath


We're incorrectly logging "Error syncing _metabase_metadata: no matching keypath [..]" if we're attempting to update a keypath to a value it already has. 
This relaxes the check.

If the kEypath truly doesn't exist, toucan will throw an exception. 
```
>(t2/update! :model/Table table-id {:foo ""})
Execution error (JdbcSQLSyntaxErrorException) at org.h2.message.DbException/getJdbcSQLException (DbException.java:502).
Column "FOO" not found; SQL statement:
UPDATE "METABASE_TABLE" SET "UPDATED_AT" = NOW(), "FOO" = ? WHERE "ID" = ? [42122-214]
```