### PR TITLE
Closes VIZ-1020 - Fixed-width dashboards have broken cut off text

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -84,6 +84,7 @@ export function Text({
         onClick={toggleFocusOn}
         isSingleRow={isSingleRow}
         isMobile={isMobile}
+        isFixedWidth={dashboard?.width === "fixed"}
       >
         {isPreviewing ? (
           <ReactMarkdownStyleWrapper
@@ -136,6 +137,7 @@ export function Text({
       className={cx(className)}
       isSingleRow={isSingleRow}
       isMobile={isMobile}
+      isFixedWidth={dashboard?.width === "fixed"}
     >
       <ReactMarkdownStyleWrapper>
         <ReactMarkdown

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.styled.tsx
@@ -16,6 +16,7 @@ const SMALL_CONTAINER_PADDING_SIZE = "0.3rem";
 interface TextCardWrapperProps {
   isSingleRow: boolean;
   isMobile: boolean;
+  isFixedWidth: boolean;
 }
 const TextCardWrapper = styled.div<TextCardWrapperProps>`
   display: flex;
@@ -28,17 +29,20 @@ const TextCardWrapper = styled.div<TextCardWrapperProps>`
 
   /* adjust styles for single row text cards on desktop resolutions to prevent
   clipping of text cards (https://github.com/metabase/metabase/issues/31613) */
-  ${({ isSingleRow, isMobile }) =>
+  ${({ isSingleRow, isMobile, isFixedWidth }) =>
     isSingleRow &&
     !isMobile &&
     css`
       padding: ${SMALL_CONTAINER_PADDING_SIZE} 0;
       font-size: 0.8em;
 
-      ${breakpointMinExtraLarge} {
-        padding: ${DEFAULT_CONTAINER_PADDING_SIZE} 0;
-        font-size: 1em;
-      }
+      ${!isFixedWidth &&
+      css`
+        ${breakpointMinExtraLarge} {
+          padding: ${DEFAULT_CONTAINER_PADDING_SIZE} 0;
+          font-size: 1em;
+        }
+      `}
     `}
 `;
 
@@ -54,6 +58,7 @@ interface EditModeProps {
   isEmpty: boolean;
   isSingleRow: boolean;
   isMobile: boolean;
+  isFixedWidth: boolean;
 }
 export const EditModeContainer = styled(TextCardWrapper)<EditModeProps>`
   border-radius: 8px;
@@ -80,7 +85,7 @@ export const EditModeContainer = styled(TextCardWrapper)<EditModeProps>`
       color: var(--mb-color-text-light);
     `}
 
-  ${({ isSingleRow, isPreviewing, isEmpty, isMobile }) => {
+  ${({ isSingleRow, isPreviewing, isEmpty, isMobile, isFixedWidth }) => {
     const borderActive = !isPreviewing || isEmpty;
 
     // adjust styles for single row text cards on desktop resolutions
@@ -97,17 +102,22 @@ export const EditModeContainer = styled(TextCardWrapper)<EditModeProps>`
           ${BORDER_ADJUSTED_SMALL_PADDING}
         `}
 
-        ${breakpointMinExtraLarge} {
-          .${DashboardS.DashCard}:hover &,
-          .${DashboardS.DashCard}:focus-within & {
-            ${BORDER_ADJUSTED_DEFAULT_PADDING}
-          }
+        ${!isFixedWidth &&
+        css`
+          ${breakpointMinExtraLarge} {
+            padding: ${DEFAULT_CONTAINER_PADDING_SIZE};
 
-          ${borderActive &&
-          css`
-            ${BORDER_ADJUSTED_DEFAULT_PADDING}
-          `}
-        }
+            .${DashboardS.DashCard}:hover &,
+            .${DashboardS.DashCard}:focus-within & {
+              ${BORDER_ADJUSTED_DEFAULT_PADDING}
+            }
+
+            ${borderActive &&
+            css`
+              ${BORDER_ADJUSTED_DEFAULT_PADDING}
+            `}
+          }
+        `}
       `;
     }
 
@@ -128,6 +138,7 @@ export const EditModeContainer = styled(TextCardWrapper)<EditModeProps>`
 interface DisplayContainerProps {
   isSingleRow: boolean;
   isMobile: boolean;
+  isFixedWidth: boolean;
 }
 export const DisplayContainer = styled(
   TextCardWrapper,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58308
Closes VIZ-1020

### Description

Updates text card "extra large" breakpoint version so it's only applied on full-width dashboards since fixed-width dashboards don't have enough height to display it without scrollbars.

This issue appears to have been introduced in v49 with the introduction of fixed width dashboards:
![v49](https://github.com/user-attachments/assets/9c40c57a-c440-4d06-943a-9efb6d2d42fe)

### How to verify

1. Navigate to a dashboard with a one-height-high text card
2. Make the dashboard "Full width" and return to non-edit mode
3. Make the browser wide enough so it displays the extra large breakpoint (gte 1920px wide)
4. Verify the extra large version of the text card is shown
5. Turn off "Full width" and return to non-edit mode
6. With the browser still at the extra large breakpoint, verify the text is readable and displays the same as it does below the extra large breakpoint

Also mess around with:
* hovering/focusing text cards in edit-mode
* changing the text card height to more than 1
* being wider and narrower than the extra large breakpoint
* being in and out of edit mode

### Demo

BEFORE:
![before](https://github.com/user-attachments/assets/105ef4bc-9d1c-45a2-86a7-6c330800e82c)

AFTER:
![after](https://github.com/user-attachments/assets/8d1c94f9-380a-4d60-b7f9-a011232cde59)

Full-width (should be the same before and after):
![full-width-no-change](https://github.com/user-attachments/assets/52366f81-7574-45e7-bb99-a2a6b3f4089b)

