### PR TITLE
feat: add update row modal based on describe API (table view)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
@@ -25,14 +25,14 @@ import { EditTableDataGrid } from "./EditTableDataGrid";
 import { EditTableDataHeader } from "./EditTableDataHeader";
 import { EditTableDataOverlay } from "./EditTableDataOverlay";
 import { ActionCreateRowFormModal } from "./modals/ActionCreateRowFormModal";
+import { ActionUpdateRowFormModal } from "./modals/ActionUpdateRowFormModal";
 import { DeleteBulkRowConfirmationModal } from "./modals/DeleteBulkRowConfirmationModal";
 import { EditBulkRowsModal } from "./modals/EditBulkRowsModal";
-import { EditingBaseRowModal } from "./modals/EditingBaseRowModal";
 import { ForeignKeyConstraintModal } from "./modals/ForeignKeyConstraintModal";
 import { UnsavedLeaveConfirmationModal } from "./modals/UnsavedLeaveConfirmationModal";
+import { useActionUpdateRowModalFromDatasetWithObjectId } from "./modals/use-action-update-row-modal-with-object-id";
 import { useForeignKeyConstraintHandling } from "./modals/use-foreign-key-constraint-handling";
 import { useTableBulkDeleteConfirmation } from "./modals/use-table-bulk-delete-confirmation";
-import { useTableEditingModalControllerWithObjectId } from "./modals/use-table-modal-with-object-id";
 import { getTableEditPathname } from "./url";
 import { useStandaloneTableQuery } from "./use-standalone-table-query";
 import { useActionFormDescription } from "./use-table-action-form-description";
@@ -92,16 +92,6 @@ export const EditTableDataContainer = ({
     },
     [databaseId, tableId, location, dispatch],
   );
-
-  const {
-    state: modalState,
-    openEditRowModal,
-    closeModal,
-  } = useTableEditingModalControllerWithObjectId({
-    currentObjectId: objectIdParam,
-    datasetData,
-    onObjectIdChange: handleCurrentObjectIdChange,
-  });
 
   const stateUpdateStrategy =
     useTableEditingStateApiUpdateStrategy(fakeTableQuery);
