### PR TITLE
Initial work on /configure API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@
 /lein-plugins/*/target
 /local
 /locales/metabase-*.pot
+/logs
 /modules/drivers/*/resources/namespaces.edn
 /modules/drivers/*/target
 /node_modules/

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.data-editing.api
   (:require
    [clojure.walk :as walk]
+   [metabase-enterprise.data-editing.configure :as data-editing.configure]
    [metabase-enterprise.data-editing.data-editing :as data-editing]
    [metabase-enterprise.data-editing.describe :as data-editing.describe]
    [metabase.actions.core :as actions]
@@ -480,6 +481,16 @@
                                      :scope       scope
                                      :action_id   action_id})))]
       (data-editing.describe/describe-unified-action unified scope input))))
+
+(def configure
+  "A temporary var for our proxy in [[metabase.actions.api]] to call, until we move this endpoint there."
+  (api.macros/defendpoint :post "/configure-form"
+    "This API returns a data representation of the form the FE will render. It does not update the configuration."
+    [{}
+     {}
+     {:keys [action_id scope]}]
+    (let [scope (actions/hydrate-scope scope)]
+      (data-editing.configure/configuration (fetch-unified-action scope action_id) scope))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-editing routes."

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -228,6 +228,36 @@
                                                :parameters]))]
       {:actions (vec (concat saved-actions table-actions))})))
 
+(mr/def ::api-action-id-saved
+  "Refers to a row in the actions table."
+  ms/PositiveInt)
+
+(mr/def ::api-action-id-primitive-or-dashboard-or-dashcard-action
+  "We refer to primitive actions through their names.
+  For now we also encode dashboard button and dashcard action ids as strings, but make we can stop that after WRK-483."
+  :string)
+
+(mr/def ::api-action-id-packed-mapping
+  "The picker currently returns negative integers which encodes certain primitive actions with some config.
+  This is just a poor man's ::api-action-expression, so maybe we can deprecate that."
+  ms/NegativeInt)
+
+(mr/def ::api-action-id
+  "Primitive actions, saved actions, and packed encodings from the picker."
+  [:or
+   ::api-action-id-saved
+   ::api-action-id-primitive-or-dashboard-or-dashcard-action
+   ::api-action-id-packed-mapping])
+
+;; TODO this should become sequential so we can save the order.
+(mr/def ::action.config.param-map
+  "Editable configuration used to transform the inputs passed to an action."
+  [:map-of :keyword :any])
+
+(mr/def ::action.config.mappings
+  "Non -editable configuration used to transform the inputs passed to an action."
+  [:map-of :keyword :any])
+
 (mr/def ::unified-action.base
   [:or
    [:map {:closed true}
@@ -236,25 +266,45 @@
     [:action-kw :keyword]
     [:mapping {:optional true} [:maybe :map]]]])
 
+;; TODO Regret this name, let's rename it to something like ::action-expression once it's pure data.
 (mr/def ::unified-action
+  "The internal representation used by our APIs, after we've parsed the relevant ids and fetched their configuration."
   [:or
    ::unified-action.base
    [:map {:closed true}
+    ;; TODO Having an opaque id like this inside is not great.
+    ;;      We eventually want to have fetched all relevant data already, so we can just dispatch.
+    ;; But, for now we're wanting to reuse legacy code which dispatches on the underlying toucan instances, and the
+    ;; time has not yet come to refactor those functions.
+    ;; TODO make this variant more self-describing, it's not clear that this integer is a dashcard id.
     [:dashboard-action ms/PositiveInt]]
    [:map {:closed true}
     [:inner-action ::unified-action.base]
-    ;; TODO type our mappings
-    [:mapping [:maybe :map]]
-    [:param-map :map]
-    ;; TODO generalize so we can support grids outside of dashboards
-    [:dashcard-id ms/PositiveInt]]])
+    [:mapping {:optional true} [:maybe ::action.config.mappings]]
+    [:param-map ::action.config.param-map]
+    ;; We will eventually want to generalize to support grids outside of dashboards.
+    [:dashcard-id {:optional true} ms/PositiveInt]
+    [:configurable {:optional true} :boolean]]])
+
+(mr/def ::api-action-expression
+  "A more relaxed version of ::unified-action that can still have opaque ::api-action-id expressions inside."
+  ;; TODO let's wait until we've written all our API tests and integrated the FE before typing this.
+  :map)
+
+(mr/def ::api-action-id-or-expression
+  "All the various ways of referring to an action with the v2 APIs."
+  [:or ::api-action-expression ::api-action-id])
 
 (mu/defn- fetch-unified-action :- ::unified-action
-  "Resolve various types of action id into a semantic map which is easier to dispatch on."
+  "Resolve various flavors of action-id into plain data, making it easier to dispatch on. Fetch config etc."
   [scope :- ::types/scope.hydrated
-   raw-id :- [:or :map :string ms/NegativeInt ms/PositiveInt]]
+   raw-id :- ::api-action-id-or-expression]
   (cond
-    (map? raw-id)     raw-id
+    (map? raw-id) (if-let [packed-id (:packed-id raw-id)]
+                    (merge
+                     {:inner-action (fetch-unified-action scope packed-id)}
+                     (dissoc raw-id :packed-id))
+                    raw-id)
     (pos-int? raw-id) {:action-id raw-id}
     (neg-int? raw-id) (let [[op param] (actions/unpack-encoded-action-id raw-id)]
                         (cond
@@ -283,17 +333,19 @@
                              unified     (fetch-unified-action scope inner-id)
                              action-type (:actionType viz-action "data-grid/row-action")
                              mapping     (:mapping viz-action)
+                             ;; TODO we should do this *later* because it's lossy - we lose the configured ordering.
                              param-map   (->> (:parameterMappings viz-action {})
                                               (u/index-by :parameterId #(dissoc % :parameterId))
                                               walk/keywordize-keys)]
-                         (assert (:enabled viz-action) "Cannot call disabled actions")
+                         (assert (:enabled viz-action true) "Cannot call disabled actions")
                          (case action-type
                            ("data-grid/built-in"
                             "data-grid/row-action")
                            {:inner-action unified
                             :mapping      mapping
                             :param-map    param-map
-                            :dashcard-id  dashcard-id}))
+                            :dashcard-id  dashcard-id
+                            :configurable (not= action-type "data-grid/built-in")}))
                        (if-let [[_ dashcard-id] (re-matches #"^dashcard:(\d+)$" raw-id)]
                          ;; Dashboard buttons can only be invoked from dashboards
                          ;; We're not checking that the scope has the correct dashboard, but if it's incorrect, there
@@ -407,17 +459,17 @@
   "A temporary var for our proxy in [[metabase.actions.api]] to call, until we move this endpoint there."
   (api.macros/defendpoint :post "/action/v2/execute"
     "The One True API for invoking actions.
-  It doesn't care whether the action is saved or primitive, and whether it has been placed.
-  In particular, it supports:
-  - Custom model actions as well as primitive actions, and encoded hack actions which use negative ids.
-  - Stand-alone actions, Dashboard actions, Row actions, and whatever else comes along.
-  Since actions are free to return multiple outputs even for a single output, the response is always plural."
+     It doesn't care whether the action is saved or primitive, and whether it has been placed.
+     In particular, it supports:
+     - Custom model actions as well as primitive actions, and encoded hack actions which use negative ids.
+     - Stand-alone actions, Dashboard actions, Row actions, and whatever else comes along.
+     Since actions are free to return multiple outputs even for a single output, the response is always plural."
     [{}
      {}
      {:keys [action_id scope params input]}
      :- [:map
        ;; TODO docstrings for these
-         [:action_id [:or :map :string ms/NegativeInt ms/PositiveInt]]
+         [:action_id ::api-action-id-or-expression]
          [:scope     ::types/scope.raw]
          [:params    {:optional true} :map]
          [:input     :map]]]
@@ -431,10 +483,10 @@
      {}
      {:keys [action_id scope inputs params]}
      :- [:map
-         [:action_id               [:or :map :string ms/NegativeInt ms/PositiveInt]]
+         [:action_id               ::api-action-id-or-expression]
          [:scope                   ::types/scope.raw]
          [:inputs                  [:sequential :map]]
-         [:params {:optional true} :map]]]
+         [:params {:optional true} [:map-of :keyword :any]]]]
     ;; TODO get rid of *params* and use :mapping pattern to handle nested deletes
     {:outputs (binding [actions/*params* params]
                 (execute!* action_id scope (dissoc params :delete-children) inputs))}))
@@ -489,6 +541,7 @@
     "This API returns a data representation of the form the FE will render. It does not update the configuration."
     [{}
      {}
+     ;; TODO pour some malli on me
      {:keys [action_id scope]}]
     (let [scope (actions/hydrate-scope scope)]
       (data-editing.configure/configuration (fetch-unified-action scope action_id) scope))))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -252,8 +252,9 @@
 (mu/defn- fetch-unified-action :- ::unified-action
   "Resolve various types of action id into a semantic map which is easier to dispatch on."
   [scope :- ::types/scope.hydrated
-   raw-id :- [:or :string ms/NegativeInt ms/PositiveInt]]
+   raw-id :- [:or :map :string ms/NegativeInt ms/PositiveInt]]
   (cond
+    (map? raw-id)     raw-id
     (pos-int? raw-id) {:action-id raw-id}
     (neg-int? raw-id) (let [[op param] (actions/unpack-encoded-action-id raw-id)]
                         (cond
@@ -416,7 +417,7 @@
      {:keys [action_id scope params input]}
      :- [:map
        ;; TODO docstrings for these
-         [:action_id [:or :string ms/NegativeInt ms/PositiveInt]]
+         [:action_id [:or :map :string ms/NegativeInt ms/PositiveInt]]
          [:scope     ::types/scope.raw]
          [:params    {:optional true} :map]
          [:input     :map]]]
@@ -430,7 +431,7 @@
      {}
      {:keys [action_id scope inputs params]}
      :- [:map
-         [:action_id               [:or :string ms/NegativeInt ms/PositiveInt]]
+         [:action_id               [:or :map :string ms/NegativeInt ms/PositiveInt]]
          [:scope                   ::types/scope.raw]
          [:inputs                  [:sequential :map]]
          [:params {:optional true} :map]]]

--- a/enterprise/backend/src/metabase_enterprise/data_editing/configure.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/configure.clj
@@ -1,0 +1,60 @@
+(ns metabase-enterprise.data-editing.configure
+  (:require
+   [metabase.actions.core :as actions]
+   [metabase.api.common :as api]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [metabase.warehouse-schema.models.table :as table]
+   [toucan2.core :as t2]))
+
+(mr/def ::param-configuration
+  [:map {:closed true}
+   [:id               :string]
+   [:sourceType       [:enum "ask-user"]]
+   [:sourceTypeTarget :string]])
+
+(mr/def ::action-configuration
+  [:map {:closed true}
+   [:title      :string]
+   [:parameters [:sequential ::param-configuration]]])
+
+(defn- configuration-for-saved-action
+  [action-id]
+  (let [action (-> (actions/select-action :id action-id
+                                          :archived false
+                                          {:where [:not [:= nil :model_id]]})
+                   api/read-check
+                   api/check-404)]
+    {:title      (:name action)
+     :parameters (for [param (:parameters action)]
+                   {:id               (:id param)
+                    :sourceType       "ask-user"
+                    :sourceTypeTarget (case (:type action)
+                                        :query (:slug param)
+                                        :implicit (:id param))})}))
+
+(defn- configuration-for-table-action
+  [table-id action-kw]
+  (let [table          (t2/select-one [:model/Table :display_name :field_order] table-id)
+        ordered-fields (table/ordered-fields table-id (:field_order table))]
+    {:title      (format "%s: %s" (:display_name table) (u/capitalize-en (name action-kw)))
+     :parameters (for [field ordered-fields
+                       :when (case action-kw
+                               :table.row/create (not (:database_is_auto_increment field))
+                               :table.row/update true
+                               :table.row/delete (isa? (:semantic_type field) :type/PK))]
+                   {:id               (format "field-%s" (:name field))
+                    :sourceType       "ask-user"
+                    :sourceTypeTarget (:name field)})}))
+
+(mu/defn configuration :- ::action-configuration
+  "Returns configuration needed for a given action."
+  [{:keys [action-id action-kw] :as unified}
+   scope]
+  (cond
+    (pos-int? action-id)
+    (configuration-for-saved-action (:action-id unified))
+
+    (and action-kw (isa? action-kw :table.row/common))
+    (configuration-for-table-action (:table-id scope) action-kw)))

--- a/enterprise/backend/src/metabase_enterprise/data_editing/describe.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/describe.clj
@@ -56,8 +56,7 @@
              param-mapping
              dashcard-viz
              row-delay]}]
-  (let [table-id                    table-id
-        table                       (api/read-check (t2/select-one :model/Table :id table-id :active true))
+  (let [table                       (api/read-check (t2/select-one :model/Table :id table-id :active true))
         field-name->mapping         (u/index-by :parameterId param-mapping)
         fields                      (-> (t2/select :model/Field :table_id table-id {:order-by [[:position]]})
                                         (t2/hydrate :dimensions
@@ -152,6 +151,7 @@
                                 api/check-404)
         param-id->viz-field (-> action :visualization_settings (:fields {}))
         param-id->mapping   (u/index-by :parameterId param-mapping)]
+    ;; TODO: this assumes this is a query action, we need to handle implicit actions as well
     {:title      (:name action)
      :parameters (->> (for [param (:parameters action)
                             ;; query type actions store most stuff in viz settings rather than the

--- a/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
@@ -5,6 +5,12 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
+;; TODO High level stuff we should do:
+;; 0. Make sure we have tests to cover every single step taken in our core user journeys.
+;; 1. Cover :create-or-update as well.
+;; 2. DRY up or otherwise streamline how we construct these scenarios - hard to see the forest for the boilerplate.
+;; 3. Consolidate test cases between /configure, /tmp-model, and /execute
+
 ;; Important missing tests
 (comment
   configure-saved-action-on-editable-on-dashboard-test
@@ -64,11 +70,11 @@
                                 ;;      staging and beta users.
                                 ;;      for now it doesn't tell you the type or the possible values, BUT maybe we want the wrapping
                                 ;;      component to know that (it just doesn't get saved)
-                                :parameters [{:id "param-a", :sourceType "ask-user", :sourceTypeTarget "a"}
-                                             {:id "param-b", :sourceType "ask-user", :sourceTypeTarget "b"}
-                                             {:id "param-c", :sourceType "ask-user", :sourceTypeTarget "c"}
-                                             {:id "param-d", :sourceType "ask-user", :sourceTypeTarget "d"}
-                                             {:id "param-e", :sourceType "ask-user", :sourceTypeTarget "e"}]}}
+                                :parameters [{:id "param-a", :sourceType "ask-user", :sourceValueTarget "a"}
+                                             {:id "param-b", :sourceType "ask-user", :sourceValueTarget "b"}
+                                             {:id "param-c", :sourceType "ask-user", :sourceValueTarget "c"}
+                                             {:id "param-d", :sourceType "ask-user", :sourceValueTarget "d"}
+                                             {:id "param-e", :sourceType "ask-user", :sourceValueTarget "e"}]}}
                       (req {:scope     {:model-id (:id model)
                                         :table-id (:id table)}
                             :action_id {:action-id (:id action)}}))))))))))
@@ -79,15 +85,15 @@
     (mt/test-drivers #{:h2 :postgres}
       (data-editing.tu/toggle-data-editing-enabled! true)
       (testing "saved actions"
-        (let [expected-id-params  [{:id "id"         :sourceType "ask-user" :sourceTypeTarget "id"}]
-              expected-row-params [{:id "user_id"    :sourceType "ask-user" :sourceTypeTarget "user_id"}
-                                   {:id "product_id" :sourceType "ask-user" :sourceTypeTarget "product_id"}
-                                   {:id "subtotal"   :sourceType "ask-user" :sourceTypeTarget "subtotal"}
-                                   {:id "tax"        :sourceType "ask-user" :sourceTypeTarget "tax"}
-                                   {:id "total"      :sourceType "ask-user" :sourceTypeTarget "total"}
-                                   {:id "discount"   :sourceType "ask-user" :sourceTypeTarget "discount"}
-                                   {:id "created_at" :sourceType "ask-user" :sourceTypeTarget "created_at"}
-                                   {:id "quantity"   :sourceType "ask-user" :sourceTypeTarget "quantity"}]
+        (let [expected-id-params  [{:id "id"         :sourceType "ask-user" :sourceValueTarget "id"}]
+              expected-row-params [{:id "user_id"    :sourceType "ask-user" :sourceValueTarget "user_id"}
+                                   {:id "product_id" :sourceType "ask-user" :sourceValueTarget "product_id"}
+                                   {:id "subtotal"   :sourceType "ask-user" :sourceValueTarget "subtotal"}
+                                   {:id "tax"        :sourceType "ask-user" :sourceValueTarget "tax"}
+                                   {:id "total"      :sourceType "ask-user" :sourceValueTarget "total"}
+                                   {:id "discount"   :sourceType "ask-user" :sourceValueTarget "discount"}
+                                   {:id "created_at" :sourceType "ask-user" :sourceValueTarget "created_at"}
+                                   {:id "quantity"   :sourceType "ask-user" :sourceValueTarget "quantity"}]
               action-kind->expected-params {"row/create" expected-row-params
                                             "row/update" (concat expected-id-params expected-row-params)
                                             "row/delete" expected-id-params}]
@@ -119,14 +125,15 @@
 
         (let [;; TODO the form for configuring a row action will need to know that ID is meant to be "locked" to
               ;;      the pk of the table underlying the data-grid.
-              expected-id-params   [{:id "field-id"        :sourceType "ask-user" :sourceTypeTarget "id"}]
-              expected-row-params  [{:id "field-text"      :sourceType "ask-user" :sourceTypeTarget "text"}
-                                    {:id "field-int"       :sourceType "ask-user" :sourceTypeTarget "int"}
-                                    {:id "field-timestamp" :sourceType "ask-user" :sourceTypeTarget "timestamp"}
-                                    {:id "field-date"      :sourceType "ask-user" :sourceTypeTarget "date"}]]
+              expected-id-params   [{:id "field-id"        :sourceType "ask-user" :sourceValueTarget "id"}]
+              expected-row-params  [{:id "field-text"      :sourceType "ask-user" :sourceValueTarget "text"}
+                                    {:id "field-int"       :sourceType "ask-user" :sourceValueTarget "int"}
+                                    {:id "field-timestamp" :sourceType "ask-user" :sourceValueTarget "timestamp"}
+                                    {:id "field-date"      :sourceType "ask-user" :sourceValueTarget "date"}]]
 
           (testing "table actions"
-            (let [{create-id "table.row/create"
+            (let [scope {:table-id @test-table}
+                  {create-id "table.row/create"
                    update-id "table.row/update"
                    delete-id "table.row/delete"} (->> (mt/user-http-request-full-response
                                                        :crowberto
@@ -135,25 +142,24 @@
                                                       :body :actions
                                                       (filter #(= @test-table (:table_id %)))
                                                       (u/index-by :kind :id))]
-              (let [scope {:table-id @test-table}]
-                (testing "create"
-                  (is (=? {:title      (mt/malli=? :string)
-                           :parameters expected-row-params}
-                          (mt/user-http-request :crowberto :post 200 "action/v2/configure"
-                                                {:scope     scope
-                                                 :action_id create-id}))))
-                (testing "update"
-                  (is (=? {:title      (mt/malli=? :string)
-                           :parameters (concat expected-id-params expected-row-params)}
-                          (mt/user-http-request :crowberto :post 200 "action/v2/configure"
-                                                {:scope     scope
-                                                 :action_id update-id}))))
-                (testing "delete"
-                  (is (=? {:title      (mt/malli=? :string)
-                           :parameters expected-id-params}
-                          (mt/user-http-request :crowberto :post 200 "action/v2/configure"
-                                                {:scope     scope
-                                                 :action_id delete-id}))))))))))))
+              (testing "create"
+                (is (=? {:title      (mt/malli=? :string)
+                         :parameters expected-row-params}
+                        (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                              {:scope     scope
+                                               :action_id create-id}))))
+              (testing "update"
+                (is (=? {:title      (mt/malli=? :string)
+                         :parameters (concat expected-id-params expected-row-params)}
+                        (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                              {:scope     scope
+                                               :action_id update-id}))))
+              (testing "delete"
+                (is (=? {:title      (mt/malli=? :string)
+                         :parameters expected-id-params}
+                        (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                              {:scope     scope
+                                               :action_id delete-id})))))))))))
 
 ;; This is the case where we are EDITING some kind of header or row action, for example.
 ;;
@@ -163,13 +169,14 @@
 ;;
 ;; Since we don't support configuration for (1) yet, this is only concerned with (2)
 (deftest configure-table-action-on-editable-on-dashboard-test
-  (let [req #(mt/user-http-request-full-response
-              (:user % :crowberto)
-              :post
-              "action/v2/configure"
-              (select-keys % [:action_id
-                              :scope
-                              :input]))]
+  (let [req #(dissoc (mt/user-http-request-full-response
+                      (:user % :crowberto)
+                      :post
+                      "action/v2/configure"
+                      (select-keys % [:action_id
+                                      :scope
+                                      :input]))
+                     :headers)]
     (mt/with-premium-features #{:table-data-editing}
       (mt/test-drivers #{:h2 :postgres}
         (data-editing.tu/toggle-data-editing-enabled! true)
@@ -186,83 +193,116 @@
                                             :visualization_settings
                                             {:table_id @test-table
 
+                                             ;; The data-grid config is NOT inherited by custom actions (yet)
                                              :table.columns
                                              [{:name "int", :enabled true}
                                               {:name "text", :enabled true}
                                               {:name "timetamp", :enabled true}
-                                               ;; this signals date should not be shown in the grid
+                                               ;; this signals date should not be shown in the grid, or be available
+                                               ;; to default actions.
                                               {:name "date", :enabled false}]
 
+                                             ;; The data-grid config is NOT inherited by custom actions (yet)
                                              :editableTable.columns
                                              ["int"
-                                               ;; this signals text is not editable
+                                               ;; this signals text is not editable by default actions
                                               #_"text"
                                               "timestamp"
                                               "date"]
 
                                              :editableTable.enabledActions
-                                              ;; We can fix this "unknown" when we move the action out of the dashcard json
-                                              ;; See [[metabase.dashboards.api/create-or-fix-action-id]]
-                                             [{:id                "dashcard:unknown:1"
-                                               :actionId          "table.row/create"
+                                              ;; See [[metabase.dashboards.api/create-or-fix-action-id]] for why this is unknown.
+                                             [{:id                "dashcard:unknown:built-in-update"
+                                               :actionId          "table.row/update"
+                                               ;; TODO Katya calls these "default" actions, maybe we should rename to match?
+                                               :actionType        "data-grid/built-in"
+                                               :enabled           true
+                                               ;; Not currently configurable.
+                                               :parameterMappings nil}
+                                              {:id                "dashcard:unknown:update"
+                                               :actionId          "table.row/update"
                                                :actionType        "data-grid/row-action"
-                                               :parameterMappings [;; because this is a CUSTOM actions
-                                                                    ;; it might not even be editing the same table,
-                                                                    ;; so we need to map the primary, unlike for
-                                                                    ;; built-in actions which assume its pk->pk
-                                                                   {:parameter "id"
-                                                                    :sourceType "row-data"
-                                                                    :value      "TODO"}
-
-                                                                   {:parameterId "int"
-                                                                    :sourceType  "const"
-                                                                    :value       42}
+                                               :enabled           true
+                                               ;; TODO make sure this stuff makes sense.
+                                               ;;      What does the FE really write? Have we messed anything up?
+                                               ;;      Have we missed any cases?
+                                               :parameterMappings [{:parameterId       "id"
+                                                                    :sourceType       "ask-user"}
+                                                                   {:parameterId       "int"
+                                                                    :sourceType        "constant"
+                                                                    :value             42}
                                                                    {:parameterId       "text"
                                                                     :sourceType        "row-data"
                                                                     :sourceValueTarget "text"
                                                                     :visibility        "readonly"}
-                                                                   {:parameterId "timestamp"
-                                                                    :visibility  "hidden"}]}]}}]
+                                                                   {:parameterId       "timestamp"
+                                                                    :visibility        "hidden"}]}]}}]
 
-              ;; insert a row for the row action
+            ;; insert a row for the row action
             (mt/user-http-request :crowberto :post 200
                                   (data-editing.tu/table-url @test-table)
                                   {:rows [{:text "a very important string"}]})
 
-            (testing "table actions on a dashcard"
-              (let [create-id "table.row/create"
-                    update-id "table.row/update"
-                    delete-id "table.row/delete"
-                      ;; Note, we're relying on this scope to fill in "unknown" on the action id
-                      ;; But in either case, we're always meant to send this for undo/redo scope anyway.
-                    scope     {:dashcard-id (:id dashcard)}
+            (testing "default table action on a data-grid"
+              (is (=? {:status 400}
+                      (req {:action_id "dashcard:unknown:built-in-update"
+                            :scope     {:dashcard-id (:id dashcard)}
+                            :input     {:id 1}
+                            :params    {:text "kcab em txet"}}))))
 
-                      ;; TODO build-in actions won't let you configure this
-                    expected-id-params []
-                      ;; params are reordered by editable (?)
-                    expected-row-params [{:id "int",  :readonly false}
-                                         {:id "text", :readonly true, :value "a very important string"}
-                                           ;; date is hidden from the editable
-                                         #_{:id "date"}
-                                           ;; timestamp is hidden in the row action
-                                         #_{:id "timestamp"}]]
+            (testing "custom table action on a data-grid"
+              (is (=? {:status 200
+                       :body   {:parameters
+                                [{:id "id",   :sourceType "ask-user"}
+                                 {:id "int",  :sourceType "constant", :value 42}
+                                 {:id "text", :sourceType "row-data", :sourceValueTarget "text", :visibility "readonly"}
+                                 ;; TODO https://linear.app/metabase/issue/WRK-476/handle-actions-whose-mapping-doesnt-cover-new-inputs
+                                 #_{:id "date", :visibility "hidden"}
+                                 {:id "timestamp", :visibility "hidden"}]}}
+                      (req {:action_id "dashcard:unknown:update"
+                            :scope     {:dashcard-id (:id dashcard)}
+                            :input     {:id 1}}))))))))))
 
-                (testing "without a table-id"
-                  (let [scope {:dashboard-id (:dashboard_id dashcard)}]
-                    (doseq [action-id [create-id update-id delete-id]]
-                      (testing action-id
-                        (is (=? {:status 400}
-                                (req {:action_id action-id, :scope scope})))))))
+;; This covers a more exotic case where we're coming back to edit the config for an action before it has been saved.
+;; This should cover both the cases where it has never been saved, or where it's simply been edited at least once since
+;; it was last saved.
+(deftest configure-pending-table-action-test
+  (mt/with-premium-features #{:table-data-editing}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/toggle-data-editing-enabled! true)
+      (with-open [test-table (data-editing.tu/open-test-table! {:id        'auto-inc-type
+                                                                :text      [:text]
+                                                                :int       [:int]
+                                                                :timestamp [:timestamp]
+                                                                :date      [:date]}
+                                                               {:primary-key [:id]})]
+        (testing "custom data-grid calling a table action, with pending configuration changes"
+          (let [{action-id "table.row/update"} (->> (mt/user-http-request-full-response
+                                                     :crowberto
+                                                     :get
+                                                     "action/v2/tmp-action")
+                                                    :body :actions
+                                                    (filter #(= @test-table (:table_id %)))
+                                                    (u/index-by :kind :id))
+                pending-config {:parameters
+                                [{:parameterId "id",        :sourceType "row-data"}
+                                 {:parameterId "int",       :sourceType "constant", :value 42}
+                                 {:parameterId "text",      :sourceType "row-data", :sourceValueTarget "text", :visibility "readonly"}
+                                 {:parameterId "timestamp", :visibility "hidden"}]}
 
-                (testing "create"
-                  (is (=? {:status 200
-                           :body   {:parameters []}}
-                          (req {:scope     scope
-                                :action_id create-id
-                                :input     {:id 1}}))))
-
-                (testing "update"
-                  (is (=? {:status 200} (req {:scope scope, :action_id update-id}))))
-
-                (testing "delete"
-                  (is (=? {:status 200} (req {:scope scope, :action_id delete-id}))))))))))))
+                ;; This gives us the format that the in-memory action looks like in the FE.
+                wrap-action    (fn [packed-id]
+                                 {:packed-id packed-id
+                                  :param-map (->> pending-config
+                                                  :parameters
+                                                  ;; TODO we won't need to do this once we change the schema for
+                                                  ;;      unified-action to use a list.
+                                                  (u/index-by :parameterId #(dissoc % :parameterId)))})
+                scope          {:table-id @test-table}]
+            (is (=? {:title      (mt/malli=? :string)
+                     :parameters (for [p (:parameters pending-config)]
+                                   ;; What a silly difference, which we should squelch.
+                                   (-> p (assoc :id (:parameterId p)) (dissoc :parameterId)))}
+                    (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                          {:scope     scope
+                                           :action_id (wrap-action action-id)})))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
@@ -1,0 +1,290 @@
+(ns metabase-enterprise.data-editing.action-v2-api-test
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
+   [clojure.test :refer :all]
+   [metabase-enterprise.data-editing.api :as data-editing.api]
+   [metabase-enterprise.data-editing.test-util :as data-editing.tu]
+   [metabase.actions.models :as actions]
+   [metabase.actions.test-util :as actions.tu]
+   [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc :as sql-jdbc]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.query-processor :as qp]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [metabase.test.data.sql :as sql.tx]
+   [metabase.util :as u]
+   [metabase.util.json :as json]
+   [metabase.warehouse-schema.models.field-values :as field-values]
+   [toucan2.core :as t2]))
+
+;; Important missing tests
+(comment
+  configure-saved-action-on-editable-on-dashboard-test
+  ;; either copy past tests or use a doseq to vary how we construct it
+  configure-saved-action-on-question-on-dashboard-test
+  configure-table-action-on-question-on-dashboard-test)
+
+;; For example, when picking a model action to add as a row action, we call this for the initial config form.
+(deftest configure-saved-action-test
+  (let [req
+        #(mt/user-http-request-full-response
+          (:user % :crowberto)
+          :post
+          "action/v2/configure"
+          (select-keys % [:action_id
+                          :scope
+                          :input]))]
+    (mt/with-premium-features #{:table-data-editing}
+      (mt/test-drivers #{:h2 :postgres}
+        (data-editing.tu/toggle-data-editing-enabled! true)
+        (testing "saved actions"
+          (mt/with-non-admin-groups-no-root-collection-perms
+            (mt/with-temp [:model/Table table {}
+                           :model/Card model {:type     :model
+                                              :table_id (:id table)}
+                           :model/Action action {:type       :query
+                                                 :name       "Do cool thing"
+                                                 :model_id   (:id model)
+                                                ;; TODO make ids != name, so test is more powerful
+                                                 :parameters [{:id   "a"
+                                                               :name "A" ;; is the slug of this being used for sourceTypeTarget?
+                                                               :type "number/="}
+                                                              {:id   "b"
+                                                               :name "B"
+                                                               :type "date/single"}
+                                                              {:id   "c"
+                                                               :name "C"
+                                                               :type "string/="}
+                                                              {:id   "d"
+                                                               :name "D"
+                                                               :type "string/="}
+                                                              {:id   "e"
+                                                               :name "E"
+                                                               :type "string/="}]
+                                                 :visualization_settings
+                                                 {:fields {"c" {:inputType "text"}
+                                                           "e" {:valueOptions ["a" "b"]}}}}]
+              (is (=? {:status 200
+                       :body   {:title      "Do cool thing"
+                               ;; TODO this is the raw format we're currently saving config like
+                               ;;      but, we want to instead return "data components" which tell us how to *change* it
+                               ;;      and also... as part of introducing /configure we are free to *change* how config is saved
+                               ;;      because it will now be encapsulated. we just need migrate on read to avoid breaking
+                               ;;      staging and beta users.
+                               ;;      for now it doesn't tell you the type or the possible values, BUT maybe we want the wrapping
+                               ;;      component to know that (it just doesn't get saved)
+                                :parameters [{:id "a", :sourceType "ask-user", :sourceTypeTarget "a"}
+                                             {:id "b", :sourceType "ask-user", :sourceTypeTarget "b"}
+                                             {:id "c", :sourceType "ask-user", :sourceTypeTarget "c"}
+                                             {:id "d", :sourceType "ask-user", :sourceTypeTarget "d"}
+                                             {:id "e", :sourceType "ask-user", :sourceTypeTarget "e"}]}}
+                      (req {:scope     {:model-id (:id model)
+                                        :table-id (:id table)}
+                            :action_id (:id action)}))))))))))
+
+;; For example, when picking a table action to add as a row action, we call this for the initial config form.
+(deftest configure-table-action-test
+  (let [list-req #(mt/user-http-request-full-response
+                   (:user % :crowberto)
+                   :get
+                   "action/v2/tmp-action")
+        req      #(mt/user-http-request-full-response
+                   (:user % :crowberto)
+                   :post
+                   "action/v2/configure"
+                   (select-keys % [:action_id
+                                   :scope
+                                   :input]))]
+    (mt/with-premium-features #{:table-data-editing}
+      (mt/test-drivers #{:h2 :postgres}
+        (data-editing.tu/toggle-data-editing-enabled! true)
+        (with-open [test-table (data-editing.tu/open-test-table! {:id        'auto-inc-type
+                                                                  :text      [:text]
+                                                                  :int       [:int]
+                                                                  :timestamp [:timestamp]
+                                                                  :date      [:date]}
+                                                                 {:primary-key [:id]})]
+
+          (let [;; TODO the form for configuring a row action will need to know that ID is meant to be "locked" to
+                ;;      the pk of the table underlying the data-grid.
+                expected-id-params   [{:id "id"         :sourceType "ask-user", :sourceTypeTarget "text"}]
+                expected-row-params  [{:id "text",      :sourceType "ask-user", :sourceTypeTarget "text"}
+                                      {:id "int",       :sourceType "ask-user", :sourceTypeTarget "text"}
+                                      {:id "timestamp", :sourceType "ask-user", :sourceTypeTarget "text"}
+                                      {:id "date",      :sourceType "ask-user", :sourceTypeTarget "text"}]]
+
+            (testing "table actions"
+              (let [{create-id "table.row/create"
+                     update-id "table.row/update"
+                     delete-id "table.row/delete"} (->> (list-req {})
+                                                        :body :actions
+                                                        (filter #(= @test-table (:table_id %)))
+                                                        (u/index-by :kind :id))]
+              ;; TODO make these assertions readable! with =?
+                (testing "create"
+                  (let [scope {:table-id @test-table}
+                        {:keys [status body]} (req {:scope     scope
+                                                    :action_id create-id})]
+                    (is (= 200 status))
+                  ;; TODO See comment above for how we will decorate this response "in a bit" (tm)
+                    (is (= expected-row-params
+                           (->> (:parameters body)
+                                (map #(select-keys % [:id :display_name :input_type])))))))
+                (testing "update"
+                  (let [scope {:table-id @test-table}
+                        {:keys [status body]} (req {:scope     scope
+                                                    :action_id update-id})]
+                    (is (= 200 status))
+                    (is (= (concat expected-id-params expected-row-params)
+                           (->> (:parameters body)
+                                (map #(select-keys % [:id :display_name :input_type])))))))
+                (testing "delete"
+                  (let [scope {:table-id @test-table}
+                        {:keys [status body]} (req {:scope     scope
+                                                    :action_id delete-id})]
+                    (is (= 200 status))
+                    (is (= expected-id-params
+                           (->> (:parameters body)
+                                (map #(select-keys % [:id :display_name :input_type]))))))))
+
+            ;; insert a row for the row action
+              (mt/user-http-request :crowberto :post 200
+                                    (data-editing.tu/table-url @test-table)
+                                    {:rows [{:text "a very important string"}]})
+
+              (let [create-id "table.row/create"
+                    update-id "table.row/update"
+                    delete-id "table.row/delete"]
+
+              ;; magic scope detection, deprecated
+                (testing "using table-id from scope"
+                  (let [scope {:table-id @test-table}]
+                    (testing "create"
+                      (is (=? {:status 200
+                               :body   {:parameters expected-row-params}}
+                              (req {:scope     scope
+                                    :action_id create-id
+                                    :input     {:id 1}})))
+
+                      (testing "update"
+                        (is (=? {:status 200
+                                 :body   {:parameters (concat expected-id-params expected-row-params)}}
+                                (req {:scope scope, :action_id update-id}))))
+
+                      (testing "delete"
+                        (is (=? {:status 200
+                                 :body   {:parameters expected-id-params}}
+                                (req {:scope scope, :action_id delete-id})))))))))))))))
+
+;; This is the case where we are EDITING some kind of header or row action, for example.
+;;
+;; There are actually two different cases here:
+;; 1. built-in actions (don't have their own configuration, but inherit parameter order from the Editable settings)
+;; 2. custom actions (have their own configuration, but no inheritance (for now, Katya working on prod doc))
+;;
+;; Since we don't support configuration for (1) yet, this is only concerned with (2)
+(deftest configure-table-action-on-editable-on-dashboard-test
+  (let [req #(mt/user-http-request-full-response
+              (:user % :crowberto)
+              :post
+              "action/v2/configure"
+              (select-keys % [:action_id
+                              :scope
+                              :input]))]
+    (mt/with-premium-features #{:table-data-editing}
+      (mt/test-drivers #{:h2 :postgres}
+        (data-editing.tu/toggle-data-editing-enabled! true)
+        (with-open [test-table (data-editing.tu/open-test-table! {:id        'auto-inc-type
+                                                                  :text      [:text]
+                                                                  :int       [:int]
+                                                                  :timestamp [:timestamp]
+                                                                  :date      [:date]}
+                                                                 {:primary-key [:id]})]
+
+          (mt/with-temp
+            [:model/Dashboard dashboard {}
+             :model/DashboardCard dashcard {:dashboard_id (:id dashboard)
+                                            :visualization_settings
+                                            {:table_id @test-table
+
+                                             :table.columns
+                                             [{:name "int", :enabled true}
+                                              {:name "text", :enabled true}
+                                              {:name "timetamp", :enabled true}
+                                             ;; this signals date should not be shown in the grid
+                                              {:name "date", :enabled false}]
+
+                                             :editableTable.columns
+                                             ["int"
+                                             ;; this signals text is not editable
+                                              #_"text"
+                                              "timestamp"
+                                              "date"]
+
+                                             :editableTable.enabledActions
+                                            ;; We can fix this "unknown" when we move the action out of the dashcard json
+                                            ;; See [[metabase.dashboards.api/create-or-fix-action-id]]
+                                             [{:id                "dashcard:unknown:1"
+                                               :actionId          "table.row/create"
+                                               :parameterMappings [;; because this is a CUSTOM actions
+                                                                  ;; it might not even be editing the same table,
+                                                                  ;; so we need to map the primary, unlike for
+                                                                  ;; built-in actions which assume its pk->pk
+                                                                   {:parameter "id"
+                                                                    :sourceType "row-data"
+                                                                    :value      "TODO"}
+
+                                                                   {:parameterId "int"
+                                                                    :sourceType  "const"
+                                                                    :value       42}
+                                                                   {:parameterId       "text"
+                                                                    :sourceType        "row-data"
+                                                                    :sourceValueTarget "text"
+                                                                    :visibility        "readonly"}
+                                                                   {:parameterId "timestamp"
+                                                                    :visibility  "hidden"}]}]}}]
+
+            ;; insert a row for the row action
+            (mt/user-http-request :crowberto :post 200
+                                  (data-editing.tu/table-url @test-table)
+                                  {:rows [{:text "a very important string"}]})
+
+            (testing "table actions on a dashcard"
+              (let [create-id "table.row/create"
+                    update-id "table.row/update"
+                    delete-id "table.row/delete"
+                    ;; Note, we're relying on this scope to fill in "unknown" on the action id
+                    ;; But in either case, we're always meant to send this for undo/redo scope anyway.
+                    scope     {:dashcard-id (:id dashcard)}
+
+                    ;; TODO build-in actions won't let you configure this
+                    expected-id-params []
+                    ;; params are reordered by editable (?)
+                    expected-row-params [{:id "int",  :readonly false}
+                                         {:id "text", :readonly true, :value "a very important string"}
+                                         ;; date is hidden from the editable
+                                         #_{:id "date"}
+                                         ;; timestamp is hidden in the row action
+                                         #_{:id "timestamp"}]]
+
+                (testing "without a table-id"
+                  (let [scope {:dashboard-id (:dashboard_id dashcard)}]
+                    (doseq [action-id [create-id update-id delete-id]]
+                      (testing action-id
+                        (is (=? {:status 400}
+                                (req {:action_id action-id, :scope scope})))))))
+
+                (testing "create"
+                  (is (=? {:status 200
+                           :body   {:parameters []}}
+                          (req {:scope     scope
+                                :action_id create-id
+                                :input     {:id 1}}))))
+
+                (testing "update"
+                  (is (=? {:status 200} (req {:scope scope, :action_id update-id}))))
+
+                (testing "delete"
+                  (is (=? {:status 200} (req {:scope scope, :action_id delete-id}))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
@@ -71,8 +71,9 @@
                                              {:id "param-e", :sourceType "ask-user", :sourceTypeTarget "e"}]}}
                       (req {:scope     {:model-id (:id model)
                                         :table-id (:id table)}
-                            :action_id (:id action)}))))))))))
+                            :action_id {:action-id (:id action)}}))))))))))
 
+;; For example, when picking a model action to add as a row action, we call this for the initial config form.
 (deftest configure-saved-implicit-action-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
@@ -87,11 +88,11 @@
                                    {:id "discount"   :sourceType "ask-user" :sourceTypeTarget "discount"}
                                    {:id "created_at" :sourceType "ask-user" :sourceTypeTarget "created_at"}
                                    {:id "quantity"   :sourceType "ask-user" :sourceTypeTarget "quantity"}]
-              action-kind->expecetd-params {"row/create" expected-row-params
+              action-kind->expected-params {"row/create" expected-row-params
                                             "row/update" (concat expected-id-params expected-row-params)
-                                            "row/delete"  expected-id-params}]
+                                            "row/delete" expected-id-params}]
 
-          (doseq [[action-kind expected-params] action-kind->expecetd-params]
+          (doseq [[action-kind expected-params] action-kind->expected-params]
             (mt/with-actions [model {:type          :model
                                      :dataset_query (mt/mbql-query orders)}
                               {action-id :action-id} {:type :implicit
@@ -102,7 +103,7 @@
                      (mt/user-http-request :crowberto :post 200 "action/v2/configure"
                                            {:scope     {:model-id (:id model)
                                                         :table-id (mt/id :orders)}
-                                            :action_id action-id}))))))))))
+                                            :action_id {:action-id action-id}}))))))))))
 
 ;; For example, when picking a table action to add as a row action, we call this for the initial config form.
 (deftest configure-table-action-test

--- a/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
@@ -1,23 +1,9 @@
 (ns metabase-enterprise.data-editing.action-v2-api-test
   (:require
-   [clojure.java.jdbc :as jdbc]
-   [clojure.set :as set]
    [clojure.test :refer :all]
-   [metabase-enterprise.data-editing.api :as data-editing.api]
    [metabase-enterprise.data-editing.test-util :as data-editing.tu]
-   [metabase.actions.models :as actions]
-   [metabase.actions.test-util :as actions.tu]
-   [metabase.driver :as driver]
-   [metabase.driver.sql-jdbc :as sql-jdbc]
-   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.query-processor :as qp]
-   [metabase.sync.core :as sync]
    [metabase.test :as mt]
-   [metabase.test.data.sql :as sql.tx]
-   [metabase.util :as u]
-   [metabase.util.json :as json]
-   [metabase.warehouse-schema.models.field-values :as field-values]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 ;; Important missing tests
 (comment
@@ -27,15 +13,14 @@
   configure-table-action-on-question-on-dashboard-test)
 
 ;; For example, when picking a model action to add as a row action, we call this for the initial config form.
-(deftest configure-saved-action-test
-  (let [req
-        #(mt/user-http-request-full-response
-          (:user % :crowberto)
-          :post
-          "action/v2/configure"
-          (select-keys % [:action_id
-                          :scope
-                          :input]))]
+(deftest configure-saved-query-action-test
+  (let [req #(mt/user-http-request-full-response
+              (:user % :crowberto)
+              :post
+              "action/v2/configure"
+              (select-keys % [:action_id
+                              :scope
+                              :input]))]
     (mt/with-premium-features #{:table-data-editing}
       (mt/test-drivers #{:h2 :postgres}
         (data-editing.tu/toggle-data-editing-enabled! true)
@@ -47,136 +32,127 @@
                            :model/Action action {:type       :query
                                                  :name       "Do cool thing"
                                                  :model_id   (:id model)
-                                                ;; TODO make ids != name, so test is more powerful
-                                                 :parameters [{:id   "a"
-                                                               :name "A" ;; is the slug of this being used for sourceTypeTarget?
-                                                               :type "number/="}
-                                                              {:id   "b"
+                                                 :parameters [{:id   "param-a"
+                                                               :name "A"
+                                                               :type "number/="
+                                                               :slug "a"}
+                                                              {:id   "param-b"
                                                                :name "B"
-                                                               :type "date/single"}
-                                                              {:id   "c"
+                                                               :type "date/single"
+                                                               :slug "b"}
+                                                              {:id   "param-c"
                                                                :name "C"
-                                                               :type "string/="}
-                                                              {:id   "d"
+                                                               :type "string/="
+                                                               :slug "c"}
+                                                              {:id   "param-d"
                                                                :name "D"
-                                                               :type "string/="}
-                                                              {:id   "e"
+                                                               :type "string/="
+                                                               :slug "d"}
+                                                              {:id   "param-e"
                                                                :name "E"
-                                                               :type "string/="}]
+                                                               :type "string/="
+                                                               :slug "e"}]
                                                  :visualization_settings
                                                  {:fields {"c" {:inputType "text"}
                                                            "e" {:valueOptions ["a" "b"]}}}}]
               (is (=? {:status 200
                        :body   {:title      "Do cool thing"
-                               ;; TODO this is the raw format we're currently saving config like
-                               ;;      but, we want to instead return "data components" which tell us how to *change* it
-                               ;;      and also... as part of introducing /configure we are free to *change* how config is saved
-                               ;;      because it will now be encapsulated. we just need migrate on read to avoid breaking
-                               ;;      staging and beta users.
-                               ;;      for now it doesn't tell you the type or the possible values, BUT maybe we want the wrapping
-                               ;;      component to know that (it just doesn't get saved)
-                                :parameters [{:id "a", :sourceType "ask-user", :sourceTypeTarget "a"}
-                                             {:id "b", :sourceType "ask-user", :sourceTypeTarget "b"}
-                                             {:id "c", :sourceType "ask-user", :sourceTypeTarget "c"}
-                                             {:id "d", :sourceType "ask-user", :sourceTypeTarget "d"}
-                                             {:id "e", :sourceType "ask-user", :sourceTypeTarget "e"}]}}
+                                ;; TODO this is the raw format we're currently saving config like
+                                ;;      but, we want to instead return "data components" which tell us how to *change* it
+                                ;;      and also... as part of introducing /configure we are free to *change* how config is saved
+                                ;;      because it will now be encapsulated. we just need migrate on read to avoid breaking
+                                ;;      staging and beta users.
+                                ;;      for now it doesn't tell you the type or the possible values, BUT maybe we want the wrapping
+                                ;;      component to know that (it just doesn't get saved)
+                                :parameters [{:id "param-a", :sourceType "ask-user", :sourceTypeTarget "a"}
+                                             {:id "param-b", :sourceType "ask-user", :sourceTypeTarget "b"}
+                                             {:id "param-c", :sourceType "ask-user", :sourceTypeTarget "c"}
+                                             {:id "param-d", :sourceType "ask-user", :sourceTypeTarget "d"}
+                                             {:id "param-e", :sourceType "ask-user", :sourceTypeTarget "e"}]}}
                       (req {:scope     {:model-id (:id model)
                                         :table-id (:id table)}
                             :action_id (:id action)}))))))))))
 
+(deftest configure-saved-implicit-action-test
+  (mt/with-premium-features #{:table-data-editing}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/toggle-data-editing-enabled! true)
+      (testing "saved actions"
+        (let [expected-id-params  [{:id "id"         :sourceType "ask-user" :sourceTypeTarget "id"}]
+              expected-row-params [{:id "user_id"    :sourceType "ask-user" :sourceTypeTarget "user_id"}
+                                   {:id "product_id" :sourceType "ask-user" :sourceTypeTarget "product_id"}
+                                   {:id "subtotal"   :sourceType "ask-user" :sourceTypeTarget "subtotal"}
+                                   {:id "tax"        :sourceType "ask-user" :sourceTypeTarget "tax"}
+                                   {:id "total"      :sourceType "ask-user" :sourceTypeTarget "total"}
+                                   {:id "discount"   :sourceType "ask-user" :sourceTypeTarget "discount"}
+                                   {:id "created_at" :sourceType "ask-user" :sourceTypeTarget "created_at"}
+                                   {:id "quantity"   :sourceType "ask-user" :sourceTypeTarget "quantity"}]
+              action-kind->expecetd-params {"row/create" expected-row-params
+                                            "row/update" (concat expected-id-params expected-row-params)
+                                            "row/delete"  expected-id-params}]
+
+          (doseq [[action-kind expected-params] action-kind->expecetd-params]
+            (mt/with-actions [model {:type          :model
+                                     :dataset_query (mt/mbql-query orders)}
+                              {action-id :action-id} {:type :implicit
+                                                      :kind action-kind
+                                                      :name "Do cool thing"}]
+              (is (= {:title      "Do cool thing"
+                      :parameters expected-params}
+                     (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                           {:scope     {:model-id (:id model)
+                                                        :table-id (mt/id :orders)}
+                                            :action_id action-id}))))))))))
+
 ;; For example, when picking a table action to add as a row action, we call this for the initial config form.
 (deftest configure-table-action-test
-  (let [list-req #(mt/user-http-request-full-response
-                   (:user % :crowberto)
-                   :get
-                   "action/v2/tmp-action")
-        req      #(mt/user-http-request-full-response
-                   (:user % :crowberto)
-                   :post
-                   "action/v2/configure"
-                   (select-keys % [:action_id
-                                   :scope
-                                   :input]))]
-    (mt/with-premium-features #{:table-data-editing}
-      (mt/test-drivers #{:h2 :postgres}
-        (data-editing.tu/toggle-data-editing-enabled! true)
-        (with-open [test-table (data-editing.tu/open-test-table! {:id        'auto-inc-type
-                                                                  :text      [:text]
-                                                                  :int       [:int]
-                                                                  :timestamp [:timestamp]
-                                                                  :date      [:date]}
-                                                                 {:primary-key [:id]})]
+  (mt/with-premium-features #{:table-data-editing}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/toggle-data-editing-enabled! true)
+      (with-open [test-table (data-editing.tu/open-test-table! {:id        'auto-inc-type
+                                                                :text      [:text]
+                                                                :int       [:int]
+                                                                :timestamp [:timestamp]
+                                                                :date      [:date]}
+                                                               {:primary-key [:id]})]
 
-          (let [;; TODO the form for configuring a row action will need to know that ID is meant to be "locked" to
-                ;;      the pk of the table underlying the data-grid.
-                expected-id-params   [{:id "id"         :sourceType "ask-user", :sourceTypeTarget "text"}]
-                expected-row-params  [{:id "text",      :sourceType "ask-user", :sourceTypeTarget "text"}
-                                      {:id "int",       :sourceType "ask-user", :sourceTypeTarget "text"}
-                                      {:id "timestamp", :sourceType "ask-user", :sourceTypeTarget "text"}
-                                      {:id "date",      :sourceType "ask-user", :sourceTypeTarget "text"}]]
+        (let [;; TODO the form for configuring a row action will need to know that ID is meant to be "locked" to
+              ;;      the pk of the table underlying the data-grid.
+              expected-id-params   [{:id "field-id"        :sourceType "ask-user" :sourceTypeTarget "id"}]
+              expected-row-params  [{:id "field-text"      :sourceType "ask-user" :sourceTypeTarget "text"}
+                                    {:id "field-int"       :sourceType "ask-user" :sourceTypeTarget "int"}
+                                    {:id "field-timestamp" :sourceType "ask-user" :sourceTypeTarget "timestamp"}
+                                    {:id "field-date"      :sourceType "ask-user" :sourceTypeTarget "date"}]]
 
-            (testing "table actions"
-              (let [{create-id "table.row/create"
-                     update-id "table.row/update"
-                     delete-id "table.row/delete"} (->> (list-req {})
-                                                        :body :actions
-                                                        (filter #(= @test-table (:table_id %)))
-                                                        (u/index-by :kind :id))]
-              ;; TODO make these assertions readable! with =?
+          (testing "table actions"
+            (let [{create-id "table.row/create"
+                   update-id "table.row/update"
+                   delete-id "table.row/delete"} (->> (mt/user-http-request-full-response
+                                                       :crowberto
+                                                       :get
+                                                       "action/v2/tmp-action")
+                                                      :body :actions
+                                                      (filter #(= @test-table (:table_id %)))
+                                                      (u/index-by :kind :id))]
+              (let [scope {:table-id @test-table}]
                 (testing "create"
-                  (let [scope {:table-id @test-table}
-                        {:keys [status body]} (req {:scope     scope
-                                                    :action_id create-id})]
-                    (is (= 200 status))
-                  ;; TODO See comment above for how we will decorate this response "in a bit" (tm)
-                    (is (= expected-row-params
-                           (->> (:parameters body)
-                                (map #(select-keys % [:id :display_name :input_type])))))))
+                  (is (=? {:title      (mt/malli=? :string)
+                           :parameters expected-row-params}
+                          (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                                {:scope     scope
+                                                 :action_id create-id}))))
                 (testing "update"
-                  (let [scope {:table-id @test-table}
-                        {:keys [status body]} (req {:scope     scope
-                                                    :action_id update-id})]
-                    (is (= 200 status))
-                    (is (= (concat expected-id-params expected-row-params)
-                           (->> (:parameters body)
-                                (map #(select-keys % [:id :display_name :input_type])))))))
+                  (is (=? {:title      (mt/malli=? :string)
+                           :parameters (concat expected-id-params expected-row-params)}
+                          (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                                {:scope     scope
+                                                 :action_id update-id}))))
                 (testing "delete"
-                  (let [scope {:table-id @test-table}
-                        {:keys [status body]} (req {:scope     scope
-                                                    :action_id delete-id})]
-                    (is (= 200 status))
-                    (is (= expected-id-params
-                           (->> (:parameters body)
-                                (map #(select-keys % [:id :display_name :input_type]))))))))
-
-            ;; insert a row for the row action
-              (mt/user-http-request :crowberto :post 200
-                                    (data-editing.tu/table-url @test-table)
-                                    {:rows [{:text "a very important string"}]})
-
-              (let [create-id "table.row/create"
-                    update-id "table.row/update"
-                    delete-id "table.row/delete"]
-
-              ;; magic scope detection, deprecated
-                (testing "using table-id from scope"
-                  (let [scope {:table-id @test-table}]
-                    (testing "create"
-                      (is (=? {:status 200
-                               :body   {:parameters expected-row-params}}
-                              (req {:scope     scope
-                                    :action_id create-id
-                                    :input     {:id 1}})))
-
-                      (testing "update"
-                        (is (=? {:status 200
-                                 :body   {:parameters (concat expected-id-params expected-row-params)}}
-                                (req {:scope scope, :action_id update-id}))))
-
-                      (testing "delete"
-                        (is (=? {:status 200
-                                 :body   {:parameters expected-id-params}}
-                                (req {:scope scope, :action_id delete-id})))))))))))))))
+                  (is (=? {:title      (mt/malli=? :string)
+                           :parameters expected-id-params}
+                          (mt/user-http-request :crowberto :post 200 "action/v2/configure"
+                                                {:scope     scope
+                                                 :action_id delete-id}))))))))))))
 
 ;; This is the case where we are EDITING some kind of header or row action, for example.
 ;;
@@ -185,106 +161,106 @@
 ;; 2. custom actions (have their own configuration, but no inheritance (for now, Katya working on prod doc))
 ;;
 ;; Since we don't support configuration for (1) yet, this is only concerned with (2)
-(deftest configure-table-action-on-editable-on-dashboard-test
-  (let [req #(mt/user-http-request-full-response
-              (:user % :crowberto)
-              :post
-              "action/v2/configure"
-              (select-keys % [:action_id
-                              :scope
-                              :input]))]
-    (mt/with-premium-features #{:table-data-editing}
-      (mt/test-drivers #{:h2 :postgres}
-        (data-editing.tu/toggle-data-editing-enabled! true)
-        (with-open [test-table (data-editing.tu/open-test-table! {:id        'auto-inc-type
-                                                                  :text      [:text]
-                                                                  :int       [:int]
-                                                                  :timestamp [:timestamp]
-                                                                  :date      [:date]}
-                                                                 {:primary-key [:id]})]
+#_(deftest configure-table-action-on-editable-on-dashboard-test
+    (let [req #(mt/user-http-request-full-response
+                (:user % :crowberto)
+                :post
+                "action/v2/configure"
+                (select-keys % [:action_id
+                                :scope
+                                :input]))]
+      (mt/with-premium-features #{:table-data-editing}
+        (mt/test-drivers #{:h2 :postgres}
+          (data-editing.tu/toggle-data-editing-enabled! true)
+          (with-open [test-table (data-editing.tu/open-test-table! {:id        'auto-inc-type
+                                                                    :text      [:text]
+                                                                    :int       [:int]
+                                                                    :timestamp [:timestamp]
+                                                                    :date      [:date]}
+                                                                   {:primary-key [:id]})]
 
-          (mt/with-temp
-            [:model/Dashboard dashboard {}
-             :model/DashboardCard dashcard {:dashboard_id (:id dashboard)
-                                            :visualization_settings
-                                            {:table_id @test-table
+            (mt/with-temp
+              [:model/Dashboard dashboard {}
+               :model/DashboardCard dashcard {:dashboard_id (:id dashboard)
+                                              :visualization_settings
+                                              {:table_id @test-table
 
-                                             :table.columns
-                                             [{:name "int", :enabled true}
-                                              {:name "text", :enabled true}
-                                              {:name "timetamp", :enabled true}
-                                             ;; this signals date should not be shown in the grid
-                                              {:name "date", :enabled false}]
+                                               :table.columns
+                                               [{:name "int", :enabled true}
+                                                {:name "text", :enabled true}
+                                                {:name "timetamp", :enabled true}
+                                               ;; this signals date should not be shown in the grid
+                                                {:name "date", :enabled false}]
 
-                                             :editableTable.columns
-                                             ["int"
-                                             ;; this signals text is not editable
-                                              #_"text"
-                                              "timestamp"
-                                              "date"]
+                                               :editableTable.columns
+                                               ["int"
+                                               ;; this signals text is not editable
+                                                #_"text"
+                                                "timestamp"
+                                                "date"]
 
-                                             :editableTable.enabledActions
-                                            ;; We can fix this "unknown" when we move the action out of the dashcard json
-                                            ;; See [[metabase.dashboards.api/create-or-fix-action-id]]
-                                             [{:id                "dashcard:unknown:1"
-                                               :actionId          "table.row/create"
-                                               :parameterMappings [;; because this is a CUSTOM actions
-                                                                  ;; it might not even be editing the same table,
-                                                                  ;; so we need to map the primary, unlike for
-                                                                  ;; built-in actions which assume its pk->pk
-                                                                   {:parameter "id"
-                                                                    :sourceType "row-data"
-                                                                    :value      "TODO"}
+                                               :editableTable.enabledActions
+                                              ;; We can fix this "unknown" when we move the action out of the dashcard json
+                                              ;; See [[metabase.dashboards.api/create-or-fix-action-id]]
+                                               [{:id                "dashcard:unknown:1"
+                                                 :actionId          "table.row/create"
+                                                 :parameterMappings [;; because this is a CUSTOM actions
+                                                                    ;; it might not even be editing the same table,
+                                                                    ;; so we need to map the primary, unlike for
+                                                                    ;; built-in actions which assume its pk->pk
+                                                                     {:parameter "id"
+                                                                      :sourceType "row-data"
+                                                                      :value      "TODO"}
 
-                                                                   {:parameterId "int"
-                                                                    :sourceType  "const"
-                                                                    :value       42}
-                                                                   {:parameterId       "text"
-                                                                    :sourceType        "row-data"
-                                                                    :sourceValueTarget "text"
-                                                                    :visibility        "readonly"}
-                                                                   {:parameterId "timestamp"
-                                                                    :visibility  "hidden"}]}]}}]
+                                                                     {:parameterId "int"
+                                                                      :sourceType  "const"
+                                                                      :value       42}
+                                                                     {:parameterId       "text"
+                                                                      :sourceType        "row-data"
+                                                                      :sourceValueTarget "text"
+                                                                      :visibility        "readonly"}
+                                                                     {:parameterId "timestamp"
+                                                                      :visibility  "hidden"}]}]}}]
 
-            ;; insert a row for the row action
-            (mt/user-http-request :crowberto :post 200
-                                  (data-editing.tu/table-url @test-table)
-                                  {:rows [{:text "a very important string"}]})
+              ;; insert a row for the row action
+              (mt/user-http-request :crowberto :post 200
+                                    (data-editing.tu/table-url @test-table)
+                                    {:rows [{:text "a very important string"}]})
 
-            (testing "table actions on a dashcard"
-              (let [create-id "table.row/create"
-                    update-id "table.row/update"
-                    delete-id "table.row/delete"
-                    ;; Note, we're relying on this scope to fill in "unknown" on the action id
-                    ;; But in either case, we're always meant to send this for undo/redo scope anyway.
-                    scope     {:dashcard-id (:id dashcard)}
+              (testing "table actions on a dashcard"
+                (let [create-id "table.row/create"
+                      update-id "table.row/update"
+                      delete-id "table.row/delete"
+                      ;; Note, we're relying on this scope to fill in "unknown" on the action id
+                      ;; But in either case, we're always meant to send this for undo/redo scope anyway.
+                      scope     {:dashcard-id (:id dashcard)}
 
-                    ;; TODO build-in actions won't let you configure this
-                    expected-id-params []
-                    ;; params are reordered by editable (?)
-                    expected-row-params [{:id "int",  :readonly false}
-                                         {:id "text", :readonly true, :value "a very important string"}
-                                         ;; date is hidden from the editable
-                                         #_{:id "date"}
-                                         ;; timestamp is hidden in the row action
-                                         #_{:id "timestamp"}]]
+                      ;; TODO build-in actions won't let you configure this
+                      expected-id-params []
+                      ;; params are reordered by editable (?)
+                      expected-row-params [{:id "int",  :readonly false}
+                                           {:id "text", :readonly true, :value "a very important string"}
+                                           ;; date is hidden from the editable
+                                           #_{:id "date"}
+                                           ;; timestamp is hidden in the row action
+                                           #_{:id "timestamp"}]]
 
-                (testing "without a table-id"
-                  (let [scope {:dashboard-id (:dashboard_id dashcard)}]
-                    (doseq [action-id [create-id update-id delete-id]]
-                      (testing action-id
-                        (is (=? {:status 400}
-                                (req {:action_id action-id, :scope scope})))))))
+                  (testing "without a table-id"
+                    (let [scope {:dashboard-id (:dashboard_id dashcard)}]
+                      (doseq [action-id [create-id update-id delete-id]]
+                        (testing action-id
+                          (is (=? {:status 400}
+                                  (req {:action_id action-id, :scope scope})))))))
 
-                (testing "create"
-                  (is (=? {:status 200
-                           :body   {:parameters []}}
-                          (req {:scope     scope
-                                :action_id create-id
-                                :input     {:id 1}}))))
+                  (testing "create"
+                    (is (=? {:status 200
+                             :body   {:parameters []}}
+                            (req {:scope     scope
+                                  :action_id create-id
+                                  :input     {:id 1}}))))
 
-                (testing "update"
-                  (is (=? {:status 200} (req {:scope scope, :action_id update-id}))))
+                  (testing "update"
+                    (is (=? {:status 200} (req {:scope scope, :action_id update-id}))))
 
-                (testing "delete"
-                  (is (=? {:status 200} (req {:scope scope, :action_id delete-id}))))))))))))
+                  (testing "delete"
+                    (is (=? {:status 200} (req {:scope scope, :action_id delete-id}))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1035,6 +1035,8 @@
                                        :params    {:status "approved"}})
                                  (select-keys [:status :body])))))))))))))))
 
+;; TODO we may want to test that data-grid/built-in actions can't get called in they're disabled?
+
 (deftest unified-execute-server-side-mapping-test
   (let [url "action/v2/execute"
         req #(mt/user-http-request-full-response (:user % :crowberto) :post url

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1413,7 +1413,14 @@
                     (testing "delete"
                       (is (=? {:status 200} (req {:scope scope, :action_id delete-id}))))))))))))))
 
-(deftest tmp-modal-table-action-on-dashboard-test
+;; Important missing tests
+(comment
+  tmp-modal-saved-action-on-editable-on-dashboard-test
+  ;; either copy past tests or use a doseq to vary how we construct it
+  tmp-modal-saved-action-on-question-on-dashboard-test
+  tmp-modal-table-action-on-question-on-dashboard-test)
+
+(deftest tmp-modal-table-action-on-editable-on-dashboard-test
   (let [req
         #(mt/user-http-request-full-response
           (:user % :crowberto)
@@ -1452,7 +1459,9 @@
                                                "date"]
 
                                               :editableTable.enabledActions
-                                              [{:id                "table.row/create"
+                                              ;; WTF this is not the right shape
+                                              [{#_:id #_"dashcard:unknown:uuid"
+                                                :id                "table.row/create" ;; should be actionId
                                                 :parameterMappings [{:parameterId "int"
                                                                      :sourceType  "const"
                                                                      :value       42}

--- a/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
@@ -22,7 +22,8 @@
   (let [table (sync/create-table! db {:name table-name
                                       ;; todo figure out how to determine default schema from driver
                                       :schema (case (:engine db) :postgres "public" nil)
-                                      :display_name table-name})]
+                                      :display_name table-name
+                                      :field_order  :database})]
     (sync/sync-fields-for-table! db table)
     (:id table)))
 

--- a/src/metabase/actions/api.clj
+++ b/src/metabase/actions/api.clj
@@ -324,6 +324,7 @@
      (api.macros/call-core-fn @(requiring-resolve ~var-sym) ~'route-params ~'query-params ~'body-params ~'request)))
 
 (evil-proxy :get  "/v2/tmp-action" 'metabase-enterprise.data-editing.api/tmp-action)
+;(evil-proxy :post "/v2/configure" 'metabase-enterprise.data-editing.api/configure)
 (evil-proxy :post "/v2/execute" 'metabase-enterprise.data-editing.api/execute-single)
 (evil-proxy :post "/v2/execute-bulk" 'metabase-enterprise.data-editing.api/execute-bulk)
 (evil-proxy :post "/v2/tmp-modal" 'metabase-enterprise.data-editing.api/tmp-modal)

--- a/src/metabase/actions/api.clj
+++ b/src/metabase/actions/api.clj
@@ -324,7 +324,7 @@
      (api.macros/call-core-fn @(requiring-resolve ~var-sym) ~'route-params ~'query-params ~'body-params ~'request)))
 
 (evil-proxy :get  "/v2/tmp-action" 'metabase-enterprise.data-editing.api/tmp-action)
-;(evil-proxy :post "/v2/configure" 'metabase-enterprise.data-editing.api/configure)
+(evil-proxy :post "/v2/configure" 'metabase-enterprise.data-editing.api/configure)
 (evil-proxy :post "/v2/execute" 'metabase-enterprise.data-editing.api/execute-single)
 (evil-proxy :post "/v2/execute-bulk" 'metabase-enterprise.data-editing.api/execute-bulk)
 (evil-proxy :post "/v2/tmp-modal" 'metabase-enterprise.data-editing.api/tmp-modal)

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -769,7 +769,7 @@
                             (let [database       (driver-api/cached-database-via-table-id table-id)
                                   field-name->id (table-id->pk-field-name->id (:id database) table-id)]
                               [table-id (keys field-name->id)]))
-        delete-children?  (:delete-children driver-api/*params*)
+        delete-children?  (:delete-children (driver-api/action-params))
         [errors results]  (batch-execution-by-table-id!
                            {:inputs        inputs
                             :row-action    :model.row/delete

--- a/src/metabase/driver_api/core.clj
+++ b/src/metabase/driver_api/core.clj
@@ -64,7 +64,6 @@
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (p/import-vars
- actions/*params*
  actions/cached-value
  actions/cached-database
  actions/cached-database-via-table-id
@@ -171,6 +170,10 @@
  sync-util/name-for-logging
  system/site-uuid
  upload/current-database)
+
+(defn action-params []
+  "temporary hack, remove when the underlying dynamic var is deleted"
+  actions/*params*)
 
 (defn ^:deprecated current-user
   "Fetch the user making the request."

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -160,7 +160,7 @@
                                            (app-db/isa :semantic_type :type/PK)       0
                                            (app-db/isa :semantic_type :type/Name)     1
                                            (app-db/isa :semantic_type :type/Temporal) 2
-                                           :else                                         3]
+                                           :else                                      3]
                                           :asc]
                                          [:%lower.name :asc]]
                           :database     [[:database_position :asc]]

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -90,7 +90,7 @@
 
 (defn- test-action-error-handling! [f]
   (mt/test-drivers (filter #(isa? driver/hierarchy % :sql-jdbc) (mt/normal-drivers-with-feature :actions))
-    (mt/dataset action-error-handling
+    (actions.tu/with-actions-temp-db action-error-handling
       (mt/with-actions-enabled
         (let [db-id          (mt/id)]
           (f {:db-id         db-id
@@ -267,7 +267,7 @@
 (deftest actions-return-rows-with-correct-names-test
   (testing "rows returned by perform action should match the name in metabase_field.name"
     (mt/test-drivers (mt/normal-drivers-with-feature :actions)
-      (mt/dataset action-error-handling
+      (actions.tu/with-actions-temp-db action-error-handling
         (mt/with-actions-enabled
           (let [db-id (mt/id)
                 created-user (actions/perform-action-with-single-input-and-output
@@ -309,7 +309,7 @@
 
 (deftest delete-row-with-children-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)
-    (mt/dataset action-error-handling
+    (actions.tu/with-actions-temp-db action-error-handling
       (mt/with-actions-enabled
         (let [group-id-col   (field-id->name (mt/id :group :id))
               group-name-col (field-id->name (mt/id :group :name))


### PR DESCRIPTION
For now this gets the most crucial cases working in a parrot fashion, returning the initial or existing configuration.

The next step will be to wrap this configuration in a "form" representation that the FE can render without much logic.