### PR TITLE
Rename initialDashboardId to dashboardIdProp

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
@@ -93,7 +93,7 @@ const EditableDashboardInner = ({
  * @param props
  */
 export const EditableDashboard = ({
-  dashboardId: initialDashboardId,
+  dashboardId: dashboardIdProp,
   initialParameters = {},
   withDownloads = false,
   drillThroughQuestionHeight,
@@ -125,7 +125,7 @@ export const EditableDashboard = ({
     isLoading,
     dashboardId,
   } = useSdkDashboardParams({
-    dashboardId: initialDashboardId,
+    dashboardId: dashboardIdProp,
     withDownloads,
     withTitle: true,
     hiddenParameters: undefined,
@@ -160,7 +160,7 @@ export const EditableDashboard = ({
   if (!dashboardId || errorPage?.status === 404) {
     return (
       <StyledPublicComponentWrapper className={className} style={style}>
-        <DashboardNotFoundError id={initialDashboardId} />
+        <DashboardNotFoundError id={dashboardIdProp} />
       </StyledPublicComponentWrapper>
     );
   }

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -69,7 +69,7 @@ export type InteractiveDashboardProps = {
   DashboardEventHandlersProps;
 
 const InteractiveDashboardInner = ({
-  dashboardId: initialDashboardId,
+  dashboardId: dashboardIdProp,
   initialParameters = {},
   withTitle = true,
   withCardTitle = true,
@@ -104,7 +104,7 @@ const InteractiveDashboardInner = ({
     dashboardId,
     isLoading,
   } = useSdkDashboardParams({
-    dashboardId: initialDashboardId,
+    dashboardId: dashboardIdProp,
     withDownloads,
     withTitle,
     hiddenParameters,
@@ -150,7 +150,7 @@ const InteractiveDashboardInner = ({
   if (!dashboardId || errorPage?.status === 404) {
     return (
       <StyledPublicComponentWrapper className={className} style={style}>
-        <DashboardNotFoundError id={initialDashboardId} />
+        <DashboardNotFoundError id={dashboardIdProp} />
       </StyledPublicComponentWrapper>
     );
   }

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -35,7 +35,7 @@ export type StaticDashboardProps = SdkDashboardDisplayProps &
   DashboardEventHandlersProps;
 
 export const StaticDashboardInner = ({
-  dashboardId: initialDashboardId,
+  dashboardId: dashboardIdProp,
   initialParameters = {},
   withTitle = true,
   withCardTitle = true,
@@ -65,7 +65,7 @@ export const StaticDashboardInner = ({
     dashboardId,
     isLoading,
   } = useSdkDashboardParams({
-    dashboardId: initialDashboardId,
+    dashboardId: dashboardIdProp,
     initialParameters,
     withTitle,
     withDownloads,
@@ -86,7 +86,7 @@ export const StaticDashboardInner = ({
   }
 
   if (!dashboardId || errorPage?.status === 404) {
-    return <DashboardNotFoundError id={initialDashboardId} />;
+    return <DashboardNotFoundError id={dashboardIdProp} />;
   }
 
   return (

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
@@ -60,7 +60,7 @@ export type SdkDashboardDisplayProps = {
 } & CommonStylingProps;
 
 export const useSdkDashboardParams = ({
-  dashboardId: initialDashboardId,
+  dashboardId: dashboardIdProp,
   withDownloads,
   withTitle,
   hiddenParameters,
@@ -68,7 +68,7 @@ export const useSdkDashboardParams = ({
 }: SdkDashboardDisplayProps) => {
   const { id: dashboardId, isLoading = false } = useValidatedEntityId({
     type: "dashboard",
-    id: initialDashboardId,
+    id: dashboardIdProp,
   });
 
   // temporary name until we change `hideDownloadButton` to `downloads`

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -50,7 +50,7 @@ const DashboardCopyModal = ({
   ...props
 }) => {
   const [isShallowCopy, setIsShallowCopy] = useState(true);
-  const initialDashboardId = Urls.extractEntityId(params.slug);
+  const dashboardIdFromSlug = Urls.extractEntityId(params.slug);
 
   const title = getTitle(dashboard, isShallowCopy);
 
@@ -68,7 +68,7 @@ const DashboardCopyModal = ({
       title={title}
       overwriteOnInitialValuesChange
       copy={async (object) =>
-        await copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
+        await copyDashboard({ id: dashboardIdFromSlug }, dissoc(object, "id"))
       }
       onClose={onClose}
       onSaved={(dashboard) => onReplaceLocation(Urls.dashboard(dashboard))}

--- a/frontend/src/metabase/dashboard/context/context.tsx
+++ b/frontend/src/metabase/dashboard/context/context.tsx
@@ -46,7 +46,7 @@ export type DashboardContextOwnProps = {
 
 export type DashboardContextOwnResult = {
   shouldRenderAsNightMode: boolean;
-  initialDashboardId: DashboardContextOwnProps["dashboardId"];
+  dashboardIdProp: DashboardContextOwnProps["dashboardId"];
   dashboardId: DashboardId | null;
 };
 
@@ -72,7 +72,7 @@ export const DashboardContext = createContext<ContextReturned | undefined>(
 );
 
 const DashboardContextProviderInner = ({
-  dashboardId: initialDashboardId,
+  dashboardId: dashboardIdProp,
   parameterQueryParams = {},
   onLoad,
   onLoadWithoutCards,
@@ -230,20 +230,16 @@ const DashboardContextProviderInner = ({
   ]);
 
   useEffect(() => {
-    if (initialDashboardId !== dashboardId) {
-      fetchId(initialDashboardId);
+    if (dashboardIdProp !== dashboardId) {
+      fetchId(dashboardIdProp);
     }
-  }, [dashboardId, dispatch, fetchId, handleError, initialDashboardId]);
+  }, [dashboardId, dispatch, fetchId, handleError, dashboardIdProp]);
 
   useEffect(() => {
-    if (
-      initialDashboardId &&
-      dashboardId &&
-      dashboardId !== previousDashboardId
-    ) {
+    if (dashboardIdProp && dashboardId && dashboardId !== previousDashboardId) {
       fetchData(dashboardId);
     }
-  }, [dashboardId, fetchData, initialDashboardId, previousDashboardId]);
+  }, [dashboardId, fetchData, dashboardIdProp, previousDashboardId]);
 
   useEffect(() => {
     if (dashboard) {
@@ -290,7 +286,7 @@ const DashboardContextProviderInner = ({
   return (
     <DashboardContext.Provider
       value={{
-        initialDashboardId,
+        dashboardIdProp,
         dashboardId,
         parameterQueryParams,
         onLoad,

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/mock-context.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/mock-context.tsx
@@ -98,7 +98,7 @@ export const MockDashboardContext = ({
 
   return (
     <ConnectedDashboardContextWithReduxProps
-      initialDashboardId={dashboardId}
+      dashboardIdProp={dashboardId}
       dashboardId={dashboardId}
       parameterQueryParams={parameterQueryParams}
       onLoad={onLoad}


### PR DESCRIPTION
This pull request standardizes the naming convention for `dashboardId` across multiple files in the codebase. The changes replace the `initialDashboardId` identifier with `dashboardIdProp` for consistency and clarity. This update impacts several components, hooks, and context providers related to dashboards.

### Naming Convention Updates:

#### Dashboard Components:
* [`enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx`](diffhunk://#diff-66e090b38b9670172985a16412e9dd3395b004ee93d32b5ff3d4dcc389a2d407L96-R96): Updated `initialDashboardId` to `dashboardIdProp` in all occurrences, including parameter passing and error handling. [[1]](diffhunk://#diff-66e090b38b9670172985a16412e9dd3395b004ee93d32b5ff3d4dcc389a2d407L96-R96) [[2]](diffhunk://#diff-66e090b38b9670172985a16412e9dd3395b004ee93d32b5ff3d4dcc389a2d407L128-R128) [[3]](diffhunk://#diff-66e090b38b9670172985a16412e9dd3395b004ee93d32b5ff3d4dcc389a2d407L163-R163)
* [`enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx`](diffhunk://#diff-64273ff62acc1f9b277c871440762a8072b635eec51bebdf147fdbcb8fa6bd7fL72-R72): Applied the same update for `InteractiveDashboardInner` component. [[1]](diffhunk://#diff-64273ff62acc1f9b277c871440762a8072b635eec51bebdf147fdbcb8fa6bd7fL72-R72) [[2]](diffhunk://#diff-64273ff62acc1f9b277c871440762a8072b635eec51bebdf147fdbcb8fa6bd7fL107-R107) [[3]](diffhunk://#diff-64273ff62acc1f9b277c871440762a8072b635eec51bebdf147fdbcb8fa6bd7fL153-R153)
* [`enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx`](diffhunk://#diff-f9cbbd32be9c58c350d93054f9162c0ca8d99e3ed436e029d03d8b922f250270L38-R38): Renamed `initialDashboardId` to `dashboardIdProp` in `StaticDashboardInner` component. [[1]](diffhunk://#diff-f9cbbd32be9c58c350d93054f9162c0ca8d99e3ed436e029d03d8b922f250270L38-R38) [[2]](diffhunk://#diff-f9cbbd32be9c58c350d93054f9162c0ca8d99e3ed436e029d03d8b922f250270L68-R68) [[3]](diffhunk://#diff-f9cbbd32be9c58c350d93054f9162c0ca8d99e3ed436e029d03d8b922f250270L89-R89)

#### Dashboard Hooks:
* [`enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts`](diffhunk://#diff-af4ad8cee534418ec7f75b6268a411fe72565f0ca320d18f26232908c7240207L63-R71): Changed `initialDashboardId` to `dashboardIdProp` in the `useSdkDashboardParams` hook to align with the updated naming convention.

#### Dashboard Context:
* [`frontend/src/metabase/dashboard/context/context.tsx`](diffhunk://#diff-f3efeafd4ff67fbbaef4715f6bf92b00fccb7adb5a2d4a47ed9714e12d35af88L49-R49): Updated `initialDashboardId` to `dashboardIdProp` in the `DashboardContextProviderInner` and related context properties. [[1]](diffhunk://#diff-f3efeafd4ff67fbbaef4715f6bf92b00fccb7adb5a2d4a47ed9714e12d35af88L49-R49) [[2]](diffhunk://#diff-f3efeafd4ff67fbbaef4715f6bf92b00fccb7adb5a2d4a47ed9714e12d35af88L75-R75) [[3]](diffhunk://#diff-f3efeafd4ff67fbbaef4715f6bf92b00fccb7adb5a2d4a47ed9714e12d35af88L233-R242) [[4]](diffhunk://#diff-f3efeafd4ff67fbbaef4715f6bf92b00fccb7adb5a2d4a47ed9714e12d35af88L293-R289)

#### Additional Updates:
* [`frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx`](diffhunk://#diff-87979164fdf64c1e4346cfbac2cf33e6fcea0b6d75b7acf0b320797b5fcba41cL53-R53): Replaced `initialDashboardId` with `dashboardIdFromSlug` for extracting entity IDs from URLs. [[1]](diffhunk://#diff-87979164fdf64c1e4346cfbac2cf33e6fcea0b6d75b7acf0b320797b5fcba41cL53-R53) [[2]](diffhunk://#diff-87979164fdf64c1e4346cfbac2cf33e6fcea0b6d75b7acf0b320797b5fcba41cL71-R71)
* [`frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/mock-context.tsx`](diffhunk://#diff-321c6f1e02949e381f2bb8398100516a732312fa778890b511d6305f70f4e948L101-R101): Updated mock context to use `dashboardIdProp` for consistency.