### PR TITLE
Revert "🤖 backported "Add text comparison support for ClickHouse UUIDs""

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -55,7 +55,6 @@
                               :left-join                       (not config/is-test?)
                               :describe-fks                    false
                               :actions                         false
-                              :uuid-type                       true
                               :metadata/key-constraints        (not config/is-test?)}]
   (defmethod driver/database-supports? [:clickhouse feature] [_driver _feature _db] supported?))
 

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -348,30 +348,25 @@
   (sql.qp/->integer-with-round driver value))
 
 (defmethod sql.qp/->honeysql [:clickhouse :value]
-  [driver [_ value {base-type :base_type effective-type :effective_type}]]
-  (when (some? value)
-    (condp #(isa? %2 %1) (or effective-type base-type)
-      :type/IPAddress [:'toIPv4 value]
-      :type/UUID (when (not= "" value) ; support is-empty/non-empty checks
-                   (try
-                     (UUID/fromString value)
-                     (catch IllegalArgumentException _
-                       (h2x/with-type-info value {:database-type "String"}))))
-      (sql.qp/->honeysql driver value))))
+  [driver value]
+  (let [[_ value {base-type :base_type}] value]
+    (when (some? value)
+      (condp #(isa? %2 %1) base-type
+        :type/IPAddress [:'toIPv4 value]
+        (sql.qp/->honeysql driver value)))))
 
 (defmethod sql.qp/->honeysql [:clickhouse :=]
   [driver [op field value]]
-  (if (and (coll? value)
-           (let [[qual valuevalue fieldinfo] value]
-             (and (isa? qual :value)
-                  (isa? (:base_type fieldinfo) :type/Text)
-                  (nil? valuevalue))))
-    (let [hsql-field (sql.qp/->honeysql driver field)
-          hsql-value (sql.qp/->honeysql driver value)]
+  (let [[qual valuevalue fieldinfo] value
+        hsql-field (sql.qp/->honeysql driver field)
+        hsql-value (sql.qp/->honeysql driver value)]
+    (if (and (isa? qual :value)
+             (isa? (:base_type fieldinfo) :type/Text)
+             (nil? valuevalue))
       [:or
        [:= hsql-field hsql-value]
-       [:= [:'empty hsql-field] 1]])
-    ((get-method sql.qp/->honeysql [:sql :=]) driver [op field value])))
+       [:= [:'empty hsql-field] 1]]
+      ((get-method sql.qp/->honeysql [:sql :=]) driver [op field value]))))
 
 (defmethod sql.qp/->honeysql [:clickhouse :!=]
   [driver [op field value]]
@@ -409,24 +404,9 @@
   [_ dt amount unit]
   (h2x/+ dt [:raw (format "INTERVAL %d %s" (int amount) (name unit))]))
 
-(defn- uuid-field?
-  [x]
-  (and (mbql.u/mbql-clause? x)
-       (isa? (or (:effective-type (get x 2))
-                 (:base-type (get x 2)))
-             :type/UUID)))
-
-(defn- maybe-cast-uuid-for-text-compare
-  "For :contains, :starts-with, and :ends-with.
-   Comparing UUID fields with these operations requires casting for the positionUTF8, startsWithUTF8, and endsWithUTF8 functions."
-  [field]
-  (if (uuid-field? field)
-    (sql.qp/->honeysql :clickhouse [:text field])
-    (sql.qp/->honeysql :clickhouse field)))
-
 (defn- clickhouse-string-fn
   [fn-name field value options]
-  (let [hsql-field (maybe-cast-uuid-for-text-compare field)
+  (let [hsql-field (sql.qp/->honeysql :clickhouse field)
         hsql-value (sql.qp/->honeysql :clickhouse value)]
     (if (get options :case-sensitive true)
       [fn-name hsql-field hsql-value]
@@ -448,7 +428,7 @@
 
 (defmethod sql.qp/->honeysql [:clickhouse :contains]
   [_ [_ field value options]]
-  (let [hsql-field (maybe-cast-uuid-for-text-compare field)
+  (let [hsql-field (sql.qp/->honeysql :clickhouse field)
         hsql-value (sql.qp/->honeysql :clickhouse value)
         position-fn (if (get options :case-sensitive true)
                       :'positionUTF8

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -338,32 +338,33 @@
 
 (deftest clickhouse-native-query-with-uuid-filter-test
   (mt/test-driver :clickhouse
-    (mt/dataset
-      (mt/dataset-definition "uuid_filter_db"
-                             ["uuid_filter_table"
-                              [{:field-name "uuid"
-                                :base-type {:native "UUID"}
-                                :semantic-type :type/PK}
-                               {:field-name "value"
-                                :base-type :type/Integer}]
-                              [[#uuid "89c77143-0c9a-4686-b241-5b21b9ab44f1" 10]
-                               [#uuid "89c77143-0c9a-4686-b241-5b21b9ab44f2" 20]]])
-      (let [query {:database   (mt/id)
-                   :type       :native
-                   :native     {:query         "select sum(value) from `uuid_filter_db`.`uuid_filter_table` where {{uuid}}"
-                                :template-tags {"uuid" {:type         :dimension
-                                                        :dimension    ["field" (mt/id :uuid_filter_table :uuid) nil]
-                                                        :default      ["89c77143-0c9a-4686-b241-5b21b9ab44f2"]
-                                                        :name         "uuid"
-                                                        :display-name "UUID"
-                                                        :widget-type  "id"}}}
-                   :parameters [{:type   "id"
-                                 :target [:dimension [:template-tag "uuid"]]
-                                 :value  ["89c77143-0c9a-4686-b241-5b21b9ab44f2"]}]}]
-        (is (= [[20]]
-               (mt/formatted-rows [int]
-                                  (qp/process-query query))))
-        (is (= (str "select sum(value) from `uuid_filter_db`.`uuid_filter_table` "
-                    "where `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('89c77143-0c9a-4686-b241-5b21b9ab44f2' AS UUID))")
-               (:query (qp.compile/compile-with-inline-parameters query))))))))
-
+    (let [uuid-1 (random-uuid)
+          uuid-2 (random-uuid)]
+      (mt/dataset
+        (mt/dataset-definition "uuid_filter_db"
+                               ["uuid_filter_table"
+                                [{:field-name "uuid"
+                                  :base-type {:native "UUID"}
+                                  :semantic-type :type/PK}
+                                 {:field-name "value"
+                                  :base-type :type/Integer}]
+                                [[uuid-1 10]
+                                 [uuid-2 20]]])
+        (let [query {:database   (mt/id)
+                     :type       :native
+                     :native     {:query         "select sum(value) from `uuid_filter_db`.`uuid_filter_table` where {{uuid}}"
+                                  :template-tags {"uuid" {:type         :dimension
+                                                          :dimension    ["field" (mt/id :uuid_filter_table :uuid) nil]
+                                                          :default      [(str uuid-2)]
+                                                          :name         "uuid"
+                                                          :display-name "UUID"
+                                                          :widget-type  "id"}}}
+                     :parameters [{:type   "id"
+                                   :target [:dimension [:template-tag "uuid"]]
+                                   :value  [(str uuid-2)]}]}]
+          (is (= [[20]]
+                 (mt/formatted-rows [int]
+                                    (qp/process-query query))))
+          (is (= (str "select sum(value) from `uuid_filter_db`.`uuid_filter_table` "
+                      (format "where `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('%s' AS UUID))" uuid-2))
+                 (:query (qp.compile/compile-with-inline-parameters query)))))))))

--- a/test/metabase/query_processor_test/uuid_test.clj
+++ b/test/metabase/query_processor_test/uuid_test.clj
@@ -27,7 +27,7 @@
                             "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]}))))))))
 
 (deftest ^:parallel joined-uuid-query-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :uuid-type ::uuids-in-create-table-statements)
+  (mt/test-drivers (mt/normal-drivers-with-feature :uuid-type ::uuids-in-create-table-statements)
     (testing "Query with joins"
       (mt/dataset uuid-dogs
         (is (= [[#uuid "d6b02fa2-bf7b-4b32-80d5-060b649c9859" "Tim"]]


### PR DESCRIPTION
Reverts metabase/metabase#58596

https://github.com/metabase/metabase/pull/59223 downgrades to 0.8.4, which causes some tests to fail after setting `uuid-type true`. Undoing the changes that set `uuid-type true` so that those tests don't fail. 