### PR TITLE
Add setting to disable reusing a dashboard's last used parameters

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -394,6 +394,7 @@
            request
            revisions
            search
+           settings
            util
            warehouse-schema
            xrays}}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -368,6 +368,7 @@
    :api  #{metabase.dashboards.api
            metabase.dashboards.autoplace
            metabase.dashboards.constants
+           metabase.dashboards.init
            metabase.dashboards.models.dashboard
            metabase.dashboards.models.dashboard-card
            metabase.dashboards.models.dashboard-tab}

--- a/src/metabase/core/init.clj
+++ b/src/metabase/core/init.clj
@@ -21,6 +21,7 @@
    [metabase.cloud-migration.init]
    [metabase.config.core :as config]
    [metabase.content-verification.init]
+   [metabase.dashboards.init]
    [metabase.driver.init]
    [metabase.eid-translation.init]
    [metabase.embedding.init]

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -17,6 +17,7 @@
    [metabase.dashboards.models.dashboard :as dashboard]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.dashboards.models.dashboard-tab :as dashboard-tab]
+   [metabase.dashboards.settings :as dashboards.settings]
    [metabase.embedding.validation :as embedding.validation]
    [metabase.events.core :as events]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
@@ -96,21 +97,22 @@
     {:name       "hydrate-dashboard-details"
      :attributes {:dashboard/id dashboard-id}}
     (binding [params/*field-id-context* (atom params/empty-field-id-context)]
-      (t2/hydrate dashboard [:dashcards
-                             ;; disabled :can_run_adhoc_query for performance reasons in 50 release
-                             [:card :can_write #_:can_run_adhoc_query [:moderation_reviews :moderator_details]]
-                             [:series :can_write #_:can_run_adhoc_query]
-                             :dashcard/action
-                             :dashcard/linkcard-info]
-                  :can_restore
-                  :can_delete
-                  :last_used_param_values
-                  :tabs
-                  :collection_authority_level
-                  :can_write
-                  :param_fields
-                  [:moderation_reviews :moderator_details]
-                  [:collection :is_personal :effective_location]))))
+      (cond->>  [[:dashcards
+                    ;; disabled :can_run_adhoc_query for performance reasons in 50 release
+                  [:card :can_write #_:can_run_adhoc_query [:moderation_reviews :moderator_details]]
+                  [:series :can_write #_:can_run_adhoc_query]
+                  :dashcard/action
+                  :dashcard/linkcard-info]
+                 :can_restore
+                 :can_delete
+                 :tabs
+                 :collection_authority_level
+                 :can_write
+                 :param_fields
+                 [:moderation_reviews :moderator_details]
+                 [:collection :is_personal :effective_location]]
+        (dashboards.settings/dashboards-save-last-used-parameters) (cons :last_used_param_values)
+        true (apply t2/hydrate dashboard)))))
 
 (api.macros/defendpoint :post "/"
   "Create a new Dashboard."

--- a/src/metabase/dashboards/init.clj
+++ b/src/metabase/dashboards/init.clj
@@ -1,2 +1,3 @@
 (ns metabase.dashboards.init
-  (:require [metabase.dashboards.settings]))
+  (:require
+   [metabase.dashboards.settings]))

--- a/src/metabase/dashboards/init.clj
+++ b/src/metabase/dashboards/init.clj
@@ -1,0 +1,2 @@
+(ns metabase.dashboards.init
+  (:require [metabase.dashboards.settings]))

--- a/src/metabase/dashboards/settings.clj
+++ b/src/metabase/dashboards/settings.clj
@@ -1,0 +1,11 @@
+(ns metabase.dashboards.settings
+  (:require
+   [metabase.settings.core :refer [defsetting]]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(defsetting dashboards-save-last-used-parameters
+  (deferred-tru "Whether dashboards should default to a user''s last used parameters on load.")
+  :default true
+  :visibility :internal
+  :export? true
+  :type :boolean)

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -491,7 +491,7 @@
                :model/DashboardCard {dashcard-b-id :id} {:parameter_mappings [{:parameter_id "a", :card_id card-id, :target [:dimension [:template-tag "id"]]}]
                                                          :card_id            card-id
                                                          :dashboard_id       dashboard-b-id}]
-              (testing "User's set parameter is saved and sent back in the dashboard response, unique per dashboard."
+              (testing "User's set parameter is not saved when saving is disabled"
                 ;; api request mimicking a user setting a parameter value
                 (is (some? (mt/user-http-request :rasta :post (format "dashboard/%d/dashcard/%s/card/%s/query" dashboard-a-id dashcard-a-id card-id)
                                                  {:parameters [{:id "a" :value ["initial value"]}]})))

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -400,7 +400,8 @@
 
 (deftest last-used-parameter-value-test
   (mt/test-helpers-set-global-values!
-    (mt/with-temporary-setting-values [synchronous-batch-updates true]
+    (mt/with-temporary-setting-values [synchronous-batch-updates true
+                                       dashboards-save-last-used-parameters true]
       (mt/dataset test-data
         (mt/with-column-remappings [orders.user_id people.name]
           (mt/as-admin
@@ -454,6 +455,54 @@
                                                  {:parameters [{:id "a" :value nil :default ["default value"]}]})))
                 (is (= {:a nil}
                        (:last_used_param_values (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-a-id)))))))))))))
+
+(deftest last-used-parameter-value-disabled-test
+  (mt/test-helpers-set-global-values!
+    (mt/with-temporary-setting-values [synchronous-batch-updates true
+                                       dashboards-save-last-used-parameters false]
+      (mt/dataset test-data
+        (mt/with-column-remappings [orders.user_id people.name]
+          (mt/as-admin
+            (mt/with-temp
+              [:model/Dashboard {dashboard-a-id :id} {:name       "Test Dashboard"
+                                                      :creator_id (mt/user->id :crowberto)
+                                                      :parameters [{:name    "Name", :slug "name", :id "a" :type :string/contains
+                                                                    :default ["default_value"]}]}
+               :model/Dashboard {dashboard-b-id :id} {:name       "Test Dashboard"
+                                                      :creator_id (mt/user->id :crowberto)
+                                                      :parameters [{:name "Name", :slug "name", :id "a" :type :string/contains}]}
+               :model/Card {card-id :id} {:database_id   (mt/id)
+                                          :query_type    :native
+                                          :name          "test question"
+                                          :creator_id    (mt/user->id :crowberto)
+                                          :dataset_query {:type     :native
+                                                          :native   {:query "SELECT COUNT(*) FROM people WHERE {{name}}"
+                                                                     :template-tags
+                                                                     {"name" {:name         "Name"
+                                                                              :display-name "name"
+                                                                              :id           "_name_"
+                                                                              :type         :dimension
+                                                                              :dimension    [:field (mt/id :people :name) nil]
+                                                                              :widget-type  :string/contains}}}
+                                                          :database (mt/id)}}
+               :model/DashboardCard {dashcard-a-id :id} {:parameter_mappings [{:parameter_id "a", :card_id card-id, :target [:dimension [:template-tag "id"]]}]
+                                                         :card_id            card-id
+                                                         :dashboard_id       dashboard-a-id}
+               :model/DashboardCard {dashcard-b-id :id} {:parameter_mappings [{:parameter_id "a", :card_id card-id, :target [:dimension [:template-tag "id"]]}]
+                                                         :card_id            card-id
+                                                         :dashboard_id       dashboard-b-id}]
+              (testing "User's set parameter is saved and sent back in the dashboard response, unique per dashboard."
+                ;; api request mimicking a user setting a parameter value
+                (is (some? (mt/user-http-request :rasta :post (format "dashboard/%d/dashcard/%s/card/%s/query" dashboard-a-id dashcard-a-id card-id)
+                                                 {:parameters [{:id "a" :value ["initial value"]}]})))
+                (is (some? (mt/user-http-request :rasta :post (format "dashboard/%d/dashcard/%s/card/%s/query" dashboard-b-id dashcard-b-id card-id)
+                                                 {:parameters [{:id "a" :value ["initial value"]}]})))
+                (is (some? (mt/user-http-request :rasta :post (format "dashboard/%d/dashcard/%s/card/%s/query" dashboard-a-id dashcard-a-id card-id)
+                                                 {:parameters [{:id "a" :value ["new value"]}]})))
+                (is (= {:dashboard-a nil
+                        :dashboard-b nil}
+                       {:dashboard-a (:last_used_param_values (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-a-id)))
+                        :dashboard-b (:last_used_param_values (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-b-id)))}))))))))))
 
 (deftest fetch-dashboard-test
   (testing "GET /api/dashboard/:id"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48055

### Description

Set MB_DASHBOARDS_SAVE_LAST_USED_PARAMETER to false to disable saving.

### How to verify

Open a dashboard, pick some parameters, reload the dashboard without the "param=blah" query string, and verify that you still get the last used parameters

Then, set the env setting to false, retry the above, and verify that you don't get the last used parameters.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
