### PR TITLE
[Metabot] Start new conversation helper

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -15,7 +15,10 @@ import {
 import { MetabotIcon } from "metabase-enterprise/metabot/components/MetabotIcon";
 import { METABOT_RESULTS_MESSAGE } from "metabase-enterprise/metabot/constants";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
-import { resetConversationId } from "metabase-enterprise/metabot/state";
+import {
+  cancelInflightAgentRequests,
+  resetConversationId,
+} from "metabase-enterprise/metabot/state";
 
 import Styles from "./MetabotChatEmbedding.module.css";
 
@@ -43,8 +46,6 @@ export const MetabotChatEmbedding = ({
     setInputExpanded(false);
   }, []);
 
-  const metabotRequestPromiseRef = useRef<{ abort: () => void } | null>(null);
-
   const handleSend = () => {
     const trimmedInput = input.trim();
     if (!trimmedInput.length || metabot.isDoingScience) {
@@ -55,7 +56,6 @@ export const MetabotChatEmbedding = ({
       trimmedInput,
       EMBEDDING_METABOT_ID,
     );
-    metabotRequestPromiseRef.current = metabotRequestPromise;
 
     metabotRequestPromise
       .then((result) => {
@@ -98,7 +98,7 @@ export const MetabotChatEmbedding = ({
     : inputPlaceholder;
 
   function cancelRequest() {
-    metabotRequestPromiseRef.current?.abort();
+    dispatch(cancelInflightAgentRequests());
   }
 
   const dispatch = useSdkDispatch();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQuickLinks.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQuickLinks.tsx
@@ -11,7 +11,7 @@ export const getMetabotQuickLinks = () => {
       key="metabot"
       path="metabot/new"
       component={(props) => {
-        const metabot = useMetabotAgent();
+        const { startNewConversation } = useMetabotAgent();
         const prompt = String(props.location.query?.q ?? "");
         const dispatch = useDispatch();
 
@@ -19,9 +19,7 @@ export const getMetabotQuickLinks = () => {
           dispatch(replace("/"));
 
           if (prompt) {
-            metabot.resetConversation();
-            metabot.setVisible(true);
-            metabot.submitInput(prompt);
+            startNewConversation(prompt);
           }
         });
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -11,9 +11,9 @@ import {
   getMessages,
   getMetabotId,
   getMetabotVisible,
-  resetConversation,
-  setVisible,
-  submitInput,
+  resetConversation as resetConversationAction,
+  setVisible as setVisibleAction,
+  submitInput as submitInputAction,
 } from "./state";
 
 export const useMetabotAgent = () => {
@@ -32,6 +32,47 @@ export const useMetabotAgent = () => {
     fixedCacheKey: METABOT_TAG,
   });
 
+  const setVisible = useCallback(
+    (isVisible: boolean) => dispatch(setVisibleAction(isVisible)),
+    [dispatch],
+  );
+
+  const resetConversation = useCallback(
+    () => dispatch(resetConversationAction()),
+    [dispatch],
+  );
+
+  const submitInput = useCallback(
+    async (message: string, metabotId?: string) => {
+      const context = await getChatContext();
+      return dispatch(
+        submitInputAction({
+          message,
+          context,
+          metabot_id: metabotId,
+        }),
+      );
+    },
+    [dispatch, getChatContext],
+  );
+
+  const startNewConversation = useCallback(
+    (message: string, metabotId?: string) => {
+      resetConversation();
+      setVisible(true);
+      if (message) {
+        submitInput(message, metabotId);
+      }
+
+      // HACK: if the user opens the command palette via the search button bar focus will be moved
+      // back to the search button bar if the metabot option is chosen, so a small delay is used
+      setTimeout(() => {
+        document.getElementById("metabot-chat-input")?.focus();
+      }, 100);
+    },
+    [submitInput, resetConversation, setVisible],
+  );
+
   return {
     metabotId: useSelector(getMetabotId as any) as ReturnType<
       typeof getMetabotId
@@ -39,10 +80,7 @@ export const useMetabotAgent = () => {
     visible: useSelector(getMetabotVisible as any) as ReturnType<
       typeof getMetabotVisible
     >,
-    setVisible: useCallback(
-      (isVisible: boolean) => dispatch(setVisible(isVisible)),
-      [dispatch],
-    ),
+    setVisible,
     messages,
     lastAgentMessages: useSelector(
       getLastAgentMessagesByType as any,
@@ -50,29 +88,9 @@ export const useMetabotAgent = () => {
     isLongConversation: useSelector(
       getIsLongMetabotConversation as any,
     ) as ReturnType<typeof getIsLongMetabotConversation>,
-    resetConversation: () => dispatch(resetConversation()),
-    submitInput: useCallback(
-      (message: string, metabotId?: string) => {
-        const context = getChatContext();
-        const history = sendMessageReq.data?.history || [];
-        const state = sendMessageReq.data?.state || {};
-        return dispatch(
-          submitInput({
-            message,
-            context,
-            history,
-            state,
-            metabot_id: metabotId,
-          }),
-        );
-      },
-      [
-        dispatch,
-        getChatContext,
-        sendMessageReq.data?.history,
-        sendMessageReq.data?.state,
-      ],
-    ),
+    submitInput,
+    startNewConversation,
+    resetConversation,
     isDoingScience: sendMessageReq.isLoading || isProcessing,
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -47,7 +47,7 @@ if (hasPremiumFeature("metabot_v3")) {
   PLUGIN_METABOT.getMetabotVisible =
     getMetabotVisible as unknown as typeof PLUGIN_METABOT.getMetabotVisible;
   PLUGIN_METABOT.useMetabotPalletteActions = (searchText: string) => {
-    const { submitInput, setVisible } = useMetabotAgent();
+    const { startNewConversation } = useMetabotAgent();
 
     return useMemo(() => {
       const ret: PaletteAction[] = [
@@ -59,21 +59,11 @@ if (hasPremiumFeature("metabot_v3")) {
           section: "metabot",
           keywords: searchText,
           icon: "metabot",
-          perform: (_currentActionImpl) => {
-            setVisible(true);
-            if (searchText) {
-              submitInput(searchText);
-            }
-            // HACK: if the user opens the command palette via the search button bar focus
-            // will be moved back to the search button bar if the metabot option is chosen
-            setTimeout(() => {
-              document.getElementById("metabot-chat-input")?.focus();
-            }, 100);
-          },
+          perform: () => startNewConversation(searchText),
         },
       ];
       return ret;
-    }, [searchText, submitInput, setVisible]);
+    }, [searchText, startNewConversation]);
   };
 
   PLUGIN_METABOT.SearchButton = MetabotSearchButton;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -16,7 +16,11 @@ import { getErrorMessage } from "../constants";
 import { notifyUnknownReaction, reactionHandlers } from "../reactions";
 
 import { metabot } from "./reducer";
-import { getIsProcessing, getMetabotConversationId } from "./selectors";
+import {
+  getIsProcessing,
+  getMetabotConversationId,
+  getPrevAgentRequestMeta,
+} from "./selectors";
 
 const isAbortError = isMatching({ name: "AbortError" });
 
@@ -47,8 +51,6 @@ export const submitInput = createAsyncThunk(
     data: {
       message: string;
       context: MetabotChatContext;
-      history: any[];
-      state: any;
       metabot_id?: string;
     },
     { dispatch, getState, signal },
@@ -59,7 +61,11 @@ export const submitInput = createAsyncThunk(
     }
 
     dispatch(addUserMessage(data.message));
-    const sendMessageRequestPromise = dispatch(sendMessageRequest(data));
+
+    const meta = getPrevAgentRequestMeta(getState() as any);
+    const sendMessageRequestPromise = dispatch(
+      sendMessageRequest({ ...data, ...meta }),
+    );
     signal.addEventListener("abort", () => {
       sendMessageRequestPromise.abort();
     });

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -2,6 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import _ from "underscore";
 
 import { getIsEmbedding } from "metabase/selectors/embed";
+import { METABOT_TAG, metabotApi } from "metabase-enterprise/api";
 
 import {
   FIXED_METABOT_IDS,
@@ -71,4 +72,23 @@ export const getIsLongMetabotConversation = createSelector(
 
 export const getMetabotId = createSelector(getIsEmbedding, (isEmbedding) =>
   isEmbedding ? FIXED_METABOT_IDS.EMBEDDED : FIXED_METABOT_IDS.DEFAULT,
+);
+
+export const getPrevAgentResponse = metabotApi.endpoints.metabotAgent.select({
+  requestId: undefined,
+  fixedCacheKey: METABOT_TAG,
+});
+
+/**
+ * Used to access values like history + state from the previous request
+ * which are meant to be repeated back on future requests
+ */
+export const getPrevAgentRequestMeta = createSelector(
+  getPrevAgentResponse,
+  (res) => {
+    return {
+      state: res.data?.state ?? {},
+      history: res.data?.history ?? [],
+    };
+  },
 );


### PR DESCRIPTION
### Description

Adds a quick helper for a pattern that's getting repeated to open metabot, reset the conversation, and send a message

### How to verify

You can engage with it via:
- the `/metabot/new?q=Your%20prompt%here` quick link url
- the command palette's metabot action 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
not needed, should preserve existing functionality
