### PR TITLE
Extract `AddFilterParameterMenu` component

### DIFF
--- a/frontend/src/metabase/dashboard/components/AddFilterParameterMenu/AddFilterParameterMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/AddFilterParameterMenu/AddFilterParameterMenu.tsx
@@ -1,0 +1,79 @@
+import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
+import { t } from "ttag";
+
+import {
+  type ParameterSection,
+  getDashboardParameterSections,
+  getDefaultOptionForParameterSectionMap,
+} from "metabase/parameters/utils/dashboard-options";
+import { getParameterIconName } from "metabase/parameters/utils/ui";
+import { Icon, Menu, type MenuProps, Text } from "metabase/ui";
+import type { ParameterMappingOptions } from "metabase-types/api";
+
+interface AddFilterParameterMenuProps extends MenuProps {
+  children: ReactNode; // trigger content
+  onSelectOption: (option: ParameterMappingOptions) => void;
+}
+
+export const AddFilterParameterMenu = ({
+  opened,
+  children,
+  onSelectOption,
+  ...menuProps
+}: AddFilterParameterMenuProps) => {
+  const sections = getDashboardParameterSections();
+  const [rightSectionWidth, setRightSectionWidth] = useState(0);
+  const rightSectionWidthRef = useRef(0);
+
+  const handleItemClick = (section: ParameterSection) => {
+    const defaultOption = getDefaultOptionForParameterSectionMap()[section.id];
+    if (defaultOption) {
+      onSelectOption(defaultOption);
+    }
+  };
+
+  const handleRightSectionRef = (rightSection: HTMLDivElement | null) => {
+    if (rightSection) {
+      rightSectionWidthRef.current = Math.max(
+        rightSectionWidthRef.current,
+        rightSection.clientWidth,
+      );
+    }
+  };
+
+  useLayoutEffect(() => {
+    if (opened) {
+      setRightSectionWidth(rightSectionWidthRef.current);
+    }
+  }, [opened]);
+
+  return (
+    <Menu opened={opened} trapFocus {...menuProps}>
+      <Menu.Target>{children}</Menu.Target>
+      <Menu.Dropdown data-testid="add-filter-parameter-dropdown">
+        <Menu.Label>{t`Add a filter or parameter`}</Menu.Label>
+        {sections.map((section) => (
+          <Menu.Item
+            key={section.id}
+            leftSection={<Icon name={getParameterIconName(section.id)} />}
+            rightSection={
+              <Text
+                ref={handleRightSectionRef}
+                c="inherit"
+                miw={rightSectionWidth}
+              >
+                {section.description}
+              </Text>
+            }
+            aria-label={section.name}
+            onClick={() => handleItemClick(section)}
+          >
+            <Text c="inherit" fw="bold">
+              {section.name}
+            </Text>
+          </Menu.Item>
+        ))}
+      </Menu.Dropdown>
+    </Menu>
+  );
+};

