### PR TITLE
Misc QP/Lib cleanup

### DIFF
--- a/.clj-kondo/src/hooks/clojure/core/ns.clj
+++ b/.clj-kondo/src/hooks/clojure/core/ns.clj
@@ -88,7 +88,6 @@
                                        :type    :metabase/modules))))))))
 
 (defn- lint-namespace-name [ns-form-node]
- ; NOCOMMIT
   (when-let [ns-symb-node (ns-form-node->ns-symb-node ns-form-node)]
     (when-not (contains? (hooks.common/ignored-linters ns-symb-node) :metabase/namespace-name)
       (let [parts (str/split (str (hooks/sexpr ns-symb-node)) #"\.")]

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ llm-payloads
 CLAUDE.local.md
 
 .eslintcache
+
+/logs

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -49,7 +49,6 @@ export interface DatasetColumn {
   nfc_path?: string[] | null;
   parent_id?: number | null;
   position?: number;
-  source_alias?: string;
 
   aggregation_type?: AggregationType;
 

--- a/frontend/src/metabase/static-viz/components/RowChart/stories-data.ts
+++ b/frontend/src/metabase/static-viz/components/RowChart/stories-data.ts
@@ -98,7 +98,6 @@ export const MULTIPLE_SERIES: StaticRowChartProps = {
         visibility_type: "normal",
         display_name: "Product → Category",
         base_type: "type/Text",
-        source_alias: "PRODUCTS__via__PRODUCT_ID",
       },
       {
         base_type: "type/BigInteger",
@@ -276,7 +275,6 @@ export const METRIC_COLUMN_WITH_SCALING: StaticRowChartProps = {
         visibility_type: "normal",
         display_name: "Product → Category",
         base_type: "type/Text",
-        source_alias: "PRODUCTS__via__PRODUCT_ID",
       },
       {
         base_type: "type/BigInteger",

--- a/frontend/src/metabase/visualizations/components/TableInteractive/hooks/use-reset-widths-on-columns-change.ts
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/hooks/use-reset-widths-on-columns-change.ts
@@ -35,7 +35,6 @@ const DATA_COLUMN_KEYS: (keyof DatasetColumn)[] = [
   "semantic_type",
   "settings",
   "source",
-  "source_alias",
   "table_id",
   "visibility_type",
 ];

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/5EsTAgs6Uu_xz69TsrUJ4_last_viewed_models.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/5EsTAgs6Uu_xz69TsrUJ4_last_viewed_models.yaml
@@ -179,7 +179,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -211,7 +210,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -243,7 +241,6 @@ result_metadata:
   semantic_type: type/Description
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/5HQS2xXAPF4hOFudut_Tg_last_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/5HQS2xXAPF4hOFudut_Tg_last_viewed_dashboards.yaml
@@ -168,7 +168,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -200,7 +199,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -232,7 +230,6 @@ result_metadata:
   semantic_type: type/Description
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/7FLoE9kUELG4Ess6DsSEY_last_downloads.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/7FLoE9kUELG4Ess6DsSEY_last_downloads.yaml
@@ -428,7 +428,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Card Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -460,7 +459,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Card Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -492,7 +490,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Dashboard Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -524,7 +521,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Dashboard Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -556,7 +552,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Databases - Database Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -588,7 +583,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Databases - Database Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -620,7 +614,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: People - User
   table_id:
   - Internal Metabase Database
   - public
@@ -652,7 +645,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: People - User
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/95Om4AllyfyB5wtl6TeGi_last_viewed_tables.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/95Om4AllyfyB5wtl6TeGi_last_viewed_tables.yaml
@@ -178,7 +178,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Tables - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -210,7 +209,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Tables - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -242,7 +240,6 @@ result_metadata:
   semantic_type: type/Description
   settings: null
   source: fields
-  source_alias: Tables - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -278,7 +275,6 @@ result_metadata:
   semantic_type: type/FK
   settings: null
   source: fields
-  source_alias: Tables - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/KXNGLyYyS1pO_9wMguHIB_total_time_spent_on_sync_per_day.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/KXNGLyYyS1pO_9wMguHIB_total_time_spent_on_sync_per_day.yaml
@@ -159,7 +159,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: breakout
-  source_alias: Databases - Database Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/LN9YtKcxZk_kybyRjJx1J_total_time_looking_for_field_values_per_day.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/LN9YtKcxZk_kybyRjJx1J_total_time_looking_for_field_values_per_day.yaml
@@ -160,7 +160,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: breakout
-  source_alias: Databases - Database Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/MOAq881VSlM2BhVUv5e_K_last_activity_on_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/MOAq881VSlM2BhVUv5e_K_last_activity_on_question.yaml
@@ -194,7 +194,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: People - User
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/WlQ-en2l-iRRCvO2-v5j1_recent_activity.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/WlQ-en2l-iRRCvO2-v5j1_recent_activity.yaml
@@ -270,7 +270,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -302,7 +301,6 @@ result_metadata:
   semantic_type: type/Category
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -334,7 +332,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/ezcT88-OmH-5HFOFNqmX7_last_viewed_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/ezcT88-OmH-5HFOFNqmX7_last_viewed_questions.yaml
@@ -178,7 +178,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -210,7 +209,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -242,7 +240,6 @@ result_metadata:
   semantic_type: type/Description
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/g-99yx3A8bwFtrfuWdIgb_active_dashboard_subscriptions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/g-99yx3A8bwFtrfuWdIgb_active_dashboard_subscriptions.yaml
@@ -444,7 +444,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: People - Creator
   table_id:
   - Internal Metabase Database
   - public
@@ -476,7 +475,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -508,7 +506,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Entity Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/gTeYI2eJtQUh63sZurc3z_last_queries.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/gTeYI2eJtQUh63sZurc3z_last_queries.yaml
@@ -383,7 +383,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Card Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -415,7 +414,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Card Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -447,7 +445,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Content - Dashboard Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -479,7 +476,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Content - Dashboard Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -511,7 +507,6 @@ result_metadata:
   semantic_type: type/PK
   settings: null
   source: fields
-  source_alias: Databases - Database Qualified
   table_id:
   - Internal Metabase Database
   - public
@@ -543,7 +538,6 @@ result_metadata:
   semantic_type: type/Name
   settings: null
   source: fields
-  source_alias: Databases - Database Qualified
   table_id:
   - Internal Metabase Database
   - public

--- a/src/metabase/cache/core.clj
+++ b/src/metabase/cache/core.clj
@@ -16,5 +16,6 @@
   root-strategy]
  [metabase.cache.settings
   enable-query-caching
+  enable-query-caching!
   query-caching-max-kb
   query-caching-max-ttl])

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -96,13 +96,13 @@
 (defn- normalize-ref-opts [opts]
   (let [opts (normalize-tokens opts :ignore-path)]
     (cond-> opts
-      (:base-type opts)      (update :base-type keyword)
-      (:effective-type opts) (update :effective-type keyword)
-      (:temporal-unit opts)  (update :temporal-unit keyword)
-      (:inherited-temporal-unit opts)  (update :inherited-temporal-unit keyword)
-      (:binning opts)        (update :binning (fn [binning]
-                                                (cond-> binning
-                                                  (:strategy binning) (update :strategy keyword)))))))
+      (:base-type opts)               (update :base-type keyword)
+      (:effective-type opts)          (update :effective-type keyword)
+      (:temporal-unit opts)           (update :temporal-unit keyword)
+      (:inherited-temporal-unit opts) (update :inherited-temporal-unit keyword)
+      (:binning opts)                 (update :binning (fn [binning]
+                                                         (cond-> binning
+                                                           (:strategy binning) (update :strategy keyword)))))))
 
 (defmethod normalize-mbql-clause-tokens :expression
   ;; For expression references (`[:expression \"my_expression\"]`) keep the arg as is but make sure it is a string.

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -95,7 +95,7 @@
                    (assoc :lib/card-id card-id)
 
                    (:metabase.lib.field/temporal-unit col)
-                   (assoc :inherited-temporal-unit (:metabase.lib.field/temporal-unit col))
+                   (assoc :inherited-temporal-unit (keyword (:metabase.lib.field/temporal-unit col)))
 
                    ;; If the incoming col doesn't have `:semantic-type :type/FK`, drop `:fk-target-field-id`.
                    ;; This comes up with metadata on SQL cards, which might be linked to their original DB field but should not be

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -408,7 +408,7 @@
   (->> (cond-> m
          ;; Following construct ensures that transformation mbql -> pmbql -> mbql, does not add base-type where those
          ;; were not present originally. Base types are added in [[metabase.lib.query/add-types-to-fields]].
-         (contains? m :metabase.lib.query/transformation-added-base-type)
+         (:metabase.lib.query/transformation-added-base-type m)
          (dissoc :metabase.lib.query/transformation-added-base-type :base-type)
 
          ;; Removing the namespaces from a few

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -449,7 +449,7 @@
 (def ReturnedColumnsOptions
   "Schema for options passed to [[returned-columns]] and [[returned-columns-method]]."
   [:map
-   [:include-remaps? {:optional true} :boolean]
+   [:include-remaps? {:optional true, :default false} :boolean]
    ;; has the signature (f str) => str
    [:unique-name-fn {:optional true} ::unique-name-fn]])
 

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -55,7 +55,7 @@
              (fn []
                (let [respond identity
                      raise   #'*error-fn*] ; capture var rather than the bound value at the time this is eval'ed
-                 (mc/coercer schema (mtx/transformer {:name :normalize}) respond raise)))))
+                 (mc/coercer schema (mtx/transformer mtx/default-value-transformer {:name :normalize}) respond raise)))))
 
 (defn normalize
   "Ensure some part of an MBQL query `x`, e.g. a clause or map, is in the right shape after coming in from JavaScript or

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -135,7 +135,7 @@
           x
           [:field
            (options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
-           (id :guard integer? pos?)]
+           (id :guard pos-int?)]
           (if (some #{:mbql/stage-metadata} &parents)
             &match
             (update &match 1 merge

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -207,7 +207,8 @@
 
 (mr/def ::stage
   [:and
-   {:decode/normalize common/normalize-map
+   {:default          {}
+    :decode/normalize common/normalize-map
     :encode/serialize #(dissoc %
                                ;; this stuff is all added at runtime by QP middleware.
                                :params

--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -139,7 +139,8 @@
 
 (mr/def ::options
   [:map
-   {:decode/normalize (fn [m]
+   {:default {}
+    :decode/normalize (fn [m]
                         (let [m (normalize-map m)]
                           ;; add `:lib/uuid` if it's missing
                           (cond-> m

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -57,8 +57,12 @@
 
 (mr/def ::join
   [:map
-   {:decode/normalize common/normalize-map}
-   [:lib/type    [:= {:decode/normalize common/normalize-keyword} :mbql/join]]
+   {:default {}, :decode/normalize (fn [join]
+                                     (let [{:keys [fields], :as join} (common/normalize-map join)]
+                                       (cond-> join
+                                         (and (not (keyword? fields)) (empty? fields))
+                                         (dissoc :fields))))}
+   [:lib/type    [:= {:default :mbql/join, :decode/normalize common/normalize-keyword} :mbql/join]]
    [:lib/options ::common/options]
    [:stages      [:ref :metabase.lib.schema/stages]]
    [:conditions  ::conditions]

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -35,7 +35,7 @@
     ;; are bucketed -- if a column contains `:inherited-temporal-unit`, it was bucketed already in previous stages,
     ;; so nil default picked to avoid another round of bucketing. Shall user bucket the column again, they have to
     ;; select the bucketing explicitly in QB.
-    [:inherited-temporal-unit  {:optional true} [:ref ::temporal-bucketing/unit]]]])
+    [:inherited-temporal-unit {:optional true} [:ref ::temporal-bucketing/unit]]]])
 
 (mr/def ::field.literal.options
   [:merge

--- a/src/metabase/lib/walk.cljc
+++ b/src/metabase/lib/walk.cljc
@@ -4,6 +4,7 @@
    [metabase.lib.join :as lib.join]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.join :as lib.schema.join]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
@@ -75,14 +76,35 @@
                                         cat
                                         [before new-items after])))))
 
-(defn walk
+(mr/def ::path-type
+  [:enum :lib.walk/join :lib.walk/stage])
+
+(mr/def ::stage-or-join
+  [:or ::lib.schema/stage ::lib.schema.join/join])
+
+(mr/def ::walk-stages-fn-result
+  "Schema for the return value for the function passed into [[walk-stages]]. One stage can be replaced with multiple
+  stages."
+  [:maybe
+   [:or
+    ::lib.schema/stage
+    [:sequential ::lib.schema/stage]]])
+
+(mr/def ::walk-fn-result
+  "Schema for the return value for the function passed into [[walk]]."
+  [:maybe
+   [:or
+    ::walk-stages-fn-result
+    ::lib.schema.join/join]])
+
+(mu/defn walk :- ::lib.schema/query
   "Depth-first recursive walk and replace for a `query`; call
 
     (f query path-type path stage-or-join)
 
   for each `stage-or-join` in the query, including recursive ones inside joins. `path-type` is either `:lib.walk/join`
   or `:lib.walk/stage`; `query` is the entire query and `path` is the absolute path to the current `stage-or-join`.
-  The results of `f`, the updated stage or join, are spliced into the query at `path` if `f` returns something; `nil`
+  The results of `f`, the updated stage(s) or join, are spliced into the query at `path` if `f` returns something; `nil`
   values are ignored and the query will not be unchanged (this is useful for walking the query for validation
   purposes).
 
@@ -105,11 +127,16 @@
               (fn [_query _path-type _path stage-or-join]
                 (when (:source-card stage-or-join)
                   (reduced true))))))"
-  [query f]
+  [query :- ::lib.schema/query
+   f     :- [:=>
+             [:cat :map ::path-type ::path ::stage-or-join]
+             ::walk-fn-result]]
   (unreduced
    (walk-query*
     query
-    (fn [query path-type path]
+    (mu/fn [query     :- :map ; query can be invalid during the walk process, only needs to be valid again at the end.
+            path-type :- ::path-type
+            path      :- ::path]
       (let [stage-or-join  (get-in query path)
             stage-or-join' (or (f query path-type path stage-or-join)
                                stage-or-join)]
@@ -119,14 +146,19 @@
           (sequential? stage-or-join')              (splice-at-point query path stage-or-join')
           :else                                     (assoc-in query path stage-or-join')))))))
 
-(defn walk-stages
+(mu/defn walk-stages :- ::lib.schema/query
   "Like [[walk]], but only walks the stages in a query. `f` is invoked like
 
-    (f query path stage)"
-  [query f]
+    (f query path stage) => updated-stage-or-nil"
+  [query :- ::lib.schema/query
+   f     :- [:=> [:cat :map ::path ::lib.schema/stage] ::walk-stages-fn-result]]
   (walk
    query
-   (fn [query path-type path stage-or-join]
+   (mu/fn :- ::walk-stages-fn-result
+     [query         :- :map ; don't re-validate query at every step in case we make edits that make it temporarily invalid
+      path-type     :- ::path-type
+      path          :- ::path
+      stage-or-join :- ::stage-or-join]
      (when (= path-type :lib.walk/stage)
        (f query path stage-or-join)))))
 
@@ -173,7 +205,7 @@
             query'                      (assoc query :stages (:stages join))]
         (recur query' (if (empty? more) [:stages 0] more))))))
 
-(defn apply-f-for-stage-at-path
+(mu/defn apply-f-for-stage-at-path
   "Use a function that takes top-level `query` and `stage-number` with a `query` and `path`,
   via [[query-for-stage-at-path]]. Lets you use stuff like [[metabase.lib.aggregation/resolve-aggregation]] in
   combination with [[walk-stages]].
@@ -183,6 +215,9 @@
     =>
 
     (f <query> <stage-number> x y)"
-  [f query stage-path & args]
+  [f          :- fn?
+   query      :- ::lib.schema/query
+   stage-path :- ::path
+   & args]
   (let [{:keys [query stage-number]} (query-for-path query stage-path)]
     (apply f query stage-number args)))

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -73,7 +73,7 @@
     (cond-> inner-query
       (seq metadata) (assoc :source-metadata metadata))))
 
-(defn- legacy-source-metadata?
+(defn- legacy-source-metadata-without-field-ref?
   "Whether this source metadata is *legacy* source metadata from < 0.38.0. Legacy source metadata did not include
   `:field_ref` or `:id`, which made it hard to correctly construct queries with. For MBQL queries, we're better off
   ignoring legacy source metadata and using [[metabase.query-processor.preprocess/query->expected-cols]] to infer the
@@ -98,7 +98,7 @@
     :keys                                            [source-metadata]}]
   (and source-query
        (or (not source-metadata)
-           (legacy-source-metadata? source-metadata))
+           (legacy-source-metadata-without-field-ref? source-metadata))
        (or (not native-source-query?)
            source-query-has-source-metadata?)))
 

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -44,7 +44,8 @@
      (fn [_query _path stage]
        (lib.util.match/match stage
          [macro-type _opts (id :guard pos-int?)]
-         (conj! ids id))))
+         (conj! ids id))
+       nil))
     (not-empty (persistent! ids))))
 
 ;;; a legacy Segment has one or more filter clauses.

--- a/src/metabase/query_processor/middleware/resolve_source_table.clj
+++ b/src/metabase/query_processor/middleware/resolve_source_table.clj
@@ -14,7 +14,8 @@
      query
      (fn [_query _path {:keys [source-table], :as _stage}]
        (when source-table
-         (vswap! source-table-ids conj source-table))))
+         (vswap! source-table-ids conj source-table))
+       nil))
     (not-empty @source-table-ids)))
 
 (defn resolve-source-tables

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -184,7 +184,8 @@
      query
      middleware)))
 
