### PR TITLE
Revert (for now) "Use NULL in place of optional SQL parameters (#58713)

### DIFF
--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -32,13 +32,7 @@
   (log/tracef "Executing action\n\n%s" (u/pprint-to-str action))
   (try
     (let [parameters (for [parameter (:parameters action)]
-                       (assoc parameter
-                              :value (get request-parameters (:id parameter))
-                              ;; Fetch an important property that's not really a visualization setting...
-                              :required (if-let [f (get-in action [:visualization_settings :fields (:id parameter)])]
-                                          (:required f)
-                                          ;; if we can't find the settings, treat it as required
-                                          true)))
+                       (assoc parameter :value (get request-parameters (:id parameter))))
           query (-> dataset_query
                     (update :type keyword)
                     (assoc :parameters parameters))]

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -949,10 +949,11 @@
   [dashcard id]
   (cond
     ;; new action, give it an id
-    (not id)
+    ;; currently the frontend is generating its own ids... we need to replace those
+    (or (not id) (not (str/starts-with? id "dashcard:")))
     (str "dashcard:" (:id dashcard "unknown") ":" (u/generate-nano-id))
     ;; chicken-and-egg resulted in a suboptimal id, fix it
-    (and (string? id) (str/starts-with? id "dashcard:unknown:") (:id dashcard))
+    (and (str/starts-with? id "dashcard:unknown:") (:id dashcard))
     (str/replace id #"dashcard:unknown" (str "dashcard:" (:id dashcard)))
     :else
     id))

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -10,10 +10,6 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]))
 
-(def ^:dynamic *optional-params*
-  "YES I TOOK A SHORTCUT"
-  #{})
-
 (defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [_field value], :as v}]
   (if (and (= params/no-value value) in-optional?)
     ;; no-value field filters inside optional clauses are ignored, and eventually emitted entirely
@@ -46,13 +42,12 @@
         (params/ReferencedQuerySnippet? v)
         (substitute-native-query-snippet [sql args missing] v)
 
-        (and (= params/no-value v) (not (contains? *optional-params* k)))
+        (= params/no-value v)
         [sql args (conj missing k)]
 
         :else
-        (let [value (when (not= params/no-value v) v)
-              {:keys [replacement-snippet prepared-statement-args]}
-              (sql.params.substitution/->replacement-snippet-info driver/*driver* value)]
+        (let [{:keys [replacement-snippet prepared-statement-args]}
+              (sql.params.substitution/->replacement-snippet-info driver/*driver* v)]
           [(str sql replacement-snippet) (concat args prepared-statement-args) missing])))))
 
 (declare substitute*)

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5162,10 +5162,11 @@
         saved   {:id 1337}]
     (mt/with-dynamic-fn-redefs [u/generate-nano-id (fn [] "rAnDoM")]
       (testing "leaves valid ids alone"
-        (is (= 1
-               (f saved 1)))
         (is (= "dashcard:7331:unique"
                (f saved "dashcard:7331:unique"))))
+      (testing "replaces temporary FE ids"
+        (is (= "dashcard:1337:rAnDoM"
+               (f saved (str (random-uuid))))))
       (testing "creates useful and unique ids"
         (is (= "dashcard:1337:rAnDoM"
                (f saved nil))))


### PR DESCRIPTION
We need to rework this fix without breaking the one e2e test. It was done in a rush as the bug was blocking a Use Case demo.

We also need to add more tests when doing this:

1. A clojure test that would have broken by this change, corresponding to the e2e test.
2. A clojure test that was broken without this change.

Will add more details to Linear when I get a chance.