--- a/frontend/src/metabase/dashboard/components/AddFilterParameterMenu/index.ts
+++ b/frontend/src/metabase/dashboard/components/AddFilterParameterMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./AddFilterParameterMenu";

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddFilterParameterButton/AddFilterParameterButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddFilterParameterButton/AddFilterParameterButton.tsx
@@ -1,4 +1,3 @@
-import { useLayoutEffect, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { ToolbarButton } from "metabase/components/ToolbarButton";
@@ -7,38 +6,18 @@ import {
   hideAddParameterPopover,
   showAddParameterPopover,
 } from "metabase/dashboard/actions";
+import { AddFilterParameterMenu } from "metabase/dashboard/components/AddFilterParameterMenu";
 import { getIsAddParameterPopoverOpen } from "metabase/dashboard/selectors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
-import {
-  type ParameterSection,
-  getDashboardParameterSections,
-  getDefaultOptionForParameterSectionMap,
-} from "metabase/parameters/utils/dashboard-options";
-import { getParameterIconName } from "metabase/parameters/utils/ui";
-import { Icon, Menu, Text } from "metabase/ui";
+import type { ParameterMappingOptions } from "metabase-types/api";
 
 export const AddFilterParameterButton = () => {
-  const sections = getDashboardParameterSections();
-  const dispatch = useDispatch();
   const isOpened = useSelector(getIsAddParameterPopoverOpen);
-  const [rightSectionWidth, setRightSectionWidth] = useState(0);
-  const rightSectionWidthRef = useRef(0);
+  const dispatch = useDispatch();
 
-  const handleItemClick = (section: ParameterSection) => {
-    const defaultOption = getDefaultOptionForParameterSectionMap()[section.id];
-    if (defaultOption) {
-      dispatch(addParameter(defaultOption));
-    }
-  };
-
-  const handleRightSectionRef = (rightSection: HTMLDivElement | null) => {
-    if (rightSection) {
-      rightSectionWidthRef.current = Math.max(
-        rightSectionWidthRef.current,
-        rightSection.clientWidth,
-      );
-    }
+  const handleSelectOption = (option: ParameterMappingOptions) => {
+    dispatch(addParameter(option));
   };
 
   useRegisterShortcut(
@@ -54,55 +33,23 @@ export const AddFilterParameterButton = () => {
     [isOpened],
   );
 
-  useLayoutEffect(() => {
-    if (isOpened) {
-      setRightSectionWidth(rightSectionWidthRef.current);
-    }
-  }, [isOpened]);
-
   return (
-    <Menu
+    <AddFilterParameterMenu
       opened={isOpened}
-      onClose={() => dispatch(hideAddParameterPopover())}
       position="bottom-end"
-      trapFocus
+      onSelectOption={handleSelectOption}
+      onClose={() => dispatch(hideAddParameterPopover())}
     >
-      <Menu.Target>
-        <ToolbarButton
-          icon="filter"
-          onClick={() =>
-            isOpened
-              ? dispatch(hideAddParameterPopover())
-              : dispatch(showAddParameterPopover())
-          }
-          aria-label={t`Add a filter or parameter`}
-          tooltipLabel={t`Add a filter or parameter`}
-        />
-      </Menu.Target>
-      <Menu.Dropdown data-testid="add-filter-parameter-dropdown">
-        <Menu.Label>{t`Add a filter or parameter`}</Menu.Label>
-        {sections.map((section) => (
-          <Menu.Item
-            key={section.id}
-            leftSection={<Icon name={getParameterIconName(section.id)} />}
-            rightSection={
-              <Text
-                ref={handleRightSectionRef}
-                c="inherit"
-                miw={rightSectionWidth}
-              >
-                {section.description}
-              </Text>
-            }
-            aria-label={section.name}
-            onClick={() => handleItemClick(section)}
-          >
-            <Text c="inherit" fw="bold">
-              {section.name}
-            </Text>
-          </Menu.Item>
-        ))}
-      </Menu.Dropdown>
-    </Menu>
+      <ToolbarButton
+        icon="filter"
+        onClick={() =>
+          isOpened
+            ? dispatch(hideAddParameterPopover())
+            : dispatch(showAddParameterPopover())
+        }
+        aria-label={t`Add a filter or parameter`}
+        tooltipLabel={t`Add a filter or parameter`}
+      />
+    </AddFilterParameterMenu>
   );
 };


### PR DESCRIPTION
We will need to add the "Add filter or parameter" menu to heading dashcards for [Allow filters to live in the body of Dashboards](https://linear.app/metabase/project/allow-filters-to-live-in-the-body-of-dashboards-f08b415b4975). The menu component is currently a part of `AddFilterParameterButton` used by the dashboard header. This PR extracts the menu component, so it can be used by both dashboard header and heading dashcards (PR in progress)

<img src="https://github.com/user-attachments/assets/856b9eb1-4c8c-46d1-88af-41e78896582d" width="320px" />

### To verify

No changes expected, CI should be green (lint-migrations and whitespace-linter are failing because of prior BE changes)
