### PR TITLE
add e2e tests for optional usage of time grouping

### DIFF
--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -442,10 +442,9 @@ describe("scenarios > question > native", () => {
           },
         };
 
-        H.createNativeQuestion(questionWithDefaultValue, {
-          wrapId: true,
-          idAlias: "q1",
-        }).then((questionId) => H.visitQuestion(questionId));
+        H.createNativeQuestion(questionWithDefaultValue).then((questionId) =>
+          H.visitQuestion(questionId),
+        );
 
         cy.findByTestId("visualization-root")
           .should("contain", "January 1, 2022")
@@ -480,10 +479,9 @@ describe("scenarios > question > native", () => {
           },
         };
 
-        H.createNativeQuestion(questionWithDefaultValue, {
-          wrapId: true,
-          idAlias: "q1",
-        }).then((questionId) => H.visitQuestion(questionId));
+        H.createNativeQuestion(questionWithDefaultValue).then((questionId) =>
+          H.visitQuestion(questionId),
+        );
 
         cy.findByTestId("query-visualization-root").should(
           "not.contain",

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -451,8 +451,7 @@ describe("scenarios > question > native", () => {
           .should("contain", "January 1, 2023");
       });
 
-      // TODO: test is broken, unskip once optional usage of time grouping is supported
-      it.skip("should handle time grouping in optional clause without default value", () => {
+      it("should handle time grouping in optional clause without default value", () => {
         const questionWithDefaultValue = {
           name: "Saved question with time grouping",
           native: {
@@ -483,10 +482,12 @@ describe("scenarios > question > native", () => {
           visitQuestion: true,
         });
 
-        cy.findByTestId("query-visualization-root").should(
-          "not.contain",
-          "Error: invalid value specified for temporal-unit parameter.",
-        );
+        // it should change in the future: when time grouping is marked as optional via [[]]
+        // a column is not included into the resulted dataset
+        // it is included currently
+        cy.findByTestId("query-visualization-root")
+          .should("contain", "October 7, 2023, 1:34 AM")
+          .should("contain", "UNIT");
       });
 
       describe("validation", () => {

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -414,6 +414,83 @@ describe("scenarios > question > native", () => {
         H.rightSidebar().should("contain", "Enter a default value…");
       });
 
+      it("should handle time grouping in optional clause", () => {
+        const questionWithDefaultValue = {
+          name: "Saved question with time grouping",
+          native: {
+            query: `
+              SELECT
+                ID [[,{{mb.time_grouping("unit", "CREATED_AT")}} as unit]]
+              FROM
+                PEOPLE
+              WHERE
+                1 = 1 [[AND ID = {{x}}]]
+              ORDER BY
+                ID
+              LIMIT
+                10
+            `,
+            "template-tags": {
+              unit: {
+                type: "temporal-unit",
+                name: "unit",
+                id: "eb345703-001c-4b2a-b7d5-71cb3efe4beb",
+                "display-name": "Unit",
+                default: "year",
+              },
+            },
+          },
+        };
+
+        H.createNativeQuestion(questionWithDefaultValue, {
+          wrapId: true,
+          idAlias: "q1",
+        }).then((questionId) => H.visitQuestion(questionId));
+
+        cy.findByTestId("visualization-root")
+          .should("contain", "January 1, 2022")
+          .should("contain", "January 1, 2023");
+      });
+
+      // TODO: test is broken, unskip once optional usage of time grouping is supported
+      it.skip("should handle time grouping in optional clause without default value", () => {
+        const questionWithDefaultValue = {
+          name: "Saved question with time grouping",
+          native: {
+            query: `
+              SELECT
+                ID [[,{{mb.time_grouping("unit", "CREATED_AT")}} as unit]]
+              FROM
+                PEOPLE
+              WHERE
+                1 = 1 [[AND ID = {{x}}]]
+              ORDER BY
+                ID
+              LIMIT
+                10
+            `,
+            "template-tags": {
+              unit: {
+                type: "temporal-unit",
+                name: "unit",
+                id: "eb345703-001c-4b2a-b7d5-71cb3efe4beb",
+                "display-name": "Unit",
+              },
+            },
+          },
+        };
+
+        H.createNativeQuestion(questionWithDefaultValue, {
+          wrapId: true,
+          idAlias: "q1",
+        }).then((questionId) => H.visitQuestion(questionId));
+
+        cy.findByTestId("query-visualization-root").should(
+          "not.contain",
+          "Error: invalid value specified for temporal-unit parameter.",
+        );
+      });
+
       describe("validation", () => {
         it("should show validation error when query is invalid", () => {
           const question = {

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -442,9 +442,9 @@ describe("scenarios > question > native", () => {
           },
         };
 
-        H.createNativeQuestion(questionWithDefaultValue).then((questionId) =>
-          H.visitQuestion(questionId),
-        );
+        H.createNativeQuestion(questionWithDefaultValue, {
+          visitQuestion: true,
+        });
 
         cy.findByTestId("visualization-root")
           .should("contain", "January 1, 2022")
@@ -479,9 +479,9 @@ describe("scenarios > question > native", () => {
           },
         };
 
-        H.createNativeQuestion(questionWithDefaultValue).then((questionId) =>
-          H.visitQuestion(questionId),
-        );
+        H.createNativeQuestion(questionWithDefaultValue, {
+          visitQuestion: true,
+        });
 
         cy.findByTestId("query-visualization-root").should(
           "not.contain",


### PR DESCRIPTION
add e2e tests to address [feedback](https://metaboat.slack.com/archives/C0645JP1W81/p1749057173175249)