### PR TITLE
Fix the default string operator

### DIFF
--- a/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.unit.spec.ts
@@ -66,9 +66,7 @@ const METADATA = createMockMetadata({
               base_type: "type/Text",
               effective_type: "type/Text",
             }),
-            createProductsCategoryField({
-              semantic_type: null,
-            }),
+            createProductsCategoryField(),
             createProductsEanField(),
           ],
         }),
@@ -282,7 +280,7 @@ describe("useStringFilter", () => {
     {
       title: "non-category column with field values",
       column: findColumn("PRODUCTS", "EAN"),
-      expectedOperator: "=",
+      expectedOperator: "contains",
     },
     {
       title: "regular column without field values",

--- a/frontend/src/metabase/querying/filters/hooks/use-string-filter/utils.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-string-filter/utils.ts
@@ -38,7 +38,7 @@ export function getDefaultOperator(
   const desiredOperator =
     Lib.isPrimaryKey(column) ||
     Lib.isForeignKey(column) ||
-    fieldValuesInfo.hasFieldValues !== "none"
+    (Lib.isCategory(column) && fieldValuesInfo.hasFieldValues !== "none")
       ? "="
       : "contains";
   return getDefaultAvailableOperator(availableOptions, desiredOperator);


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/56921
Context https://metaboat.slack.com/archives/C0645JP1W81/p1747293549433229?thread_ts=1747248202.950129&cid=C0645JP1W81

Now: Default to `=` only for PKs, FKs, or **Category** columns with field values. 
Before: Default to `=` only for PKs, FKs, or any column with field values. 