### PR TITLE
Use substring optimization on any text fields

### DIFF
--- a/src/metabase/driver/common/table_rows_sample.clj
+++ b/src/metabase/driver/common/table_rows_sample.clj
@@ -34,15 +34,6 @@
     [:order-by        {:optional true} (helpers/distinct (helpers/non-empty [:sequential ::mbql.s/OrderBy]))]
     [:rff             {:optional true} fn?]]])
 
-(defn- text-field?
-  "Identify text fields which can accept our substring optimization.
-
-  JSON and XML fields are now marked as `:type/Structured` but in the past were marked as `:type/Text` so its not
-  enough to just check the base type."
-  [{:keys [base_type semantic_type]}]
-  (and (= base_type :type/Text)
-       (not (isa? semantic_type :type/Structured))))
-
 (defn- table-rows-sample-query
   "Returns the mbql query to query a table for sample rows"
   [table
@@ -50,7 +41,7 @@
    {:keys [truncation-size limit order-by] :or {limit max-sample-rows} :as _opts}]
   (let [database           (t2/select-one :model/Database (:db_id table))
         driver             (driver.u/database->driver database)
-        text-fields        (filter text-field? fields)
+        text-fields        (filter (comp #{:type/Text} (some-fn :effective_type :base_type)) fields)
         field->expressions (when (and truncation-size (driver.u/supports? driver :expressions database))
                              (into {} (for [field text-fields]
                                         [field [(str (gensym "substring"))

--- a/test/metabase/driver/common/table_rows_sample_test.clj
+++ b/test/metabase/driver/common/table_rows_sample_test.clj
@@ -59,12 +59,27 @@
           (with-redefs [driver.u/supports? (constantly false)]
             (let [query (#'table-rows-sample/table-rows-sample-query table fields {:truncation-size 4})]
               (is (empty? (get-in query [:query :expressions])))))))
-      (testing "pre-existing json fields are still marked as `:type/Text`"
+      (testing "serialized json stored in text columns is treated as text (potentially large, OOM risk)"
         (let [table (mi/instance :model/Table {:id 1234})
               fields [(mi/instance :model/Field {:id 4321, :base_type :type/Text, :semantic_type :type/SerializedJSON})]]
           (with-redefs [driver.u/supports? (constantly true)]
             (let [query (#'table-rows-sample/table-rows-sample-query table fields {:truncation-size 4})]
-              (is (empty? (get-in query [:query :expressions]))))))))))
+              (is (seq (get-in query [:query :expressions])))))))
+      (testing "substring is not called upon type/Text derivates"
+        (doseq [base-type (filter #(not (or (isa? % :Semantic/*)
+                                            (isa? % :Relation/*)))
+                                  (descendants :type/Text))]
+          (let [table (mi/instance :model/Table {:id 1234})
+                fields [(mi/instance :model/Field {:id 4321, :base_type base-type})]]
+            (with-redefs [driver.u/supports? (constantly true)]
+              (let [query (#'table-rows-sample/table-rows-sample-query table fields {:truncation-size 4})]
+                (is (empty? (get-in query [:query :expressions]))))))))
+      (testing "primary check is on effective_type"
+        (with-redefs [driver.u/supports? (constantly true)]
+          (let [table (mi/instance :model/Table {:id 1234})
+                fields [(mi/instance :model/Field {:id 4321, :base_type :type/Number :effective_type :type/Text})]
+                query (#'table-rows-sample/table-rows-sample-query table fields {:truncation-size 4})]
+            (is (seq (get-in query [:query :expressions])))))))))
 
 (deftest mbql-on-table-requires-filter-will-include-the-filter-test
   (mt/with-temp
@@ -85,14 +100,3 @@
                   (table-rows-sample/table-rows-sample table [] (constantly conj))))
           (is (=? {:filter [:> [:field (:id field2) {:base-type :type/Integer}] (mt/malli=? int?)]}
                   @query)))))))
-
-(deftest ^:parallel text-field?-test
-  (testing "recognizes fields suitable for fingerprinting"
-    (doseq [field [{:base_type :type/Text}
-                   {:base_type :type/Text :semantic_type :type/State}
-                   {:base_type :type/Text :semantic_type :type/URL}]]
-      (is (#'table-rows-sample/text-field? field)))
-    (doseq [field [{:base_type :type/JSON} ; json fields in pg
-                   {:base_type :type/Text :semantic_type :type/SerializedJSON} ; "legacy" json fields in pg
-                   {:base_type :type/Text :semantic_type :type/XML}]]
-      (is (not (#'table-rows-sample/text-field? field))))))

--- a/test/metabase/driver/common/table_rows_sample_test.clj
+++ b/test/metabase/driver/common/table_rows_sample_test.clj
@@ -6,6 +6,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.models.interface :as mi]
    [metabase.query-processor :as qp]
+   [metabase.sync.analyze.fingerprint :as fingerprint]
    [metabase.test :as mt]
    [metabase.warehouse-schema.models.table :as table]
    [toucan2.core :as t2]))
@@ -80,6 +81,34 @@
                 fields [(mi/instance :model/Field {:id 4321, :base_type :type/Number :effective_type :type/Text})]
                 query (#'table-rows-sample/table-rows-sample-query table fields {:truncation-size 4})]
             (is (seq (get-in query [:query :expressions])))))))))
+
+(deftest ^:synchronized coerced-field-substring-integration-test
+  (testing "For coerced fields, effective type is used for fingerprinting (string -> number exmaple)"
+    (mt/dataset
+      string-nums-db
+      (mt/with-temp-copy-of-db
+        (doseq [id (t2/select-fn-vec :id :model/Field :table_id (mt/id :string_nums))]
+          (t2/update! :model/Field :id id {:coercion_strategy :Coercion/String->Float
+                                           :effective_type    :type/Float
+                                           :fingerprint nil
+                                           :fingerprint_version 0}))
+        (let [fingerprints (atom [])
+              fingerprint-query (atom nil)
+              orig-table-rows-sample-query @#'table-rows-sample/table-rows-sample-query]
+          (with-redefs [fingerprint/save-fingerprint! (fn [_field fingerprint]
+                                                        (swap! fingerprints conj fingerprint))
+                        table-rows-sample/table-rows-sample-query (fn [& args]
+                                                                    (reset! fingerprint-query
+                                                                            (apply orig-table-rows-sample-query args)))]
+            (fingerprint/fingerprint-table! (t2/select-one :model/Table :id (mt/id :string_nums)))
+            (testing "empty expressions = no substring optimization in sample query = use of effective type"
+              (is (empty? (-> @fingerprint-query :query :expressions)))
+              (is (seq (-> @fingerprint-query :query :fields))))
+            (testing "query returns number types due coercion -> numbers are fingerprinted"
+              (is (=? [{:type {:type/Number {}}}
+                       {:type {:type/Number {}}}
+                       {:type {:type/Number {}}}]
+                      @fingerprints)))))))))
 
 (deftest mbql-on-table-requires-filter-will-include-the-filter-test
   (mt/with-temp


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/SEM-375/fix-possible-oom

### Description

More context can be found [here](https://metaboat.slack.com/archives/C08GVMC3E1K/p1749076743760739).

Briefly, prior this fix OOM condition may have been provoked by large enough json serialized in text columns.

I believe it is safe to change that condition nowadays. It was put in place ~5 years ago. I assume the `:type/JSON` was not a thing back then. Hence I'd expect all json (db typed) fields to use that. This fixes the situation for the remainder (text + sem type/SerializedJSON). 

### How to verify

Run new tests. Or follow the context link to reconstruct the scenario.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
