### PR TITLE
[Metabot] Unit test flake fix

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -40,6 +40,7 @@ frontend_specs: &frontend_specs
   - "frontend/test/**"
   - "frontend/**/tests/**"
   - "frontend/**/*.unit.*"
+  - "enterprise/frontend/**/*.unit.*"
   - ".github/**/*.unit.spec.*"
   - "jest.config.js"
   - "jest.tz.unit.conf.json"

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminSuggestedPrompts.unit.spec.tsx
@@ -76,6 +76,11 @@ describe("suggested prompts", () => {
   });
 
   it("should successfully render a list of prompts", async () => {
+    await setup();
+    await expectVisiblePrompts(defaultMetabotMockedPrompts.slice(0, 3));
+  });
+
+  it("should show loading state", async () => {
     setupMetabotPromptSuggestionsEndpoint(
       FIXED_METABOT_IDS.DEFAULT,
       defaultMetabotMockedPrompts,
@@ -87,11 +92,6 @@ describe("suggested prompts", () => {
       { delay: 50 },
     );
     await setup({ mockInitialPage: false });
-    await expectVisiblePrompts(defaultMetabotMockedPrompts.slice(0, 3));
-  });
-
-  it("should show loading state", async () => {
-    await setup();
     const [loadingRow] = await screen.findAllByTestId("prompt-loading-row");
     expect(loadingRow).toBeInTheDocument();
   });


### PR DESCRIPTION
### Description

This is a whoops on my end. I noticed a unit test flaked occasionally so I added a fix... to the wrong test. This PR corrects that and will unblock #59313. I'm not backporting this change, but will cherry pick the commit as part of #59313.

This PR also makes it so that if the only change is a change to the unit test files in our `enterprise/frontend` folder, that we don't skip running our unit test suite.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
