### PR TITLE
Fix can't download static SQL question

### DIFF
--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -7,6 +7,7 @@ import {
 import { createMockParameter } from "metabase-types/api/mocks";
 
 const { PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATABASE;
+import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 
 /** These tests are about the `downloads` flag for static embeds, both dashboards and questions.
  *  Unless the product changes, these should test the same things as `public-resource-downloads.cy.spec.ts`
@@ -297,17 +298,20 @@ H.describeWithSnowplowEE(
       });
 
       describe("with native question parameters", () => {
-        const FILTER_VALUES = ["NY", "NH"];
-
         beforeEach(() => {
           cy.signInAsAdmin();
 
           H.setTokenFeatures("all");
+        });
+
+        it("should be able to download a static embedded question as CSV with correct parameters when field filters has multiple values (metabase#52430)", () => {
+          const FILTER_VALUES = ["NY", "CA"];
+          const QUESTION_NAME = "Native question with a Field parameter";
 
           // Can't figure out the type if I extracted `questionDetails` to a variable.
           H.createNativeQuestion(
             {
-              name: "Native question with a parameter",
+              name: QUESTION_NAME,
               native: {
                 "template-tags": {
                   state: {
@@ -323,7 +327,8 @@ H.describeWithSnowplowEE(
                     "widget-type": "string/contains",
                   },
                 },
-                query: "select id, email, state from people where {{state}}",
+                query:
+                  "select id, email, state from people where {{state}} limit 2",
               },
               parameters: [
                 {
@@ -349,9 +354,7 @@ H.describeWithSnowplowEE(
             },
           );
           cy.signOut();
-        });
 
-        it("should be able to download a static embedded question as CSV with correct parameters when field filters has multiple values (metabase#52430)", () => {
           cy.get("@questionId").then((questionId) => {
             H.visitEmbeddedPage(
               {
@@ -375,12 +378,118 @@ H.describeWithSnowplowEE(
             "leffler.dominique@hotmail.com",
             FILTER_VALUES[0],
           ];
+          const SECOND_ROW = [
+            13,
+            "mustafa.thiel@hotmail.com",
+            FILTER_VALUES[1],
+          ];
 
           H.assertTableData({
             columns: ["ID", "EMAIL", "STATE"],
+            firstRows: [FIRST_ROW, SECOND_ROW],
+          });
+
+          cy.findByRole("heading", { name: QUESTION_NAME }).realHover();
+          H.downloadAndAssert(
+            {
+              isDashboard: false,
+              isEmbed: true,
+              enableFormatting: true,
+              fileType: "csv",
+              downloadUrl: "/api/embed/card/*/query/csv*",
+              downloadMethod: "GET",
+            },
+            (sheet) => {
+              expect(sheet["A2"].v).to.eq(FIRST_ROW[0]);
+              expect(sheet["B2"].v).to.eq(FIRST_ROW[1]);
+              expect(sheet["C2"].v).to.eq(FIRST_ROW[2]);
+
+              expect(sheet["A3"].v).to.eq(SECOND_ROW[0]);
+              expect(sheet["B3"].v).to.eq(SECOND_ROW[1]);
+              expect(sheet["C3"].v).to.eq(SECOND_ROW[2]);
+            },
+          );
+
+          H.expectUnstructuredSnowplowEvent({
+            event: "download_results_clicked",
+            resource_type: "question",
+            accessed_via: "static-embed",
+            export_type: "csv",
+          });
+        });
+
+        it("should be able to download a static embedded question as CSV when a filter expects 1 parameter value e.g. date (metabase#58957, 59074)", () => {
+          const FILTER_VALUE = "2025-02-11";
+          const QUESTION_NAME = "Native question with a Date parameter";
+
+          // Can't figure out the type if I extracted `questionDetails` to a variable.
+          H.createNativeQuestion(
+            {
+              name: QUESTION_NAME,
+              native: {
+                "template-tags": {
+                  created_at: {
+                    id: "c9bbcc68-c59b-4ac1-b5e7-50d2123b4150",
+                    name: "created_at",
+                    "display-name": "Created At",
+                    type: "date",
+                  },
+                },
+                query:
+                  "select id, created_at, quantity from orders where created_at >= {{created_at}} limit 1",
+              },
+              parameters: [
+                {
+                  id: "c9bbcc68-c59b-4ac1-b5e7-50d2123b4150",
+                  type: "date/single",
+                  options: {
+                    "case-sensitive": false,
+                  },
+                  target: ["variable", ["template-tag", "created_at"]],
+                  name: "Created At",
+                  slug: "created_at",
+                },
+              ],
+              enable_embedding: true,
+              embedding_params: {
+                created_at: "enabled",
+              },
+            },
+            {
+              idAlias: "questionId",
+              wrapId: true,
+            },
+          );
+          cy.signOut();
+
+          cy.get("@questionId").then((questionId) => {
+            H.visitEmbeddedPage(
+              {
+                resource: { question: Number(questionId) },
+                params: {},
+              },
+              {
+                pageStyle: {
+                  downloads: true,
+                },
+              },
+            );
+          });
+
+          cy.button("Created At").should("be.visible").click();
+          DateFilter.setSingleDate(FILTER_VALUE);
+          H.popover().findByText("Add filter").click();
+
+          waitLoading();
+
+          const FIRST_ROW = [1, "February 11, 2025, 9:40 PM", 2];
+
+          H.assertTableData({
+            columns: ["ID", "CREATED_AT", "QUANTITY"],
             firstRows: [FIRST_ROW],
           });
 
+          cy.findByRole("heading", { name: QUESTION_NAME }).realHover();
           H.downloadAndAssert(
             {
               isDashboard: false,
@@ -396,13 +505,6 @@ H.describeWithSnowplowEE(
               expect(sheet["C2"].v).to.eq(FIRST_ROW[2]);
             },
           );
-
-          H.expectUnstructuredSnowplowEvent({
-            event: "download_results_clicked",
-            resource_type: "question",
-            accessed_via: "static-embed",
-            export_type: "csv",
-          });
         });
       });
     });

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -236,12 +236,15 @@ const getDatasetParams = ({
       const params = new URLSearchParams(window.location.search);
 
       const convertSearchParamsToObject = (params: URLSearchParams) => {
-        const object: Record<string, string[]> = {};
+        const object: Record<string, string | string[]> = {};
         for (const [key, value] of params.entries()) {
           if (object[key]) {
-            object[key] = [...object[key], value];
+            object[key] = ([] as string[]).concat(
+              object[key] as string | string[],
+              value,
+            );
           } else {
-            object[key] = [value];
+            object[key] = value;
           }
         }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59074
Closes https://github.com/metabase/metabase/issues/58957

### Description

This bug was introduced by a fix to another P1 bug #58423. Basically, in that PR, I always set the embedded question parameter values to an array, even if there is a single value. Apparently, not all parameter types accept an array. So the fix is to set the value to just value and make it an array when there are more than 1 value.

This only happens when we set parameters in the UI, so we need to make the parameter `editable` and set the value there instead of passing the value in JWT (making it a locked parameter).

I also strengthen the first existing test for #52430 by asserting one more lines with a different parameter value to ensure both parameter values are used in the query correctly.

### How to verify

The new tests should pass. You can verify by reverting the code and the new E2E test should fail.



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
