### PR TITLE
Content translation: Normalize locales

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
@@ -73,7 +73,7 @@ describe("scenarios > admin > localization > content translation", () => {
         assertOnlyTheseTranslationsAreStored(germanFieldNames);
       });
 
-      it("accepts a CSV upload with non-ASCII characters", () => {
+      it.only("accepts a CSV upload with non-ASCII characters", () => {
         uploadTranslationDictionary(nonAsciiFieldNames);
         cy.findByTestId("content-localization-setting").findByText(
           "Dictionary uploaded",
@@ -143,7 +143,7 @@ describe("scenarios > admin > localization > content translation", () => {
           .contains(/couldn.*t upload the file/)
           .should("be.visible");
         cy.findAllByRole("alert")
-          .contains(/Row 2: Invalid locale: xx/)
+          .contains(/Row 2: Invalid locale/)
           .should("be.visible");
       });
 
@@ -170,10 +170,10 @@ describe("scenarios > admin > localization > content translation", () => {
           .should("be.visible");
         cy.log("The first error is in row 2 (the first row is the header)");
         cy.findAllByRole("alert")
-          .contains(/Row 2: Invalid locale: ze/)
+          .contains(/Row 2: Invalid locale/)
           .should("be.visible");
         cy.findAllByRole("alert")
-          .contains(/Row 5: Invalid locale: qe/)
+          .contains(/Row 5: Invalid locale/)
           .should("be.visible");
       });
 

--- a/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
@@ -73,7 +73,7 @@ describe("scenarios > admin > localization > content translation", () => {
         assertOnlyTheseTranslationsAreStored(germanFieldNames);
       });
 
-      it.only("accepts a CSV upload with non-ASCII characters", () => {
+      it("accepts a CSV upload with non-ASCII characters", () => {
         uploadTranslationDictionary(nonAsciiFieldNames);
         cy.findByTestId("content-localization-setting").findByText(
           "Dictionary uploaded",

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -5,7 +5,6 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as util]
    [metabase.util.i18n :as i18n :refer [tru]]
-   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -45,18 +44,6 @@
    (or
     (str/blank? msgstr)
     (re-matches #"^[,;\s]*$" msgstr))))
-
-(defn standardize-locale
-  "For example, pt_BR, pt_br, pt-br, and PT-BR are all standardized as pt-BR."
-  [locale-name]
-  (let [s (str/replace locale-name "_" "-")
-        parts (str/split s #"-")]
-    (str/join "-" (map-indexed
-                   (fn [idx part]
-                     (if (zero? idx)
-                       (util/lower-case-en part)
-                       (when s (str (util/upper-case-en part)))))
-                   parts))))
 
 (defn format-row
   "Formats a row to be inserted into the content translation table. Locales are standardized, and all fields are trimmed. Extra fields are included as well."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -3,7 +3,6 @@
   (:require
    [clojure.string :as str]
    [metabase.premium-features.core :as premium-features]
-   [metabase.util :as util]
    [metabase.util.i18n :as i18n :refer [tru]]
    [toucan2.core :as t2]))
 

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -26,7 +26,7 @@
   "Returns an error message if a row does not have a valid locale."
   [_state index {:keys [locale]}]
   (when (not (i18n/available-locale? locale))
-    (tru "Row {0}: Invalid locale: {1}" (adjust-index index) locale)))
+    (tru "Row {0}: Invalid locale" (adjust-index index))))
 
 (defn- collect-duplication-error
   "Returns an error message if this translation key has already been seen in the file. A translation key is a string

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -44,7 +44,7 @@
     (str/blank? msgstr)
     (re-matches #"^[,;\s]*$" msgstr))))
 
-(defn format-row
+(defn- format-row
   "Formats a row to be inserted into the content translation table. Locales are standardized, and all fields are trimmed. Extra fields are included as well."
   [row]
   (let [[locale msgid msgstr & extras] row

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -3,13 +3,14 @@
   (:require
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [metabase-enterprise.api.routes.common :as ee.api.common]
    [metabase-enterprise.content-translation.dictionary :as dictionary]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.content-translation.models :as ct]
    [metabase.embedding.jwt :as embedding.jwt]
-   [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
    [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
@@ -71,7 +72,7 @@
   ;; this will error if bad
   (embedding.jwt/unsign token)
   (if locale
-    {:data (ct/get-translations locale)}
+    {:data (ct/get-translations (i18n/normalized-locale-string (str/trim locale)))}
     (throw (ex-info (str (tru "Locale is required.")) {:status-code 400}))))
 
 (defn- +require-content-translation [handler]

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -118,7 +118,7 @@
         (let [rows [["es" "Hello" "Hola"]
                     ["fr" "Goodbye" "Au revoir"]
                     ["de" "Thank you" "Danke"]
-                    ["pt_br" "Thank you" "Obrigado"]]]
+                    ["pt-br" "Thank you" "Obrigado"]]]
           (dictionary/import-translations! rows)
           (is (= 4 (count-translations)) "All translations should be imported")
 

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -41,7 +41,7 @@
     (let [rows [["invalidlocale" "Hello" "Hola"]]
           result (#'dictionary/process-rows rows)]
       (is (= 1 (count (:errors result))))
-      (is (re-find #"Row 2.*Invalid locale.*invalidlocale" (first (:errors result))))))
+      (is (re-find #"Row 2.*Invalid locale" (first (:errors result))))))
 
   (testing "Duplicate translation keys generate error"
     (let [rows [["fr" "Hello" "Bonjour"]

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -96,20 +96,20 @@
   (testing "Format function standardizes locale"
     (is (=
          ["pt_BR" "msgid" "msgstr"]
-         (dictionary/format-row ["pt-br" "msgid" "msgstr"])))
+         (#'dictionary/format-row ["pt-br" "msgid" "msgstr"])))
     (is (=
          ["pt_BR" "msgid" "msgstr"]
-         (dictionary/format-row ["Pt-bR" "msgid" "msgstr"])))
+         (#'dictionary/format-row ["Pt-bR" "msgid" "msgstr"])))
     (is (=
          ["pt_BR" "msgid" "msgstr"]
-         (dictionary/format-row ["pt_br" "msgid" "msgstr"])))
+         (#'dictionary/format-row ["pt_br" "msgid" "msgstr"])))
     (is (=
          ["zh_CN" "msgid" "msgstr"]
-         (dictionary/format-row ["ZH-cn" "msgid" "msgstr"]))))
+         (#'dictionary/format-row ["ZH-cn" "msgid" "msgstr"]))))
   (testing "Format function trims all fields"
     (is (=
          ["pt_BR" "msgid" "msgstr"]
-         (dictionary/format-row [" pt-BR " "msgid " " msgstr"])))))
+         (#'dictionary/format-row [" pt-BR " "msgid " " msgstr"])))))
 
 (deftest import-translations-success-test
   (ct-utils/with-clean-translations!

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -38,10 +38,10 @@
 
 (deftest ^:parallel process-rows-validation-test
   (testing "Invalid locale generates error"
-    (let [rows [["invalid-locale" "Hello" "Hola"]]
+    (let [rows [["invalidlocale" "Hello" "Hola"]]
           result (#'dictionary/process-rows rows)]
       (is (= 1 (count (:errors result))))
-      (is (re-find #"Row 2.*Invalid locale.*invalid-locale" (first (:errors result))))))
+      (is (re-find #"Row 2.*Invalid locale.*invalidlocale" (first (:errors result))))))
 
   (testing "Duplicate translation keys generate error"
     (let [rows [["fr" "Hello" "Bonjour"]
@@ -92,15 +92,35 @@
     (is (= 3 (#'dictionary/adjust-index 1)) "Second row becomes row 3")
     (is (= 10 (#'dictionary/adjust-index 8)) "Ninth row becomes row 10")))
 
+(deftest ^:parallel format-row-test
+  (testing "Format function standardizes locale"
+    (is (=
+         ["pt_BR" "msgid" "msgstr"]
+         (dictionary/format-row ["pt-br" "msgid" "msgstr"])))
+    (is (=
+         ["pt_BR" "msgid" "msgstr"]
+         (dictionary/format-row ["Pt-bR" "msgid" "msgstr"])))
+    (is (=
+         ["pt_BR" "msgid" "msgstr"]
+         (dictionary/format-row ["pt_br" "msgid" "msgstr"])))
+    (is (=
+         ["zh_CN" "msgid" "msgstr"]
+         (dictionary/format-row ["ZH-cn" "msgid" "msgstr"]))))
+  (testing "Format function trims all fields"
+    (is (=
+         ["pt_BR" "msgid" "msgstr"]
+         (dictionary/format-row [" pt-BR " "msgid " " msgstr"])))))
+
 (deftest import-translations-success-test
   (ct-utils/with-clean-translations!
     (testing "Valid translations are imported when content translation feature is present"
       (mt/with-premium-features #{:content-translation}
         (let [rows [["es" "Hello" "Hola"]
                     ["fr" "Goodbye" "Au revoir"]
-                    ["de" "Thank you" "Danke"]]]
+                    ["de" "Thank you" "Danke"]
+                    ["pt_br" "Thank you" "Obrigado"]]]
           (dictionary/import-translations! rows)
-          (is (= 3 (count-translations)) "All translations should be imported")
+          (is (= 4 (count-translations)) "All translations should be imported")
 
           (let [translations (get-translations)]
             (is (some #(and (= (:locale %) "es")
@@ -111,7 +131,10 @@
                             (= (:msgstr %) "Au revoir")) translations))
             (is (some #(and (= (:locale %) "de")
                             (= (:msgid %) "Thank you")
-                            (= (:msgstr %) "Danke")) translations))))))
+                            (= (:msgstr %) "Danke")) translations))
+            (is (some #(and (= (:locale %) "pt_BR") ; Check that locale was standardized
+                            (= (:msgid %) "Thank you")
+                            (= (:msgstr %) "Obrigado")) translations))))))
     (testing "Unusable translations are filtered out"
       (mt/with-premium-features #{:content-translation}
         (let [rows [["en" "Hello" "Hola"]     ; Usable
@@ -140,19 +163,37 @@
                clojure.lang.ExceptionInfo
                #"The file could not be uploaded due to the following error"
                (dictionary/import-translations! invalid-rows))))))
-    (testing "Error contains multiple validation messages"
+    (testing "Import fails when one row has too many fields"
       (mt/with-premium-features #{:content-translation}
-        (let [invalid-rows [["invalid-locale" "Hello" "Hola"]
-                            ["en" "Test" "Translation" "extra"]]]
+        (let [invalid-rows [["en" "Test" "Translation" "extra"]]]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"The file could not be uploaded due to the following error"
+               (dictionary/import-translations! invalid-rows))))))
+    (testing "Import fails when two rows have the same msgid and the same standardized locale"
+      (mt/with-premium-features #{:content-translation}
+        (let [invalid-rows [["pt-br" "Test" "Translation"]
+                            ["pt_BR" "Test" "Another translation"]]]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"The file could not be uploaded due to the following error"
+               (dictionary/import-translations! invalid-rows))))))
+    (testing "Multiple error messages can be returned"
+      (mt/with-premium-features #{:content-translation}
+        (let [invalid-rows [["invalidlocale" "Hello" "Hola"]
+                            ["fr" "Too" "many" "fields"]
+                            ["en" "Test" "Translation1"]
+                            ["en" "Test" "Translation2"]]]
           (try
             (dictionary/import-translations! invalid-rows)
             (is false "Should have thrown exception")
             (catch Exception e
               (let [data (ex-data e)]
                 (is (= 422 (:status-code data)))
-                (is (= 2 (count (:errors data))))
+                (is (= 3 (count (:errors data))))
                 (is (some #(re-find #"Invalid locale" %) (:errors data)))
-                (is (some #(re-find #"Invalid format" %) (:errors data)))))))))
+                (is (some #(re-find #"Invalid format" %) (:errors data)))
+                (is (some #(re-find #"earlier in the file" %) (:errors data)))))))))
     (testing "Existing translations are replaced"
       (mt/with-premium-features #{:content-translation}
         ;; First import

--- a/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
@@ -88,29 +88,29 @@
   (with-static-embedding!
     (ct-utils/with-clean-translations!
       (with-new-secret-key! [k]
-        (mt/with-premium-features #{:content-translation}
-          (testing "GET /api/ee/content-translation/dictionary/:token"
-            (mt/with-temp [:model/ContentTranslation _ {:locale "sv" :msgid "blueberry" :msgstr "blåbär"}]
-              (testing "provides translations"
-                (let [resp (client/client :get 200
-                                          (str (embedded-dictionary-url (jwt/sign {} k))
-                                               "?locale=sv"))]
-                  (is (= 1 (count (:data resp))))
-                  (is (=? {:data [{:locale "sv"
-                                   :msgid "blueberry"
-                                   :msgstr "blåbär"}]}
-                          resp))))
-              (testing "requires content-translation feature"
-                (mt/with-premium-features #{}
-                  (mt/assert-has-premium-feature-error
-                   "Content translation"
-                   (client/client :get 402 (str (embedded-dictionary-url (jwt/sign {} k))
-                                                "?locale=sv")))))
-              (testing "requires locale"
-                (is (= "Locale is required."
-                       (client/client :get 400 (embedded-dictionary-url (jwt/sign {} k))))))
-              (testing "requires valid token"
-                (is (= "Message seems corrupt or manipulated"
-                       (client/client :get 400 (str (embedded-dictionary-url
-                                                     (jwt/sign {} (random-embedding-secret-key)))
-                                                    "?locale=sv"))))))))))))
+                            (mt/with-premium-features #{:content-translation}
+                              (testing "GET /api/ee/content-translation/dictionary/:token"
+                                (testing "provides translations"
+                                  (mt/with-temp [:model/ContentTranslation _ {:locale "sv" :msgid "blueberry" :msgstr "blåbär"}]
+                                    (let [resp (client/client :get 200
+                                                              (str (embedded-dictionary-url (jwt/sign {} k))
+                                                                   "?locale=sv"))]
+                                      (is (= 1 (count (:data resp))))
+                                      (is (=? {:data [{:locale "sv"}
+                                                      :msgid "blueberry"
+                                                      :msgstr "blåbär"]}
+                                              resp)))))
+                                (testing "requires content-translation feature"
+                                  (mt/with-premium-features #{}
+                                    (mt/assert-has-premium-feature-error
+                                     "Content translation"
+                                     (client/client :get 402 (str (embedded-dictionary-url (jwt/sign {} k))
+                                                                  "?locale=sv")))))
+                                (testing "requires locale"
+                                  (is (= "Locale is required."
+                                         (client/client :get 400 (embedded-dictionary-url (jwt/sign {} k))))))
+                                (testing "requires valid token"
+                                  (is (= "Message seems corrupt or manipulated"
+                                         (client/client :get 400 (str (embedded-dictionary-url
+                                                                       (jwt/sign {} (random-embedding-secret-key)))
+                                                                      "?locale=sv")))))))))))


### PR DESCRIPTION
We typically normalize locales in the BE, converting "pt-br" to "pt_BR" for example. Let's also normalize locales when a user uploads a content translation dictionary. This means it doesn't matter whether they use "pt-br" or "pt_BR" - these will be treated as equivalent. This sticks with our existing pattern and also removes a potential headache for an admin trying to upload a dictionary.