### PR TITLE
feat: new action form from describe endpoint on table view

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
@@ -1,4 +1,6 @@
 import type {
+  DescribeActionFormRequest,
+  DescribeActionFormResponse,
   TableDeleteRowsRequest,
   TableDeleteRowsResponse,
   TableExecuteActionRequest,
@@ -107,6 +109,16 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
         return response?.outputs?.[0];
       },
     }),
+    describeActionForm: builder.mutation<
+      DescribeActionFormResponse,
+      DescribeActionFormRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: `/api/ee/data-editing/tmp-modal`,
+        body,
+      }),
+    }),
   }),
 });
 
@@ -118,4 +130,5 @@ export const {
   useTableRedoMutation,
   useGetActionsQuery,
   useExecuteActionMutation,
+  useDescribeActionFormMutation,
 } = tableDataEditApi;

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
@@ -18,10 +18,13 @@ import { extractRemappedColumns } from "metabase/visualizations";
 import { isDatabaseTableEditingEnabled } from "metabase-enterprise/data_editing/settings";
 import { getRowCountMessage } from "metabase-lib/v1/queries/utils/row-count";
 
+import { PrimitiveTableAction } from "../types";
+
 import S from "./EditTableData.module.css";
 import { EditTableDataGrid } from "./EditTableDataGrid";
 import { EditTableDataHeader } from "./EditTableDataHeader";
 import { EditTableDataOverlay } from "./EditTableDataOverlay";
+import { ActionCreateRowFormModal } from "./modals/ActionCreateRowFormModal";
 import { DeleteBulkRowConfirmationModal } from "./modals/DeleteBulkRowConfirmationModal";
 import { EditBulkRowsModal } from "./modals/EditBulkRowsModal";
 import { EditingBaseRowModal } from "./modals/EditingBaseRowModal";
@@ -32,6 +35,7 @@ import { useTableBulkDeleteConfirmation } from "./modals/use-table-bulk-delete-c
 import { useTableEditingModalControllerWithObjectId } from "./modals/use-table-modal-with-object-id";
 import { getTableEditPathname } from "./url";
 import { useStandaloneTableQuery } from "./use-standalone-table-query";
+import { useActionFormDescription } from "./use-table-action-form-description";
 import { useTableCRUD } from "./use-table-crud";
 import { useEditingTableRowSelection } from "./use-table-row-selection";
 import { useTableSorting } from "./use-table-sorting";
