### PR TITLE
fix(sdk): omit jwt token response from error messages

### DIFF
--- a/enterprise/frontend/src/embedding/auth-common/jwt.ts
+++ b/enterprise/frontend/src/embedding/auth-common/jwt.ts
@@ -11,12 +11,14 @@ export async function jwtDefaultRefreshTokenFunction(
     customFetchRequestToken,
   );
 
-  const mbAuthUrl = new URL(`${instanceUrl}/auth/sso`);
-  mbAuthUrl.searchParams.set("jwt", jwtTokenResponse);
+  const mbAuthUrl = `${instanceUrl}/auth/sso`;
+
+  const mbAuthUrlWithJwt = new URL(mbAuthUrl);
+  mbAuthUrlWithJwt.searchParams.set("jwt", jwtTokenResponse);
 
   let authSsoResponse;
   try {
-    authSsoResponse = await fetch(mbAuthUrl.toString(), {
+    authSsoResponse = await fetch(mbAuthUrlWithJwt.toString(), {
       headers: requestHeaders,
     });
   } catch (e) {


### PR DESCRIPTION
Closes EMB-453

Omit the JWT token from error message, as it can get shown in the UI and looks scary:

![image-2](https://github.com/user-attachments/assets/d46b43c5-0d15-40bb-9405-ecb0d111a142)
