### PR TITLE
fix: increase starburst percentile acceptable epsilon

### DIFF
--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -1010,7 +1010,7 @@
                               (< (abs (- aggregation-value metric-value))
                                  (if (and (#{:percentile :median} operator)
                                           (driver/database-supports? driver/*driver* :test/inaccurate-approx-percentile nil))
-                                   1
+                                   3
                                    0.01)))
                             results-combined))))))))))
 


### PR DESCRIPTION
Fixes this flake where starburst gives a difference > 1 https://github.com/metabase/metabase/actions/runs/15439066511/job/43454205916