@@ -163,6 +153,20 @@ export const EditTableDataContainer = ({
   const { data: createRowFormDescription } = useActionFormDescription({
     actionId: BuiltInTableAction.Create,
     scope: editingScope,
+  });
+
+  const {
+    opened: isUpdateRowModalOpen,
+    rowIndex: updateModalRowIndex,
+    rowData: updateModalRowData,
+    actionFormDescription: updateActionFormDescription,
+    openUpdateRowModal,
+    closeUpdateRowModal,
+  } = useActionUpdateRowModalFromDatasetWithObjectId({
+    datasetData,
+    scope: editingScope,
+    currentObjectId: objectIdParam,
+    onObjectIdChange: handleCurrentObjectIdChange,
   });
 
   const {
@@ -250,7 +254,7 @@ export const EditTableDataContainer = ({
                 cellsWithFailedUpdatesMap={cellsWithFailedUpdatesMap}
                 getColumnSortDirection={getColumnSortDirection}
                 onCellValueUpdate={handleCellValueUpdate}
-                onRowExpandClick={openEditRowModal}
+                onRowExpandClick={openUpdateRowModal}
                 onRowSelectionChange={setRowSelection}
                 rowSelection={rowSelection}
                 onColumnSort={handleChangeColumnSort}
@@ -277,21 +281,15 @@ export const EditTableDataContainer = ({
           />
         )}
       </Stack>
-      <EditingBaseRowModal
-        modalState={modalState}
-        onClose={closeModal}
-        onEdit={handleRowUpdate}
-        onRowCreate={handleRowCreate}
+      <ActionUpdateRowFormModal
+        rowIndex={updateModalRowIndex}
+        rowData={updateModalRowData}
+        description={updateActionFormDescription}
+        opened={isUpdateRowModalOpen}
+        onClose={closeUpdateRowModal}
+        onRowUpdate={handleRowUpdate}
         onRowDelete={handleRowDelete}
-        datasetColumns={datasetData.cols}
-        currentRowData={
-          modalState.rowIndex !== undefined
-            ? datasetData.rows[modalState.rowIndex]
-            : undefined
-        }
-        fieldMetadataMap={tableFieldMetadataMap}
-        isLoading={isInserting}
-        hasDeleteAction
+        withDelete
       />
       <ActionCreateRowFormModal
         description={createRowFormDescription}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputSearchableSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputSearchableSelect.tsx
@@ -47,7 +47,6 @@ export const ActionInputSearchableSelect = ({
 
   const combobox = useCombobox({
     defaultOpened: autoFocus,
-    onDropdownClose: onBlur,
     onDropdownOpen: focusSearchInput,
   });
 
@@ -61,9 +60,12 @@ export const ActionInputSearchableSelect = ({
     (value: string | null) => {
       setValue(value ?? "");
       onChange?.(value);
+
+      // Close the dropdown
+      onBlur?.(value);
       combobox.toggleDropdown();
     },
-    [setValue, onChange, combobox],
+    [setValue, onChange, onBlur, combobox],
   );
 
   const inputLabel = useMemo(() => {

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionUpdateRowFormModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/ActionUpdateRowFormModal.tsx
@@ -1,0 +1,144 @@
+import { useDisclosure } from "@mantine/hooks";
+import cx from "classnames";
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import { ActionIcon, Group, Icon, Loader, Modal, rem } from "metabase/ui";
+import type { RowValue } from "metabase-types/api";
+
+import type {
+  ActionFormParameter,
+  DescribeActionFormResponse,
+  UpdatedRowHandlerParams,
+} from "../../types";
+import { ParameterActionInput } from "../inputs_v2/ParameterActionInput";
+
+import { ActionFormModalParameter } from "./ActionFormModalParameter";
+import { DeleteRowConfirmationModal } from "./DeleteRowConfirmationModal";
+import S from "./EditingBaseRowModal.module.css";
+
+interface ActionUpdateRowFormModalProps {
+  opened: boolean;
+  rowIndex: number | null;
+  rowData: Record<string, RowValue> | null;
+  description?: DescribeActionFormResponse;
+  onClose: () => void;
+  onRowUpdate: (data: UpdatedRowHandlerParams) => Promise<boolean>;
+  onRowDelete: (rowIndex: number) => Promise<boolean>;
+  withDelete?: boolean;
+}
+
+export function ActionUpdateRowFormModal({
+  opened,
+  rowIndex,
+  rowData,
+  description,
+  onClose,
+  onRowUpdate,
+  onRowDelete,
+  withDelete = false,
+}: ActionUpdateRowFormModalProps) {
+  const [
+    isDeleteRequested,
+    { open: requestDeletion, close: closeDeletionModal },
+  ] = useDisclosure();
+
+  const handleValueUpdated = useCallback(
+    (field: string, value: RowValue) => {
+      if (rowIndex !== null) {
+        onRowUpdate({ updatedData: { [field]: value }, rowIndex });
+      }
+    },
+    [onRowUpdate, rowIndex],
+  );
+
+  const handleDeleteConfirmation = useCallback(async () => {
+    if (rowIndex !== null) {
+      closeDeletionModal();
+      onClose();
+
+      await onRowDelete(rowIndex);
+    }
+  }, [closeDeletionModal, onRowDelete, rowIndex, onClose]);
+
+  if (isDeleteRequested) {
+    return (
+      <DeleteRowConfirmationModal
+        onCancel={closeDeletionModal}
+        onConfirm={handleDeleteConfirmation}
+      />
+    );
+  }
+
+  return (
+    <Modal.Root opened={opened} onClose={onClose}>
+      <Modal.Overlay />
+      <Modal.Content>
+        <Modal.Header px="xl" pb="0" className={S.modalHeader}>
+          <Modal.Title>{t`Create a new record`}</Modal.Title>
+          <Group
+            gap="xs"
+            mr={rem(-5) /* aligns cross with modal right padding */}
+          >
+            {withDelete && (
+              <ActionIcon variant="subtle" onClick={requestDeletion}>
+                <Icon name="trash" />
+              </ActionIcon>
+            )}
+            <ActionIcon variant="subtle" onClick={onClose}>
+              <Icon name="close" />
+            </ActionIcon>
+          </Group>
+        </Modal.Header>
+        <Modal.Body px="xl" py="lg" className={cx(S.modalBody)}>
+          {!description ? (
+            <Loader />
+          ) : (
+            description.parameters.map((parameter) => {
+              return (
+                <ActionFormModalParameter
+                  key={parameter.id}
+                  parameter={parameter}
+                >
+                  <UpdateRowFormInput
+                    initialValue={rowData?.[parameter.id]}
+                    parameter={parameter}
+                    onValueUpdated={handleValueUpdated}
+                  />
+                </ActionFormModalParameter>
+              );
+            })
+          )}
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+type UpdateRowFormInputProps = {
+  initialValue?: RowValue;
+  parameter: ActionFormParameter;
+  onValueUpdated: (field: string, value: RowValue) => void;
+};
+
+export function UpdateRowFormInput({
+  initialValue,
+  parameter,
+  onValueUpdated,
+}: UpdateRowFormInputProps) {
+  const handleValueUpdated = useCallback(
+    (value: RowValue) => {
+      onValueUpdated(parameter.id, value);
+    },
+    [parameter.id, onValueUpdated],
+  );
+
+  return (
+    <ParameterActionInput
+      initialValue={initialValue?.toString()}
+      parameter={parameter}
+      onBlur={handleValueUpdated}
+      onEnter={handleValueUpdated}
+    />
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/use-action-update-row-modal-with-object-id.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/use-action-update-row-modal-with-object-id.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect } from "react";
+
+import { isPK } from "metabase-lib/v1/types/utils/isa";
+import type { DatasetData } from "metabase-types/api";
+
+import type { TableEditingScope } from "../../types";
+
+import { useActionUpdateRowModalFromDataset } from "./use-action-update-row-modal";
+
+type UseActionUpdateRowModalFromDatasetWithObjectId = {
+  currentObjectId?: string;
+  onObjectIdChange: (objectId?: string) => void;
+  datasetData?: DatasetData;
+  scope: TableEditingScope;
+};
+
+/**
+ * In contrast to the `useActionUpdateRowModalFromDataset`, this hook relies on the
+ * `currentObjectId` prop to determine which modal to open and when. It's designed
+ * for editing modals with direct URL access, where the `currentObjectId` is passed
+ * as a prop. This allows to keep the URL in sync with the modal state as well as
+ * to support history navigation.
+ *
+ * Basically opening a modal triggers a URL change, which triggers `useEffect` hook
+ * to open the modal based on the current object ID.
+ */
+export function useActionUpdateRowModalFromDatasetWithObjectId({
+  currentObjectId,
+  datasetData,
+  scope,
+  onObjectIdChange,
+}: UseActionUpdateRowModalFromDatasetWithObjectId) {
+  const {
+    opened,
+    actionFormDescription,
+    rowIndex,
+    rowData,
+    openUpdateRowModal,
+    closeUpdateRowModal,
+  } = useActionUpdateRowModalFromDataset({
+    datasetData,
+    scope,
+  });
+
+  useEffect(() => {
+    switch (currentObjectId) {
+      case undefined:
+        closeUpdateRowModal();
+        break;
+
+      default:
+        if (datasetData) {
+          const pkColumnIndex = datasetData.cols.findIndex(isPK);
+          const rowIndex = datasetData.rows.findIndex(
+            (row) =>
+              row[pkColumnIndex] === currentObjectId ||
+              row[pkColumnIndex] === Number(currentObjectId),
+          );
+
+          if (rowIndex !== -1) {
+            openUpdateRowModal(rowIndex);
+          }
+        }
+    }
+  }, [currentObjectId, datasetData, openUpdateRowModal, closeUpdateRowModal]);
+
+  const handleOpenUpdateRowModal = useCallback(
+    (rowIndex: number) => {
+      if (!datasetData) {
+        return;
+      }
+
+      const pkColumnIndex = datasetData.cols.findIndex(isPK);
+      const objectId = datasetData.rows[rowIndex][pkColumnIndex];
+      onObjectIdChange(objectId?.toString());
+    },
+    [datasetData, onObjectIdChange],
+  );
+
+  const handleCloseUpdateRowModal = useCallback(() => {
+    onObjectIdChange(undefined);
+  }, [onObjectIdChange]);
+
+  return {
+    opened,
+    actionFormDescription,
+    rowIndex,
+    rowData,
+    openUpdateRowModal: handleOpenUpdateRowModal,
+    closeUpdateRowModal: handleCloseUpdateRowModal,
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/use-action-update-row-modal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/modals/use-action-update-row-modal.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useMemo, useState } from "react";
+
+import type { DatasetData, RowValue } from "metabase-types/api";
+
+import type { TableEditingScope } from "../../types";
+import { BuiltInTableAction } from "../../types";
+import { useActionFormDescription } from "../use-table-action-form-description";
+
+type UseActionUpdateRowModalFromDatasetParams = {
+  datasetData?: DatasetData;
+  scope: TableEditingScope;
+};
+
+export function useActionUpdateRowModalFromDataset({
+  datasetData,
+  scope,
+}: UseActionUpdateRowModalFromDatasetParams) {
+  const [rowIndex, setRowIndex] = useState<number | null>(null);
+
+  const { data: actionFormDescription } = useActionFormDescription({
+    actionId: BuiltInTableAction.Update,
+    scope,
+  });
+
+  const openUpdateRowModal = useCallback((rowIndex: number) => {
+    setRowIndex(rowIndex);
+  }, []);
+
+  const closeUpdateRowModal = useCallback(() => {
+    setRowIndex(null);
+  }, []);
+
+  const rowData = useMemo(() => {
+    if (rowIndex === null || !datasetData) {
+      return null;
+    }
+
+    const { cols, rows } = datasetData;
+    const row = rows[rowIndex];
+
+    // Remap the row to a record of field names to values
+    return cols.reduce(
+      (acc, col, index) => {
+        acc[col.name] = row[index];
+        return acc;
+      },
+      {} as Record<string, RowValue>,
+    );
+  }, [rowIndex, datasetData]);
+
+  return {
+    opened: rowIndex !== null,
+    actionFormDescription,
+    rowIndex,
+    rowData,
+    openUpdateRowModal,
+    closeUpdateRowModal,
+  };
+}


### PR DESCRIPTION
Update record modal is now based on new action form describe API.

Resolves [WRK-509](https://linear.app/metabase/issue/WRK-509/use-describe-api-for-update-row-modal-database-view)

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/bc9f578f-8830-4e94-8497-09f085e659b3" />
