### PR TITLE
Select the most viewed tables when generating SQL queries

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/ai_sql_generation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/ai_sql_generation/api.clj
@@ -24,7 +24,8 @@
                            :db_id database-id
                            :active true
                            :visibility_type nil
-                           {:limit all-tables-limit})
+                           {:order-by [[:view_count :desc]]
+                            :limit    all-tables-limit})
          tables (filter mi/can-read? tables)
          tables (t2/hydrate tables :fields)]
      (mapv (fn [{:keys [fields] :as table}]


### PR DESCRIPTION
Fixes BOT-181

### Description

This PR adds the `view_count desc` order by clause requested in BOT-181. The rest of the items require no change.

This is the minimal change for BOT-181, but I noticed that we list tables the user has no right to create native queries for. I'm not sure this is a real issue, because the user might not be able to reach the point where SQL queries are generated without them having native query right for the whole database (and native querying rights cannot be granular ATM). Anyway, I've opened #59360, which addresses this "problem".

Note that I'll be away for ten days, so if the PR gets approved, it should be merged by somebody else.