### PR TITLE
fix: truncate category select labels for category edit inputs

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellCategorySelect.tsx
@@ -11,6 +11,7 @@ import {
   Input,
   Loader,
   type SelectOption,
+  Text,
   TextInput,
   useCombobox,
 } from "metabase/ui";
@@ -119,14 +120,18 @@ export const EditingBodyCellCategorySelect = ({
           maybeHydratedDatasetColumn.remapping.get(value) ??
           maybeHydratedDatasetColumn.remapping.get(intValue);
 
-        return getSelectedLabelText({
-          value: value,
-          label: remappedValue,
-        });
+        return (
+          <Text truncate="end">
+            {getSelectedLabelText({
+              value: value,
+              label: remappedValue,
+            })}
+          </Text>
+        );
       }
 
       // Fallback to the raw value instead of a label
-      return value;
+      return <Text truncate="end">{value}</Text>;
     }
 
     return null;
@@ -159,6 +164,7 @@ export const EditingBodyCellCategorySelect = ({
             wrapper: classNames?.wrapper,
             input: classNames?.selectTextInputElement,
           }}
+          style={{ overflow: "hidden" }} // for label truncation
           rightSectionPointerEvents="all"
           rightSection={
             shouldDisplayClearButton && (


### PR DESCRIPTION
Resolves [WRK-469](https://linear.app/metabase/issue/WRK-469/uuid-for-foreign-key-doesnt-fit-in-record-creation-field)