-(defn- restore-join-aliases [preprocessed-query]
+(mu/defn- restore-join-aliases :- :map
+  [preprocessed-query :- :map]
   (let [replacement (-> preprocessed-query :info :alias/escaped->original)]
     (escape-join-aliases/restore-aliases preprocessed-query replacement)))
 

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -89,8 +89,7 @@
   (when options
     (not-empty (into {}
                      (remove (fn [[k _]]
-                               (when (keyword? k)
-                                 (namespace k))))
+                               (qualified-keyword? k)))
                      options))))
 
 (defn normalize-clause

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -960,16 +960,15 @@
       (mc/assert SettingDefinition <>)
       (validate-default-value-for-type <>)
       ;; eastwood complains about (setting-name @registered-settings) for shadowing the function `setting-name`
-      ;; NOCOMMIT
-      #_(when-let [registered-setting (core/get @registered-settings setting-name)]
-          (when (not= setting-ns (:namespace registered-setting))
+      (when-let [registered-setting (core/get @registered-settings setting-name)]
+        (when (not= setting-ns (:namespace registered-setting))
           ;; not i18n'ed because this is supposed to be developer-facing only.
-            (throw (ex-info (format "Setting %s already registered in %s. You can remove the old definition with (swap! %s dissoc %s)"
-                                    setting-name
-                                    (:namespace registered-setting)
-                                    `registered-settings
-                                    (keyword setting-name))
-                            {:existing-setting (dissoc registered-setting :on-change :getter :setter)}))))
+          (throw (ex-info (format "Setting %s already registered in %s. You can remove the old definition with (swap! %s dissoc %s)"
+                                  setting-name
+                                  (:namespace registered-setting)
+                                  `registered-settings
+                                  (keyword setting-name))
+                          {:existing-setting (dissoc registered-setting :on-change :getter :setter)}))))
       (when-let [same-munge (first (filter (comp #{munged-name} :munged-name)
                                            (vals @registered-settings)))]
         (when (not= setting-name (:name same-munge)) ;; redefinitions are fine

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -763,8 +763,7 @@
                                                                                          :percent-email 0
                                                                                          :percent-state 0
                                                                                          :average-length 6.375}}}
-                                                        :base_type :type/Text
-                                                        :source_alias "Products"}
+                                                        :base_type :type/Text}
                                                        {:name "count"
                                                         :display_name "Count"
                                                         :base_type :type/Integer
@@ -784,8 +783,7 @@
                                                                           :percent-email 0
                                                                           :percent-state 0
                                                                           :average-length 6.375}}}
