### PR TITLE
Auto Focus save button on the SaveQuestion Modal

### DIFF
--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -369,7 +369,8 @@ describe("scenarios > question > new", () => {
       cy.findByTestId("qb-header").findByText("Save").click();
 
       cy.log("should be able to tab through fields (metabase#41683)");
-      cy.realPress("Tab").realPress("Tab");
+      // Since the submit button has initial focus on this modal, we need an extra tab to get past the modal close button
+      cy.realPress("Tab").realPress("Tab").realPress("Tab");
       cy.findByLabelText("Description").should("be.focused");
 
       cy.findByTestId("save-question-modal")
@@ -419,7 +420,8 @@ describe("scenarios > question > new", () => {
       cy.findByTestId("qb-header").findByText("Save").click();
 
       cy.log("should be able to tab through fields (metabase#41683)");
-      cy.realPress("Tab").realPress("Tab");
+      // Since the submit button has initial focus on this modal, we need an extra tab to get past the modal close button
+      cy.realPress("Tab").realPress("Tab").realPress("Tab");
       cy.findByLabelText("Description").should("be.focused");
 
       cy.findByTestId("save-question-modal")

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -158,6 +158,7 @@ export const SaveQuestionForm = ({
           data-testid="save-question-button"
           variant="filled"
           onSuccess={onSaveSuccess}
+          data-autofocus
         />
       </FormFooter>
     </Form>

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -250,11 +250,14 @@ describe("SaveQuestionModal", () => {
   });
 
   describe("new question", () => {
-    it("should suggest a name for structured queries", async () => {
-      await setup(getQuestion());
+    it("should suggest a name for structured queries and pressing enter should submit the form", async () => {
+      const { onCreateMock } = await setup(getQuestion());
       expect(screen.getByLabelText("Name")).toHaveValue(
         EXPECTED_SUGGESTED_NAME,
       );
+      expect(await screen.findByRole("button", { name: "Save" })).toHaveFocus();
+      await userEvent.keyboard("{Enter}");
+      expect(onCreateMock).toHaveBeenCalled();
     });
 
     it("should not suggest a name for native queries", async () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54708

### Description
Small change to ensure that the save button is auto focused when the Save Question Modal renders. This helps ensure quick creation of questions using suggested question names

### How to verify

1. New -> Question -> pick a data source
2. Hit save, and when the modal renders, just hit `Enter`
3. The form should submit, and the modal should be dismissed
4. 
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
