### PR TITLE
Fix initial id for data-grid actions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -265,9 +265,9 @@
                                                                                               :op        op
                                                                                               :param     param}))))
     (string? raw-id) (if-let [[_ dashcard-id _nested-id] (re-matches #"^dashcard:([^:]+):(.*)$" raw-id)]
-                       ;; If the id was created before the dashcard was saved, it couldn't capture its parents id.
+                       ;; If the id was created before the dashcard was saved, it couldn't capture its parent's id.
                        ;; So, as a hack, we get it from the scope.
-                       (let [dashcard-id (if (= "unknown" dashcard-id) (:dashcard-id scope) (parse-long dashcard-id))
+                       (let [dashcard-id (when (not= "unknown" dashcard-id) (parse-long dashcard-id))
                              dashcard-id (if (pos-int? dashcard-id) dashcard-id (:dashcard-id scope))
                              dashcard    (api/check-404 (some->> dashcard-id (t2/select-one [:model/DashboardCard :visualization_settings])))
                              ;; TODO: this should belongs to our configuration

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -271,7 +271,7 @@
                        (let [dashcard-id (when (not= "unknown" dashcard-id) (parse-long dashcard-id))
                              ;; So, if we only have a placeholder for the dashcard id, get it from the scope.
                              ;; This hack always works since the frontend can't invoke row actions from anywhere else.
-                             ;; From a semantic point of view however, this hack sucks. It'll be fixed by WRK-483.
+                             ;; From a semantic point of view, this hack still sucks. It'll be fixed by WRK-483.
                              dashcard-id (if (pos-int? dashcard-id) dashcard-id (:dashcard-id scope))
                              dashcard    (api/check-404 (some->> dashcard-id (t2/select-one [:model/DashboardCard :visualization_settings])))
                              ;; TODO: this should belongs to our configuration

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -265,7 +265,10 @@
                                                                                               :op        op
                                                                                               :param     param}))))
     (string? raw-id) (if-let [[_ dashcard-id _nested-id] (re-matches #"^dashcard:([^:]+):(.*)$" raw-id)]
+                       ;; If the id was created before the dashcard was saved, it couldn't capture its parents id.
+                       ;; So, as a hack, we get it from the scope.
                        (let [dashcard-id (if (= "unknown" dashcard-id) (:dashcard-id scope) (parse-long dashcard-id))
+                             dashcard-id (if (pos-int? dashcard-id) dashcard-id (:dashcard-id scope))
                              dashcard    (api/check-404 (some->> dashcard-id (t2/select-one [:model/DashboardCard :visualization_settings])))
                              ;; TODO: this should belongs to our configuration
                              actions     (-> dashcard :visualization_settings :editableTable.enabledActions)

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -951,7 +951,13 @@
     ;; new action, give it an id
     ;; currently the frontend is generating its own ids... we need to replace those
     (or (not id) (not (str/starts-with? id "dashcard:")))
-    (str "dashcard:" (:id dashcard "unknown") ":" (u/generate-nano-id))
+    (str "dashcard:"
+         (let [dashcard-id (:id dashcard "unknown")]
+           (if (pos-int? dashcard-id)
+             dashcard-id
+             "unknown"))
+         ":"
+         (u/generate-nano-id))
     ;; chicken-and-egg resulted in a suboptimal id, fix it
     (and (str/starts-with? id "dashcard:unknown:") (:id dashcard))
     (str/replace id #"dashcard:unknown" (str "dashcard:" (:id dashcard)))

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -946,20 +946,17 @@
   the semantically dubious dependency on :scope is minimized.
 
   Once these actions are stored in some sort of first-class action table, we won't have this issue."
-  [dashcard id]
+  [{dashcard-id :id} id]
   (cond
     ;; new action, give it an id
     ;; currently the frontend is generating its own ids... we need to replace those
     (or (not id) (not (str/starts-with? id "dashcard:")))
     (format "dashcard:%s:%s"
-            (let [dashcard-id (:id dashcard "unknown")]
-              (if (pos-int? dashcard-id)
-                dashcard-id
-                "unknown"))
+            (if (pos-int? dashcard-id) dashcard-id "unknown")
             (u/generate-nano-id))
     ;; chicken-and-egg resulted in a suboptimal id, fix it
-    (and (str/starts-with? id "dashcard:unknown:") (:id dashcard))
-    (str/replace id #"dashcard:unknown" (str "dashcard:" (:id dashcard)))
+    (and (str/starts-with? id "dashcard:unknown:") dashcard-id)
+    (str/replace id #"dashcard:unknown" (str "dashcard:" dashcard-id))
     :else
     id))
 

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -951,13 +951,12 @@
     ;; new action, give it an id
     ;; currently the frontend is generating its own ids... we need to replace those
     (or (not id) (not (str/starts-with? id "dashcard:")))
-    (str "dashcard:"
-         (let [dashcard-id (:id dashcard "unknown")]
-           (if (pos-int? dashcard-id)
-             dashcard-id
-             "unknown"))
-         ":"
-         (u/generate-nano-id))
+    (format "dashcard:%s:%s"
+            (let [dashcard-id (:id dashcard "unknown")]
+              (if (pos-int? dashcard-id)
+                dashcard-id
+                "unknown"))
+            (u/generate-nano-id))
     ;; chicken-and-egg resulted in a suboptimal id, fix it
     (and (str/starts-with? id "dashcard:unknown:") (:id dashcard))
     (str/replace id #"dashcard:unknown" (str "dashcard:" (:id dashcard)))

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5172,7 +5172,8 @@
                (f saved nil))))
       (testing "does its best without a parent"
         (is (= "dashcard:unknown:rAnDoM"
-               (f unsaved nil))))
+               (f unsaved nil)
+               (f nil nil))))
       (testing "accepts its new parent"
         (is (= "dashcard:1337:SAVE_ME"
                (f saved "dashcard:unknown:SAVE_ME")))))))

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5158,7 +5158,7 @@
 
 (deftest create-or-fix-action-id-test
   (let [f       #'api.dashboard/create-or-fix-action-id
-        unsaved {}
+        unsaved {:id -1}
         saved   {:id 1337}]
     (mt/with-dynamic-fn-redefs [u/generate-nano-id (fn [] "rAnDoM")]
       (testing "leaves valid ids alone"


### PR DESCRIPTION
This fix is need so that `/execute` and `/configure` will work correctly on the actions that are created on dashcards that have not been created yet.

Without this fix, we also end up with ids like `dashcard:-1:{uuid}` and these don't get fixed once the dashcard gets saved, and if we add more dashcards in future we can end up with duplicates, as the negative increment will have reset on the frontend beween API calls.