### PR TITLE
Get rid of params hack

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
@@ -17,21 +17,12 @@
 
 (defmethod actions/action-arg-map-schema :data-grid.row/common
   [_action]
-  ::actions.args/row)
+  ::actions.args/table.common)
 
 (defmethod actions/normalize-action-arg-map :data-grid.row/common
   [_action input]
-  (update-keys input u/qualified-name))
-
-(defn- scope->table-id [context]
-  (u/prog1 (-> context :scope :table-id)
-    (when-not <>
-      (throw (ex-info "Cannot perform data-grid actions without a table in scope."
-                      {:error :data-grid.row/unknown-table})))))
-
-(defn- map-inputs [table-id inputs]
-  (for [row (data-editing/apply-coercions table-id inputs)]
-    {:table-id table-id :row row}))
+  (-> (assoc input :database (:id (actions/cached-database-via-table-id (:table-id input))))
+      (update :row #(update-keys % u/qualified-name))))
 
 (defn- perform-table-row-action!
   "Perform an action directly, skipping permissions checks etc, and generate outputs based on the table modifications."
@@ -46,26 +37,43 @@
         [op pretty-row] (map vector (map :op diffs) pretty-rows)]
     {:op op, :table-id table-id, :row pretty-row}))
 
-(defn- perform! [action-kw context inputs]
-  ;; We could enhance this in future to work more richly with multi-table editable models.
-  (let [table-id     (scope->table-id context)
-        next-inputs  (map-inputs table-id inputs)]
+(defn- coerce-inputs [inputs]
+  (let [input->coerced (u/for-map [[table-id inputs] (group-by :table-id inputs)
+                                   :let [coerced (data-editing/apply-coercions table-id (map :row inputs))]
+                                   input+row (map vector inputs coerced)]
+                         input+row)]
+    (for [input inputs]
+      (assoc input :row (input->coerced input)))))
+
+(defn- perform-data-grid-action! [action-kw context inputs]
+  (let [next-inputs  (coerce-inputs inputs)]
     (perform-table-row-action! action-kw context next-inputs
                                (if (= :table.row/delete action-kw)
                                  identity
                                  post-process))))
 
 (mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/create]
-  [_action context inputs :- [:sequential ::actions.args/row]]
-  (perform! :table.row/create context inputs))
+  [_action context inputs]
+  (perform-data-grid-action! :table.row/create context inputs))
 
 (mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/update]
-  [_action context inputs :- [:sequential ::actions.args/row]]
-  (perform! :table.row/update context inputs))
+  [_action context inputs]
+  (perform-data-grid-action! :table.row/update context inputs))
 
 (mu/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/delete]
-  [_action context inputs :- [:sequential ::actions.args/row]]
-  (perform! :table.row/delete context inputs))
+  [_action context inputs]
+  (perform-data-grid-action! :table.row/delete context inputs))
+
+(mu/defmethod actions/default-mapping :data-grid.row/common
+  [_ scope]
+  (assoc (select-keys scope [:table-id]) :row ::root))
+
+(mu/defmethod actions/default-mapping :data-grid.row/delete
+  [_ scope]
+  (assoc (select-keys scope [:table-id])
+         ;; TODO yeah, a shorter namespace would be nice, that doesn't require importing from EE
+         :row :metabase-enterprise.data-editing.api/input
+         :delete-children [:metabase-enterprise.data-editing.api/param :delete-children]))
 
 ;; undo
 
@@ -81,7 +89,7 @@
   (case (:error (ex-data e))
     :undo/none            (ex-info (tru "Nothing to do")                                         {:status-code 204} e)
     :undo/cannot-undelete (ex-info (tru "You cannot undo your previous change.")                 {:status-code 405} e)
-    :undo/cannot-undo     (ex-info (tru "Your previous change cannot be undone")                            {:status-code 405} e)
+    :undo/cannot-undo     (ex-info (tru "Your previous change cannot be undone")                 {:status-code 405} e)
     :undo/conflict        (ex-info (tru "Your previous change has a conflict with another edit") {:status-code 409} e)
     e))
 

