### PR TITLE
Fix the stale database cache when we enable or disable uploads for a certain database

### DIFF
--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.unit.spec.tsx
@@ -1,17 +1,36 @@
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
 
-import { setupSchemaEndpoints } from "__support__/server-mocks";
+import {
+  setupDatabaseListEndpoint,
+  setupPropertiesEndpoints,
+  setupSchemaEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+} from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  waitForLoaderToBeRemoved,
+  within,
+} from "__support__/ui";
+import { findRequests } from "__support__/utils";
 import { UndoListing } from "metabase/containers/UndoListing";
 import type { Database } from "metabase-types/api";
-import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
+import {
+  createMockDatabase,
+  createMockSettings,
+  createMockTable,
+} from "metabase-types/api/mocks";
 import type { UploadsSettings } from "metabase-types/api/settings";
 import { createMockState } from "metabase-types/store/mocks";
 
-import { UploadSettingsFormView } from "./UploadSettingsForm";
+import {
+  UploadSettingsForm,
+  UploadSettingsFormView,
+} from "./UploadSettingsForm";
 
 const TEST_DATABASES = [
   createMockDatabase({
@@ -73,11 +92,6 @@ function setup({
     setupSchemaEndpoints(db);
   });
 
-  fetchMock.get(
-    { url: "path:/api/database", overwriteRoutes: true },
-    { data: databases, total: databases.length },
-  );
-
   const updateSpy = jest.fn(() => Promise.resolve({ error: "" }));
 
   renderWithProviders(
@@ -94,7 +108,40 @@ function setup({
   return { updateSpy };
 }
 
-describe("Admin > Settings > UploadSettingsForm", () => {
+async function setupOuter({
+  databases = TEST_DATABASES,
+  uploadsSettings = {
+    db_id: null,
+    schema_name: null,
+    table_prefix: null,
+  },
+  isHosted = false,
+}: SetupOpts = {}) {
+  const settings = createMockSettings({
+    "is-hosted?": isHosted,
+    "uploads-settings": uploadsSettings,
+  });
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupUpdateSettingEndpoint();
+  setupDatabaseListEndpoint(databases);
+
+  databases.forEach((db) => {
+    setupSchemaEndpoints(db);
+  });
+
+  renderWithProviders(
+    <>
+      <UploadSettingsForm />
+      <UndoListing />
+    </>,
+  );
+
+  await waitForLoaderToBeRemoved();
+}
+
+describe("Admin > Settings > UploadSettingsFormView", () => {
   it("should render a description", async () => {
     setup();
     expect(
@@ -300,10 +347,6 @@ describe("Admin > Settings > UploadSettingsForm", () => {
         schema_name: null,
         table_prefix: null,
       },
-    });
-
-    await waitFor(() => {
-      expect(fetchMock.calls("path:/api/database")).toHaveLength(2);
     });
   });
 
@@ -637,6 +680,53 @@ describe("Admin > Settings > UploadSettingsForm", () => {
         /By enabling uploads to the Sample Database, you agree that you will not upload or otherwise transmit any individually identifiable information/,
       ),
     ).toBeInTheDocument();
+  });
+});
+
+describe("Admin > Settings > UploadSettingsForm", () => {
+  it("should re-fetch databases after update", async () => {
+    await setupOuter({
+      uploadsSettings: {
+        db_id: null,
+        schema_name: null,
+        table_prefix: null,
+      },
+    });
+    await userEvent.click(
+      await screen.findByPlaceholderText("Select a database"),
+    );
+
+    const dbItem = await screen.findByText("Db Uno");
+    await userEvent.click(dbItem);
+    await screen.findByDisplayValue("1");
+
+    const schemaDropdown =
+      await screen.findByPlaceholderText("Select a schema");
+    await waitFor(() => expect(schemaDropdown).toBeEnabled());
+    await userEvent.click(schemaDropdown);
+
+    const schemaItem = await screen.findByText("uploads");
+
+    await userEvent.click(schemaItem);
+
+    const gets = await findRequests("GET");
+    const databaseGets = gets.filter((req) =>
+      req.url.includes("/api/database"),
+    );
+    expect(databaseGets).toHaveLength(2);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Enable uploads" }),
+    );
+
+    const puts = await findRequests("PUT");
+    expect(puts).toHaveLength(1);
+
+    const gets2 = await findRequests("GET");
+    const databaseGets2 = gets2.filter((req) =>
+      req.url.includes("/api/database"),
+    );
+    expect(databaseGets2).toHaveLength(3);
   });
 });
 

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import { setupSchemaEndpoints } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
@@ -71,6 +72,11 @@ function setup({
   databases.forEach((db) => {
     setupSchemaEndpoints(db);
   });
+
+  fetchMock.get(
+    { url: "path:/api/database", overwriteRoutes: true },
+    { data: databases, total: databases.length },
+  );
 
   const updateSpy = jest.fn(() => Promise.resolve({ error: "" }));
 
@@ -294,6 +300,10 @@ describe("Admin > Settings > UploadSettingsForm", () => {
         schema_name: null,
         table_prefix: null,
       },
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.calls("path:/api/database")).toHaveLength(2);
     });
   });
 

--- a/frontend/src/metabase/api/settings.ts
+++ b/frontend/src/metabase/api/settings.ts
@@ -9,7 +9,7 @@ import type {
 } from "metabase-types/api";
 
 import { Api } from "./api";
-import { invalidateTags, tag } from "./tags";
+import { invalidateTags, listTag, tag } from "./tags";
 
 export const settingsApi = Api.injectEndpoints({
   endpoints: (builder) => ({
@@ -51,8 +51,12 @@ export const settingsApi = Api.injectEndpoints({
         url: `/api/setting/${encodeURIComponent(key)}`,
         body: { value },
       }),
-      invalidatesTags: (_, error) =>
-        invalidateTags(error, [tag("session-properties")]),
+      invalidatesTags: (_, error, { key }) => {
+        return invalidateTags(error, [
+          tag("session-properties"),
+          ...(key === "uploads-settings" ? [listTag("database")] : []),
+        ]);
+      },
     }),
     updateSettings: builder.mutation<void, Partial<EnterpriseSettings>>({
       query: (settings) => ({

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -34,9 +34,12 @@ export function setupDatabaseUsageInfoEndpoint(
   fetchMock.get(`path:/api/database/${db.id}/usage_info`, usageInfo);
 }
 
-export function setupDatabaseListEndpoint(databases: Database[]) {
+export function setupDatabaseListEndpoint(
+  databases: Database[],
+  { overwriteRoutes = false }: { overwriteRoutes?: boolean } = {},
+) {
   fetchMock.get(
-    { url: "path:/api/database", overwriteRoutes: true },
+    { url: "path:/api/database", overwriteRoutes },
     { data: databases, total: databases.length },
   );
 }

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -34,6 +34,13 @@ export function setupDatabaseUsageInfoEndpoint(
   fetchMock.get(`path:/api/database/${db.id}/usage_info`, usageInfo);
 }
 
+export function setupDatabaseListEndpoint(databases: Database[]) {
+  fetchMock.get(
+    { url: "path:/api/database", overwriteRoutes: true },
+    { data: databases, total: databases.length },
+  );
+}
+
 export function setupDatabasesEndpoints(
   databases: Database[],
   { hasSavedQuestions = true } = {},
@@ -53,10 +60,7 @@ export function setupDatabasesEndpoints(
       total: databasesWithSavedQuestions.length,
     },
   );
-  fetchMock.get(
-    { url: "path:/api/database", overwriteRoutes: false },
-    { data: databases, total: databases.length },
-  );
+  setupDatabaseListEndpoint(databases);
   fetchMock.post("path:/api/database", async (url) => {
     const lastCall = fetchMock.lastCall(url);
     return await lastCall?.request?.json();


### PR DESCRIPTION
Fixes PRG-31.
Slack context: https://metaboat.slack.com/archives/C064EB1UE5P/p1749224096023579

tl;dr
Before this PR, there wasn't a single mechanism that would look at the `key` or `value` we're sending in the `PUT /api/setting` endpoint. Up until now, we were simply invalidating the `session-properties`.

This resulted in the stale database cache when we enable or disable uploads. This PR fixes that.