### PR TITLE
Fix re-rendering error modal on collection upload

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -156,6 +156,17 @@ H.describeWithSnowplow(
             H.queryWritableDB(tableQuery, dialect).then((result) => {
               expect(result.rows.length).to.equal(0);
             });
+
+            cy.log("metabase#55382");
+            cy.findByRole("dialog", { name: "Upload error details" })
+              .findByRole("button", { name: "Close" })
+              .click();
+
+            H.openCollectionMenu();
+            H.popover().findByText("Move to trash").click();
+            cy.findByRole("dialog", { name: "Upload error details" }).should(
+              "not.exist",
+            );
           });
         });
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/PausedModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/PausedModal.tsx
@@ -75,7 +75,7 @@ export const FileUploadErrorModal = ({
   }
 
   return (
-    <_FileUploadErrorModal onClose={onClose} fileName={fileName}>
+    <_FileUploadErrorModal onClose={onClose} fileName={fileName} opened>
       {children}
     </_FileUploadErrorModal>
   );

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
@@ -1,28 +1,31 @@
 import { t } from "ttag";
 
 import { ErrorBox } from "metabase/components/ErrorDetails";
-import Modal from "metabase/components/Modal";
-import ModalContent from "metabase/components/ModalContent";
-import { Text } from "metabase/ui";
+import { Modal, Text } from "metabase/ui";
 
 // OSS Component, do not use directly, use through PLUGIN_UPLOAD_MANAGEMENT
 export const _FileUploadErrorModal = ({
   onClose,
   fileName,
   children,
+  opened,
 }: {
   onClose: () => void;
   fileName?: string;
   children: string;
+  opened: boolean;
 }) => {
   return (
-    <Modal small>
-      <ModalContent title={t`Upload error details`} onClose={onClose}>
-        {fileName && (
-          <Text>{t`There were some errors while uploading ${fileName}:`}</Text>
-        )}
-        <ErrorBox>{children}</ErrorBox>
-      </ModalContent>
+    <Modal
+      opened={opened}
+      size="md"
+      title={t`Upload error details`}
+      onClose={onClose}
+    >
+      {fileName && (
+        <Text>{t`There were some errors while uploading ${fileName}:`}</Text>
+      )}
+      <ErrorBox>{children}</ErrorBox>
     </Modal>
   );
 };

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -150,6 +150,7 @@ const UploadErrorDisplay = ({ upload }: { upload: FileUpload }) => {
         <PLUGIN_UPLOAD_MANAGEMENT.FileUploadErrorModal
           fileName={upload.name}
           onClose={() => setShowErrorModal(false)}
+          opened={showErrorModal}
         >
           {String(upload.error)}
         </PLUGIN_UPLOAD_MANAGEMENT.FileUploadErrorModal>

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
@@ -1,3 +1,4 @@
+import type { PropsWithChildren } from "react";
 import { t } from "ttag";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
@@ -81,6 +82,12 @@ const StatusLarge = ({
   );
 };
 
+const LinkWrapper = ({
+  children,
+  item,
+}: PropsWithChildren<{ item: StatusItem }>) =>
+  item?.href ? <Link to={item.href}>{children}</Link> : children;
+
 interface StatusCardProps {
   item: StatusItem;
   isActive?: boolean;
@@ -95,15 +102,12 @@ const StatusCard = ({
 
   const isVisible = useStatusVisibility(isActive || isInProgress);
 
-  const LinkWrapper = ({ children }: { children: JSX.Element }) =>
-    item?.href ? <Link to={item.href}>{children}</Link> : children;
-
   if (!isVisible) {
     return null;
   }
 
   return (
-    <LinkWrapper key={id}>
+    <LinkWrapper item={item} key={id}>
       <StatusCardRoot hasBody={!!description}>
         <StatusCardIcon>
           <Icon name={icon as unknown as IconName} />


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55382

### Description
Modal was re-rending due to recomputed `<LinkWrapper>` on every render, causing the error modal to re-mount, and the open state to reset to `true`. Having this component be defined outside of the `<StatusCard>` component fixes the problem

### How to verify

1. Go to a collection and attempt to upload a corrupted CSV (throw some extra commas in there)
2. Dismiss the error modal, but keep the File Status alert open in the bottom right corner
3. Next, to go the collection action and select "move to trash"
4. The confirmation modal should appear, and the upload error modal should not re-appear.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