@@ -91,7 +95,6 @@ export const EditTableDataContainer = ({
 
   const {
     state: modalState,
-    openCreateRowModal,
     openEditRowModal,
     closeModal,
   } = useTableEditingModalControllerWithObjectId({
@@ -151,6 +154,16 @@ export const EditTableDataContainer = ({
       scope: editingScope,
       stateUpdateStrategy,
     });
+
+  const [
+    isCreateRowModalOpen,
+    { open: openCreateRowModal, close: closeCreateRowModal },
+  ] = useDisclosure(false);
+
+  const { data: createRowFormDescription } = useActionFormDescription({
+    actionId: PrimitiveTableAction.Create,
+    scope: editingScope,
+  });
 
   const {
     isDeleteBulkRequested,
@@ -279,6 +292,13 @@ export const EditTableDataContainer = ({
         fieldMetadataMap={tableFieldMetadataMap}
         isLoading={isInserting}
         hasDeleteAction
+      />
+      <ActionCreateRowFormModal
+        description={createRowFormDescription}
+        opened={isCreateRowModalOpen}
+        onClose={closeCreateRowModal}
+        isInserting={isInserting}
+        onRowCreate={handleRowCreate}
       />
       <EditBulkRowsModal
         opened={isBulkEditingRequested}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
@@ -18,7 +18,7 @@ import { extractRemappedColumns } from "metabase/visualizations";
 import { isDatabaseTableEditingEnabled } from "metabase-enterprise/data_editing/settings";
 import { getRowCountMessage } from "metabase-lib/v1/queries/utils/row-count";
 
-import { PrimitiveTableAction } from "../types";
+import { BuiltInTableAction } from "../types";
 
 import S from "./EditTableData.module.css";
 import { EditTableDataGrid } from "./EditTableDataGrid";
@@ -161,7 +161,7 @@ export const EditTableDataContainer = ({
   ] = useDisclosure(false);
 
   const { data: createRowFormDescription } = useActionFormDescription({
-    actionId: PrimitiveTableAction.Create,
+    actionId: BuiltInTableAction.Create,
     scope: editingScope,
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputDateTime.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputDateTime.tsx
@@ -1,0 +1,121 @@
+import { DatesProvider, useDatesContext } from "@mantine/dates";
+import dayjs from "dayjs";
+import { type KeyboardEvent, useCallback, useMemo, useState } from "react";
+
+import {
+  DEFAULT_DATE_STYLE,
+  DEFAULT_TIME_STYLE,
+} from "metabase/lib/formatting/datetime-utils";
+import { useSelector } from "metabase/lib/redux";
+import { getSetting } from "metabase/selectors/settings";
+import { DateInput } from "metabase/ui";
+
+import type { ActionInputSharedProps } from "./types";
+
+const DEFAULT_DATETIME_STYLE = `${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`;
+
+type ActionInputDateTimeProps = ActionInputSharedProps & {
+  isDateTime?: boolean;
+  dateStyle?: string;
+  dateTimeStyle?: string;
+  classNames?: {
+    wrapper?: string;
+    dateTextInputElement?: string;
+  };
+};
+
+export const ActionInputDateTime = ({
+  isDateTime,
+  dateStyle = DEFAULT_DATE_STYLE,
+  dateTimeStyle = DEFAULT_DATETIME_STYLE,
+  autoFocus,
+  inputProps,
+  initialValue,
+  classNames,
+  onChange,
+  onBlur,
+  onEscape,
+  onEnter,
+}: ActionInputDateTimeProps) => {
+  const { locale, firstDayOfWeek, consistentWeeks } = useDatesContext();
+  const reportTimezone = useSelector((state) =>
+    getSetting(state, "report-timezone-long"),
+  );
+
+  const { restoreTimezone, initialDate } = useMemo(
+    () => ({
+      initialDate: initialValue ? new Date(initialValue.toString()) : null,
+      restoreTimezone: (date: Date | null) => {
+        if (!date) {
+          return null;
+        }
+
+        return dayjs(date)
+          .tz(reportTimezone)
+          .format("YYYY-MM-DDTHH:mm:ss.SSSZ");
+      },
+    }),
+    [initialValue, reportTimezone],
+  );
+
+  const valueFormat = isDateTime ? dateTimeStyle : dateStyle;
+
+  const [value, setValue] = useState<Date | null>(initialDate);
+  const [isFocused, setFocused] = useState(false);
+
+  const handleChange = useCallback(
+    (value: Date | null) => {
+      setValue(value);
+      onChange?.(restoreTimezone(value));
+    },
+    [onChange, restoreTimezone],
+  );
+
+  const handleFocus = useCallback(() => {
+    setFocused(true);
+  }, [setFocused]);
+
+  const handleBlur = useCallback(() => {
+    setFocused(false);
+    onBlur?.(restoreTimezone(value));
+  }, [value, onBlur, restoreTimezone]);
+
+  const handleKeyUp = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onEscape?.(restoreTimezone(value));
+      } else if (event.key === "Enter") {
+        onEnter?.(restoreTimezone(value));
+      }
+    },
+    [value, onEscape, onEnter, restoreTimezone],
+  );
+
+  return (
+    <DatesProvider
+      settings={{
+        timezone: reportTimezone,
+        locale,
+        firstDayOfWeek,
+        consistentWeeks,
+      }}
+    >
+      <DateInput
+        autoFocus={autoFocus}
+        value={value}
+        valueFormat={valueFormat}
+        classNames={{
+          wrapper: classNames?.wrapper,
+          input: classNames?.dateTextInputElement,
+        }}
+        // Keeps popover mounted when focused to improve time editing UX
+        popoverProps={{ opened: isFocused }}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        onKeyUp={handleKeyUp}
+        {...inputProps}
+      />
+    </DatesProvider>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputText.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputText.tsx
@@ -1,0 +1,46 @@
+import { Input } from "metabase/ui";
+
+import type { ActionInputSharedProps } from "./types";
+
+type ActionInputTextProps = ActionInputSharedProps & {
+  classNames?: {
+    wrapper?: string;
+    textInputElement?: string;
+  };
+};
+
+export const ActionInputText = ({
+  autoFocus,
+  inputProps,
+  initialValue,
+  classNames,
+  onEscape,
+  onEnter,
+  onBlur,
+  onChange,
+}: ActionInputTextProps) => {
+  return (
+    <Input
+      defaultValue={(initialValue ?? "").toString()}
+      autoFocus={autoFocus}
+      onKeyUp={(event) => {
+        if (event.key === "Escape") {
+          onEscape?.(event.currentTarget.value);
+        } else if (event.key === "Enter") {
+          onEnter?.(event.currentTarget.value);
+        }
+      }}
+      onChange={(event) => {
+        onChange?.(event.currentTarget.value);
+      }}
+      onBlur={(event) => {
+        onBlur?.(event.currentTarget.value);
+      }}
+      classNames={{
+        wrapper: classNames?.wrapper,
+        input: classNames?.textInputElement,
+      }}
+      {...inputProps}
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputTextarea.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputTextarea.tsx
@@ -1,0 +1,58 @@
+import { Textarea } from "metabase/ui";
+
+import type { ActionInputSharedProps } from "./types";
+
+const DEFAULT_MAX_ROWS = 8;
+const DEFAULT_MIN_ROWS = 1;
+
+type ActionInputTextareaProps = ActionInputSharedProps & {
+  minRows?: number;
+  maxRows?: number;
+  classNames?: {
+    wrapper?: string;
+    textInputElement?: string;
+  };
+};
+
+export const ActionInputTextarea = ({
+  minRows = DEFAULT_MIN_ROWS,
+  maxRows = DEFAULT_MAX_ROWS,
+  autoFocus,
+  inputProps,
+  initialValue,
+  classNames,
+  onBlur,
+  onEscape,
+  onChange,
+}: ActionInputTextareaProps) => {
+  return (
+    <Textarea
+      defaultValue={(initialValue ?? "").toString()}
+      autoFocus={autoFocus}
+      onKeyUp={(event) => {
+        if (event.key === "Escape") {
+          onEscape?.(event.currentTarget.value);
+        }
+        // We skip handling Enter here because it might break the
+        // default behavior of the Textarea and we don't want to
+        // override it.
+      }}
+      onChange={(event) => {
+        onChange?.(event.currentTarget.value);
+      }}
+      onBlur={(event) => {
+        onBlur?.(event.currentTarget.value);
+      }}
+      classNames={{
+        wrapper: classNames?.wrapper,
+        input: classNames?.textInputElement,
+      }}
+      {...inputProps}
+      // Match the line height for single line text (should look like a regular input)
+      styles={{ input: { lineHeight: "165%" } }}
+      maxRows={maxRows}
+      minRows={minRows}
+      autosize
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ParameterActionInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ParameterActionInput.tsx
@@ -1,0 +1,23 @@
+import type { ActionFormParameter } from "../../types";
+import { ActionFormParameterType } from "../../types";
+
+import { ActionInputDateTime } from "./ActionInputDateTime";
+import { ActionInputText } from "./ActionInputText";
+import type { ActionInputSharedProps } from "./types";
+
+type ParameterActionInputProps = ActionInputSharedProps & {
+  parameter: ActionFormParameter;
+};
+
+export function ParameterActionInput(props: ParameterActionInputProps) {
+  const { parameter, ...rest } = props;
+
+  switch (parameter.type) {
+    case ActionFormParameterType.Date:
+      return <ActionInputDateTime {...rest} />;
+    case ActionFormParameterType.DateTime:
+      return <ActionInputDateTime {...rest} isDateTime />;
+    default:
+      return <ActionInputText {...rest} />;
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ParameterActionInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ParameterActionInput.tsx
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import type { ActionFormParameter } from "../../types";
 import { ActionFormParameterType } from "../../types";
 
@@ -12,12 +14,21 @@ type ParameterActionInputProps = ActionInputSharedProps & {
 export function ParameterActionInput(props: ParameterActionInputProps) {
   const { parameter, ...rest } = props;
 
+  // TOOD: add `Auto populated` label for db-generated values when BE supports it
+  const placeholder = parameter.optional ? t`Optional` : undefined;
+  const inputProps = {
+    ...rest.inputProps,
+    placeholder,
+  };
+
   switch (parameter.type) {
     case ActionFormParameterType.Date:
-      return <ActionInputDateTime {...rest} />;
+      return <ActionInputDateTime {...rest} inputProps={inputProps} />;
     case ActionFormParameterType.DateTime:
-      return <ActionInputDateTime {...rest} isDateTime />;
+      return (
+        <ActionInputDateTime {...rest} inputProps={inputProps} isDateTime />
+      );
     default:
-      return <ActionInputText {...rest} />;
+      return <ActionInputText {...rest} inputProps={inputProps} />;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/types.ts
@@ -1,0 +1,21 @@
+import type { MantineSize, TextInputProps } from "metabase/ui";
+
+export type ActionInputInputProps = {
+  size?: MantineSize;
+  variant?: TextInputProps["variant"];
+  placeholder?: string;
+  disabled?: boolean;
+  error?: TextInputProps["error"];
+  rightSection?: TextInputProps["rightSection"];
+  rightSectionPointerEvents?: TextInputProps["rightSectionPointerEvents"];
+};
+
+export type ActionInputSharedProps = {
+  autoFocus?: boolean;
+  initialValue?: string;
+  inputProps?: ActionInputInputProps;
+  onChange?: (value: string | null) => unknown;
+  onBlur?: (value: string | null) => unknown;
+  onEscape?: (value: string | null) => unknown;
+  onEnter?: (value: string | null) => unknown;
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionCreateRowFormModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionCreateRowFormModal.tsx
@@ -46,7 +46,7 @@ export function ActionCreateRowFormModal({
       const errors: Record<string, string> = {};
 
       description?.parameters.forEach((parameter) => {
-        const isRequired = parameter.optional;
+        const isRequired = !parameter.optional;
         if (isRequired && !values[parameter.id]) {
           errors[parameter.id] = t`This column is required`;
         }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionCreateRowFormModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionCreateRowFormModal.tsx
@@ -1,0 +1,159 @@
+import cx from "classnames";
+import { useFormik } from "formik";
+import { useCallback, useEffect } from "react";
+import { t } from "ttag";
+
+import {
+  ActionIcon,
+  Button,
+  Flex,
+  Group,
+  Icon,
+  Loader,
+  Modal,
+  rem,
+} from "metabase/ui";
+import type { RowValue } from "metabase-types/api";
+
+import type {
+  ActionFormParameter,
+  DescribeActionFormResponse,
+} from "../../types";
+import { ParameterActionInput } from "../inputs_v2/ParameterActionInput";
+
+import { ActionFormModalParameter } from "./ActionFormModalParameter";
+import S from "./EditingBaseRowModal.module.css";
+
+type CreateRowFormValues = Record<string, RowValue>;
+
+interface ActionCreateRowFormModalProps {
+  opened: boolean;
+  description?: DescribeActionFormResponse;
+  isInserting: boolean;
+  onClose: () => void;
+  onRowCreate: (data: CreateRowFormValues) => Promise<boolean>;
+}
+
+export function ActionCreateRowFormModal({
+  opened,
+  description,
+  isInserting,
+  onClose,
+  onRowCreate,
+}: ActionCreateRowFormModalProps) {
+  const validateForm = useCallback(
+    (values: CreateRowFormValues) => {
+      const errors: Record<string, string> = {};
+
+      description?.parameters.forEach((parameter) => {
+        const isRequired = parameter.optional;
+        if (isRequired && !values[parameter.id]) {
+          errors[parameter.id] = t`This column is required`;
+        }
+      });
+
+      return errors;
+    },
+    [description?.parameters],
+  );
+
+  const onSubmit = useCallback(
+    async (values: CreateRowFormValues) => {
+      const success = await onRowCreate(values);
+      if (success) {
+        onClose();
+      }
+    },
+    [onClose, onRowCreate],
+  );
+
+  const {
+    isValid,
+    resetForm,
+    setFieldValue,
+    handleSubmit,
+    validateForm: revalidateForm,
+  } = useFormik({
+    initialValues: {} as CreateRowFormValues,
+    onSubmit,
+    validate: validateForm,
+    validateOnMount: true,
+  });
+
+  // Clear new row data when modal is opened
+  useEffect(() => {
+    if (opened) {
+      resetForm();
+      revalidateForm();
+    }
+  }, [opened, resetForm, revalidateForm]);
+
+  return (
+    <Modal.Root opened={opened} onClose={onClose}>
+      <Modal.Overlay />
+      <Modal.Content>
+        <form onSubmit={handleSubmit}>
+          <Modal.Header px="xl" pb="0" className={S.modalHeader}>
+            <Modal.Title>{t`Create a new record`}</Modal.Title>
+            <Group
+              gap="xs"
+              mr={rem(-5) /* aligns cross with modal right padding */}
+            >
+              <ActionIcon variant="subtle" onClick={onClose}>
+                <Icon name="close" />
+              </ActionIcon>
+            </Group>
+          </Modal.Header>
+          <Modal.Body px="xl" py="lg" className={cx(S.modalBody)}>
+            {!description ? (
+              <Loader />
+            ) : (
+              description.parameters.map((parameter) => {
+                return (
+                  <ActionFormModalParameter
+                    key={parameter.id}
+                    parameter={parameter}
+                  >
+                    <CreateRowFormInput
+                      parameter={parameter}
+                      onChange={setFieldValue}
+                    />
+                  </ActionFormModalParameter>
+                );
+              })
+            )}
+          </Modal.Body>
+          <Flex px="xl" className={S.modalFooter} gap="lg" justify="flex-end">
+            <Button variant="subtle" onClick={onClose}>
+              {t`Cancel`}
+            </Button>
+            <Button
+              disabled={isInserting || !isValid}
+              variant="filled"
+              type="submit"
+            >{t`Create new record`}</Button>
+          </Flex>
+        </form>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+type CreateRowFormInputProps = {
+  parameter: ActionFormParameter;
+  onChange: (field: string, value: RowValue) => void;
+};
+
+export function CreateRowFormInput({
+  parameter,
+  onChange,
+}: CreateRowFormInputProps) {
+  const handleChange = useCallback(
+    (value: RowValue) => {
+      onChange(parameter.id, value);
+    },
+    [parameter.id, onChange],
+  );
+
+  return <ParameterActionInput parameter={parameter} onChange={handleChange} />;
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionFormModalParameter.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionFormModalParameter.tsx
@@ -33,7 +33,7 @@ export function ActionFormModalParameter({
         />
         <Text className={S.modalBodyColumn}>
           {parameter.display_name}
-          {parameter.optional && (
+          {!parameter.optional && (
             <Text component="span" c="error">
               *
             </Text>

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionFormModalParameter.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionFormModalParameter.tsx
@@ -1,0 +1,46 @@
+import type { PropsWithChildren } from "react";
+
+import { Group, Icon, type IconName, Text } from "metabase/ui";
+
+import { type ActionFormParameter, ActionFormParameterType } from "../../types";
+
+import S from "./EditingBaseRowModal.module.css";
+
+type ActionFormModalParameterProps = PropsWithChildren<{
+  parameter: ActionFormParameter;
+}>;
+
+const DEFAULT_PARAMETER_ICON = "string";
+const PARAMETER_ICON_MAP: Record<ActionFormParameterType, IconName> = {
+  [ActionFormParameterType.Text]: "string",
+  [ActionFormParameterType.Number]: "number",
+  [ActionFormParameterType.Date]: "calendar",
+  [ActionFormParameterType.DateTime]: "calendar",
+  [ActionFormParameterType.Integer]: "number",
+  [ActionFormParameterType.BigInteger]: "number",
+};
+
+export function ActionFormModalParameter({
+  parameter,
+  children,
+}: ActionFormModalParameterProps) {
+  return (
+    <>
+      <Group h="2.5rem" align="center">
+        <Icon
+          className={S.modalBodyColumn}
+          name={PARAMETER_ICON_MAP[parameter.type] ?? DEFAULT_PARAMETER_ICON}
+        />
+        <Text className={S.modalBodyColumn}>
+          {parameter.display_name}
+          {parameter.optional && (
+            <Text component="span" c="error">
+              *
+            </Text>
+          )}
+        </Text>
+      </Group>
+      {children}
+    </>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-action-form-description.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-action-form-description.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+import { useDescribeActionFormMutation } from "metabase-enterprise/api";
+
+import type { PrimitiveTableAction, TableEditingScope } from "../types";
+
+type UseTableDescribeTmpModalProps = {
+  actionId: PrimitiveTableAction;
+  scope: TableEditingScope;
+};
+
+export const useActionFormDescription = ({
+  actionId,
+  scope,
+}: UseTableDescribeTmpModalProps) => {
+  const [fetchModalDescription, { data, isLoading }] =
+    useDescribeActionFormMutation();
+
+  useEffect(() => {
+    if (!data) {
+      fetchModalDescription({
+        action_id: actionId,
+        scope,
+      });
+    }
+  }, [fetchModalDescription, actionId, scope, data]);
+
+  return {
+    data,
+    isLoading,
+  };
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-action-form-description.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-action-form-description.ts
@@ -2,10 +2,10 @@ import { useEffect } from "react";
 
 import { useDescribeActionFormMutation } from "metabase-enterprise/api";
 
-import type { PrimitiveTableAction, TableEditingScope } from "../types";
+import type { BuiltInTableAction, TableEditingScope } from "../types";
 
 type UseTableDescribeTmpModalProps = {
-  actionId: PrimitiveTableAction;
+  actionId: BuiltInTableAction;
   scope: TableEditingScope;
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
@@ -87,14 +87,14 @@ export type TableExecuteActionResponse = {
   "rows-affected": number;
 };
 
-export enum PrimitiveTableAction {
+export enum BuiltInTableAction {
   Create = "table.row/create",
   Update = "table.row/update",
   Delete = "table.row/delete",
 }
 
 export type DescribeActionFormRequest = {
-  action_id: PrimitiveTableAction | number;
+  action_id: BuiltInTableAction | number;
   scope: TableEditingScope;
   input?: Record<string, unknown>;
 };

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/types.ts
@@ -86,3 +86,37 @@ export type TableExecuteActionRequest = {
 export type TableExecuteActionResponse = {
   "rows-affected": number;
 };
+
+export enum PrimitiveTableAction {
+  Create = "table.row/create",
+  Update = "table.row/update",
+  Delete = "table.row/delete",
+}
+
+export type DescribeActionFormRequest = {
+  action_id: PrimitiveTableAction | number;
+  scope: TableEditingScope;
+  input?: Record<string, unknown>;
+};
+
+export enum ActionFormParameterType {
+  Text = "type/Text",
+  Number = "type/Number",
+  Date = "type/Date",
+  DateTime = "type/DateTime",
+  Integer = "type/Integer",
+  BigInteger = "type/BigInteger",
+}
+
+export type ActionFormParameter = {
+  id: string;
+  display_name: string;
+  type: ActionFormParameterType;
+  optional?: boolean;
+  nullable?: boolean;
+};
+
+export type DescribeActionFormResponse = {
+  title: string;
+  parameters: ActionFormParameter[];
+};


### PR DESCRIPTION
New create row form modal is enabled only on edit table view (not the dashboard view).
Resolves [WRK-442](https://linear.app/metabase/issue/WRK-442/use-new-describe-api-to-power-create-row)
