### PR TITLE
Fix single and multi-value string filter widget for non-string columns

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
@@ -9,6 +9,7 @@ import type { InputProps } from "metabase/core/components/Input";
 import Input from "metabase/core/components/Input";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { delay } from "metabase/lib/delay";
+import { isEqualOptionItem } from "metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils";
 import { Checkbox, Flex, Text } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
@@ -114,7 +115,9 @@ export const ListField = ({
     if (
       event.key === "Enter" &&
       filter.trim().length > 0 &&
-      !_.find(augmentedOptions, (option) => option[0] === filter)
+      !_.find(augmentedOptions, (option) =>
+        isEqualOptionItem(option[0], filter),
+      )
     ) {
       event.preventDefault();
       setAddedOptions([...addedOptions, [filter]]);

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
@@ -9,7 +9,7 @@ import type { InputProps } from "metabase/core/components/Input";
 import Input from "metabase/core/components/Input";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { delay } from "metabase/lib/delay";
-import { isEqualOptionItem } from "metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils";
+import { optionItemEqualsFilter } from "metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils";
 import { Checkbox, Flex, Text } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
@@ -116,7 +116,7 @@ export const ListField = ({
       event.key === "Enter" &&
       filter.trim().length > 0 &&
       !_.find(augmentedOptions, (option) =>
-        isEqualOptionItem(option[0], filter),
+        optionItemEqualsFilter(option[0], filter),
       )
     ) {
       event.preventDefault();

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.unit.spec.tsx
@@ -149,4 +149,16 @@ describe("ListField", () => {
       expect(screen.queryByLabelText("Select all")).not.toBeInTheDocument(),
     );
   });
+
+  it("should not create duplicate options on pressing Enter for non-string values", async () => {
+    setup({
+      value: [],
+      options: [[true], [false]],
+      placeholder: "Find...",
+      optionRenderer: ([value]) => <span>{String(value)}</span>,
+    });
+    const input = screen.getByPlaceholderText("Find...");
+    await userEvent.type(input, "false");
+    expect(screen.getAllByText("false")).toHaveLength(1);
+  });
 });

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
@@ -28,9 +28,9 @@ function createOptionsFromValuesWithoutOptions(
   values: RowValue[],
   options: Option[],
 ): Option {
-  const optionsMap = _.indexBy(options, "0");
+  const optionsMap = new Map(options.map((option) => [option[0], option]));
   return values
-    .filter((value) => !optionsMap[String(value)])
+    .filter((value) => !optionsMap.has(value))
     .map((value) => [value]);
 }
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
@@ -20,7 +20,7 @@ import {
   OptionsList,
 } from "./SingleSelectListField.styled";
 import type { Option, SingleSelectListFieldProps } from "./types";
-import { isValidOptionItem } from "./utils";
+import { isEqualOptionItem, isValidOptionItem } from "./utils";
 
 const DEBOUNCE_FILTER_TIME = delay(100);
 
@@ -30,7 +30,7 @@ function createOptionsFromValuesWithoutOptions(
 ): Option {
   const optionsMap = _.indexBy(options, "0");
   return values
-    .filter((value) => typeof value !== "string" || !optionsMap[value])
+    .filter((value) => !optionsMap[String(value)])
     .map((value) => [value]);
 }
 
@@ -71,7 +71,7 @@ const SingleSelectListField = ({
   const [filter, setFilter] = useState("");
   const debouncedFilter = useDebouncedValue(filter, DEBOUNCE_FILTER_TIME);
 
-  const isFilterInValues = value[0] === filter;
+  const isFilterInValues = isEqualOptionItem(value, filter);
 
   const filteredOptions = useMemo(() => {
     const formattedFilter = debouncedFilter.trim().toLowerCase();
@@ -118,7 +118,7 @@ const SingleSelectListField = ({
     if (
       event.key === "Enter" &&
       filter.trim().length > 0 &&
-      !_.find(augmentedOptions, (option) => option[0] === filter)
+      !_.find(augmentedOptions, (option) => isEqualOptionItem(option, filter))
     ) {
       event.preventDefault();
       setAddedOptions([...addedOptions, [filter]]);

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
@@ -20,7 +20,7 @@ import {
   OptionsList,
 } from "./SingleSelectListField.styled";
 import type { Option, SingleSelectListFieldProps } from "./types";
-import { isEqualOptionItem, isValidOptionItem } from "./utils";
+import { optionItemContainsFilter, optionItemEqualsFilter } from "./utils";
 
 const DEBOUNCE_FILTER_TIME = delay(100);
 
@@ -71,7 +71,7 @@ const SingleSelectListField = ({
   const [filter, setFilter] = useState("");
   const debouncedFilter = useDebouncedValue(filter, DEBOUNCE_FILTER_TIME);
 
-  const isFilterInValues = isEqualOptionItem(value, filter);
+  const isFilterInValues = optionItemEqualsFilter(value, filter);
 
   const filteredOptions = useMemo(() => {
     const formattedFilter = debouncedFilter.trim().toLowerCase();
@@ -93,13 +93,13 @@ const SingleSelectListField = ({
       if (
         option.length > 1 &&
         option[1] &&
-        isValidOptionItem(option[1], formattedFilter)
+        optionItemContainsFilter(option[1], formattedFilter)
       ) {
         return true;
       }
 
       // option as: [id]
-      return isValidOptionItem(option[0], formattedFilter);
+      return optionItemContainsFilter(option[0], formattedFilter);
     });
   }, [augmentedOptions, debouncedFilter, sortedOptions, isFilterInValues]);
 
@@ -118,7 +118,9 @@ const SingleSelectListField = ({
     if (
       event.key === "Enter" &&
       filter.trim().length > 0 &&
-      !_.find(augmentedOptions, (option) => isEqualOptionItem(option, filter))
+      !_.find(augmentedOptions, (option) =>
+        optionItemEqualsFilter(option, filter),
+      )
     ) {
       event.preventDefault();
       setAddedOptions([...addedOptions, [filter]]);

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.unit.spec.js
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.unit.spec.js
@@ -1,3 +1,6 @@
+import { waitForElementToBeRemoved } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
 import { render, screen } from "__support__/ui";
 
 import ValueComponent from "../../Value";
@@ -61,5 +64,27 @@ describe("SingleSelectListField", () => {
 
     expect(screen.getByText(firstOption)).toBeInTheDocument();
     expect(screen.getByText(secondOption)).toBeInTheDocument();
+  });
+
+  it("should not create duplicate options for non-string values", () => {
+    setup({ value: [true, false], options: [[true], [false]] });
+    expect(screen.getAllByText("true")).toHaveLength(1);
+    expect(screen.getAllByText("false")).toHaveLength(1);
+  });
+
+  it("should not create duplicate options when searching with non-string values", async () => {
+    setup({ value: [], options: [[true], [false]] });
+    const input = screen.getByPlaceholderText("Find...");
+    await userEvent.type(input, "false");
+    await waitForElementToBeRemoved(() => screen.queryByText("true"));
+    expect(screen.getAllByText("false")).toHaveLength(1);
+  });
+
+  it("should not create duplicate options on pressing Enter for non-string values", async () => {
+    setup({ value: [], options: [[true], [false]] });
+    const input = screen.getByPlaceholderText("Find...");
+    await userEvent.type(input, "false{enter}");
+    expect(screen.getAllByText("true")).toHaveLength(1);
+    expect(screen.getAllByText("false")).toHaveLength(1);
   });
 });

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils.ts
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils.ts
@@ -1,7 +1,13 @@
-export function isValidOptionItem(optionItem: any, filter: string): boolean {
-  return String(optionItem).toLowerCase().includes(filter);
+export function optionItemEqualsFilter(
+  optionItem: any,
+  filter: string,
+): boolean {
+  return String(optionItem) === filter;
 }
 
-export function isEqualOptionItem(optionItem: any, filter: string): boolean {
-  return String(optionItem) === filter;
+export function optionItemContainsFilter(
+  optionItem: any,
+  filter: string,
+): boolean {
+  return String(optionItem).toLowerCase().includes(filter);
 }

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils.ts
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils.ts
@@ -1,3 +1,7 @@
 export function isValidOptionItem(optionItem: any, filter: string): boolean {
   return String(optionItem).toLowerCase().includes(filter);
 }
+
+export function isEqualOptionItem(optionItem: any, filter: string): boolean {
+  return String(optionItem) === filter;
+}

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils.unit.spec.ts
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/utils.unit.spec.ts
@@ -1,7 +1,7 @@
-import { isValidOptionItem } from "./utils";
+import { optionItemContainsFilter } from "./utils";
 
 describe("ListField - utils", () => {
-  describe("isValidOptionItem", () => {
+  describe("optionItemContainsFilter", () => {
     const TEST_CASES = [
       ["Marble Shoes", "marble", true],
       [[6, "Marble Shoes"], "marble", true],
@@ -14,7 +14,7 @@ describe("ListField - utils", () => {
 
     TEST_CASES.map(([optionItem, filter, expectedResult]) => {
       it(`includes "${filter}" in: ${optionItem}`, () => {
-        const result = isValidOptionItem(optionItem, String(filter));
+        const result = optionItemContainsFilter(optionItem, String(filter));
         expect(result).toEqual(expectedResult);
       });
     });


### PR DESCRIPTION
Regression since https://github.com/metabase/metabase/pull/43293
Stop creating duplicate values for non-string options.

Context: https://metaboat.slack.com/archives/C0645JP1W81/p1749666045221899