### PR TITLE
[Parameters] Drop any `:fields` when (ab)using a card for field values

### DIFF
--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -82,7 +82,8 @@
                                       {:source-query inner-mbql}
                                       inner-mbql)]
                    (-> inner-mbql
-                       (dissoc :aggregation :order-by)
+                       (dissoc :aggregation :order-by :fields)
+                       (m/update-existing :joins (fn [joins] (mapv #(dissoc % :fields) joins)))
                        (assoc :breakout        [value-field-ref]
                               :breakout-idents (lib.ident/indexed-idents 1))
                        (update :limit (fnil min *max-rows*) *max-rows*)


### PR DESCRIPTION
Closes #59394.

### Description

If the card we're trying to use for parameters values has an explicit `:fields` clause, that was surviving into
the final query, which causes us to generate bad SQL and throw a 500. This discards the `:fields`, which aren't
relevant when we're overwriting the query's last stage with a single breakout.

### How to verify

Follow the [repro](https://github.com/metabase/metabase/issues/59394#issuecomment-2967617699) of Products with an
explicit fields list from the bug.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
