### PR TITLE
Remapped columns in model should not break

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2628,7 +2628,7 @@ describe("issue 23449", () => {
     });
   };
 
-  it("Remapped fields should work in a model", () => {
+  it("Remapped fields should work in a model (metabase#23449)", () => {
     cy.log("set the metadata for review");
     cy.visit(
       `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${SAMPLE_DATABASE.REVIEWS_ID}`,

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2629,7 +2629,7 @@ describe("issue 23449", () => {
     cy.findByLabelText("Custom mapping").click();
 
     const values = { 1: "A", 2: "B", 3: "C", 4: "D", 5: "E" };
-    for (let k of Object.keys(values)) {
+    for (const k of Object.keys(values)) {
       cy.get(`input[value="${k}"]`).clear().type(values[k]);
     }
     cy.get("button").contains("Save").click();

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2621,8 +2621,15 @@ describe("issue 23449", () => {
     cy.signInAsAdmin();
   });
 
+  const checkTable = () => {
+    H.assertTableData({
+      columns: ["ID", "Product ID", "Reviewer", "Rating", "Created At"],
+      firstRows: [[1, 1, "christ", "E", "May 15, 2024, 8:25 PM"]],
+    });
+  };
+
   it("Remapped fields should work in a model", () => {
-    // set the metadata for review
+    cy.log("set the metadata for review");
     cy.visit(
       `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${SAMPLE_DATABASE.REVIEWS_ID}`,
     );
@@ -2631,38 +2638,34 @@ describe("issue 23449", () => {
     cy.findAllByTestId("select-button").contains("Use original value").click();
     cy.findByLabelText("Custom mapping").click();
 
-    const values = { 1: "A", 2: "B", 3: "C", 4: "D", 5: "E" };
-    for (const [key, value] of Object.entries(values)) {
-      cy.findByDisplayValue(key).clear().type(value);
-    }
+    cy.findByDisplayValue("1").clear().type("A");
+    cy.findByDisplayValue("2").clear().type("B");
+    cy.findByDisplayValue("3").clear().type("C");
+    cy.findByDisplayValue("4").clear().type("D");
+    cy.findByDisplayValue("5").clear().type("E");
+
     cy.button("Save").click();
 
-    // make a model on Reviews
+    cy.log("make a model on Reviews");
     cy.findByRole("link", { name: "Exit admin" }).click();
     H.navigationSidebar().findByLabelText("Browse models").click();
     cy.findByLabelText("Create a new model").click();
     cy.findByRole("link", { name: /Use the notebook editor/ }).click();
     H.entityPickerModal().findByText("Reviews").click();
 
-    // Remove Body column
+    cy.log("Remove Body column");
     cy.findByLabelText("Pick columns").click();
     H.popover().findByText("Body").click();
 
-    // save model
+    cy.log("save model");
     cy.button("Save").click();
     cy.findByTestId("save-question-button").click();
 
-    // check that the data renders
-    const checkTable = () => {
-      H.assertTableData({
-        columns: ["ID", "Product ID", "Reviewer", "Rating", "Created At"],
-        firstRows: [[1, 1, "christ", "E", "May 15, 2024, 8:25 PM"]],
-      });
-    };
+    cy.log("check that the data renders");
     checkTable();
 
-    // reload to flush cached results
-    cy.reload(true);
+    cy.log("reload to flush cached results and check again");
+    cy.findByTestId("qb-header").button("Refresh").click();
     checkTable();
   });
 });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2659,7 +2659,7 @@ describe("issue 23449", () => {
 
     cy.log("save model");
     cy.findByTestId("dataset-edit-bar").button("Save").click();
-    
+
     cy.log("confirm save in a modal");
     H.modal().button("Save").click();
 

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2610,3 +2610,47 @@ describe("issue 32499", () => {
     }
   });
 });
+
+describe("issue 23449", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("Remapped fields should work in a model", () => {
+    // set the metadata for review
+    cy.visit("/admin/datamodel");
+    cy.findAllByTestId("admin-metadata-table-list-item")
+      .contains("Reviews")
+      .click();
+
+    cy.findByTestId("column-RATING").findByLabelText("Field settings").click();
+    cy.findAllByTestId("select-button").contains("Use original value").click();
+    cy.findByLabelText("Custom mapping").click();
+
+    const values = { 1: "A", 2: "B", 3: "C", 4: "D", 5: "E" };
+    for (let k of Object.keys(values)) {
+      cy.get(`input[value="${k}"]`).clear().type(values[k]);
+    }
+    cy.get("button").contains("Save").click();
+
+    // make a model on Reviews
+    cy.visit("/model/new");
+    cy.get("a").contains("Use the notebook editor").click();
+    cy.findAllByTestId("picker-item").contains("Reviews").click();
+
+    // Remove Body column
+    cy.findByLabelText("Pick columns").click();
+    cy.get("li").contains("Body").click();
+
+    // save model
+    cy.findByTestId("dataset-edit-bar").get("button").contains("Save").click();
+    cy.findByTestId("save-question-button").click();
+
+    // check that the data renders
+    H.tableHeaderColumn("Rating").should("exist");
+    // reload to flush cached results
+    cy.reload(true);
+    H.tableHeaderColumn("Rating").should("exist");
+  });
+});

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2658,8 +2658,10 @@ describe("issue 23449", () => {
     H.popover().findByText("Body").click();
 
     cy.log("save model");
-    cy.button("Save").click();
-    cy.findByTestId("save-question-button").click();
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
+    
+    cy.log("confirm save in a modal");
+    H.modal().button("Save").click();
 
     cy.log("check that the data renders");
     checkTable();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23449

### Description

Way back in 2022 (v43.3), if you remapped a column's values in a table's metadata then created a model, the query would break. I reproduced it in the jar for v43.3, but it was already fixed in master. This test merely prevents regressions. See [the issue](https://github.com/metabase/metabase/issues/23449) for reproduction steps.