### PR TITLE
Workaround for FE generating its own action ids

### DIFF
--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -949,10 +949,11 @@
   [dashcard id]
   (cond
     ;; new action, give it an id
-    (not id)
+    ;; currently the frontend is generating its own ids... we need to replace those
+    (or (not id) (not (str/starts-with? id "dashcard:")))
     (str "dashcard:" (:id dashcard "unknown") ":" (u/generate-nano-id))
     ;; chicken-and-egg resulted in a suboptimal id, fix it
-    (and (string? id) (str/starts-with? id "dashcard:unknown:") (:id dashcard))
+    (and (str/starts-with? id "dashcard:unknown:") (:id dashcard))
     (str/replace id #"dashcard:unknown" (str "dashcard:" (:id dashcard)))
     :else
     id))

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5162,10 +5162,11 @@
         saved   {:id 1337}]
     (mt/with-dynamic-fn-redefs [u/generate-nano-id (fn [] "rAnDoM")]
       (testing "leaves valid ids alone"
-        (is (= 1
-               (f saved 1)))
         (is (= "dashcard:7331:unique"
                (f saved "dashcard:7331:unique"))))
+      (testing "replaces temporary FE ids"
+        (is (= "dashcard:1337:rAnDoM"
+               (f saved (str (random-uuid))))))
       (testing "creates useful and unique ids"
         (is (= "dashcard:1337:rAnDoM"
                (f saved nil))))


### PR DESCRIPTION
Execution relies on a particular ID format, and expects the BE to assign the IDs.

Currently the FE is assigning IDs before we save, so this updates the BE to override them.