### PR TITLE
Parse Back to prior release in release logs

### DIFF
--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -14,8 +14,9 @@ type CommitInfo = {
 const tablePageTemplate = fs.readFileSync('./src/tablePageTemplate.html', 'utf8');
 
 export async function gitLog(majorVersion: number) {
-  const { stdout: baseCommit } = await $`git merge-base origin/release-x.${majorVersion}.x origin/master`;
-  const { stdout } = await $`git log origin/release-x.${majorVersion}.x ..${baseCommit.trim()} --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'`;
+  const previousMajorVersion = majorVersion - 1; // we want to parse back to the prior major version to get everything in the .0 release.
+  const { stdout: baseCommit } = await $`git merge-base origin/release-x.${previousMajorVersion}.x origin/master`;
+  const { stdout } = await $`git log origin/release-x.${majorVersion}.x ...${baseCommit.trim()} --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'`;
   const processedCommits = stdout.split('\n').map(processCommit);
   return buildTable(processedCommits, majorVersion);
 }

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -34,8 +34,17 @@ export function processCommit(commitLine: string): CommitInfo {
 
 const issueLink = (issueNumber: string) => `https://github.com/metabase/metabase/issues/${issueNumber}`;
 
+function escapeHtml(unsafe: string) {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 function linkifyIssueNumbers(message: string) {
-  return message?.replace(issueNumberRegex, (_, issueNumber) => {
+  return escapeHtml(message)?.replace(issueNumberRegex, (_, issueNumber) => {
     return `<a href="${issueLink(issueNumber)}" target="_blank">(#${issueNumber})</a>`;
   }) ?? message ?? '';
 }


### PR DESCRIPTION

Closes ADM-899

### Description

Parse back to the prior release when creating release logs in order to show everything in the .0 release

Also adds some code to escape html entities.