### PR TITLE
SEM-370 Hide/show table button not shown when focused but not hovered

### DIFF
--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/Results.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/Results.module.css
@@ -64,7 +64,9 @@
   flex-shrink: 0;
   opacity: 0;
 
+  &:focus,
   .item:hover &,
+  .item:focus &,
   .item.selected &,
   .item.active & {
     opacity: 0.75;


### PR DESCRIPTION
Fixes [SEM-370](https://linear.app/metabase/issue/SEM-370/hideshow-table-button-not-shown-when-focused-but-not-hovered)

### Description

Tab key can be used to navigate to the hide/show button, but when it was focused in such way you couldn't see the button.
Also, When table row was focused with Tab key, you wouldn't see the hide/show button.

### Before

https://github.com/user-attachments/assets/626d20cf-484e-40ef-ae5f-15c4301a3754

### After

https://github.com/user-attachments/assets/143038f5-442c-4816-b86a-38a13adccece

