### PR TITLE
Provide support for sending test messages for system event notifications

### DIFF
--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -40,7 +40,10 @@
         [:event_name [:fn #(= "event" (-> % keyword namespace))]]
         [:action     {:optional true} [:maybe :keyword]]
         [:table_id   {:optional true} [:maybe pos-int?]]]]
-      [:event_info  [:maybe :map]]]]
+      [:event_info {:optional true} [:maybe :map]]
+      ;; used to shortcut creating the payload from the event_info and using this payload as-is
+      ;; this is useful for send-now functionality.
+      [:notification/custom-payload {:optional true} [:maybe :map]]]]
     [:notification/card
      [:map
       [:payload    {:optional true} ::models.notification/NotificationCard]

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -315,7 +315,8 @@
 
 (mu/defmethod notification.payload/notification-payload :notification/system-event :- :map
   [notification-info :- ::notification.payload/Notification]
-  (transform-event-info notification-info))
+  (or (:notification/custom-payload notification-info) ; used to shortcut event_info if the payload has been provided automatically (send-now)
+      (transform-event-info notification-info)))
 
 (defmethod notification.payload/notification-payload-schema :notification/system-event
   [notification-info]


### PR DESCRIPTION
Adds a `:custom_payload` parameter to `notification/send`. This lets you vary the payload returned by `notification/payload` and test its usage with a channel. 

This solves a problem with system events, where currently you would have to fabricate the system event `event_info` to trial a send. `event_info` seems an internal detail that is unreasonable to couple the client to.

The goal is to allow users to try out their templates and see how they render in e.g a test slack message