-                                         :base_type :type/Text
-                                         :source_alias "Products"}
+                                         :base_type :type/Text}
                                         {:name "count"
                                          :display_name "Count"
                                          :base_type :type/Integer

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -147,7 +147,7 @@
                 (lib/expression-parts query stage-number (lib.ref/ref col))))))
 
     (testing "unknown column reference"
-      (let [unknown-ref [:field {:lib/uuid (str (random-uuid))} 100]]
+      (let [unknown-ref [:field {:lib/uuid (str (random-uuid))} 12345678]]
         (mu/disable-enforcement
           (is (=? {:lib/type :metadata/column
                    :display-name "Unknown Field"}

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -7,7 +7,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.ident :as lib.metadata.ident]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util :as lib.util]
@@ -506,27 +505,17 @@
                     (lib/join (-> (lib/join-clause (meta/table-metadata :orders)
                                                    [(lib/= (meta/field-metadata :venues :id)
                                                            (meta/field-metadata :orders :id))])
-                                  (lib/with-join-fields [(meta/field-metadata :orders :subtotal)]))))
-          join-ident (:ident (first (lib/joins query)))]
-      (is (=? [{:name  "ID"
-                :ident (meta/ident :venues :id)}
-               {:name  "CATEGORY_ID"
-                :ident (meta/ident :venues :category-id)}
-               {:name  "price10"
-                :ident (lib.options/ident (first (lib/expressions query)))}
-               {:name  "SUBTOTAL"
-                :ident (lib.metadata.ident/explicitly-joined-ident (meta/ident :orders :subtotal) join-ident)}]
+                                  (lib/with-join-fields [(meta/field-metadata :orders :subtotal)]))))]
+      (is (=? [{:name  "ID"}
+               {:name  "CATEGORY_ID"}
+               {:name  "price10"}
+               {:name  "SUBTOTAL"}]
               (lib/returned-columns query)))