--- a/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/actions.clj
@@ -66,7 +66,7 @@
 
 (mu/defmethod actions/default-mapping :data-grid.row/common
   [_ scope]
-  (assoc (select-keys scope [:table-id]) :row ::root))
+  (assoc (select-keys scope [:table-id]) :row :metabase-enterprise.data-editing.api/root))
 
 (mu/defmethod actions/default-mapping :data-grid.row/delete
   [_ scope]

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -29,63 +29,48 @@
   (when (require-authz?)
     (api/check-superuser)))
 
+(declare execute!*)
+
 (api.macros/defendpoint :post "/table/:table-id"
   "Insert row(s) into the given table."
   [{:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]
    {}
-   {:keys [rows scope]} :- [:map
-                            [:rows [:sequential {:min 1} :map]]
-                            ;; TODO make this non-optional in the future
-                            [:scope {:optional true} ::types/scope.raw]]]
+   {:keys [rows]} :- [:map [:rows [:sequential {:min 1} :map]]]]
   (check-permissions)
-  (let [;; This is a bit unfortunate... we ignore the table-id in the path when called with a custom scope...
-        ;; The solution is to stop accepting custom scope once we migrate the data grid to action/execute
-        scope (or scope {:table-id table-id})]
-    {:created-rows (map :row (:outputs (actions/perform-action! :data-grid.row/create scope rows)))}))
+  (let [scope {:table-id table-id}]
+    {:created-rows (map :row (:outputs #p (execute!* "data-grid.row/create" scope {} rows)))}))
 
 (api.macros/defendpoint :put "/table/:table-id"
   "Update row(s) within the given table."
   [{:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]
    {}
-   {:keys [rows pks updates scope]}
+   {:keys [rows pks updates]}
    :- [:multi {:dispatch #(cond
                             (:rows %) :mixed-updates
                             (:pks %)  :uniform-updates)}
-       [:mixed-updates [:map
-                        [:rows [:sequential {:min 1} :map]]
-                        ;; TODO make :scope required
-                        [:scope {:optional true} ::types/scope.raw]]]
+       [:mixed-updates [:map [:rows [:sequential {:min 1} :map]]]]
        [:uniform-updates [:map
                           [:pks [:sequential {:min 1} :map]]
-                          [:updates :map]
-                          ;; TODO make :scope required
-                          [:scope {:optional true} ::types/scope.raw]]]]]
+                          [:updates :map]]]]]
   (check-permissions)
   (if (empty? (or rows pks))
     {:updated []}
-    (let [;; This is a bit unfortunate... we ignore the table-id in the path when called with a custom scope...
-          ;; The solution is to stop accepting custom scope once we migrate the data grid to action/execute
-          scope   (or scope {:table-id table-id})
+    (let [scope   {:table-id table-id}
           rows    (or rows
                       ;; For now, it's just a shim, because we haven't implemented an efficient bulk update action yet.
                       ;; This is a dumb shim; we're not checking that the pk maps are really (just) the pks.
                       (map #(merge % updates) pks))]
-      {:updated (map :row (:outputs (actions/perform-action! :data-grid.row/update scope rows)))})))
+      {:updated (map :row (:outputs (execute!* "data-grid.row/update" scope nil rows)))})))
 
 ;; This is a POST instead of DELETE as not all web proxies pass on the body of DELETE requests.
 (api.macros/defendpoint :post "/table/:table-id/delete"
   "Delete row(s) from the given table"
   [{:keys [table-id]} :- [:map [:table-id ms/PositiveInt]]
    {}
-   {:keys [rows scope]} :- [:map
-                            [:rows [:sequential {:min 1} :map]]
-                            ;; make this non-optional in the future
-                            [:scope {:optional true} ::types/scope.raw]]]
+   {:keys [rows]} :- [:map [:rows [:sequential {:min 1} :map]]]]
   (check-permissions)
-  ;; This is a bit unfortunate... we ignore the table-id in the path when called with a custom scope...
-  ;; The solution is to stop accepting custom scope once we migrate the data grid to action/execute
-  (let [scope (or scope {:table-id table-id})]
-    (actions/perform-action! :data-grid.row/delete scope rows)
+  (let [scope {:table-id table-id}]
+    (execute!* "data-grid.row/delete" scope nil rows)
     {:success true}))
 
 ;; might later be changed, or made driver specific, we might later drop the requirement depending on admin trust

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -38,7 +38,7 @@
    {:keys [rows]} :- [:map [:rows [:sequential {:min 1} :map]]]]
   (check-permissions)
   (let [scope {:table-id table-id}]
-    {:created-rows (map :row (:outputs (execute!* "data-grid.row/create" scope {} rows)))}))
+    {:created-rows (map :row (execute!* "data-grid.row/create" scope {} rows))}))
 
 (api.macros/defendpoint :put "/table/:table-id"
   "Update row(s) within the given table."
@@ -60,7 +60,7 @@
                       ;; For now, it's just a shim, because we haven't implemented an efficient bulk update action yet.
                       ;; This is a dumb shim; we're not checking that the pk maps are really (just) the pks.
                       (map #(merge % updates) pks))]
-      {:updated (map :row (:outputs (execute!* "data-grid.row/update" scope nil rows)))})))
+      {:updated (map :row (execute!* "data-grid.row/update" scope nil rows))})))
 
 ;; This is a POST instead of DELETE as not all web proxies pass on the body of DELETE requests.
 (api.macros/defendpoint :post "/table/:table-id/delete"

--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -38,7 +38,7 @@
    {:keys [rows]} :- [:map [:rows [:sequential {:min 1} :map]]]]
   (check-permissions)
   (let [scope {:table-id table-id}]
-    {:created-rows (map :row (:outputs #p (execute!* "data-grid.row/create" scope {} rows)))}))
+    {:created-rows (map :row (:outputs (execute!* "data-grid.row/create" scope {} rows)))}))
 
 (api.macros/defendpoint :put "/table/:table-id"
   "Update row(s) within the given table."

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -289,7 +289,7 @@
                     (mt/user-http-request :crowberto :post 400 execute-v2-url
                                           body))))
 
