### PR TITLE
fix: audit migration for schema casing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -108,7 +108,7 @@
                                                                :where [:and
                                                                        [:= :self_table.db_id :table.db_id]
                                                                        [:or
-                                                                        [:= :self_table.schema :table.schema]
+                                                                        [:= :self_table.schema [:lower :table.schema]]
                                                                         [:and
                                                                          [:= :self_table.schema [:inline "public"]]
                                                                          [:= :table.schema nil]]]
@@ -129,7 +129,7 @@
                                                                :where [:and
                                                                        [:= :self_table.db_id :table.db_id]
                                                                        [:or
-                                                                        [:= :self_table.schema :table.schema]
+                                                                        [:= :self_table.schema [:lower :table.schema]]
                                                                         [:and
                                                                          [:= :self_table.schema [:inline "public"]]
                                                                          [:= :table.schema nil]]]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
@@ -198,6 +198,16 @@
                                    :schema nil
                                    :name "accounts"}
 
+                   ;; Create another table that has both upper and lower case schemas
+                   ;; and table names
+                   :model/Table _ {:db_id audit-db-id
+                                   :schema "public"
+                                   :name "friends"}
+
+                   :model/Table _ {:db_id audit-db-id
+                                   :schema "PUBLIC"
+                                   :name "FRIENDS"}
+
                    :model/Table {no-schema-table :id} {:db_id audit-db-id
                                                        :schema nil
                                                        :name "products"}


### PR DESCRIPTION
### Description

We can have tables in migrated instances that have two copies of the audit db tables one with a 'public' schema and one with a 'PUBLIC' schema. This handles that case.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
