### PR TITLE
fix(sdk): Properly expose `initialParameters` type on dashboard components

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
@@ -1,4 +1,3 @@
-import type { Query } from "history";
 import type { ComponentType, FC } from "react";
 import type { ConnectedProps } from "react-redux";
 import _ from "underscore";
@@ -36,6 +35,7 @@ import type {
   DashboardLoaderWrapperProps,
   DashboardRefreshPeriodControls,
 } from "metabase/dashboard/types";
+import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import { connect } from "metabase/lib/redux";
 import { useDashboardLoadHandlers } from "metabase/public/containers/PublicOrEmbeddedDashboard/use-dashboard-load-handlers";
 import { closeNavbar, setErrorPage } from "metabase/redux/app";
@@ -87,7 +87,7 @@ type ReduxProps = ConnectedProps<typeof connector>;
 type ConnectedDashboardProps = {
   dashboardId: DashboardId;
   isLoading: boolean;
-  parameterQueryParams: Query;
+  parameterQueryParams: ParameterValues;
 
   downloadsEnabled?: boolean;
   onNavigateToNewCardFromDashboard: (

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
@@ -1,4 +1,3 @@
-import type { Query } from "history";
 import { pick } from "underscore";
 
 import type { SdkDashboardId } from "embedding-sdk/types/dashboard";
@@ -10,6 +9,7 @@ import {
   useRefreshDashboard,
 } from "metabase/dashboard/hooks";
 import type { EmbedDisplayParams } from "metabase/dashboard/types";
+import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
 import { isNotNull } from "metabase/lib/types";
 
@@ -32,7 +32,7 @@ export type SdkDashboardDisplayProps = {
    * <br/>
    * - Combining {@link SdkDashboardDisplayProps.initialParameters | initialParameters} and {@link SdkDashboardDisplayProps.hiddenParameters | hiddenParameters} to declutter the user interface is fine.
    */
-  initialParameters?: Query;
+  initialParameters?: ParameterValues;
 
   /**
    * Whether the dashboard should display a title.

--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -62,3 +62,5 @@ export type {
 } from "./types/refresh-token";
 
 export type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
+
+export type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -1,5 +1,3 @@
-import type { Query } from "history";
-
 import type {
   EntityTypeFilterKeys,
   MetabaseTheme,
@@ -7,6 +5,7 @@ import type {
 } from "embedding-sdk";
 import type { MetabaseError } from "embedding-sdk/errors";
 import type { MetabaseEmbeddingSessionToken } from "embedding-sdk/types/refresh-token";
+import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import type { CollectionId } from "metabase-types/api";
 
 /** Events that the embed.js script listens for */
@@ -46,7 +45,7 @@ export interface DashboardEmbedOptions {
   withDownloads?: boolean;
 
   // parameters
-  initialParameters?: Query;
+  initialParameters?: ParameterValues;
   hiddenParameters?: string[];
 
   // incompatible options

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -1,5 +1,4 @@
 import { createAction } from "@reduxjs/toolkit";
-import type { Query } from "history";
 import { getIn } from "icepick";
 import { denormalize, normalize, schema } from "normalizr";
 import { match } from "ts-pattern";
@@ -26,6 +25,7 @@ import {
   isQuestionDashCard,
   isVirtualDashCard,
 } from "metabase/dashboard/utils";
+import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import Dashboards from "metabase/entities/dashboards";
 import type { Deferred } from "metabase/lib/promise";
 import { defer } from "metabase/lib/promise";
@@ -630,7 +630,7 @@ export const fetchDashboard = createAsyncThunk(
       options: { preserveParameters = false, clearCache = true } = {},
     }: {
       dashId: DashboardId;
-      queryParams: Query;
+      queryParams: ParameterValues;
       options?: { preserveParameters?: boolean; clearCache?: boolean };
     },
     { getState, dispatch, rejectWithValue },

--- a/frontend/src/metabase/embedding-sdk/types/dashboard.ts
+++ b/frontend/src/metabase/embedding-sdk/types/dashboard.ts
@@ -1,0 +1,4 @@
+export type ParameterValues = Record<
+  string,
+  string | string[] | undefined | null
+>;

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
@@ -1,4 +1,3 @@
-import type { Query } from "history";
 import { useEffect, useRef } from "react";
 import type { ConnectedProps } from "react-redux";
 import { usePrevious, useUnmount } from "react-use";
@@ -28,6 +27,7 @@ import type {
   FetchDashboardResult,
   SuccessfulFetchDashboardResult,
 } from "metabase/dashboard/types";
+import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import { connect } from "metabase/lib/redux";
 import { type DispatchFn, useDispatch } from "metabase/lib/redux";
 import { LocaleProvider } from "metabase/public/LocaleProvider";
@@ -65,7 +65,7 @@ type ReduxProps = ConnectedProps<typeof connector>;
 
 type OwnProps = {
   dashboardId: DashboardId;
-  parameterQueryParams: Query;
+  parameterQueryParams: ParameterValues;
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
   ) => void;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58337, closes EMB-409

### Description

Stop using `Query` from `history` and use our own type insteaad. This is similar to how we're exposing `SqlParameterValues`.
https://github.com/metabase/metabase/blob/9b77830a96a65a1c1d69c475317b70a63b97c5d1/enterprise/frontend/src/embedding-sdk/types/question.ts#L64

Please note that I inline the type from `Query` exactly to not have to deal with type incompatibility with query builder code. I tested that even if we pass string number, the dashboard componets will eventually parse it according to the widget type correctly, so even if you pass `"1"` as a parameter value, it will be turned into `1` (number) in `dashboards.parameterValues[string]` correctly.

### How to verify

1. Run `yarn build-embedding-sdk` and install the built package in your application.
1. Try to use autocompletion on `InteractiveDashboard`'s `initialParameters` and see that the type should be reported correctly, no as `any` anymore.

### Demo
#### After 
![Screenshot 2025-06-06 at 9 20 10 PM](https://github.com/user-attachments/assets/40e218b0-aacb-4c10-a55e-c5b2b1502075)

#### Before
![image](https://github.com/user-attachments/assets/85395e0b-7292-4601-bae3-b174dd749af6)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Just type change
