### PR TITLE
Cloes VIZ-1098 polish for approximate number of intervals setting

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -845,20 +845,6 @@ export const GRAPH_AXIS_SETTINGS = {
     getHidden: (series, vizSettings) =>
       vizSettings["graph.y_axis.auto_range"] !== false,
   },
-  "graph.y_axis.split_number": {
-    get section() {
-      return t`Axes`;
-    },
-    get group() {
-      return t`Y-axis`;
-    },
-    index: 7,
-    get title() {
-      return t`Approximate number of intervals`;
-    },
-    widget: "number",
-    placeholder: "auto",
-  },
   "graph.y_axis.auto_split": {
     get section() {
       return t`Axes`;
@@ -923,6 +909,22 @@ export const GRAPH_AXIS_SETTINGS = {
     widget: "toggle",
     inline: true,
     getDefault: getIsYAxisLabelEnabledDefault,
+  },
+  "graph.y_axis.split_number": {
+    get section() {
+      return t`Axes`;
+    },
+    get group() {
+      return t`Y-axis`;
+    },
+    get title() {
+      return t`Number of lines`;
+    },
+    widget: "number",
+    placeholder: "auto",
+    getHidden: (_series, settings) => {
+      return settings["graph.y_axis.axis_enabled"] === false;
+    },
   },
   "graph.y_axis.title_text": {
     get section() {


### PR DESCRIPTION
Closes [VIZ-1098: Polish for "Approximate number of intervals" setting](https://linear.app/metabase/issue/VIZ-1098/polish-for-approximate-number-of-intervals-setting)

### Description

 - adjust copy
 - move setting
 - hide it conditionally
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/bce00cbe-04a8-426e-b803-83ac370d550a" />
