### PR TITLE
refactor(sdk): rename authMethod to preferredAuthMethod

### DIFF
--- a/docs/embedding/sdk/authentication.md
+++ b/docs/embedding/sdk/authentication.md
@@ -10,12 +10,12 @@ For using the SDK in production, you'll need to set up authentication with JWT S
 
 If you're developing locally, you can also set up authentication with [API keys](#authenticating-locally-with-api-keys).
 
-If both SAML and JWT are enabled in your Metabase, the SDK will default to using SAML authentication unless you explicitly set the `authMethod` to `"jwt"` in your `MetabaseAuthConfig`:
+If both SAML and JWT are enabled in your Metabase, the SDK will default to using SAML authentication unless you explicitly set the `preferredAuthMethod` to `"jwt"` in your `MetabaseAuthConfig`:
 
 ```javascript
 authConfig: {
   metabaseInstanceUrl: "...",
-  authMethod: "jwt",
+  preferredAuthMethod: "jwt",
   // other JWT config...
 }
 ```

--- a/docs/embedding/sdk/authentication.md
+++ b/docs/embedding/sdk/authentication.md
@@ -140,7 +140,7 @@ Then you can then use the API key to authenticate with Metabase in your applicat
 
 To use SAML single sign-on with the Embedded analytics SDK, you'll need to set up SAML in both your Metabase and your Identity Provider (IdP). See the docs on [SAML-based authentication](../../people-and-groups/authenticating-with-saml.md).
 
