### PR TITLE
Closes VIZ-162 - Stacked bar chart with mixed negative and positive values creates nonsensical percentage breakdowns in tooltips

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -671,22 +671,20 @@ describe("scenarios > visualizations > bar chart", () => {
     H.assertEChartsTooltip({
       rows: [
         {
-          color: "#A989C5",
-          name: "blue",
-          value: "-16",
-          secondaryValue: "-200.00 %",
-        },
-        {
           color: "#F9D45C",
           name: "yellow",
           value: "8",
           secondaryValue: "100 %",
         },
+        { name: "Total positive", value: "8" },
         {
-          name: "Total",
-          value: "-8",
-          secondaryValue: "-100.00 %",
+          color: "#A989C5",
+          name: "blue",
+          value: "-16",
+          secondaryValue: "-100 %",
         },
+        { name: "Total negative", value: "-16" },
+        { name: "Total", value: "-8" },
       ],
     });
     H.echartsTriggerBlur();
@@ -695,22 +693,20 @@ describe("scenarios > visualizations > bar chart", () => {
     H.assertEChartsTooltip({
       rows: [
         {
-          color: "#A989C5",
-          name: "blue",
-          value: "-7",
-          secondaryValue: "-350.00 %",
-        },
-        {
           color: "#F9D45C",
           name: "yellow",
           value: "5",
-          secondaryValue: "250.00 %",
+          secondaryValue: "100 %",
         },
+        { name: "Total positive", value: "5" },
         {
-          name: "Total",
-          value: "-2",
-          secondaryValue: "-100.00 %",
+          color: "#A989C5",
+          name: "blue",
+          value: "-7",
+          secondaryValue: "-100 %",
         },
+        { name: "Total negative", value: "-7" },
+        { name: "Total", value: "-2" },
       ],
     });
     H.echartsTriggerBlur();
@@ -722,19 +718,17 @@ describe("scenarios > visualizations > bar chart", () => {
           color: "#A989C5",
           name: "blue",
           value: "2",
-          secondaryValue: "Infinity %",
+          secondaryValue: "100 %",
         },
+        { name: "Total positive", value: "2" },
         {
           color: "#F9D45C",
           name: "yellow",
           value: "-2",
-          secondaryValue: "-Infinity %",
+          secondaryValue: "-100 %",
         },
-        {
-          name: "Total",
-          value: "0",
-          secondaryValue: "NaN %",
-        },
+        { name: "Total negative", value: "-2" },
+        { name: "Total", value: "0" },
       ],
     });
     H.echartsTriggerBlur();
@@ -746,19 +740,77 @@ describe("scenarios > visualizations > bar chart", () => {
           color: "#A989C5",
           name: "blue",
           value: "3",
-          secondaryValue: "300.00 %",
+          secondaryValue: "100 %",
         },
+        { name: "Total positive", value: "3" },
         {
           color: "#F9D45C",
           name: "yellow",
           value: "-2",
-          secondaryValue: "-200.00 %",
+          secondaryValue: "-100 %",
+        },
+        { name: "Total negative", value: "-2" },
+        { name: "Total", value: "1" },
+      ],
+    });
+    H.echartsTriggerBlur();
+  });
+
+  it("should correctly show tool-tips when stacked bar charts contain multiple positive and multiple negative segments (#47596)", () => {
+    cy.signInAsAdmin();
+
+    H.createNativeQuestion(
+      {
+        name: "47596",
+        native: {
+          query: `${[
+            "select date '2024-05-21' AS created_at, 'cat1' AS category, 2 as v",
+            "select date '2024-05-21', 'cat2', -1",
+            "select date '2024-05-21', 'cat3', 1",
+            "select date '2024-05-21', 'cat4', -1",
+          ].join(" union all ")} order by created_at`,
+        },
+
+        display: "bar",
+        visualization_settings: {
+          "graph.dimensions": ["CREATED_AT", "CATEGORY"],
+          "graph.metrics": ["V"],
+          "stackable.stack_type": "stacked",
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    H.chartPathWithFillColor("#F9D45C").eq(0).realHover();
+    H.assertEChartsTooltip({
+      rows: [
+        {
+          color: "#EF8C8C",
+          name: "cat1",
+          value: "2",
+          secondaryValue: "66.67 %",
         },
         {
-          name: "Total",
+          color: "#F2A86F",
+          name: "cat3",
           value: "1",
-          secondaryValue: "100 %",
+          secondaryValue: "33.33 %",
         },
+        { name: "Total positive", value: "3" },
+        {
+          color: "#98D9D9",
+          name: "cat4",
+          value: "-1",
+          secondaryValue: "-50.00 %",
+        },
+        {
+          color: "#F9D45C",
+          name: "cat2",
+          value: "-1",
+          secondaryValue: "-50.00 %",
+        },
+        { name: "Total negative", value: "-2" },
+        { name: "Total", value: "1" },
       ],
     });
     H.echartsTriggerBlur();

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -34,4 +34,4 @@ export const formatNumber = (number: number, options?: NumberFormatOptions) => {
 };
 
 export const formatPercent = (percent: number) =>
-  `${(100 * percent).toFixed(percent === 1 ? 0 : 2)} %`;
+  `${(100 * percent).toFixed(Math.abs(percent) === 1 ? 0 : 2)} %`;


### PR DESCRIPTION
Closes #47596
Closes VIZ-162

### Description
Updates percent calculation for stacked bar charts’ tooltips for bars with mixed negative and positive values so they make more sense. Positive values are a percentage of the positive total and negative values are a percentage of the negative total.

General approach decided on here: [Slack](https://metaboat.slack.com/archives/C064QMXEV9N/p1749495162499799?thread_ts=1749159879.201589&cid=C064QMXEV9N) + [Figma](https://www.figma.com/design/p7cBpEVMCs3bS2xeH2tl3g/Handling-positive-and-negative-stacked-bar--s-in-tooltips?node-id=4-2&t=rGUYhz9ONqhsxeKc-0)

### How to verify

1. Navigate to a stacked bar chart that has bars with a mix of positive and negative values
2. Verify all-positive bars work the same as before
3. Verify all-negative bars work the same as before (except the tooltip row order is corrected, also "-100.00%" -> "-100%" to mirror "100%")
4. Verify mixed bars have positive and negative totals split into sections with the final total displayed at the bottom but without the potentially confusing/redundant "100%" cells. Positive values should be a percentage of the positive total and negative values should be a percentage of the negative total.

### Demo

https://github.com/user-attachments/assets/ba1338a1-9b27-4f96-946b-54582357aae9

