### PR TITLE
Use latest docker-compose for Sample App e2e CI

### DIFF
--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -218,6 +218,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # We have to use the latest version that does not have this issue https://github.com/docker/compose/pull/12752
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+        with:
+          version: latest
+
       - name: Get Sample App name
         id: get-sample-app-name
         shell: bash


### PR DESCRIPTION
Use latest docker-compose for Sample App e2e CI

https://github.com/docker/compose/pull/12752

Sometimes Sample App CI is failing because of a bug in a non-latest version docker-compose version:
https://github.com/metabase/metabase/actions/runs/15608919896/job/43965788373?pr=58212#step:11:327