### PR TITLE
Some small fixes to "describe"

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -589,9 +589,13 @@
       ;; table action
       (:action-kw unified)
       (describe-table-action
-       :action-kw (:action-kw unified)
-       :table-id (or (:table-id input) (:table-id (:mapping unified)))
-       :row-action-mapping (:param-mapping unified))
+       {:action-kw          (:action-kw unified)
+        ;; todo this should come from applying the (arbitrarily nested) mappings to the input
+        ;;      ... and we also need apply-mapping to pull constants out of the form configuration as well!
+        :table-id           (or (:table-id (:mapping (:row-action unified)))
+                                (:table-id (:mapping unified))
+                                (:table-id input))
+        :row-action-mapping (:param-mapping unified)})
 
       (:row-action unified)
       (let [row-action  (:row-action unified)

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -455,11 +455,12 @@
   such that they can be presented correctly in a modal ahead of execution."
   [{}
    {}
+   ;; TODO support for bulk actions
    {:keys [action_id scope input]}]
   (let [scope (actions/hydrate-scope scope)
         unified
         ;; this mess can go once callers are on new listing API, leaving only the unified-action call.
-        ;; but then this routes lifetime should be similarly limited!
+        ;; but then this route's lifetime should be similarly limited!
         (cond
           (not (#{"table.row/create"
                   "table.row/update"
@@ -610,8 +611,10 @@
             _           (when-not table-id
                           (throw (ex-info "Must provide table-id" {:status-code 400})))
             row-delay   (delay
-                         (when table-id
-                           (let [pk-fields    (data-editing/select-table-pk-fields table-id)
+                         ;; TODO this is incorrect - in general the row will not come from the table we are acting
+                         ;;      upon - this is not even true for our first use case!
+                          (when table-id
+                            (let [pk-fields    (data-editing/select-table-pk-fields table-id)
                                   pk           (select-keys input (mapv (comp keyword :name) pk-fields))
                                   pk-satisfied (= (count pk) (count pk-fields))]
                               (when pk-satisfied

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -602,7 +602,10 @@
             action-kw   (:action-kw row-action)
             table-id    (or (:table-id mapping)
                             (:table-id (:mapping row-action))
+                            (:table-id input)
                             (:table-id scope))
+            _           (when-not table-id
+                          (throw (ex-info "Must provide table-id" {:status-code 400})))
             row-delay   (delay
                           (when table-id
                             (let [pk-fields    (data-editing/select-table-pk-fields table-id)

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -456,7 +456,7 @@
   [{}
    {}
    {:keys [action_id scope input]}]
-  (let [scope   (actions/hydrate-scope scope)
+  (let [scope (actions/hydrate-scope scope)
         unified
         ;; this mess can go once callers are on new listing API, leaving only the unified-action call.
         ;; but then this routes lifetime should be similarly limited!
@@ -491,8 +491,8 @@
           :else
           (throw (ex-info "Using table.row/* actions require either a table-id or dashcard-id in the scope"
                           {:status-code 400
-                           :scope scope
-                           :action_id action_id})))
+                           :scope       scope
+                           :action_id   action_id})))
 
         param-value
         (fn [param-mapping row-delay]
@@ -517,33 +517,33 @@
             {:title (:name action)
              :parameters
              (->> (for [param (:parameters action)
-                        ;; query type actions store most stuff in viz settings rather than the
-                        ;; parameter
-                        :let [viz-field (param-id->viz-field (:id param))
+                              ;; query type actions store most stuff in viz settings rather than the
+                              ;; parameter
+                        :let [viz-field     (param-id->viz-field (:id param))
                               param-mapping (param-id->mapping (:id param))]
                         :when (and (not (:hidden viz-field))
                                    (not= "hidden" (:visibility param-mapping)))]
                     (u/remove-nils
-                     {:id (:id param)
-                      :display_name (or (:display-name param) (:name param))
+                     {:id            (:id param)
+                      :display_name  (or (:display-name param) (:name param))
                       :param-mapping param-mapping
-                      :type (case (:type param)
-                              :string/=    :type/Text
-                              :number/=    :type/Number
-                              :date/single :type/Date
-                              (if (= "type" (namespace (:type param)))
-                                (:type param)
-                                (throw
-                                 (ex-info "Unsupported query action parameter type"
-                                          {:status-code 500
-                                           :param-type (:type param)
-                                           :scope scope
-                                           :unified unified}))))
+                      :type          (case (:type param)
+                                       :string/= :type/Text
+                                       :number/= :type/Number
+                                       :date/single :type/Date
+                                       (if (= "type" (namespace (:type param)))
+                                         (:type param)
+                                         (throw
+                                          (ex-info "Unsupported query action parameter type"
+                                                   {:status-code 500
+                                                    :param-type  (:type param)
+                                                    :scope       scope
+                                                    :unified     unified}))))
                       :value_options (:valueOptions viz-field)
-                      :optional (and (not (:required param)) (not (:required viz-field)))
-                      :nullable true ; is there a way to know this?
-                      :readonly (= "readonly" (:visibility param-mapping))
-                      :value    (param-value param-mapping row-delay)}))
+                      :optional      (and (not (:required param)) (not (:required viz-field)))
+                      :nullable      true             ; is there a way to know this?
+                      :readonly      (= "readonly" (:visibility param-mapping))
+                      :value         (param-value param-mapping row-delay)}))
                   vec)}))
 
         describe-table-action
@@ -560,34 +560,33 @@
                         :let [pk            (= :type/PK (:semantic_type field))
                               param-mapping (field-name->mapping (:name field))]
                         :when (case action-kw
-                                ;; create does not take pk cols if auto increment, todo generated cols?
+                                      ;; create does not take pk cols if auto increment, todo generated cols?
                                 :table.row/create (not (:database_is_auto_increment field))
-                                ;; delete only requires pk cols
+                                      ;; delete only requires pk cols
                                 :table.row/delete pk
-                                ;; update takes both the pk and field (if not a row action)
+                                      ;; update takes both the pk and field (if not a row action)
                                 :table.row/update true)
                         :when (not= "hidden" (:visibility param-mapping))
                         :let [required (or pk (:database_required field))]]
                     (u/remove-nils
-                     {:id           (:name field)
-                      :display_name (:display_name field)
-                      :type (:base_type field)
-                      :semantic_type (:semantic_type field)
-                      :field_id (:id field)
+                     {:id                 (:name field)
+                      :display_name       (:display_name field)
+                      :type               (:base_type field)
+                      :semantic_type      (:semantic_type field)
+                      :field_id           (:id field)
                       :fk_target_field_id (:fk_target_field_id field)
-                      :optional (not required)
-                      :nullable (:database_is_nullable field)
-                      :readonly (= "readonly" (:visibility param-mapping))
-                      :value (param-value param-mapping row-delay)}))
-
+                      :optional           (not required)
+                      :nullable           (:database_is_nullable field)
+                      :readonly           (= "readonly" (:visibility param-mapping))
+                      :value              (param-value param-mapping row-delay)}))
                   vec)}))]
 
     (cond
-  ;; saved action
+      ;; saved action
       (:action-id unified)
       (describe-saved-action :action-id (:action-id unified))
 
-  ;; table action
+      ;; table action
       (:action-kw unified)
       (describe-table-action
        :action-kw (:action-kw unified)
@@ -607,8 +606,8 @@
             _           (when-not table-id
                           (throw (ex-info "Must provide table-id" {:status-code 400})))
             row-delay   (delay
-                          (when table-id
-                            (let [pk-fields    (data-editing/select-table-pk-fields table-id)
+                         (when table-id
+                           (let [pk-fields    (data-editing/select-table-pk-fields table-id)
                                   pk           (select-keys input (mapv (comp keyword :name) pk-fields))
                                   pk-satisfied (= (count pk) (count pk-fields))]
                               (when pk-satisfied

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1296,13 +1296,10 @@
                     delete-id "table.row/delete"]
 
                 (testing "without a table-id"
-                  (let [scope           {:dashboard-id (:dashboard_id dashcard)}]
-                    (testing "create"
-                      (is (=? {:status 400} (req {:action_id create-id, :scope scope}))))
-                    (testing "update"
-                      (is (=? {:status 400} (req {:action_id update-id, :scope scope}))))
-                    (testing "delete"
-                      (is (=? {:status 400} (req {:action_id update-id, :scope scope}))))))
+                  (let [scope {:dashboard-id (:dashboard_id dashcard)}]
+                    (doseq [action-id [create-id update-id delete-id]]
+                      (testing action-id
+                        (is (=? {:status 400} (req {:action_id action-id, :scope scope})))))))
 
                 (testing "using a partially constructed :input"
                   (let [unrelated-table Long/MAX_VALUE

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1298,30 +1298,26 @@
                                              ["dashcard scope" {:dashcard-id (:id dashcard)}]]]
                   (testing testing-msg
                     (testing "create"
-                      (let [{:keys [status
-                                    body]} (req {:scope     scope
-                                                 :action_id create-id
-                                                 :input     {:id 1}})]
-                        (is (= 200 status))
-                        (when (:dashcard-id scope)
-                          (is (= [{:id "text" :readonly true  :value "a very important string"}
-                                  {:id "int"  :readonly false}
-                                 ;; note that timestamp is now hidden
-                                  {:id "date" :readonly false}]
-                                 (map #(select-keys % [:id
-                                                       :readonly
-                                                       :value])
-                                      (:parameters body)))))))
+                      (is (=? {:status 200
+                               :body   {:parameters
+                                        (if (:dashcard-id scope)
+                                          [{:id "text" :readonly true :value "a very important string"}
+                                           {:id "int" :readonly false}
+                                           ;; note that timestamp is now hidden
+                                           {:id "date" :readonly false}]
+                                          [{:id "text" :readonly false}
+                                           {:id "int" :readonly false}
+                                           {:id "timestamp" :readonly false}
+                                           {:id "date" :readonly false}])}}
+                              (req {:scope     scope
+                                    :action_id create-id
+                                    :input     {:id 1}}))))
 
                     (testing "update"
-                      (let [{:keys [status]} (req {:scope scope
-                                                   :action_id update-id})]
-                        (is (= 200 status))))
+                      (is (=? {:status 200} (req {:scope scope, :action_id update-id}))))
 
                     (testing "delete"
-                      (let [{:keys [status]} (req {:scope scope
-                                                   :action_id delete-id})]
-                        (is (= 200 status))))))))))))))
+                      (is (=? {:status 200} (req {:scope scope, :action_id delete-id}))))))))))))))
 
 (deftest tmp-modal-test)
 


### PR DESCRIPTION
Fixed a few small issues, mostly to clarify semantics. Haven't thought through how much current FE could trip over them.

1. Conflating `mapping` with `params-mapping` (different shapes and purposes)
2. Relying on scope to determine table being acted on (TODO: remove even as a fallback)
3. Handling the correct precedence of table-id when it can be overridden in layered actions.
4. Tweaks to handle some error cases, improve test coverage a bit.

Most importantly it applies some of our whitespace conventions - I am blind otherwise!

There are still at least a fairly important problems I can see:

1. Won't handle bulk operations. Since we've wired `update` for bulk, we'll have to leave legacy form code for it.
2. Won't handle row actions on questions. These don't have an underlying table to 
3. Doesn't query the correct table for the row. It looks at the *target* table, not the table underlying the "editable".

Some issues looking further out:

5. It won't handle primitive actions that aren't table actions.
4. It won't handle deeply nested actions (e.g. when we add chaining)

These problems will all be fix by unifying with code from execute (or merging completely), so stopping here for now.