### PR TITLE
fix: enable manual value input into the FK field

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellFKSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs/EditingBodyCellFKSelect.tsx
@@ -22,7 +22,8 @@ export const EditingBodyCellFKSelect = (props: EditingBodyPrimitiveProps) => {
       {...props}
       getDropdownLabelText={getDropdownLabelText}
       getSelectedLabelText={getSelectedLabelText}
-      withCreateNew={false}
+      // Temporary enable create new for FKs (see WRK-490)
+      withCreateNew={true}
     />
   );
 };


### PR DESCRIPTION
Resolves [WRK-490](https://linear.app/metabase/issue/WRK-490/enable-manual-value-input-into-the-fk-field-when-creating-or-updating)
<img width="533" alt="Screenshot 2025-06-09 at 2 24 28 PM" src="https://github.com/user-attachments/assets/5e56791b-7aa7-486c-87ff-9b91511a6893" />
