### PR TITLE
Adding Native Query Editory shortcuts to glossary

### DIFF
--- a/frontend/src/metabase/lib/browser.ts
+++ b/frontend/src/metabase/lib/browser.ts
@@ -49,3 +49,4 @@ export function isMac() {
 }
 
 export const METAKEY = isMac() ? "⌘" : "Ctrl";
+export const ALTKEY = isMac() ? "⌥" : "Alt";

--- a/frontend/src/metabase/palette/components/PaletteShortcutsModal/PaletteShortcutsModal.tsx
+++ b/frontend/src/metabase/palette/components/PaletteShortcutsModal/PaletteShortcutsModal.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import Styles from "metabase/css/core/index.css";
-import { METAKEY } from "metabase/lib/browser";
+import { ALTKEY, METAKEY } from "metabase/lib/browser";
 import { shortcuts as ALL_SHORTCUTS } from "metabase/palette/shortcuts";
 import type { ShortcutDef, ShortcutGroup } from "metabase/palette/types";
 import {
@@ -131,8 +131,9 @@ const Shortcut = (props: { shortcut: string }) => {
 
   const string = props.shortcut
     .replace("$mod", METAKEY)
+    .replace("Alt", ALTKEY)
     .replace(" ", " > ")
-    .replace("+", " + ");
+    .replace(/\+/g, " + ");
   const result = string.split(" ").map((x) => {
     if (x === "+" || x === ">") {
       return x;

--- a/frontend/src/metabase/palette/shortcuts/question.ts
+++ b/frontend/src/metabase/palette/shortcuts/question.ts
@@ -71,4 +71,115 @@ export const questionShortcuts = {
     shortcut: ["$mod+backspace"],
     shortcutGroup: "question" as const,
   },
+
+  "native-query-move-line-up": {
+    get name() {
+      return t`Move the current line up`;
+    },
+    shortcut: ["Alt+ArrowUp"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-move-line-down": {
+    get name() {
+      return t`Move the current line down`;
+    },
+    shortcut: ["Alt+ArrowDown"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-copy-line-up": {
+    get name() {
+      return t`Copy the current line up`;
+    },
+    shortcut: ["Alt+Shift+ArrowUp"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-copy-line-down": {
+    get name() {
+      return t`Copy the current line down`;
+    },
+    shortcut: ["Alt+Shift+ArrowDown"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-indent-line-more": {
+    get name() {
+      return t`Indent the current line more`;
+    },
+    shortcut: ["$mod+]"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-indent-line-less": {
+    get name() {
+      return t`Indent the current line less`;
+    },
+    shortcut: ["$mod+["],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-delete-current-line": {
+    get name() {
+      return t`Delete the current line`;
+    },
+    shortcut: ["Shift+$mod+k"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-jump-to-matching-bracket": {
+    get name() {
+      return t`Jump to the matching bracket`;
+    },
+    shortcut: ["Shift+$mod+\\"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-comment-current-line": {
+    get name() {
+      return t`Comment out the current line`;
+    },
+    shortcut: ["$mod+\\"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-add-cursor": {
+    get name() {
+      return t`Add an additional cursor`;
+    },
+    shortcut: ["$mod+Click"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
+  "native-query-find-selection": {
+    get name() {
+      return t`Find highlighted text`;
+    },
+    shortcut: ["$mod+d"],
+    shortcutGroup: "question" as const,
+    get shortcutContext() {
+      return t`Native Editor`;
+    },
+  },
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/59284

### Description
Adds Native Editor shortcuts to the `Keyboard Shortcut Glossary` under Questions -> Native Editor. Note that these are only informational, and will not produce analytics when they're used

### How to verify

1. Press `Shift+?` to open the keyboard shortcuts modal
2. Navigate to questions and see the new section
3. Give some a try

### Demo
<img width="798" alt="image" src="https://github.com/user-attachments/assets/d39bad87-7116-46dc-9dc9-1de7b43ec74e" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ This PR only adds data, no functionality
