### PR TITLE
Added validation for email-from-name

### DIFF
--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -3,9 +3,7 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
-   [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as u.str]))

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -4,6 +4,7 @@
    [java-time.api :as t]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as u.str]))
@@ -134,7 +135,12 @@
   (deferred-tru "The name you want to use for the sender of emails.")
   :encryption :no
   :visibility :settings-manager
-  :audit      :getter)
+  :audit      :getter
+  :setter     (fn [new-value]
+                ;; Validate based on chars in https://www.ietf.org/rfc/rfc5322.txt via https://docs.aws.amazon.com/ses/latest/dg/send-email-concepts-email-format.html
+                (when (and new-value (not (re-matches #"^[\w\d !#$%&'*+-/=?^_`{|}~]*$" new-value)))
+                  (throw (ex-info (tru "Invalid special character included.") {:status-code 400})))
+                (setting/set-value-of-type! :string :email-from-name new-value)))
 
 (defsetting bcc-enabled?
   (deferred-tru "Whether or not bcc emails are enabled, default behavior is that it is")

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -3,7 +3,9 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.settings.core :as setting :refer [defsetting]]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as u.str]))
@@ -137,7 +139,7 @@
   :audit      :getter
   :setter     (fn [new-value]
                 ;; Validate based on chars in https://www.ietf.org/rfc/rfc5322.txt via https://docs.aws.amazon.com/ses/latest/dg/send-email-concepts-email-format.html
-                (when (and new-value (not (re-matches #"^[\w\d !#$%&'*+-/=?^_`{|}~]*$" new-value)))
+                (when (and new-value (re-matches #".*[()<>\[\]:;@/\\,\.\"].*" new-value))
                   (throw (ex-info (tru "Invalid special character included.") {:status-code 400})))
                 (setting/set-value-of-type! :string :email-from-name new-value)))
 

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -3,8 +3,7 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]
-   [metabase.util.i18n :refer [tru]]
+   [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as u.str]))

--- a/test/metabase/channel/settings_test.clj
+++ b/test/metabase/channel/settings_test.clj
@@ -3,7 +3,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.channel.settings :as channel.settings]
-   [metabase.test :as mt]))
+   [metabase.test :as mt])
+  (:import (clojure.lang ExceptionInfo)))
 
 (deftest slack-app-token-truncation-test
   (testing "slack-app-token is truncated when fetched by the setting's custom getter"
@@ -15,3 +16,19 @@
   (mt/with-temporary-setting-values [slack-channels-and-usernames-last-updated nil]
     (is (= channel.settings/zoned-time-epoch
            (channel.settings/slack-channels-and-usernames-last-updated)))))
+
+(deftest email-from-name-validation
+  (mt/with-temporary-setting-values [email-from-name nil]
+    (testing "valid names"
+      (doseq [valid-name [nil
+                          "Test Name"
+                          "Test-Name"
+                          "Test123!#$%&'*+-/=?^`{|}~"]]
+        (channel.settings/email-from-name! valid-name)
+        (is (= (channel.settings/email-from-name) valid-name))))
+    (testing "invalid names"
+      (doseq [invalid-name ["Name : Invalid"
+                            ":"
+                            "Name \" Invalid"]]
+        (is (thrown-with-msg? ExceptionInfo #"Invalid special character included."
+                              (channel.settings/email-from-name! invalid-name)))))))

--- a/test/metabase/channel/settings_test.clj
+++ b/test/metabase/channel/settings_test.clj
@@ -23,12 +23,20 @@
       (doseq [valid-name [nil
                           "Test Name"
                           "Test-Name"
-                          "Test123!#$%&'*+-/=?^`{|}~"]]
-        (channel.settings/email-from-name! valid-name)
-        (is (= (channel.settings/email-from-name) valid-name))))
+                          "Test 123 !#$%&'*+-=?^`~"
+                          "\uD83D\uDC7E"
+                          "بسمة"]]
+        (testing valid-name
+          (channel.settings/email-from-name! valid-name)
+          (is (= (channel.settings/email-from-name) valid-name)))))
     (testing "invalid names"
-      (doseq [invalid-name ["Name : Invalid"
+      (doseq [invalid-name ["Bad :"
                             ":"
-                            "Name \" Invalid"]]
-        (is (thrown-with-msg? ExceptionInfo #"Invalid special character included."
-                              (channel.settings/email-from-name! invalid-name)))))))
+                            "Bad \""
+                            "Bad ("
+                            "Bad )"
+                            "Bad ("
+                            "Bad @"]]
+        (testing invalid-name
+          (is (thrown-with-msg? ExceptionInfo #"Invalid special character included."
+                                (channel.settings/email-from-name! invalid-name))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #58037
### Description

Allowed characters from the email "From Name" are specified in [Internet Message Format specification RFC 5322](https://www.ietf.org/rfc/rfc5322.txt), based on the [AWS SES docs](https://docs.aws.amazon.com/ses/latest/dg/send-email-concepts-email-format.html)

Special chars **can** be present if quoted, but then we have to deal with balancing quotes and tracking that they are just in the quoted sections, so we will simply disallow any special char usage.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
