### PR TITLE
Disable auto-wiring for inline filters

### DIFF
--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
@@ -13,6 +13,7 @@ import { getExistingDashCards } from "metabase/dashboard/actions/utils";
 import {
   getDashCardById,
   getDashboard,
+  getDashboardHeaderParameters,
   getParameters,
   getQuestions,
   getSelectedTabId,
@@ -126,8 +127,10 @@ export function showAutoWireToastNewCard({
     }
 
     const questions = getQuestions(getState());
-    const parameters = getParameters(getState());
     const selectedTabId = getSelectedTabId(getState());
+
+    // Inline dashcard parameters should not be used for auto-wiring
+    const parameters = getDashboardHeaderParameters(getState());
 
     const dashcards = getExistingDashCards(
       dashboardState.dashboards,

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -62,6 +62,7 @@ import {
 } from "../selectors";
 import {
   findDashCardForInlineParameter,
+  isDashcardInlineParameter,
   isQuestionDashCard,
   supportsInlineParameters,
 } from "../utils";
@@ -245,9 +246,14 @@ export const setParameterMapping = createThunkAction(
     return (dispatch, getState) => {
       dispatch(closeAutoWireParameterToast());
 
+      const dashcards = Object.values(getDashcards(getState()));
       const dashcard = getDashCardById(getState(), dashcardId);
 
-      if (target !== null && isQuestionDashCard(dashcard)) {
+      if (
+        target !== null &&
+        isQuestionDashCard(dashcard) &&
+        !isDashcardInlineParameter(parameterId, dashcards)
+      ) {
         const selectedTabId = getSelectedTabId(getState());
 
         dispatch(


### PR DESCRIPTION
Disables auto-wiring for filters in dashboard cards for both cases:

- when adding a new card with a dimension that's already connected to a filter by another question
- when connecting a filter to a dimension that is present in other questions

### To verify

1. Create question: Count of orders by product category (Q1)
2. Create question: Average of total by product category (Q2)
3. Create a dashboard with Q1 and a heading card
4. Add a "Category" filter to the heading card and connect it to Q1
5. Add Q2 to the dashboard and make sure that auto-wiring doesn't doesn't show up
6. Disconnect the filter from Q1
7. Connect the filter to Q1 and make sure that auto-wiring doesn't doesn't show up