### PR TITLE
Better detection of card metadata changes

### DIFF
--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -78,7 +78,7 @@
     rff   :- [:maybe ::qp.schema/rff]]
    (qp.setup/with-qp-setup [query query]
      (let [rff (or rff qp.reducible/default-rff)]
-       (process-query* query rff)))))
+       (process-query* (assoc-in query [:middleware :skip-results-metadata?] true) rff)))))
 
 (mu/defn userland-query :- ::qp.schema/query
   "Add middleware options and `:info` to a `query` so it is ran as a 'userland' query, which slightly changes the QP

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -78,7 +78,7 @@
     rff   :- [:maybe ::qp.schema/rff]]
    (qp.setup/with-qp-setup [query query]
      (let [rff (or rff qp.reducible/default-rff)]
-       (process-query* (assoc-in query [:middleware :skip-results-metadata?] true) rff)))))
+       (process-query* query rff)))))
 
 (mu/defn userland-query :- ::qp.schema/query
   "Add middleware options and `:info` to a `query` so it is ran as a 'userland' query, which slightly changes the QP

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -19,6 +19,10 @@
 ;;; |                                                   Middleware                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn- standardize-metadata [metadata]
+  "Smooth out any unimportant differences in metadata so we can do an easy equality check."
+  (mapv #(dissoc % :ident) metadata))
+
 (defn- record-metadata! [{{:keys [card-id]} :info, :as query} metadata]
   (try
     ;; At the very least we can skip the Extra DB call to update this Card's metadata results
@@ -30,7 +34,7 @@
                ;; don't want to update metadata when we use a Card as a source Card.
                (not (:qp/source-card-id query))
                ;; Only update changed metadata
-               (not= metadata (qp.store/miscellaneous-value [::card-stored-metadata])))
+               (not= (standardize-metadata metadata) (standardize-metadata (qp.store/miscellaneous-value [::card-stored-metadata]))))
       (t2/update! :model/Card card-id {:result_metadata metadata
                                        :updated_at      :updated_at}))
     ;; if for some reason we weren't able to record results metadata for this query then just proceed as normal

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -19,8 +19,9 @@
 ;;; |                                                   Middleware                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- standardize-metadata [metadata]
+(defn- standardize-metadata
   "Smooth out any unimportant differences in metadata so we can do an easy equality check."
+  [metadata]
   (mapv #(dissoc % :ident) metadata))
 
 (defn- record-metadata! [{{:keys [card-id]} :info, :as query} metadata]

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -19,7 +19,7 @@
 ;;; |                                                   Middleware                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- standardize-metadata
+(defn- comparable-metadata
   "Smooth out any unimportant differences in metadata so we can do an easy equality check."
   [metadata]
   (mapv #(dissoc % :ident) metadata))
@@ -35,7 +35,7 @@
                ;; don't want to update metadata when we use a Card as a source Card.
                (not (:qp/source-card-id query))
                ;; Only update changed metadata
-               (not= (standardize-metadata metadata) (standardize-metadata (qp.store/miscellaneous-value [::card-stored-metadata]))))
+               (not= (comparable-metadata metadata) (comparable-metadata (qp.store/miscellaneous-value [::card-stored-metadata]))))
       (t2/update! :model/Card card-id {:result_metadata metadata
                                        :updated_at      :updated_at}))
     ;; if for some reason we weren't able to record results metadata for this query then just proceed as normal


### PR DESCRIPTION
### Description

The check for changed metadata was causing an update of cards on every view due to `:ident` being in the comparison.

Removing that as part of the equality check

### How to verify

1. View a dashboard (such as the example dashboard) tracking calls to `metabase.query-processor.middleware.results-metadata/record-metadata!`
2. There should not be any updates to the metadata between requests

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
