### PR TITLE
__METABASE_ROUTER__ instead of primary db

### DIFF
--- a/docs/permissions/database-routing.md
+++ b/docs/permissions/database-routing.md
@@ -34,7 +34,7 @@ For database routing to work, your users must have a user attribute that Metabas
 
 You can add user attributes manually, or via Single Sign-On (SSO) via [JWT](../people-and-groups/authenticating-with-jwt.md) or [SAML](../people-and-groups/authenticating-with-saml.md).
 
-If an admin user lacks a value for the user attribute, they'll see the router database. You can also explicitly set the value for admins (or any user) to `__METABASE_PRIMARY_DB__`.
+If an admin user lacks a value for the user attribute, they'll see the router database. You can also explicitly set the value for admins (or any user) to `__METABASE_ROUTER__`.
 
 If a non-admin user account lacks a valid value for the user attribute, they won't be able to view the question at all.
 


### PR DESCRIPTION
The attribute value to hit the primary db is actually `__METABASE_ROUTER__`