### PR TITLE
Downgrade clickhouse jdbc driver to 0.8.4

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -222,9 +222,9 @@
               (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                              :attributes     {"impersonation_attr" role-a}}
                 (is (= [[100]]
-                       (mt/rows
-                        (mt/run-mbql-query venues
-                          {:aggregation [[:count]]}))))
+                       (mt/formatted-rows [int]
+                                          (mt/run-mbql-query venues
+                                            {:aggregation [[:count]]}))))
                 (is (thrown?
                      java.lang.Exception
                      (mt/run-mbql-query checkins
@@ -232,9 +232,9 @@
               (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                              :attributes     {"impersonation_attr" role-b}}
                 (is (= [[1000]]
-                       (mt/rows
-                        (mt/run-mbql-query checkins
-                          {:aggregation [[:count]]}))))
+                       (mt/formatted-rows [int]
+                                          (mt/run-mbql-query checkins
+                                            {:aggregation [[:count]]}))))
                 (is (thrown?
                      java.lang.Exception
                      (mt/run-mbql-query venues

--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src" "resources"]
  :deps
- {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.6"}
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -55,7 +55,7 @@
                               :left-join                       (not config/is-test?)
                               :describe-fks                    false
                               :actions                         false
-                              :uuid-type                       true
+                              :uuid-type                       false
                               :metadata/key-constraints        (not config/is-test?)}]
   (defmethod driver/database-supports? [:clickhouse feature] [_driver _feature _db] supported?))
 

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -371,19 +371,19 @@
         [{:field-name "mystring" :base-type :type/Text}]
         [["foo"] ["bar"] ["   "] [""] [nil]]])
       (testing "null strings count"
-        (is (= 2
+        (is (= 2M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:is-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "nullable strings not null filter"
-        (is (= 3
+        (is (= 3M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:not-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "filter nullable string by value"
-        (is (= 1
+        (is (= 1M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:= $mystring "foo"]
                       :aggregation [:count]})


### PR DESCRIPTION
### Description

Upgrade to ClickHouse JDBC driver 0.8.6 introduced more issues than it resolved so revert back to 0.8.4.

Downgrading to 0.8.4 causes some `uuid-type` tests to fail so setting this feature to false.

### How to verify

### Demo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
