### PR TITLE
Update react-virtualized-to-9.22.6

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1010,7 +1010,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     function assertTopMostRowTotalValue(value) {
       // Warning: Fragile selector!
       // TODO: refactor once we have a better HTML structure for tables.
-      cy.get("[role=rowgroup] > div").eq(5).invoke("text").should("eq", value);
+      cy.get("[role=row] > div").eq(5).invoke("text").should("eq", value);
     }
   });
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import cx from "classnames";
+import { forwardRef } from "react";
 import { t } from "ttag";
 
 import EmptyState from "metabase/components/EmptyState";
@@ -19,36 +20,39 @@ import {
   ListCellItem,
 } from "./AccordionListCell.styled";
 
-export const AccordionListCell = ({
-  style,
-  sections,
-  row,
-  onChange,
-  itemIsSelected,
-  itemIsClickable,
-  sectionIsExpanded,
-  canToggleSections,
-  alwaysExpanded,
-  toggleSection,
-  renderSectionIcon,
-  renderItemLabel,
-  renderItemName,
-  renderItemDescription,
-  renderItemIcon,
-  renderItemExtra,
-  renderItemWrapper,
-  showSpinner,
-  searchText,
-  onChangeSearchText,
-  searchPlaceholder = t`Find...`,
-  showItemArrows,
-  itemTestId,
-  getItemClassName,
-  getItemStyles,
-  searchInputProps,
-  hasCursor,
-  withBorders,
-}) => {
+export const AccordionListCell = forwardRef(function AccordionListCell(
+  {
+    style,
+    sections,
+    row,
+    onChange,
+    itemIsSelected,
+    itemIsClickable,
+    sectionIsExpanded,
+    canToggleSections,
+    alwaysExpanded,
+    toggleSection,
+    renderSectionIcon,
+    renderItemLabel,
+    renderItemName,
+    renderItemDescription,
+    renderItemIcon,
+    renderItemExtra,
+    renderItemWrapper,
+    showSpinner,
+    searchText,
+    onChangeSearchText,
+    searchPlaceholder = t`Find...`,
+    showItemArrows,
+    itemTestId,
+    getItemClassName,
+    getItemStyles,
+    searchInputProps,
+    hasCursor,
+    withBorders,
+  },
+  ref,
+) {
   const {
     type,
     section,
@@ -326,6 +330,7 @@ export const AccordionListCell = ({
 
   return (
     <div
+      ref={ref}
       style={style}
       aria-expanded={sectionIsExpanded}
       data-element-id="list-section"
@@ -339,4 +344,4 @@ export const AccordionListCell = ({
       {content}
     </div>
   );
-};
+});

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-router-redux": "^4.0.8",
     "react-transition-group": "^4.4.5",
     "react-use": "^17.5.1",
-    "react-virtualized": "9.22.5",
+    "react-virtualized": "9.22.6",
     "reduce-reducers": "^1.0.4",
     "redux-actions": "^2.0.1",
     "redux-auth-wrapper": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17842,10 +17842,10 @@ react-virtual@^2.8.2:
   dependencies:
     "@reach/observe-rect" "^1.1.0"
 
-react-virtualized@9.22.5:
-  version "9.22.5"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.5.tgz#bfb96fed519de378b50d8c0064b92994b3b91620"
-  integrity sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==
+react-virtualized@9.22.6:
+  version "9.22.6"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.6.tgz#3ae2aa69eca61cf3af332e2f9d6b4aa5638786d5"
+  integrity sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==
   dependencies:
     "@babel/runtime" "^7.7.2"
     clsx "^1.0.4"


### PR DESCRIPTION
Update react-virtualized-to-9.22.6 to avoid findDOMNode warnings

This version introduces the breaking changes:
- one of them is the following, but it does not affect us https://github.com/bvaughn/react-virtualized/pull/1866#issuecomment-2724376962
- other is for CellMeasurer that needs a component that supports passing the `ref` prop, so i adjusted code a bit