### PR TITLE
Prevent long dashboard names Inline

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -589,6 +589,15 @@ describe("scenarios > dashboard", () => {
             });
         });
       });
+
+      const longTitle =
+        "a really really really really really really really really really really really really really really really really long title";
+
+      it("should prevent entering a title longer than 100 chars", () => {
+        const dashboardNameInput = cy.findByTestId("dashboard-name-heading");
+        dashboardNameInput.clear().type(longTitle).blur();
+        dashboardNameInput.invoke("text").should("have.length", 100);
+      });
     });
 
     it(

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -207,6 +207,7 @@ export function DashboardHeaderView({
                     isDisabled={!dashboard.can_write}
                     data-testid="dashboard-name-heading"
                     onChange={handleUpdateCaption}
+                    maxLength={100}
                   />
                   <PLUGIN_MODERATION.EntityModerationIcon
                     dashboard={dashboard}


### PR DESCRIPTION
Closes #5030

The original issue asked for better error messages, but I think we should just not allow the user to submit a name that is too long. We already prevent this in the create dialog, but it's still allowed in the inline editor currently.

I used `maxLength={100}` because in dashboard creation 100 chars is the max. 

<img width="943" alt="Screenshot 2025-06-10 at 12 48 01 PM" src="https://github.com/user-attachments/assets/32305ddc-3bcc-4d33-a3a9-8628c0742a53" />
