### PR TITLE
Fix fast-reload response for table actions with multiple PKs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/data_editing.clj
@@ -66,14 +66,14 @@
                      (if (= 1 (count pk-fields))
                        (apply lib/in
                               (lib.metadata/field mp (:id (first pk-fields)))
-                              (map (comp first vals) row-pks))
+                              (map (comp val first) row-pks))
                        ;; Optimizing this could be done in many cases, but it would be complex.
                        (apply* lib/or
                                (for [row-pk row-pks]
                                  (apply* lib/and
                                          (for [field pk-fields]
                                            (lib/= (lib.metadata/field mp (:id field))
-                                                  (get row-pk (keyword (:name field))))))))))]
+                                                  (get row-pk (:name field)))))))))]
           (->> query
                qp/userland-query-with-default-constraints
                qp/process-query

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -125,8 +125,8 @@
                      (mt/user-http-request :crowberto :post 200 url
                                            {:action_id "data-grid.row/create"
                                             :scope     {:table-id table-id}
-                                            :inputs    [{:name "Pidgey" :song "Car alarms"}
-                                                        {:name "Spearow" :song "Hold music"}
+                                            :inputs    [{:name "Pidgey"     :song "Car alarms"}
+                                                        {:name "Spearow"    :song "Hold music"}
                                                         {:name "Farfetch'd" :song "The land of lisp"}]})))))
 
             (is (= [[1 "Pidgey" "Car alarms"]
@@ -143,28 +143,29 @@
                                            {:action_id "data-grid.row/update"
                                             :scope     {:table-id table-id}
                                             :inputs    [{:id 1 :song "Join us now and share the software"}
-                                                        {:id 2 :name "Speacolumn"}]}))))
+                                                        {:id 2 :name "Speacolumn"}]})))))
 
-                (is (= #{[1 "Pidgey" "Join us now and share the software"]
-                         [2 "Speacolumn" "Hold music"]
-                         [3 "Farfetch'd" "The land of lisp"]}
-                       (set (table-rows table-id))))))
+            (is (= #{[1 "Pidgey" "Join us now and share the software"]
+                     [2 "Speacolumn" "Hold music"]
+                     [3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
 
-          ;; Leaning against not adding this action.
-          #_(testing "PUT can also do bulk updates"
-              (is (= #{{:id 1, :name "Pidgey",     :song "The Star-Spangled Banner"}
-                       {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}
-                     (set
-                      (:updated
-                       (mt/user-http-request :crowberto :put 200 url
-                                             {:pks     [{:id 1}
+          (testing "PUT can also do bulk updates"
+            (is (= #{{:op "updated", :table-id table-id, :row {:id 1, :name "Pidgey",     :song "The Star-Spangled Banner"}}
+                     {:op "updated", :table-id table-id, :row {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id 1}
                                                         {:id 2}]
-                                              :updates {:song "The Star-Spangled Banner"}}))))
+                                            :params    {:song "The Star-Spangled Banner"}})))))
 
-                  (is (= #{[1 "Pidgey" "The Star-Spangled Banner"]
-                           [2 "Speacolumn" "The Star-Spangled Banner"]
-                           [3 "Farfetch'd" "The land of lisp"]}
-                         (set (table-rows table-id))))))
+            (is (= #{[1 "Pidgey" "The Star-Spangled Banner"]
+                     [2 "Speacolumn" "The Star-Spangled Banner"]
+                     [3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
 
           (testing "DELETE should remove the corresponding rows"
             (is (= #{{:op "deleted", :table-id table-id, :row {:id 1}}
@@ -176,6 +177,85 @@
                                             :scope     {:table-id table-id}
                                             :inputs    [{:id 1}
                                                         {:id 2}]})))))
+            (is (= [[3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id)))))))))
+
+(deftest table-operations-via-action-execute-with-compound-pk-test
+  (mt/with-premium-features #{:table-data-editing}
+    (mt/test-drivers #{:h2 :postgres}
+      (with-open [table-ref (data-editing.tu/open-test-table!
+                             {:id_1   'auto-inc-type
+                              :id_2   'auto-inc-type
+                              :name  [:text]
+                              :song  [:text]}
+                             {:primary-key [:id_1 :id_2]})]
+        (let [table-id @table-ref
+              url      "ee/data-editing/action/v2/execute-bulk"]
+          (data-editing.tu/toggle-data-editing-enabled! true)
+          (testing "Initially the table is empty"
+            (is (= [] (table-rows table-id))))
+
+          (testing "POST should insert new rows"
+            (is (= #{{:op "created", :table-id table-id, :row {:id_1 1, :id_2 1, :name "Pidgey",     :song "Car alarms"}}
+                     {:op "created", :table-id table-id, :row {:id_1 2, :id_2 2, :name "Spearow",    :song "Hold music"}}
+                     {:op "created", :table-id table-id, :row {:id_1 3, :id_2 3, :name "Farfetch'd", :song "The land of lisp"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/create"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:name "Pidgey"     :song "Car alarms"}
+                                                        {:name "Spearow"    :song "Hold music"}
+                                                        {:name "Farfetch'd" :song "The land of lisp"}]})))))
+
+            (is (= [[1 1 "Pidgey" "Car alarms"]
+                    [2 2 "Spearow" "Hold music"]
+                    [3 3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
+
+          (testing "PUT should update the relevant rows and columns"
+            (is (= #{{:op "updated", :table-id table-id :row {:id_1 1, :id_2 1, :name "Pidgey",     :song "Join us now and share the software"}}
+                     {:op "updated", :table-id table-id :row {:id_1 2, :id_2 2, :name "Speacolumn", :song "Hold music"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id_1 1, :id_2 1, :song "Join us now and share the software"}
+                                                        {:id_1 2, :id_2 2, :name "Speacolumn"}]})))))
+
+            (is (= #{[1 1 "Pidgey" "Join us now and share the software"]
+                     [2 2 "Speacolumn" "Hold music"]
+                     [3 3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
+
+          (testing "PUT can also do bulk updates"
+            (is (= #{{:id_1 1, :id_2 1, :name "Pidgey",     :song "The Star-Spangled Banner"}
+                     {:id_1 2, :id_2 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}
+                   (set
+                    (:updated
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id_1 1, :id_2 1}
+                                                        {:id_1 2, :id_2 2}]
+                                            :params    {:song "The Star-Spangled Banner"}})))))
+
+            (is (= #{[1 1 "Pidgey" "The Star-Spangled Banner"]
+                     [2 2 "Speacolumn" "The Star-Spangled Banner"]
+                     [3 3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
+
+          (testing "DELETE should remove the corresponding rows"
+            (is (= #{{:op "deleted", :table-id table-id, :row {:id 1}}
+                     {:op "deleted", :table-id table-id, :row {:id 2}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/delete"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id_1 1, :id_2 1}
+                                                        {:id_1 2, :id_2 2}]})))))
             (is (= [[3 "Farfetch'd" "The land of lisp"]]
                    (table-rows table-id)))))))))
 


### PR DESCRIPTION
Closes WRK-477 

Keywords versus strings strikes again!

The issue here was that we'd had no integration tests for compound keys, so they got left behind in our recent switch back to strings.