### PR TITLE
chore: split NativeQueryEditor to components

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -23,8 +23,6 @@ import {
 import SnippetFormModal from "metabase/query_builder/components/template_tags/SnippetFormModal";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
-import { Flex } from "metabase/ui";
-import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type {
@@ -33,28 +31,22 @@ import type {
   DatabaseId,
   NativeQuerySnippet,
   ParameterId,
-  TableId,
 } from "metabase-types/api";
-
-import { ResponsiveParametersList } from "../ResponsiveParametersList";
 
 import {
   CodeMirrorEditor,
   type CodeMirrorEditorProps,
   type CodeMirrorEditorRef,
 } from "./CodeMirrorEditor";
-import DataSourceSelectors from "./DataSourceSelectors";
 import S from "./NativeQueryEditor.module.css";
 import type { Features as SidebarFeatures } from "./NativeQueryEditorActionButtons";
-import { NativeQueryEditorActionButtons } from "./NativeQueryEditorActionButtons";
 import { NativeQueryEditorRunButton } from "./NativeQueryEditorRunButton/NativeQueryEditorRunButton";
+import { NativeQueryEditorTopBar } from "./NativeQueryEditorTopBar/NativeQueryEditorTopBar";
 import { RightClickPopover } from "./RightClickPopover";
-import { VisibilityToggler } from "./VisibilityToggler";
 import { MIN_HEIGHT_LINES } from "./constants";
 import type { SelectionRange } from "./types";
 import {
   calcInitialEditorHeight,
-  formatQuery,
   getEditorLineHeight,
   getMaxAutoSizeLines,
 } from "./utils";
@@ -135,7 +127,6 @@ interface NativeQueryEditorState {
   initialHeight: number;
   isSelectedTextPopoverOpen: boolean;
   mobileShowParameterList: boolean;
-  isPromptInputVisible: boolean;
 }
 
 class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
@@ -150,7 +141,6 @@ class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
       initialHeight: calcInitialEditorHeight({ query, viewHeight }),
       isSelectedTextPopoverOpen: false,
       mobileShowParameterList: false,
-      isPromptInputVisible: false,
     };
   }
 
@@ -206,41 +196,10 @@ class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
     this.editor.current?.focus();
   }
 
-  // Change the Database we're currently editing a query for.
-  setDatabaseId = (databaseId: DatabaseId) => {
-    const { query, setDatasetQuery, question, onSetDatabaseId } = this.props;
-
-    if (question.databaseId() !== databaseId) {
-      setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
-
-      onSetDatabaseId?.(databaseId);
-      this.focus();
-    }
-  };
-
-  setTableId = (tableId: TableId) => {
-    const { query, setDatasetQuery } = this.props;
-    const table = query.metadata().table(tableId);
-    if (table && table.name !== query.collection()) {
-      setDatasetQuery(query.setCollectionName(table.name));
-    }
-  };
-
-  setParameterIndex = (parameterId: ParameterId, parameterIndex: number) => {
-    const { query, setDatasetQuery } = this.props;
-    setDatasetQuery(query.setParameterIndex(parameterId, parameterIndex));
-  };
-
   handleFilterButtonClick = () => {
     this.setState({
       mobileShowParameterList: !this.state.mobileShowParameterList,
     });
-  };
-
-  togglePromptVisibility = () => {
-    this.setState((prev) => ({
-      isPromptInputVisible: !prev.isPromptInputVisible,
-    }));
   };
 
   handleRightClickSelection = () => {
@@ -274,49 +233,25 @@ class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
     this.focus();
   };
 
