### PR TITLE
[Metabot] Suggestions UI improvements

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -304,6 +304,27 @@ describe("metabot", () => {
         screen.queryByTestId("metabot-prompt-suggestions"),
       ).not.toBeInTheDocument();
     });
+
+    it("should make a request for new suggested prompts when the conversation is reset", async () => {
+      setup({ promptSuggestions: [] });
+      await waitFor(async () => {
+        expect(
+          fetchMock.calls(
+            `path:/api/ee/metabot-v3/metabot/1/prompt-suggestions`,
+          ),
+        ).toHaveLength(1);
+      });
+
+      await userEvent.click(await resetChatButton());
+
+      await waitFor(async () => {
+        expect(
+          fetchMock.calls(
+            `path:/api/ee/metabot-v3/metabot/1/prompt-suggestions`,
+          ),
+        ).toHaveLength(2);
+      });
+    });
   });
 
   describe("message", () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -139,6 +139,8 @@ export const resetConversation = createAsyncThunk(
         fixedCacheKey: METABOT_TAG,
       }),
     );
+    // clear out suggested prompts so the user is shown something fresh
+    dispatch(EnterpriseApi.util.invalidateTags(["metabot-prompt-suggestions"]));
 
     dispatch(clearMessages());
     dispatch(resetConversationId());


### PR DESCRIPTION
### Description

This PR makes two improvements on the suggestions experience
1. Add a loading indicator when updating a metabot collection in the admin settings ([Demo video](https://github.com/user-attachments/assets/8d7c3dc9-f39a-456c-b974-efe86b723eec))
2. Updates the suggested prompts when a conversation is reset ([Demo video](https://github.com/user-attachments/assets/2a646165-ec05-486c-9abf-45ae1ad98a9f))

### Checklist

- [x] Tests have been added/updated to cover changes in this PR