### PR TITLE
Ability to specify auth method in new iframe embedding

### DIFF
--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -24,6 +24,7 @@ export interface BaseEmbedTestPageOptions {
   template?: "exploration";
   theme?: MetabaseTheme;
   locale?: string;
+  preferredAuthMethod?: "jwt" | "saml";
 
   // Options for the test page
   origin?: string;

--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -1,4 +1,3 @@
-import { setupSaml } from "e2e/test/scenarios/admin-2/sso/shared/helpers";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme/MetabaseTheme";
 
 import { createApiKey } from "./api";

--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -4,7 +4,10 @@ import { createApiKey } from "./api";
 import { setTokenFeatures } from "./e2e-enterprise-helpers";
 import { enableJwtAuth } from "./e2e-jwt-helpers";
 import { restore } from "./e2e-setup-helpers";
-import { mockAuthProviderAndJwtSignIn } from "./embedding-sdk-testing";
+import {
+  enableSamlAuth,
+  mockAuthProviderAndJwtSignIn,
+} from "./embedding-sdk-testing";
 
 const EMBED_JS_PATH = "http://localhost:4000/app/embed.js";
 
@@ -153,12 +156,18 @@ export function prepareSdkIframeEmbedTest({
   setupMockAuthProviders(enabledAuthMethods);
 }
 
-type EnabledAuthMethods = "jwt" | "api-key";
+type EnabledAuthMethods = "jwt" | "saml" | "api-key";
 
 function setupMockAuthProviders(enabledAuthMethods: EnabledAuthMethods[]) {
   if (enabledAuthMethods.includes("jwt")) {
     enableJwtAuth();
     mockAuthProviderAndJwtSignIn();
+  }
+
+  // Doesn't actually allow us to login via SAML, but this tricks
+  // Metabase into thinking that SAML is enabled and configured.
+  if (enabledAuthMethods.includes("saml")) {
+    enableSamlAuth();
   }
 
   if (enabledAuthMethods.includes("api-key")) {

--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -1,3 +1,4 @@
+import { setupSaml } from "e2e/test/scenarios/admin-2/sso/shared/helpers";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme/MetabaseTheme";
 
 import { createApiKey } from "./api";

--- a/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
+++ b/e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers.ts
@@ -65,6 +65,19 @@ export function signInAsAdminAndEnableEmbeddingSdk() {
 
 const MOCK_SAML_IDP_URI = "https://example.test/saml";
 
+export function enableSamlAuth() {
+  cy.readFile<string>("test_resources/sso/auth0-public-idp.cert", "utf8").then(
+    (certificate) => {
+      cy.request("PUT", "/api/setting", {
+        "saml-enabled": true,
+        "saml-identity-provider-uri": MOCK_SAML_IDP_URI,
+        "saml-identity-provider-certificate": certificate,
+        "saml-identity-provider-issuer": "https://example.test/issuer",
+      });
+    },
+  );
+}
+
 export function mockAuthSsoEndpointForSamlAuthProvider() {
   cy.intercept("GET", "/auth/sso", (req) => {
     req.reply({

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -107,8 +107,21 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     });
   });
 
-  it("uses SAML when authMethod is set to 'saml' and both SAML and JWT are enabled", () => {
+  it("uses JWT when authMethod is set to 'jwt' and both SAML and JWT are enabled", () => {
     cy.intercept("GET", "/auth/sso").as("authSso");
+    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt", "saml"] });
+    cy.signOut();
+
+    const frame = H.loadSdkIframeEmbedTestPage({
+      dashboardId: ORDERS_DASHBOARD_ID,
+      authMethod: "saml",
+    });
+
+    cy.wait("@authSso").its("response.body.method").should("eq", "jwt");
+    assertDashboardLoaded(frame);
+  });
+
+  it("uses SAML when authMethod is set to 'saml' and both SAML and JWT are enabled", () => {
     mockAuthSsoEndpointForSamlAuthProvider();
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt", "saml"] });
     cy.signOut();
@@ -119,21 +132,6 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
       onVisitPage: () => stubWindowOpenForSamlPopup(),
     });
 
-    cy.wait("@authSso").its("response.body.method").should("eq", "saml");
-    assertDashboardLoaded(frame);
-  });
-
-  it("uses JWT when authMethod is set to 'jwt' and both SAML and JWT are enabled", () => {
-    cy.intercept("GET", "/auth/sso").as("authSso");
-    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt", "saml"] });
-    cy.signOut();
-
-    const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      authMethod: "jwt",
-    });
-
-    cy.wait("@authSso").its("response.body.method").should("eq", "jwt");
     assertDashboardLoaded(frame);
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -109,7 +109,15 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
 
   it("uses JWT when authMethod is set to 'jwt' and both SAML and JWT are enabled", () => {
     cy.intercept("GET", "/auth/sso").as("authSso");
-    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt", "saml"] });
+
+    // Enable SAML to test the authMethod fallback logic.
+    cy.request("PUT", "/api/setting", {
+      "saml-enabled": true,
+      "saml-identity-provider-uri": "https://example.test",
+      "saml-identity-provider-issuer": "https://example.test/issuer",
+    });
+
+    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt"] });
     cy.signOut();
 
     const frame = H.loadSdkIframeEmbedTestPage({
@@ -123,7 +131,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
 
   it("uses SAML when authMethod is set to 'saml' and both SAML and JWT are enabled", () => {
     mockAuthSsoEndpointForSamlAuthProvider();
-    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt", "saml"] });
+    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt"] });
     cy.signOut();
 
     const frame = H.loadSdkIframeEmbedTestPage({

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -115,7 +115,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
 
     const frame = H.loadSdkIframeEmbedTestPage({
       dashboardId: ORDERS_DASHBOARD_ID,
-      authMethod: "jwt",
+      preferredAuthMethod: "jwt",
     });
 
     cy.wait("@authSso").its("response.body.method").should("eq", "jwt");
@@ -130,7 +130,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
 
     const frame = H.loadSdkIframeEmbedTestPage({
       dashboardId: ORDERS_DASHBOARD_ID,
-      authMethod: "saml",
+      preferredAuthMethod: "saml",
     });
 
     cy.log("must fail to login via SAML as the SAML endpoint does not exist");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -106,6 +106,36 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
         .should("not.exist");
     });
   });
+
+  it("uses SAML when authMethod is set to 'saml' and both SAML and JWT are enabled", () => {
+    cy.intercept("GET", "/auth/sso").as("authSso");
+    mockAuthSsoEndpointForSamlAuthProvider();
+    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt", "saml"] });
+    cy.signOut();
+
+    const frame = H.loadSdkIframeEmbedTestPage({
+      dashboardId: ORDERS_DASHBOARD_ID,
+      authMethod: "saml",
+      onVisitPage: () => stubWindowOpenForSamlPopup(),
+    });
+
+    cy.wait("@authSso").its("response.body.method").should("eq", "saml");
+    assertDashboardLoaded(frame);
+  });
+
+  it("uses JWT when authMethod is set to 'jwt' and both SAML and JWT are enabled", () => {
+    cy.intercept("GET", "/auth/sso").as("authSso");
+    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt", "saml"] });
+    cy.signOut();
+
+    const frame = H.loadSdkIframeEmbedTestPage({
+      dashboardId: ORDERS_DASHBOARD_ID,
+      authMethod: "jwt",
+    });
+
+    cy.wait("@authSso").its("response.body.method").should("eq", "jwt");
+    assertDashboardLoaded(frame);
+  });
 });
 
 function assertDashboardLoaded(frame: Cypress.Chainable) {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -25,7 +25,7 @@ const ALLOWED_EMBED_SETTING_KEYS = [
   "template",
   "theme",
   "locale",
-  "authMethod",
+  "preferredAuthMethod",
 ] as const satisfies EmbedSettingKey[];
 
 type AllowedEmbedSettingKey = (typeof ALLOWED_EMBED_SETTING_KEYS)[number];
@@ -229,11 +229,11 @@ class MetabaseEmbed {
    * @returns {{ method: "saml" | "jwt", sessionToken: {jwt: string} }}
    */
   private async _getMetabaseSessionToken() {
-    const { instanceUrl, authMethod } = this._settings;
+    const { instanceUrl, preferredAuthMethod } = this._settings;
 
     const urlResponseJson = await connectToInstanceAuthSso(instanceUrl, {
       headers: this._getAuthRequestHeader(),
-      authMethod,
+      authMethod: preferredAuthMethod,
     });
 
     const { method, url: responseUrl, hash } = urlResponseJson || {};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -25,6 +25,7 @@ const ALLOWED_EMBED_SETTING_KEYS = [
   "template",
   "theme",
   "locale",
+  "authMethod",
 ] as const satisfies EmbedSettingKey[];
 
 type AllowedEmbedSettingKey = (typeof ALLOWED_EMBED_SETTING_KEYS)[number];
@@ -228,10 +229,11 @@ class MetabaseEmbed {
    * @returns {{ method: "saml" | "jwt", sessionToken: {jwt: string} }}
    */
   private async _getMetabaseSessionToken() {
-    const { instanceUrl } = this._settings;
+    const { instanceUrl, authMethod } = this._settings;
 
     const urlResponseJson = await connectToInstanceAuthSso(instanceUrl, {
       headers: this._getAuthRequestHeader(),
+      authMethod,
     });
 
     const { method, url: responseUrl, hash } = urlResponseJson || {};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -109,15 +109,4 @@ describe("embed.js script tag for sdk iframe embedding", () => {
       );
     },
   );
-
-  it("allows setting authMethod in settings", () => {
-    expect(() => {
-      new MetabaseEmbed({
-        ...defaultSettings,
-        dashboardId: 1,
-        target: document.createElement("div"),
-        authMethod: "saml",
-      });
-    }).not.toThrow();
-  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -109,4 +109,15 @@ describe("embed.js script tag for sdk iframe embedding", () => {
       );
     },
   );
+
+  it("allows setting authMethod in settings", () => {
+    expect(() => {
+      new MetabaseEmbed({
+        ...defaultSettings,
+        dashboardId: 1,
+        target: document.createElement("div"),
+        authMethod: "saml",
+      });
+    }).not.toThrow();
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -111,7 +111,7 @@ type SdkIframeEmbedBaseSettings = {
   instanceUrl: string;
   theme?: MetabaseTheme;
   locale?: string;
-  authMethod?: MetabaseAuthMethod;
+  preferredAuthMethod?: MetabaseAuthMethod;
   // Whether the embed is running on localhost. Cannot be set by the user.
   _isLocalhost?: boolean;
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -6,6 +6,7 @@ import type {
   SqlParameterValues,
 } from "embedding-sdk";
 import type { MetabaseError } from "embedding-sdk/errors";
+import type { MetabaseAuthMethod } from "embedding-sdk/types";
 import type { MetabaseEmbeddingSessionToken } from "embedding-sdk/types/refresh-token";
 import type { CollectionId } from "metabase-types/api";
 
@@ -23,7 +24,7 @@ export type SdkIframeEmbedMessage =
   | {
       type: "metabase.embed.submitSessionToken";
       data: {
-        authMethod: SdkIframeAuthMethod;
+        authMethod: MetabaseAuthMethod;
         sessionToken: MetabaseEmbeddingSessionToken;
       };
     }
@@ -33,8 +34,6 @@ export type SdkIframeEmbedMessage =
         error: MetabaseError<string, unknown>;
       };
     };
-
-type SdkIframeAuthMethod = "saml" | "jwt";
 
 // --- Embed Option Interfaces ---
 
@@ -112,7 +111,7 @@ type SdkIframeEmbedBaseSettings = {
   instanceUrl: string;
   theme?: MetabaseTheme;
   locale?: string;
-
+  authMethod?: MetabaseAuthMethod;
   // Whether the embed is running on localhost. Cannot be set by the user.
   _isLocalhost?: boolean;
 };


### PR DESCRIPTION
Closes EMB-442

Adds the `authMethod` configuration to allow new iframe embedding users to select their authentication methods when both SAML and JWT are enabled and configured.

### How to verify

- Setup both JWT and SAML on your local instance. Make sure both is enabled and configured.
- Setup the following HTML page and serve it locally. You need target, instanceUrl, dashboardId and authMethod.

```html
<script src="http://localhost:3000/app/embed.js"></script>
<div id="metabase-embed-container"></div>

<style>
  body {margin: 0; }
  #metabase-embed-container { height: 100vh; }
</style>

<script>
  const { MetabaseEmbed } = window["metabase.embed"];

  const embed = new MetabaseEmbed({
    target: "#metabase-embed-container",
    instanceUrl: "http://localhost:3000",
    dashboardId: 1,
    authMethod: "jwt"
  });
</script>
```

- Set `authMethod` to JWT. Now we should be using JWT and you shouldn't see any popups.
- Set `authMethod` to SAML. Now we should be using SAML and you should see a popup.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