-      (is (=? [{:name  "ID"
-                :ident (meta/ident :venues :id)}
-               {:name  "CATEGORY_ID"
-                :ident (meta/ident :venues :category-id)}
-               {:name  "price10"
-                :ident (lib.options/ident (first (lib/expressions query)))}
-               {:name  "NAME"
-                :ident (lib.metadata.ident/remap-ident (meta/ident :categories :name) (meta/ident :venues :category-id))}
-               {:name  "SUBTOTAL"
-                :ident (lib.metadata.ident/explicitly-joined-ident (meta/ident :orders :subtotal) join-ident)}]
+      (is (=? [{:name  "ID"}
+               {:name  "CATEGORY_ID"}
+               {:name  "price10"}
+               {:name  "NAME"}
+               {:name  "SUBTOTAL"}]
               (lib/returned-columns query -1 (lib.util/query-stage query -1) {:include-remaps? true}))))))
 
 (deftest ^:parallel remapped-columns-test-2-remapping-in-joins

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -122,7 +122,7 @@
 
 (deftest ^:parallel coalasce-type-of-with-fields-only-test
   ;; Ideally expression/type-of should have enough information to determine the types of fields.
-  (testing "The type of a case expression can be determined even if it consists of fields only."
+  (testing "The type of a coalesce expression can be determined even if it consists of fields only."
     (is (= ::expression/type.unknown
            (expression/type-of
             [:coalesce

--- a/test/metabase/lib/walk_test.cljc
+++ b/test/metabase/lib/walk_test.cljc
@@ -1,8 +1,15 @@
 (ns metabase.lib.walk-test
   (:require
-   [clojure.test :refer [are deftest is testing]]
+   #?(:clj [metabase.util.malli.fn :as mu.fn])
+   [clojure.test :refer [are deftest is testing use-fixtures]]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli.registry :as mr]))
+
+(use-fixtures :each (fn [thunk]
+                      ;;; disable schema enforcement so we don't need mega queries to test stuff here.
+                      #?(:clj (binding [mu.fn/*enforce* false]
+                                (thunk))
+                         :cljs (thunk))))
 
 (deftest ^:parallel walk-test
   (let [query {:stages [{:joins [{:stages [{:source-card 1}]}]}]}

--- a/test/metabase/query_processor/metadata_test.clj
+++ b/test/metabase/query_processor/metadata_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]
-   [metabase.lib.core :as lib]
    [metabase.query-processor.metadata :as qp.metadata]
    [metabase.test :as mt]
    [metabase.util :as u]))

--- a/test/metabase/query_processor/metadata_test.clj
+++ b/test/metabase/query_processor/metadata_test.clj
@@ -48,32 +48,26 @@
                     (assoc-in [:info :card-entity-id] eid))]
       (is (=? [{:lib/type      :metadata/column
                 :name          "ID"
-                :ident         (lib/native-ident "ID" eid)
                 :database-type "BIGINT"
                 :base-type     :type/BigInteger}
                {:lib/type      :metadata/column
                 :name          "NAME"
-                :ident         (lib/native-ident "NAME" eid)
                 :database-type "CHARACTER VARYING"
                 :base-type     :type/Text}
                {:lib/type      :metadata/column
                 :name          "CATEGORY_ID"
-                :ident         (lib/native-ident "CATEGORY_ID" eid)
                 :database-type "INTEGER"
                 :base-type     :type/Integer}
                {:lib/type      :metadata/column
                 :name          "LATITUDE"
-                :ident         (lib/native-ident "LATITUDE" eid)
                 :database-type "DOUBLE PRECISION"
                 :base-type     :type/Float}
                {:lib/type      :metadata/column
                 :name          "LONGITUDE"
-                :ident         (lib/native-ident "LONGITUDE" eid)
                 :database-type "DOUBLE PRECISION"
                 :base-type     :type/Float}
                {:lib/type      :metadata/column
                 :name          "PRICE"
-                :ident         (lib/native-ident "PRICE" eid)
                 :database-type "INTEGER"
                 :base-type     :type/Integer}]
               (qp.metadata/result-metadata query))))))

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -205,15 +205,13 @@
                                           :field_ref     field-ref
                                           :id            %categories.name
                                           :display_name  "c → Name"
