### PR TITLE
Stabilize flaky mongo tests

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -49,13 +49,17 @@ describe("issue 13504", () => {
 
 const externalDatabaseId = 2;
 
-describe("issue 16170", { tags: "@mongo" }, () => {
+describe("issue 16170", () => {
   function replaceMissingValuesWith(value) {
     cy.get('[data-field-title="Replace missing values with"]').within(() => {
       cy.findByTestId("chart-setting-select").click();
     });
 
     H.popover().contains(value).click();
+    H.popover().findByDisplayValue(value);
+
+    // click outside popover
+    cy.findByTestId("chartsettings-list-container").click();
   }
 
   function assertOnTheYAxis() {
@@ -92,13 +96,12 @@ describe("issue 16170", { tags: "@mongo" }, () => {
 
       replaceMissingValuesWith(replacementValue);
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Done").click();
-
       assertOnTheYAxis();
 
-      // eslint-disable-next-line no-unsafe-element-filtering
-      H.cartesianChartCircle().eq(-2).trigger("mousemove");
+      H.cartesianChartCircle()
+        .should("have.length", 6)
+        .eq(-2)
+        .trigger("mousemove");
 
       H.assertEChartsTooltip({
         header: "2019",

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -49,7 +49,7 @@ describe("issue 13504", () => {
 
 const externalDatabaseId = 2;
 
-describe("issue 16170", () => {
+describe("issue 16170", { tags: "@mongo" }, () => {
   function replaceMissingValuesWith(value) {
     cy.get('[data-field-title="Replace missing values with"]').within(() => {
       cy.findByTestId("chart-setting-select").click();


### PR DESCRIPTION
closes viz-1067

### Description

- remove lint ignore comments to stabilize actions
- instead of closing the viz sidebar (which does nothing that this test cares about) and causing a reflow, just click outside the popover
- [x] [stress test](https://github.com/metabase/metabase/actions/runs/15472384258)
