### PR TITLE
Correctly remove inline filters from header dashboard cards

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -64,7 +64,7 @@ export function removeDashboardCard(index = 0) {
     .findByTestId("dashboardcard-actions-panel")
     .should("be.visible")
     .icon("close")
-    .click();
+    .click({ force: true });
 }
 
 export function showDashcardVisualizationSettings(index = 0) {

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -806,7 +806,7 @@ describe("scenarios > dashboard > parameters", () => {
       slug: "count",
       sectionId: "number",
     });
-    
+
     const categoryFieldRef = [
       "field",
       PRODUCTS.CATEGORY,

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -34,6 +34,7 @@ import {
   createDashCard,
   createVirtualCard,
   generateTemporaryDashcardId,
+  hasInlineParameters,
   isQuestionDashCard,
   isVirtualDashCard,
 } from "../utils";
@@ -50,6 +51,7 @@ import {
   setDashCardAttributes,
 } from "./core";
 import { cancelFetchCardData, fetchCardData } from "./data-fetching";
+import { removeParameterAndReferences } from "./parameters";
 import { getExistingDashCards } from "./utils";
 
 export type NewDashCardOpts = {
@@ -365,10 +367,15 @@ export const removeCardFromDashboard = createThunkAction(
     dashcardId: DashCardId;
     cardId: DashboardCard["card_id"];
   }) =>
-    (dispatch) => {
+    (dispatch, getState) => {
+      const dashcard = getDashCardById(getState(), dashcardId);
       dispatch(closeAddCardAutoWireToasts());
-
       dispatch(cancelFetchCardData(cardId, dashcardId));
+      if (hasInlineParameters(dashcard)) {
+        dashcard.inline_parameters.forEach((parameterId) => {
+          removeParameterAndReferences(dispatch, getState, parameterId);
+        });
+      }
       return { dashcardId };
     },
 );

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -60,7 +60,11 @@ import {
   getQuestions,
   getSelectedTabId,
 } from "../selectors";
-import { isQuestionDashCard, supportsInlineParameters } from "../utils";
+import {
+  findDashCardForInlineParameter,
+  isQuestionDashCard,
+  supportsInlineParameters,
+} from "../utils";
 
 import {
   type SetDashCardAttributesOpts,
@@ -198,6 +202,23 @@ export const removeParameter = createThunkAction(
           return parameter;
         });
     });
+
+    const dashcards = Object.values(getDashcards(getState()));
+    const parameterDashcard = findDashCardForInlineParameter(
+      parameterId,
+      dashcards,
+    );
+    if (parameterDashcard) {
+      const inline_parameters = parameterDashcard.inline_parameters.filter(
+        (id) => id !== parameterId,
+      );
+      dispatch(
+        setDashCardAttributes({
+          id: parameterDashcard.id,
+          attributes: { inline_parameters },
+        }),
+      );
+    }
 
     return { id: parameterId };
   },

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -179,29 +179,37 @@ export const addParameter = createThunkAction(
     },
 );
 
+export function removeParameterAndReferences(
+  dispatch: Dispatch,
+  getState: GetState,
+  parameterId: ParameterId,
+) {
+  updateParameters(dispatch, getState, (parameters) => {
+    return parameters
+      .filter((parameter) => parameter.id !== parameterId)
+      .map((parameter) => {
+        if (parameter.filteringParameters) {
+          const filteringParameters = parameter.filteringParameters.filter(
+            (filteringParameter) => {
+              return filteringParameter !== parameterId;
+            },
+          );
+
+          return { ...parameter, filteringParameters };
+        }
+
+        return parameter;
+      });
+  });
+}
+
 export const REMOVE_PARAMETER = "metabase/dashboard/REMOVE_PARAMETER";
 export const removeParameter = createThunkAction(
   REMOVE_PARAMETER,
   (parameterId: ParameterId) => (dispatch, getState) => {
     dispatch(closeAddCardAutoWireToasts());
 
-    updateParameters(dispatch, getState, (parameters) => {
-      return parameters
-        .filter((parameter) => parameter.id !== parameterId)
-        .map((parameter) => {
-          if (parameter.filteringParameters) {
-            const filteringParameters = parameter.filteringParameters.filter(
-              (filteringParameter) => {
-                return filteringParameter !== parameterId;
-              },
-            );
-
-            return { ...parameter, filteringParameters };
-          }
-
-          return parameter;
-        });
-    });
+    removeParameterAndReferences(dispatch, getState, parameterId);
 
     const dashcards = Object.values(getDashcards(getState()));
     const parameterDashcard = findDashCardForInlineParameter(


### PR DESCRIPTION
Closes [VIZ-1059](https://linear.app/metabase/issue/VIZ-1059/remove-filters-when-removing-a-dashcard)

Adds proper remove logic for inline parameters:

1. Removing an inline parameter now removes it from both `dashboard.parameters` and `dashcard.inline_parameters`. Orphaned parameter mappings are automatically cleaned up before saving the dashboard
2. Removing a dashcard with inline parameters now removes them from `dashboard.parameters`. Orphaned parameter mappings are automatically cleaned up before saving the dashboard

### Demo

https://github.com/user-attachments/assets/4c195f8a-2d27-4b7d-8311-6310b26cfdf2