-                                          :base_type     :type/Text
-                                          :source_alias  "c"}
+                                          :base_type     :type/Text}
                                          {:table_id     $$categories
                                           :name         "NAME"
                                           :field_ref    $category-id->categories.name
                                           :id           %categories.name
                                           :display_name "Category → Name"
-                                          :base_type    :type/Text
-                                          :source_alias "CATEGORIES__via__CATEGORY_ID"}]})]
+                                          :base_type    :type/Text}]})]
           (is (=? (lib.tu.macros/$ids [$venues.id
                                        (mbql.u/update-field-options field-ref dissoc :temporal-unit)
                                        $venues.category-id->categories.name])

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -759,7 +759,6 @@
                                           :parent_id         nil
                                           :semantic_type     nil
                                           :settings          nil
-                                          :source_alias      "PRODUCTS__via__PRODUCT_ID"
                                           :table_id          $$products}]
                        :fields          [[:field %product-id {::namespaced true}]
                                          [:field

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -406,8 +406,7 @@
                               (qp.preprocess/query->expected-cols query))
           ;; the actual metadata this middleware should return. Doesn't have all the columns that come back from
           ;; `qp.preprocess/query->expected-cols`
-          expected-metadata (for [col metadata]
-                              (merge (results-col col) (select-keys col [:source_alias])))]
+          expected-metadata (map results-col metadata)]
       (letfn [(added-metadata [query]
                 (get-in (add-source-metadata query) [:query :source-metadata]))]
         (testing "\nShould add source metadata if there's none already"

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -410,8 +410,8 @@
       (letfn [(added-metadata [query]
                 (get-in (add-source-metadata query) [:query :source-metadata]))]
         (testing "\nShould add source metadata if there's none already"
-          (is (= expected-metadata
-                 (added-metadata query))))
+          (is (=? expected-metadata
+                  (added-metadata query))))
         (testing "\nShould use existing metadata if it's already there"
           ;; since it's using the existing metadata, it should have all the extra keys instead of the subset in
           ;; `expected-metadata`
@@ -421,8 +421,8 @@
           ;; pre-0.38.0 metadata didn't have `field_ref` or `id.`
           (let [legacy-metadata (for [col metadata]
                                   (dissoc col :field_ref :id))]
-            (is (= expected-metadata
-                   (added-metadata (assoc-in query [:query :source-metadata] legacy-metadata))))))))))
+            (is (=? expected-metadata
+                    (added-metadata (assoc-in query [:query :source-metadata] legacy-metadata))))))))))
 
 (deftest ^:parallel add-correct-metadata-fields-for-deeply-nested-source-queries-test
   (testing "Make sure we add correct `:fields` from deeply-nested source queries (#14872)"

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -128,8 +128,7 @@
                   :field_ref    $category-id->categories.name
                   :fk_field_id  %category-id
                   :ident        (lib/implicitly-joined-ident (meta/ident :categories :name)
-                                                             (meta/ident :venues :category-id))
-                  :source_alias "CATEGORIES__via__CATEGORY_ID"}]
+                                                             (meta/ident :venues :category-id))}]
                 (annotate/column-info
                  {:type  :query
                   :query {:fields [&CATEGORIES__via__CATEGORY_ID.categories.name]
@@ -150,8 +149,7 @@
         (is (=? [{:display_name "Categories → Name"
                   :source       :fields
                   :field_ref    &Categories.categories.name
-                  :ident        (lib/explicitly-joined-ident (meta/ident :categories :name) "4LzfvdZnP61w1n73B7nDu")
-                  :source_alias "Categories"}]
+                  :ident        (lib/explicitly-joined-ident (meta/ident :categories :name) "4LzfvdZnP61w1n73B7nDu")}]
                 (annotate/column-info
                  {:type  :query
                   :query {:fields [&Categories.categories.name]
@@ -1011,17 +1009,13 @@
                        [{:display_name "ID"
                          :ident        (:ident (lib.metadata/field (mt/metadata-provider) (mt/id :orders :id)))
                          :field_ref    $orders.id}
-                        (merge
-                         {:display_name (str join-alias " → Title")
-                          :ident        (-> (lib.metadata/field (mt/metadata-provider) (mt/id :products :title))
-                                            :ident
-                                            (lib/explicitly-joined-ident join-ident))
-                          :field_ref    [:field %products.title {:join-alias join-alias}]}
-                         ;; `source_alias` is only included in `data.cols`, but not in `results_metadata`
-                         (when (= location "data.cols")
-                           {:source_alias join-alias}))])
+                        {:display_name (str join-alias " → Title")
+                         :ident        (-> (lib.metadata/field (mt/metadata-provider) (mt/id :products :title))
+                                           :ident
+                                           (lib/explicitly-joined-ident join-ident))
+                         :field_ref    [:field %products.title {:join-alias join-alias}]}])
                      (map
-                      #(select-keys % [:display_name :field_ref :source_alias :ident])
+                      #(select-keys % [:display_name :field_ref :ident])
                       metadata))))))))))
 
 (deftest ^:parallel breakout-of-model-field-ident-test

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -5,7 +5,6 @@
    [malli.error :as me]
    [metabase.analyze.query-results :as qr]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
-   [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-util :as lib.tu]
    [metabase.permissions.models.permissions :as perms]
@@ -29,12 +28,11 @@
   [data]
   (mt/round-all-decimals 2 data))
 
