### PR TITLE
[MBQL lib] Update downstream refs after swapping clauses

### DIFF
--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -92,7 +92,7 @@
               new-name    ((some-fn :lib/desired-column-alias :name) new-column)]
           (assoc &match 2 new-name))))))
 
-(defn- update-stale-references
+(defn update-stale-references
   "Update stale refs in query after clause removal.
 
   ## Gist

--- a/src/metabase/lib/swap.cljc
+++ b/src/metabase/lib/swap.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.swap
   (:require
    [metabase.lib.options :as lib.options]
+   [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.util :as lib.util]
    [metabase.util.log :as log]))
 
@@ -40,5 +41,6 @@
         source-path (uuid-match stage source-clause)
         target-path (uuid-match stage target-clause)]
     (if (and source-path target-path)
-      (lib.util/update-query-stage query stage-number do-swap source-path target-path source-clause target-clause)
+      (let [swapped (lib.util/update-query-stage query stage-number do-swap source-path target-path source-clause target-clause)]
+        (lib.remove-replace/update-stale-references swapped stage-number query))
       query)))

--- a/test/metabase/lib/swap_test.cljc
+++ b/test/metabase/lib/swap_test.cljc
@@ -113,3 +113,83 @@
         (lib/swap-clauses query -1 a1 a2)
         (is (=? [{:level :warn, :message #"Ambiguous match for clause in swap-clauses \[:sum .*"}]
                 (messages)))))))
+
+(deftest ^:parallel swap-clauses-aggregations-with-downstream-refs-test
+  (testing "swap-clauses updates downstream refs even if names change"
+    (let [base                 (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                   (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                                   (lib/aggregate (lib/sum (meta/field-metadata :orders :total)))
+                                   (lib/aggregate (lib/sum (meta/field-metadata :orders :tax)))
+                                   lib/append-stage)
+          ;; These three aggregations end up being named sum, sum_2 and sum_3 in later stages.
+          aggs-by-id           (->> (lib/aggregations base 0)
+                                    m/indexed
+                                    (into {}))
+          [subtotal total tax] (lib/visible-columns base)]
+      (doseq [[i1 agg1] aggs-by-id
+              [i2 agg2] aggs-by-id
+              :when (not= i1 i2)
+              :let [before (-> base
+                               (lib/filter (lib/< subtotal 100))
+                               (lib/filter (lib/< total    200))
+                               (lib/filter (lib/< tax      300)))
+                    after  (lib/swap-clauses before 0 agg1 agg2)]]
+        (testing "the aggregations really did get swapped"
+          (let [exp-aggs (merge aggs-by-id
+                                {i1 agg2
+                                 i2 agg1})]
+            (is (=? (map exp-aggs (range (count exp-aggs)))
+                    (lib/aggregations after 0)))))
+        ;; The refs in the three filters should match the same columns as before, even though the names have changed
+        ;; when swapped.
+        (let [filter-cols (fn [query]
+                            (let [cols (lib/visible-columns query)]
+                              (for [[_< _opts agg _value] (lib/filters query -1)]
+                                (lib/find-matching-column agg cols))))
+              cols-before (filter-cols before)
+              cols-after  (filter-cols after)]
+          (is (every? some? cols-before))
+          (is (every? some? cols-after))
+          (is (every? :lib/source-uuid cols-before))
+          (is (every? :lib/source-uuid cols-after))
+          (testing "the ref always points at the correct underlying column"
+            (is (=? (map :lib/source-uuid cols-before)
+                    (map :lib/source-uuid cols-after)))
+            (testing "even though the names have changed where they were swapped"
+              (let [dcas-before (mapv :lib/desired-column-alias cols-before)
+                    dcas-after  (mapv :lib/desired-column-alias cols-after)]
+                (is (not= (nth dcas-before i1)
+                          (nth dcas-after  i1)))
+                (is (not= (nth dcas-before i2)
+                          (nth dcas-after  i2)))
+                (for [i-unchanged (remove #{i1 i2} (range (count aggs-by-id)))]
+                  (is (= (nth dcas-before i-unchanged)
+                         (nth dcas-after  i-unchanged))))))))))))
+
+(deftest ^:parallel swap-clauses-breakouts-on-same-column-test
+  (testing "swapping two breakouts of the same column with different time granularity maintains downstream refs"
+    (let [base          (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                            (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month))
+                            (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :day))
+                            lib/append-stage)
+          [months days] (lib/visible-columns base)
+          before        (-> base
+                            (lib/filter (lib/= months 4))
+                            (lib/expression "days-ago" (lib/- (lib/now) days)))
+          [brk1 brk2]   (lib/breakouts base 0)
+          after         (lib/swap-clauses before 0 brk1 brk2)
+          cols-after    (lib/visible-columns after)
+          days-after    (assoc days
+                               :lib/source-column-alias  "CREATED_AT"
+                               :lib/desired-column-alias "CREATED_AT")
+          months-after  (assoc months
+                               :lib/source-column-alias  "CREATED_AT_2"
+                               :lib/desired-column-alias "CREATED_AT_2")]
+      (testing "\nthe columns have swapped places and their names have changed"
+        (is (=? [days-after months-after {:name "days-ago"}]
+                cols-after)))
+      (testing "the refs to those breakouts are still aimed at the same columns as before, despite the name change"
+        (let [[_- _opts _now days-ref] (first (lib/expressions after))]
+          (is (=? days-after (lib/find-matching-column days-ref cols-after))))
+        (let [[_= _opts months-ref _value] (first (lib/filters after))]
+          (is (=? months-after (lib/find-matching-column months-ref cols-after))))))))


### PR DESCRIPTION
Closes #59273.
Closes #48306.

### Description

Swapping two clauses can change their names, eg. two sum aggregations
`sum` and `sum_2`. Since refs in later stages are based on those names,
the refs need updating to track the same column, rather than change
targets.

`lib.remove-replace` already has logic for this when replacing a clause,
it was readily reused here. I added tests for swapping aggregations and
multiple breakouts of the same column.

Note that viz settings (also based on the names) are not updated as part
of this PR. There are separate bugs open for that issue both when
removing a clause and reordering them.


### How to verify

1. New question -> Sample Dataset -> Orders
2. Aggregate: Sum of Subtotal, Sum of Total, Sum of Tax
3. Next stage, filter on `[Sum of Subtotal] < 100`
4. Drag to reorder the `Sum of Subtotal` aggregation with one of the others

Before this change, the filter would now silently be pointing at whichever
aggregation was first in the list.

With this change, the filter is updated internally, so it continues to point at the same column.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
