### PR TITLE
Fix filtering for string SQL columns

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -825,6 +825,7 @@ describe("scenarios > question > custom column", () => {
     });
     H.expressionEditorWidget().button("Done").click();
     H.getNotebookStep("expression").button("Filter").click();
+    H.selectFilterOperator("Is");
     H.clauseStepPopover().within(() => {
       cy.findByText("If").click();
       cy.findByPlaceholderText("Enter some text").type("Other");

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -825,9 +825,11 @@ describe("scenarios > question > custom column", () => {
     });
     H.expressionEditorWidget().button("Done").click();
     H.getNotebookStep("expression").button("Filter").click();
-    H.selectFilterOperator("Is");
     H.clauseStepPopover().within(() => {
       cy.findByText("If").click();
+    });
+    H.selectFilterOperator("Is");
+    H.clauseStepPopover().within(() => {
       cy.findByPlaceholderText("Enter some text").type("Other");
       cy.button("Add filter").click();
     });

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -366,7 +366,7 @@ describe("issue 22230", () => {
 
     H.clauseStepPopover().within(() => {
       cy.findByText("Max of Name").click();
-      cy.findByText("Is").click();
+      cy.findByText("Contains").click();
     });
     cy.findByRole("menu").findByText("Starts with").click();
 

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -849,7 +849,7 @@
           search-field-id (:id search-column)]
       {:field-id (when (int? column-field-id) column-field-id)
        :search-field-id (when (int? search-field-id) search-field-id)
-       :search-field search-column
-       :has-field-values (if column
+       :search-field (when (int? search-field-id) search-column)
+       :has-field-values (if (int? column-field-id)
                            (infer-has-field-values column)
                            :none)})))

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1760,7 +1760,19 @@
                  (:venues/native (lib.tu/mock-cards)))
                 lib/append-stage
                 lib/visible-columns
-                first)))))
+                first))))
+    (is (= {:field-id nil
+            :search-field-id nil
+            :search-field nil
+            :has-field-values :none}
+           (lib.field/field-values-search-info
+            meta/metadata-provider
+            (->> (-> (lib.tu/query-with-stage-metadata-from-card
+                      meta/metadata-provider
+                      (:venues/native (lib.tu/mock-cards)))
+                     lib/append-stage
+                     lib/visible-columns)
+                 (m/find-first (comp #{"NAME"} :name)))))))
   (testing "field-id with custom metadata (#37100)"
     (is (=? {:field-id 1
              :search-field-id 1

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1767,11 +1767,11 @@
             :has-field-values :none}
            (lib.field/field-values-search-info
             meta/metadata-provider
-            (->> (-> (lib.tu/query-with-stage-metadata-from-card
-                      meta/metadata-provider
-                      (:venues/native (lib.tu/mock-cards)))
-                     lib/append-stage
-                     lib/visible-columns)
+            (->> (lib.tu/query-with-stage-metadata-from-card
+                  meta/metadata-provider
+                  (:venues/native (lib.tu/mock-cards)))
+                 lib/append-stage
+                 lib/visible-columns
                  (m/find-first (comp #{"NAME"} :name)))))))
   (testing "field-id with custom metadata (#37100)"
     (is (=? {:field-id 1


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/56921

There was a subtle bug in `field-values-search-info`. It didn't check that the `searchable-column` has an ID and actually can be used for searching. This issue made the UI behave in a wrong way, suggesting `Is` over `Contains`.

How to verify:
- New -> SQL -> `SELECT * FROM PRODUCTS` -> Save
- Explore results -> Click on `CATEGORY` -> Filter on this column
- The operator should be `Contains` because it's not a PK/FK and we cannot search.