-(defn- default-card-results [card-entity-id]
+(defn- default-card-results []
   (let [id->fingerprint   (t2/select-pk->fn :fingerprint :model/Field :table_id (mt/id :venues))
         name->fingerprint (comp id->fingerprint (partial mt/id :venues))]
     [{:name           "ID"
       :display_name   "ID"
-      :ident          (lib/native-ident "ID" card-entity-id)
       :base_type      :type/BigInteger
       :effective_type :type/BigInteger
       :database_type  "BIGINT"
@@ -43,7 +41,6 @@
       :field_ref      [:field "ID" {:base-type :type/BigInteger}]}
      {:name           "NAME"
       :display_name   "Name"
-      :ident          (lib/native-ident "NAME" card-entity-id)
       :base_type      :type/Text
       :effective_type :type/Text
       :database_type  "CHARACTER VARYING"
@@ -52,7 +49,6 @@
       :field_ref      [:field "NAME" {:base-type :type/Text}]}
      {:name           "PRICE"
       :display_name   "Price"
-      :ident          (lib/native-ident "PRICE" card-entity-id)
       :base_type      :type/Integer
       :effective_type :type/Integer
       :database_type  "INTEGER"
@@ -61,7 +57,6 @@
       :field_ref      [:field "PRICE" {:base-type :type/Integer}]}
      {:name           "CATEGORY_ID"
       :display_name   "Category ID"
-      :ident          (lib/native-ident "CATEGORY_ID" card-entity-id)
       :base_type      :type/Integer
       :effective_type :type/Integer
       :database_type  "INTEGER"
@@ -70,7 +65,6 @@
       :field_ref      [:field "CATEGORY_ID" {:base-type :type/Integer}]}
      {:name           "LATITUDE"
       :display_name   "Latitude"
-      :ident          (lib/native-ident "LATITUDE" card-entity-id)
       :base_type      :type/Float
       :effective_type :type/Float
       :database_type  "DOUBLE PRECISION"
@@ -79,7 +73,6 @@
       :field_ref      [:field "LATITUDE" {:base-type :type/Float}]}
      {:name           "LONGITUDE"
       :display_name   "Longitude"
-      :ident          (lib/native-ident "LONGITUDE" card-entity-id)
       :base_type      :type/Float
       :effective_type :type/Float
       :database_type  "DOUBLE PRECISION"
@@ -87,10 +80,9 @@
       :fingerprint    (name->fingerprint :longitude)
       :field_ref      [:field "LONGITUDE" {:base-type :type/Float}]}]))
 
-(defn- default-card-results-native
-  "These are rounded to two decimal places."
-  [card-entity-id]
-  (for [column (-> (default-card-results card-entity-id)
+(defn- default-card-results-native  "These are rounded to two decimal places."
+  []
+  (for [column (-> (default-card-results)
                    (update-in [3 :fingerprint] assoc :type {:type/Number {:min 2.0
                                                                           :max 74.0
                                                                           :avg 29.98
@@ -111,8 +103,8 @@
                         :query-hash     (qp.util/query-hash {})}))]
           (when-not (= :completed (:status result))
             (throw (ex-info "Query failed." result))))
-        (is (= (round-to-2-decimals (default-card-results-native (:entity_id card)))
-               (-> card card-metadata round-to-2-decimals)))
+        (is (=? (round-to-2-decimals (default-card-results-native))
+                (-> card card-metadata round-to-2-decimals)))
 
         ;; updated_at should not be modified when saving result metadata
         (is (= (:updated_at card)
@@ -124,7 +116,6 @@
      :entity_id       eid
      :result_metadata [{:name         "NAME"
                         :display_name "Name"
-                        :ident        (lib/native-ident "NAME" eid)
                         :base_type    :type/Text}]}))
 
 (deftest save-result-metadata-test-2
@@ -132,7 +123,6 @@
     (mt/with-temp [:model/Card card (test-card-1)]
       (is (= [{:name         "NAME"
                :display_name "Name"
-               :ident        (lib/native-ident "NAME" (:entity_id card))
                :base_type    :type/Text}]
              (card-metadata card)))
       (let [result (qp/process-query
@@ -144,7 +134,6 @@
                       result)))
       (is (= [{:name         "NAME"
                :display_name "Name"
-               :ident        (lib/native-ident "NAME" (:entity_id card))
                :base_type    :type/Text}]
              (card-metadata card))))))
 
@@ -158,7 +147,6 @@
                                                         :query    {:source-table (str "card__" (u/the-id card))}})
       (is (= [{:name         "NAME"
                :display_name "Name"
-               :ident        (lib/native-ident "NAME" (:entity_id card))
                :base_type    :type/Text}]
              (card-metadata card))))))
 
