### PR TITLE
Don't count dashboard subscriptions as a reason to count a card as recently viewed

### DIFF
--- a/src/metabase/activity_feed/events/recent_views.clj
+++ b/src/metabase/activity_feed/events/recent_views.clj
@@ -49,7 +49,7 @@
   (try
     (let [user-id  (or user-id api/*current-user-id*)]
       ;; we don't want to count pinned card views
-      (when-not (#{:collection :dashboard} context)
+      (when-not (#{:collection :dashboard :dashboard-subscription} context)
         (recent-views/update-users-recent-views! user-id :model/Card card-id :view)))
     (catch Throwable e
       (log/warnf e "Failed to process recent_views event: %s" topic))))

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -29,6 +29,13 @@
           (events/publish-event! :event/card-query {:card-id (:id card-2)
                                                     :user-id (mt/user->id :rasta)
                                                     :context :collection})
+          (is (nil? (most-recent-view (mt/user->id :rasta) (:id card-2) "card")))))
+
+      (testing "dashboard subscriptions should not be counted"
+        (mt/with-temp [:model/Card card-2 {:creator_id (mt/user->id :rasta)}]
+          (events/publish-event! :event/card-query {:card-id (:id card-2)
+                                                    :user-id (mt/user->id :rasta)
+                                                    :context :dashboard-subscription})
           (is (nil? (most-recent-view (mt/user->id :rasta) (:id card-2) "card"))))))))
 
 (deftest table-read-test


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59069
### Description

Updates the `recent_views` logic to not update on a dashboard-subscription

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
