### PR TITLE
Unskip skipped test

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -143,12 +143,17 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     getSdkRoot().contains("My Orders");
   });
 
-  it.skip("should respect `entityTypes` prop", () => {
+  it("should respect `entityTypes` prop", () => {
     cy.signOut();
     mockAuthProviderAndJwtSignIn();
     cy.intercept("POST", "/api/card").as("createCard");
 
-    const MODEL_COUNT = 14;
+    /**
+     * We have changed the default MB_SEARCH_ENGINE from "in-place" to "appdb", and it affects the results here.
+     * Previously, when the engine was "in-place", we'll get models from the "Usage Analytics" collection as well,
+     * so the number was different.
+     */
+    const MODEL_COUNT = 1;
     const TABLE_COUNT = 4;
 
     cy.log('1. `entityTypes` = ["table"]');


### PR DESCRIPTION
A followup task for EMB-447, #59029

### Description

This is a manual backport, since we need #58891 to be merged first. Actually, I forgot that I should modify the test in that PR's backport, but here I am.

After this PR is merged, I'll release a new SDK version and remove `MB_SEARCH_ENGINE` in `e2e-component-tests-embedding-sdk-cross-version.yml`
