### PR TITLE
Migrate legacy actions to execute API

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1604,13 +1604,13 @@
    :api #{}
    :uses #{actions
            api
-           enterprise/data-editing
            driver
            events
            lib
            query-processor
            upload
-           util}}
+           util
+           enterprise/data-editing}}
 
   enterprise/database-routing
   {:team "Admin Webapp"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -497,8 +497,8 @@
            metabase.events.init}
    :uses #{api
            audit-app
-           config
            channel
+           config
            driver
            models
            notification
@@ -706,8 +706,8 @@
            dashboards
            driver
            events
-           models
            lib
+           models
            parameters
            permissions
            premium-features
@@ -1584,11 +1584,11 @@
 
   enterprise/data-editing
   {:team "Workflows"
-   :api  #{metabase-enterprise.data-editing.core
-           metabase-enterprise.data-editing.api
+   :api  #{metabase-enterprise.data-editing.api
+           metabase-enterprise.data-editing.core
            metabase-enterprise.data-editing.init}
-   :uses #{api
-           actions
+   :uses #{actions
+           api
            driver
            events
            lib
@@ -1602,8 +1602,8 @@
   enterprise/data-editing-public
   {:team "Workflows"
    :api #{}
-   :uses #{api
-           actions
+   :uses #{actions
+           api
            enterprise/data-editing
            driver
            events

--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -7,7 +7,7 @@ VERSION_PROPERTY_NAME="src_hash"
 source-hash() {
   # hash all the files that might change a backend-only uberjar build (for integration tests)
   (
-    find src enterprise/backend deps.edn resources/sample-database.db.mv.db -type f -print0 | xargs -0 shasum ;
+    find src enterprise/backend/src deps.edn resources/sample-database.db.mv.db -type f -print0 | xargs -0 shasum ;
     find resources -type f \( -iname \*.clj -o -iname \*.edn -o -iname \*.yaml -o -iname \*.properties -o -iname \*.html \) -not -name "version.properties" -print0 | xargs -0 shasum ;
   ) | shasum | awk '{ print $1 }'
 }

--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -7,7 +7,7 @@ VERSION_PROPERTY_NAME="src_hash"
 source-hash() {
   # hash all the files that might change a backend-only uberjar build (for integration tests)
   (
-    find src deps.edn resources/sample-database.db.mv.db -type f -print0 | xargs -0 shasum ;
+    find src enterprise/backend deps.edn resources/sample-database.db.mv.db -type f -print0 | xargs -0 shasum ;
     find resources -type f \( -iname \*.clj -o -iname \*.edn -o -iname \*.yaml -o -iname \*.properties -o -iname \*.html \) -not -name "version.properties" -print0 | xargs -0 shasum ;
   ) | shasum | awk '{ print $1 }'
 }

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -22,7 +22,9 @@ describe(
   () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/action?model-id=*").as("getModelActions");
-      cy.intercept("POST", "/api/action/*/execute").as("executeAction");
+      cy.intercept("POST", "/api/ee/data-editing/action/v2/execute").as(
+        "executeAction",
+      );
       cy.intercept("GET", "/api/action/*/execute?parameters=*").as(
         "prefetchValues",
       );

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -27,7 +27,7 @@ const MODEL_NAME = "Test Action Model";
           "/api/dashboard/*/dashcard/*/execute?parameters=*",
         ).as("prefetchValues");
 
-        cy.intercept("POST", "/api/dashboard/*/dashcard/*/execute").as(
+        cy.intercept("POST", "/api/ee/data-editing/action/v2/execute").as(
           "executeAction",
         );
       });
@@ -1061,7 +1061,7 @@ describe("action error handling", { tags: ["@external", "@actions"] }, () => {
     cy.intercept("GET", "/api/dashboard/*/dashcard/*/execute?parameters=*").as(
       "prefetchValues",
     );
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/execute").as(
+    cy.intercept("POST", "/api/ee/data-editing/action/v2/execute").as(
       "executeAction",
     );
   });

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -430,7 +430,9 @@ describe("issue 32840", () => {
       H.visitModel(modelId);
     });
 
