### PR TITLE
change sql pivots viz settings format

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -74,7 +74,10 @@ export const settings = {
       return { rows, value };
     },
   },
+  "pivot_table.aggregation_stage": {},
   [NATIVE_COLUMN_SPLIT_SETTING]: {
+    readDependencies: ["pivot_table.aggregation_stage"],
+    writeDependencies: ["pivot_table.aggregation_stage"],
     get section() {
       return t`Columns`;
     },


### PR DESCRIPTION
### Description

This PR changes the format of the SQL pivot viz settings:
- "pivot_table.column_split" should remain unchanged and match MBQL pivots format where columns are referred by their names
- "pivot_table.aggregation_stage" — new viz setting that contains breakouts and aggregations that should be applied on top of the native query stage

```
"pivot_table.aggregation_stage": {
    "breakout": [
        [
            "field",
            "CREATED_AT",
            {...}
        ],
       [
            "field",
            "DISCOUNT",
            {...}
        ]
    ],
    "aggregation": [
        [
            "count"
        ],
        [
            "avg"
        ]
    ],
},
"pivot_table.column_split": { // unchanged
  "rows": [
    "CREATED_AT"
  ],
  "columns": [
    "DISCOUNT"
  ],
  "values": [
    "count",
    "avg"
  ]
}
```


