### PR TITLE
Row action not rendering on editable table after saving

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1453,8 +1453,6 @@ describe("issue 48878", () => {
     H.restore();
     cy.signInAsAdmin();
     H.setActionsEnabledForDB(SAMPLE_DB_ID);
-    // TODO: Remove when tmp-action is moved from EE to OSS
-    H.setTokenFeatures("all");
 
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1453,6 +1453,8 @@ describe("issue 48878", () => {
     H.restore();
     cy.signInAsAdmin();
     H.setActionsEnabledForDB(SAMPLE_DB_ID);
+    // TODO: Remove when tmp-action is moved from EE to OSS
+    H.setTokenFeatures("all");
 
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");

--- a/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
@@ -1,3 +1,5 @@
+import type { SkipToken } from "@reduxjs/toolkit/query";
+
 import type {
   DescribeActionFormRequest,
   DescribeActionFormResponse,
@@ -79,10 +81,14 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
         },
       }),
     }),
-    getActions: builder.query<DataGridWritebackAction[], void>({
-      query: () => ({
+    getActions: builder.query<
+      DataGridWritebackAction[],
+      null | SkipToken | void
+    >({
+      query: (params) => ({
         method: "GET",
         url: `/api/action/v2/tmp-action`,
+        params,
       }),
       transformResponse: (response: { actions: DataGridWritebackAction[] }) =>
         response?.actions,

--- a/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
@@ -1,5 +1,6 @@
 import type { SkipToken } from "@reduxjs/toolkit/query";
 
+import { removeNullAndUndefinedValues } from "metabase/lib/types";
 import type {
   DescribeActionFormRequest,
   DescribeActionFormResponse,
@@ -102,7 +103,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
         url: `/api/action/v2/execute`,
         body: {
           input,
-          params,
+          params: removeNullAndUndefinedValues(params),
           // Here we pass a dummy table id, because the BE doesn't allow scope to be optional,
           // but it's not actually used for this case.
           scope: { "table-id": 1 },

--- a/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/table-data-edit.ts
@@ -1,6 +1,5 @@
 import type { SkipToken } from "@reduxjs/toolkit/query";
 
-import { removeNullAndUndefinedValues } from "metabase/lib/types";
 import type {
   DescribeActionFormRequest,
   DescribeActionFormResponse,
@@ -103,7 +102,7 @@ export const tableDataEditApi = EnterpriseApi.injectEndpoints({
         url: `/api/action/v2/execute`,
         body: {
           input,
-          params: removeNullAndUndefinedValues(params),
+          params,
           // Here we pass a dummy table id, because the BE doesn't allow scope to be optional,
           // but it's not actually used for this case.
           scope: { "table-id": 1 },

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
@@ -14,13 +14,13 @@ import { formatValue } from "metabase/lib/formatting/value";
 import { Box, Icon } from "metabase/ui";
 import type { OrderByDirection } from "metabase-lib";
 import type {
+  DataGridWritebackAction,
   DatasetColumn,
   DatasetData,
   Field,
   FieldWithMetadata,
   RowValue,
   RowValues,
-  WritebackAction,
 } from "metabase-types/api";
 
 import { canEditField } from "../../helpers";
@@ -50,8 +50,8 @@ type EditTableDataGridProps = {
     column: DatasetColumn,
   ) => OrderByDirection | undefined;
   cellsWithFailedUpdatesMap?: Record<CellUniqKey, true>;
-  rowActions?: WritebackAction[];
-  onActionRun?: (action: WritebackAction, row: Row<RowValues>) => void;
+  rowActions?: DataGridWritebackAction[];
+  onActionRun?: (action: DataGridWritebackAction, row: Row<RowValues>) => void;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onColumnSort?: (field: Field) => void;

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/execution/use-table-actions-execute.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/execution/use-table-actions-execute.ts
@@ -1,8 +1,9 @@
 import type { Row } from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
 
-import { skipToken, useListActionsQuery } from "metabase/api";
+import { skipToken } from "metabase/api";
 import type { SelectedTableActionState } from "metabase/visualizations/types/table-actions";
+import { useGetActionsQuery } from "metabase-enterprise/api";
 import type {
   ActionFormInitialValues,
   DatasetData,
@@ -29,8 +30,8 @@ export const useTableActionsExecute = ({
 
   const hasAddedActions = actionsVizSettings && actionsVizSettings.length > 0;
 
-  const { data: actions } = useListActionsQuery(
-    hasAddedActions ? {} : skipToken,
+  const { data: actions } = useGetActionsQuery(
+    hasAddedActions ? null : skipToken,
   );
 
   const { tableActions, tableActionsVizSettingsSet } = useMemo(() => {

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/execution/use-table-actions-execute.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/execution/use-table-actions-execute.ts
@@ -6,11 +6,11 @@ import type { SelectedTableActionState } from "metabase/visualizations/types/tab
 import { useGetActionsQuery } from "metabase-enterprise/api";
 import type {
   ActionFormInitialValues,
+  DataGridWritebackAction,
   DatasetData,
   RowValues,
   TableActionDisplaySettings,
   TableRowActionDisplaySettings,
-  WritebackAction,
 } from "metabase-types/api";
 
 import {
@@ -66,7 +66,7 @@ export const useTableActionsExecute = ({
   }, [actions, actionsVizSettings]);
 
   const handleTableActionRun = useCallback(
-    (action: WritebackAction, row: Row<RowValues>) => {
+    (action: DataGridWritebackAction, row: Row<RowValues>) => {
       if (!datasetData) {
         console.warn("Failed to trigger action, datasetData is null");
         return;

--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -132,6 +132,7 @@ export interface TableAction
   > {
   table_id: number;
   table_name: string;
+  name: string;
   database_id?: DatabaseId;
   database_enabled_actions: boolean;
   kind: string;

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -1,5 +1,9 @@
-import type { FormikHelpers } from "formik";
-import { useCallback, useMemo } from "react";
+import {
+  type FormikContextType,
+  type FormikHelpers,
+  useFormikContext,
+} from "formik";
+import { useCallback, useEffect, useMemo } from "react";
 import { t } from "ttag";
 
 import useActionForm from "metabase/actions/hooks/use-action-form";
@@ -38,6 +42,9 @@ interface ActionFormProps {
     actions: FormikHelpers<ParametersForActionExecution>,
   ) => void;
   onClose?: () => void;
+  onContextUpdate?: (
+    context: FormikContextType<ParametersForActionExecution>,
+  ) => void;
 }
 
 function ActionForm({
@@ -46,6 +53,7 @@ function ActionForm({
   hiddenFields = [],
   onSubmit,
   onClose,
+  onContextUpdate,
 }: ActionFormProps): JSX.Element {
   const { initialValues, form, validationSchema, getCleanValues } =
     useActionForm({
@@ -82,6 +90,7 @@ function ActionForm({
       enableReinitialize
     >
       <Form role="form" data-testid="action-form">
+        <ActionFormContext onContextUpdate={onContextUpdate} />
         {editableFields.map((field) => (
           <ActionFormFieldWidget key={field.name} formField={field} />
         ))}
@@ -101,3 +110,19 @@ function ActionForm({
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default ActionForm;
+
+function ActionFormContext({
+  onContextUpdate,
+}: {
+  onContextUpdate?: (
+    context: FormikContextType<ParametersForActionExecution>,
+  ) => void;
+}) {
+  const context = useFormikContext<ParametersForActionExecution>();
+  useEffect(() => {
+    onContextUpdate?.(context);
+  }, [context, onContextUpdate]);
+
+  // This component is just for providing state updates to the parent component, so it renders nothing.
+  return null;
+}

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -1,4 +1,4 @@
-import type { FormikHelpers } from "formik";
+import type { FormikContextType, FormikHelpers } from "formik";
 import { useCallback, useMemo } from "react";
 
 import ActionForm from "metabase/actions/components/ActionForm";
@@ -18,6 +18,9 @@ export interface ActionParametersInputFormProps {
     actions: FormikHelpers<ParametersForActionExecution>,
   ) => void;
   onCancel?: () => void;
+  onContextUpdate?: (
+    context: FormikContextType<ParametersForActionExecution>,
+  ) => void;
 }
 
 function ActionParametersInputForm({
@@ -27,6 +30,7 @@ function ActionParametersInputForm({
   onCancel,
   onSubmit,
   onSubmitSuccess,
+  onContextUpdate,
 }: ActionParametersInputFormProps) {
   const hiddenFields = useMemo(() => {
     const hiddenFieldIds = Object.values(
@@ -64,6 +68,7 @@ function ActionParametersInputForm({
       hiddenFields={hiddenFields}
       onSubmit={handleSubmit}
       onClose={onCancel}
+      onContextUpdate={onContextUpdate}
     />
   );
 }

--- a/frontend/src/metabase/data-grid/types.ts
+++ b/frontend/src/metabase/data-grid/types.ts
@@ -18,7 +18,7 @@ import type { VirtualItem } from "@tanstack/react-virtual";
 import type React from "react";
 import type { RefObject } from "react";
 
-import type { WritebackAction } from "metabase-types/api";
+import type { DataGridWritebackAction } from "metabase-types/api";
 
 import type { ColumnsReordering } from "./hooks/use-columns-reordering";
 import type { VirtualGrid } from "./hooks/use-virtual-grid";
@@ -134,10 +134,10 @@ export interface RowIdColumnOptions {
 }
 
 export interface RowActionsColumnConfig<TData> {
-  actions: WritebackAction[];
-  onActionRun: (action: WritebackAction, row: Row<TData>) => void;
+  actions: DataGridWritebackAction[];
+  onActionRun: (action: DataGridWritebackAction, row: Row<TData>) => void;
   renderCell?: (
-    actions: WritebackAction[],
+    actions: DataGridWritebackAction[],
     rowIndex: number,
   ) => React.ReactNode;
 }

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -69,6 +69,7 @@ import type {
   DashCardId,
   Dashboard,
   DashboardId,
+  DataGridWritebackAction,
   Database as DatabaseType,
   Dataset,
   DatasetData,
@@ -89,7 +90,6 @@ import type {
   TimelineEvent,
   User,
   VisualizationSettings,
-  WritebackAction,
 } from "metabase-types/api";
 import type {
   AdminPath,
@@ -791,10 +791,10 @@ export const PLUGIN_TABLE_ACTIONS = {
       handleTableActionRun: _.noop,
       handleExecuteActionModalClose: _.noop,
     }) as {
-      tableActions: WritebackAction[];
+      tableActions: DataGridWritebackAction[];
       selectedTableActionState: SelectedTableActionState | null;
       handleTableActionRun: (
-        action: WritebackAction,
+        action: DataGridWritebackAction,
         row: Row<RowValues>,
       ) => void;
       handleExecuteActionModalClose: () => void;


### PR DESCRIPTION
Closes [WRK-492](https://linear.app/metabase/issue/WRK-492/metabase-row-action-not-rendering-on-editable-table-after-saving)

### Description
`useTableActionsExecute` and `TableActionExecuteModalContent` used legacy action APIs to get the list of available actions to render row actions.

Updated the code to use `/api/ee/data-editing/tmp-action` endpoint which returns both model and table actions, along with some types to reflect new data model.

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/c4c629da-3b7f-4262-8c66-fa5bac8111a6" />