-  formatQuery = async () => {
-    const { question } = this.props;
-    const query = question.query();
-    const engine = Lib.engine(query);
-    const queryText = Lib.rawNativeQuery(query);
-
-    if (!engine) {
-      // no engine found, do nothing
-      return;
-    }
-
-    const formattedQuery = await formatQuery(queryText, engine);
-    this.onChange(formattedQuery);
-    this.focus();
-  };
-
   render() {
     const {
       question,
       query,
-      setParameterValue,
       readOnly,
       isNativeEditorOpen,
       openSnippetModalWithSelectedText,
       openDataReferenceAtQuestion,
-      hasParametersList = true,
       hasTopBar = true,
       hasEditingSidebar = true,
       resizableBoxProps = {},
       snippetCollections = [],
       resizable,
-      editorContext = "question",
       setDatasetQuery,
       setNativeEditorSelectedRange,
-      sidebarFeatures,
-      canChangeDatabase,
-      setParameterValueToDefault,
       forwardedRef,
       runQuery,
       highlightedLineNumbers,
     } = this.props;
-
-    const parameters = query.question().parameters();
 
     const dragHandle = resizable ? (
       <div className={S.dragHandleContainer}>
@@ -335,64 +270,35 @@ class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
         ref={forwardedRef}
       >
         {hasTopBar && (
-          <Flex align="flex-start" data-testid="native-query-top-bar">
-            {canChangeDatabase && (
-              <DataSourceSelectors
-                isNativeEditorOpen={isNativeEditorOpen}
-                query={query}
-                question={question}
-                readOnly={readOnly}
-                setDatabaseId={this.setDatabaseId}
-                setTableId={this.setTableId}
-                editorContext={editorContext}
-              />
-            )}
-            {hasParametersList && (
-              <ResponsiveParametersList
-                question={question}
-                parameters={parameters}
-                setParameterValue={setParameterValue}
-                setParameterIndex={this.setParameterIndex}
-                setParameterValueToDefault={setParameterValueToDefault}
-                enableParameterRequiredBehavior
-              />
-            )}
-            <Flex ml="auto" gap="lg" mr="lg" align="center" h="55px">
-              {isNativeEditorOpen && hasEditingSidebar && !readOnly && (
-                <NativeQueryEditorActionButtons
-                  features={sidebarFeatures}
-                  onShowPromptInput={this.togglePromptVisibility}
-                  onFormatQuery={this.formatQuery}
-                  onGenerateQuery={this.onChange}
-                  question={question}
-                  nativeEditorSelectedText={this.props.nativeEditorSelectedText}
-                  snippetCollections={snippetCollections}
-                  snippets={this.props.snippets}
-                  isRunnable={this.props.isRunnable}
-                  isRunning={this.props.isRunning}
-                  isResultDirty={this.props.isResultDirty}
-                  isShowingDataReference={this.props.isShowingDataReference}
-                  isShowingTemplateTagsEditor={
-                    this.props.isShowingTemplateTagsEditor
-                  }
-                  isShowingSnippetSidebar={this.props.isShowingSnippetSidebar}
-                  onOpenModal={this.props.onOpenModal}
-                  toggleDataReference={this.props.toggleDataReference}
-                  toggleTemplateTagsEditor={this.props.toggleTemplateTagsEditor}
-                  toggleSnippetSidebar={this.props.toggleSnippetSidebar}
-                />
-              )}
-              {query.hasWritePermission() &&
-                !query.question().isArchived() &&
-                this.props.setIsNativeEditorOpen && (
-                  <VisibilityToggler
-                    isOpen={isNativeEditorOpen}
-                    readOnly={!!readOnly}
-                    toggleEditor={this.props.toggleEditor}
-                  />
-                )}
-            </Flex>
-          </Flex>
+          <NativeQueryEditorTopBar
+            isRunnable={this.props.isRunnable}
+            isRunning={this.props.isRunning}
+            isResultDirty={this.props.isResultDirty}
+            isShowingDataReference={this.props.isShowingDataReference}
+            onOpenModal={this.props.onOpenModal}
+            isShowingTemplateTagsEditor={this.props.isShowingTemplateTagsEditor}
+            toggleDataReference={this.props.toggleDataReference}
+            toggleSnippetSidebar={this.props.toggleSnippetSidebar}
+            toggleTemplateTagsEditor={this.props.toggleTemplateTagsEditor}
+            setIsNativeEditorOpen={this.props.setIsNativeEditorOpen}
+            snippets={this.props.snippets}
+            nativeEditorSelectedText={this.props.nativeEditorSelectedText}
+            editorContext={this.props.editorContext}
+            onSetDatabaseId={this.props.onSetDatabaseId}
+            canChangeDatabase={this.props.canChangeDatabase}
+            onChange={this.onChange}
+            focus={this.focus}
+            hasEditingSidebar={hasEditingSidebar}
+            question={question}
+            query={query}
+            isShowingSnippetSidebar={this.props.isShowingSnippetSidebar}
+            isNativeEditorOpen={this.props.isNativeEditorOpen}
+            sidebarFeatures={this.props.sidebarFeatures}
+            toggleEditor={this.props.toggleEditor}
+            setParameterValueToDefault={this.props.setParameterValueToDefault}
+            setParameterValue={this.props.setParameterValue}
+            setDatasetQuery={this.props.setDatasetQuery}
+          />
         )}
         <ResizableBox
           ref={this.resizeBox}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -273,6 +273,7 @@ class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
           <NativeQueryEditorTopBar
             isRunnable={this.props.isRunnable}
             isRunning={this.props.isRunning}
+            hasParametersList={this.props.hasParametersList}
             isResultDirty={this.props.isResultDirty}
             isShowingDataReference={this.props.isShowingDataReference}
             onOpenModal={this.props.onOpenModal}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorActionButtons/NativeQueryEditorActionButtons.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorActionButtons/NativeQueryEditorActionButtons.tsx
@@ -35,11 +35,9 @@ interface NativeQueryEditorActionButtonsProps {
   isShowingDataReference: boolean;
   isShowingTemplateTagsEditor: boolean;
   isShowingSnippetSidebar: boolean;
-  isPromptInputVisible?: boolean;
   runQuery?: () => void;
   cancelQuery?: () => void;
   onOpenModal: (modalType: QueryModalType) => void;
-  onShowPromptInput: () => void;
   toggleDataReference: () => void;
   toggleTemplateTagsEditor: () => void;
   toggleSnippetSidebar: () => void;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
@@ -1,0 +1,197 @@
+import type { QueryModalType } from "metabase/query_builder/constants";
+import { Flex } from "metabase/ui";
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
+import type {
+  Collection,
+  DatabaseId,
+  NativeQuerySnippet,
+  ParameterId,
+  TableId,
+} from "metabase-types/api";
+
+import { ResponsiveParametersList } from "../../ResponsiveParametersList";
+import DataSourceSelectors from "../DataSourceSelectors/DataSourceSelectors";
+import type { Features as SidebarFeatures } from "../NativeQueryEditorActionButtons";
+import { NativeQueryEditorActionButtons } from "../NativeQueryEditorActionButtons/NativeQueryEditorActionButtons";
+import { VisibilityToggler } from "../VisibilityToggler/VisibilityToggler";
+import { formatQuery } from "../utils";
+
+interface NativeQueryEditorTopBarProps {
+  question: Question;
+  query: NativeQuery;
+
+  isRunnable: boolean;
+  isRunning: boolean;
+  isResultDirty: boolean;
+  isShowingSnippetSidebar: boolean;
+  isShowingDataReference: boolean;
+  isShowingTemplateTagsEditor: boolean;
+  isNativeEditorOpen: boolean;
+  nativeEditorSelectedText?: string;
+  canChangeDatabase: boolean;
+  hasParametersList?: boolean;
+  hasEditingSidebar: boolean;
+  readOnly?: boolean;
+
+  snippets?: NativeQuerySnippet[];
+  editorContext?: "question";
+  snippetCollections?: Collection[];
+  sidebarFeatures: SidebarFeatures;
+
+  toggleDataReference: () => void;
+  toggleTemplateTagsEditor: () => void;
+  toggleEditor: () => void;
+  toggleSnippetSidebar: () => void;
+  setIsNativeEditorOpen?: (isOpen: boolean) => void;
+  onSetDatabaseId?: (id: DatabaseId) => void;
+  onOpenModal: (modalType: QueryModalType) => void;
+  onChange: (queryText: string) => void;
+  setParameterValueToDefault: (parameterId: ParameterId) => void;
+  setParameterValue: (parameterId: ParameterId, value: string) => void;
+  focus: () => void;
+  setDatasetQuery: (query: NativeQuery) => Promise<Question>;
+}
+
+const NativeQueryEditorTopBar = (props: NativeQueryEditorTopBarProps) => {
+  const {
+    query,
+    question,
+    onChange,
+    canChangeDatabase,
+    isNativeEditorOpen,
+    readOnly,
+    editorContext = "question",
+    setParameterValue,
+    sidebarFeatures,
+    hasEditingSidebar,
+    snippetCollections,
+    focus: setFocus,
+    snippets,
+    isRunnable,
+    isRunning,
+    isResultDirty,
+    isShowingDataReference,
+    isShowingTemplateTagsEditor,
+    isShowingSnippetSidebar,
+    onOpenModal,
+    toggleDataReference,
+    toggleTemplateTagsEditor,
+    toggleSnippetSidebar,
+    nativeEditorSelectedText,
+    setIsNativeEditorOpen,
+    toggleEditor,
+    onSetDatabaseId,
+    hasParametersList = true,
+    setParameterValueToDefault,
+    setDatasetQuery,
+  } = props;
+
+  const setTableId = (tableId: TableId) => {
+    const table = query.metadata().table(tableId);
+    if (table && table.name !== query.collection()) {
+      setDatasetQuery(query.setCollectionName(table.name));
+    }
+  };
+
+  const setParameterIndex = (
+    parameterId: ParameterId,
+    parameterIndex: number,
+  ) => {
+    // could be
+    // dispatch(updateQuestion(question.setDatasetQuery(datasetQuery)));
+    setDatasetQuery(query.setParameterIndex(parameterId, parameterIndex));
+  };
+
+  // Change the Database we're currently editing a query for.
+  const setDatabaseId = (databaseId: DatabaseId) => {
+    if (question.databaseId() !== databaseId) {
+      setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
+
+      onSetDatabaseId?.(databaseId);
+      setFocus();
+    }
+  };
+
+  const handleFormatQuery = async () => {
+    const query = question.query();
+    const engine = Lib.engine(query);
+    const queryText = Lib.rawNativeQuery(query);
+
+    if (!engine) {
+      // no engine found, do nothing
+      return;
+    }
+
+    const formattedQuery = await formatQuery(queryText, engine);
+    onChange(formattedQuery);
+    setFocus();
+  };
+
+  if (!question) {
+    return null;
+  }
+
+  const parameters = question.parameters();
+
+  return (
+    <Flex align="flex-start" data-testid="native-query-top-bar">
+      {canChangeDatabase && (
+        <DataSourceSelectors
+          isNativeEditorOpen={isNativeEditorOpen}
+          query={query}
+          question={question}
+          readOnly={readOnly}
+          setDatabaseId={setDatabaseId}
+          setTableId={setTableId}
+          editorContext={editorContext}
+        />
+      )}
+      {hasParametersList && (
+        <ResponsiveParametersList
+          question={question}
+          parameters={parameters}
+          setParameterValue={setParameterValue}
+          setParameterIndex={setParameterIndex}
+          setParameterValueToDefault={setParameterValueToDefault}
+          enableParameterRequiredBehavior
+        />
+      )}
+      <Flex ml="auto" gap="lg" mr="lg" align="center" h="55px">
+        {isNativeEditorOpen && hasEditingSidebar && !readOnly && (
+          <NativeQueryEditorActionButtons
+            features={sidebarFeatures}
+            onFormatQuery={handleFormatQuery}
+            onGenerateQuery={onChange}
+            question={question}
+            nativeEditorSelectedText={nativeEditorSelectedText}
+            snippetCollections={snippetCollections}
+            snippets={snippets}
+            isRunnable={isRunnable}
+            isRunning={isRunning}
+            isResultDirty={isResultDirty}
+            isShowingDataReference={isShowingDataReference}
+            isShowingTemplateTagsEditor={isShowingTemplateTagsEditor}
+            isShowingSnippetSidebar={isShowingSnippetSidebar}
+            onOpenModal={onOpenModal}
+            toggleDataReference={toggleDataReference}
+            toggleTemplateTagsEditor={toggleTemplateTagsEditor}
+            toggleSnippetSidebar={toggleSnippetSidebar}
+          />
+        )}
+        {query.hasWritePermission() &&
+          !question.isArchived() &&
+          setIsNativeEditorOpen && (
+            <VisibilityToggler
+              isOpen={isNativeEditorOpen}
+              readOnly={!!readOnly}
+              toggleEditor={toggleEditor}
+            />
+          )}
+      </Flex>
+    </Flex>
+  );
+};
+
+export { NativeQueryEditorTopBar };


### PR DESCRIPTION
separate NativeQueryEditorTopBar from a main NativeQueryEditor component to avoid unnecessary re-renderings because of the state changes