### PR TITLE
chore: replace moment with dayjs in unit tests

### DIFF
--- a/frontend/src/metabase/components/DateTime/DateTime.unit.spec.tsx
+++ b/frontend/src/metabase/components/DateTime/DateTime.unit.spec.tsx
@@ -1,4 +1,4 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 
 import { render, screen } from "__support__/ui";
 import DateTime from "metabase/components/DateTime";
@@ -40,7 +40,7 @@ describe("DateTime", () => {
     date_style = DEFAULT_DATE_STYLE,
     time_style = DEFAULT_TIME_STYLE,
   } = {}) {
-    return moment(TEST_DATE).format(`${date_style}, ${time_style}`);
+    return dayjs(TEST_DATE).format(`${date_style}, ${time_style}`);
   }
 
   it("uses default formatting", () => {

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable/BaseItemsTable.unit.spec.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable/BaseItemsTable.unit.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 import { Route } from "react-router";
 
 import { getIcon, renderWithProviders, screen } from "__support__/ui";
@@ -86,7 +86,7 @@ describe("BaseItemsTable", () => {
 
   it("displays item data", () => {
     setup();
-    const lastEditedAt = moment(timestamp).format("MMMM D, YYYY");
+    const lastEditedAt = dayjs(timestamp).format("MMMM D, YYYY");
 
     expect(screen.getByText(ITEM.name)).toBeInTheDocument();
     expect(screen.getByText("John Doe")).toBeInTheDocument();
@@ -95,12 +95,12 @@ describe("BaseItemsTable", () => {
 
   it("displays last edit time on hover", async () => {
     setup();
-    const lastEditedAt = moment(timestamp).format("MMMM D, YYYY");
+    const lastEditedAt = dayjs(timestamp).format("MMMM D, YYYY");
 
     await userEvent.hover(screen.getByText(lastEditedAt));
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      moment(timestamp).format(`${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`),
+      dayjs(timestamp).format(`${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`),
     );
   });
 

--- a/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.unit.spec.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.unit.spec.js
@@ -1,5 +1,5 @@
+import dayjs from "dayjs";
 import mockDate from "mockdate";
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockUser } from "metabase-types/api/mocks";
@@ -11,7 +11,7 @@ describe("LastEditInfoLabel", () => {
     mockDate.reset();
   });
 
-  const NOW_REAL = moment().toISOString();
+  const NOW_REAL = dayjs().toISOString();
 
   const TEST_USER = createMockUser({
     id: 2,
@@ -45,16 +45,17 @@ describe("LastEditInfoLabel", () => {
     );
   }
 
-  const A_FEW_SECONDS_AGO = moment().add(5, "seconds");
-  const IN_15_MIN = moment().add(15, "minutes");
-  const IN_HOUR = moment().add(1, "hours");
-  const IN_4_HOURS = moment().add(4, "hours");
-  const TOMORROW = moment().add(1, "days");
-  const IN_THREE_DAYS = moment().add(3, "days");
-  const NEXT_WEEK = moment().add(1, "week");
-  const NEXT_MONTH = moment().add(1, "month");
-  const IN_4_MONTHS = moment().add(4, "month");
-  const NEXT_YEAR = moment().add(1, "year");
+  const now = dayjs();
+  const A_FEW_SECONDS_AGO = now.add(5, "seconds");
+  const IN_15_MIN = now.add(15, "minutes");
+  const IN_HOUR = now.add(1, "hours");
+  const IN_4_HOURS = now.add(4, "hours");
+  const TOMORROW = now.add(1, "days");
+  const IN_THREE_DAYS = now.add(3, "days");
+  const NEXT_WEEK = now.add(1, "week");
+  const NEXT_MONTH = now.add(1, "month");
+  const IN_4_MONTHS = now.add(4, "month");
+  const NEXT_YEAR = now.add(1, "year");
 
   const testCases = [
     {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.tz.unit.spec.js
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.tz.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 
 import testAcrossTimezones from "__support__/timezones";
 import { computeTimeseriesDataInverval } from "metabase/visualizations/echarts/cartesian/utils/timeseries";
@@ -17,7 +17,7 @@ testAcrossTimezones((reportTz) => {
     ].map(([expectedUnit, expectedCount, data]) => {
       it(`should return ${expectedCount} ${expectedUnit}`, () => {
         // parse timestamps in reporting timezone and serialize
-        const xValues = data.map((d) => moment.tz(d, reportTz).format());
+        const xValues = data.map((d) => dayjs.tz(d, reportTz).format());
 
         const { unit, count } = computeTimeseriesDataInverval(xValues);
 


### PR DESCRIPTION
closes QUE-1331

1:1 replacement of moment-timezone with dayjs in unit tests