-    cy.intercept("POST", "/api/action/*/execute").as("executeAction");
+    cy.intercept("POST", "/api/ee/data-editing/action/v2/execute").as(
+      "executeAction",
+    );
   });
 
   it("uses correct timestamp when executing implicit update action (metabase#32840)", () => {

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -80,7 +80,9 @@ describe(
       cy.intercept("GET", "/api/action/*").as("getAction");
       cy.intercept("GET", "/api/action?model-id=*").as("getModelAction");
       cy.intercept("PUT", "/api/action/*").as("updateAction");
-      cy.intercept("POST", "/api/action/*/execute").as("executeAction");
+      cy.intercept("POST", "/api/ee/data-editing/action/v2/execute").as(
+        "executeAction",
+      );
       cy.intercept("POST", "/api/action").as("createAction");
       cy.intercept("GET", "/api/table/*/query_metadata*").as("fetchMetadata");
       cy.intercept("GET", "/api/search?archived=true").as("getArchived");

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -198,7 +198,7 @@
   [_
    _
    _]
-  (api/check-superuser)
+  (check-permissions)
   (let [databases          (t2/select [:model/Database :id :settings])
         editable-database? (comp boolean :database-enable-table-editing :settings)
         editable-databases (filter editable-database? databases)

--- a/frontend/src/metabase/actions/actions.ts
+++ b/frontend/src/metabase/actions/actions.ts
@@ -19,11 +19,12 @@ export const executeAction =
   async (dispatch: Dispatch): Promise<ActionFormSubmitResult> => {
     try {
       const result = await ActionsApi.execute({
-        id: action.id,
-        parameters,
+        action_id: action.id,
+        input: parameters,
+        scope: { unknown: "legacy-action" },
       });
 
-      const message = getActionExecutionMessage(action, result);
+      const message = getActionExecutionMessage(action, result?.outputs?.[0]);
       dispatch(addUndo({ message, toastColor: "success" }));
       return { success: true, message };
     } catch (error) {

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -41,7 +41,7 @@ import Action from "./Action";
 const DASHBOARD_ID = 123;
 const DASHCARD_ID = 456;
 const ACTION_MODEL_ID = 777;
-const ACTION_EXEC_MOCK_PATH = `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`;
+const ACTION_EXEC_MOCK_PATH = `path:/api/ee/data-editing/action/v2/execute`;
 
 const DATABASE_ID = 1;
 
@@ -133,7 +133,9 @@ async function setup({
 
   if (getActionIsEnabledInDatabase(dashcard)) {
     fetchMock.get(ACTION_EXEC_MOCK_PATH, {});
-    fetchMock.post(ACTION_EXEC_MOCK_PATH, { "rows-updated": [1] });
+    fetchMock.post(ACTION_EXEC_MOCK_PATH, {
+      outputs: [{ "rows-updated": [1] }],
+    });
 
     // for ActionCreator modal (action edit modal)
     setupDatabasesEndpoints([database]);
@@ -308,8 +310,9 @@ describe("Actions > ActionViz > Action", () => {
 
       const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
       expect(await call?.request?.json()).toEqual({
-        modelId: ACTION_MODEL_ID,
-        parameters: {
+        action_id: `dashcard:${DASHCARD_ID}`,
+        scope: { "dashboard-id": DASHBOARD_ID },
+        input: {
           parameter_1: 44,
         },
       });
@@ -456,8 +459,9 @@ describe("Actions > ActionViz > Action", () => {
 
     it("should submit provided form input values to the action execution endpoint", async () => {
       const expectedBody = {
-        modelId: ACTION_MODEL_ID,
-        parameters: {
+        action_id: `dashcard:${DASHCARD_ID}`,
+        scope: { "dashboard-id": DASHBOARD_ID },
+        input: {
           parameter_1: "foo",
           parameter_2: 5,
         },
@@ -485,8 +489,9 @@ describe("Actions > ActionViz > Action", () => {
 
     it("should combine data from dashboard parameters and form input when submitting for execution", async () => {
       const expectedBody = {
-        modelId: ACTION_MODEL_ID,
-        parameters: {
+        action_id: `dashcard:${DASHCARD_ID}`,
+        scope: { "dashboard-id": DASHBOARD_ID },
+        input: {
           parameter_1: "foo",
           parameter_2: 5,
         },

--- a/frontend/src/metabase/lib/errors/messages.ts
+++ b/frontend/src/metabase/lib/errors/messages.ts
@@ -18,6 +18,15 @@ export function getResponseErrorMessage(error: unknown): string | undefined {
     ) {
       return response.data.errors?._error;
     }
+
+    if (
+      Array.isArray(response.data?.errors) &&
+      response.data.errors.length > 0
+    ) {
+      const error =
+        response.data.errors[0]?.error || response.data.errors[0]?.message;
+      return error;
+    }
   }
 
   if (response.message) {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -376,14 +376,12 @@ function setDashboardEndpoints(prefix) {
 }
 
 export const ActionsApi = {
-  execute: POST("/api/action/:id/execute"),
+  execute: POST("/api/ee/data-editing/action/v2/execute"),
   prefetchValues: GET("/api/action/:id/execute"),
   prefetchDashcardValues: GET(
     "/api/dashboard/:dashboardId/dashcard/:dashcardId/execute",
   ),
-  executeDashcardAction: POST(
-    "/api/dashboard/:dashboardId/dashcard/:dashcardId/execute",
-  ),
+  executeDashcardAction: POST("/api/ee/data-editing/action/v2/execute"),
 };
 
 export const CacheConfigApi = {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/DeleteObjectModal.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/DeleteObjectModal.tsx
@@ -29,10 +29,11 @@ export const DeleteObjectModal: FunctionComponent<Props> = ({
   const handleSubmit = async () => {
     try {
       await ActionsApi.execute({
-        id: actionId,
-        parameters: {
+        action_id: actionId,
+        input: {
           id: typeof objectId === "string" ? parseInt(objectId, 10) : objectId,
         },
+        scope: { unknown: "legacy-action" },
       });
 
       const message = t`Successfully deleted`;

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -32,13 +32,7 @@
   (log/tracef "Executing action\n\n%s" (u/pprint-to-str action))
   (try
     (let [parameters (for [parameter (:parameters action)]
-                       (assoc parameter
-                              :value (get request-parameters (:id parameter))
-                              ;; Fetch an important property that's not really a visualization setting...
-                              :required (if-let [f (get-in action [:visualization_settings :fields (:id parameter)])]
-                                          (:required f)
-                                          ;; if we can't find the settings, treat it as required
-                                          true)))
+                       (assoc parameter :value (get request-parameters (:id parameter))))
           query (-> dataset_query
                     (update :type keyword)
                     (assoc :parameters parameters))]

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -10,10 +10,6 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]))
 
-(def ^:dynamic *optional-params*
-  "YES I TOOK A SHORTCUT"
-  #{})
-
 (defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [_field value], :as v}]
   (if (and (= params/no-value value) in-optional?)
     ;; no-value field filters inside optional clauses are ignored, and eventually emitted entirely
@@ -46,13 +42,12 @@
         (params/ReferencedQuerySnippet? v)
         (substitute-native-query-snippet [sql args missing] v)
 
-        (and (= params/no-value v) (not (contains? *optional-params* k)))
+        (= params/no-value v)
         [sql args (conj missing k)]
 
         :else
-        (let [value (when (not= params/no-value v) v)
-              {:keys [replacement-snippet prepared-statement-args]}
-              (sql.params.substitution/->replacement-snippet-info driver/*driver* value)]
+        (let [{:keys [replacement-snippet prepared-statement-args]}
+              (sql.params.substitution/->replacement-snippet-info driver/*driver* v)]
           [(str sql replacement-snippet) (concat args prepared-statement-args) missing])))))
 
 (declare substitute*)

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -319,8 +319,8 @@
   [instance]
   (validate-notification-handler instance)
   (when (some #{:channel_id :template_id :channel_type} (-> instance t2/changes keys))
-    (cross-check-channel-type-and-template-type instance)
-    instance))
+    (cross-check-channel-type-and-template-type instance))
+  instance)
 
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                   :model/NotificationRecipient                                  ;;


### PR DESCRIPTION
Closes [WRK-501](https://linear.app/metabase/issue/WRK-501/migrate-legacy-actions)

### Description

Updating last parts of logic for actions execution to use new `execute` API (public actions are left untouched for now).

For @metabase/devexp team, this branch has a related closed PR. It turned out that `bin/build-for-test` script didn't consider the content of `enterprise/backend/src` directory when generating hash for uberjar for e2e tests. I've found it when debugging one of failing tests which required to make changes in `enterprise/backend/src/metabase_enterprise/data_editing/api.clj`, when the backend fix wasn't registered in the e2e environment. Unfortunately, updating the script seemingly didn't help to fix an already open PR, so I've decided to close it and open a new one to trigger a clean CI run.