### PR TITLE
Fix t2 multiple method error

### DIFF
--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -129,3 +129,8 @@
       ;; loading the model namespace by calling `resolve-model` can add a new implementation to `table-name`, and
       ;; apparently we need to refer back to the var to pick up the updated multimethod.
       (#'t2.model/table-name (t2.model/resolve-model model)))))
+
+(methodical/prefer-method!
+ #'toucan2.pipeline/build
+ [:toucan.query-type/select.instances-from-pks :toucan2.tools.transformed/transformed.model :default]
+ [:toucan.query-type/select.* :toucan2.tools.before-select/model :default])


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Under rare (and near-impossible to reproduce) circumstances, we get "multiple matching methods and neither is preferred errors when selecting stuff from the db.  This should add in a preference.  The ordering between these two methods shouldn't matter, so either order is reasonable.

### How to verify

??? We don't have a repro

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