-          (testing "sucess with delete-children options"
+          (testing "success with delete-children options"
             (is (=? {:outputs [{:table-id (mt/id :products) :op "deleted" :row {(keyword (mt/format-name :id)) 1}}
                                {:table-id (mt/id :products) :op "deleted" :row {(keyword (mt/format-name :id)) 2}}]}
                     (mt/user-http-request :crowberto :post 200 execute-v2-url

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -22,6 +22,15 @@
    [toucan2.core :as t2])
   (:import (clojure.lang ExceptionInfo)))
 
+(defmulti default-mapping
+  "Allow actions to dynamically generating a :mapping, in none has been configured."
+  ;; TODO revise this version when we land it
+  {:arglists '([action-kw scope]), :added "0.9999.0"}
+  (fn [action-kw _scope]
+    action-kw))
+
+(defmethod default-mapping :default [_ _])
+
 (defmulti perform-action!*
   "Multimethod for doing an Action. The specific `action` is a keyword like `:model.row/create` or `:table.row/create`; the shape
   of each input depends on the action being performed. [[action-arg-map-schema]] returns the appropriate spec to use to
@@ -268,9 +277,9 @@
           (cond
             (:query arg-map) (qp.perms/check-query-action-permissions* arg-map)
             (:table-id arg-map) (qp.perms/check-query-action-permissions*
-                                 {:type :query,
+                                 {:type     :query,
                                   :database (:database arg-map)
-                                  :query {:source-table (:table-id arg-map)}}))))
+                                  :query    {:source-table (:table-id arg-map)}}))))
 
       (let [result (let [context (-> existing-context
                                      ;; TODO fix tons of tests which execute without user scope

--- a/src/metabase/actions/args.clj
+++ b/src/metabase/actions/args.clj
@@ -152,24 +152,25 @@
   ::table.common)
 
 (defmethod normalize-action-arg-map :table.row/common
-  [_action {:keys [database table-id row] row-arg :arg :as _arg-map}]
+  [_action-kw {:keys [database table-id row delete-children] row-arg :arg :as _arg-map}]
   (when (seq row-arg)
     (log/warn ":arg is deprecated, use :row instead"))
-  ;; TODO fix tests that rely on fetching db_id using table_id
-  {:database (or database (when table-id (t2/select-one-fn :db_id :model/Table table-id)))
-   :table-id table-id
-   :row      (update-keys (or row row-arg) u/qualified-name)})
+  ;; TODO it would be nice to use cached-database-via-table-id here, but need to solve circular dependency.
+  (cond-> {:database (or database (when table-id (t2/select-one-fn :db_id :model/Table table-id)))
+           :table-id table-id
+           :row      (update-keys (or row row-arg) u/qualified-name)}
+    delete-children (assoc :delete-children delete-children)))
 
 ;;;; `:table.row/create-or-update` -- similar to common but with additional :key field
 
-(mr/def ::table.create-or-udpate
+(mr/def ::table.create-or-update
   [:merge
    ::table.common
    [:map [:row-key ::row]]])
 
 (defmethod action-arg-map-schema :table.row/create-or-update
   [_action]
-  ::table.create-or-udpate)
+  ::table.create-or-update)
 
 (defmethod normalize-action-arg-map :table.row/create-or-update
   [_action {:keys [database table-id row row-key] :as _arg-map}]

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -28,6 +28,7 @@
   cached-database
   cached-database-via-table-id
   cached-table
+  default-mapping
   handle-effects!*
   perform-action!
   ;; allow actions to be defined in the data-editing module
@@ -63,8 +64,3 @@
  [metabase.actions.scope
   hydrate-scope
   normalize-scope])
-
-(def ^:dynamic *params*
-  "Temporary dynamic vars used to pass params from api to actions execution.
-  Should be removed once we reworked the inputs for perform-action!*."
-  {})

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -776,20 +776,19 @@
                            {:inputs       inputs
                             :row-action   :model.row/delete
                             :row-fn       (if delete-children? row-delete!*-with-children row-delete!*)
-                            ;; TODO :delete-children should get passed in as part of inputs, and we should get rid of *params*
-                           :validate-fn   (fn [database table-id rows]
-                                            (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]
-                                              (check-consistent-row-keys rows)
-                                              (check-rows-have-expected-columns-and-no-other-keys rows (keys pk-name->id))
-                                              (check-unique-rows rows)
-                                              (when-not delete-children?
-                                                (check-rows-have-no-children (:id database) table-id rows))))
-                           :input-fn      (fn [{db-id :id} table-id row]
-                                            {:database db-id
-                                             :type     :query
-                                             :query    {:source-table table-id
-                                                        :filter       (row->mbql-filter-clause
-                                                                       (table-id->pk-field-name->id db-id table-id) row)}})})]
+                            :validate-fn   (fn [database table-id rows]
+                                             (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]
+                                               (check-consistent-row-keys rows)
+                                               (check-rows-have-expected-columns-and-no-other-keys rows (keys pk-name->id))
+                                               (check-unique-rows rows)
+                                               (when-not delete-children?
+                                                 (check-rows-have-no-children (:id database) table-id rows))))
+                            :input-fn      (fn [{db-id :id} table-id row]
+                                             {:database db-id
+                                              :type     :query
+                                              :query    {:source-table table-id
+                                                         :filter       (row->mbql-filter-clause
+                                                                        (table-id->pk-field-name->id db-id table-id) row)}})})]
     (when (seq errors)
       (throw (ex-info (tru "Error(s) deleting rows.")
                       {:status-code 400

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -765,29 +765,31 @@
 
 (mu/defmethod driver-api/perform-action!* [:sql-jdbc :table.row/delete]
   [_action context inputs :- [:sequential ::table-row-input]]
-  (let [table-id->pk-keys (u/for-map [table-id (distinct (map :table-id inputs))]
+  (when (< 1 (count (distinct (keep :delete-children inputs))))
+    (throw (ex-info (tru "Cannot mix values of :delete-children, behavior would be ambiguous") {:status-code 400})))
+  (let [delete-children?  (some :delete-children inputs)
+        table-id->pk-keys (u/for-map [table-id (distinct (map :table-id inputs))]
                             (let [database       (driver-api/cached-database-via-table-id table-id)
                                   field-name->id (table-id->pk-field-name->id (:id database) table-id)]
                               [table-id (keys field-name->id)]))
-        delete-children?  (:delete-children (driver-api/action-params))
         [errors results]  (batch-execution-by-table-id!
-                           {:inputs        inputs
-                            :row-action    :model.row/delete
-                            :row-fn        (if delete-children? row-delete!*-with-children row-delete!*)
+                           {:inputs       inputs
+                            :row-action   :model.row/delete
+                            :row-fn       (if delete-children? row-delete!*-with-children row-delete!*)
                             ;; TODO :delete-children should get passed in as part of inputs, and we should get rid of *params*
-                            :validate-fn   (fn [database table-id rows]
-                                             (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]
-                                               (check-consistent-row-keys rows)
-                                               (check-rows-have-expected-columns-and-no-other-keys rows (keys pk-name->id))
-                                               (check-unique-rows rows)
-                                               (when-not delete-children?
-                                                 (check-rows-have-no-children (:id database) table-id rows))))
-                            :input-fn      (fn [{db-id :id} table-id row]
-                                             {:database db-id
-                                              :type     :query
-                                              :query    {:source-table table-id
-                                                         :filter       (row->mbql-filter-clause
-                                                                        (table-id->pk-field-name->id db-id table-id) row)}})})]
+                           :validate-fn   (fn [database table-id rows]
+                                            (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]
+                                              (check-consistent-row-keys rows)
+                                              (check-rows-have-expected-columns-and-no-other-keys rows (keys pk-name->id))
+                                              (check-unique-rows rows)
+                                              (when-not delete-children?
+                                                (check-rows-have-no-children (:id database) table-id rows))))
+                           :input-fn      (fn [{db-id :id} table-id row]
+                                            {:database db-id
+                                             :type     :query
+                                             :query    {:source-table table-id
+                                                        :filter       (row->mbql-filter-clause
+                                                                       (table-id->pk-field-name->id db-id table-id) row)}})})]
     (when (seq errors)
       (throw (ex-info (tru "Error(s) deleting rows.")
                       {:status-code 400

--- a/src/metabase/driver_api/core.clj
+++ b/src/metabase/driver_api/core.clj
@@ -171,10 +171,6 @@
  system/site-uuid
  upload/current-database)
 
-(defn action-params []
-  "temporary hack, remove when the underlying dynamic var is deleted"
-  actions/*params*)
-
 (defn ^:deprecated current-user
   "Fetch the user making the request."
   []

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -5,7 +5,6 @@
    [clojure.test :refer :all]
    [metabase.actions.actions :as actions]
    [metabase.actions.args :as actions.args]
-   [metabase.actions.core :as actions.core]
    [metabase.actions.error :as actions.error]
    [metabase.actions.test-util :as actions.tu]
    [metabase.driver :as driver]

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -359,17 +359,14 @@
                      :row      {group-id-col created-group-id}})))
 
               (testing "success if delete-children is enabled"
-                (binding [actions.core/*params* {:delete-children true}]
-                  (is (=? {:op :deleted
-                           :row {group-id-col created-group-id}}
-                          (actions/perform-action-with-single-input-and-output
-                           :table.row/delete
-                           {:database (mt/id)
-                            :table-id (mt/id :group)
-                            :row      {group-id-col created-group-id}})))
-
-                  (testing "users are also dedeted"
-                    (is (zero? (users-of-group created-group-id))))))))
+                (is (=? {:op  :deleted
+                         :row {group-id-col created-group-id}}
+                        (actions/perform-action-with-single-input-and-output
+                         :table.row/delete
+                         {:database        (mt/id)
+                          :table-id        (mt/id :group)
+                          :row             {group-id-col created-group-id}
+                          :delete-children true}))))))
 
           (testing "group without user can be deleted without delete-children option"
             (let [created-group-id (new-group)]


### PR DESCRIPTION
In order to pass `:delete-children` in the normal way, and to get ride of the weird hack of fetching the scope from the context to get the table in question, we introduce a "default mapping" for the `data-grid/built-in` actions.