@@ -167,11 +155,9 @@
     (mt/with-temp [:model/Card card {:dataset_query   (mt/mbql-query venues {:fields [$name]})
                                      :result_metadata [{:name         "NAME"
                                                         :display_name "Custom Name"
-                                                        :ident        (mt/ident :venues :name)
                                                         :base_type    :type/Text}]}]
       (is (= [{:name         "NAME"
                :display_name "Custom Name"
-               :ident        (mt/ident :venues :name)
                :base_type    :type/Text}]
              (card-metadata card)))
       (let [result (qp/process-query
@@ -183,7 +169,6 @@
                       result)))
       (is (= [{:name         "NAME"
                :display_name "Custom Name"
-               :ident        (mt/ident :venues :name)
                :base_type    :type/Text}]
              (card-metadata card))))))
 
@@ -197,7 +182,6 @@
           [{:base_type :type/Text
             :database_type "CHARACTER VARYING"
             :display_name "NAME"
-            :ident "native[]__NAME"
             :effective_type :type/Text
             :field_ref [:field "NAME" {:base-type :type/Text}]
             :fingerprint {:global {:distinct-count 100, :nil% 0.0}
@@ -226,18 +210,18 @@
 (deftest ^:parallel metadata-in-results-test
   (testing "make sure that queries come back with metadata"
     (let [card-eid (u/generate-nano-id)]
-      (is (= {:columns  (for [col (round-to-2-decimals (default-card-results-native card-eid))]
-                          (-> col (update :semantic_type keyword) (update :base_type keyword)))}
-             (-> (qp/process-query
-                  (qp/userland-query
-                   (mt/native-query {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"})
-                   {:card-entity-id card-eid}))
-                 (get-in [:data :results_metadata])
-                 round-to-2-decimals))))))
+      (is (=? {:columns  (for [col (round-to-2-decimals (default-card-results-native))]
+                           (-> col (update :semantic_type keyword) (update :base_type keyword)))}
+              (-> (qp/process-query
+                   (qp/userland-query
+                    (mt/native-query {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"})
+                    {:card-entity-id card-eid}))
+                  (get-in [:data :results_metadata])
+                  round-to-2-decimals))))))
 
 (deftest ^:parallel metadata-in-results-test-2
-  (testing "datasets"
-    (testing "metadata from datasets can be preserved"
+  (testing "models"
+    (testing "metadata from models can be preserved"
       (letfn [(choose [col] (select-keys col [:name :description :display_name :semantic_type]))
               (refine-type [base-type] (condp #(isa? %2 %1) base-type
                                          :type/Integer :type/Quantity
@@ -255,9 +239,9 @@
                                               cols)))]
         (testing "native"
           (let [card-eid (u/generate-nano-id)
-                fields (str/join ", " (map :name (default-card-results-native card-eid)))
+                fields (str/join ", " (map :name (default-card-results-native)))
                 native-query (str "SELECT " fields " FROM VENUES")
-                existing-metadata (add-preserved (default-card-results-native card-eid))
+                existing-metadata (add-preserved (default-card-results-native))
                 results (-> (mt/native-query   {:query native-query})
                             (qp/userland-query {:metadata/model-metadata existing-metadata
                                                 :card-entity-id          card-eid})
@@ -427,8 +411,7 @@
 (deftest ^:parallel result-metadata-preservation-test
   (testing "result_metadata is preserved in the query processor if passed into the context"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card {base-card-id :id
-                                  :as base-card}    {:dataset_query {:database (mt/id)
+      (mt/with-temp [:model/Card {base-card-id :id} {:dataset_query {:database (mt/id)
                                                                      :type     :query
                                                                      :query    {:source-table (mt/id :orders)
                                                                                 :expressions  {"Tax Rate" [:/
@@ -444,11 +427,6 @@
                                                                             :database (mt/id)
                                                                             :query    {:source-table (format "card__%s" base-card-id)}}
                                                           :result_metadata [{:semantic_type :type/Percentage
-                                                                             :ident         (get-in base-card
-                                                                                                    [:dataset_query
-                                                                                                     :query
-                                                                                                     :expression-idents
-                                                                                                     "Tax Rate"])
                                                                              :name          "Tax Rate"}]}]
         (testing "The baseline behavior is for data results_metadata to be independently computed"
           (let [results (qp/process-query dataset-query)]

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -87,12 +87,10 @@
                     :display_name "Created At"}
                    {:name "ID"
                     :field_ref [:field (mt/id :orders :id) {:join-alias "Question 54"}]
-                    :display_name "Question 54 → ID"
-                    :source_alias "Question 54"}
+                    :display_name "Question 54 → ID"}
                    {:name "ADDRESS"
                     :field_ref [:field (mt/id :people :address) {:join-alias "Question 54"}]
-                    :display_name "Question 54 → Address"
-                    :source_alias "Question 54"}]
+                    :display_name "Question 54 → Address"}]
                   (qp.preprocess/query->expected-cols query))))))))
 
 (deftest ^:parallel deduplicate-column-names-test

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -22,7 +22,6 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
-   [metabase.query-processor.middleware.add-implicit-joins :as qp.add-implicit-joins]
    [metabase.query-processor.middleware.annotate :as qp.annotate]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.store :as qp.store]
@@ -184,11 +183,7 @@
     (-> dest-col
         (update :display_name (partial format "%s → %s" (str/replace (:display_name source-col) #"(?i)\sid$" "")))
         (assoc :field_ref    [:field (:id dest-col) {:source-field (:id source-col)}]
-               :fk_field_id  (:id source-col)
-               :source_alias (let [table-name (if (qp.store/initialized?)
-                                                (:name (lib.metadata/table (qp.store/metadata-provider) (data/id dest-table-kw)))
-                                                (t2/select-one-fn :name :model/Table :id (data/id dest-table-kw)))]
-                               (#'qp.add-implicit-joins/join-alias table-name (:name source-col) nil))))))
+               :fk_field_id  (:id source-col)))))
 
 (declare cols)
 
@@ -366,7 +361,7 @@
 (defn cols
   "Return the result `:cols` from query `results`, or throw an Exception if they're missing."
   [results]
-  (or (some->> (data results) :cols (mapv #(into {} (dissoc % :position))))
+  (or (some->> (data results) :cols (mapv #(dissoc % :position)))
       (throw (ex-info "Query does not have any :cols in results." results))))
 
 (defn rows-and-cols

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -638,12 +638,10 @@
                     :display_name "Created At"}
                    {:name         "ID"
                     :field_ref    [:field (meta/id :orders :id) {:join-alias "Question 54"}]
-                    :display_name "Question 54 → ID"
-                    :source_alias "Question 54"}
+                    :display_name "Question 54 → ID"}
                    {:name         "ADDRESS"
                     :field_ref    [:field (meta/id :people :address) {:join-alias "Question 54"}]
-                    :display_name "Question 54 → Address"
-                    :source_alias "Question 54"}]
+                    :display_name "Question 54 → Address"}]
                   (qp.preprocess/query->expected-cols query))))))))
 
 (deftest ^:parallel use-source-unique-aliases-test

--- a/test/metabase/query_processor/util/nest_query_test.clj
+++ b/test/metabase/query_processor/util/nest_query_test.clj
@@ -114,15 +114,15 @@
                                                                             ::add/position      0}]
                                                        [:expression "favorite" {::add/desired-alias "favorite"
                                                                                 ::add/position      1}]]}
-                         :filter       [:= [:field %name {::add/source-table ::add/source,
-                                                          ::add/source-alias "NAME",
-                                                          ::add/desired-alias "NAME",
-                                                          ::add/position 0,
+                         :filter       [:= [:field %name {::add/source-table ::add/source
+                                                          ::add/source-alias "NAME"
+                                                          ::add/desired-alias "NAME"
+                                                          ::add/position 0
                                                           :qp/ignore-coercion true}]
-                                        [:field "favorite" {:base-type :type/Text,
-                                                            ::add/source-table ::add/source,
-                                                            ::add/source-alias "favorite",
-                                                            ::add/desired-alias "favorite",
+                                        [:field "favorite" {:base-type :type/Text
+                                                            ::add/source-table ::add/source
+                                                            ::add/source-alias "favorite"
+                                                            ::add/desired-alias "favorite"
                                                             ::add/position 1}]]
                          :order-by     [[:asc *favorite/Text]]})
                       (-> (lib.tu.macros/mbql-query venues
@@ -298,7 +298,7 @@
                                          reviews
                                          {:breakout [$product_id]
                                           :aggregation [[:count]]
-                                                    ;; filter on an implicit join
+                                          ;; filter on an implicit join
                                           :filter [:= $product_id->products.category "Doohickey"]})}]
         ;; the result returned is not important, just important that the query is valid and completes
         (is (vector?
@@ -801,7 +801,7 @@
                                                      [:field %vendor nil]
                                                      [:field %price nil]
                                                      [:field %rating nil]
-                                                     [:field %created-at {:temporal-unit :default}]]},
+                                                     [:field %created-at {:temporal-unit :default}]]}
                        :expressions {"pivot-grouping" [:abs 0]}
                        :breakout    [[:field "CATEGORY" {:base-type :type/Text}]
                                      [:field "CREATED_AT" {:base-type :type/DateTime, :temporal-unit :month}]

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -384,12 +384,12 @@
                                                                  qp.preprocess/query->expected-cols
                                                                  (map :name))
                     cid2 (str cid "_2")
-                    col-data-fn   (juxt            :id       :name     :source_alias)
-                    top-card-cols [[(mt/id :people :id)      cid       nil]
-                                   [(mt/id :orders :user_id) cuser-id  "ord1"]
-                                   [nil                      ccount    "ord1"]
-                                   [(mt/id :orders :user_id) cuser-id2 "ord2"]
-                                   [nil                      ccount2   "ord2"]]]
+                    col-data-fn   (juxt            :id       :name)
+                    top-card-cols [[(mt/id :people :id)      cid]
+                                   [(mt/id :orders :user_id) cuser-id]
+                                   [nil                      ccount]
+                                   [(mt/id :orders :user_id) cuser-id2]
+                                   [nil                      ccount2]]]
                 (testing "sanity"
                   (is (= top-card-cols
                          (->> top-card-query

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -168,15 +168,13 @@
                                  :name          (mt/format-name "name_2")
                                  :remapped_from (mt/format-name "category_id")
                                  :field_ref     $category_id->categories.name))]}
-                (-> (select-columns (set (map mt/format-name ["name" "price" "name_2"]))
-                                    (mt/format-rows-by
-                                     [str int str str]
-                                     (mt/run-mbql-query venues
-                                       {:fields   [$name $price $category_id]
-                                        :order-by [[:asc $name]]
-                                        :limit    4})))
-                    (update :cols (fn [[c1 c2 c3]]
-                                    [c1 c2 (dissoc c3 :source_alias)])))))))))
+                (select-columns (set (map mt/format-name ["name" "price" "name_2"]))
+                                (mt/format-rows-by
+                                 [str int str str]
+                                 (mt/run-mbql-query venues
+                                   {:fields   [$name $price $category_id]
+                                    :order-by [[:asc $name]]
+                                    :limit    4})))))))))
 
 (deftest ^:parallel remap-inside-mbql-query-test
   (testing "Test that we can remap inside an MBQL query"


### PR DESCRIPTION
Misc cleanup spun out from my `annotate` => MLv2 PR.

- Support `:default` values in MLv2 schema normalization (this is mostly for convenience in REPL usage)
- Remove the requirement that `source_alias` be returned in QP results metadata (this is unused by the FE and will likely be removed in the `annotate` => MLv2 PR)
- Misc formatting cleanup
- Remove some tests looking for `:ident` in results metadata will it will be removed in the `annotate` => MLv2 PR

Resolves QUE-1355
Resolves QUE-1356