### PR TITLE
no archived collections in perm graph

### DIFF
--- a/src/metabase/permissions/models/collection/graph.clj
+++ b/src/metabase/permissions/models/collection/graph.clj
@@ -72,6 +72,7 @@
                                                 ;; Does 'NULL != "trash"'? Postgres says the answer is undefined, aka
                                                 ;; NULL, which... is falsey. :sob:
                                                 [:or [:= :type nil] [:not= :type "trash"]]
+                                                [:not :archived]
                                                 (perms/audit-namespace-clause :namespace (u/qualified-name collection-namespace))
                                                 [:= :personal_owner_id nil]]
                                                (for [collection-id personal-collection-ids]


### PR DESCRIPTION
Exclude archived collections from the permissions graph

When updating the permissions graph we just walk through the ones that were sent in the incoming graph. The UI doesn't let you change permissions for archived collections and there's not really a reason to do so anyway.

Fixes [ADM-895: exclude archived collections from `/api/collection/graph` endpoint](https://linear.app/metabase/issue/ADM-895/exclude-archived-collections-from-apicollectiongraph-endpoint)