### PR TITLE
Closes VIZ-1057 VIZ-1056 touch up filter appearance

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -166,7 +166,7 @@ export function notificationList() {
  * @todo Extract into a separate helper file.
  */
 export function filterWidget() {
-  return cy.get("fieldset");
+  return cy.findAllByTestId("parameter-widget");
 }
 
 export function clearFilterWidget(index = 0) {

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1030,7 +1030,7 @@ describe("scenarios > dashboard > parameters", () => {
       H.dashboardParameterSidebar().button("Remove").click();
 
       H.getDashboardCard(0).within(() => {
-        cy.findByDisplayValue("Heading Text").should("exist");
+        cy.findByText("Heading Text").should("exist");
         cy.findByText("Count").should("not.exist");
 
         cy.findByText("Category").click();

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -958,8 +958,11 @@ describe("scenarios > dashboard > parameters", () => {
       H.saveDashboard();
 
       H.getDashboardCard(0).within(() => {
-        cy.findByText("Count").should("exist");
-        cy.findByText("4,000").should("exist");
+        cy.findByLabelText("Count").within(() => {
+          // exact: false so that it matches "Count\u00a0" (with a non-breaking space)
+          cy.findByText("Count", { exact: false }).should("exist");
+          cy.findByText("4,000").should("exist");
+        });
         cy.findByText("Category").should("not.exist");
       });
 

--- a/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
@@ -1,3 +1,5 @@
+import type { ComponentProps } from "react";
+
 import {
   setEditingParameter,
   setParameterIndex,
@@ -17,7 +19,11 @@ import type { Parameter } from "metabase-types/api";
 
 import { ParametersList } from "../../../parameters/components/ParametersList";
 
-interface DashboardParameterListProps {
+interface DashboardParameterListProps
+  extends Pick<
+    ComponentProps<typeof ParametersList>,
+    "widgetsVariant" | "widgetsWithinPortal" | "vertical"
+  > {
   parameters: Array<Parameter & { value: unknown }>;
   isSortable?: boolean;
   isFullscreen: boolean;
@@ -27,6 +33,9 @@ export function DashboardParameterList({
   parameters,
   isSortable = true,
   isFullscreen,
+  widgetsVariant,
+  widgetsWithinPortal,
+  vertical,
 }: DashboardParameterListProps) {
   const dashboard = useSelector(getDashboardComplete);
   const editingParameter = useSelector(getEditingParameter);
@@ -54,6 +63,9 @@ export function DashboardParameterList({
         dispatch(setParameterValueToDefault(id))
       }
       enableParameterRequiredBehavior
+      widgetsVariant={widgetsVariant}
+      widgetsWithinPortal={widgetsWithinPortal}
+      vertical={vertical}
     />
   );
 }

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
   type ItemCallback,
-  Layout,
   Responsive as ReactGridLayout,
 } from "react-grid-layout";
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -483,7 +483,11 @@ export const getQuestionByCard = createCachedSelector(
     return isQuestionCard(card) ? new Question(card, metadata) : undefined;
   },
 )((_state, props) => {
-  return props.card.id;
+  // Sometime card doesn't have an id.
+  // In that case, we use the stringified version of the card as a cache key.
+  // That's nless than ideal, but it avoids flooding the console with warnings
+  // and it's still better than using `undefined` as a cache key.
+  return props.card.id ?? JSON.stringify(props.card).slice(0, 50);
 });
 
 export const getDashcardParameterMappingOptions = createCachedSelector(

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
@@ -5,12 +5,16 @@
   min-height: 30px;
   min-width: 150px;
   color: var(--mb-color-text-secondary);
-}
 
-.parameter.selected {
-  font-weight: bold;
-  color: var(--mb-color-brand);
-  border-color: var(--mb-color-brand);
+  &.selected {
+    font-weight: bold;
+    color: var(--mb-color-brand);
+    border-color: var(--mb-color-brand);
+  }
+
+  &.subtle {
+    font-weight: 400;
+  }
 }
 
 .parameter input {

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.module.css
@@ -6,14 +6,29 @@
   min-width: 150px;
   color: var(--mb-color-text-secondary);
 
+  &.subtle {
+    font-weight: 400;
+    border: 1px solid var(--mb-color-border);
+    padding-left: 12px;
+    padding-right: 12px;
+    border-radius: 4px;
+  }
+
   &.selected {
     font-weight: bold;
     color: var(--mb-color-brand);
     border-color: var(--mb-color-brand);
   }
 
-  &.subtle {
+  .Prefix {
+    color: var(--mb-color-text-secondary);
     font-weight: 400;
+  }
+
+  &:hover {
+    .Prefix {
+      color: inherit;
+    }
   }
 }
 

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { t } from "ttag";
 
 import { Sortable } from "metabase/core/components/Sortable";
@@ -50,6 +50,7 @@ export type ParameterValueWidgetProps = {
   mimicMantine?: boolean;
   isSortable?: boolean;
   variant?: "default" | "subtle";
+  prefix?: ReactNode;
 } & Partial<PopoverProps>;
 
 export const ParameterValueWidget = ({
@@ -70,6 +71,7 @@ export const ParameterValueWidget = ({
   setValue,
   value,
   variant = "default",
+  prefix,
   ...popoverProps
 }: ParameterValueWidgetProps) => {
   const tc = useTranslateContent();
@@ -214,6 +216,7 @@ export const ParameterValueWidget = ({
               size={16}
             />
           )}
+          {prefix}
           <ParameterDropdownWidget
             parameter={parameter}
             parameters={parameters}
@@ -279,6 +282,7 @@ export const ParameterValueWidget = ({
                   size={16}
                 />
               )}
+              {prefix && <div className={S.Prefix}>{prefix}</div>}
               <div
                 className={cx(CS.mr1, {
                   [S[variant]]: variant,

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -49,6 +49,7 @@ export type ParameterValueWidgetProps = {
   enableRequiredBehavior?: boolean;
   mimicMantine?: boolean;
   isSortable?: boolean;
+  variant?: "default" | "subtle";
 } & Partial<PopoverProps>;
 
 export const ParameterValueWidget = ({
@@ -68,6 +69,7 @@ export const ParameterValueWidget = ({
   setParameterValueToDefault,
   setValue,
   value,
+  variant = "default",
   ...popoverProps
 }: ParameterValueWidgetProps) => {
   const tc = useTranslateContent();
@@ -79,7 +81,8 @@ export const ParameterValueWidget = ({
   const fieldHasValueOrFocus = parameter.value != null || isFocused;
   const noPopover = hasNoPopover(parameter);
   const parameterTypeIcon = getParameterIconName(parameter);
-  const showTypeIcon = !isEditing && !hasValue && !isFocused;
+  const showTypeIcon =
+    !isEditing && !hasValue && !isFocused && !(variant === "subtle");
 
   const [isOpen, { close, toggle }] = useDisclosure();
 
@@ -200,6 +203,7 @@ export const ParameterValueWidget = ({
       >
         <ParameterValueWidgetTrigger
           className={cx(S.noPopover, className)}
+          variant={variant}
           ariaLabel={parameter.name}
           hasValue={hasValue}
         >
@@ -266,6 +270,7 @@ export const ParameterValueWidget = ({
               className={className}
               ariaLabel={placeholder}
               mimicMantine={mimicMantine}
+              variant={variant}
             >
               {showTypeIcon && (
                 <Icon
@@ -275,7 +280,9 @@ export const ParameterValueWidget = ({
                 />
               )}
               <div
-                className={cx(CS.mr1)}
+                className={cx(CS.mr1, {
+                  [S[variant]]: variant,
+                })}
                 style={
                   isStringParameter(parameter) ? { maxWidth: "190px" } : {}
                 }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.tsx
@@ -16,12 +16,14 @@ function ParameterValueWidgetTriggerInner(
     ariaLabel,
     className,
     mimicMantine = false,
+    variant = "default",
   }: {
     children: ReactNode;
     hasValue: boolean;
     ariaLabel?: string;
     className?: string;
     mimicMantine?: boolean;
+    variant?: "default" | "subtle";
   },
   ref: Ref<HTMLDivElement>,
 ) {
@@ -47,6 +49,7 @@ function ParameterValueWidgetTriggerInner(
       ref={ref}
       className={cx(S.parameter, className, {
         [S.selected]: hasValue,
+        [S[variant]]: variant,
       })}
       role="button"
       aria-label={ariaLabel}

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.module.css
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.module.css
@@ -11,12 +11,6 @@
     border-color: var(--mb-color-brand);
   }
 
-  &.subtle {
-    height: 32px;
-    border-width: 1px;
-    background: transparent;
-  }
-
   legend {
     text-transform: none;
     position: relative;
@@ -29,6 +23,29 @@
   @media screen and (min-width: 440px) {
     margin-right: 0.85em;
     width: auto;
+  }
+}
+
+.SubtleParameterWidget {
+  height: 32px;
+  border-width: 1px;
+  background: transparent;
+  margin: 0;
+
+  &.fullWidth {
+    width: 100%;
+
+    & > * {
+      width: 100%;
+    }
+  }
+
+  @media screen and (min-width: 440px) {
+    margin-right: 0;
+  }
+
+  &:hover {
+    color: var(--mb-color-brand);
   }
 }
 

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.module.css
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.module.css
@@ -11,6 +11,12 @@
     border-color: var(--mb-color-brand);
   }
 
+  &.subtle {
+    height: 32px;
+    border-width: 1px;
+    background: transparent;
+  }
+
   legend {
     text-transform: none;
     position: relative;
@@ -26,12 +32,18 @@
   }
 }
 
-.ParameterContainer {
+.EditingParameterContainer {
   border: 1px solid var(--mb-color-border);
   background-color: var(--mb-color-bg-white);
   border-radius: 0.5rem;
   cursor: pointer;
   margin: 0.25rem 0.5rem 0.25rem 0;
+
+  &.subtle {
+    height: 32px;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 
   &.isEditingParameter {
     border-color: var(--mb-color-brand);

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
@@ -39,6 +39,7 @@ type ParameterWidgetProps = PropsWithChildren<
       dragHandle: ReactNode;
       variant?: "default" | "subtle";
       withinPortal?: boolean;
+      fullWidth?: boolean;
     } & Pick<DashboardFullscreenControls, "isFullscreen">
   >
 >;
@@ -62,6 +63,7 @@ export const ParameterWidget = ({
   dragHandle,
   variant = "default",
   withinPortal,
+  fullWidth,
 }: ParameterWidgetProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const isEditingParameter = editingParameter?.id === parameter.id;
@@ -100,6 +102,43 @@ export const ParameterWidget = ({
           <Icon ml="auto" pl="md" name="gear" />
         </Flex>
       </Sortable>
+    );
+  }
+
+  if (variant === "subtle") {
+    return (
+      <Flex
+        fz={isFullscreen ? "md" : undefined}
+        align="center"
+        className={cx(className, S.SubtleParameterWidget, {
+          [S.fullWidth]: fullWidth,
+        })}
+      >
+        <ParameterValueWidget
+          offset={{
+            mainAxis: 8,
+            crossAxis: -16,
+          }}
+          parameter={parameter}
+          parameters={parameters}
+          question={question}
+          dashboard={dashboard}
+          value={parameter.value}
+          setValue={(value) => setValue?.(value)}
+          isEditing={isEditingParameter}
+          placeholder={parameter.name}
+          focusChanged={setIsFocused}
+          isFullscreen={isFullscreen}
+          commitImmediately={commitImmediately}
+          setParameterValueToDefault={setParameterValueToDefault}
+          enableRequiredBehavior={enableParameterRequiredBehavior}
+          isSortable={isSortable && isEditing}
+          variant={variant}
+          withinPortal={withinPortal}
+          prefix={legend ? legend + ":\u00a0" : undefined}
+        />
+        {children}
+      </Flex>
     );
   }
 

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
@@ -144,9 +144,8 @@ export const ParameterWidget = ({
   }
 
   return (
-    <Box fz={isFullscreen ? "md" : undefined}>
+    <Box fz={isFullscreen ? "md" : undefined} data-testid="parameter-widget">
       <FieldSet
-        data-testid="parameter-widget"
         className={cx(
           className,
           DashboardS.ParameterFieldSet,

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
@@ -37,55 +37,11 @@ type ParameterWidgetProps = PropsWithChildren<
       isFullscreen: boolean;
       setEditingParameter: (parameterId: ParameterId | null) => void;
       dragHandle: ReactNode;
+      variant?: "default" | "subtle";
+      withinPortal?: boolean;
     } & Pick<DashboardFullscreenControls, "isFullscreen">
   >
 >;
-
-const EditParameterWidget = ({
-  dragHandle,
-  isSortable,
-  isEditing,
-  parameter,
-  setEditingParameter,
-  isEditingParameter,
-}: {
-  isEditingParameter: boolean;
-} & Pick<
-  ParameterWidgetProps,
-  | "parameter"
-  | "setEditingParameter"
-  | "isEditing"
-  | "isSortable"
-  | "dragHandle"
->) => {
-  return (
-    <Sortable
-      id={parameter.id}
-      draggingStyle={{ opacity: 0.5 }}
-      disabled={!isEditing || !isSortable}
-      role="listitem"
-    >
-      <Flex
-        align="center"
-        miw="170px"
-        p="sm"
-        fw="bold"
-        className={cx(S.ParameterContainer, {
-          [S.isEditingParameter]: isEditingParameter,
-        })}
-        onClick={() =>
-          setEditingParameter?.(isEditingParameter ? null : parameter.id)
-        }
-      >
-        <div className={CS.mr1} onClick={(e) => e.stopPropagation()}>
-          {dragHandle}
-        </div>
-        {parameter.name}
-        <Icon ml="auto" pl="md" name="gear" />
-      </Flex>
-    </Sortable>
-  );
-};
 
 export const ParameterWidget = ({
   question,
@@ -104,6 +60,8 @@ export const ParameterWidget = ({
   setValue,
   children,
   dragHandle,
+  variant = "default",
+  withinPortal,
 }: ParameterWidgetProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const isEditingParameter = editingParameter?.id === parameter.id;
@@ -114,56 +72,79 @@ export const ParameterWidget = ({
 
   const legend = fieldHasValueOrFocus ? maybeTranslatedParameterName : "";
 
-  if (!isEditing || !setEditingParameter) {
+  if (isEditing && setEditingParameter) {
     return (
-      <Box fz={isFullscreen ? "md" : undefined}>
-        <FieldSet
-          className={cx(
-            className,
-            DashboardS.ParameterFieldSet,
-            EmbedFrameS.ParameterFieldSet,
-            S.ParameterFieldSet,
-            {
-              [S.fieldHasValueOrFocus]: fieldHasValueOrFocus,
-            },
-          )}
-          legend={legend}
-          required={enableParameterRequiredBehavior && parameter.required}
-          noPadding
+      <Sortable
+        id={parameter.id}
+        draggingStyle={{ opacity: 0.5 }}
+        disabled={!isEditing}
+        role="listitem"
+      >
+        <Flex
+          align="center"
+          miw="170px"
+          p="sm"
+          fw="bold"
+          className={cx(S.EditingParameterContainer, {
+            [S.isEditingParameter]: isEditingParameter,
+            [S[variant]]: variant,
+          })}
+          onClick={() =>
+            setEditingParameter?.(isEditingParameter ? null : parameter.id)
+          }
         >
-          <ParameterValueWidget
-            offset={{
-              mainAxis: 8,
-              crossAxis: -16,
-            }}
-            parameter={parameter}
-            parameters={parameters}
-            question={question}
-            dashboard={dashboard}
-            value={parameter.value}
-            setValue={(value) => setValue?.(value)}
-            isEditing={isEditingParameter}
-            placeholder={parameter.name}
-            focusChanged={setIsFocused}
-            isFullscreen={isFullscreen}
-            commitImmediately={commitImmediately}
-            setParameterValueToDefault={setParameterValueToDefault}
-            enableRequiredBehavior={enableParameterRequiredBehavior}
-            isSortable={isSortable && isEditing}
-          />
-          {children}
-        </FieldSet>
-      </Box>
+          <div className={CS.mr1} onClick={(e) => e.stopPropagation()}>
+            {dragHandle}
+          </div>
+          {parameter.name}
+          <Icon ml="auto" pl="md" name="gear" />
+        </Flex>
+      </Sortable>
     );
   }
 
   return (
-    <EditParameterWidget
-      isEditingParameter={isEditingParameter}
-      parameter={parameter}
-      setEditingParameter={setEditingParameter}
-      isEditing={isEditing}
-      dragHandle={dragHandle}
-    />
+    <Box fz={isFullscreen ? "md" : undefined}>
+      <FieldSet
+        className={cx(
+          className,
+          DashboardS.ParameterFieldSet,
+          EmbedFrameS.ParameterFieldSet,
+          S.ParameterFieldSet,
+
+          {
+            [S.fieldHasValueOrFocus]: fieldHasValueOrFocus,
+            [S[variant]]: variant,
+          },
+        )}
+        legend={legend}
+        required={enableParameterRequiredBehavior && parameter.required}
+        noPadding
+      >
+        <ParameterValueWidget
+          offset={{
+            mainAxis: 8,
+            crossAxis: -16,
+          }}
+          parameter={parameter}
+          parameters={parameters}
+          question={question}
+          dashboard={dashboard}
+          value={parameter.value}
+          setValue={(value) => setValue?.(value)}
+          isEditing={isEditingParameter}
+          placeholder={parameter.name}
+          focusChanged={setIsFocused}
+          isFullscreen={isFullscreen}
+          commitImmediately={commitImmediately}
+          setParameterValueToDefault={setParameterValueToDefault}
+          enableRequiredBehavior={enableParameterRequiredBehavior}
+          isSortable={isSortable && isEditing}
+          variant={variant}
+          withinPortal={withinPortal}
+        />
+        {children}
+      </FieldSet>
+    </Box>
   );
 };

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
@@ -108,6 +108,7 @@ export const ParameterWidget = ({
   if (variant === "subtle") {
     return (
       <Flex
+        data-testid="parameter-widget"
         fz={isFullscreen ? "md" : undefined}
         align="center"
         className={cx(className, S.SubtleParameterWidget, {
@@ -145,6 +146,7 @@ export const ParameterWidget = ({
   return (
     <Box fz={isFullscreen ? "md" : undefined}>
       <FieldSet
+        data-testid="parameter-widget"
         className={cx(
           className,
           DashboardS.ParameterFieldSet,

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -10,7 +10,7 @@ import { SortableList } from "metabase/core/components/Sortable";
 import CS from "metabase/css/core/index.css";
 import type { ParametersListProps } from "metabase/parameters/components/ParametersList/types";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
-import { Icon } from "metabase/ui";
+import { Flex, Icon } from "metabase/ui";
 import type { Parameter, ParameterId } from "metabase-types/api";
 
 import { ParameterWidget } from "../ParameterWidget";
@@ -66,6 +66,7 @@ export const ParametersList = ({
     <ParameterWidget
       key={`sortable-${id}`}
       variant={widgetsVariant}
+      fullWidth={vertical}
       withinPortal={widgetsWithinPortal}
       className={cx({ [CS.mb2]: vertical })}
       isEditing={isEditing}
@@ -102,14 +103,13 @@ export const ParametersList = ({
   );
 
   return visibleValuePopulatedParameters.length > 0 ? (
-    <div
-      className={cx(
-        className,
-        CS.flex,
-        CS.alignEnd,
-        CS.flexWrap,
-        vertical ? CS.flexColumn : CS.flexRow,
-      )}
+    <Flex
+      display="flex"
+      direction={vertical ? "column" : "row"}
+      align="end"
+      wrap="wrap"
+      gap="sm"
+      className={className}
     >
       {isSortable ? (
         <SortableList
@@ -129,6 +129,6 @@ export const ParametersList = ({
           )}
         </>
       )}
-    </div>
+    </Flex>
   ) : null;
 };

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -38,6 +38,8 @@ export const ParametersList = ({
   setParameterIndex,
   setEditingParameter,
   enableParameterRequiredBehavior,
+  widgetsVariant = "default",
+  widgetsWithinPortal,
 }: ParametersListProps) => {
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: { distance: 15 },
@@ -63,6 +65,8 @@ export const ParametersList = ({
   }: RenderItemProps<Parameter>) => (
     <ParameterWidget
       key={`sortable-${id}`}
+      variant={widgetsVariant}
+      withinPortal={widgetsWithinPortal}
       className={cx({ [CS.mb2]: vertical })}
       isEditing={isEditing}
       isFullscreen={isFullscreen}

--- a/frontend/src/metabase/parameters/components/ParametersList/types.ts
+++ b/frontend/src/metabase/parameters/components/ParametersList/types.ts
@@ -28,6 +28,9 @@ export type ParametersListProps = {
     ) => void;
     setEditingParameter: (parameterId: ParameterId | null) => void;
     enableParameterRequiredBehavior: boolean;
+    widgetsVariant?: "default" | "subtle";
+    widgetsWithinPortal?: boolean;
+    layout?: "horizontal" | "vertical";
   } & Pick<DashboardFullscreenControls, "isFullscreen"> &
     Pick<DashboardNightModeControls, "isNightMode"> &
     Pick<EmbedHideParametersControls, "hideParameters">

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.styled.tsx
@@ -10,6 +10,7 @@ interface InputContainerProps {
   isEmpty: boolean;
 }
 
+// TODO move this to CSS module
 export const InputContainer = styled.div<InputContainerProps>`
   display: flex;
   width: 100%;
@@ -18,12 +19,13 @@ export const InputContainer = styled.div<InputContainerProps>`
   align-items: center;
   overflow: hidden;
   padding-left: 0.75rem;
+  padding-right: 0.75rem;
   pointer-events: auto;
   border-radius: 8px;
+  border: 1px solid transparent;
 
-  &:hover {
-    /* adjust for border on hover */
-    padding-left: calc(0.75rem - 1px);
+  * {
+    pointer-events: auto;
   }
 
   .${DashboardS.DashCard}:hover &,
@@ -32,7 +34,7 @@ export const InputContainer = styled.div<InputContainerProps>`
   }
 
   .${DashboardS.DashCard}.resizing & {
-    border: 1px solid var(--mb-color-brand);
+    border-color: var(--mb-color-brand);
   }
 
   ${({ isPreviewing, isEmpty }) =>
@@ -67,11 +69,12 @@ export const TextInput = styled.input`
 
 interface HeadingContentProps {
   isEditing?: boolean;
+  hasFilters?: boolean;
 }
 
 export const HeadingContent = styled.h2<HeadingContentProps>`
+  flex: 1;
   max-height: 100%;
-  max-width: 100%;
   overflow-x: hidden;
   overflow-y: auto;
   font-size: 1.375rem;
@@ -84,4 +87,16 @@ export const HeadingContent = styled.h2<HeadingContentProps>`
     css`
       cursor: text;
     `}
+
+  ${({ hasFilters }) =>
+    hasFilters &&
+    css`
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    `}
+`;
+
+export const HeadingTextInput = styled(TextInput)`
+  flex: 1;
+  text-overflow: ellipsis;
 `;

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@mantine/hooks";
 import type { ComponentProps, MouseEvent } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { ToolbarButton } from "metabase/components/ToolbarButton";
@@ -81,22 +81,30 @@ export function Heading({
   const container = useRef<HTMLDivElement>(null);
   const [isNarrow, setIsNarrow] = useState(false);
 
+  const handleResize = useCallback(() => {
+    if (!container.current) {
+      return;
+    }
+
+    const { width } = container.current.getBoundingClientRect();
+    setIsNarrow(width < 600); // Adjust the threshold as needed
+  }, []);
+
   useEffect(() => {
     const element = container.current;
     if (!element) {
       return;
     }
 
-    const handleResize = (e: ResizeObserverEntry) => {
-      const { width } = e.contentRect;
-      setIsNarrow(width < 600); // Adjust the threshold as needed
-    };
-
     resizeObserver.subscribe(element, handleResize);
     return () => {
       resizeObserver.unsubscribe(element, handleResize);
     };
-  }, []);
+  }, [handleResize]);
+
+  useEffect(() => {
+    handleResize();
+  }, [isEditing, handleResize]);
 
   const translatedText = useMemo(() => tc(settings.text), [settings.text, tc]);
 

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -116,13 +116,15 @@ export function Heading({
 
   const content = useMemo(
     () =>
-      fillParametersInText({
-        dashcard,
-        dashboard,
-        parameterValues,
-        text: translatedText,
-      }),
-    [dashcard, dashboard, parameterValues, translatedText],
+      isEditing
+        ? translatedText
+        : fillParametersInText({
+            dashcard,
+            dashboard,
+            parameterValues,
+            text: translatedText,
+          }),
+    [dashcard, dashboard, parameterValues, translatedText, isEditing],
   );
 
   const hasContent = !isEmpty(settings.text);

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -39,6 +39,10 @@ interface HeadingProps {
   dashcard: VirtualDashboardCard;
   settings: VisualizationSettings;
   dashboard: Dashboard;
+  gridSize: {
+    width: number;
+    height: number;
+  };
 }
 
 export function Heading({
@@ -47,6 +51,7 @@ export function Heading({
   settings,
   isEditing,
   isFullscreen,
+  gridSize,
   onUpdateVisualizationSettings,
   isMobile,
 }: HeadingProps) {
@@ -58,6 +63,7 @@ export function Heading({
   const justAdded = useMemo(() => dashcard?.justAdded || false, [dashcard]);
 
   const tc = useTranslateContent();
+  const isShort = gridSize.height < 2;
 
   const [isFocused, { open: toggleFocusOn, close: toggleFocusOff }] =
     useDisclosure(justAdded);
@@ -167,6 +173,9 @@ export function Heading({
         isPreviewing={isPreviewing}
         onClick={toggleFocusOn}
         ref={container}
+        style={{
+          paddingRight: isNarrow && isShort ? "2.5rem" : undefined,
+        }}
       >
         {leftContent}
         {inlineParameters.length > 0 && (
@@ -236,11 +245,15 @@ function ParametersList(props: ParametersListProps) {
 
     return (
       <Menu>
-        <Menu.Target>
+        <Menu.Target data-testid="show-filter-parameter-button">
           <ToolbarButton
             icon="filter"
             aria-label={t`Show filters`}
             tooltipLabel={t`Show filters`}
+            onClick={(e) => {
+              // To avoid focusing the input when clicking the button
+              e.stopPropagation();
+            }}
           />
         </Menu.Target>
         <Menu.Dropdown

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@mantine/hooks";
 import type { ComponentProps, MouseEvent } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { ToolbarButton } from "metabase/components/ToolbarButton";
@@ -81,30 +81,25 @@ export function Heading({
   const container = useRef<HTMLDivElement>(null);
   const [isNarrow, setIsNarrow] = useState(false);
 
-  const handleResize = useCallback(() => {
-    if (!container.current) {
-      return;
-    }
-
-    const { width } = container.current.getBoundingClientRect();
-    setIsNarrow(width < 600); // Adjust the threshold as needed
-  }, []);
-
   useEffect(() => {
     const element = container.current;
     if (!element) {
       return;
     }
 
+    const handleResize = () => {
+      if (!container.current) {
+        return;
+      }
+
+      setIsNarrow(container.current.getBoundingClientRect().width < 600);
+    };
+
     resizeObserver.subscribe(element, handleResize);
     return () => {
       resizeObserver.unsubscribe(element, handleResize);
     };
-  }, [handleResize]);
-
-  useEffect(() => {
-    handleResize();
-  }, [isEditing, handleResize]);
+  }, [isEditing]);
 
   const translatedText = useMemo(() => tc(settings.text), [settings.text, tc]);
 

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -17,7 +17,7 @@ import { useTranslateContent } from "metabase/i18n/hooks";
 import { useSelector } from "metabase/lib/redux";
 import resizeObserver from "metabase/lib/resize-observer";
 import { isEmpty } from "metabase/lib/validate";
-import { Flex, Menu } from "metabase/ui";
+import { Flex, Icon, Menu } from "metabase/ui";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 import type {
   Dashboard,
@@ -227,6 +227,10 @@ function ParametersList(props: ParametersListProps) {
   const { isNarrow, ...rest } = props;
 
   const editingParameter = useSelector(getEditingParameter);
+  const parametersWithValues = useMemo(
+    () => rest.parameters.filter((p) => p.value != null),
+    [rest.parameters],
+  );
 
   if (isNarrow) {
     if (editingParameter) {
@@ -247,14 +251,20 @@ function ParametersList(props: ParametersListProps) {
       <Menu>
         <Menu.Target data-testid="show-filter-parameter-button">
           <ToolbarButton
-            icon="filter"
             aria-label={t`Show filters`}
             tooltipLabel={t`Show filters`}
             onClick={(e) => {
               // To avoid focusing the input when clicking the button
               e.stopPropagation();
             }}
-          />
+          >
+            <Icon name="filter" />
+            {parametersWithValues.length > 0 && (
+              <span data-testid="show-filter-parameter-count">
+                &nbsp;{parametersWithValues.length}
+              </span>
+            )}
+          </ToolbarButton>
         </Menu.Target>
         <Menu.Dropdown
           data-testid="show-filter-parameter-dropdown"

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
@@ -45,6 +45,7 @@ const defaultProps = {
   },
   settings: { text: "" },
   parameterValues: {},
+  gridSize: { x: 0, y: 0, width: 0, height: 0 },
 };
 
 const setup = ({ parameterValues, isEditingParameter, ...props }: Options) => {


### PR DESCRIPTION
Closes [VIZ-1057: Update filter widget appearance](https://linear.app/metabase/issue/VIZ-1057/update-filter-widget-appearance)

<img width="1538" alt="image" src="https://github.com/user-attachments/assets/631c1eb4-16f4-49bc-a86d-6fb863524340" />

Also closes [VIZ-1056: Handle heading cards with many filters](https://linear.app/metabase/issue/VIZ-1056/handle-heading-cards-with-many-filters)
<img width="1539" alt="image" src="https://github.com/user-attachments/assets/b5068d28-2c07-477e-a222-5d746df99d7f" />

