### PR TITLE
Adds :input_type and :human_readable_field_id to `tmp-modal`

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1174,7 +1174,13 @@
                                                                           :type "string/="}
                                                                          {:id "d"
                                                                           :name "D"
-                                                                          :type "string/="}]}]
+                                                                          :type "string/="}
+                                                                         {:id "e"
+                                                                          :name "E"
+                                                                          :type "string/="}]
+                                                          :visualization_settings
+                                                          {:fields {"c" {:inputType "text"}
+                                                                    "e" {:valueOptions ["a" "b"]}}}}]
               (let [{:keys [status, body]} (req {:scope {:model-id (:id model)
                                                          :table-id (:id table)}
                                                  :action_id (:id action)})]
@@ -1182,18 +1188,22 @@
                 (is (= "Do cool thing" (:title body)))
                 (is (= [{:id "a"
                          :display_name "A"
-                         :type "type/Number"}
+                         :input_type "text"}
                         {:id "b"
                          :display_name "B"
-                         :type "type/Date"}
+                         :input_type "date"}
                         {:id "c"
                          :display_name "C"
-                         :type "type/Text"}
+                         :input_type "textarea"}
                         {:id "d"
                          :display_name "D"
-                         :type "type/Text"}]
+                         :input_type "text"}
+                        {:id "e"
+                         :display_name "E"
+                         :input_type "dropdown"
+                         :value_options ["a" "b"]}]
                        (->> (:parameters body)
-                            (map #(select-keys % [:id :display_name :type])))))))))))))
+                            (map #(select-keys % [:id :display_name :input_type :value_options])))))))))))))
 
 (deftest tmp-modal-table-action-test
   (let [list-req
@@ -1232,24 +1242,24 @@
                       {:keys [status body]} (req {:scope scope
                                                   :action_id create-id})]
                   (is (= 200 status))
-                  (is (= [{:id "text"      :display_name "Text"      :type "type/Text"}
-                          {:id "int"       :display_name "Int"       :type "type/Integer"}
-                          {:id "timestamp" :display_name "Timestamp" :type "type/DateTime"}
-                          {:id "date"      :display_name "Date"      :type "type/Date"}]
+                  (is (= [{:id "text"      :display_name "Text"      :input_type "text"}
+                          {:id "int"       :display_name "Int"       :input_type "text"}
+                          {:id "timestamp" :display_name "Timestamp" :input_type "datetime"}
+                          {:id "date"      :display_name "Date"      :input_type "date"}]
                          (->> (:parameters body)
-                              (map #(select-keys % [:id :display_name :type])))))))
+                              (map #(select-keys % [:id :display_name :input_type])))))))
               (testing "update"
                 (let [scope {:table-id @test-table}
                       {:keys [status body]} (req {:scope scope
                                                   :action_id update-id})]
                   (is (= 200 status))
-                  (is (= [{:id "id"        :display_name "ID"        :type "type/BigInteger"}
-                          {:id "text"      :display_name "Text"      :type "type/Text"}
-                          {:id "int"       :display_name "Int"       :type "type/Integer"}
-                          {:id "timestamp" :display_name "Timestamp" :type "type/DateTime"}
-                          {:id "date"      :display_name "Date"      :type "type/Date"}]
+                  (is (= [{:id "id"        :display_name "ID"        :input_type "text"}
+                          {:id "text"      :display_name "Text"      :input_type "text"}
+                          {:id "int"       :display_name "Int"       :input_type "text"}
+                          {:id "timestamp" :display_name "Timestamp" :input_type "datetime"}
+                          {:id "date"      :display_name "Date"      :input_type "date"}]
                          (->> (:parameters body)
-                              (map #(select-keys % [:id :display_name :type])))))))
+                              (map #(select-keys % [:id :display_name :input_type])))))))
               (testing "delete"
                 (let [scope {:table-id @test-table}
                       {:keys [status body]} (req {:scope scope
@@ -1257,9 +1267,9 @@
                   (is (= 200 status))
                   (is (= [{:id "id"
                            :display_name "ID"
-                           :type "type/BigInteger"}]
+                           :input_type "text"}]
                          (->> (:parameters body)
-                              (map #(select-keys % [:id :display_name :type])))))))))
+                              (map #(select-keys % [:id :display_name :input_type])))))))))
 
           (mt/with-temp
             [:model/Dashboard     dashboard {}


### PR DESCRIPTION
input_type reflects the actual behaviour and limitations of the FE as it
stands.

- Numeric inputs are not yet supported, so leave those as "text"
- All select/dropdowns (categories, fks, model action params with
values) are "dropdown"
- We best-effort textarea vs text using the viz-settings on model action
params, or the :type/Description semantic_type on fields

Extraneous information that is not yet used has been removed.