### PR TITLE
fix: refetch modal description on viz settings change

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo } from "react";
 import { push } from "react-router-redux";
 import { useLocation } from "react-use";
 import { t } from "ttag";
@@ -241,13 +241,25 @@ export const EditTableDashcardVisualization = memo(
       { open: openCreateRowModal, close: closeCreateRowModal },
     ] = useDisclosure(false);
 
-    const { data: createRowFormDescription } = useActionFormDescription({
+    const {
+      data: createRowFormDescription,
+      refetch: refetchCreateRowFormDescription,
+    } = useActionFormDescription({
       actionId: BuiltInTableAction.Create,
       scope: editingScope,
-      // Refetch when visualizationSettings change, but only if card is not currently being edited
-      skip: !hasCreateAction || isEditing,
-      refetchDependencies: [visualizationSettings],
+      fetchOnMount: false,
     });
+
+    useEffect(() => {
+      if (hasCreateAction && !isEditing) {
+        refetchCreateRowFormDescription();
+      }
+    }, [
+      visualizationSettings, // refetch on visualizationSettings change
+      hasCreateAction,
+      isEditing,
+      refetchCreateRowFormDescription,
+    ]);
 
     const shouldDisableActions = isUndoLoading || isRedoLoading;
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
@@ -244,7 +244,9 @@ export const EditTableDashcardVisualization = memo(
     const { data: createRowFormDescription } = useActionFormDescription({
       actionId: BuiltInTableAction.Create,
       scope: editingScope,
-      skip: !hasCreateAction,
+      // Refetch when visualizationSettings change, but only if card is not currently being edited
+      skip: !hasCreateAction || isEditing,
+      refetchDependencies: [visualizationSettings],
     });
 
     const shouldDisableActions = isUndoLoading || isRedoLoading;

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-action-form-description.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-action-form-description.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useDescribeActionFormMutation } from "metabase-enterprise/api";
 
@@ -8,24 +8,39 @@ type UseTableDescribeTmpModalProps = {
   actionId: BuiltInTableAction;
   scope: TableEditingScope;
   skip?: boolean;
+  refetchDependencies?: unknown[];
 };
 
 export const useActionFormDescription = ({
   actionId,
   scope,
   skip,
+  refetchDependencies = [],
 }: UseTableDescribeTmpModalProps) => {
+  const [shouldFetch, setShouldFetch] = useState(!skip);
   const [fetchModalDescription, { data, isLoading }] =
     useDescribeActionFormMutation();
 
+  // Request re-fetch when `refetchDependencies` or `skip` changes
   useEffect(() => {
-    if (!data && !skip) {
+    if (!skip) {
+      setShouldFetch(true);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skip, ...refetchDependencies]);
+
+  // Fetch modal description when `shouldFetch` is true and not currently loading
+  useEffect(() => {
+    if (shouldFetch && !isLoading) {
       fetchModalDescription({
         action_id: actionId,
         scope,
+      }).then(() => {
+        setShouldFetch(false);
       });
     }
-  }, [fetchModalDescription, actionId, scope, data, skip]);
+  }, [fetchModalDescription, shouldFetch, isLoading, actionId, scope]);
 
   return {
     data,

--- a/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
@@ -5,10 +5,11 @@ import _ from "underscore";
 import { PLUGIN_DATA_EDITING } from "metabase/plugins";
 import { Flex, Loader, Title } from "metabase/ui";
 import LoadingView from "metabase/visualizations/components/Visualization/LoadingView";
-import { mergeSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import Question from "metabase-lib/v1/Question";
 import type { Card, DatasetData } from "metabase-types/api";
+
+import { mergeSettings } from "../../lib/settings/typed-utils";
 
 import { TableEditableConfigureActionButton } from "./TableEditableConfigureActionButton";
 

--- a/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
@@ -1,9 +1,11 @@
 import { Component } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import { PLUGIN_DATA_EDITING } from "metabase/plugins";
 import { Flex, Loader, Title } from "metabase/ui";
 import LoadingView from "metabase/visualizations/components/Visualization/LoadingView";
+import { mergeSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import Question from "metabase-lib/v1/Question";
 import type { Card, DatasetData } from "metabase-types/api";
@@ -101,7 +103,10 @@ export class TableEditable extends Component<
       return <LoadingView isSlow={false} />;
     }
 
-    const visualizationSettings = dashcard.visualization_settings;
+    const visualizationSettings = getMergedVisualizationSettings(
+      card.visualization_settings,
+      dashcard.visualization_settings,
+    );
 
     const hasVisibleColumns =
       !visualizationSettings?.["table.columns"] ||
@@ -134,3 +139,13 @@ export class TableEditable extends Component<
     );
   }
 }
+
+const getMergedVisualizationSettings = _.memoize(
+  (cardSettings: any, dashcardSettings: any) => {
+    return mergeSettings(cardSettings, dashcardSettings);
+  },
+  (cardSettings: any, dashcardSettings: any) => {
+    // Create a cache key from both settings objects
+    return JSON.stringify([cardSettings, dashcardSettings]);
+  },
+);

--- a/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TableEditable/TableEditable.tsx
@@ -1,6 +1,5 @@
 import { Component } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { PLUGIN_DATA_EDITING } from "metabase/plugins";
 import { Flex, Loader, Title } from "metabase/ui";
@@ -8,8 +7,6 @@ import LoadingView from "metabase/visualizations/components/Visualization/Loadin
 import type { VisualizationProps } from "metabase/visualizations/types";
 import Question from "metabase-lib/v1/Question";
 import type { Card, DatasetData } from "metabase-types/api";
-
-import { mergeSettings } from "../../lib/settings/typed-utils";
 
 import { TableEditableConfigureActionButton } from "./TableEditableConfigureActionButton";
 
@@ -104,10 +101,7 @@ export class TableEditable extends Component<
       return <LoadingView isSlow={false} />;
     }
 
-    const visualizationSettings = getMergedVisualizationSettings(
-      card.visualization_settings,
-      dashcard.visualization_settings,
-    );
+    const visualizationSettings = dashcard.visualization_settings;
 
     const hasVisibleColumns =
       !visualizationSettings?.["table.columns"] ||
@@ -140,13 +134,3 @@ export class TableEditable extends Component<
     );
   }
 }
-
-const getMergedVisualizationSettings = _.memoize(
-  (cardSettings: any, dashcardSettings: any) => {
-    return mergeSettings(cardSettings, dashcardSettings);
-  },
-  (cardSettings: any, dashcardSettings: any) => {
-    // Create a cache key from both settings objects
-    return JSON.stringify([cardSettings, dashcardSettings]);
-  },
-);


### PR DESCRIPTION
Currently create row form description is fetched only once, so when user edits viz settings, the modal configuration stays the same. The PR tries to fix this behaviour.

Before:

https://github.com/user-attachments/assets/c3767ad9-ce98-4bce-a765-59eb6a86fd5c

After:

https://github.com/user-attachments/assets/37ca2427-0405-4c00-a70f-bd0b86ed9453

