### PR TITLE
WRK-457 slack template preview

### DIFF
--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -92,6 +92,16 @@
   :setter (fn [channel-name]
             (setting/set-value-of-type! :string :slack-bug-report-channel (process-files-channel-name channel-name))))
 
+(defsetting slack-team-id
+  "A cache storing the team_id (workspace)"
+  :encryption :when-encryption-key-set
+  :visibility :internal
+  :cache?     false
+  :type       :string
+  :doc        false
+  :audit      :never
+  :export?    false)
+
 (defsetting attachment-table-row-limit
   (deferred-tru "Maximum number of rows to render in an alert or subscription image.")
   :visibility :internal

--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -225,7 +225,7 @@
                :email      "bot@metabase.com"}}
 
     :channel/slack
-    {:type :notificaiton-recipient/raw-value
+    {:type :notification-recipient/raw-value
      :details {:value "#metabase-example-channel"}}))
 
 (api.macros/defendpoint :post "/preview_template"

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -67,8 +67,9 @@
   [:timestamp {:gen/fmap (fn [_x] (u.date/format (t/zoned-date-time)))} :any])
 
 (def ^:private scope-schema
-  [:scope [:map {:gen/return {:type       "dashboard"
-                              :origin_url (urls/dashboard-url 1337)}}
+  [:scope [:map {:gen/fmap (fn [_]
+                             {:type       "dashboard"
+                              :origin_url (urls/dashboard-url 1337)})}
            [:type :keyword]
            [:origin_url :string]]])
 


### PR DESCRIPTION
A new attribute `:preview_url` has been added to the body-response of `preview_template`

- This allows the FE to produce a link for slack templates that shows a preview
in slacks block-kit-builder tool. 
- Only applies to slack templates (obviously!)
- Uses a new setting `slack-team-id` which is maintained with the
channels/users cache

It seems possible for larger templates that URL limits could be reached,
so we should consider appropriate policy for that in a follow up (or
think of a better way to preview).

> **note** slack seems to normalize urls when loading the document, which will usually be fine, but if you have embedded links with encoding (e.g http://foo.com/hello%20world) then they might not be encoded correctly in the preview. 
 This should not affect sending, so I think its probably acceptable in practice.