### PR TITLE
Port dev-scripts to mage start-db

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -82,7 +82,7 @@
                 ["./bin/mage start-db mysql oldest" "start the oldest mysql db we support"]]
    :requires   [[mage.start-db :as start-db]]
    :arg-schema [:tuple
-                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle :presto :sparksql]
+                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle :presto :sparksql :vertica]
                 [:enum :oldest :latest]]
    :db-info      {:postgres   {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
                   :mysql      {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
@@ -91,9 +91,10 @@
                   :sqlserver  {:ports {:oldest 1433 :latest 1434}   :eol-url "https://endoflife.date/api/mssqlserver.json"}
                   :oracle     {:ports {:oldest 1521 :latest 1522}   :eol-url "https://endoflife.date/api/oracle-database.json"}
                   ;; some databases aren't on endoflife.date
-                  :presto     {:ports {:oldest 8080 :latest 8081}    :eol-url nil}
+                  :vertica    {:ports {:oldest 5434 :latest 5435}   :eol-url nil}
+                  :presto     {:ports {:oldest 8080 :latest 8081}   :eol-url nil}
                   :sparksql   {:ports {:oldest 10000 :latest 10001} :eol-url nil}
-                  :clickhouse {:ports {:oldest 8124 :latest 8123}    :eol-url nil}}
+                  :clickhouse {:ports {:oldest 8124 :latest 8123}   :eol-url nil}}
    :usage-fn   start-db/usage
    :task       (task!
                 (let [[db version] (:arguments parsed)]

--- a/bb.edn
+++ b/bb.edn
@@ -82,12 +82,13 @@
                 ["./bin/mage start-db mysql oldest" "start the oldest mysql db we support"]]
    :requires   [[mage.start-db :as start-db]]
    :arg-schema [:tuple
-                [:enum :postgres :mysql :mariadb :mongo]
+                [:enum :postgres :mysql :mariadb :mongo :clickhouse]
                 [:enum :oldest :latest]]
    :db-info      {:postgres {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
                   :mysql    {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
                   :mariadb  {:ports {:oldest 3306  :latest 3307}  :eol-url "https://endoflife.date/api/mariadb.json"}
-                  :mongo    {:ports {:oldest 27017 :latest 27018} :eol-url "https://endoflife.date/api/mongodb.json"}}
+                  :mongo    {:ports {:oldest 27017 :latest 27018} :eol-url "https://endoflife.date/api/mongodb.json"}
+                  :clickhouse {:ports {:oldest 8124 :latest 8123} :eol-url nil}}
    :usage-fn   start-db/usage
    :task       (task!
                 (let [[db version] (:arguments parsed)]

--- a/bb.edn
+++ b/bb.edn
@@ -82,12 +82,13 @@
                 ["./bin/mage start-db mysql oldest" "start the oldest mysql db we support"]]
    :requires   [[mage.start-db :as start-db]]
    :arg-schema [:tuple
-                [:enum :postgres :mysql :mariadb :mongo :clickhouse]
+                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver]
                 [:enum :oldest :latest]]
    :db-info      {:postgres {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
                   :mysql    {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
                   :mariadb  {:ports {:oldest 3306  :latest 3307}  :eol-url "https://endoflife.date/api/mariadb.json"}
                   :mongo    {:ports {:oldest 27017 :latest 27018} :eol-url "https://endoflife.date/api/mongodb.json"}
+                  :sqlserver {:ports {:oldest 1433 :latest 1434} :eol-url "https://endoflife.date/api/mssqlserver.json"}
                   :clickhouse {:ports {:oldest 8124 :latest 8123} :eol-url nil}} ;; clickhouse is not on endoflife.date
    :usage-fn   start-db/usage
    :task       (task!

--- a/bb.edn
+++ b/bb.edn
@@ -82,7 +82,7 @@
                 ["./bin/mage start-db mysql oldest" "start the oldest mysql db we support"]]
    :requires   [[mage.start-db :as start-db]]
    :arg-schema [:tuple
-                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle :presto :sparksql :vertica]
+                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle :presto :sparksql :vertica :druid]
                 [:enum :oldest :latest]]
    :db-info      {:postgres   {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
                   :mysql      {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
@@ -92,6 +92,7 @@
                   :oracle     {:ports {:oldest 1521 :latest 1522}   :eol-url "https://endoflife.date/api/oracle-database.json"}
                   ;; some databases aren't on endoflife.date
                   :vertica    {:ports {:oldest 5434 :latest 5435}   :eol-url nil}
+                  :druid      {:ports {:oldest 8082 :latest 8083}   :eol-url nil}
                   :presto     {:ports {:oldest 8080 :latest 8081}   :eol-url nil}
                   :sparksql   {:ports {:oldest 10000 :latest 10001} :eol-url nil}
                   :clickhouse {:ports {:oldest 8124 :latest 8123}   :eol-url nil}}

--- a/bb.edn
+++ b/bb.edn
@@ -82,14 +82,15 @@
                 ["./bin/mage start-db mysql oldest" "start the oldest mysql db we support"]]
    :requires   [[mage.start-db :as start-db]]
    :arg-schema [:tuple
-                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver]
+                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle]
                 [:enum :oldest :latest]]
-   :db-info      {:postgres {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
-                  :mysql    {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
-                  :mariadb  {:ports {:oldest 3306  :latest 3307}  :eol-url "https://endoflife.date/api/mariadb.json"}
-                  :mongo    {:ports {:oldest 27017 :latest 27018} :eol-url "https://endoflife.date/api/mongodb.json"}
-                  :sqlserver {:ports {:oldest 1433 :latest 1434} :eol-url "https://endoflife.date/api/mssqlserver.json"}
-                  :clickhouse {:ports {:oldest 8124 :latest 8123} :eol-url nil}} ;; clickhouse is not on endoflife.date
+   :db-info      {:postgres   {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
+                  :mysql      {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
+                  :mariadb    {:ports {:oldest 3306  :latest 3307}  :eol-url "https://endoflife.date/api/mariadb.json"}
+                  :mongo      {:ports {:oldest 27017 :latest 27018} :eol-url "https://endoflife.date/api/mongodb.json"}
+                  :sqlserver  {:ports {:oldest 1433 :latest 1434}   :eol-url "https://endoflife.date/api/mssqlserver.json"}
+                  :oracle     {:ports {:oldest 1521 :latest 1522}   :eol-url "https://endoflife.date/api/oracle-database.json"}
+                  :clickhouse {:ports {:oldest 8124 :latest 8123}   :eol-url nil}} ;; clickhouse is not on endoflife.date
    :usage-fn   start-db/usage
    :task       (task!
                 (let [[db version] (:arguments parsed)]

--- a/bb.edn
+++ b/bb.edn
@@ -82,7 +82,7 @@
                 ["./bin/mage start-db mysql oldest" "start the oldest mysql db we support"]]
    :requires   [[mage.start-db :as start-db]]
    :arg-schema [:tuple
-                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle :presto]
+                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle :presto :sparksql]
                 [:enum :oldest :latest]]
    :db-info      {:postgres   {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
                   :mysql      {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
@@ -91,8 +91,9 @@
                   :sqlserver  {:ports {:oldest 1433 :latest 1434}   :eol-url "https://endoflife.date/api/mssqlserver.json"}
                   :oracle     {:ports {:oldest 1521 :latest 1522}   :eol-url "https://endoflife.date/api/oracle-database.json"}
                   ;; some databases aren't on endoflife.date
-                  :presto     {:ports {:oldest 8080 :latest 8081}   :eol-url nil}
-                  :clickhouse {:ports {:oldest 8124 :latest 8123}   :eol-url nil}}
+                  :presto     {:ports {:oldest 8080 :latest 8081}    :eol-url nil}
+                  :sparksql   {:ports {:oldest 10000 :latest 10001} :eol-url nil}
+                  :clickhouse {:ports {:oldest 8124 :latest 8123}    :eol-url nil}}
    :usage-fn   start-db/usage
    :task       (task!
                 (let [[db version] (:arguments parsed)]

--- a/bb.edn
+++ b/bb.edn
@@ -82,7 +82,7 @@
                 ["./bin/mage start-db mysql oldest" "start the oldest mysql db we support"]]
    :requires   [[mage.start-db :as start-db]]
    :arg-schema [:tuple
-                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle]
+                [:enum :postgres :mysql :mariadb :mongo :clickhouse :sqlserver :oracle :presto]
                 [:enum :oldest :latest]]
    :db-info      {:postgres   {:ports {:oldest 5432  :latest 5433}  :eol-url "https://endoflife.date/api/postgres.json"}
                   :mysql      {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
@@ -90,7 +90,9 @@
                   :mongo      {:ports {:oldest 27017 :latest 27018} :eol-url "https://endoflife.date/api/mongodb.json"}
                   :sqlserver  {:ports {:oldest 1433 :latest 1434}   :eol-url "https://endoflife.date/api/mssqlserver.json"}
                   :oracle     {:ports {:oldest 1521 :latest 1522}   :eol-url "https://endoflife.date/api/oracle-database.json"}
-                  :clickhouse {:ports {:oldest 8124 :latest 8123}   :eol-url nil}} ;; clickhouse is not on endoflife.date
+                  ;; some databases aren't on endoflife.date
+                  :presto     {:ports {:oldest 8080 :latest 8081}   :eol-url nil}
+                  :clickhouse {:ports {:oldest 8124 :latest 8123}   :eol-url nil}}
    :usage-fn   start-db/usage
    :task       (task!
                 (let [[db version] (:arguments parsed)]

--- a/bb.edn
+++ b/bb.edn
@@ -88,7 +88,7 @@
                   :mysql    {:ports {:oldest 3308  :latest 3309}  :eol-url "https://endoflife.date/api/mysql.json"}
                   :mariadb  {:ports {:oldest 3306  :latest 3307}  :eol-url "https://endoflife.date/api/mariadb.json"}
                   :mongo    {:ports {:oldest 27017 :latest 27018} :eol-url "https://endoflife.date/api/mongodb.json"}
-                  :clickhouse {:ports {:oldest 8124 :latest 8123} :eol-url nil}}
+                  :clickhouse {:ports {:oldest 8124 :latest 8123} :eol-url nil}} ;; clickhouse is not on endoflife.date
    :usage-fn   start-db/usage
    :task       (task!
                 (let [[db version] (:arguments parsed)]

--- a/mage/mage/start_db.clj
+++ b/mage/mage/start_db.clj
@@ -84,6 +84,10 @@
   [database db-info]
   "0.286")
 
+(defmethod fetch-oldest-supported-version :sparksql
+  [database db-info]
+  "2.1.1")
+
 (defn- resolve-version [db-info database version]
   (if (= version :oldest)
     (fetch-oldest-supported-version database db-info)
@@ -102,8 +106,7 @@
 
 (defmethod docker-cmd :postgres
   [_db container-name resolved-version port]
-  ["docker" "run"
-   "-d"
+  ["docker" "run" "-d"
    "-p" (str port ":5432")
    ;; "--network" "psql-metabase-network"
    "-e" "POSTGRES_USER=metabase"
@@ -116,8 +119,7 @@
 
 (defmethod docker-cmd :mysql
   [_db container-name resolved-version port]
-  ["docker" "run"
-   "-d"
+  ["docker" "run" "-d"
    "-p" (str port ":3306")
    "-e" "MYSQL_DATABASE=metabase_test"
    "-e" "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
@@ -126,8 +128,7 @@
 
 (defmethod docker-cmd :mariadb
   [_db container-name resolved-version port]
-  ["docker" "run"
-   "-d"
+  ["docker" "run" "-d"
    "-p" (str port ":3306")
    "-e" "MYSQL_DATABASE=metabase_test"
    "-e" "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
@@ -136,8 +137,7 @@
 
 (defmethod docker-cmd :mongo
   [_db container-name resolved-version port]
-  ["docker" "run"
-   "-d"
+  ["docker" "run" "-d"
    "-p" (str port ":27017")
    "--name" container-name
    (str "mongo:" resolved-version)])
@@ -153,8 +153,7 @@
 
 (defmethod docker-cmd :sqlserver
   [_db container-name resolved-version port]
-  ["docker" "run"
-   "-d"
+  ["docker" "run" "-d"
    "-p" (str port ":1433")
    "-e" "ACCEPT_EULA=Y"
    "-e" "SA_PASSWORD=P@ssw0rd"
@@ -163,8 +162,7 @@
 
 (defmethod docker-cmd :oracle
   [_db container-name resolved-version port]
-  ["docker" "run"
-   "-d"
+  ["docker" "run" "-d"
    "-p" (str port ":1521")
    "-e" "ORACLE_PASSWORD=password"
    "--name" container-name
@@ -175,13 +173,19 @@
 (defmethod docker-cmd :presto
   [_db container-name resolved-version port]
   (let [https-port (if (= resolved-version "latest") 8444 8443)]
-    ["docker" "run"
-     "-d"
+    ["docker" "run" "-d"
      "-p" (str port ":8080")
      "-p" (str https-port ":8443")
      "--name" container-name
      "--hostname" "presto"
      (str "prestodb/presto:" resolved-version)]))
+
+(defmethod docker-cmd :sparksql
+  [_db container-name resolved-version port]
+  ["docker" "run" "-d"
+   "-p" (str port ":10000")
+   "--name" container-name
+   (str "metabase/spark:" resolved-version)])
 
 (defn- start-db!
   [database version resolved-version port]

--- a/mage/mage/start_db.clj
+++ b/mage/mage/start_db.clj
@@ -78,7 +78,11 @@
 
 (defmethod fetch-oldest-supported-version :clickhouse
   [database db-info]
-  23.3)
+  "23.3")
+
+(defmethod fetch-oldest-supported-version :presto
+  [database db-info]
+  "0.286")
 
 (defn- resolve-version [db-info database version]
   (if (= version :oldest)
@@ -167,6 +171,17 @@
    (if (= resolved-version "latest")
      "gvenzl/oracle-free:latest"
      (str "gvenzl/oracle-xe:" resolved-version))])
+
+(defmethod docker-cmd :presto
+  [_db container-name resolved-version port]
+  (let [https-port (if (= resolved-version "latest") 8444 8443)]
+    ["docker" "run"
+     "-d"
+     "-p" (str port ":8080")
+     "-p" (str https-port ":8443")
+     "--name" container-name
+     "--hostname" "presto"
+     (str "prestodb/presto:" resolved-version)]))
 
 (defn- start-db!
   [database version resolved-version port]

--- a/mage/mage/start_db.clj
+++ b/mage/mage/start_db.clj
@@ -108,6 +108,10 @@
   [database db-info]
   "29.0.0")
 
+(defmethod fetch-latest-supported-version :sqlserver
+  [database db-info]
+  "2022-latest")
+
 (defn- resolve-version [db-info database version]
   (if (= version :oldest)
     (fetch-oldest-supported-version database db-info)

--- a/mage/mage/start_db.clj
+++ b/mage/mage/start_db.clj
@@ -92,6 +92,10 @@
   [database db-info]
   "23.4.0-0")
 
+(defmethod fetch-oldest-supported-version :druid
+  [database db-info]
+  "0.20.2")
+
 (defn- resolve-version [db-info database version]
   (if (= version :oldest)
     (fetch-oldest-supported-version database db-info)
@@ -206,6 +210,18 @@
        "-p" (str port ":5433")
        "--name" container-name
        (str "opentext/vertica-ce:" resolved-version)])))
+
+(defmethod docker-cmd :druid
+  [_db container-name resolved-version port]
+  (let [host-port (if (= resolved-version "latest") 8085 8084)
+        router-port (if (= resolved-version "latest") 8890 8889)
+        version (if (= resolved-version "latest") "29.0.0" resolved-version)]
+    ["docker" "run" "-d"
+     "-p" (str port ":8081")
+     "-p" (str host-port ":8082")
+     "-p" (str router-port ":8888")
+     "--name" container-name
+     (str "metabase/druid:" version)]))
 
 (defn- start-db!
   [database version resolved-version port]

--- a/modules/drivers/clickhouse/docker-compose.yml
+++ b/modules/drivers/clickhouse/docker-compose.yml
@@ -51,6 +51,7 @@ services:
   ##########################################################################################################
 
   clickhouse_older_version:
+    # if the oldest supported veresion changes please update fetch-supported-versions in mage/mage/start_db.clj
     image: 'clickhouse/clickhouse-server:23.3-alpine'
     container_name: 'mb-clickhouse-oldest'
     hostname: clickhouse.older

--- a/modules/drivers/clickhouse/docker-compose.yml
+++ b/modules/drivers/clickhouse/docker-compose.yml
@@ -5,8 +5,8 @@ services:
   ##########################################################################################################
 
   clickhouse:
-    image: 'clickhouse/clickhouse-server:25.2-alpine'
-    container_name: 'metabase-driver-clickhouse-server'
+    image: 'clickhouse/clickhouse-server:latest-alpine'
+    container_name: 'mb-clickhouse-latest'
     hostname: clickhouse
     ports:
       - '8123:8123'
@@ -52,7 +52,7 @@ services:
 
   clickhouse_older_version:
     image: 'clickhouse/clickhouse-server:23.3-alpine'
-    container_name: 'metabase-driver-clickhouse-server-older-version'
+    container_name: 'mb-clickhouse-oldest'
     hostname: clickhouse.older
     ports:
       - '8124:8123'


### PR DESCRIPTION
### Description

Ports scripts from the [dev-scripts repo](https://github.com/metabase/dev-scripts) to `./bin/mage start-db`. 

### How to verify

`$ ./bin/mage start-db {db} {latest|oldest}`

Should start a container 

### Demo

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
