### PR TITLE
Do not normalize escaped join aliases 

### DIFF
--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -96,13 +96,13 @@
 (defn- normalize-ref-opts [opts]
   (let [opts (normalize-tokens opts :ignore-path)]
     (cond-> opts
-      (:base-type opts)      (update :base-type keyword)
-      (:effective-type opts) (update :effective-type keyword)
-      (:temporal-unit opts)  (update :temporal-unit keyword)
-      (:inherited-temporal-unit opts)  (update :inherited-temporal-unit keyword)
-      (:binning opts)        (update :binning (fn [binning]
-                                                (cond-> binning
-                                                  (:strategy binning) (update :strategy keyword)))))))
+      (:base-type opts)               (update :base-type keyword)
+      (:effective-type opts)          (update :effective-type keyword)
+      (:temporal-unit opts)           (update :temporal-unit keyword)
+      (:inherited-temporal-unit opts) (update :inherited-temporal-unit keyword)
+      (:binning opts)                 (update :binning (fn [binning]
+                                                         (cond-> binning
+                                                           (:strategy binning) (update :strategy keyword)))))))
 
 (defmethod normalize-mbql-clause-tokens :expression
   ;; For expression references (`[:expression \"my_expression\"]`) keep the arg as is but make sure it is a string.
@@ -440,8 +440,10 @@
    :info            {:metadata/model-metadata identity
                      ;; the original query that runs through qp.pivot should be ignored here entirely
                      :pivot/original-query    (fn [_] nil)
-                     ;; don't try to normalize the keys in viz-settings passed in as part of `:info`.
+                     ;; don't try to normalize the keys in viz-settings or `:alias/escaped->original` passed in as
+                     ;; part of `:info`.
                      :visualization-settings  identity
+                     :alias/escaped->original identity
                      :context                 maybe-normalize-token}
    :parameters      {::sequence normalize-query-parameter}
    ;; TODO -- when does query ever have a top-level `:context` key??

--- a/src/metabase/lib/schema/info.cljc
+++ b/src/metabase/lib/schema/info.cljc
@@ -5,6 +5,7 @@
   (:require
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.join :as lib.schema.join]
    [metabase.util.malli.registry :as mr]))
 
 ;;; Schema for `info.context`; used for informational purposes to record how a query was executed.
@@ -62,7 +63,7 @@
    [:card-entity-id          {:optional true} [:maybe ::lib.schema.common/non-blank-string]]
    [:card-name               {:optional true} [:maybe ::lib.schema.common/non-blank-string]]
    [:dashboard-id            {:optional true} [:maybe ::lib.schema.id/dashboard]]
-   [:alias/escaped->original {:optional true} [:maybe [:map-of :any :any]]]
+   [:alias/escaped->original {:optional true} [:maybe [:map-of ::lib.schema.join/alias ::lib.schema.join/alias]]]
    [:pulse-id                {:optional true} [:maybe ::lib.schema.id/pulse]]
    ;; Metadata for datasets when querying the dataset. This ensures that user edits to dataset metadata are blended in
    ;; with runtime computed metadata so that edits are saved.

--- a/test/metabase/query_processor/util/transformations/nest_breakouts_test.clj
+++ b/test/metabase/query_processor/util/transformations/nest_breakouts_test.clj
@@ -146,7 +146,5 @@
                                        "test_data_products__v_f48e965c"]]
                            :aggregation [[:count {:name "count"}]
                                          [:cum-count {:name "count_2"}]]}]
-                 ;; unrelated TODO, but I think `:alias/escaped->original` should be a string -> string map not keyword ->
-                 ;; string
-                 :info {:alias/escaped->original {:test-data-products--v-af2712b9 "test_data_products__via__product_id"}}}
+                 :info {:alias/escaped->original {"test_data_products__v_af2712b9" "test_data_products__via__product_id"}}}
                 actual))))))


### PR DESCRIPTION
Fixes QUE-1353
Fixes #42307

We can't restore truncated join aliases within the QP if we lose the original names because we normalize them to lower-case/kebab-case keys