### PR TITLE
Closes VIZ-187 double scrollbar on viz settings

### DIFF
--- a/frontend/src/metabase/query_builder/components/SidebarContent/SidebarContent.module.css
+++ b/frontend/src/metabase/query_builder/components/SidebarContent/SidebarContent.module.css
@@ -1,6 +1,8 @@
 .SidebarContentMain {
   overflow-y: auto;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .FooterButton {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #48322
Closes [VIZ-187: Viz settings can get into a weird place with a double scrollbar](https://linear.app/metabase/issue/VIZ-187/viz-settings-can-get-into-a-weird-place-with-a-double-scrollbar)

### Description

Double scrollbar was caused by improper CSS under specific conditions (showing the viz settings from the viz selector)

### Demo

Before:
<img width="1608" alt="image" src="https://github.com/user-attachments/assets/762d6bbb-1286-41b7-a3c6-3c971b147394" />


After:
<img width="1609" alt="image" src="https://github.com/user-attachments/assets/60aaa6ca-d4a6-4075-865b-620d09b25d08" />