### PR TITLE
Fix editing filters in heading dashboard cards

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -378,6 +378,23 @@ export function dashboardParameterSidebar() {
   return cy.findByTestId("dashboard-parameter-sidebar");
 }
 
+export function setDashboardParameterName(name: string) {
+  dashboardParameterSidebar().findByLabelText("Label").clear().type(name);
+}
+
+export function setDashboardParameterType(type: string) {
+  dashboardParameterSidebar()
+    .findByText("Filter or parameter type")
+    .next()
+    .click();
+  popover().findByText(type).click();
+}
+
+export function setDashboardParameterOperator(operatorName: string) {
+  dashboardParameterSidebar().findByText("Filter operator").next().click();
+  popover().findByText(operatorName).click();
+}
+
 export function dashboardParametersDoneButton() {
   return dashboardParameterSidebar().button("Done");
 }

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -813,29 +813,6 @@ describe("scenarios > dashboard > parameters", () => {
       },
     };
 
-    function getHeadingAndQuestionDashCards(baseQuestionDashcard) {
-      return [
-        createMockHeadingDashboardCard({
-          inline_parameters: [categoryParameter.id],
-          size_x: 24,
-          size_y: 1,
-        }),
-        {
-          id: baseQuestionDashcard.id,
-          row: 1,
-          size_x: 12,
-          size_y: 6,
-          parameter_mappings: [
-            {
-              parameter_id: categoryParameter.id,
-              card_id: baseQuestionDashcard.card_id,
-              target: ["dimension", categoryFieldRef, { "stage-number": 0 }],
-            },
-          ],
-        },
-      ];
-    }
-
     it("should be able to add and use filters", () => {
       H.createQuestionAndDashboard({
         questionDetails: ordersCountByCategory,
@@ -923,7 +900,30 @@ describe("scenarios > dashboard > parameters", () => {
       }).then(({ body: dashcard }) => {
         H.updateDashboardCards({
           dashboard_id: dashcard.dashboard_id,
-          cards: getHeadingAndQuestionDashCards(dashcard),
+          cards: [
+            createMockHeadingDashboardCard({
+              inline_parameters: [categoryParameter.id],
+              size_x: 24,
+              size_y: 1,
+            }),
+            {
+              id: dashcard.id,
+              row: 1,
+              size_x: 12,
+              size_y: 6,
+              parameter_mappings: [
+                {
+                  parameter_id: categoryParameter.id,
+                  card_id: dashcard.card_id,
+                  target: [
+                    "dimension",
+                    categoryFieldRef,
+                    { "stage-number": 0 },
+                  ],
+                },
+              ],
+            },
+          ],
         });
         H.visitDashboard(dashcard.dashboard_id);
         H.editDashboard();

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -796,6 +796,7 @@ describe("scenarios > dashboard > parameters", () => {
       name: "Category",
       type: "string/=",
       slug: "category",
+      sectionId: "string",
     });
 
     const categoryFieldRef = [
@@ -931,33 +932,38 @@ describe("scenarios > dashboard > parameters", () => {
 
       H.getDashboardCard(0).findByText("Category").click();
 
-      H.dashboardParameterSidebar().within(() => {
-        cy.findByLabelText("Label").clear().type("New Category");
-        cy.findByLabelText("Default value").click();
-      });
+      H.setDashboardParameterName("Count");
+      H.setDashboardParameterType("Number");
+      H.setDashboardParameterOperator("Less than or equal to");
+
+      // Set default value
+      H.dashboardParameterSidebar().findByLabelText("Default value").click();
       H.popover().within(() => {
-        cy.findByText("Gizmo").click();
+        cy.findByPlaceholderText("Enter a number").type("4000");
         cy.button("Add filter").click();
       });
-      H.dashboardParameterSidebar().button("Done").click();
 
+      // Connect to the card
+      H.selectDashboardFilter(H.getDashboardCard(1), "Count");
+
+      H.dashboardParameterSidebar().button("Done").click();
       H.saveDashboard();
 
       H.getDashboardCard(0).within(() => {
+        cy.findByText("Count").should("exist");
+        cy.findByText("4,000").should("exist");
         cy.findByText("Category").should("not.exist");
-        cy.findByText("New Category").should("exist");
-        cy.findByText("Gizmo").should("exist");
       });
 
       H.getDashboardCard(1).within(() => {
-        cy.findByText("Gizmo").should("be.visible");
+        cy.findByText("Doohickey").should("be.visible");
+        cy.findByText("Gizmo").should("not.exist");
         cy.findByText("Gadget").should("not.exist");
-        cy.findByText("Doohickey").should("not.exist");
         cy.findByText("Widget").should("not.exist");
       });
 
       cy.location().should(({ search }) => {
-        expect(search).to.eq("?new_category=Gizmo");
+        expect(search).to.eq("?count=4000");
       });
     });
   });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -9,6 +9,7 @@ import { useClickBehaviorData } from "metabase/dashboard/hooks";
 import { getDashcardData } from "metabase/dashboard/selectors";
 import {
   getVirtualCardType,
+  isHeadingDashCard,
   isQuestionCard,
   isVirtualDashCard,
 } from "metabase/dashboard/utils";
@@ -444,9 +445,13 @@ export function DashCardVisualization({
   return (
     <Visualization
       className={cx(CS.flexFull, {
-        [CS.pointerEventsNone]: isEditingDashboardLayout,
         [CS.overflowAuto]: visualizationOverlay,
         [CS.overflowHidden]: !visualizationOverlay,
+
+        // Heading dashcards configure pointer events on their own
+        // to make the inner input and inline filters interactive.
+        [CS.pointerEventsNone]:
+          isEditingDashboardLayout && !isHeadingDashCard(dashcard),
       })}
       dashboard={dashboard}
       dashcard={dashcard}

--- a/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
@@ -18,11 +18,13 @@ import { ParametersList } from "../../../parameters/components/ParametersList";
 
 interface DashboardParameterListProps {
   parameters: Array<Parameter & { value: unknown }>;
+  isSortable?: boolean;
   isFullscreen: boolean;
 }
 
 export function DashboardParameterList({
   parameters,
+  isSortable = true,
   isFullscreen,
 }: DashboardParameterListProps) {
   const dashboard = useSelector(getDashboardComplete);
@@ -39,6 +41,7 @@ export function DashboardParameterList({
       editingParameter={editingParameter}
       hideParameters={hiddenParameterSlugs}
       dashboard={dashboard}
+      isSortable={isSortable}
       isFullscreen={isFullscreen}
       isNightMode={shouldRenderAsNightMode}
       isEditing={isEditing}

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -37,6 +37,7 @@ import type {
   DashboardId,
   DashboardParameterMapping,
   ParameterId,
+  VirtualCard,
 } from "metabase-types/api";
 import type {
   ClickBehaviorSidebarState,
@@ -363,7 +364,7 @@ export const getEditingParameter = createSelector(
   },
 );
 
-const getCard = (state: State, { card }: { card: Card }) => card;
+const getCard = (state: State, { card }: { card: Card | VirtualCard }) => card;
 const getDashCard = (state: State, { dashcard }: { dashcard: DashboardCard }) =>
   dashcard;
 
@@ -474,7 +475,10 @@ export const getMissingRequiredParameters = createSelector(
  * It's a memoized version, it uses LRU cache per card identified by id
  */
 export const getQuestionByCard = createCachedSelector(
-  [(_state: State, props: { card: Card }) => props.card, getMetadata],
+  [
+    (_state: State, props: { card: Card | VirtualCard }) => props.card,
+    getMetadata,
+  ],
   (card, metadata) => {
     return isQuestionCard(card) ? new Question(card, metadata) : undefined;
   },

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
@@ -42,6 +42,7 @@ type ParameterWidgetProps = PropsWithChildren<
 
 const EditParameterWidget = ({
   dragHandle,
+  isSortable,
   isEditing,
   parameter,
   setEditingParameter,
@@ -50,13 +51,17 @@ const EditParameterWidget = ({
   isEditingParameter: boolean;
 } & Pick<
   ParameterWidgetProps,
-  "parameter" | "setEditingParameter" | "isEditing" | "dragHandle"
+  | "parameter"
+  | "setEditingParameter"
+  | "isEditing"
+  | "isSortable"
+  | "dragHandle"
 >) => {
   return (
     <Sortable
       id={parameter.id}
       draggingStyle={{ opacity: 0.5 }}
-      disabled={!isEditing}
+      disabled={!isEditing || !isSortable}
       role="listitem"
     >
       <Flex

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -26,6 +26,7 @@ export const ParametersList = ({
   dashboard,
   editingParameter,
 
+  isSortable = true,
   isFullscreen,
   hideParameters,
   isEditing,
@@ -79,7 +80,7 @@ export const ParametersList = ({
       enableParameterRequiredBehavior={enableParameterRequiredBehavior}
       commitImmediately={commitImmediately}
       dragHandle={
-        isEditing && setParameterIndex ? (
+        isSortable && isEditing && setParameterIndex ? (
           <div
             className={cx(
               CS.flex,
@@ -92,7 +93,7 @@ export const ParametersList = ({
           </div>
         ) : null
       }
-      isSortable
+      isSortable={isSortable}
     />
   );
 
@@ -106,13 +107,24 @@ export const ParametersList = ({
         vertical ? CS.flexColumn : CS.flexRow,
       )}
     >
-      <SortableList
-        items={visibleValuePopulatedParameters}
-        getId={getId}
-        renderItem={renderItem}
-        onSortEnd={handleSortEnd}
-        sensors={[pointerSensor]}
-      />
+      {isSortable ? (
+        <SortableList
+          items={visibleValuePopulatedParameters}
+          getId={getId}
+          renderItem={renderItem}
+          onSortEnd={handleSortEnd}
+          sensors={[pointerSensor]}
+        />
+      ) : (
+        <>
+          {visibleValuePopulatedParameters.map((parameter) =>
+            renderItem({
+              item: parameter,
+              id: getId(parameter),
+            }),
+          )}
+        </>
+      )}
     </div>
   ) : null;
 };

--- a/frontend/src/metabase/parameters/components/ParametersList/types.ts
+++ b/frontend/src/metabase/parameters/components/ParametersList/types.ts
@@ -17,6 +17,7 @@ export type ParametersListProps = {
     editingParameter: Parameter | null | undefined;
 
     isEditing: boolean;
+    isSortable?: boolean;
     vertical: boolean;
     commitImmediately: boolean;
     setParameterValue: (parameterId: ParameterId, value: any) => void;

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -32,6 +32,7 @@ import type {
   ParameterTarget,
   ParameterVariableTarget,
   StructuredParameterDimensionTarget,
+  VirtualCard,
   WritebackParameter,
 } from "metabase-types/api";
 import { isStructuredDimensionTarget } from "metabase-types/guards";
@@ -129,7 +130,7 @@ export type ParameterMappingOption =
 export function getParameterMappingOptions(
   question: Question | undefined,
   parameter: Parameter | null | undefined = null,
-  card: Card,
+  card: Card | VirtualCard,
   dashcard: BaseDashboardCard | null | undefined = null,
 ): ParameterMappingOption[] {
   if (dashcard && isVirtualDashCard(dashcard)) {

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -6,6 +6,7 @@ import { DashCardParameterMapper } from "metabase/dashboard/components/DashCard/
 import { DashboardParameterList } from "metabase/dashboard/components/DashboardParameterList";
 import {
   getDashCardInlineValuePopulatedParameters,
+  getDashcardParameterMappingOptions,
   getIsEditingParameter,
   getParameterValues,
 } from "metabase/dashboard/selectors";
@@ -45,8 +46,15 @@ export function Heading({
     getDashCardInlineValuePopulatedParameters(state, dashcard?.id),
   );
   const parameterValues = useSelector(getParameterValues);
-
   const isEditingParameter = useSelector(getIsEditingParameter);
+
+  const mappingOptions = useSelector((state) =>
+    getDashcardParameterMappingOptions(state, {
+      card: dashcard.card,
+      dashcard,
+    }),
+  );
+  const hasVariables = mappingOptions.length > 0;
 
   const justAdded = useMemo(() => dashcard?.justAdded || false, [dashcard]);
 
@@ -85,7 +93,7 @@ export function Heading({
         isPreviewing={isPreviewing}
         onClick={toggleFocusOn}
       >
-        {isEditingParameter ? (
+        {isEditingParameter && hasVariables ? (
           <DashCardParameterMapper dashcard={dashcard} isMobile={isMobile} />
         ) : isPreviewing ? (
           <HeadingContent
@@ -101,6 +109,7 @@ export function Heading({
             data-testid="editing-dashboard-heading-input"
             placeholder={placeholder}
             value={textValue}
+            disabled={isEditingParameter}
             autoFocus={justAdded || isFocused}
             onChange={(e) => setTextValue(e.target.value)}
             onMouseDown={preventDragging}

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -117,6 +117,7 @@ export function Heading({
           <Flex style={{ flex: "0 0 auto" }}>
             <DashboardParameterList
               parameters={inlineParameters}
+              isSortable={false}
               isFullscreen={isFullscreen}
             />
           </Flex>


### PR DESCRIPTION
Closes [VIZ-1076](https://linear.app/metabase/issue/VIZ-1076/fix-editing-filters-in-heading-dashcards)

Fixes header dashcard layout to propagate clicks on filter widgets in dashboard edit mode and to keep filters visible when mapping filter values to card variables

### Demo

https://github.com/user-attachments/assets/aea8028f-02b6-4c11-aac9-cfa1db9eb0b1