-Once SAML is configured in Metabase and your IdP, you can configure the SDK to use SAML by setting the `authMethod` in your `MetabaseAuthConfig` to `"saml"`:
+Once SAML is configured in Metabase and your IdP, you can configure the SDK to use SAML by setting the `preferredAuthMethod` in your `MetabaseAuthConfig` to `"saml"`:
 
 ```typescript
 {% include_file "{{ dirname }}/snippets/authentication/auth-config-saml.tsx" snippet="example" %}

--- a/docs/embedding/sdk/snippets/authentication/auth-config-saml.tsx
+++ b/docs/embedding/sdk/snippets/authentication/auth-config-saml.tsx
@@ -4,6 +4,6 @@ import { defineMetabaseAuthConfig } from "@metabase/embedding-sdk-react";
 // Pass this configuration to MetabaseProvider.
 const authConfig = defineMetabaseAuthConfig({
   metabaseInstanceUrl: "http://localhost:3000",
-  authMethod: "saml",
+  preferredAuthMethod: "saml",
 });
 // [<endsnippet example>]

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/setup.tsx
@@ -49,6 +49,8 @@ export const TestComponent = ({ config }: { config: MetabaseConfigProps }) => {
     authConfig: createMockSdkConfig({
       ...config,
       metabaseInstanceUrl: config.metabaseInstanceUrl ?? MOCK_INSTANCE_URL,
+
+      // @ts-expect-error -- partial config were passed in the config prop
       preferredAuthMethod: config.preferredAuthMethod,
     }),
   });

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/setup.tsx
@@ -49,6 +49,7 @@ export const TestComponent = ({ config }: { config: MetabaseConfigProps }) => {
     authConfig: createMockSdkConfig({
       ...config,
       metabaseInstanceUrl: config.metabaseInstanceUrl ?? MOCK_INSTANCE_URL,
+      preferredAuthMethod: config.preferredAuthMethod,
     }),
   });
 
@@ -56,7 +57,7 @@ export const TestComponent = ({ config }: { config: MetabaseConfigProps }) => {
     dispatch(
       refreshTokenAsync({
         metabaseInstanceUrl: MOCK_INSTANCE_URL,
-        authMethod: config.authMethod,
+        preferredAuthMethod: config.preferredAuthMethod,
       }),
     );
 

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/setup.tsx
@@ -49,9 +49,6 @@ export const TestComponent = ({ config }: { config: MetabaseConfigProps }) => {
     authConfig: createMockSdkConfig({
       ...config,
       metabaseInstanceUrl: config.metabaseInstanceUrl ?? MOCK_INSTANCE_URL,
-
-      // @ts-expect-error -- partial config were passed in the config prop
-      preferredAuthMethod: config.preferredAuthMethod,
     }),
   });
 

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/specify-auth-method.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/test/specify-auth-method.unit.spec.tsx
@@ -12,9 +12,9 @@ describe("useInitData - specifying authentication methods", () => {
     ["saml", setupMockSamlEndpoints],
   ] as const)(
     "can use %s as the preferred auth method",
-    async (authMethod, setupMockEndpoints) => {
+    async (preferredAuthMethod, setupMockEndpoints) => {
       setupMockEndpoints();
-      setup({ authMethod });
+      setup({ preferredAuthMethod });
 
       expect(await screen.findByTestId("test-component")).toHaveAttribute(
         "data-is-logged-in",

--- a/enterprise/frontend/src/embedding-sdk/store/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/auth/auth.ts
@@ -26,7 +26,7 @@ import { getFetchRefreshTokenFn } from "../selectors";
 export const initAuth = createAsyncThunk(
   "sdk/token/INIT_AUTH",
   async (
-    { metabaseInstanceUrl, authMethod, apiKey }: MetabaseAuthConfig,
+    { metabaseInstanceUrl, preferredAuthMethod, apiKey }: MetabaseAuthConfig,
     { dispatch },
   ) => {
     // remove any stale tokens that might be there from a previous session=
@@ -46,7 +46,7 @@ export const initAuth = createAsyncThunk(
         const session = await dispatch(
           getOrRefreshSession({
             metabaseInstanceUrl,
-            authMethod,
+            preferredAuthMethod,
           }),
         ).unwrap();
         if (session?.id) {
@@ -58,7 +58,7 @@ export const initAuth = createAsyncThunk(
         await dispatch(
           getOrRefreshSession({
             metabaseInstanceUrl,
-            authMethod,
+            preferredAuthMethod,
           }),
         ).unwrap();
       } catch (e) {
@@ -107,15 +107,15 @@ export const refreshTokenAsync = createAsyncThunk(
   async (
     {
       metabaseInstanceUrl,
-      authMethod,
-    }: Pick<MetabaseAuthConfig, "metabaseInstanceUrl" | "authMethod">,
+      preferredAuthMethod,
+    }: Pick<MetabaseAuthConfig, "metabaseInstanceUrl" | "preferredAuthMethod">,
     { getState },
   ): Promise<MetabaseEmbeddingSessionToken | null> => {
     const customGetRefreshToken =
       getFetchRefreshTokenFn(getState() as SdkStoreState) ?? undefined;
     const session = await getRefreshToken({
       metabaseInstanceUrl,
-      authMethod,
+      preferredAuthMethod,
       fetchRequestToken: customGetRefreshToken,
     });
     validateSessionToken(session);
@@ -126,14 +126,14 @@ export const refreshTokenAsync = createAsyncThunk(
 
 const getRefreshToken = async ({
   metabaseInstanceUrl,
-  authMethod,
+  preferredAuthMethod,
   fetchRequestToken: customGetRequestToken,
 }: Pick<
   MetabaseAuthConfig,
-  "metabaseInstanceUrl" | "fetchRequestToken" | "authMethod"
+  "metabaseInstanceUrl" | "fetchRequestToken" | "preferredAuthMethod"
 >) => {
   const urlResponseJson = await connectToInstanceAuthSso(metabaseInstanceUrl, {
-    authMethod,
+    preferredAuthMethod,
     headers: getSdkRequestHeaders(),
   });
   const { method, url: responseUrl, hash } = urlResponseJson || {};

--- a/enterprise/frontend/src/embedding-sdk/store/reducer.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/reducer.ts
@@ -37,7 +37,10 @@ const GET_OR_REFRESH_SESSION = "sdk/token/GET_OR_REFRESH_SESSION";
 export const getOrRefreshSession = createAsyncThunk(
   GET_OR_REFRESH_SESSION,
   async (
-    authConfig: Pick<MetabaseAuthConfig, "metabaseInstanceUrl" | "authMethod">,
+    authConfig: Pick<
+      MetabaseAuthConfig,
+      "metabaseInstanceUrl" | "preferredAuthMethod"
+    >,
     { dispatch, getState },
   ) => {
     // necessary to ensure that we don't use a popup every time the user

--- a/enterprise/frontend/src/embedding-sdk/test/auth-flow/jwt.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/auth-flow/jwt.unit.spec.tsx
@@ -101,7 +101,7 @@ describe("Auth Flow - JWT", () => {
 
     const authConfig = defineMetabaseAuthConfig({
       metabaseInstanceUrl: MOCK_INSTANCE_URL,
-      authMethod: "jwt",
+      preferredAuthMethod: "jwt",
       fetchRequestToken: customFetchFunction,
     });
 

--- a/enterprise/frontend/src/embedding-sdk/types/auth-config.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/auth-config.ts
@@ -14,9 +14,9 @@ export type MetabaseAuthConfigWithJwt = BaseMetabaseAuthConfig & {
   /**
    * Which authentication method to use.
    * If both SAML and JWT are enabled at the same time,
-   * it defaults to SAML unless the authMethod is specified.
+   * it defaults to SAML unless the preferredAuthMethod is specified.
    */
-  authMethod?: "jwt";
+  preferredAuthMethod?: "jwt";
 
   /**
    * Specifies a function to fetch the refresh token.
@@ -34,9 +34,9 @@ export type MetabaseAuthConfigWithSaml = BaseMetabaseAuthConfig & {
   /**
    * Which authentication method to use.
    * If both SAML and JWT are enabled at the same time,
-   * it defaults to SAML unless the authMethod is specified.
+   * it defaults to SAML unless the preferredAuthMethod is specified.
    */
-  authMethod?: "saml";
+  preferredAuthMethod?: "saml";
   apiKey?: never;
   fetchRequestToken?: never;
 };
@@ -46,7 +46,7 @@ export type MetabaseAuthConfigWithSaml = BaseMetabaseAuthConfig & {
  */
 export type MetabaseAuthConfigWithApiKey = BaseMetabaseAuthConfig & {
   apiKey: string;
-  authMethod?: never;
+  preferredAuthMethod?: never;
   fetchRequestToken?: never;
 };
 
@@ -59,6 +59,6 @@ export type MetabaseAuthConfig =
   | MetabaseAuthConfigWithSaml;
 
 export type MetabaseAuthMethod = Exclude<
-  MetabaseAuthConfig["authMethod"],
+  MetabaseAuthConfig["preferredAuthMethod"],
   undefined
 >;

--- a/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
+++ b/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
@@ -5,19 +5,26 @@ export async function connectToInstanceAuthSso(
   url: string,
   {
     headers,
-    authMethod,
-  }: { headers?: Record<string, string>; authMethod?: MetabaseAuthMethod } = {},
+    preferredAuthMethod,
+  }: {
+    headers?: Record<string, string>;
+    preferredAuthMethod?: MetabaseAuthMethod;
+  } = {},
 ) {
-  if (authMethod && authMethod !== "jwt" && authMethod !== "saml") {
+  if (
+    preferredAuthMethod &&
+    preferredAuthMethod !== "jwt" &&
+    preferredAuthMethod !== "saml"
+  ) {
     throw MetabaseError.INVALID_AUTH_METHOD({
-      method: authMethod,
+      method: preferredAuthMethod,
     });
   }
 
   const ssoUrl = new URL("/auth/sso", url);
 
-  if (authMethod) {
-    ssoUrl.searchParams.set("preferred_method", authMethod);
+  if (preferredAuthMethod) {
+    ssoUrl.searchParams.set("preferred_method", preferredAuthMethod);
   }
 
   try {


### PR DESCRIPTION
Renames `authMethod` to `preferredAuthMethod` for clarity, as we only take `preferredAuthMethod` into consideration when both JWT and SAML is enabled and configured. As recommended by Kelvin [in this comment](https://github.com/metabase/metabase/pull/59033#discussion_r2131927524).