### PR TITLE
Remove the workaround for embedding SDK test

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -184,12 +184,6 @@ jobs:
 
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
-        env:
-          # This is a temporary workaround, until the test "should respect `entityTypes` prop" in
-          # e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx has a MODEL_COUNT of 1
-          # and make a new release of the SDK. Since this workflow relies on the tests on the commit the
-          # latest SDK version is built from.
-          MB_SEARCH_ENGINE: in-place
 
       - name: Make app db snapshot
         run: node e2e/runner/run_cypress_ci.js snapshot --browser ${{ steps.cypress-prep.outputs.chrome-path }}


### PR DESCRIPTION
A followup task for EMB-447, #59029

### Description

Remove a workaround added in PR #58891.

Back then, the bacckport PR failed on the cross version testing because the workflow will use tests from the latest SDK release's built commit. At the time, the test still relies on search engine `in-place`. Now that we have merged https://github.com/metabase/metabase/pull/59088 and released a new SDK version. We shouldn't require this workaround anymore.

### How to verify

CI should be green.
