### PR TITLE
Content translation: Informative error messages for invalid CSV

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
@@ -11,6 +11,7 @@ import {
 import {
   assertOnlyTheseTranslationsAreStored,
   generateLargeCSV,
+  getCSVWithHeaderRow,
   uploadTranslationDictionary,
   uploadTranslationDictionaryViaAPI,
 } from "./helpers/e2e-content-translation-helpers";
@@ -196,6 +197,24 @@ describe("scenarios > admin > localization > content translation", () => {
           "The frontend should prevent the upload attempt; the endpoint should not be called",
         );
         cy.get("@uploadDictionarySpy").should("not.have.been.called");
+      });
+
+      it("rejects invalid CSV", () => {
+        cy.visit("/admin/settings/localization");
+        const validCSV = getCSVWithHeaderRow(germanFieldNames);
+        const invalidCSV = validCSV + "!";
+        cy.get("#content-translation-dictionary-upload-input").selectFile(
+          {
+            contents: Cypress.Buffer.from(invalidCSV),
+            fileName: "file.csv",
+            mimeType: "text/csv",
+          },
+          { force: true },
+        );
+        cy.findAllByRole("alert")
+          .contains(/Invalid CSV/)
+          .should("be.visible");
+        cy.wait("@uploadDictionary");
       });
     });
   });

--- a/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
@@ -202,7 +202,8 @@ describe("scenarios > admin > localization > content translation", () => {
       it("rejects invalid CSV", () => {
         cy.visit("/admin/settings/localization");
         const validCSV = getCSVWithHeaderRow(germanFieldNames);
-        const invalidCSV = validCSV + "!";
+        const invalidCSV = validCSV + '\nde,Price,"Preis"X';
+
         cy.get("#content-translation-dictionary-upload-input").selectFile(
           {
             contents: Cypress.Buffer.from(invalidCSV),

--- a/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
@@ -212,7 +212,7 @@ describe("scenarios > admin > localization > content translation", () => {
           { force: true },
         );
         cy.findAllByRole("alert")
-          .contains(/Invalid CSV/)
+          .contains(/CSV error/)
           .should("be.visible");
         cy.wait("@uploadDictionary");
       });

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -6,7 +6,6 @@
    [clojure.string :as str]
    [metabase.premium-features.core :as premium-features]
    [metabase.util.i18n :as i18n :refer [tru]]
-   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -114,21 +113,17 @@
     (let [lines (line-seq reader)]
       (doseq [[i line] (map-indexed vector lines)]
         (try
-          (log/info (str "Processing line: " line))
           (doall (csv/read-csv (java.io.StringReader. line)))
-          (log/info "No problems with that line")
           (catch Exception e
             (let [error-message (.getMessage ^Exception e)
                   error-message (if (zero? i)
                                   (tru "Header row: {0}" error-message)
                                   (tru "Row {0}: {1}" i error-message))]
-              (log/info (str "throwing error: " error-message))
               (throw (ex-info
                       error-message
                       {:status-code http-status-unprocessable
                        :errors [error-message]})))))))
     (let [error-message (str (.getMessage ^Exception original-exception))]
-      (log/info (str "throwing generic error: " error-message))
       (throw (ex-info
               error-message
               {:status-code http-status-unprocessable
@@ -141,5 +136,4 @@
     (try
       (doall (csv/read-csv reader))
       (catch Exception original-exception
-        (log/info "Exception found, attempting to make it more informative")
         (throw-informative-csv-error file original-exception)))))

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -123,7 +123,7 @@
                       error-message
                       {:status-code http-status-unprocessable
                        :errors [error-message]})))))))
-    (let [error-message (str (.getMessage ^Exception original-exception))]
+    (let [error-message (.getMessage ^Exception original-exception)]
       (throw (ex-info
               error-message
               {:status-code http-status-unprocessable

--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -107,7 +107,9 @@
           (t2/insert! :model/ContentTranslation usable-rows))))))
 
 (defn throw-informative-csv-error
-  "Throw an error that mentions the specific line number that fails"
+  "Throw an error that mentions the specific line number that fails. In the happy path, for the sake of efficiency, we
+  send the whole file to csv/read-csv. In this function, to learn the line number where the error arose, we send the
+  file to csv/read-csv again, line by line."
   [file original-exception]
   (with-open [reader (io/reader file)]
     (let [lines (line-seq reader)]

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -59,9 +59,8 @@
                       {:status-code http-status-content-too-large})))
     (when-not (instance? java.io.File file)
       (throw (ex-info (tru "No file provided") {:status-code 400})))
-    (with-open [rdr (io/reader file)]
-      (let [[_header & rows] (csv/read-csv rdr)]
-        (dictionary/import-translations! rows)))
+    (let [[_header & rows] (dictionary/read-csv file)]
+      (dictionary/import-translations! rows))
     {:success true}))
 
 (api.macros/defendpoint :get "/dictionary/:token"


### PR DESCRIPTION
Previously we rejected invalid CSV with a generic error message. This PR ensures that the admin receives a more informative error message, including the line number that contains failing CSV.